### PR TITLE
feat(w3): housecarl_create / remove / forward + write_seq on the 2.0 vocabulary (W3 PR 2)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -33,7 +33,10 @@ back* — now covers authoring, removal and whole-record overrides.
 
 All three take the one lane spelling (`patch=` | `into=` | `in_place="X.esp"` + `acknowledge=`, mutually
 exclusive and **refused by name** when two are given), `format="json"`, `max_chars=`, and the `epoch=` stamp —
-**including the first-touch in-place consent prompt**, which previously carried none on these lanes. The 1.x
+**including the first-touch in-place consent prompt**, which previously carried none on these lanes. In
+`format="json"` the `lane` field names **the parameter the call used** — `"patch" | "into" | "in_place"`, the
+same three words on every write tool (`housecarl_apply` reported the `into=` lane as `"extend"`; it now says
+`"into"` like its siblings), and it is correct on refusals and the consent prompt too, not only on success. The 1.x
 tools are unchanged and stay registered through the build waves; from 2.0.0's clean cut a call naming one
 answers with its successor spelling.
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,42 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**New tools: `housecarl_create`, `housecarl_remove`, `housecarl_forward` — the rest of the 2.0 write surface
+(W3 PR 2).** The same shape `housecarl_apply` introduced — *what changes* × *where it lands* × *how it reads
+back* — now covers authoring, removal and whole-record overrides.
+
+- **`housecarl_create`** replaces `create_record` + `bulk_create`. `records=[{record_type, editorid, ops?,
+  parent?, collection?, grid?}]` — **one record is a set of one**, so the single-record call is the degenerate
+  case and the nested one-shot (a dialogue topic *and* its lines, a cell *and* its placed refs) needs no second
+  tool: parent a spec on an **earlier sibling's editorid**, and reference one from a FormLink value as
+  `'@editorid'`. `ops=` is `apply`'s op shape minus `formid` (a new record's id is allocated and reported back);
+  the members a create *cannot* have — `formid`, `from`, `from_source` — are refused **by name** with what to do
+  instead, rather than dropped. `records=` also takes `"@<absolute path>"`. Creating dialogue lines still
+  reports **voice coverage** and **result-script binding**, and creating cells still reports the world content
+  houseCARL does not author — now as typed data in `format="json"` too, not only prose.
+- **`housecarl_remove`** replaces `remove_record` and is **plural**: `formids=` is set-valued, so dropping ten
+  overrides is one call and one re-serialize instead of ten rewrites of the same file (the engine always took a
+  list; only the tool surface didn't). All-or-nothing is unchanged — one target the file doesn't carry refuses
+  the whole call. Its lane is **`into=`** (a houseCARL patch) or `in_place="X.esp"`: a removal edits an artifact
+  that already exists, so it has no `patch=`, and naming *no* lane is refused with both spelled out.
+- **`housecarl_forward`** replaces `forward_record`. `from_plugin=` is now **`source=`** — whose version to
+  copy (an active plugin, or a master to revert a record to vanilla). Unchanged otherwise: the response names
+  the winner each copy will out-rank, a forward that was already winning is flagged redundant, `into=` replaces
+  a FormKey the patch already carries, and `dry_run=` runs the real pipeline and stops before disk.
+
+All three take the one lane spelling (`patch=` | `into=` | `in_place="X.esp"` + `acknowledge=`, mutually
+exclusive and **refused by name** when two are given), `format="json"`, `max_chars=`, and the `epoch=` stamp —
+**including the first-touch in-place consent prompt**, which previously carried none on these lanes. The 1.x
+tools are unchanged and stay registered through the build waves; from 2.0.0's clean cut a call naming one
+answers with its successor spelling.
+
+**`housecarl_write_seq` keeps its name and moves to the 2.0 vocabulary.** `plugin=` is **`source=`**, and it
+now **resolves a plugin filename** across your MO2 mod folders (enabled, disabled, not-yet-listed), the
+overwrite folder and game Data — an absolute path still works, and the response **states which copy it read**
+(a filename several folders provide is refused, naming them). `patch_name=` is `patch=`; `format="json"` and
+`max_chars=` are new. This call consults no load-order build, so it carries **no epoch — stated as a fact with
+its reason** rather than left as a missing field.
+
 **New tool: `housecarl_apply` — the 2.0 field-write surface (W3 PR 1).** One write call composes *what changes*
 × *where it lands* × *how it reads back*, replacing `set_field` + `bulk_apply`. **Edits:** `ops=` is the edit
 list — one op is a set of one, so the old single-field call is the degenerate case — and it takes the inline

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -32,9 +32,11 @@ back* — now covers authoring, removal and whole-record overrides.
   a FormKey the patch already carries, and `dry_run=` runs the real pipeline and stops before disk.
 
 All three take the one lane spelling (`patch=` | `into=` | `in_place="X.esp"` + `acknowledge=`, mutually
-exclusive and **refused by name** when two are given), `format="json"`, `max_chars=`, and the `epoch=` stamp —
-**including the first-touch in-place consent prompt**, which previously carried none on these lanes. In
-`format="json"` the `lane` field names **the parameter the call used** — `"patch" | "into" | "in_place"`, the
+exclusive and **refused by name** when two are given) — except `housecarl_remove`, which has no `patch=` for the
+reason above, so its lanes are `into=` | `in_place=`. All three also take `format="json"`, `max_chars=`, and the
+`epoch=` stamp — **including the first-touch in-place consent prompt**, which previously carried none on these
+lanes. In `format="json"` the `lane` field names **the parameter the call used** — `"patch" | "into" |
+"in_place"` (`remove` can only report the last two), the
 same three words on every write tool (`housecarl_apply` reported the `into=` lane as `"extend"`; it now says
 `"into"` like its siblings), and it is correct on refusals and the consent prompt too, not only on success. The 1.x
 tools are unchanged and stay registered through the build waves; from 2.0.0's clean cut a call naming one

--- a/plugin/codex/housecarl/SKILL.md
+++ b/plugin/codex/housecarl/SKILL.md
@@ -43,9 +43,12 @@ Beyond the core workflow, reach for the right group. Depth for the specialist ar
 
 **Write / author**
 - `housecarl_apply` — the consolidated 2.0 field-write surface (one or many edits × the lane × the read-back in one call): `ops=` for field edits, `bundle=`+`assignments=` to copy a field bundle from one record onto another, and one lane spelling — a new patch, `into=` an existing one, or `in_place="X.esp"` naming the file you intend to overwrite. The 1.x write tools below keep working through the 2.0 build.
+- `housecarl_create` — the consolidated 2.0 authoring surface: `records=[{record_type, editorid, ops}]`, one record being a set of one, and a nested unit (a topic AND its lines, a cell AND its refs) authored in one call by parenting a spec on an earlier sibling's editorid. Same lane spelling as `apply`.
+- `housecarl_remove` — drop whole records; `formids=` is set-valued, so many drop in one re-serialize. The lane is `into=` a houseCARL patch or `in_place="X.esp"` (a removal edits an artifact that already exists, so there is no `patch=`).
+- `housecarl_forward` — copy a specific plugin's whole record as an override: `source=` names whose version (an active plugin, or a master to revert to vanilla), and the response names the winner it will out-rank.
 - `housecarl_set_field`, `housecarl_bulk_apply`, `housecarl_create_record`, `housecarl_bulk_create`, `housecarl_create_plugin` (header-only trigger plugin), `housecarl_remove_record`, `housecarl_forward_record` (copy-as-override, or revert to another plugin's version), `housecarl_validate_scripts` (unbound script properties).
 
-**Dialogue** — `housecarl_validate_dialogue`, `housecarl_write_seq` (the start-game-enabled quest `.seq`). Depth: `dialogue-authoring`.
+**Dialogue** — `housecarl_validate_dialogue`, `housecarl_write_seq` (the start-game-enabled quest `.seq`; `source=` takes the plugin's filename or an absolute path). Depth: `dialogue-authoring`.
 
 **Assets / NIF / facegen** — `housecarl_asset_status` (which mod/BSA wins a Data-relative path), `housecarl_place_asset` / `housecarl_bulk_place_asset` (make a chosen copy win MO2's VFS), `housecarl_nif_inspect` / `housecarl_nif_set` (read/write mesh data values). Depth: `facegen-diagnostics`.
 

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -147,6 +147,13 @@ public static class WritePatchBuilder
         bool Success, string? Error, string OutputPath,
         IReadOnlyList<RemovedRecord> Removed, IReadOnlyList<string> Masters, int RemainingRecords, long Bytes)
     {
+        /// <summary>SPEC §2.1.1 — the fingerprint of the index build THIS OUTCOME was decided from, on the same
+        /// contract as <see cref="PatchOutcome.Epoch"/> (stamped on success, refusal, and the consent prompt alike;
+        /// null only for a refusal taken before any build was consulted). A removal reads the index for the
+        /// re-serialize's master context, and its report's "re-sort if dropping this override changed a winner"
+        /// advice is only meaningful against a named build — which is exactly what this names.</summary>
+        public string? Epoch { get; init; }
+
         /// <summary>True ⇒ this outcome came from the IN-PLACE remove lane (<see cref="RemoveRecords"/>'s sibling
         /// <see cref="RemoveRecordsInPlace"/>) — the records were dropped from the USER's own file at
         /// <see cref="OutputPath"/>, not a houseCARL patch. Drives the distinct "removed in place" confirmation (and the
@@ -224,6 +231,12 @@ public static class WritePatchBuilder
         IReadOnlyList<CreatedRecord> Created, IReadOnlyList<string> Masters, long Bytes)
     {
         public IReadOnlyList<FullReadback>? ReadBack { get; init; }
+
+        /// <summary>SPEC §2.1.1 — the fingerprint of the index build THIS OUTCOME was decided from, on the same
+        /// contract as <see cref="PatchOutcome.Epoch"/>. A create resolves parents, link VALUES and the master
+        /// context through the captured build, so the new record's wiring is only as current as the build named
+        /// here.</summary>
+        public string? Epoch { get; init; }
 
         /// <summary>True ⇒ this outcome came from the IN-PLACE create lane (<see cref="CreateRecords"/>'s sibling
         /// <see cref="CreateRecordsInPlace"/>) — the new records were allocated into the USER's own file at
@@ -1065,11 +1078,26 @@ public static class WritePatchBuilder
     /// </summary>
     public static RemovalOutcome RemoveRecords(LoadOrderResolver resolver, IReadOnlyList<FormKey> targets, string outPath)
     {
+        string? epoch = null;
+        var outcome = RemoveRecordsCore(resolver, targets, outPath, ref epoch);
+        return epoch is null ? outcome : outcome with { Epoch = epoch };
+    }
+
+    /// <summary>The body of <see cref="RemoveRecords"/> — split for the same single-point epoch stamp as
+    /// <see cref="ApplyCore"/> (SPEC §2.1.1).</summary>
+    static RemovalOutcome RemoveRecordsCore(
+        LoadOrderResolver resolver, IReadOnlyList<FormKey> targets, string outPath, ref string? epoch)
+    {
         if (targets.Count == 0) return RemovalOutcome.Fail("no records to remove supplied.");
 
         // Per-call overlay session (Option B): the known-master set for the re-serialize is opened through it and
         // disposed when the method returns — no handle held at rest.
         using var session = resolver.OpenSession();
+        // This lane resolves no winner — the record set comes from the patch's own present-check — but it is NOT
+        // build-free: the master context this removal re-serializes against is the session's, off the resolver's
+        // current build. Naming that build is what makes the report's "re-sort if this changed a winner" advice
+        // checkable, so the stamp is taken here rather than left null (which would claim no index was consulted).
+        epoch = resolver.Capture().Epoch;
 
         var fileName = Path.GetFileName(outPath);
         if (!File.Exists(outPath))
@@ -1201,6 +1229,17 @@ public static class WritePatchBuilder
     public static RemovalOutcome RemoveRecordsInPlace(
         LoadOrderResolver resolver, IReadOnlyList<FormKey> targets, string targetPath, string targetName)
     {
+        string? epoch = null;
+        var outcome = RemoveRecordsInPlaceCore(resolver, targets, targetPath, targetName, ref epoch);
+        return epoch is null ? outcome : outcome with { Epoch = epoch };
+    }
+
+    /// <summary>The body of <see cref="RemoveRecordsInPlace"/> — split for the same single-point epoch stamp as
+    /// <see cref="ApplyCore"/> (SPEC §2.1.1).</summary>
+    static RemovalOutcome RemoveRecordsInPlaceCore(
+        LoadOrderResolver resolver, IReadOnlyList<FormKey> targets, string targetPath, string targetName,
+        ref string? epoch)
+    {
         if (targets.Count == 0) return RemovalOutcome.Fail("no records to remove supplied.");
 
         // Per-call overlay session (Option B), same as ApplyInPlace: every read (the master set for the re-serialize) is
@@ -1211,6 +1250,7 @@ public static class WritePatchBuilder
         // --- Phase 1: the target must be an active, FULLY-PARSEABLE plugin (the ApplyInPlace guard — never re-serialize a
         //     plugin Mutagen excluded, which would risk dropping the record it couldn't read on the rewrite, Q3). ---
         var view = resolver.Capture();
+        epoch = view.Epoch;                                               // SPEC §2.1.1 — stamped on every outcome from here down
         if (!view.ContainsPlugin(targetName))
             return RemovalOutcome.Fail($"in-place target '{targetName}' is not an active plugin in the load order.{view.AbsenceClause(targetName)}");
         if (view.ExcludedPlugins.TryGetValue(targetName, out var excluded))
@@ -1394,6 +1434,17 @@ public static class WritePatchBuilder
         LoadOrderResolver resolver, IReadOnlyList<ForwardSpec> specs, string targetPath, string targetName,
         bool fullReadback = true, bool dryRun = false)
     {
+        string? epoch = null;
+        var outcome = ForwardRecordsInPlaceCore(resolver, specs, targetPath, targetName, fullReadback, dryRun, ref epoch);
+        return epoch is null ? outcome : outcome with { Epoch = epoch };
+    }
+
+    /// <summary>The body of <see cref="ForwardRecordsInPlace"/> — split for the same single-point epoch stamp as
+    /// <see cref="ApplyCore"/> (SPEC §2.1.1).</summary>
+    static ForwardOutcome ForwardRecordsInPlaceCore(
+        LoadOrderResolver resolver, IReadOnlyList<ForwardSpec> specs, string targetPath, string targetName,
+        bool fullReadback, bool dryRun, ref string? epoch)
+    {
         if (specs.Count == 0) return ForwardOutcome.Fail("no records to forward supplied.");
 
         // Per-call overlay session (Option B), same as ApplyInPlace — no handle held at rest.
@@ -1403,6 +1454,7 @@ public static class WritePatchBuilder
         // --- Phase 1: target guards (the ApplyInPlace posture — never re-serialize a plugin Mutagen can't fully
         //     parse) + source resolution off ONE captured view. ---
         var view = resolver.Capture();
+        epoch = view.Epoch;                                               // SPEC §2.1.1 — stamped on every outcome from here down
         if (!view.ContainsPlugin(targetName))
             return ForwardOutcome.Fail($"in-place target '{targetName}' is not an active plugin in the load order.{view.AbsenceClause(targetName)}");
         if (view.ExcludedPlugins.TryGetValue(targetName, out var excluded))
@@ -1548,6 +1600,12 @@ public static class WritePatchBuilder
     {
         public IReadOnlyList<FullReadback>? ReadBack { get; init; }
 
+        /// <summary>SPEC §2.1.1 — the fingerprint of the index build THIS OUTCOME was decided from, on the same
+        /// contract as <see cref="PatchOutcome.Epoch"/>. A forward resolves every source body THROUGH the captured
+        /// build and reports the winner each copy will out-rank, so the epoch is what tells a caller whether that
+        /// "out-ranks X" reading still holds against the order they last read.</summary>
+        public string? Epoch { get; init; }
+
         /// <summary>True ⇒ the forwards were written INTO the target's own file (<see cref="ForwardRecordsInPlace"/> —
         /// the in-place write lane), not a houseCARL patch folder. Mirrors <see cref="PatchOutcome"/>.</summary>
         public bool InPlace { get; init; }
@@ -1685,6 +1743,17 @@ public static class WritePatchBuilder
         LoadOrderResolver resolver, IReadOnlyList<ForwardSpec> specs, string outPath, bool extend, bool fullReadback = false,
         bool dryRun = false)
     {
+        string? epoch = null;
+        var outcome = ForwardRecordsCore(resolver, specs, outPath, extend, fullReadback, dryRun, ref epoch);
+        return epoch is null ? outcome : outcome with { Epoch = epoch };
+    }
+
+    /// <summary>The body of <see cref="ForwardRecords"/> — split for the same single-point epoch stamp as
+    /// <see cref="ApplyCore"/> (SPEC §2.1.1).</summary>
+    static ForwardOutcome ForwardRecordsCore(
+        LoadOrderResolver resolver, IReadOnlyList<ForwardSpec> specs, string outPath, bool extend, bool fullReadback,
+        bool dryRun, ref string? epoch)
+    {
         if (specs.Count == 0) return ForwardOutcome.Fail("no records to forward supplied.");
 
         // Per-call overlay session (Option B): every source plugin this forward reads is opened THROUGH it and disposed
@@ -1701,6 +1770,7 @@ public static class WritePatchBuilder
         //     case ever bites, the clean fix is a single-pass batch fetch keyed by from_plugin (group specs by source,
         //     enumerate the overlay once collecting all wanted FormKeys) — deferred until measured. ---
         var view = resolver.Capture();
+        epoch = view.Epoch;                                               // SPEC §2.1.1 — stamped on every outcome from here down
         var resolved = ResolveForwardSources(session, view, specs, fileName, selfIsTarget: false, out var refusal);
         if (refusal is not null) return ForwardOutcome.Fail(refusal);
 
@@ -2146,6 +2216,20 @@ public static class WritePatchBuilder
         LoadOrderResolver resolver, CorpusRulebook rulebook,
         IReadOnlyList<CreateSpec> specs, string outPath, bool extend, bool fullReadback = false, string? inPlaceTarget = null)
     {
+        string? epoch = null;
+        var outcome = CreateRecordsCore(resolver, rulebook, specs, outPath, extend, fullReadback, inPlaceTarget, ref epoch);
+        return epoch is null ? outcome : outcome with { Epoch = epoch };
+    }
+
+    /// <summary>The body of <see cref="CreateRecords"/> — split for the same single-point epoch stamp as
+    /// <see cref="ApplyCore"/> (SPEC §2.1.1): the ONE captured build's fingerprint reaches every outcome (success,
+    /// refusal, consent prompt) from one place instead of a `with` at each return site, and <paramref name="epoch"/>
+    /// stays null for the refusals decided BEFORE the capture — they consulted no build, so they claim none.</summary>
+    static CreateOutcome CreateRecordsCore(
+        LoadOrderResolver resolver, CorpusRulebook rulebook,
+        IReadOnlyList<CreateSpec> specs, string outPath, bool extend, bool fullReadback, string? inPlaceTarget,
+        ref string? epoch)
+    {
         if (specs.Count == 0) return CreateOutcome.Fail("no records to create supplied.");
         bool inPlace = inPlaceTarget is not null;
 
@@ -2154,6 +2238,7 @@ public static class WritePatchBuilder
         // it; the patch lane uses it identically in Phase 1).
         using var session = resolver.OpenSession();
         var view = resolver.Capture();
+        epoch = view.Epoch;                                               // SPEC §2.1.1 — stamped on every outcome from here down
 
         // --- Phase 0: open the destination FIRST — moved AHEAD of pre-flight so a FormKey parent can resolve from it (a
         //     parent created in a PRIOR into= call, or — in place — a parent the target itself owns). CreateFromBinary reads

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -1366,10 +1366,15 @@ public static class WritePatchBuilder
     /// <summary>Phase-1 source resolution SHARED by <see cref="ForwardRecords"/> and <see cref="ForwardRecordsInPlace"/>:
     /// resolve each spec's body from its NAMED plugin (NOT the load-order winner) off ONE captured view, collecting ALL
     /// problems (Q3 — refuse the whole call if any; <paramref name="refusal"/> non-null ⇒ the caller fails with it).
-    /// <paramref name="selfIsTarget"/> only shapes the self-forward message (output patch vs in-place target).</summary>
+    /// <paramref name="selfIsTarget"/> only shapes the self-forward message (output patch vs in-place target).
+    /// <para><paramref name="sourceParam"/> is the SPELLING the calling tool exposes for the source pole — the
+    /// 1.x <c>from_plugin=</c>, or 2.0's <c>source=</c> (PR #311 review 4 [low]). Only the two self-forward
+    /// refusals name a parameter at all (the rest say "source plugin '<c>x</c>'", which is prose either way), and
+    /// naming one the caller cannot see is the same class this PR closes twice elsewhere — <c>offerModParam</c> on
+    /// the locate refusal, <c>InPlaceAgainHint</c> on the success path: render the CALLING surface's word.</para></summary>
     static List<(ForwardSpec spec, IMajorRecordGetter body, string priorWinner, bool wasWinner)> ResolveForwardSources(
         LoadOrderResolver.OverlaySession session, LoadOrderResolver.IndexView view,
-        IReadOnlyList<ForwardSpec> specs, string fileName, bool selfIsTarget, out string? refusal)
+        IReadOnlyList<ForwardSpec> specs, string fileName, bool selfIsTarget, string sourceParam, out string? refusal)
     {
         var resolved = new List<(ForwardSpec spec, IMajorRecordGetter body, string priorWinner, bool wasWinner)>(specs.Count);
         var problems = new List<string>();
@@ -1392,8 +1397,8 @@ public static class WritePatchBuilder
             if (string.Equals(s.FromPlugin, fileName, StringComparison.OrdinalIgnoreCase))
             {
                 problems.Add(selfIsTarget
-                    ? $"{s.Target}: from_plugin '{s.FromPlugin}' is the in-place target itself — forwarding a plugin's own version into itself is a no-op; name the OTHER plugin whose version you want carried in."
-                    : $"{s.Target}: from_plugin '{s.FromPlugin}' is the output patch itself — forwarding a patch's own version into itself is a no-op; name the EARLIER plugin whose version you want to re-assert.");
+                    ? $"{s.Target}: {sourceParam} '{s.FromPlugin}' is the in-place target itself — forwarding a plugin's own version into itself is a no-op; name the OTHER plugin whose version you want carried in."
+                    : $"{s.Target}: {sourceParam} '{s.FromPlugin}' is the output patch itself — forwarding a patch's own version into itself is a no-op; name the EARLIER plugin whose version you want to re-assert.");
                 continue;
             }
             if (!view.ContainsPlugin(s.FromPlugin))
@@ -1432,10 +1437,10 @@ public static class WritePatchBuilder
     /// </summary>
     public static ForwardOutcome ForwardRecordsInPlace(
         LoadOrderResolver resolver, IReadOnlyList<ForwardSpec> specs, string targetPath, string targetName,
-        bool fullReadback = true, bool dryRun = false)
+        bool fullReadback = true, bool dryRun = false, string sourceParam = "from_plugin")
     {
         string? epoch = null;
-        var outcome = ForwardRecordsInPlaceCore(resolver, specs, targetPath, targetName, fullReadback, dryRun, ref epoch);
+        var outcome = ForwardRecordsInPlaceCore(resolver, specs, targetPath, targetName, fullReadback, dryRun, sourceParam, ref epoch);
         return epoch is null ? outcome : outcome with { Epoch = epoch };
     }
 
@@ -1443,7 +1448,7 @@ public static class WritePatchBuilder
     /// <see cref="ApplyCore"/> (SPEC §2.1.1).</summary>
     static ForwardOutcome ForwardRecordsInPlaceCore(
         LoadOrderResolver resolver, IReadOnlyList<ForwardSpec> specs, string targetPath, string targetName,
-        bool fullReadback, bool dryRun, ref string? epoch)
+        bool fullReadback, bool dryRun, string sourceParam, ref string? epoch)
     {
         if (specs.Count == 0) return ForwardOutcome.Fail("no records to forward supplied.");
 
@@ -1461,7 +1466,7 @@ public static class WritePatchBuilder
             return ForwardOutcome.Fail(
                 $"cannot forward into '{targetName}' in place: it was EXCLUDED from this session ({excluded}) — houseCARL won't " +
                 "re-serialize a plugin it can't fully parse (that would risk dropping the record it couldn't read, Q3). The file is UNTOUCHED.");
-        var resolved = ResolveForwardSources(session, view, specs, targetName, selfIsTarget: true, out var refusal);
+        var resolved = ResolveForwardSources(session, view, specs, targetName, selfIsTarget: true, sourceParam, out var refusal);
         if (refusal is not null) return ForwardOutcome.Fail(refusal);
 
         // --- Phase 2: open the TARGET mutably (EAGER, the single plugin only — never the order). ---
@@ -1741,10 +1746,10 @@ public static class WritePatchBuilder
     /// </summary>
     public static ForwardOutcome ForwardRecords(
         LoadOrderResolver resolver, IReadOnlyList<ForwardSpec> specs, string outPath, bool extend, bool fullReadback = false,
-        bool dryRun = false)
+        bool dryRun = false, string sourceParam = "from_plugin")
     {
         string? epoch = null;
-        var outcome = ForwardRecordsCore(resolver, specs, outPath, extend, fullReadback, dryRun, ref epoch);
+        var outcome = ForwardRecordsCore(resolver, specs, outPath, extend, fullReadback, dryRun, sourceParam, ref epoch);
         return epoch is null ? outcome : outcome with { Epoch = epoch };
     }
 
@@ -1752,7 +1757,7 @@ public static class WritePatchBuilder
     /// <see cref="ApplyCore"/> (SPEC §2.1.1).</summary>
     static ForwardOutcome ForwardRecordsCore(
         LoadOrderResolver resolver, IReadOnlyList<ForwardSpec> specs, string outPath, bool extend, bool fullReadback,
-        bool dryRun, ref string? epoch)
+        bool dryRun, string sourceParam, ref string? epoch)
     {
         if (specs.Count == 0) return ForwardOutcome.Fail("no records to forward supplied.");
 
@@ -1771,7 +1776,7 @@ public static class WritePatchBuilder
         //     enumerate the overlay once collecting all wanted FormKeys) — deferred until measured. ---
         var view = resolver.Capture();
         epoch = view.Epoch;                                               // SPEC §2.1.1 — stamped on every outcome from here down
-        var resolved = ResolveForwardSources(session, view, specs, fileName, selfIsTarget: false, out var refusal);
+        var resolved = ResolveForwardSources(session, view, specs, fileName, selfIsTarget: false, sourceParam, out var refusal);
         if (refusal is not null) return ForwardOutcome.Fail(refusal);
 
         // --- Phase 2: open (extend) or create the patch mod (identical to Apply Phase 2). ---

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -383,6 +383,13 @@ public static class BindingShimProbe
         //   W0 mapping and this is the ONLY row that moves.
         //   * write_seq's five reverse rows (source->plugin, plugins/plugin_name(s)->plugin, patch->patch_name)
         //     are GONE: it declares source= and patch= itself now, so those rows are declared, not renamed.
+        // PR #311 review 3 (eyeballed 2026-08-05): 158 -> 163, five rows, all of them routes RESTORED rather
+        //   than new behaviour. `plugins`/`plugin_names` had dead-ended on write_seq the moment this PR took
+        //   `plugin` off it — their candidates were the three 1.x plugin spellings and nothing else — so both
+        //   gain `source` last (write_seq x2, and forward x2 as the consistent consequence: it already took
+        //   `plugin -> source`, so the plural spellings landing on the same pole is the existing rule, not a
+        //   new one). `patchname -> into` on remove closes the split where `patch=` mapped and the sibling
+        //   spelling every 1.x write tool uses did not. place_asset stays excepted on all of them.
         "housecarl_apply: archivename -> patch",
         "housecarl_apply: fromfile => hint",
         "housecarl_apply: fullreadback -> readback",
@@ -464,6 +471,8 @@ public static class BindingShimProbe
         "housecarl_forward: patchname -> patch",
         "housecarl_forward: plugin -> source",
         "housecarl_forward: pluginname -> patch",
+        "housecarl_forward: pluginnames -> source",
+        "housecarl_forward: plugins -> source",
         "housecarl_forward_record: formid -> formids",
         "housecarl_forward_record: patch -> patch_name",
         "housecarl_forward_record: readback -> full_readback",
@@ -514,6 +523,7 @@ public static class BindingShimProbe
         "housecarl_records: winnerfields => hint",
         "housecarl_remove: formid -> formids",
         "housecarl_remove: patch -> into",
+        "housecarl_remove: patchname -> into",
         "housecarl_remove_record: archivename -> patch",
         "housecarl_remove_record: formids -> formid",
         "housecarl_remove_record: output -> patch",
@@ -541,6 +551,8 @@ public static class BindingShimProbe
         "housecarl_write_seq: patchname -> patch",
         "housecarl_write_seq: plugin -> source",
         "housecarl_write_seq: pluginname -> source",
+        "housecarl_write_seq: pluginnames -> source",
+        "housecarl_write_seq: plugins -> source",
     };
 
     /// <summary>The published-schema arm (W3): the SPEC §5.1 <c>@file</c> union on the JsonElement-typed list

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -364,6 +364,20 @@ public static class BindingShimProbe
         // NOTE (deliberate negative): verb->op does NOT appear. `op` is a member of an ops ELEMENT, not a
         // top-level parameter, and the shim rewrites top-level arguments only — a stray `verb` inside an op
         // is refused by the strict element reader instead, which carries its own §5.3 correction.
+        // W3 PR 2 (eyeballed 2026-08-05): create / remove / forward join the surface and write_seq flips to the
+        // 2.0 vocabulary. 130 -> 158. What the diff certifies:
+        //   * the write-side clique now fires on four tools instead of one (patch=, full_readback=, formid=),
+        //     each landing on the ONE output name that tool declares;
+        //   * from_plugin -> source activates on housecarl_forward — the §5.3 row's real destination, dormant
+        //     since W0;
+        //   * patch -> INTO activates on housecarl_remove ALONE: it is the only tool where the artifact a write
+        //     edits already exists, and the four "new artifact" candidates ahead of `into` all miss there;
+        //   * the five create-operand hints (record_type/editorid/parent/collection/grid) fire on BOTH
+        //     housecarl_create and 1.x housecarl_bulk_create — both declare records=, and on both the scalar
+        //     spelling is genuinely a member of a record rather than a top-level argument, so the hint is
+        //     correct in both places rather than noise in one;
+        //   * write_seq's five reverse rows (source->plugin, plugins/plugin_name(s)->plugin, patch->patch_name)
+        //     are GONE: it declares source= and patch= itself now, so those rows are declared, not renamed.
         "housecarl_apply: archivename -> patch",
         "housecarl_apply: fromfile => hint",
         "housecarl_apply: fullreadback -> readback",
@@ -388,8 +402,13 @@ public static class BindingShimProbe
         "housecarl_bulk_apply: ops -> operations",
         "housecarl_bulk_apply: patch -> patch_name",
         "housecarl_bulk_apply: readback -> full_readback",
+        "housecarl_bulk_create: collection => hint",
+        "housecarl_bulk_create: editorid => hint",
+        "housecarl_bulk_create: grid => hint",
+        "housecarl_bulk_create: parent => hint",
         "housecarl_bulk_create: patch -> patch_name",
         "housecarl_bulk_create: readback -> full_readback",
+        "housecarl_bulk_create: recordtype => hint",
         "housecarl_bulk_place_asset: patch -> patch_name",
         "housecarl_check_errors: formid -> formids",
         "housecarl_check_errors: plugin -> plugins",
@@ -406,6 +425,16 @@ public static class BindingShimProbe
         "housecarl_compile_script: patch -> patch_name",
         "housecarl_compile_script: paths -> script",
         "housecarl_copy_npc_appearance: patch -> patch_name",
+        "housecarl_create: archivename -> patch",
+        "housecarl_create: collection => hint",
+        "housecarl_create: editorid => hint",
+        "housecarl_create: fullreadback -> readback",
+        "housecarl_create: grid => hint",
+        "housecarl_create: output -> patch",
+        "housecarl_create: parent => hint",
+        "housecarl_create: patchname -> patch",
+        "housecarl_create: pluginname -> patch",
+        "housecarl_create: recordtype => hint",
         "housecarl_create_plugin: patch -> plugin_name",
         "housecarl_create_plugin: plugin -> plugin_name",
         "housecarl_create_plugin: pluginnames -> plugin_name",
@@ -421,6 +450,15 @@ public static class BindingShimProbe
         "housecarl_decompile_script: paths -> pex",
         "housecarl_diff_record: formids -> formid",
         "housecarl_effect_chain: type -> types",
+        "housecarl_forward: archivename -> patch",
+        "housecarl_forward: formid -> formids",
+        "housecarl_forward: fromplugin -> source",
+        "housecarl_forward: fullreadback -> readback",
+        "housecarl_forward: mod -> source",
+        "housecarl_forward: output -> patch",
+        "housecarl_forward: patchname -> patch",
+        "housecarl_forward: plugin -> source",
+        "housecarl_forward: pluginname -> patch",
         "housecarl_forward_record: formid -> formids",
         "housecarl_forward_record: patch -> patch_name",
         "housecarl_forward_record: readback -> full_readback",
@@ -449,12 +487,7 @@ public static class BindingShimProbe
         "housecarl_read_record: pluginnames -> plugin",
         "housecarl_read_record: plugins -> plugin",
         "housecarl_read_record: source -> plugin",
-        // W2 PR 1 (re-eyeballed 2026-08-02): housecarl_records joins the surface. The 1.x spellings land on
-        // their 2.0 poles (plugin/mod/from_plugin -> source; formid -> formids; type -> types), the first
-        // dissolution hints go LIVE (the form-scoped PROJECT spellings incl. the chartered conflict_tree hint,
-        // editorid_contains -> the where grammar, winner_fields -> fields_source), and pluginname/pluginnames
-        // list plugins= as their schema-level candidate (kind-gated at runtime: a string cannot bind the
-        // structured scope object, so a live stray still refuses named rather than renaming).
+        "housecarl_records: closure => hint",
         "housecarl_records: conflicttree => hint",
         "housecarl_records: depth => hint",
         "housecarl_records: editoridcontains => hint",
@@ -462,23 +495,20 @@ public static class BindingShimProbe
         "housecarl_records: formid -> formids",
         "housecarl_records: fromplugin -> source",
         "housecarl_records: groupby => hint",
+        "housecarl_records: mgefformid => hint",
         "housecarl_records: mod -> source",
+        "housecarl_records: moda => hint",
+        "housecarl_records: modb => hint",
         "housecarl_records: plugin -> source",
+        "housecarl_records: plugina => hint",
+        "housecarl_records: pluginb => hint",
         "housecarl_records: pluginname -> plugins",
         "housecarl_records: pluginnames -> plugins",
         "housecarl_records: resolvenames => hint",
         "housecarl_records: type -> types",
         "housecarl_records: winnerfields => hint",
-        // W2 PR 2 (re-eyeballed 2026-08-04): versus= and walk= land on housecarl_records, so their gated
-        // hints go LIVE — the diff_record pole spellings (plugin_a/b, mod_a/b -> the source=/versus= poles)
-        // and the walk-carried absorptions (effect_chain's mgef_formid; copy's closure). 113 -> 119, all six
-        // on housecarl_records.
-        "housecarl_records: closure => hint",
-        "housecarl_records: mgefformid => hint",
-        "housecarl_records: moda => hint",
-        "housecarl_records: modb => hint",
-        "housecarl_records: plugina => hint",
-        "housecarl_records: pluginb => hint",
+        "housecarl_remove: formid -> formids",
+        "housecarl_remove: patch -> into",
         "housecarl_remove_record: archivename -> patch",
         "housecarl_remove_record: formids -> formid",
         "housecarl_remove_record: output -> patch",
@@ -499,11 +529,13 @@ public static class BindingShimProbe
         "housecarl_validate_scripts: pluginname -> plugins",
         "housecarl_validate_scripts: pluginnames -> plugins",
         "housecarl_validate_scripts: types -> type",
-        "housecarl_write_seq: patch -> patch_name",
-        "housecarl_write_seq: pluginname -> plugin",
-        "housecarl_write_seq: pluginnames -> plugin",
-        "housecarl_write_seq: plugins -> plugin",
-        "housecarl_write_seq: source -> plugin",
+        "housecarl_write_seq: archivename -> patch",
+        "housecarl_write_seq: fromplugin -> source",
+        "housecarl_write_seq: mod -> source",
+        "housecarl_write_seq: output -> patch",
+        "housecarl_write_seq: patchname -> patch",
+        "housecarl_write_seq: plugin -> source",
+        "housecarl_write_seq: pluginname -> patch",
     };
 
     /// <summary>The published-schema arm (W3): the SPEC §5.1 <c>@file</c> union on the JsonElement-typed list

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -376,6 +376,11 @@ public static class BindingShimProbe
         //     housecarl_create and 1.x housecarl_bulk_create — both declare records=, and on both the scalar
         //     spelling is genuinely a member of a record rather than a top-level argument, so the hint is
         //     correct in both places rather than noise in one;
+        // PR #311 review [low], folded: write_seq's `pluginname` row now lands on SOURCE, not patch. Once the
+        //   tool declared source= AND patch=, the likeliest 1.x word for THE PLUGIN was the one that could not
+        //   reach the plugin pole — plugin_name= silently renamed the OUTPUT FOLDER. `source` is appended LAST
+        //   to the candidate list (+ patch suppressed on this tool), so records/ scope-bearing tools keep the
+        //   W0 mapping and this is the ONLY row that moves.
         //   * write_seq's five reverse rows (source->plugin, plugins/plugin_name(s)->plugin, patch->patch_name)
         //     are GONE: it declares source= and patch= itself now, so those rows are declared, not renamed.
         "housecarl_apply: archivename -> patch",
@@ -535,7 +540,7 @@ public static class BindingShimProbe
         "housecarl_write_seq: output -> patch",
         "housecarl_write_seq: patchname -> patch",
         "housecarl_write_seq: plugin -> source",
-        "housecarl_write_seq: pluginname -> patch",
+        "housecarl_write_seq: pluginname -> source",
     };
 
     /// <summary>The published-schema arm (W3): the SPEC §5.1 <c>@file</c> union on the JsonElement-typed list
@@ -543,23 +548,34 @@ public static class BindingShimProbe
     static int SchemaArm(JsonElement toolsList)
     {
         int failures = 0;
-        JsonElement apply = default;
-        bool found = false;
-        foreach (var t in toolsList.GetProperty("tools").EnumerateArray())
-            if (t.GetProperty("name").GetString() == "housecarl_apply") { apply = t; found = true; break; }
 
-        failures += Check("SCHEMA: housecarl_apply is published", found, "tool absent from tools/list");
-        if (found)
+        // One row per ToolSchemas.FileListParams entry — (tool, parameter, a member that proves the generator ran
+        // over the real C# type). PR #311 review [low]: this arm used to hardcode housecarl_apply, so
+        // housecarl_create's records= row was covered only by the generic dangling-$ref sweep — and a dropped or
+        // mis-spelled row degrades that parameter back to the bare {} the declared JsonElement gives, which has no
+        // refs to dangle and so passed silently. Every published union is named here.
+        foreach (var (toolName, param, member) in new[]
+                 {
+                     ("housecarl_apply",  "ops",         "field_path"),
+                     ("housecarl_apply",  "assignments", "target"),
+                     ("housecarl_create", "records",     "record_type"),
+                 })
         {
-            foreach (var (param, member) in new[] { ("ops", "field_path"), ("assignments", "target") })
+            JsonElement tool = default;
+            bool found = false;
+            foreach (var t in toolsList.GetProperty("tools").EnumerateArray())
+                if (t.GetProperty("name").GetString() == toolName) { tool = t; found = true; break; }
+
+            failures += Check($"SCHEMA: {toolName} is published", found, "tool absent from tools/list");
+            if (found)
             {
                 JsonElement arms = default;
-                var ok = apply.GetProperty("inputSchema").GetProperty("properties").TryGetProperty(param, out var node)
+                var ok = tool.GetProperty("inputSchema").GetProperty("properties").TryGetProperty(param, out var node)
                       && node.TryGetProperty("anyOf", out arms)
                       && arms.GetArrayLength() == 2
                       && arms[0].TryGetProperty("type", out var t0) && t0.GetString() == "array"
                       && arms[1].TryGetProperty("type", out var t1) && t1.GetString() == "string";
-                failures += Check($"SCHEMA: {param}= publishes anyOf[<generated array>, string] — not the bare {{}} the declared JsonElement would give",
+                failures += Check($"SCHEMA: {toolName} {param}= publishes anyOf[<generated array>, string] — not the bare {{}} the declared JsonElement would give",
                     ok, ok ? "" : node.ValueKind == JsonValueKind.Undefined ? "parameter absent" : node.GetRawText());
 
                 // The array arm must be the GENERATED element schema, not an empty placeholder: a named member
@@ -567,7 +583,7 @@ public static class BindingShimProbe
                 bool typed = ok && arms[0].TryGetProperty("items", out var items)
                                 && items.TryGetProperty("properties", out var mprops)
                                 && mprops.TryGetProperty(member, out _);
-                failures += Check($"SCHEMA: {param}='s array arm carries the generated element members (e.g. {member})", typed, "");
+                failures += Check($"SCHEMA: {toolName} {param}='s array arm carries the generated element members (e.g. {member})", typed, "");
             }
         }
 

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -89,6 +89,12 @@ public static class CiAll
         // exclusive destinations, in_place as the overwritten file's NAME, the consent handshake), the §4.5
         // bundle x assignments cross-record copy zip, CopyFrom on the in-place lane, and json/epoch TRANSPORT.
         ("apply-guard", ApplyGuardProbe.RunGuard),
+        // W3 PR 2 — the REST of the 2.0 S1 write surface (create / remove / forward / the migrated write_seq):
+        // the records grammar incl. the nested one-shot and the strict reader's corrections, the LANE grammar on
+        // every tool (removal creates no artifact, so it refuses a call naming no lane), removal's recovered
+        // plural capability, forward's renamed source= pole, and json/epoch TRANSPORT — including write_seq's
+        // ABSENT epoch, stated as a fact with its reason.
+        ("write-surface-guard", WriteSurfaceGuardProbe.RunGuard),
         ("writelock-guard", WriteLockProbe.RunGuard),
         // #225 dry_run= on the write tools — the real pipeline HALTED before serialize, nothing written: refusal
         // parity with the real call, prediction parity (path/After/masters), the pre-empted missing-master failure,

--- a/src/housecarl-generator/CodexUmbrellaCoverageProbe.cs
+++ b/src/housecarl-generator/CodexUmbrellaCoverageProbe.cs
@@ -159,10 +159,11 @@ public static class CodexUmbrellaCoverageProbe
     }
 
     /// <summary>Required names not present in the umbrella text and not allow-listed. Matched on an IDENTIFIER
-    /// BOUNDARY: an occurrence only counts when the character after it is not another identifier character, so
-    /// <c>housecarl_create_record</c> in the text does NOT satisfy <c>housecarl_create</c>. (Only the trailing side
-    /// needs checking — every required name starts at a word boundary in prose, and the collisions on this surface
-    /// are all suffix extensions: the 2.0 tools are prefixes of the 1.x names they absorb.)</summary>
+    /// BOUNDARY on BOTH sides (see <see cref="ReferencedAtBoundary"/>), so neither
+    /// <c>housecarl_create_record</c> satisfies <c>housecarl_create</c> nor <c>bulk-record-jobs</c> satisfies a
+    /// future <c>record-jobs</c>. (This note used to claim only the trailing side needed checking — the assumption
+    /// SUFFIX-RED now disproves; PR #311 review 3 [nit] caught it still standing next to the fixed matcher, where
+    /// a later maintainer taking it at face value would have re-opened exactly that hole.)</summary>
     static List<string> MissingRefs(string umbrella, IEnumerable<string> required, ISet<string> allow)
         => required.Where(r => !allow.Contains(r) && !ReferencedAtBoundary(umbrella, r))
                    .OrderBy(r => r, StringComparer.Ordinal).ToList();

--- a/src/housecarl-generator/CodexUmbrellaCoverageProbe.cs
+++ b/src/housecarl-generator/CodexUmbrellaCoverageProbe.cs
@@ -61,15 +61,24 @@ public static class CodexUmbrellaCoverageProbe
 
             // The coverage check matches on an IDENTIFIER BOUNDARY, not a bare substring. It has to: the 2.0
             // surface renames tools onto prefixes of the 1.x names they absorb (housecarl_create ⊂
-            // housecarl_create_record, and the same for remove/forward), which is exactly the case the old
-            // GUARD-SELF arm predicted and told a future session to fix with "a boundary match or rename" —
-            // renaming is not available, the names are the SPEC's. The teeth move to a RED arm below.
+            // housecarl_create_record, and the same for remove/forward), which the old Contains match would
+            // false-pass. GUARD-SELF is now the EXECUTABLE form of that claim rather than a restated assumption
+            // (PR #311 round-2 review [low]: the first version computed the colliding pairs and then asserted the
+            // literal `true`, which vouched for nothing): for EVERY pair where one required name is a substring of
+            // another — prefix, suffix or infix — a text mentioning ONLY the longer one must NOT satisfy the
+            // shorter one. That is the exact false-pass the matcher exists to prevent, checked against the real
+            // name set rather than against the shape of collision we happened to think of.
             var required = tools.Concat(skills).ToList();
-            var prefixPairs = required
-                .Where(a => required.Any(b => b != a && b.StartsWith(a, StringComparison.Ordinal)))
-                .OrderBy(a => a, StringComparer.Ordinal).ToList();
-            Check($"GUARD-SELF prefix-named tools exist ({prefixPairs.Count}) and the matcher is boundary-aware, not Contains",
-                true, new());
+            var collisions = (from shortName in required
+                              from longName in required
+                              where longName != shortName && longName.Contains(shortName, StringComparison.Ordinal)
+                              select (shortName, longName)).ToList();
+            var falsePasses = collisions
+                .Where(c => ReferencedAtBoundary($"- `{c.longName}` mentioned alone", c.shortName))
+                .Select(c => $"'{c.shortName}' is satisfied by a text that only mentions '{c.longName}' — the boundary matcher cannot tell them apart")
+                .OrderBy(m => m, StringComparer.Ordinal).ToList();
+            Check($"GUARD-SELF the boundary matcher tells apart every colliding name pair ({collisions.Count} pairs on this surface)",
+                falsePasses.Count == 0, falsePasses);
 
             // INV1 — every tool referenced.
             var missTools = MissingRefs(umbrella, tools, Allow);
@@ -98,6 +107,16 @@ public static class CodexUmbrellaCoverageProbe
             // …and the same matcher must NOT report a name the router really does mention in backticks.
             var greenPrefix = MissingRefs("- `housecarl_create` — the 2.0 tool", new[] { "housecarl_create" }, Empty());
             Check("PREFIX-GREEN a genuinely referenced name is not reported missing", greenPrefix.Count == 0, greenPrefix, redArm: true);
+
+            // SUFFIX-RED — the other half of the boundary, on a SYNTHETIC pair. GUARD-SELF above is an invariant
+            // over the REAL name set, and today that set collides only by prefix, so it cannot prove the leading
+            // check has teeth until the day such a pair actually lands — which is one day too late. This arm names
+            // the reviewer's own scenario (PR #311 round-2 [low]): a future skill slug `record-jobs` alongside the
+            // existing `bulk-record-jobs`, with the router mentioning only the latter. Trailing-side-only matching
+            // reports the shorter one as ROUTED when it is not.
+            var redSuffix = MissingRefs("- `bulk-record-jobs` (catalogues, audits, link graphs)", new[] { "record-jobs" }, Empty());
+            Check("SUFFIX-RED a name mentioned only as another name's SUFFIX is still reported missing",
+                redSuffix.Contains("record-jobs"), redSuffix, redArm: true);
 
             // The allow-list must actually suppress — else an Allow entry would be a lie.
             var allowed = MissingRefs("router text that mentions no tools", new[] { "housecarl_read_record" },
@@ -148,19 +167,27 @@ public static class CodexUmbrellaCoverageProbe
         => required.Where(r => !allow.Contains(r) && !ReferencedAtBoundary(umbrella, r))
                    .OrderBy(r => r, StringComparer.Ordinal).ToList();
 
-    /// <summary>Does the text mention <paramref name="name"/> as a whole identifier (not as another name's prefix)?</summary>
+    /// <summary>Does the text mention <paramref name="name"/> as a whole identifier — not as part of a LONGER
+    /// required name? Both sides are checked (PR #311 round-2 review [low]: checking only the trailing side let a
+    /// suffix collision through — a future skill slug `record-jobs` would have been reported as routed by a router
+    /// that mentions only `bulk-record-jobs`). The identifier alphabet includes <c>-</c>, because skill slugs are
+    /// kebab-case: without it the hyphen in `bulk-record-jobs` would read as a word boundary and re-open exactly
+    /// that hole.</summary>
     static bool ReferencedAtBoundary(string text, string name)
     {
         for (int i = text.IndexOf(name, StringComparison.Ordinal); i >= 0;
              i = text.IndexOf(name, i + 1, StringComparison.Ordinal))
         {
+            if (i > 0 && IsNamePart(text[i - 1])) continue;
             int after = i + name.Length;
-            if (after >= text.Length) return true;
-            char c = text[after];
-            if (!(char.IsLetterOrDigit(c) || c == '_')) return true;
+            if (after >= text.Length || !IsNamePart(text[after])) return true;
         }
         return false;
     }
+
+    /// <summary>The identifier alphabet these names are written in: tool names are snake_case, skill slugs are
+    /// kebab-case, so a letter, digit, <c>_</c> or <c>-</c> continues a name rather than ending it.</summary>
+    static bool IsNamePart(char c) => char.IsLetterOrDigit(c) || c == '_' || c == '-';
 
     static void Check(string label, bool ok, List<string> detail, bool redArm = false)
     {

--- a/src/housecarl-generator/CodexUmbrellaCoverageProbe.cs
+++ b/src/housecarl-generator/CodexUmbrellaCoverageProbe.cs
@@ -59,16 +59,17 @@ public static class CodexUmbrellaCoverageProbe
             Check($"GREEN found bundled skill folders ({skills.Count})", skills.Count > 0,
                 new() { "no folders under .claude/skills — wrong CWD or empty tree" });
 
-            // The Contains() coverage check below is only sound if no required name is a substring of ANOTHER
-            // required name — else referencing the longer one would falsely satisfy the shorter one being missing.
-            // Assert that invariant instead of trusting it: a future prefix-named tool (housecarl_read ⊂
-            // housecarl_read_record) trips THIS arm rather than silently passing unrouted.
+            // The coverage check matches on an IDENTIFIER BOUNDARY, not a bare substring. It has to: the 2.0
+            // surface renames tools onto prefixes of the 1.x names they absorb (housecarl_create ⊂
+            // housecarl_create_record, and the same for remove/forward), which is exactly the case the old
+            // GUARD-SELF arm predicted and told a future session to fix with "a boundary match or rename" —
+            // renaming is not available, the names are the SPEC's. The teeth move to a RED arm below.
             var required = tools.Concat(skills).ToList();
-            var subsumed = required
-                .Where(a => required.Any(b => b != a && b.Contains(a, StringComparison.Ordinal)))
+            var prefixPairs = required
+                .Where(a => required.Any(b => b != a && b.StartsWith(a, StringComparison.Ordinal)))
                 .OrderBy(a => a, StringComparer.Ordinal).ToList();
-            Check("GUARD-SELF no required name is a substring of another (Contains match is unambiguous)", subsumed.Count == 0,
-                subsumed.Select(a => $"'{a}' is a substring of another required name — the Contains coverage check could false-pass it; use a boundary match or rename").ToList());
+            Check($"GUARD-SELF prefix-named tools exist ({prefixPairs.Count}) and the matcher is boundary-aware, not Contains",
+                true, new());
 
             // INV1 — every tool referenced.
             var missTools = MissingRefs(umbrella, tools, Allow);
@@ -86,6 +87,17 @@ public static class CodexUmbrellaCoverageProbe
 
             var redSkill = MissingRefs("router text that mentions no skills", new[] { "facegen-diagnostics" }, Empty());
             Check("INV2-RED  a missing skill reference is caught", redSkill.Contains("facegen-diagnostics"), redSkill, redArm: true);
+
+            // The boundary matcher's own teeth: a router that mentions ONLY the longer 1.x name must still report
+            // the shorter 2.0 name missing. A bare Contains would false-pass this — which, with three such pairs
+            // on the surface now, would silently un-route the three newest tools.
+            var redPrefix = MissingRefs("- `housecarl_create_record` — the 1.x tool", new[] { "housecarl_create" }, Empty());
+            Check("PREFIX-RED a name mentioned only as another name's PREFIX is still reported missing",
+                redPrefix.Contains("housecarl_create"), redPrefix, redArm: true);
+
+            // …and the same matcher must NOT report a name the router really does mention in backticks.
+            var greenPrefix = MissingRefs("- `housecarl_create` — the 2.0 tool", new[] { "housecarl_create" }, Empty());
+            Check("PREFIX-GREEN a genuinely referenced name is not reported missing", greenPrefix.Count == 0, greenPrefix, redArm: true);
 
             // The allow-list must actually suppress — else an Allow entry would be a lie.
             var allowed = MissingRefs("router text that mentions no tools", new[] { "housecarl_read_record" },
@@ -127,11 +139,28 @@ public static class CodexUmbrellaCoverageProbe
             : new();
     }
 
-    /// <summary>Required names not present in the umbrella text and not allow-listed. Ordinal substring match — no
-    /// tool or skill name is a substring of another, so a plain Contains is unambiguous.</summary>
+    /// <summary>Required names not present in the umbrella text and not allow-listed. Matched on an IDENTIFIER
+    /// BOUNDARY: an occurrence only counts when the character after it is not another identifier character, so
+    /// <c>housecarl_create_record</c> in the text does NOT satisfy <c>housecarl_create</c>. (Only the trailing side
+    /// needs checking — every required name starts at a word boundary in prose, and the collisions on this surface
+    /// are all suffix extensions: the 2.0 tools are prefixes of the 1.x names they absorb.)</summary>
     static List<string> MissingRefs(string umbrella, IEnumerable<string> required, ISet<string> allow)
-        => required.Where(r => !allow.Contains(r) && !umbrella.Contains(r, StringComparison.Ordinal))
+        => required.Where(r => !allow.Contains(r) && !ReferencedAtBoundary(umbrella, r))
                    .OrderBy(r => r, StringComparer.Ordinal).ToList();
+
+    /// <summary>Does the text mention <paramref name="name"/> as a whole identifier (not as another name's prefix)?</summary>
+    static bool ReferencedAtBoundary(string text, string name)
+    {
+        for (int i = text.IndexOf(name, StringComparison.Ordinal); i >= 0;
+             i = text.IndexOf(name, i + 1, StringComparison.Ordinal))
+        {
+            int after = i + name.Length;
+            if (after >= text.Length) return true;
+            char c = text[after];
+            if (!(char.IsLetterOrDigit(c) || c == '_')) return true;
+        }
+        return false;
+    }
 
     static void Check(string label, bool ok, List<string> detail, bool redArm = false)
     {

--- a/src/housecarl-generator/SeqWriteGuardProbe.cs
+++ b/src/housecarl-generator/SeqWriteGuardProbe.cs
@@ -228,10 +228,32 @@ internal static class SeqWriteGuardProbe
             Check(oEmpty.Success && oEmpty.SeqPath is null && oEmpty.Quests.Count == 0 && foldersAfter == foldersBefore,
                 $"EMPTY-NOOP no SGE quests → nothing written, no folder cut — success={oEmpty.Success} path=[{oEmpty.SeqPath}] folders {foldersBefore}->{foldersAfter}");
 
-            // REFUSE-NOFILE: a missing plugin path is refused, named.
+            // REFUSE-NOFILE: a missing plugin path is refused, named — and (W3 PR 2) the refusal states BOTH
+            // accepted source= spellings, since a filename is now resolvable and "pass the full path" alone would
+            // send the caller down the narrower of the two lanes.
             var oMiss = svc.WriteSeq(Path.Combine(root, "does-not-exist.esp"), null, null);
-            Check(!oMiss.Success && oMiss.Error is not null && oMiss.Error.Contains("no such plugin", StringComparison.OrdinalIgnoreCase),
-                $"REFUSE-NOFILE missing plugin path refused + named — err=[{oMiss.Error}]");
+            Check(!oMiss.Success && oMiss.Error is not null
+                  && oMiss.Error.Contains("no file at path", StringComparison.OrdinalIgnoreCase)
+                  && oMiss.Error.Contains("FILENAME", StringComparison.Ordinal)
+                  && oMiss.Error.Contains("ABSOLUTE path", StringComparison.Ordinal),
+                $"REFUSE-NOFILE missing plugin path refused + named, both spellings offered — err=[{oMiss.Error}]");
+
+            // REFUSE-UNFINDABLE (W3 PR 2): a bare FILENAME that no mod folder, the overwrite folder or Data
+            // provides is refused by name too — the filename lane must not degrade into "treat it as a relative
+            // path and fail somewhere else".
+            var oNoName = svc.WriteSeq("HcSeqNoSuchPlugin.esp", null, null);
+            Check(!oNoName.Success && oNoName.Error is not null
+                  && oNoName.Error.Contains("HcSeqNoSuchPlugin.esp", StringComparison.OrdinalIgnoreCase)
+                  && oNoName.Error.Contains("mod folder", StringComparison.OrdinalIgnoreCase),
+                $"REFUSE-UNFINDABLE unlocatable filename refused + named — err=[{oNoName.Error}]");
+
+            // FILENAME-LANE (W3 PR 2): the plugin that SERVICE-WRITE reached by absolute path is reachable by its
+            // bare filename too, and the outcome states which copy it read (SPEC §4.2 — the arm is never silent).
+            var oByName = svc.WriteSeq(Path.GetFileName(svcPlugin), null, null);
+            Check(oByName.Success && oByName.SeqPath is not null
+                  && oByName.ResolvedFrom is { Length: > 0 }
+                  && string.Equals(oByName.PluginPath, Path.GetFullPath(svcPlugin), StringComparison.OrdinalIgnoreCase),
+                $"FILENAME-LANE source= by filename resolves to the same file and states its arm — from=[{oByName.ResolvedFrom}] path=[{oByName.PluginPath}] err=[{oByName.Error}]");
         }
         catch (Exception ex)
         {

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -530,6 +530,19 @@ public static class WriteSurfaceGuardProbe
                 && !bareText.TrimStart().StartsWith("{", StringComparison.Ordinal), bareText);
         }
 
+        // A null ELEMENT inside a spec's ops= is legal JSON that STJ passes straight through (PR #311 review 7
+        // [low]): it used to NRE and be answered as "an internal houseCARL failure (the arguments bound fine) —
+        // retry once", which is wrong on both counts and loops a caller over deterministic bad input. The arm
+        // asserts the by-name refusal AND that the internal-fault wording is gone.
+        var nullOp = CreateTools.Create(fx.Svc, patch: "W2NullOp", records: Json("""
+            [{"record_type":"Keyword","editorid":"W2NullOp","ops":[null]}]
+            """));
+        Check("create: a null op element is refused BY NAME, never as an 'internal failure — retry once'",
+            nullOp.StartsWith("error:", StringComparison.Ordinal)
+            && nullOp.Contains("records[0]: ops[0] is null", StringComparison.Ordinal)
+            && !nullOp.Contains("internal houseCARL failure", StringComparison.Ordinal)
+            && !nullOp.Contains("Retry once", StringComparison.OrdinalIgnoreCase), nullOp);
+
         // Refusals below the tool layer name THIS surface's words, index label included (PR #311 review 6 [low]).
         // `records[0]` was already the caller's spelling via the origins thread; `op[0]` was nobody's — the member
         // is ops=, and in a generated batch of hundreds the index label IS the navigational handle.
@@ -566,6 +579,19 @@ public static class WriteSurfaceGuardProbe
         Check("remove format=json: the no-lane refusal is a document too",
             removeRefusal.Length > 0 && TryJson(removeRefusal, out var rmdoc)
             && rmdoc!.RootElement.GetProperty("error").GetString()!.Contains("in_place="), removeRefusal);
+
+        // readback_full describes the DOCUMENT; readback_requested keeps the caller's ask (PR #311 review 7 [nit]).
+        // The in-place lane forces the read-back in the service, so the two genuinely differ there — which is the
+        // case that used to publish readback_full:false beside a complete field dump.
+        var rbForced = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: fx.MasterName,
+            in_place: fx.ReplacerName, acknowledge: true, readback: false, format: "json");
+        Check("json: an in-place lane that FORCED the read-back reports readback_full:true, ask kept separately",
+            TryJson(rbForced, out var rbdoc)
+            && rbdoc!.RootElement.TryGetProperty("readback_full", out var rbf) && rbf.GetBoolean()
+            && rbdoc.RootElement.TryGetProperty("readback_requested", out var rbr) && !rbr.GetBoolean()
+            && rbdoc.RootElement.TryGetProperty("readback", out var rbarr)
+            && rbarr.GetArrayLength() > 0
+            && rbarr[0].TryGetProperty("fields", out _), rbForced);
 
         var forwardJson = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: fx.MasterName,
             patch: "W2FwdJson", format: "json");
@@ -675,6 +701,17 @@ public static class WriteSurfaceGuardProbe
             && vnote.Contains("plays SILENT", StringComparison.Ordinal)
             // and it must NOT prescribe re-issuing: this block rides a WRITE render.
             && !vnote.Contains("raise max_chars", StringComparison.OrdinalIgnoreCase), reportCapped);
+
+        // The TEXT twins of those blocks must not contradict the json census (PR #311 review 7 [medium]): they rode
+        // the create render still saying "raise max_chars to see the rest", i.e. re-issue a create — while the json
+        // block added one round earlier says "Do NOT re-issue the write to widen this". One call, two transports,
+        // opposite advice. Rendered directly, since the shared fixture's creates make no dialogue lines.
+        var voiceCappedText = WriteTools.RenderCreate(synthetic, maxChars: 900);
+        Check("create text: the voice-coverage cut notice refuses to prescribe re-issuing the create",
+            voiceCappedText.Contains("voice coverage truncated", StringComparison.Ordinal)
+            && Bracket(voiceCappedText, "voice coverage truncated") is { } vct
+            && vct.Contains("Do NOT re-issue the create", StringComparison.Ordinal)
+            && !vct.Contains("raise max_chars to see the rest", StringComparison.Ordinal), voiceCappedText);
 
         // The counts ride on the COMPLETE render too — rendered == total is the positive statement that the list is
         // whole, so a consumer never infers completeness from a missing marker.

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -713,6 +713,28 @@ public static class WriteSurfaceGuardProbe
             && vct.Contains("Do NOT re-issue the create", StringComparison.Ordinal)
             && !vct.Contains("raise max_chars to see the rest", StringComparison.Ordinal), voiceCappedText);
 
+        // The cell-shell block was the LAST unbudgeted one on the write renders (PR #311 review 7 [low-medium],
+        // Aaron-go): text rendered every cell and took the silent host cut while its json twin stopped at the cap.
+        // Both poles asserted, and the two Q3 notes below the list must survive the cut — they are the accounting a
+        // truncated report still needs, and the grid-occupancy seam in particular must not be what a cut swallows.
+        var cells = Enumerable.Range(0, 30).Select(i => new CellShell(
+            default, $"W2CellShell{i:D2}", i % 2 == 0,
+            new[] { "lighting template", "terrain / landscape", "water height", "navmesh", "an encounter zone" })).ToList();
+        var cellOutcome = synthetic with { Voice = null, CellShell = new CellShellReport(cells) };
+
+        var cellCapped = WriteTools.RenderCreate(cellOutcome, maxChars: 700);
+        Check("create text: the cell-shell block is BUDGETED, with an explicit notice (it was the last unbudgeted one)",
+            cellCapped.Contains("cell shell truncated: rendered ", StringComparison.Ordinal)
+            && cellCapped.Contains(" of 30 cell(s)", StringComparison.Ordinal)
+            && !cellCapped.Contains("W2CellShell29", StringComparison.Ordinal), cellCapped);
+        Check("create text: a CUT cell-shell block still renders the grid-occupancy seam below it",
+            cellCapped.Contains("does NOT check grid-occupancy", StringComparison.Ordinal), cellCapped);
+
+        var cellFull = WriteTools.RenderCreate(cellOutcome);
+        Check("create text: without a cap every cell renders (the budget is not a permanent cut)",
+            cellFull.Contains("W2CellShell29", StringComparison.Ordinal)
+            && !cellFull.Contains("cell shell truncated", StringComparison.Ordinal), cellFull);
+
         // The counts ride on the COMPLETE render too — rendered == total is the positive statement that the list is
         // whole, so a consumer never infers completeness from a missing marker.
         Check("json create: an UNCUT voice block still carries the census, with truncated:false",

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -344,6 +344,14 @@ public static class WriteSurfaceGuardProbe
         Check("create in place: acknowledge=true writes into the ORIGINAL file, reported as the in-place lane",
             wrote.Contains("IN PLACE", StringComparison.Ordinal)
             && EditorIdsIn(Path.Combine(fx.ModsDir, "W2Repl", fx.ReplacerName)).Contains("W2InPlaceKw"), wrote);
+
+        // The closing "keep going" line must teach THIS tool's spelling (PR #311 round-2 review [medium]): the 2.0
+        // tools declare a single string in_place= and no target=, so the 1.x pair would send a caller to an
+        // undeclared parameter plus a boolean-into-a-string. Asserted as a positive AND a negative — the positive
+        // alone would still pass if the old sentence were merely appended.
+        Check("the in-place follow-up hint teaches in_place=\"X.esp\", never the 1.x target= + in_place=true pair",
+            wrote.Contains($"pass in_place=\"{fx.ReplacerName}\" again", StringComparison.Ordinal)
+            && !wrote.Contains("target=", StringComparison.Ordinal), wrote);
     }
 
     // ================= ARM 3 — remove, plural =================
@@ -520,6 +528,47 @@ public static class WriteSurfaceGuardProbe
             in_place: "NotAPlugin.esp", format: "json");
         Check("json lane on a service-side in-place refusal says in_place too",
             TryJson(laneInPlace, out var lidoc) && lidoc!.RootElement.GetProperty("lane").GetString() == "in_place", laneInPlace);
+
+        // ONE lane vocabulary across all four tools (PR #311 round-2 review [low]): the value NAMES the parameter
+        // that selected the lane, so an into= call answers "into" everywhere — a json client that learned the
+        // words from apply must not fall into its unknown branch on remove (or the reverse, as it did when apply
+        // said "extend" and remove said "into" for the same lane).
+        var laneCreateInto = CreateTools.Create(fx.Svc, records: Json("""[{"record_type":"Keyword","editorid":"W2LaneKw3"}]"""),
+            into: "NoSuchPatch3.esp", format: "json");
+        var laneFwdInto = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: fx.MasterName,
+            into: "NoSuchPatch3.esp", format: "json");
+        Check("the into= lane is spelled the same on create / forward / remove — the parameter's own name",
+            TryJson(laneCreateInto, out var lcdoc) && lcdoc!.RootElement.GetProperty("lane").GetString() == "into"
+            && TryJson(laneFwdInto, out var lfdoc) && lfdoc!.RootElement.GetProperty("lane").GetString() == "into",
+            laneCreateInto + " || " + laneFwdInto);
+
+        // The three post-write REPORTS are inside the json budget (PR #311 round-2 review [low-medium]). Rendered
+        // DIRECTLY off a synthetic outcome rather than through a create call: a report big enough to blow a
+        // ceiling means dozens of voiced lines, and building those in the fixture would pin the budget behind a
+        // pile of unrelated dialogue plumbing. The claim under test is the RENDERER's — the reports were outside
+        // the cap and the document still closed with truncated:false.
+        var voiced = Enumerable.Range(0, 40).Select(i => new VoiceLine(
+            default, "W2VoiceTopic", i,
+            $@"sound\voice\W2.esp\MaleNord\W2VoiceTopic_{i:D4}.fuz", false, null, false,
+            $@"sound\voice\W2.esp\MaleNord\W2VoiceTopic_{i:D4}.lip", false,
+            false)).ToList();
+        var synthetic = new WritePatchBuilder.CreateOutcome(
+            true, null, @"C:\mods\W2Rep\W2Rep.esp", false,
+            new[] { new WritePatchBuilder.CreatedRecord(default, "DialogResponses", "W2RepL1", Array.Empty<WritePatchBuilder.OpResult>()) },
+            Array.Empty<string>(), 512)
+            { Epoch = "deadbeefdeadbeef", Voice = new VoiceReport(voiced, Array.Empty<VoiceUndetermined>()) };
+
+        var reportFull = JsonWire.RenderCreateOutcome(synthetic, 0, false, "patch");
+        Check("json create: the voice-coverage report is emitted in full when the budget allows (truncated:false)",
+            TryJson(reportFull, out var rfdoc)
+            && rfdoc!.RootElement.GetProperty("voice_coverage").GetProperty("lines").GetArrayLength() == 40
+            && !rfdoc.RootElement.GetProperty("truncated").GetBoolean(), reportFull);
+
+        var reportCapped = JsonWire.RenderCreateOutcome(synthetic, 1200, false, "patch");
+        Check("json create: a ceiling the REPORTS blow past is reported as truncated:true, with the rows dropped",
+            TryJson(reportCapped, out var rcdoc)
+            && rcdoc!.RootElement.GetProperty("truncated").GetBoolean()
+            && rcdoc.RootElement.GetProperty("voice_coverage").GetProperty("lines").GetArrayLength() < 40, reportCapped);
 
         // max_chars reaches the TEXT render too, not only json (PR #311 review [medium] / [low-medium]): the
         // parameter's own description promises trailing rows drop with an explicit notice, and removal is

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -843,6 +843,19 @@ public static class WriteSurfaceGuardProbe
         }
         else Check("forward into= remedy arm: fixture (a patch to extend)", false, "no patch path");
 
+        // apply's json render budgets its `ops` array and carried the same "raise max_chars" the other four write
+        // renders were moved off (PR #311 review 6 — an unrequested sibling, declared on the PR): apply shares the
+        // LANE axis with forward, so it shares the lane-aware remedy. Default lane here ⇒ the into= wording.
+        var applyCapped = ApplyTools.Apply(fx.Svc, patch: "W2ApCap", format: "json", max_chars: 300,
+            ops: Json($$"""[{"formid":"{{fx.SubjectFid}}","field_path":"Name","value":"W2ApCapName"}]"""));
+        Check("apply format=json: the truncation note carries the lane-aware remedy, not a bare 'raise max_chars'",
+            TryJson(applyCapped, out var apdoc)
+            && apdoc!.RootElement.TryGetProperty("truncated_note", out var apn)
+            && apn.GetString() is { } apnote
+            && apnote.Contains("pass into=", StringComparison.Ordinal)
+            && apnote.Contains("SECOND patch mod", StringComparison.Ordinal)
+            && !apnote.Contains("raise max_chars to see the rest", StringComparison.Ordinal), applyCapped);
+
         // IN_PLACE is its own pole (PR #311 review 6 [low]): the first pass lumped it with into=, but a re-issue
         // there re-serializes the caller's OWN plugin — the file this render just called backup-less — purely to
         // widen a display. It gets the read-back remedy instead. (fx.ReplacerName was acknowledged by an arm
@@ -888,6 +901,13 @@ public static class WriteSurfaceGuardProbe
         Check("write_seq text render: without a cap every quest row is listed (the notice is not a permanent cut)",
             seqUncapped.Contains("HcSeqQuestCharlie", StringComparison.Ordinal)
             && !seqUncapped.Contains("[truncated:", StringComparison.Ordinal), seqUncapped);
+
+        // The absent epoch is stated on the TEXT transport too (PR #311 review 6 [low]) — the class doc claimed
+        // "the render says so", which was true of the json twin only, leaving the DEFAULT transport unable to tell
+        // "no build was consulted, by design" from "the stamp was dropped" (the same observable either way).
+        Check("write_seq text render: the ABSENT epoch is stated with its reason, like the json twin (D2)",
+            seqUncapped.Contains("no epoch on this call", StringComparison.Ordinal)
+            && seqUncapped.Contains("load-order-independent", StringComparison.Ordinal), seqUncapped);
 
         // …and the json twin says the SAME thing (PR #311 review 5 [medium]): the review-4 fold moved the text
         // notice off "raise max_chars" and left the json document on it, so the guard's teeth were on one lane

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -1,0 +1,520 @@
+using System.Text.Json;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REGRESSION GUARD (standing CI instrument, self-contained) for the REST of the 2.0 S1 write surface —
+/// <c>housecarl_create</c>, <c>housecarl_remove</c>, <c>housecarl_forward</c> and the migrated
+/// <c>housecarl_write_seq</c> (tool-surface-2.0 W3 PR 2; SPEC §2.2 ACT, §5.1/§5.2, §6.1). Sibling of
+/// <c>apply-guard</c>, same posture: the REAL end-to-end tool path — a synthetic MO2 instance in temp +
+/// <see cref="LoadOrderService"/> + the tool methods themselves — so the wire readers, the LANE grammar, the
+/// alias-visible vocabulary and the engines are exercised exactly as a caller hits them. Five arms:
+/// <list type="number">
+/// <item><b>create grammar</b> — one record is a set of one, the nested one-shot (a same-call sibling parent +
+/// an '@editorid' link value), the @file spelling, and the strict element reader's NAMED refusals with the
+/// corrections for the members a create cannot have.</item>
+/// <item><b>LANE</b> — the destinations are exclusive and a dropped one is refused BY NAME on every tool;
+/// removal (which creates no artifact) refuses a call that names NO lane; in_place is the file's NAME with its
+/// consent handshake.</item>
+/// <item><b>remove, plural</b> — the recovered engine capability: many records dropped in ONE re-serialize, and
+/// all-or-nothing when one target isn't carried (NOTHING removed).</item>
+/// <item><b>forward</b> — source= (the renamed pole) decides the content, the prior winner is named, dry_run
+/// writes nothing, and a non-active source is refused by name rather than read as "doesn't define it".</item>
+/// <item><b>TRANSPORT</b> — format=json is valid JSON carrying the same data, a REFUSAL is a document too, and
+/// every response carries the §2.1.1 epoch — including write_seq, whose ABSENT epoch is stated as a fact with
+/// its reason rather than left as a missing field.</item>
+/// </list>
+///
+/// Run: <c>dotnet run --project src/housecarl-generator write-surface-guard</c>
+/// </summary>
+public static class WriteSurfaceGuardProbe
+{
+    static int _pass, _fail;
+    static void Check(string label, bool ok, string? got = null)
+    {
+        Console.WriteLine($"   [{(ok ? "PASS" : "FAIL")}] {label}");
+        if (!ok && got is not null) Console.WriteLine($"          got: {Trim(got)}");
+        if (ok) _pass++; else _fail++;
+    }
+    static string Trim(string s) => s.Length <= 400 ? s.Replace("\n", " | ") : s[..400].Replace("\n", " | ") + " …";
+
+    static JsonElement Json(string raw) => JsonDocument.Parse(raw).RootElement.Clone();
+
+    public static int RunGuard(string[] args)
+    {
+        _pass = _fail = 0;
+        Console.WriteLine("################  REGRESSION GUARD — create / remove / forward / write_seq (the 2.0 S1 write surface, PR 2)  ################");
+        Console.WriteLine();
+
+        var root = Path.Combine(Path.GetTempPath(), "hc_write2_guard_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            // `using`, not a trailing Dispose(): an arm that throws lands in the catch below, and a bare Dispose()
+            // there would be skipped — leaking the service and its overlays, which then makes the finally's
+            // Directory.Delete fail silently (apply-guard's own scar).
+            using var fx = Fixture.Build(Path.Combine(root, "fx"));
+            CreateGrammarArm(fx, root);
+            LaneArm(fx);
+            RemovePluralArm(fx);
+            ForwardArm(fx);
+            TransportArm(fx);
+
+            Console.WriteLine();
+            Console.WriteLine($"=== write-surface-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
+            return _fail == 0 ? 0 : 1;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"   FAIL (unexpected): {ex.GetType().Name}: {ex.Message}\n{ex.StackTrace}");
+            return 1;
+        }
+        finally { try { Directory.Delete(root, recursive: true); } catch { } }
+    }
+
+    // ================= the shared synthetic order =================
+
+    /// <summary>Master + replacer. The replacer WINS the subject weapon at a DIFFERENT damage, so a forward from
+    /// the master genuinely changes the content (and "forwarded the master's version" is distinguishable from
+    /// "copied the winner"). The replacer is also the in-place target: it owns the records it overrides.</summary>
+    sealed class Fixture : IDisposable
+    {
+        public required LoadOrderService Svc { get; init; }
+        public required string SubjectFid { get; init; }     // the weapon: master Damage 10, replacer Damage 99
+        public required FormKey SubjectKey { get; init; }
+        public required string ModsDir { get; init; }
+        public required string MasterName { get; init; }
+        public required string ReplacerName { get; init; }
+
+        public void Dispose() => Svc.Dispose();
+
+        public static Fixture Build(string dir)
+        {
+            string instance = Path.Combine(dir, "instance");
+            string profiles = Path.Combine(instance, "profiles", "Default");
+            string mods = Path.Combine(instance, "mods");
+            Directory.CreateDirectory(profiles); Directory.CreateDirectory(mods);
+            Directory.CreateDirectory(Path.Combine(dir, "game", "Data"));
+            File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+                "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                + Path.Combine(dir, "game").Replace(@"\", @"\\") + ")\r\n");
+
+            var mKey = new ModKey("HcW2Master", ModType.Master);
+            var rKey = new ModKey("HcW2Repl", ModType.Plugin);
+            var masterPath = Path.Combine(mods, "W2Master", mKey.FileName.String);
+            var replPath = Path.Combine(mods, "W2Repl", rKey.FileName.String);
+            Directory.CreateDirectory(Path.GetDirectoryName(masterPath)!);
+            Directory.CreateDirectory(Path.GetDirectoryName(replPath)!);
+
+            var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
+            var subject = m.Weapons.AddNew();
+            subject.EditorID = "W2Subject";
+            subject.Name = "Master Sword";
+            subject.BasicStats = new WeaponBasicStats { Damage = 10 };
+            m.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            var r = new SkyrimMod(rKey, SkyrimRelease.SkyrimSE);
+            var rw = (IWeapon)WriteEngine.GenericGetOrAddAsOverride(r, subject);
+            rw.Name = "Winner Sword";
+            rw.BasicStats = new WeaponBasicStats { Damage = 99 };
+            r.BeginWrite.ToPath(replPath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
+
+            File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + mKey.FileName + "\r\n" + rKey.FileName + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + mKey.FileName + "\r\n*" + rKey.FileName + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+W2Repl\r\n+W2Master\r\n");
+
+            var genDir = Path.Combine(dir, "corpus-gen");
+            try { _ = CorpusRulebook.LoadCorpus(); }
+            catch { CorpusGenerator.GenerateAll(genDir, Path.Combine(dir, "corpus-ref")); CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json"); }
+
+            var store = new UserConfigStore(Path.Combine(dir, "houseCARL.user.json"));
+            var svc = LoadOrderService.WithInstance(instance, 0, store);
+            svc.Stats();   // warm the lazy index once
+
+            return new Fixture
+            {
+                Svc = svc,
+                SubjectFid = $"{subject.FormKey.ID:X6}:{mKey.FileName}",
+                SubjectKey = subject.FormKey,
+                ModsDir = mods,
+                MasterName = mKey.FileName.String,
+                ReplacerName = rKey.FileName.String,
+            };
+        }
+    }
+
+    /// <summary>The written artifact's path, parsed out of the text render (the render is what a caller actually
+    /// gets, so reading the path from it keeps the guard honest about the reported artifact).</summary>
+    static string? ArtifactPathFrom(Fixture fx, string render)
+    {
+        if (!render.StartsWith("wrote ", StringComparison.Ordinal) && !render.StartsWith("extended ", StringComparison.Ordinal)) return null;
+        var file = render[(render.IndexOf(' ') + 1)..];
+        file = file[..file.IndexOf(' ')];
+        var mod = render.Contains("mod folder: ", StringComparison.Ordinal)
+            ? render[(render.IndexOf("mod folder: ", StringComparison.Ordinal) + 12)..].Split('\n')[0].Split("  ")[0].Trim()
+            : null;
+        return mod is null ? null : Path.Combine(fx.ModsDir, mod, file);
+    }
+
+    /// <summary>Every EditorID the written plugin carries (flat + nested), for the created/removed assertions.</summary>
+    static List<string> EditorIdsIn(string espPath)
+    {
+        var found = new List<string>();
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(espPath, SkyrimRelease.SkyrimSE);
+            foreach (var rec in ov.EnumerateMajorRecords())
+                if (rec.EditorID is { Length: > 0 } e) found.Add(e);
+        }
+        catch { /* the caller asserts on the contents, and an unreadable file fails those */ }
+        finally { (ov as IDisposable)?.Dispose(); }
+        return found;
+    }
+
+    static ushort? DamageIn(string espPath, FormKey fk)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(espPath, SkyrimRelease.SkyrimSE);
+            return ov.Weapons.FirstOrDefault(w => w.FormKey == fk)?.BasicStats?.Damage;
+        }
+        catch { return null; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    // ================= ARM 1 — the create grammar =================
+    static void CreateGrammarArm(Fixture fx, string root)
+    {
+        Console.WriteLine("── ARM 1: the records grammar — a set of one, the nested one-shot, @file, and the strict reader ──");
+
+        // ONE record is a set of one — the whole reason the scalar create tool dissolves.
+        var one = CreateTools.Create(fx.Svc,
+            records: Json("""[{"record_type":"Keyword","editorid":"W2KwOne"}]"""), patch: "W2One");
+        var onePath = ArtifactPathFrom(fx, one);
+        Check("one record is a set of one: a single Keyword lands in a new patch with its editorid",
+            onePath is not null && EditorIdsIn(onePath).Contains("W2KwOne"), one);
+
+        // MANY records in one call, with ops= setting fields (the op shape minus formid).
+        var many = CreateTools.Create(fx.Svc,
+            records: Json("""
+                [{"record_type":"Keyword","editorid":"W2KwA"},
+                 {"record_type":"Weapon","editorid":"W2WeapA","ops":[{"field_path":"Name","value":"Guard Blade"},
+                                                                     {"field_path":"BasicStats.Damage","value":"33"}]}]
+                """), patch: "W2Many");
+        var manyPath = ArtifactPathFrom(fx, many);
+        var manyIds = manyPath is null ? new List<string>() : EditorIdsIn(manyPath);
+        Check("many records in ONE call, with ops= setting the new record's fields",
+            manyPath is not null && manyIds.Contains("W2KwA") && manyIds.Contains("W2WeapA")
+            && many.Contains("Guard Blade", StringComparison.Ordinal), many);
+
+        // The NESTED one-shot: a child whose parent= names an EARLIER sibling's editorid, plus an '@editorid'
+        // FormLink value pointing at that same sibling — the two same-call reference forms, in one call.
+        var nested = CreateTools.Create(fx.Svc,
+            records: Json("""
+                [{"record_type":"DialogTopic","editorid":"W2Topic"},
+                 {"record_type":"DialogResponses","editorid":"W2Topic_L1","parent":"W2Topic",
+                  "ops":[{"field_path":"Topic","value":"@W2Topic"}]}]
+                """), patch: "W2Nested");
+        var nestedPath = ArtifactPathFrom(fx, nested);
+        var nestedIds = nestedPath is null ? new List<string>() : EditorIdsIn(nestedPath);
+        Check("the nested one-shot: a child parented on a same-call sibling, with an '@editorid' link value",
+            nestedPath is not null && nestedIds.Contains("W2Topic") && nestedIds.Contains("W2Topic_L1"), nested);
+
+        // The @file spelling — the same array from disk (SPEC §5.1's one list-input convention).
+        var manifest = Path.Combine(root, "records.json");
+        File.WriteAllText(manifest, """[{"record_type":"Keyword","editorid":"W2KwFromFile"}]""");
+        var viaFile = CreateTools.Create(fx.Svc, records: Json($"\"@{manifest.Replace("\\", "\\\\")}\""), patch: "W2File");
+        var viaFilePath = ArtifactPathFrom(fx, viaFile);
+        Check("records=\"@<path>\" reads the SAME array from a JSON manifest on disk",
+            viaFilePath is not null && EditorIdsIn(viaFilePath).Contains("W2KwFromFile"), viaFile);
+
+        // A MIXED inline/@file array has no meaning — refused, never half-honored.
+        var mixed = CreateTools.Create(fx.Svc,
+            records: Json($$"""["@{{manifest.Replace("\\", "\\\\")}}", {"record_type":"Keyword","editorid":"W2Mixed"}]"""));
+        Check("a MIXED inline/@file records array is refused by name, never half-honored",
+            mixed.StartsWith("error:") && mixed.Contains("cannot be mixed with inline elements"), mixed);
+
+        // records=[] is a SUPPLIED parameter, not an absent one (the accepted-and-dropped class this surface closes).
+        var empty = CreateTools.Create(fx.Svc, records: Json("[]"));
+        Check("records=[] is refused by name, not read as absent",
+            empty.StartsWith("error:") && empty.Contains("empty array"), empty);
+
+        // No records= at all — its own refusal, spelling the parameter.
+        var none = CreateTools.Create(fx.Svc, patch: "W2None");
+        Check("no records= at all: refused naming the parameter and the @file alternative",
+            none.StartsWith("error:") && none.Contains("records=[{record_type"), none);
+
+        // The 1.x element vocabulary: `operations` inside a record spec is refused BY NAME with the rename.
+        var oldOps = CreateTools.Create(fx.Svc,
+            records: Json("""[{"record_type":"Keyword","editorid":"W2Old","operations":[{"field_path":"Name","value":"x"}]}]"""));
+        Check("an element member the shape doesn't declare (operations) is refused BY NAME with the ops= correction",
+            oldOps.StartsWith("error:") && oldOps.Contains("operations") && oldOps.Contains("ops"), oldOps);
+
+        // A create op cannot carry formid= — and the correction says WHY (the id is allocated), not just "unknown".
+        var opFormid = CreateTools.Create(fx.Svc,
+            records: Json($$"""[{"record_type":"Keyword","editorid":"W2Bad","ops":[{"formid":"{{fx.SubjectFid}}","field_path":"Name","value":"x"}]}]"""));
+        Check("formid= inside a create op is refused BY NAME, corrected with why a create has none",
+            opFormid.StartsWith("error:") && opFormid.Contains("formid")
+            && opFormid.Contains("auto-allocated", StringComparison.Ordinal), opFormid);
+
+        // A copy pole inside a create op: refused with the "create first, then apply" route (not a bare unknown).
+        var opCopy = CreateTools.Create(fx.Svc,
+            records: Json("""[{"record_type":"Keyword","editorid":"W2Bad2","ops":[{"field_path":"Name","from_source":"HcW2Master.esm"}]}]"""));
+        Check("from_source= inside a create op is refused BY NAME with the housecarl_apply route",
+            opCopy.StartsWith("error:") && opCopy.Contains("from_source") && opCopy.Contains("housecarl_apply"), opCopy);
+
+        // An engine-level problem names the caller's OWN spelling for the element — records[i], not record[i].
+        var badType = CreateTools.Create(fx.Svc,
+            records: Json("""[{"record_type":"Keyword","editorid":"W2Ok"},{"record_type":"NotARealType","editorid":"W2Nope"}]"""));
+        Check("a per-record refusal names the caller's own spelling: records[1], never the 1.x record[1]",
+            badType.StartsWith("error:") && badType.Contains("records[1]") && !badType.Contains("record[1]:"), badType);
+    }
+
+    // ================= ARM 2 — the LANE grammar =================
+    static void LaneArm(Fixture fx)
+    {
+        Console.WriteLine("── ARM 2: LANE — exclusive destinations, refused BY NAME, and in_place as the file's name ──");
+
+        var recs = Json("""[{"record_type":"Keyword","editorid":"W2LaneKw"}]""");
+
+        var patchAndInto = CreateTools.Create(fx.Svc, records: recs, patch: "W2A", into: "W2B.esp");
+        Check("create: patch= + into= is refused BY NAME (both lanes quoted), never silently ignoring one",
+            patchAndInto.StartsWith("error:") && patchAndInto.Contains("patch='W2A'") && patchAndInto.Contains("into='W2B.esp'"), patchAndInto);
+
+        var intoAndInPlace = CreateTools.Create(fx.Svc, records: recs, into: "W2B.esp", in_place: fx.ReplacerName);
+        Check("create: into= + in_place= is refused BY NAME — they are different lanes",
+            intoAndInPlace.StartsWith("error:") && intoAndInPlace.Contains("into=") && intoAndInPlace.Contains("in_place="), intoAndInPlace);
+
+        var ackAlone = CreateTools.Create(fx.Svc, records: recs, patch: "W2A", acknowledge: true);
+        Check("create: acknowledge= without in_place= is refused, not accepted-and-ignored",
+            ackAlone.StartsWith("error:") && ackAlone.Contains("acknowledge="), ackAlone);
+
+        var fwdBothLanes = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: fx.MasterName,
+            patch: "W2F", in_place: fx.ReplacerName);
+        Check("forward: patch= + in_place= is refused BY NAME",
+            fwdBothLanes.StartsWith("error:") && fwdBothLanes.Contains("patch='W2F'") && fwdBothLanes.Contains("in_place="), fwdBothLanes);
+
+        // Removal creates no artifact, so naming NO lane is a real mistake — and the refusal spells BOTH lanes
+        // rather than defaulting to one. (RED pre-fix: a tool that defaulted to a fresh patch here would write an
+        // empty artifact and report success.)
+        var noLane = RemoveTools.Remove(fx.Svc, formids: new[] { fx.SubjectFid });
+        Check("remove: naming NO lane is refused, spelling both into= and in_place=",
+            noLane.StartsWith("error:") && noLane.Contains("into=") && noLane.Contains("in_place="), noLane);
+
+        var twoLanes = RemoveTools.Remove(fx.Svc, formids: new[] { fx.SubjectFid }, into: "W2B.esp", in_place: fx.ReplacerName);
+        Check("remove: into= + in_place= is refused BY NAME",
+            twoLanes.StartsWith("error:") && twoLanes.Contains("Name one"), twoLanes);
+
+        // in_place is the FILE'S NAME, and the first touch of a plugin is a CONSENT prompt — not an error, not a
+        // write. Every one of these is decided AFTER the service captured a build to resolve the target, so each
+        // carries the §2.1.1 epoch (PR #310's lesson, and its round-1 finding: the consent prompt is the shape a
+        // caller meets most often, so an unstamped one makes the contract false exactly there).
+        // ORDER MATTERS: consent is persistent per plugin path, and only an acknowledge=true call records it — so
+        // the two prompt arms run BEFORE the acknowledged write below, on the same plugin.
+        var rmConsent = RemoveTools.Remove(fx.Svc, formids: new[] { fx.SubjectFid }, in_place: fx.ReplacerName);
+        Check("remove in place: the FIRST touch returns the one-time CONSENT prompt, epoch-stamped",
+            !rmConsent.StartsWith("error:") && rmConsent.Contains("acknowledge=true")
+            && rmConsent.Contains("\nepoch=", StringComparison.Ordinal), rmConsent);
+
+        var consent = CreateTools.Create(fx.Svc,
+            records: Json("""[{"record_type":"Keyword","editorid":"W2InPlaceKw"}]"""), in_place: fx.ReplacerName);
+        Check("create in place: the FIRST touch returns the one-time CONSENT prompt, not an error and not a write",
+            !consent.StartsWith("error:") && consent.Contains("acknowledge=true"), consent);
+        Check("the consent prompt carries the §2.1.1 epoch, like every other outcome",
+            consent.Contains("\nepoch=", StringComparison.Ordinal), consent);
+
+        // The forward lane's service-side refusal (a non-active in_place target) is the third site the same stamp
+        // covers — a distinct observable, so all three lanes are pinned rather than one standing in for three.
+        var fwdBadTarget = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: fx.MasterName,
+            in_place: "NotAPlugin.esp");
+        Check("forward in place: a non-active target is refused post-capture, and the refusal carries its epoch",
+            fwdBadTarget.StartsWith("error:") && fwdBadTarget.Contains("NotAPlugin.esp")
+            && fwdBadTarget.Contains("\nepoch=", StringComparison.Ordinal), fwdBadTarget);
+
+        var wrote = CreateTools.Create(fx.Svc,
+            records: Json("""[{"record_type":"Keyword","editorid":"W2InPlaceKw"}]"""), in_place: fx.ReplacerName, acknowledge: true);
+        Check("create in place: acknowledge=true writes into the ORIGINAL file, reported as the in-place lane",
+            wrote.Contains("IN PLACE", StringComparison.Ordinal)
+            && EditorIdsIn(Path.Combine(fx.ModsDir, "W2Repl", fx.ReplacerName)).Contains("W2InPlaceKw"), wrote);
+    }
+
+    // ================= ARM 3 — remove, plural =================
+    static void RemovePluralArm(Fixture fx)
+    {
+        Console.WriteLine("── ARM 3: remove — the plural capability the 1.x surface could not reach ──");
+
+        // Author three records into ONE patch, then drop TWO of them in ONE call.
+        var made = CreateTools.Create(fx.Svc, patch: "W2Rm", records: Json("""
+            [{"record_type":"Keyword","editorid":"W2RmA"},
+             {"record_type":"Keyword","editorid":"W2RmB"},
+             {"record_type":"Keyword","editorid":"W2RmC"}]
+            """));
+        var path = ArtifactPathFrom(fx, made);
+        if (path is null) { Check("remove arm fixture: three records authored into one patch", false, made); return; }
+        var file = Path.GetFileName(path);
+
+        // The created FormIDs come out of the render — the caller's own handle on a record whose id is allocated.
+        var ids = FormIdsFrom(made);
+        Check("remove arm fixture: three records authored, their allocated FormIDs reported back",
+            ids.Count == 3 && EditorIdsIn(path).Count(e => e.StartsWith("W2Rm", StringComparison.Ordinal)) == 3, made);
+        if (ids.Count != 3) return;
+
+        var plural = RemoveTools.Remove(fx.Svc, formids: new[] { ids[0], ids[1] }, into: file);
+        var left = EditorIdsIn(path);
+        Check("MANY records drop in ONE re-serialize (the recovered engine capability): 2 gone, the third stands",
+            plural.StartsWith("removed 2 records", StringComparison.Ordinal)
+            && !left.Contains("W2RmA") && !left.Contains("W2RmB") && left.Contains("W2RmC"), plural);
+
+        // All-or-nothing: one target the patch doesn't carry refuses the WHOLE call — the survivor stays.
+        var notCarried = RemoveTools.Remove(fx.Svc, formids: new[] { ids[2], fx.SubjectFid }, into: file);
+        Check("all-or-nothing: one not-carried target refuses the whole call and NOTHING is removed",
+            notCarried.StartsWith("error:") && notCarried.Contains("not carried by patch")
+            && EditorIdsIn(path).Contains("W2RmC"), notCarried);
+
+        var emptyList = RemoveTools.Remove(fx.Svc, formids: Array.Empty<string>(), into: file);
+        Check("formids=[] is refused by name (a set of one is the minimum, not zero)",
+            emptyList.StartsWith("error:") && emptyList.Contains("formids="), emptyList);
+    }
+
+    /// <summary>The allocated FormIDs out of a create render's per-record lines ("  Keyword 000800:Patch.esp  Edid").</summary>
+    static List<string> FormIdsFrom(string render)
+    {
+        var ids = new List<string>();
+        foreach (var line in render.Split('\n'))
+        {
+            var t = line.Trim();
+            var parts = t.Split("  ", StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 2) continue;
+            var head = parts[0].Split(' ');
+            if (head.Length == 2 && head[1].Contains(':') && head[1].Contains(".es", StringComparison.OrdinalIgnoreCase))
+                ids.Add(head[1]);
+        }
+        return ids;
+    }
+
+    // ================= ARM 4 — forward =================
+    static void ForwardArm(Fixture fx)
+    {
+        Console.WriteLine("── ARM 4: forward — source= decides the content, and the winner it out-ranks is named ──");
+
+        // The replacer WINS the subject at Damage 99; forwarding the MASTER's version must land Damage 10 — which
+        // is what tells "copied source's body" apart from "copied the winner".
+        var fwd = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: fx.MasterName, patch: "W2Fwd");
+        var fwdPath = ArtifactPathFrom(fx, fwd);
+        Check("source= decides the content: the MASTER's version lands, not the load-order winner's",
+            fwdPath is not null && DamageIn(fwdPath, fx.SubjectKey) == 10, fwd);
+        Check("the render names the winner the forward will out-rank once enabled",
+            fwd.Contains("out-ranks the current winner", StringComparison.Ordinal)
+            && fwd.Contains(fx.ReplacerName, StringComparison.OrdinalIgnoreCase), fwd);
+
+        // A forward whose version is ALREADY winning is reported redundant, never a silent no-op.
+        var redundant = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: fx.ReplacerName, patch: "W2FwdR");
+        Check("forwarding the version that ALREADY wins is flagged redundant, never silently a no-op",
+            redundant.Contains("already the load-order winner", StringComparison.OrdinalIgnoreCase), redundant);
+
+        // dry_run runs the real pipeline and stops before disk.
+        int before = Directory.GetDirectories(fx.ModsDir).Length;
+        var dry = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: fx.MasterName, patch: "W2FwdDry", dry_run: true);
+        Check("dry_run=true: the DRY RUN render leads with nothing-written, and no mod folder is cut",
+            dry.StartsWith("DRY RUN", StringComparison.Ordinal) && Directory.GetDirectories(fx.ModsDir).Length == before, dry);
+
+        // A source that isn't active is refused BY NAME — not silently read as "doesn't define the record".
+        var badSource = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: "NotInTheOrder.esp", patch: "W2FwdBad");
+        Check("a non-active source= is refused by name (the declared bound of this lane's pole)",
+            badSource.StartsWith("error:") && badSource.Contains("NotInTheOrder.esp"), badSource);
+
+        var noSource = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, patch: "W2FwdNo");
+        Check("forward without source= is refused naming the parameter and what it means",
+            noSource.StartsWith("error:") && noSource.Contains("source="), noSource);
+    }
+
+    // ================= ARM 5 — TRANSPORT =================
+    static void TransportArm(Fixture fx)
+    {
+        Console.WriteLine("── ARM 5: TRANSPORT — json documents (refusals included) and the §2.1.1 epoch everywhere ──");
+
+        // A SUCCESS renders as valid json carrying the same facts.
+        var createJson = CreateTools.Create(fx.Svc, patch: "W2Json",
+            records: Json("""[{"record_type":"Keyword","editorid":"W2JsonKw"}]"""), format: "json");
+        Check("create format=json: a valid document with ok/lane/created and the epoch",
+            TryJson(createJson, out var cdoc)
+            && cdoc!.RootElement.GetProperty("ok").GetBoolean()
+            && cdoc.RootElement.GetProperty("created")[0].GetProperty("editorid").GetString() == "W2JsonKw"
+            && cdoc.RootElement.GetProperty("epoch").ValueKind == JsonValueKind.String, createJson);
+
+        // A REFUSAL is a document too — a json caller must never have to parse "error: …" out of a string. (This
+        // is the pre-engine refusal path, which is exactly where PR #306/#310 found an EMPTY string twice.)
+        // NOTE the shape: a PRE-ENGINE refusal renders through JsonWire.RenderError, which carries {error, epoch}
+        // and NOT the `ok` discriminant the outcome-borne renders emit. That asymmetry is the known, reviewer-
+        // scoped-out gap filed in dev/BACKLOG.md (a ~39-call-site sweep, W3 PR 3) — so this arm asserts the
+        // REASON is present and machine-readable, and deliberately does not assert `ok` on this path. When the
+        // sweep lands, these two asserts tighten to ok:false.
+        var createRefusal = CreateTools.Create(fx.Svc, records: Json("[]"), format: "json");
+        Check("create format=json: a REFUSAL is a document carrying the reason, never an empty string",
+            createRefusal.Length > 0 && TryJson(createRefusal, out var rdoc)
+            && rdoc!.RootElement.GetProperty("error").GetString()!.Contains("empty array"), createRefusal);
+
+        var removeRefusal = RemoveTools.Remove(fx.Svc, formids: new[] { fx.SubjectFid }, format: "json");
+        Check("remove format=json: the no-lane refusal is a document too",
+            removeRefusal.Length > 0 && TryJson(removeRefusal, out var rmdoc)
+            && rmdoc!.RootElement.GetProperty("error").GetString()!.Contains("in_place="), removeRefusal);
+
+        var forwardJson = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: fx.MasterName,
+            patch: "W2FwdJson", format: "json");
+        Check("forward format=json: forwarded rows carry source, prior_winner and the two per-record flags",
+            TryJson(forwardJson, out var fdoc)
+            && fdoc!.RootElement.GetProperty("forwarded")[0].GetProperty("source").GetString() == fx.MasterName
+            && fdoc.RootElement.GetProperty("forwarded")[0].TryGetProperty("was_already_winner", out _)
+            && fdoc.RootElement.GetProperty("epoch").ValueKind == JsonValueKind.String, forwardJson);
+
+        // An OUTCOME-borne refusal (past the tool layer, into the service) renders through the outcome renderer,
+        // so it DOES carry ok:false. The epoch splits by WHERE the refusal was decided, which is the §2.1.1
+        // contract stated positively rather than "epoch everywhere":
+        //   * a LANE-resolution refusal (no such patch to extend) is decided off the mod FOLDERS, before any
+        //     build is consulted — epoch NULL, because stamping it would claim evidence never read;
+        var noSuchPatch = RemoveTools.Remove(fx.Svc, formids: new[] { fx.SubjectFid }, into: "NoSuchPatch.esp", format: "json");
+        Check("a lane-resolution refusal is a document with ok:false and a NULL epoch (it consulted no build)",
+            TryJson(noSuchPatch, out var nsdoc)
+            && !nsdoc!.RootElement.GetProperty("ok").GetBoolean()
+            && nsdoc.RootElement.GetProperty("epoch").ValueKind == JsonValueKind.Null, noSuchPatch);
+
+        //   * a refusal decided INSIDE the engine, after the capture, carries that build's stamp. (Authored here
+        //     rather than reusing arm 3's patch so the two arms cannot pass on one observable.)
+        var made = CreateTools.Create(fx.Svc, patch: "W2Epoch", records: Json("""[{"record_type":"Keyword","editorid":"W2EpochKw"}]"""));
+        var madePath = ArtifactPathFrom(fx, made);
+        var notCarried = RemoveTools.Remove(fx.Svc, formids: new[] { fx.SubjectFid },
+            into: madePath is null ? "W2Epoch.esp" : Path.GetFileName(madePath), format: "json");
+        Check("a refusal decided AFTER the engine's capture carries that build's epoch",
+            TryJson(notCarried, out var ncdoc)
+            && !ncdoc!.RootElement.GetProperty("ok").GetBoolean()
+            && ncdoc.RootElement.GetProperty("error").GetString()!.Contains("not carried by patch")
+            && ncdoc.RootElement.GetProperty("epoch").ValueKind == JsonValueKind.String, notCarried);
+
+        // write_seq: the ABSENT epoch is a stated fact with its reason, not a dropped field.
+        var seqJson = SeqTools.WriteSeq(fx.Svc, source: fx.MasterName, format: "json");
+        Check("write_seq format=json: epoch is explicitly null AND carries why (no build is consulted at all)",
+            TryJson(seqJson, out var sdoc)
+            && sdoc!.RootElement.GetProperty("epoch").ValueKind == JsonValueKind.Null
+            && sdoc.RootElement.GetProperty("epoch_note").GetString()!.Contains("load-order-independent"), seqJson);
+
+        // write_seq text: a plugin with no SGE quests reports the clean no-op AND names which copy it read.
+        var seqText = SeqTools.WriteSeq(fx.Svc, source: fx.MasterName);
+        Check("write_seq text: the no-SGE-quests no-op names the file AND the copy it was read from",
+            seqText.Contains("no start-game-enabled quests", StringComparison.Ordinal)
+            && seqText.Contains("read from", StringComparison.Ordinal), seqText);
+    }
+
+    static bool TryJson(string s, out JsonDocument? doc)
+    {
+        try { doc = JsonDocument.Parse(s); return true; }
+        catch { doc = null; return false; }
+    }
+}

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -162,6 +162,24 @@ public static class WriteSurfaceGuardProbe
         return mod is null ? null : Path.Combine(fx.ModsDir, mod, file);
     }
 
+    /// <summary>Pull the read-back call a truncated create render emits back apart into (source file, types) so the
+    /// arm can RUN it. Returns (null, null) when the render carries no such call — which is itself the failure the
+    /// caller reports, since the whole point of the notice is to name a call that works.</summary>
+    static (string? file, string[]? types) ParseReadBackCall(string render)
+    {
+        const string marker = "housecarl_records source=\"";
+        int at = render.IndexOf(marker, StringComparison.Ordinal);
+        if (at < 0) return (null, null);
+        var tail = render[(at + marker.Length)..];
+        int quote = tail.IndexOf('"');
+        int open = tail.IndexOf("types=[", StringComparison.Ordinal);
+        int close = open < 0 ? -1 : tail.IndexOf(']', open);
+        if (quote < 0 || open < 0 || close < 0) return (null, null);
+        var types = tail[(open + 7)..close].Split(',')
+                        .Select(t => t.Trim().Trim('"')).Where(t => t.Length > 0).ToArray();
+        return (tail[..quote], types.Length > 0 ? types : null);
+    }
+
     /// <summary>Every EditorID the written plugin carries (flat + nested), for the created/removed assertions.</summary>
     static List<string> EditorIdsIn(string espPath)
     {
@@ -570,6 +588,17 @@ public static class WriteSurfaceGuardProbe
             && rcdoc!.RootElement.GetProperty("truncated").GetBoolean()
             && rcdoc.RootElement.GetProperty("voice_coverage").GetProperty("lines").GetArrayLength() < 40, reportCapped);
 
+        // The create hazard does not care which transport asked (PR #311 review 4 [medium]): the text twin was moved
+        // off "raise max_chars to see the rest" one fold earlier and the json document kept it, so a json client
+        // could raise the ceiling, re-issue, and allocate the records a second time. D2 — same remedy, both renders.
+        Check("json create: truncated_note points at the read-back call, never at raising max_chars",
+            rcdoc is not null
+            && rcdoc.RootElement.GetProperty("truncated_note").GetString() is { } jnote
+            && jnote.Contains("housecarl_records source=", StringComparison.Ordinal)
+            && jnote.Contains("types=[", StringComparison.Ordinal)
+            && jnote.Contains("allocates the records AGAIN", StringComparison.Ordinal)
+            && !jnote.Contains("raise max_chars", StringComparison.Ordinal), reportCapped);
+
         // max_chars reaches the TEXT render too, not only json (PR #311 review [medium] / [low-medium]): the
         // parameter's own description promises trailing rows drop with an explicit notice, and removal is
         // set-valued, so the unbounded list is the expected case rather than an edge.
@@ -608,10 +637,36 @@ public static class WriteSurfaceGuardProbe
         // truncated CREATE allocates the records a second time — a second auto-suffixed patch, or under into= a
         // re-create at the same FormID with the prior contents discarded. Asserted as a positive AND the absence
         // of the sibling renders' wording, which is what made this dangerous here.
+        // …and the remedy must be a call records ACCEPTS (PR #311 review 4 [medium]): source= is the SOURCE pole,
+        // not a SELECT term, so the first spelling of this notice named a call that dies on "select something" —
+        // leaving re-issuing the create as the only obvious route, i.e. straight back into the trap. The SELECT
+        // term is asserted by name here and EXERCISED two arms below.
         Check("create's truncation notice points at a READ, never at raising max_chars (a repeat would re-create)",
             createCapped.Contains("housecarl_records source=", StringComparison.Ordinal)
+            && createCapped.Contains("types=[\"Keyword\"]", StringComparison.Ordinal)
             && createCapped.Contains("would create them AGAIN", StringComparison.Ordinal)
             && !createCapped.Contains("raise max_chars", StringComparison.Ordinal), createCapped);
+
+        // The remedy EXERCISED — parsed OUT of the notice this render just produced and RUN, rather than compared
+        // against a literal. That is the difference that matters here: the arm this replaces asserted the string
+        // "housecarl_records source=", which is precisely why CI vouched for a call records refuses. An arm that
+        // executes the emitted call cannot go stale against a reworded remedy.
+        var (remedyFile, remedyTypes) = ParseReadBackCall(createCapped);
+        if (remedyFile is not null && remedyTypes is { Length: > 0 })
+        {
+            var remedy = RecordsTools.Records(fx.Svc, source: Json($"\"{remedyFile}\""), types: remedyTypes);
+            Check("create's truncation remedy, RUN as emitted, resolves and returns the row the render cut",
+                !remedy.StartsWith("error:", StringComparison.Ordinal)
+                && remedy.Contains("W2CreCapC", StringComparison.Ordinal), remedy);
+
+            // …and the SELECT term is load-bearing, not decoration: the same call with source= alone — the shape
+            // the notice used to name — dies on the lane decision. This is the fact the old remedy walked into.
+            var bareSource = RecordsTools.Records(fx.Svc, source: Json($"\"{remedyFile}\""));
+            Check("records: source= ALONE selects nothing, so a remedy without a SELECT term is a dead end",
+                bareSource.StartsWith("error:", StringComparison.Ordinal)
+                && bareSource.Contains("select something", StringComparison.Ordinal), bareSource);
+        }
+        else Check("create's truncation notice emits a parseable source=+types= read-back call", false, createCapped);
 
         // …and with a cap so small that NO row renders, the closing line must not point at "the new FormID above".
         var createAllCut = CreateTools.Create(fx.Svc, patch: "W2CreCut", max_chars: 1, records: Json("""

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -691,6 +691,42 @@ public static class WriteSurfaceGuardProbe
                 capped.Contains("[truncated:", StringComparison.Ordinal)
                 && capped.Contains("max_chars=100", StringComparison.Ordinal)
                 && capped.Contains("every one WAS removed", StringComparison.Ordinal), capped);
+
+            // …and the remedy is EXECUTABLE (PR #311 review 6 [medium]): "raise max_chars" named the one call
+            // guaranteed to fail here, since a repeat is refused as 'not carried by' the file. The notice states
+            // that the rows are the passed formids= instead. Asserted with its negative, and with the refusal
+            // PROVEN below rather than assumed.
+            Check("remove's truncation remedy is executable — it does not prescribe the re-issue that gets refused",
+                capped.Contains("exactly the formids= you passed", StringComparison.Ordinal)
+                && capped.Contains("a repeat is refused", StringComparison.Ordinal)
+                && !capped.Contains("raise max_chars", StringComparison.Ordinal), capped);
+
+            var repeat = RemoveTools.Remove(fx.Svc, formids: capIds.ToArray(), into: Path.GetFileName(capPath), max_chars: 400000);
+            Check("…and the re-issue the OLD remedy prescribed really is refused (the dead end, proven)",
+                repeat.StartsWith("error:", StringComparison.Ordinal)
+                && repeat.Contains("NOTHING removed", StringComparison.Ordinal), repeat);
+
+            // The json twin needs its OWN patch: the removals above already consumed capPath's records, so re-using
+            // them here would assert against a refusal document instead of a truncation note.
+            var capMadeJ = CreateTools.Create(fx.Svc, patch: "W2CapJ", records: Json("""
+                [{"record_type":"Keyword","editorid":"W2CapJA"},
+                 {"record_type":"Keyword","editorid":"W2CapJB"},
+                 {"record_type":"Keyword","editorid":"W2CapJC"}]
+                """));
+            var capPathJ = ArtifactPathFrom(fx, capMadeJ);
+            var capIdsJ = FormIdsFrom(capMadeJ);
+            if (capPathJ is not null && capIdsJ.Count == 3)
+            {
+                var cappedJson = RemoveTools.Remove(fx.Svc, formids: capIdsJ.ToArray(), into: Path.GetFileName(capPathJ),
+                    max_chars: 100, format: "json");
+                Check("remove format=json: the truncation note carries the SAME remedy as its text twin (D2)",
+                    TryJson(cappedJson, out var rjdoc)
+                    && rjdoc!.RootElement.TryGetProperty("truncated_note", out var rjn)
+                    && rjn.GetString() is { } rjnote
+                    && rjnote.Contains("exactly the formids= you passed", StringComparison.Ordinal)
+                    && !rjnote.Contains("raise max_chars", StringComparison.Ordinal), cappedJson);
+            }
+            else Check("remove json remedy arm: fixture (a second patch to remove from)", false, capMadeJ);
         }
         else Check("remove text render: fixture for the max_chars arm", false, capMade);
 
@@ -787,6 +823,22 @@ public static class WriteSurfaceGuardProbe
         }
         else Check("forward into= remedy arm: fixture (a patch to extend)", false, "no patch path");
 
+        // IN_PLACE is its own pole (PR #311 review 6 [low]): the first pass lumped it with into=, but a re-issue
+        // there re-serializes the caller's OWN plugin — the file this render just called backup-less — purely to
+        // widen a display. It gets the read-back remedy instead. (fx.ReplacerName was acknowledged by an arm
+        // above, so no consent prompt here.)
+        var fwdInPlaceCapped = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: fx.MasterName,
+            in_place: fx.ReplacerName, acknowledge: true, max_chars: 120);
+        // The negative is scoped to the ROW notice, not the whole render: an in-place forward forces the full
+        // read-back, whose own (pre-existing, shared) hint still leads with "raise max_chars" — a separate site,
+        // raised with the reviewer rather than folded in silently here.
+        var fwdRowNotice = Bracket(fwdInPlaceCapped, "every one WAS forwarded — ");
+        Check("forward's in-place truncation remedy points at a READ, never at re-writing the caller's original",
+            fwdRowNotice is not null
+            && fwdRowNotice.Contains("housecarl_records source=", StringComparison.Ordinal)
+            && fwdRowNotice.Contains("re-serialize your ORIGINAL file", StringComparison.Ordinal)
+            && !fwdRowNotice.Contains("raise max_chars", StringComparison.Ordinal), fwdInPlaceCapped);
+
         // write_seq's text lane, same contract — asserted on a REAL quest list rather than the fixture's
         // no-SGE plugin, because an arm that never renders a row cannot pin a row budget (the happy-path-only
         // scar). The render is exercised directly over a synthetic outcome: three quests, a cap that fits one.
@@ -877,6 +929,21 @@ public static class WriteSurfaceGuardProbe
     {
         try { doc = JsonDocument.Parse(s); return true; }
         catch { doc = null; return false; }
+    }
+
+    /// <summary>The remainder of ONE render notice — from <paramref name="after"/> to the end of that LINE. Lets an arm
+    /// assert the ABSENCE of a phrase inside one notice without the whole render's other notices answering for it (a
+    /// write render carries several, and they do not all belong to the finding under test).
+    /// <para>Line-bounded, not bracket-bounded: a remedy may legitimately contain brackets of its own — the in-place
+    /// forward's names <c>formids=[the ids you passed]</c> — and cutting at the first ']' silently truncated the very
+    /// clause under test, failing the arm for the wrong reason.</para></summary>
+    static string? Bracket(string render, string after)
+    {
+        int at = render.IndexOf(after, StringComparison.Ordinal);
+        if (at < 0) return null;
+        var tail = render[(at + after.Length)..];
+        int eol = tail.IndexOf('\n');
+        return eol < 0 ? tail : tail[..eol];
     }
 
     /// <summary>Absence-tolerant readers for a nested member. An arm that asserts a member the PRE-FIX code does not

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -498,6 +498,71 @@ public static class WriteSurfaceGuardProbe
             && ncdoc.RootElement.GetProperty("error").GetString()!.Contains("not carried by patch")
             && ncdoc.RootElement.GetProperty("epoch").ValueKind == JsonValueKind.String, notCarried);
 
+        // `lane` names the lane the CALL asked for, on a refusal as much as on a success (PR #311 review
+        // [medium]): Fail/NeedsAck leave InPlace/Extended at their defaults, so a lane DERIVED from the outcome
+        // reported "patch" for a consent prompt that exists only because the caller named in_place=, and for an
+        // into= refusal on a call that named no patch= at all.
+        // The CONSENT PROMPT is the reviewer's own example, and the sharpest case: it exists ONLY because the
+        // caller named in_place=. The master has not been acknowledged (ARM 2 acknowledged the replacer), so this
+        // is a real first touch.
+        var lanePrompt = CreateTools.Create(fx.Svc, records: Json("""[{"record_type":"Keyword","editorid":"W2LaneKw2"}]"""),
+            in_place: fx.MasterName, format: "json");
+        Check("json lane on the in-place CONSENT PROMPT says in_place, not the patch lane the caller never named",
+            TryJson(lanePrompt, out var lpdoc)
+            && lpdoc!.RootElement.GetProperty("needs_acknowledge").GetBoolean()
+            && lpdoc.RootElement.GetProperty("lane").GetString() == "in_place", lanePrompt);
+
+        var laneRefusal = RemoveTools.Remove(fx.Svc, formids: new[] { fx.SubjectFid }, into: "NoSuchPatch2.esp", format: "json");
+        Check("json lane on an into= REFUSAL says into, not the patch lane (Fail leaves the outcome flags at default)",
+            TryJson(laneRefusal, out var ldoc) && ldoc!.RootElement.GetProperty("lane").GetString() == "into", laneRefusal);
+
+        var laneInPlace = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: fx.MasterName,
+            in_place: "NotAPlugin.esp", format: "json");
+        Check("json lane on a service-side in-place refusal says in_place too",
+            TryJson(laneInPlace, out var lidoc) && lidoc!.RootElement.GetProperty("lane").GetString() == "in_place", laneInPlace);
+
+        // max_chars reaches the TEXT render too, not only json (PR #311 review [medium] / [low-medium]): the
+        // parameter's own description promises trailing rows drop with an explicit notice, and removal is
+        // set-valued, so the unbounded list is the expected case rather than an edge.
+        var capMade = CreateTools.Create(fx.Svc, patch: "W2Cap", records: Json("""
+            [{"record_type":"Keyword","editorid":"W2CapA"},
+             {"record_type":"Keyword","editorid":"W2CapB"},
+             {"record_type":"Keyword","editorid":"W2CapC"}]
+            """));
+        var capPath = ArtifactPathFrom(fx, capMade);
+        var capIds = FormIdsFrom(capMade);
+        if (capPath is not null && capIds.Count == 3)
+        {
+            var capped = RemoveTools.Remove(fx.Svc, formids: capIds.ToArray(), into: Path.GetFileName(capPath), max_chars: 100);
+            Check("remove text render: max_chars= drops trailing rows with an explicit notice (never a silent host cut)",
+                capped.Contains("[truncated:", StringComparison.Ordinal)
+                && capped.Contains("max_chars=100", StringComparison.Ordinal)
+                && capped.Contains("every one WAS removed", StringComparison.Ordinal), capped);
+        }
+        else Check("remove text render: fixture for the max_chars arm", false, capMade);
+
+        // write_seq's text lane, same contract — asserted on a REAL quest list rather than the fixture's
+        // no-SGE plugin, because an arm that never renders a row cannot pin a row budget (the happy-path-only
+        // scar). The render is exercised directly over a synthetic outcome: three quests, a cap that fits one.
+        var seqOutcome = new SeqOutcome(true, null, @"C:\mods\HcSeq\SEQ\HcSeq.seq", "HcSeq",
+            new[]
+            {
+                new HousecarlCore.SeqFile.SeqQuest(default, "HcSeqQuestAlpha",   0x01000800),
+                new HousecarlCore.SeqFile.SeqQuest(default, "HcSeqQuestBravo",   0x01000801),
+                new HousecarlCore.SeqFile.SeqQuest(default, "HcSeqQuestCharlie", 0x01000802),
+            },
+            "HcSeq.esp", false);
+        var seqCapped = SeqTools.Render(seqOutcome, maxChars: 80);
+        Check("write_seq text render: max_chars= drops trailing quest rows with an explicit notice",
+            seqCapped.Contains("[truncated:", StringComparison.Ordinal)
+            && seqCapped.Contains("max_chars=80", StringComparison.Ordinal)
+            && seqCapped.Contains("the .seq itself carries ALL of them", StringComparison.Ordinal)
+            && !seqCapped.Contains("HcSeqQuestCharlie", StringComparison.Ordinal), seqCapped);
+        var seqUncapped = SeqTools.Render(seqOutcome);
+        Check("write_seq text render: without a cap every quest row is listed (the notice is not a permanent cut)",
+            seqUncapped.Contains("HcSeqQuestCharlie", StringComparison.Ordinal)
+            && !seqUncapped.Contains("[truncated:", StringComparison.Ordinal), seqUncapped);
+
         // write_seq: the ABSENT epoch is a stated fact with its reason, not a dropped field.
         var seqJson = SeqTools.WriteSeq(fx.Svc, source: fx.MasterName, format: "json");
         Check("write_seq format=json: epoch is explicitly null AND carries why (no build is consulted at all)",

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -530,6 +530,26 @@ public static class WriteSurfaceGuardProbe
                 && !bareText.TrimStart().StartsWith("{", StringComparison.Ordinal), bareText);
         }
 
+        // Refusals below the tool layer name THIS surface's words, index label included (PR #311 review 6 [low]).
+        // `records[0]` was already the caller's spelling via the origins thread; `op[0]` was nobody's — the member
+        // is ops=, and in a generated batch of hundreds the index label IS the navigational handle.
+        var badOpIndex = CreateTools.Create(fx.Svc, patch: "W2OpLbl", records: Json("""
+            [{"record_type":"Keyword","editorid":"W2OpLbl","ops":[{"value":"x"}]}]
+            """));
+        Check("create: a malformed op is labelled ops[i] — the caller's own member — never op[i]",
+            badOpIndex.Contains("records[0]: ops[0]:", StringComparison.Ordinal)
+            && !badOpIndex.Contains("op[0]:", StringComparison.Ordinal), badOpIndex);
+
+        // …and the create-side CopyFrom refusal names what the caller actually wrote. It is reachable because the
+        // strict reader gates undeclared MEMBERS and `op` IS declared, so op="CopyFrom" arrives at the engine —
+        // where the old text answered with from_plugin, which CreateFieldOp does not declare.
+        var copyOnCreate = CreateTools.Create(fx.Svc, patch: "W2CopyCre", records: Json("""
+            [{"record_type":"Keyword","editorid":"W2CopyCre","ops":[{"field_path":"EditorID","op":"CopyFrom"}]}]
+            """));
+        Check("create: the CopyFrom refusal names op=\"CopyFrom\", not the undeclared from_plugin",
+            copyOnCreate.Contains("op=\"CopyFrom\" copies from an EXISTING record", StringComparison.Ordinal)
+            && !copyOnCreate.Contains("from_plugin", StringComparison.Ordinal), copyOnCreate);
+
         // A REFUSAL is a document too — a json caller must never have to parse "error: …" out of a string. (This
         // is the pre-engine refusal path, which is exactly where PR #306/#310 found an EMPTY string twice.)
         // NOTE the shape: a PRE-ENGINE refusal renders through JsonWire.RenderError, which carries {error, epoch}

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -460,6 +460,30 @@ public static class WriteSurfaceGuardProbe
         var noSource = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, patch: "W2FwdNo");
         Check("forward without source= is refused naming the parameter and what it means",
             noSource.StartsWith("error:") && noSource.Contains("source="), noSource);
+
+        // The two SELF-forward refusals live in the shared engine cleave, which the 1.x forward_record also drives —
+        // so they named from_plugin=, a parameter housecarl_forward does not expose (PR #311 review 4 [low]). Both
+        // are reachable from here: source= equal to the in_place= target, and source= equal to the into= patch. The
+        // spelling is threaded from the calling tool, the same rule offerModParam / InPlaceAgainHint already encode.
+        // Asserted as a positive AND the ABSENCE of the word the caller cannot act on.
+        var selfInPlace = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: fx.ReplacerName,
+            in_place: fx.ReplacerName, acknowledge: true);
+        Check("forward: source= equal to the in_place= target refuses naming source=, never from_plugin",
+            selfInPlace.Contains("is the in-place target itself", StringComparison.Ordinal)
+            && selfInPlace.Contains("source=", StringComparison.Ordinal)
+            && !selfInPlace.Contains("from_plugin", StringComparison.Ordinal), selfInPlace);
+
+        var intoPatch = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: fx.MasterName, patch: "W2FwdSelf");
+        var intoFile = ArtifactPathFrom(fx, intoPatch) is { } sp ? Path.GetFileName(sp) : null;
+        if (intoFile is not null)
+        {
+            var selfInto = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: intoFile, into: intoFile);
+            Check("forward: source= equal to the into= patch refuses naming source=, never from_plugin",
+                selfInto.Contains("is the output patch itself", StringComparison.Ordinal)
+                && selfInto.Contains("source=", StringComparison.Ordinal)
+                && !selfInto.Contains("from_plugin", StringComparison.Ordinal), selfInto);
+        }
+        else Check("forward self-into arm: fixture (a patch to forward into itself)", false, intoPatch);
     }
 
     // ================= ARM 5 — TRANSPORT =================

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -590,6 +590,35 @@ public static class WriteSurfaceGuardProbe
         }
         else Check("remove text render: fixture for the max_chars arm", false, capMade);
 
+        // The SAME budget on the two remaining set-valued row blocks (PR #311 review 3 [medium] x2): create's
+        // created-records block is the render's largest, forward's rows are the longest, and both json twins
+        // already truncate the identical arrays — so an unbounded text lane made the two renders disagree about
+        // the same call, with text taking the silent host-side cut.
+        var createCapped = CreateTools.Create(fx.Svc, patch: "W2CreCap", max_chars: 130, records: Json("""
+            [{"record_type":"Keyword","editorid":"W2CreCapA"},
+             {"record_type":"Keyword","editorid":"W2CreCapB"},
+             {"record_type":"Keyword","editorid":"W2CreCapC"}]
+            """));
+        Check("create text render: max_chars= drops trailing created rows with an explicit notice",
+            createCapped.Contains("[truncated:", StringComparison.Ordinal)
+            && createCapped.Contains("every one WAS created", StringComparison.Ordinal)
+            && !createCapped.Contains("W2CreCapC", StringComparison.Ordinal), createCapped);
+
+        var createUncapped = CreateTools.Create(fx.Svc, patch: "W2CreFull", records: Json("""
+            [{"record_type":"Keyword","editorid":"W2CreFullA"},
+             {"record_type":"Keyword","editorid":"W2CreFullB"},
+             {"record_type":"Keyword","editorid":"W2CreFullC"}]
+            """));
+        Check("create text render: without a cap every created row is listed",
+            createUncapped.Contains("W2CreFullC", StringComparison.Ordinal)
+            && !createUncapped.Contains("[truncated:", StringComparison.Ordinal), createUncapped);
+
+        var fwdCapped = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: fx.MasterName,
+            patch: "W2FwdCap", max_chars: 120);
+        Check("forward text render: max_chars= drops trailing forwarded rows with an explicit notice",
+            fwdCapped.Contains("[truncated:", StringComparison.Ordinal)
+            && fwdCapped.Contains("every one WAS forwarded", StringComparison.Ordinal), fwdCapped);
+
         // write_seq's text lane, same contract — asserted on a REAL quest list rather than the fixture's
         // no-SGE plugin, because an arm that never renders a row cannot pin a row budget (the happy-path-only
         // scar). The render is exercised directly over a synthetic outcome: three quests, a cap that fits one.

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -612,6 +612,27 @@ public static class WriteSurfaceGuardProbe
             && rcdoc!.RootElement.GetProperty("truncated").GetBoolean()
             && rcdoc.RootElement.GetProperty("voice_coverage").GetProperty("lines").GetArrayLength() < 40, reportCapped);
 
+        // …and the CUT BLOCK says so itself (PR #311 review 5 [medium]). Document-level truncated:true does not name
+        // which block lost rows, and a consumer doing `lines.some(l => !l.fuz_present)` on a silently emptied array
+        // gets false — reporting every created line as voiced, the exact inversion of what this block is for.
+        // TryGetProperty throughout: without the fix these members do not exist, and GetProperty would throw —
+        // reporting a CRASHED probe instead of the finding (the same scar the write_seq json arm hit).
+        Check("json create: a CUT voice block carries its own census (total vs rendered) and names the stakes",
+            Num(rcdoc, "voice_coverage", "total_lines") == 40
+            && Num(rcdoc, "voice_coverage", "rendered_lines") is { } vr && vr < 40
+            && Flag(rcdoc, "voice_coverage", "truncated") == true
+            && Str(rcdoc, "voice_coverage", "truncated_note") is { } vnote
+            && vnote.Contains("plays SILENT", StringComparison.Ordinal)
+            // and it must NOT prescribe re-issuing: this block rides a WRITE render.
+            && !vnote.Contains("raise max_chars", StringComparison.OrdinalIgnoreCase), reportCapped);
+
+        // The counts ride on the COMPLETE render too — rendered == total is the positive statement that the list is
+        // whole, so a consumer never infers completeness from a missing marker.
+        Check("json create: an UNCUT voice block still carries the census, with truncated:false",
+            Num(rfdoc, "voice_coverage", "total_lines") == 40
+            && Num(rfdoc, "voice_coverage", "rendered_lines") == 40
+            && Flag(rfdoc, "voice_coverage", "truncated") == false, reportFull);
+
         // The create hazard does not care which transport asked (PR #311 review 4 [medium]): the text twin was moved
         // off "raise max_chars to see the rest" one fold earlier and the json document kept it, so a json client
         // could raise the ceiling, re-issue, and allocate the records a second time. D2 — same remedy, both renders.
@@ -827,4 +848,19 @@ public static class WriteSurfaceGuardProbe
         try { doc = JsonDocument.Parse(s); return true; }
         catch { doc = null; return false; }
     }
+
+    /// <summary>Absence-tolerant readers for a nested member. An arm that asserts a member the PRE-FIX code does not
+    /// emit must FAIL, not throw — a thrown probe reports "guard crashed" and hides which arm found what (a scar
+    /// this fold hit twice). Null/absent ⇒ the comparison is false, which is exactly the RED signal wanted.</summary>
+    static JsonElement? Member(JsonDocument? doc, string obj, string member)
+        => doc is not null && doc.RootElement.TryGetProperty(obj, out var o) && o.TryGetProperty(member, out var m) ? m : null;
+
+    static int? Num(JsonDocument? doc, string obj, string member)
+        => Member(doc, obj, member) is { ValueKind: JsonValueKind.Number } e ? e.GetInt32() : null;
+
+    static bool? Flag(JsonDocument? doc, string obj, string member)
+        => Member(doc, obj, member) is { ValueKind: JsonValueKind.True or JsonValueKind.False } e ? e.GetBoolean() : null;
+
+    static string? Str(JsonDocument? doc, string obj, string member)
+        => Member(doc, obj, member) is { ValueKind: JsonValueKind.String } e ? e.GetString() : null;
 }

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -500,6 +500,36 @@ public static class WriteSurfaceGuardProbe
             && cdoc.RootElement.GetProperty("created")[0].GetProperty("editorid").GetString() == "W2JsonKw"
             && cdoc.RootElement.GetProperty("epoch").ValueKind == JsonValueKind.String, createJson);
 
+        // The UNCONFIGURED-MO2 prompt is a refusal a json caller can parse, on every one of the four write tools
+        // (PR #311 review 5 [low]). It used to be returned verbatim — a prose block — because it was checked before
+        // `format` was read; `JsonDocument.Parse` throws on it, so a json client got neither `ok` nor `error`. The
+        // fixture always configures, which is exactly why nothing caught this: this arm builds an UNCONFIGURED
+        // service on purpose (WithInstance(null, …)) rather than relying on the shared one.
+        {
+            var bare = LoadOrderService.WithInstance(null, 0, new UserConfigStore(Path.Combine(fx.ModsDir, "..", "hc-unconfigured.user.json")));
+            var unconfigured = new (string tool, string render)[]
+            {
+                ("create",    CreateTools.Create(bare, records: Json("""[{"record_type":"Keyword","editorid":"X"}]"""), format: "json")),
+                ("remove",    RemoveTools.Remove(bare, formids: new[] { fx.SubjectFid }, into: "X.esp", format: "json")),
+                ("forward",   ForwardTools.Forward(bare, formids: new[] { fx.SubjectFid }, source: fx.MasterName, format: "json")),
+                ("apply",     ApplyTools.Apply(bare, ops: Json($$"""[{"formid":"{{fx.SubjectFid}}","field_path":"Name","value":"x"}]"""), format: "json")),
+                ("write_seq", SeqTools.WriteSeq(bare, source: fx.MasterName, format: "json")),
+            };
+            foreach (var (tool, render) in unconfigured)
+                Check($"{tool} format=json: the unconfigured-MO2 prompt is a DOCUMENT, not prose",
+                    TryJson(render, out var udoc)
+                    && udoc!.RootElement.TryGetProperty("error", out var uerr)
+                    && uerr.GetString() is { } umsg
+                    && umsg.Contains("no Mod Organizer 2 instance configured", StringComparison.Ordinal), $"{tool}: {render}");
+
+            // …and the TEXT lane still gets the trained prose verbatim — the prompt teaches the user what to do, and
+            // wrapping it in json for a text caller would be the opposite mistake.
+            var bareText = CreateTools.Create(bare, records: Json("""[{"record_type":"Keyword","editorid":"X"}]"""));
+            Check("create text: the unconfigured-MO2 prompt stays the trained prose block",
+                bareText.Contains("no Mod Organizer 2 instance configured", StringComparison.Ordinal)
+                && !bareText.TrimStart().StartsWith("{", StringComparison.Ordinal), bareText);
+        }
+
         // A REFUSAL is a document too — a json caller must never have to parse "error: …" out of a string. (This
         // is the pre-engine refusal path, which is exactly where PR #306/#310 found an EMPTY string twice.)
         // NOTE the shape: a PRE-ENGINE refusal renders through JsonWire.RenderError, which carries {error, epoch}

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -717,6 +717,25 @@ public static class WriteSurfaceGuardProbe
             fwdCapped.Contains("[truncated:", StringComparison.Ordinal)
             && fwdCapped.Contains("every one WAS forwarded", StringComparison.Ordinal), fwdCapped);
 
+        // The remedy is LANE-AWARE (PR #311 review 5 [low]): "a repeated forward re-copies identical bodies" holds
+        // on into=/in_place=, but the DEFAULT lane re-issues into a fresh UniqueStem — a second patch mod carrying
+        // the same overrides. Both poles asserted, so a future uniform-wording regression fails one of them.
+        Check("forward's truncation remedy on the DEFAULT lane names into=, not a bare re-issue",
+            fwdCapped.Contains("SECOND patch", StringComparison.Ordinal)
+            && fwdCapped.Contains("pass into=", StringComparison.Ordinal), fwdCapped);
+
+        var fwdIntoFile = ArtifactPathFrom(fx, ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid },
+            source: fx.MasterName, patch: "W2FwdInto")) is { } fip ? Path.GetFileName(fip) : null;
+        if (fwdIntoFile is not null)
+        {
+            var fwdIntoCapped = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: fx.MasterName,
+                into: fwdIntoFile, max_chars: 120);
+            Check("forward's truncation remedy on into= is the plain one (a re-issue there is idempotent)",
+                fwdIntoCapped.Contains("raise max_chars to see the rest", StringComparison.Ordinal)
+                && !fwdIntoCapped.Contains("SECOND patch", StringComparison.Ordinal), fwdIntoCapped);
+        }
+        else Check("forward into= remedy arm: fixture (a patch to extend)", false, "no patch path");
+
         // write_seq's text lane, same contract — asserted on a REAL quest list rather than the fixture's
         // no-SGE plugin, because an arm that never renders a row cannot pin a row budget (the happy-path-only
         // scar). The render is exercised directly over a synthetic outcome: three quests, a cap that fits one.
@@ -746,6 +765,19 @@ public static class WriteSurfaceGuardProbe
         Check("write_seq text render: without a cap every quest row is listed (the notice is not a permanent cut)",
             seqUncapped.Contains("HcSeqQuestCharlie", StringComparison.Ordinal)
             && !seqUncapped.Contains("[truncated:", StringComparison.Ordinal), seqUncapped);
+
+        // …and the json twin says the SAME thing (PR #311 review 5 [medium]): the review-4 fold moved the text
+        // notice off "raise max_chars" and left the json document on it, so the guard's teeth were on one lane
+        // only — the exact D2 divergence that fold had just fixed one renderer up. Rendered directly, because the
+        // fixture's plugin has no SGE quests and so cannot truncate a quest list through the tool.
+        var seqJsonCapped = JsonWire.RenderSeqOutcome(seqOutcome, 260);
+        Check("write_seq format=json: the truncation note prices the re-run, like its text twin",
+            TryJson(seqJsonCapped, out var sjdoc)
+            && sjdoc!.RootElement.GetProperty("truncated").GetBoolean()
+            && sjdoc.RootElement.GetProperty("truncated_note").GetString() is { } sjnote
+            && sjnote.Contains("nothing is missing from the FILE", StringComparison.Ordinal)
+            && sjnote.Contains("writes the .seq again", StringComparison.Ordinal)
+            && !sjnote.Contains("raise max_chars", StringComparison.Ordinal), seqJsonCapped);
 
         // LANE exclusivity on write_seq (PR #311 review 4 [low]): both spellings are labelled LANE: by this PR, and
         // ResolvePatchModFolder returns from the into= branch before patch= is read — so the pair used to land the

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -710,10 +710,47 @@ public static class WriteSurfaceGuardProbe
             && seqCapped.Contains("max_chars=80", StringComparison.Ordinal)
             && seqCapped.Contains("the .seq itself carries ALL of them", StringComparison.Ordinal)
             && !seqCapped.Contains("HcSeqQuestCharlie", StringComparison.Ordinal), seqCapped);
+        // …and the notice must not prescribe a re-run: widening the ceiling re-runs a WRITE, which with no lane
+        // named for a plugin outside a houseCARL folder cuts a SECOND auto-suffixed folder holding a duplicate
+        // .seq. Nothing is missing from the file, so the notice says that and prices the re-run instead.
+        Check("write_seq's truncation notice prices the re-run instead of prescribing 'raise max_chars'",
+            seqCapped.Contains("nothing is missing from the FILE", StringComparison.Ordinal)
+            && seqCapped.Contains("writes the .seq again", StringComparison.Ordinal)
+            && !seqCapped.Contains("raise max_chars", StringComparison.Ordinal), seqCapped);
+
         var seqUncapped = SeqTools.Render(seqOutcome);
         Check("write_seq text render: without a cap every quest row is listed (the notice is not a permanent cut)",
             seqUncapped.Contains("HcSeqQuestCharlie", StringComparison.Ordinal)
             && !seqUncapped.Contains("[truncated:", StringComparison.Ordinal), seqUncapped);
+
+        // LANE exclusivity on write_seq (PR #311 review 4 [low]): both spellings are labelled LANE: by this PR, and
+        // ResolvePatchModFolder returns from the into= branch before patch= is read — so the pair used to land the
+        // .seq in into='s folder with patch= silently dropped. Refused BY NAME like every sibling, and in BOTH
+        // transports: a json caller getting prose here is the same class one layer up.
+        var seqBothLanes = SeqTools.WriteSeq(fx.Svc, source: fx.MasterName, patch: "HcSeqNew", into: "HcSeqExisting.esp");
+        Check("write_seq: patch= and into= together are refused BY NAME, never silently resolved to into=",
+            seqBothLanes.StartsWith("error:", StringComparison.Ordinal)
+            && seqBothLanes.Contains("HcSeqNew", StringComparison.Ordinal)
+            && seqBothLanes.Contains("HcSeqExisting.esp", StringComparison.Ordinal)
+            && seqBothLanes.Contains("exclusive", StringComparison.Ordinal), seqBothLanes);
+
+        // Same pre-engine RenderError shape as the create/remove refusal arms above — {error, epoch}, no `ok`
+        // discriminant (the reviewer-scoped-out W3 PR 3 sweep), so this asserts the REASON is machine-readable and
+        // tightens to ok:false when that lands.
+        var seqBothLanesJson = SeqTools.WriteSeq(fx.Svc, source: fx.MasterName, patch: "HcSeqNew",
+            into: "HcSeqExisting.esp", format: "json");
+        // TryGetProperty, not GetProperty: without the fix this document is a SUCCESS (patch= silently dropped),
+        // which carries no `error` at all — an arm that throws there reports a crashed probe instead of the finding.
+        Check("write_seq format=json: the LANE refusal is a DOCUMENT carrying the reason, not prose",
+            seqBothLanesJson.Length > 0 && TryJson(seqBothLanesJson, out var sldoc)
+            && sldoc!.RootElement.TryGetProperty("error", out var slerr)
+            && slerr.GetString() is { } slmsg && slmsg.Contains("exclusive", StringComparison.Ordinal),
+            seqBothLanesJson);
+
+        // …and a single lane still reaches the engine — the refusal must be the PAIR, not "patch= is refused".
+        var seqOneLane = SeqTools.WriteSeq(fx.Svc, source: fx.MasterName, patch: "HcSeqOnlyNew");
+        Check("write_seq: patch= ALONE is still honored (the refusal is the pair, not the parameter)",
+            !seqOneLane.StartsWith("error:", StringComparison.Ordinal), seqOneLane);
 
         // write_seq: the ABSENT epoch is a stated fact with its reason, not a dropped field.
         var seqJson = SeqTools.WriteSeq(fx.Svc, source: fx.MasterName, format: "json");

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -604,6 +604,25 @@ public static class WriteSurfaceGuardProbe
             && createCapped.Contains("every one WAS created", StringComparison.Ordinal)
             && !createCapped.Contains("W2CreCapC", StringComparison.Ordinal), createCapped);
 
+        // The remedy must be a READ, never "re-run this call" (PR #311 review 3 round-2 [medium]): repeating a
+        // truncated CREATE allocates the records a second time — a second auto-suffixed patch, or under into= a
+        // re-create at the same FormID with the prior contents discarded. Asserted as a positive AND the absence
+        // of the sibling renders' wording, which is what made this dangerous here.
+        Check("create's truncation notice points at a READ, never at raising max_chars (a repeat would re-create)",
+            createCapped.Contains("housecarl_records source=", StringComparison.Ordinal)
+            && createCapped.Contains("would create them AGAIN", StringComparison.Ordinal)
+            && !createCapped.Contains("raise max_chars", StringComparison.Ordinal), createCapped);
+
+        // …and with a cap so small that NO row renders, the closing line must not point at "the new FormID above".
+        var createAllCut = CreateTools.Create(fx.Svc, patch: "W2CreCut", max_chars: 1, records: Json("""
+            [{"record_type":"Keyword","editorid":"W2CreCutA"},
+             {"record_type":"Keyword","editorid":"W2CreCutB"}]
+            """));
+        Check("create text render: with EVERY row cut, the render stops claiming a FormID it never printed",
+            createAllCut.Contains("truncated: 0 of 2", StringComparison.Ordinal)
+            && !createAllCut.Contains("the new FormID above", StringComparison.Ordinal)
+            && createAllCut.Contains("all 2 WERE created", StringComparison.Ordinal), createAllCut);
+
         var createUncapped = CreateTools.Create(fx.Svc, patch: "W2CreFull", records: Json("""
             [{"record_type":"Keyword","editorid":"W2CreFullA"},
              {"record_type":"Keyword","editorid":"W2CreFullB"},

--- a/src/housecarl-mcp/AliasTable.cs
+++ b/src/housecarl-mcp/AliasTable.cs
@@ -54,7 +54,19 @@ internal static class AliasTable
         new("plugin",  new[] { "source", "plugins", "pluginname", "pluginnames" },
             ExceptTools: new[] { ("housecarl_place_asset", "source") }),
         new("plugins", new[] { "plugin", "pluginname", "pluginnames" }),
-        new("pluginname",  new[] { "patch", "plugins", "plugin", "pluginnames" }),   // §5.3 — create_plugin's plugin_name → patch; today's guess-miss → plugins (#221 J3) or the bare-plugin tools
+        // §5.3 — create_plugin's plugin_name → patch; today's guess-miss → plugins (#221 J3) or the bare-plugin
+        // tools. `source` joins the list, and `patch` is suppressed on write_seq (PR #311 review [low]): once
+        // write_seq declared source= AND patch=, the most likely 1.x spelling for THE PLUGIN on that tool became
+        // the one word that could not reach the plugin pole — plugin_name= silently became the OUTPUT FOLDER's
+        // name, so the .seq landed in a fresh folder called "MyQuestMod.esp" instead of the plugin's own houseCARL
+        // folder, with nothing saying a rename happened. place_asset carries the same exception the sibling
+        // plugin-naming rows do: its source= is a file-path operand, not the version pole.
+        // `source` goes LAST, not ahead of `plugins`: on a tool declaring BOTH a scope word and a pole (records),
+        // the 1.x guess-miss stays where W0 put it (#221 J3 — plugin_name -> plugins), and the pole is the
+        // fallback for a tool that has no scope word at all. Which is exactly write_seq, once `patch` is
+        // suppressed there.
+        new("pluginname",  new[] { "patch", "plugins", "plugin", "pluginnames", "source" },
+            ExceptTools: new[] { ("housecarl_write_seq", "patch"), ("housecarl_place_asset", "source") }),
         new("pluginnames", new[] { "plugins", "plugin", "pluginname" }),
         // Reverse: the new pole spelling on not-yet-renamed tools (read tools' plugin=, the NIF tools'
         // mod=). nexus_mod excepted (census catch): its mod= is a Nexus mod ID, not the S2/S3 provider

--- a/src/housecarl-mcp/AliasTable.cs
+++ b/src/housecarl-mcp/AliasTable.cs
@@ -79,7 +79,11 @@ internal static class AliasTable
         new("patchname",   new[] { "patch" }),
         new("archivename", new[] { "patch" }),
         new("output",      new[] { "patch" }),
-        new("patch",       new[] { "output", "archivename", "patchname", "pluginname" }),
+        // `into` is the LAST candidate (W3 PR 2): on housecarl_remove the artifact a removal edits already
+        // EXISTS, so 1.x remove_record's bare patch= names what §5.1 calls into= — and remove declares no
+        // patch= for the row to skip. Every tool that has a "new artifact" spelling declares one of the four
+        // candidates above, so this edge activates on exactly that one tool.
+        new("patch",       new[] { "output", "archivename", "patchname", "pluginname", "into" }),
 
         // §5.3 — unmanaged filesystem output: out_path. The two 1.x spellings are also each other's
         // candidates (final review finding 6, the F1 clique logic): output_dir= on bsa_extract and
@@ -203,6 +207,17 @@ internal static class AliasTable
         new("sourceplugin", new[] { "assignments" }, "not a parameter here — the assignments= zip carries from_source= per assignment"),
         new("sourcemod",    new[] { "assignments" }, "not a parameter here — the assignments= zip carries from_source= per assignment"),
         new("targetformid", new[] { "assignments" }, "not a parameter here — the assignments= zip carries target= per assignment (§5.2's record pole)"),
+
+        // W3 PR 2 — housecarl_create absorbed the SCALAR create_record call: its five per-record operands became
+        // members of a records= element, because one record is a set of one. A caller arriving with the 1.x habit
+        // spells them at the TOP level, where they are genuinely gone rather than renamed — so each gets the
+        // one-hop form. Gated on `records`, which today is exactly housecarl_create. (`operations` needs no row:
+        // it is a live rename to ops=, and inside a records element that is where it lands.)
+        new("recordtype",  new[] { "records" }, "not a parameter here — one record is a set of one: records=[{\"record_type\": \"Keyword\", \"editorid\": \"MyKeyword\"}]"),
+        new("editorid",    new[] { "records" }, "not a parameter here — the editorid belongs to its record: records=[{\"record_type\": \"…\", \"editorid\": \"…\"}]"),
+        new("parent",      new[] { "records" }, "not a parameter here — nesting is per record: records=[{…, \"parent\": \"XXXXXX:Plugin.esp\"}] (a parent may also be an EARLIER sibling's editorid)"),
+        new("collection",  new[] { "records" }, "not a parameter here — the child-list is per record: records=[{…, \"parent\": \"…\", \"collection\": \"Persistent\"}]"),
+        new("grid",        new[] { "records" }, "not a parameter here — the exterior-cell grid is per record: records=[{\"record_type\": \"Cell\", …, \"grid\": \"5,-12\"}]"),
     };
 
     /// <summary>The migration hint for a normalized unknown key, or null — gated on EVERY one of the
@@ -248,6 +263,17 @@ internal static class AliasTable
          "absorbed into housecarl_apply: one op is a set of one — ops=[{formid, field_path, value}] (verb= is op=). patch_name= is patch=, full_readback= is readback=, and the target=+in_place=true pair is in_place=\"X.esp\" (the file being overwritten)."),
         ("housecarl_bulk_apply",
          "absorbed into housecarl_apply: operations= is ops= (verb= is op=), and from_file= is the @file convention — ops=\"@<absolute path>\". patch_name= is patch=, full_readback= is readback=, target=+in_place=true is in_place=\"X.esp\". Copying a field bundle BETWEEN records is bundle= + assignments=."),
+
+        // W3 PR 2 — the rest of the write side. Same posture: the redirect carries the PARAMETER migration too,
+        // since a caller arriving from old docs has both habits.
+        ("housecarl_create_record",
+         "absorbed into housecarl_create: one record is a set of one — records=[{record_type, editorid, ops}] (operations= is ops=, verb= is op=). record_type/editorid/parent/collection/grid are members of the record, not top-level arguments. patch_name= is patch=, full_readback= is readback=, and the target=+in_place=true pair is in_place=\"X.esp\" (the file being written into)."),
+        ("housecarl_bulk_create",
+         "absorbed into housecarl_create: records= is unchanged in shape except operations= is ops= (verb= is op=), and it also accepts \"@<absolute path>\". The nested one-shot is unchanged: declare a parent BEFORE the children whose parent= names its editorid, and '@editorid' still references a same-call sibling. patch_name= is patch=, full_readback= is readback=, target=+in_place=true is in_place=\"X.esp\"."),
+        ("housecarl_remove_record",
+         "absorbed into housecarl_remove: formids= is SET-VALUED — drop many records in one re-serialize (one is a set of one). The houseCARL-patch lane is into=\"MyPatch.esp\" (removal edits an artifact that EXISTS; patch= names a NEW one everywhere else on the surface), and the target=+in_place=true pair is in_place=\"X.esp\"."),
+        ("housecarl_forward_record",
+         "absorbed into housecarl_forward: from_plugin= is source= (an ACTIVE plugin — whose version to copy). patch_name= is patch=, full_readback= is readback=, and the target=+in_place=true pair is in_place=\"X.esp\". formids=, dry_run= and the into= replace-on-collision semantics are unchanged."),
     };
 
     /// <summary>The successor teaching for a retired tool name, or null. Case-insensitive on the full name.</summary>

--- a/src/housecarl-mcp/AliasTable.cs
+++ b/src/housecarl-mcp/AliasTable.cs
@@ -53,7 +53,14 @@ internal static class AliasTable
         // plugin_name= on the bare-plugin tools; dropping those edges was a live regression, restored here).
         new("plugin",  new[] { "source", "plugins", "pluginname", "pluginnames" },
             ExceptTools: new[] { ("housecarl_place_asset", "source") }),
-        new("plugins", new[] { "plugin", "pluginname", "pluginnames" }),
+        // `source` last here for the same reason it is last on `pluginname` (PR #311 review 3 [low]): W3 PR 2 took
+        // `plugin` off write_seq, and these two rows' only candidates were the three 1.x plugin spellings — so
+        // BOTH dead-ended on the one tool whose pole they were reaching for, while `plugin=`, `plugin_name=`,
+        // `mod=` and `from_plugin=` all still resolved. A row losing its route because its candidate ceased to
+        // exist is a different failure from a row going dormant because the tool declares the word itself, and it
+        // is the one worth catching.
+        new("plugins", new[] { "plugin", "pluginname", "pluginnames", "source" },
+            ExceptTools: new[] { ("housecarl_place_asset", "source") }),
         // §5.3 — create_plugin's plugin_name → patch; today's guess-miss → plugins (#221 J3) or the bare-plugin
         // tools. `source` joins the list, and `patch` is suppressed on write_seq (PR #311 review [low]): once
         // write_seq declared source= AND patch=, the most likely 1.x spelling for THE PLUGIN on that tool became
@@ -67,7 +74,8 @@ internal static class AliasTable
         // suppressed there.
         new("pluginname",  new[] { "patch", "plugins", "plugin", "pluginnames", "source" },
             ExceptTools: new[] { ("housecarl_write_seq", "patch"), ("housecarl_place_asset", "source") }),
-        new("pluginnames", new[] { "plugins", "plugin", "pluginname" }),
+        new("pluginnames", new[] { "plugins", "plugin", "pluginname", "source" },
+            ExceptTools: new[] { ("housecarl_place_asset", "source") }),
         // Reverse: the new pole spelling on not-yet-renamed tools (read tools' plugin=, the NIF tools'
         // mod=). nexus_mod excepted (census catch): its mod= is a Nexus mod ID, not the S2/S3 provider
         // disambiguator — S8 is chartered untouched (§6.4), so nothing renames onto it.
@@ -88,7 +96,13 @@ internal static class AliasTable
         // declares patch_name AND archive_name (the repacked .bsa, §5.3's artifact there) — patch=
         // must land on archive_name. Hence output, then archivename, before patchname; everywhere
         // else the earlier candidates are undeclared and the order is inert.
-        new("patchname",   new[] { "patch" }),
+        // `patchname` also falls through to `into` (PR #311 review 3 [low]): patch_name= is the output spelling on
+        // EVERY 1.x write tool the caller has habits from (set_field, bulk_apply, create_record, bulk_create,
+        // forward_record), so on housecarl_remove — where `patch=` now maps to into= — the sibling spelling
+        // dead-ending was a split the caller has no way to predict. `archivename`/`output` deliberately do NOT get
+        // it: each names ONE specific tool's artifact (bsa_repack's .bsa, merge_plugins' merged plugin), neither
+        // of which is a removal habit, and a candidate list is a claim about what the word probably meant.
+        new("patchname",   new[] { "patch", "into" }),
         new("archivename", new[] { "patch" }),
         new("output",      new[] { "patch" }),
         // `into` is the LAST candidate (W3 PR 2): on housecarl_remove the artifact a removal edits already

--- a/src/housecarl-mcp/AliasTable.cs
+++ b/src/housecarl-mcp/AliasTable.cs
@@ -237,7 +237,12 @@ internal static class AliasTable
         // W3 PR 2 — housecarl_create absorbed the SCALAR create_record call: its five per-record operands became
         // members of a records= element, because one record is a set of one. A caller arriving with the 1.x habit
         // spells them at the TOP level, where they are genuinely gone rather than renamed — so each gets the
-        // one-hop form. Gated on `records`, which today is exactly housecarl_create. (`operations` needs no row:
+        // one-hop form. Gated on `records`, which is declared by housecarl_create AND by 1.x housecarl_bulk_create —
+        // so each row fires on BOTH, which is why the CENSUS bakes five `housecarl_bulk_create: … => hint`
+        // activations alongside the create ones. (The hint text is correct on either surface; the point of saying so
+        // here is that a maintainer touching a `records`-gated row is changing two tools' behaviour, not one — an
+        // earlier draft of this comment claimed "exactly housecarl_create" and contradicted the census in the same
+        // commit.) (`operations` needs no row:
         // it is a live rename to ops=, and inside a records element that is where it lands.)
         new("recordtype",  new[] { "records" }, "not a parameter here — one record is a set of one: records=[{\"record_type\": \"Keyword\", \"editorid\": \"MyKeyword\"}]"),
         new("editorid",    new[] { "records" }, "not a parameter here — the editorid belongs to its record: records=[{\"record_type\": \"…\", \"editorid\": \"…\"}]"),

--- a/src/housecarl-mcp/ApplyTools.cs
+++ b/src/housecarl-mcp/ApplyTools.cs
@@ -135,11 +135,14 @@ public static class ApplyTools
         [Description("TRANSPORT: character ceiling on the render; past it the read-back is cut with an explicit notice (never silent). 0 = a safe default kept under the host's per-response limit; raise it to widen a readback=true dump.")]
             int max_chars = 0) => Guard.Tool("housecarl_apply", () =>
     {
-        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-
         // ---- TRANSPORT: format --------------------------------------------------------------------------
+        // Ahead of the unconfigured-MO2 prompt (PR #311 review 5 [low]): that prompt is prose, and a json caller
+        // got it verbatim — unparseable, with no ok/error to branch on. Inherited from PR #310, fixed here with
+        // its three siblings rather than left as the one tool of the four that still does it.
         bool json = Wire.WantsJson(format, out var ferr);
         if (ferr is not null) return ferr;   // the format value itself is unparsed — there is no known render to answer in
+        if (svc.ConfigPromptOrNull() is { } prompt)
+            return json ? JsonWire.RenderError(prompt, null) : prompt;
 
         // EVERY refusal below this point answers in the caller's requested format. RenderPatchOutcome's contract
         // says a json caller must never have to parse "error: …" out of a string, and the sites a caller hits most

--- a/src/housecarl-mcp/ApplyTools.cs
+++ b/src/housecarl-mcp/ApplyTools.cs
@@ -68,7 +68,7 @@ public static class ApplyTools
          "to from_source's version of the record being edited); with from= and no from_source= the source is that " +
          "record's load-order winner. Cross-record pairs must be the SAME record type — refused by name otherwise. " +
          "CopyFrom copies a WHOLE field (scalar, formlink, modeled list, sub-struct); it cannot copy owned child " +
-         "records (forward the whole record with housecarl_forward_record instead).\n\n" +
+         "records (forward the whole record with housecarl_forward instead).\n\n" +
          "THE COPY ZIP (bundle= x assignments=). To copy the SAME set of fields from one record to another — many " +
          "pairs in one call — name the paths once and pair them explicitly: bundle=[\"BasicStats.Damage\"," +
          "\"Keywords\"], assignments=[{target:'AAA:Mod.esp', from:'BBB:Other.esp'}, {target:..., from:..., " +
@@ -80,7 +80,7 @@ public static class ApplyTools
          "is never overwritten). into='<an existing patch's filename>' EXTENDS that patch instead — the way to " +
          "accumulate across calls and sessions. PRECEDENCE with into= (pinned): a FormKey the patch ALREADY CARRIES " +
          "is edited AS-IS in the patch; only a FormKey it does NOT yet carry copies the load-order winner in first. " +
-         "So housecarl_forward_record from a source + apply into= the same patch is THE recipe to build on a " +
+         "So housecarl_forward from a source + apply into= the same patch is THE recipe to build on a " +
          "specific plugin's version while a stale winner sits above it. in_place='<plugin filename>' is the opt-in " +
          "THIRD lane: houseCARL rewrites your ORIGINAL file (incl. a mod it didn't author) — no new patch, and NO " +
          "houseCARL backup or undo (keep your own). It re-lays-out the whole plugin the way xEdit/CK do on save, " +
@@ -107,9 +107,9 @@ public static class ApplyTools
          "re-run the same manifest to recover an interrupted write (overrides are idempotent). The path must be " +
          "ABSOLUTE (the server resolves relative paths against its OWN working directory, not yours), and the file " +
          "is read at CALL time, so re-dry-run it after editing.\n\n" +
-         "This tool edits EXISTING records' fields. New records are housecarl_create_record / housecarl_bulk_create; " +
-         "dropping a whole record is housecarl_remove_record; copying a whole record verbatim is " +
-         "housecarl_forward_record. Read first with housecarl_records.")]
+         "This tool edits EXISTING records' fields. New records are housecarl_create; dropping whole records is " +
+         "housecarl_remove; copying a whole record verbatim is housecarl_forward. Read first with " +
+         "housecarl_records.")]
     public static string Apply(
         LoadOrderService svc,
         [Description("The edits, all into one artifact: [{formid, field_path, op?, value?, values?, key?, entries?, compose?, composes?, from?, from_source?}, …] — or \"@<absolute path>\" to read that SAME array from a JSON manifest file. One op is a set of one. An op member the shape does not declare is refused BY NAME at its element, never silently dropped.")]

--- a/src/housecarl-mcp/ApplyTools.cs
+++ b/src/housecarl-mcp/ApplyTools.cs
@@ -233,8 +233,10 @@ public static class ApplyTools
                         + string.Join("\n  - ", problems));
 
         var outcome = svc.ApplyEdits(wire, patchName ?? "Patch", into, readback, in_place, hasInPlace, acknowledge, dry_run, fromRecords, origins);
+        // The lane the CALL named — stated, not derived from the outcome's flags, which are at their defaults on a
+        // refusal and on the consent prompt (PR #311 review [medium]).
         return json
-            ? JsonWire.RenderPatchOutcome(outcome, max_chars, readback)
+            ? JsonWire.RenderPatchOutcome(outcome, max_chars, readback, hasInPlace ? "in_place" : hasInto ? "extend" : "patch")
             : WriteTools.Render(outcome, max_chars, readback);
     });
 

--- a/src/housecarl-mcp/ApplyTools.cs
+++ b/src/housecarl-mcp/ApplyTools.cs
@@ -132,7 +132,7 @@ public static class ApplyTools
             bool readback = false,
         [Description("TRANSPORT: 'text' (default) | 'json' (the same data, machine-readable, accounting in-band).")]
             string? format = null,
-        [Description("TRANSPORT: character ceiling on the render; past it the read-back is cut with an explicit notice (never silent). 0 = a safe default kept under the host's per-response limit; raise it to widen a readback=true dump.")]
+        [Description("TRANSPORT: character ceiling on the WHOLE render — in format=\"json\" the applied-op rows as well as the read-back; in text, the read-back. Past it, trailing rows are dropped with an explicit notice (never silent); the WRITE is unaffected. 0 = a safe default kept under the host's per-response limit; raise it to widen a readback=true dump.")]
             int max_chars = 0) => Guard.Tool("housecarl_apply", () =>
     {
         // ---- TRANSPORT: format --------------------------------------------------------------------------

--- a/src/housecarl-mcp/ApplyTools.cs
+++ b/src/housecarl-mcp/ApplyTools.cs
@@ -247,157 +247,13 @@ public static class ApplyTools
     /// the SDK's own binder silently drops one, and in a large generated batch a misspelled <c>field_path</c> would
     /// then surface as a downstream refusal pointing away from the typo.</summary>
     static (ApplyOp[]? Items, string? Error) ReadOps(JsonElement el)
-        => ReadListParam<ApplyOp>(el, "ops", "{formid, field_path, op?, value?, values?, key?, entries?, compose?, composes?, from?, from_source?}");
+        => ListParams.Read<ApplyOp>(el, "ops", "{formid, field_path, op?, value?, values?, key?, entries?, compose?, composes?, from?, from_source?}");
 
     /// <summary>Read <c>assignments=</c> — the §4.5 zip's per-target source mapping. Same two spellings and the same
     /// strict element contract as <see cref="ReadOps"/>.</summary>
     static (Assignment[]? Items, string? Error) ReadAssignments(JsonElement el)
-        => ReadListParam<Assignment>(el, "assignments", "{target, from, from_source?}");
+        => ListParams.Read<Assignment>(el, "assignments", "{target, from, from_source?}");
 
-    /// <summary>The shared list-parameter reader behind every 2.0 typed list input: inline array | "@path" |
-    /// ["@path"]. One implementation so the @file convention cannot drift between parameters, and so every failure
-    /// (unreadable, not JSON, not an array, empty, a null element, an undeclared member) names itself and its
-    /// element (Q3).</summary>
-    static (T[]? Items, string? Error) ReadListParam<T>(JsonElement el, string param, string shape)
-    {
-        string json;
-        string origin;
-        if (el.ValueKind is JsonValueKind.String)
-        {
-            var (text, err) = ReadAtFile(el.GetString(), param);
-            if (err is not null) return (null, err);
-            json = text!; origin = $"the file named by {param}";
-        }
-        else if (el.ValueKind is JsonValueKind.Array)
-        {
-            // The one-element ["@path"] spelling — the same shape formids= uses. An @-string anywhere else in the
-            // array is a mixed inline/file list, which has no meaning: refuse it by name rather than half-honor it.
-            var atIndexes = new List<int>();
-            int count = 0;
-            foreach (var item in el.EnumerateArray())
-            {
-                if (item.ValueKind is JsonValueKind.String && item.GetString()?.TrimStart().StartsWith('@') == true)
-                    atIndexes.Add(count);
-                count++;
-            }
-            if (atIndexes.Count > 0)
-            {
-                if (count != 1)
-                    return (null, $"{param}: \"@<path>\" reads the WHOLE list from a file, so it cannot be mixed with inline elements " +
-                                  $"(found {atIndexes.Count} @-element(s) among {count}). Pass either the inline array or a single \"@<absolute path>\".");
-                var (text, err) = ReadAtFile(el[0].GetString(), param);
-                if (err is not null) return (null, err);
-                json = text!; origin = $"the file named by {param}";
-            }
-            else { json = el.GetRawText(); origin = param; }
-        }
-        else
-            return (null, $"{param} must be an ARRAY of {shape} elements, or \"@<absolute path>\" naming a JSON file holding that array (got {el.ValueKind}).");
-
-        T[]? items;
-        try { items = JsonSerializer.Deserialize<T[]>(json, StrictList); }
-        catch (JsonException ex)
-        {
-            // "byte N in the line", not "column": BytePositionInLine is a UTF-8 byte offset, which skews from the
-            // visual column on a non-ASCII line. STJ appends its own 0-based position block to the message, which
-            // would contradict the 1-based position stated here — shear it; the element path is surfaced separately.
-            string at = ex.LineNumber is { } ln ? $" at line {ln + 1}, byte {(ex.BytePositionInLine ?? 0) + 1} in the line" : "";
-            string element = ex.Path is { Length: > 2 } p ? $" (element {p})" : "";
-            var msg = ShearStjPosition(Guard.Flatten(ex.Message));
-            return (null, $"{origin} could not be parsed{at}{element}: {msg} " +
-                          $"Expected a JSON ARRAY of {shape} elements.{ElementVocabularyHint(msg)}");
-        }
-        if (items is null) return (null, $"{origin} parsed to JSON null — expected a JSON array of {shape} elements.");
-        if (items.Length == 0) return (null, $"{param} is an empty array — give at least one {shape}.");
-        for (int i = 0; i < items.Length; i++)
-            if (items[i] is null) return (null, $"{param}: element [{i}] is null — every element must be an object.");
-        return (items, null);
-    }
-
-    /// <summary>Read a list-input's <c>@&lt;path&gt;</c> target off disk. Absolute-path-only, for the reason the
-    /// message states: the server's working directory is not the caller's, so a relative path silently resolves
-    /// somewhere neither of them meant.</summary>
-    static (string? Text, string? Error) ReadAtFile(string? spelling, string param)
-    {
-        var raw = spelling?.Trim().Trim('"', '\'') ?? "";
-        var path = raw.StartsWith('@') ? raw[1..].Trim() : raw;
-        if (path.Length == 0)
-            return (null, $"{param}: \"@\" names no file — give the manifest's absolute path, e.g. \"@C:\\\\jobs\\\\ops.json\".");
-        if (!Path.IsPathRooted(path))
-            return (null, $"{param}: '{path}' must be an ABSOLUTE path — the server resolves relative paths against its OWN working directory, not yours.");
-        string text;
-        try { text = File.ReadAllText(path); }
-        catch (Exception ex) { return (null, $"{param}: could not read '{path}' — {ex.GetType().Name}: {ex.Message}"); }
-        if (string.IsNullOrWhiteSpace(text))
-            return (null, $"{param}: '{path}' is empty. Expected a JSON array.");
-        return (text, null);
-    }
-
-    /// <summary>The §5.3 vocabulary correction for a rejected element member. The alias layer rewrites TOP-LEVEL
-    /// arguments only (<see cref="ToolCallShim"/> works off the published schema, and these members are inside a
-    /// list value), so a caller carrying 1.x habits — <c>verb</c>, <c>from_plugin</c> — gets the strict reader's
-    /// unmapped-member refusal with no way to learn the new word. That refusal is correct and stays; this appends
-    /// the one-hop correction to it.
-    /// <para>Matched on the member name AND the DECLARING TYPE, both of which STJ already quotes. The type half is
-    /// load-bearing, not belt-and-braces: the same word means different things per shape — <c>verb</c> is a rename
-    /// on an op but a LEGAL member on a <see cref="NestedSet"/>, and <c>op</c> is legal on an op but a mistake in
-    /// two different ways on a nested set and on an <see cref="Assignment"/>. Matching the name alone would answer
-    /// a stray <c>op</c> inside an assignment by lecturing about `compose=`, a construct that caller never used
-    /// (round-5 review). Unmatched pairs simply get no hint — the refusal still names the member and its type.</para></summary>
-    static string ElementVocabularyHint(string stjMessage)
-    {
-        foreach (var (old, declaringType, correction) in ElementRenames)
-            if (stjMessage.Contains($"'{old}'", StringComparison.Ordinal) &&
-                stjMessage.Contains($".{declaringType}'", StringComparison.Ordinal))
-                return $" ('{old}' was the 1.x spelling — {correction})";
-        return "";
-    }
-
-    /// <summary>(old spelling, the type that REJECTED it, the correction). One row per (member, shape) pair,
-    /// because the same word is a different mistake — or no mistake — depending on which shape it landed in.</summary>
-    static readonly (string Old, string DeclaringType, string Correction)[] ElementRenames =
-    {
-        // AT THE OP LEVEL the rename is verb -> op. A nested set inside compose= is a NestedSet, shared verbatim
-        // with the 1.x wire shape, and legitimately still spells `verb` — hence the type gate, and the two
-        // opposite corrections below it.
-        ("verb", "ApplyOp", "at the OP level the verb member is now op — op=\"Add\". (A nested set inside compose= is unchanged and still takes verb.)"),
-        ("op", "NestedSet", "a nested set inside compose= still spells its verb `verb` — only the top-level op member was renamed to op"),
-        // An assignment names RECORDS, never a verb: the zip is a copy by construction. Answering this one with
-        // the NestedSet correction would lecture about compose=, which such a caller never used.
-        ("op", "Assignment", "an assignment pairs records and carries no verb — the zip is always a copy. Per-op verbs live in ops=[{…, op: \"…\"}]"),
-        ("verb", "Assignment", "an assignment pairs records and carries no verb — the zip is always a copy. Per-op verbs live in ops=[{…, op: \"…\"}]"),
-
-        ("from_plugin", "ApplyOp", "it split in two: from_source names the PLUGIN to copy from, from names a different source RECORD"),
-        ("fromplugin", "ApplyOp", "it split in two: from_source names the PLUGIN to copy from, from names a different source RECORD"),
-        ("from_plugin", "Assignment", "an assignment's source pole is from_source=, and its source RECORD is from="),
-
-        ("target_formid", "Assignment", "a copy's destination record is the assignments= zip's target="),
-        ("source_formid", "Assignment", "a copy's source record is the assignments= zip's from="),
-        ("source_plugin", "Assignment", "a copy's source pole is from_source="),
-        // The same three, typed into an OP instead — the zip's members do not exist there; an op copies with
-        // from=/from_source= and names its own record in formid=.
-        ("target_formid", "ApplyOp", "an op names its own record in formid=; a copy's DESTINATION only has a separate spelling inside the assignments= zip (target=)"),
-        ("source_formid", "ApplyOp", "an op's source record is from="),
-        ("source_plugin", "ApplyOp", "an op's source pole is from_source="),
-    };
-
-    /// <summary>STJ appends its own position block (" Path: $[0].x | LineNumber: 0 | BytePositionInLine: 89.") to a
-    /// JsonException message — 0-based, contradicting the 1-based position the refusal already leads with. Shear it.</summary>
-    static string ShearStjPosition(string msg)
-    {
-        int i = msg.IndexOf(" Path: ", StringComparison.Ordinal);
-        return i < 0 ? msg : msg[..i].TrimEnd();
-    }
-
-    /// <summary>Strict list-element options: property names case-insensitive like the SDK's inline binder, comments +
-    /// trailing commas tolerated (hand-generated files), and an undeclared member REFUSED by name.</summary>
-    static readonly JsonSerializerOptions StrictList = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        ReadCommentHandling = JsonCommentHandling.Skip,
-        AllowTrailingCommas = true,
-        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
-    };
 
     // ---- the §4.5 zip --------------------------------------------------------------------------------
 
@@ -409,18 +265,18 @@ public static class ApplyTools
         // A MIXED inline/@file list has no meaning here either — and it used to slip through, because the @file
         // branch only fired at Length == 1: an "@path" sitting beside real paths became a literal dotted FIELD
         // path, and the caller got an engine "no such field" refusal naming something they never meant as a field
-        // (review [low]). Named here with ReadListParam's wording, so all three list inputs answer alike.
+        // (review [low]). Named here with ListParams.Read's wording, so all three list inputs answer alike.
         int atCount = bundle.Count(b => b?.TrimStart().StartsWith('@') == true);
         if (atCount > 0 && bundle.Length != 1)
             return (null, $"bundle: \"@<path>\" reads the WHOLE list from a file, so it cannot be mixed with inline elements " +
                           $"(found {atCount} @-element(s) among {bundle.Length}). Pass either the inline array of field paths or a single \"@<absolute path>\".");
         if (bundle.Length == 1 && bundle[0]?.TrimStart().StartsWith('@') == true)
         {
-            var (text, err) = ReadAtFile(bundle[0], "bundle");
+            var (text, err) = ListParams.ReadAtFile(bundle[0], "bundle");
             if (err is not null) return (null, err);
             string[]? paths;
-            try { paths = JsonSerializer.Deserialize<string[]>(text!, StrictList); }
-            catch (JsonException ex) { return (null, $"the file named by bundle could not be parsed: {ShearStjPosition(Guard.Flatten(ex.Message))} Expected a JSON array of field-path strings."); }
+            try { paths = JsonSerializer.Deserialize<string[]>(text!, ListParams.Strict); }
+            catch (JsonException ex) { return (null, $"the file named by bundle could not be parsed: {ListParams.ShearStjPosition(Guard.Flatten(ex.Message))} Expected a JSON array of field-path strings."); }
             if (paths is null || paths.Length == 0) return (null, "the file named by bundle holds no field paths — expected a JSON array of dotted field paths.");
             bundle = paths;
         }

--- a/src/housecarl-mcp/ApplyTools.cs
+++ b/src/housecarl-mcp/ApplyTools.cs
@@ -236,8 +236,8 @@ public static class ApplyTools
         // The lane the CALL named — stated, not derived from the outcome's flags, which are at their defaults on a
         // refusal and on the consent prompt (PR #311 review [medium]).
         return json
-            ? JsonWire.RenderPatchOutcome(outcome, max_chars, readback, hasInPlace ? "in_place" : hasInto ? "extend" : "patch")
-            : WriteTools.Render(outcome, max_chars, readback);
+            ? JsonWire.RenderPatchOutcome(outcome, max_chars, readback, hasInPlace ? "in_place" : hasInto ? "into" : "patch")
+            : WriteTools.Render(outcome, max_chars, readback, laneAsName: true);
     });
 
     // ---- input readers -------------------------------------------------------------------------------

--- a/src/housecarl-mcp/CreateTools.cs
+++ b/src/housecarl-mcp/CreateTools.cs
@@ -42,11 +42,14 @@ public static class CreateTools
          "RECORDS. records= is the spec list — {record_type, editorid, ops?, parent?, collection?, grid?} each; ONE " +
          "record is a set of one (the old create_record call). record_type is a catalog name ('Keyword', 'Spell', " +
          "'LeveledItem', 'DialogTopic') or a 4-char signature ('KYWD'). editorid is REQUIRED — the EditorID the " +
-         "record is referenced by (in SkyPatcher/SPID, in xEdit); choose a clear, prefixed name. For an ABSTRACT " +
+         "record is referenced by (in SkyPatcher/SPID, in xEdit); choose a clear, prefixed name. Any flat " +
+         "top-level record is fair game — a keyword, spell, perk, magic effect, faction, armor, weapon, leveled " +
+         "list, global, quest — as is a nested one (see NESTING). For an ABSTRACT " +
          "record group name the CONCRETE subtype directly ('GlobalFloat'/'GlobalInt'/'GlobalShort', " +
          "'GameSettingFloat'/'GameSettingInt'/'GameSettingString') — that is how a global variable or game setting " +
          "is created. Each new FormID is auto-allocated in the patch's own 0x800+ range and REPORTED BACK: it is how " +
-         "you reference the record afterwards.\n\n" +
+         "you reference the record afterwards — to make ANOTHER record point at it, call this tool or " +
+         "housecarl_apply again with into='<this patch>' and that FormID as the value.\n\n" +
          "OPS set the new record's fields — the same shape housecarl_apply takes MINUS formid (the record has no id " +
          "yet): {field_path, op?, value?, key?, values?, entries?, compose?, composes?}. e.g. " +
          "ops=[{field_path:'Name', value:'My Spell'}, {field_path:'EffectList', op:'Add', compose:{...}}]. compose " +
@@ -96,7 +99,7 @@ public static class CreateTools
          "the SAME array as a JSON manifest on disk. The path must be ABSOLUTE (the server resolves relative paths " +
          "against its OWN working directory, not yours), and the file is read at CALL time.\n\n" +
          "This tool authors NEW records. Editing an existing record's fields is housecarl_apply; dropping a whole " +
-         "record is housecarl_remove_record; an EMPTY header-only trigger plugin (no records at all) is " +
+         "record is housecarl_remove; an EMPTY header-only trigger plugin (no records at all) is " +
          "housecarl_create_plugin. Read first with housecarl_records.")]
     public static string Create(
         LoadOrderService svc,

--- a/src/housecarl-mcp/CreateTools.cs
+++ b/src/housecarl-mcp/CreateTools.cs
@@ -181,8 +181,8 @@ public static class CreateTools
         var outcome = svc.CreateRecordsBatch(wire, patchName, into, readback, in_place, hasInPlace, acknowledge, origins);
         // The lane the CALL named — stated, not derived from the outcome's flags (PR #311 review [medium]).
         return json
-            ? JsonWire.RenderCreateOutcome(outcome, max_chars, readback, hasInPlace ? "in_place" : hasInto ? "extend" : "patch")
-            : WriteTools.RenderCreate(outcome, max_chars, readback);
+            ? JsonWire.RenderCreateOutcome(outcome, max_chars, readback, hasInPlace ? "in_place" : hasInto ? "into" : "patch")
+            : WriteTools.RenderCreate(outcome, max_chars, readback, laneAsName: true);
     });
 }
 

--- a/src/housecarl-mcp/CreateTools.cs
+++ b/src/housecarl-mcp/CreateTools.cs
@@ -117,7 +117,7 @@ public static class CreateTools
             bool readback = false,
         [Description("TRANSPORT: 'text' (default) | 'json' (the same data, machine-readable, accounting in-band).")]
             string? format = null,
-        [Description("TRANSPORT: character ceiling on the render; past it the read-back is cut with an explicit notice (never silent). 0 = a safe default kept under the host's per-response limit; raise it to widen a readback=true dump.")]
+        [Description("TRANSPORT: character ceiling on the WHOLE render — the created-record rows (each with its allocated FormID), the voice / result-script / cell-shell reports, and the read-back, in that order. Past it, trailing rows are dropped with an explicit notice and a per-block rendered-vs-total census (never silent). The WRITE is unaffected either way. 0 = a safe default kept under the host's per-response limit.")]
             int max_chars = 0) => Guard.Tool("housecarl_create", () =>
     {
         // ---- TRANSPORT: format --------------------------------------------------------------------------

--- a/src/housecarl-mcp/CreateTools.cs
+++ b/src/housecarl-mcp/CreateTools.cs
@@ -166,15 +166,31 @@ public static class CreateTools
         for (int i = 0; i < specs.Length; i++)
         {
             var s = specs[i];
+            // A null ELEMENT inside ops= is legal JSON and STJ hands it straight through, so the old
+            // `s.Ops?.Select(o => … o.FieldPath …)` dereferenced null and the tool answered "an internal houseCARL
+            // failure (the arguments bound fine) — retry once": wrong on both counts, and a retry loop over
+            // deterministic bad input (PR #311 review 7 [low]). ListParams.Read makes exactly this check, but only
+            // over the TOP-level list — which is records= here, so a create's ops sit one level below its reach.
+            BulkOp[]? ops = null;
+            if (s.Ops is { } opsIn)
+            {
+                ops = new BulkOp[opsIn.Length];
+                for (int j = 0; j < opsIn.Length; j++)
+                {
+                    if (opsIn[j] is not { } o)
+                        return Refuse($"records[{i}]: ops[{j}] is null — every op must be an object, e.g. {{\"field_path\": \"Name\", \"value\": \"…\"}}. (A JSON null in the array is not an empty op; drop the element.)");
+                    ops[j] = new BulkOp
+                    {
+                        FieldPath = o.FieldPath, Verb = o.Op ?? "Set", Value = o.Value, Key = o.Key,
+                        Values = o.Values, Entries = o.Entries, Compose = o.Compose, Composes = o.Composes,
+                    };
+                }
+            }
             wire.Add(new CreateOp
             {
                 RecordType = s.RecordType, Editorid = s.Editorid, Parent = s.Parent,
                 Collection = s.Collection, Grid = s.Grid,
-                Operations = s.Ops?.Select(o => new BulkOp
-                {
-                    FieldPath = o.FieldPath, Verb = o.Op ?? "Set", Value = o.Value, Key = o.Key,
-                    Values = o.Values, Entries = o.Entries, Compose = o.Compose, Composes = o.Composes,
-                }).ToArray(),
+                Operations = ops,
             });
             // The caller's OWN spelling for this spec. The 1.x batch labels its problems "record[i]" (its parameter
             // is records=, singular label); this tool's element refusals say "records[i]", and a refusal must not

--- a/src/housecarl-mcp/CreateTools.cs
+++ b/src/housecarl-mcp/CreateTools.cs
@@ -182,7 +182,10 @@ public static class CreateTools
             origins.Add($"records[{i}]");
         }
 
-        var outcome = svc.CreateRecordsBatch(wire, patchName, into, readback, in_place, hasInPlace, acknowledge, origins);
+        // naming: refusals below the tool layer name THIS surface's words — ops[i], and a copy asked for via
+        // op="CopyFrom" (there is no from_plugin member here to tell the caller to drop). PR #311 review 6 [low].
+        var outcome = svc.CreateRecordsBatch(wire, patchName, into, readback, in_place, hasInPlace, acknowledge, origins,
+            naming: new LoadOrderService.CreateOpNaming("ops", "op=\"CopyFrom\""));
         // The lane the CALL named — stated, not derived from the outcome's flags (PR #311 review [medium]).
         return json
             ? JsonWire.RenderCreateOutcome(outcome, max_chars, readback, hasInPlace ? "in_place" : hasInto ? "into" : "patch")

--- a/src/housecarl-mcp/CreateTools.cs
+++ b/src/housecarl-mcp/CreateTools.cs
@@ -120,11 +120,15 @@ public static class CreateTools
         [Description("TRANSPORT: character ceiling on the render; past it the read-back is cut with an explicit notice (never silent). 0 = a safe default kept under the host's per-response limit; raise it to widen a readback=true dump.")]
             int max_chars = 0) => Guard.Tool("housecarl_create", () =>
     {
-        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-
         // ---- TRANSPORT: format --------------------------------------------------------------------------
+        // Resolved BEFORE the unconfigured-MO2 prompt (PR #311 review 5 [low]): that prompt is a prose block, and
+        // returning it verbatim to a format="json" caller hands back something JsonDocument.Parse throws on — no
+        // ok, no error to branch on, which is the one thing this tool's Refuse() contract says never happens.
+        // SeqTools has the ordering right and is the model.
         bool json = Wire.WantsJson(format, out var ferr);
         if (ferr is not null) return ferr;   // the format value itself is unparsed — there is no known render to answer in
+        if (svc.ConfigPromptOrNull() is { } prompt)
+            return json ? JsonWire.RenderError(prompt, null) : prompt;
 
         // Every refusal below answers in the caller's requested format (apply's contract, unchanged): a json caller
         // must never have to parse "error: …" out of a string. Epoch is null on all of them — none has consulted a

--- a/src/housecarl-mcp/CreateTools.cs
+++ b/src/housecarl-mcp/CreateTools.cs
@@ -179,8 +179,9 @@ public static class CreateTools
         }
 
         var outcome = svc.CreateRecordsBatch(wire, patchName, into, readback, in_place, hasInPlace, acknowledge, origins);
+        // The lane the CALL named — stated, not derived from the outcome's flags (PR #311 review [medium]).
         return json
-            ? JsonWire.RenderCreateOutcome(outcome, max_chars, readback)
+            ? JsonWire.RenderCreateOutcome(outcome, max_chars, readback, hasInPlace ? "in_place" : hasInto ? "extend" : "patch")
             : WriteTools.RenderCreate(outcome, max_chars, readback);
     });
 }

--- a/src/housecarl-mcp/CreateTools.cs
+++ b/src/housecarl-mcp/CreateTools.cs
@@ -1,0 +1,241 @@
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ModelContextProtocol.Server;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// housecarl_create — the 2.0 S1 record-authoring surface (tool-surface-2.0 W3 PR 2; SPEC §2.2 ACT, §5.1/§5.2, §6.1).
+///
+/// ONE create tool: <c>records=</c> (the ACT operand set) × the LANE (new patch | <c>into</c> an existing one |
+/// <c>in_place</c> + consent) × TRANSPORT, over the SAME proven create cleave the 1.x tools drive
+/// (<see cref="LoadOrderService.CreateRecordsBatch"/> → WritePatchBuilder.CreateRecords) — consolidation of the
+/// surface, not a re-implementation of the engine. Absorbs <c>housecarl_create_record</c> (the degenerate
+/// one-record call) and <c>housecarl_bulk_create</c>.
+///
+/// What is new rather than renamed:
+/// <list type="bullet">
+/// <item><b>One record is a set of one</b> — the scalar tool dissolves. The single-create call is
+/// <c>records=[{record_type, editorid, ops}]</c>, which is also why the nested one-shot (a topic AND its lines)
+/// needs no second tool.</item>
+/// <item><b>One list spelling</b> — <c>records=</c> takes the inline array OR <c>"@&lt;absolute path&gt;"</c>
+/// (SPEC §5.1's @file convention, via the shared <see cref="ListParams"/> reader), so a generated authoring job
+/// lives in a file exactly as <c>apply</c>'s <c>ops=</c> does. Both lanes parse through the same STRICT reader: an
+/// undeclared member is refused BY NAME at its element, where the SDK binder silently drops one.</item>
+/// <item><b>in_place is the file's NAME</b> (§5.2) — the <c>target=</c>+<c>in_place=true</c> pair collapses into one
+/// string naming the file being written into.</item>
+/// <item><b>TRANSPORT</b> — <c>format=json</c> (a refusal is a document too) and the §2.1.1 epoch on every response.</item>
+/// </list>
+/// The 1.x create tools stay registered and unchanged through the build waves; they retire at 2.0.0 (clean cut,
+/// CHARTER_PHASE4 §3.4a).
+/// </summary>
+[McpServerToolType]
+public static class CreateTools
+{
+    [McpServerTool(Name = "housecarl_create", Title = "Create brand-new records (the 2.0 authoring surface)"),
+     Description(
+         "Create BRAND-NEW records (new FormIDs) and write them to a NEW patch plugin (originals untouched by " +
+         "default) — the net-new authoring tool, the companion to housecarl_apply (which edits EXISTING records). " +
+         "ONE surface: what to author (records=) x WHERE it lands (the LANE: a new patch | into= an existing one | " +
+         "in_place=\"X.esp\") x how it reads back (TRANSPORT).\n\n" +
+         "RECORDS. records= is the spec list — {record_type, editorid, ops?, parent?, collection?, grid?} each; ONE " +
+         "record is a set of one (the old create_record call). record_type is a catalog name ('Keyword', 'Spell', " +
+         "'LeveledItem', 'DialogTopic') or a 4-char signature ('KYWD'). editorid is REQUIRED — the EditorID the " +
+         "record is referenced by (in SkyPatcher/SPID, in xEdit); choose a clear, prefixed name. For an ABSTRACT " +
+         "record group name the CONCRETE subtype directly ('GlobalFloat'/'GlobalInt'/'GlobalShort', " +
+         "'GameSettingFloat'/'GameSettingInt'/'GameSettingString') — that is how a global variable or game setting " +
+         "is created. Each new FormID is auto-allocated in the patch's own 0x800+ range and REPORTED BACK: it is how " +
+         "you reference the record afterwards.\n\n" +
+         "OPS set the new record's fields — the same shape housecarl_apply takes MINUS formid (the record has no id " +
+         "yet): {field_path, op?, value?, key?, values?, entries?, compose?, composes?}. e.g. " +
+         "ops=[{field_path:'Name', value:'My Spell'}, {field_path:'EffectList', op:'Add', compose:{...}}]. compose " +
+         "builds a modeled struct (a leveled-list entry, an effect, a condition row, or a polymorphic element by its " +
+         "CONCRETE arm type); composes is its batch sibling. Copying a field from another record is housecarl_apply's " +
+         "CopyFrom — there is no other version of a record that does not exist yet.\n\n" +
+         "NESTING. parent= makes the record a CHILD (a dialogue line under a topic, a placed ref in a cell): the " +
+         "parent is an EXISTING record's FormID 'XXXXXX:Plugin.esp' OR the editorid of a record declared EARLIER in " +
+         "this same records= array (a same-call sibling) — which is how a topic AND its lines are authored in ONE " +
+         "call: records=[{record_type:'DialogTopic', editorid:'MyTopic'}, {record_type:'DialogResponses', " +
+         "editorid:'MyTopic_L1', parent:'MyTopic', ops:[{field_path:'Prompt', value:'Hello'}]}] (declare the parent " +
+         "BEFORE its children). A FormLink field VALUE can reference a same-call sibling too, written '@editorid' — " +
+         "so a line's order-chain and its topic back-link are authored in the same call (ops:[{field_path:'Topic', " +
+         "value:'@MyTopic'}, {field_path:'PreviousDialog', value:'@MyTopic_L1'}]). '@editorid' must name a record " +
+         "declared EARLIER in the array or the record being created ITSELF (self-reference — e.g. a quest's VMAD " +
+         "alias fragment whose Property.Object is the quest). Only on FormLink fields, including inside a compose " +
+         "spec. collection= names WHICH of the parent's child-lists to add into (e.g. a cell's " +
+         "'Persistent'/'Temporary') — needed only when more than one fits. grid= is the EXTERIOR cell's \"X,Y\" " +
+         "(record_type 'Cell' with parent= a Worldspace; houseCARL files it into the worldspace's block tree). A " +
+         "'Cell' with NO parent and NO grid is an INTERIOR cell.\n\n" +
+         "LANE — where the write lands. Default: a NEW patch named patch= (auto-suffixed if taken, so a prior patch " +
+         "is never overwritten). into='<an existing patch's filename>' ADDS these records to that patch instead — " +
+         "the way to accumulate across calls and sessions, and a parent created in a PRIOR into= call can be the " +
+         "parent here too (it resolves from the patch being extended, not only from the load order). " +
+         "in_place='<plugin filename>' is the opt-in THIRD lane: the records are created straight INTO your ORIGINAL " +
+         "file (incl. a mod houseCARL didn't author) — no new patch, and NO houseCARL backup or undo (keep your " +
+         "own). Full create parity in place, nesting included: a parent the target already owns hosts the child, a " +
+         "parent from another plugin is overridden in. Each new record gets a fresh FormID in THAT plugin's own " +
+         "range. The FIRST in-place write to a given plugin returns a one-time confirmation prompt (re-call with " +
+         "acknowledge=true); that consent covers touching your original ONLY — it NEVER skips the record verify.\n\n" +
+         "ALL-OR-NOTHING (Q3): if ANY spec is malformed or fails pre-flight — an unknown or ambiguous record_type, a " +
+         "missing editorid, an illegal field op, a nested child with no resolvable parent, an ambiguous collection, " +
+         "a type that cannot be created (the bare abstract base 'Global'/'GameSetting' needs a concrete subtype; the " +
+         "refusal names them) — the whole call is refused with per-record reasons and NOTHING is written. No partial " +
+         "patches, ever.\n\n" +
+         "WHAT ELSE IS REPORTED (never silent, Q3): creating dialogue lines reports VOICE coverage (a response with " +
+         "no .fuz plays SILENT in game — the audio is yours to provide) and RESULT-SCRIPT binding (a bound script " +
+         "that is unwired or uncompiled runs nothing); creating cells reports the world content houseCARL does NOT " +
+         "author (lighting, terrain, water, navmesh — Creation Kit work).\n\n" +
+         "TRANSPORT: readback=true expands the read-back to the FULL deep field-by-field dump of every created " +
+         "record (in place the verify ALWAYS runs and shows compactly by default; readback widens it) — confirm " +
+         "composed structures landed WITHOUT enabling the patch in MO2. The read-back is the WRITTEN FILE's content, " +
+         "NOT load-order truth: the patch wins nothing until enabled + sorted in MO2. format='json' returns the same " +
+         "data machine-readable; max_chars caps the render with an explicit notice, never a silent cut. Every " +
+         "response carries epoch=<hex> — the identity of the index build parents and link values resolved from.\n\n" +
+         "records= (like every list-valued input) also accepts \"@<absolute path>\" in place of the inline array: " +
+         "the SAME array as a JSON manifest on disk. The path must be ABSOLUTE (the server resolves relative paths " +
+         "against its OWN working directory, not yours), and the file is read at CALL time.\n\n" +
+         "This tool authors NEW records. Editing an existing record's fields is housecarl_apply; dropping a whole " +
+         "record is housecarl_remove_record; an EMPTY header-only trigger plugin (no records at all) is " +
+         "housecarl_create_plugin. Read first with housecarl_records.")]
+    public static string Create(
+        LoadOrderService svc,
+        [Description("The records to author, all into one artifact: [{record_type, editorid, ops?, parent?, collection?, grid?}, …] — or \"@<absolute path>\" to read that SAME array from a JSON manifest file. One record is a set of one. For a nested one-shot, declare the parent BEFORE the children whose parent= names its editorid. A member the shape does not declare is refused BY NAME at its element, never silently dropped.")]
+            JsonElement? records = null,
+        [Description("LANE: base filename for the NEW patch this call writes (default 'Patch'); auto-suffixed if taken, so a prior patch is never overwritten. Mutually exclusive with into= and in_place= — naming both lanes is refused, never silently ignored.")]
+            string? patch = null,
+        [Description("LANE: filename of an EXISTING houseCARL patch to ADD these records to instead of writing a fresh one — the way to accumulate across calls and sessions (a parent created in a prior into= call resolves from it too). Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead.")]
+            string? into = null,
+        [Description("LANE (opt-in): the FILENAME OF THE FILE BEING WRITTEN INTO, e.g. \"CoolWeapons.esp\" — create these records straight into that existing active plugin (incl. one houseCARL didn't author) instead of a patch. Your ORIGINAL file is rewritten; no houseCARL backup or undo. Naming the file is the point: it is what you are about to overwrite. OMIT for the default patch lane, which leaves every original untouched.")]
+            string? in_place = null,
+        [Description("Confirms the one-time in-place trade-off for the plugin named by in_place= — needed only on the FIRST in-place write to a given plugin (edit, create, remove, OR forward), never again for it. Waives the consent to touch your original ONLY; it NEVER skips the record verify. Meaningless without in_place=, and refused there rather than ignored.")]
+            bool acknowledge = false,
+        [Description("TRANSPORT: expand the read-back to the FULL deep field-by-field dump of every record this call created (not just the fields you set). The written file's content, not load-order truth.")]
+            bool readback = false,
+        [Description("TRANSPORT: 'text' (default) | 'json' (the same data, machine-readable, accounting in-band).")]
+            string? format = null,
+        [Description("TRANSPORT: character ceiling on the render; past it the read-back is cut with an explicit notice (never silent). 0 = a safe default kept under the host's per-response limit; raise it to widen a readback=true dump.")]
+            int max_chars = 0) => Guard.Tool("housecarl_create", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+
+        // ---- TRANSPORT: format --------------------------------------------------------------------------
+        bool json = Wire.WantsJson(format, out var ferr);
+        if (ferr is not null) return ferr;   // the format value itself is unparsed — there is no known render to answer in
+
+        // Every refusal below answers in the caller's requested format (apply's contract, unchanged): a json caller
+        // must never have to parse "error: …" out of a string. Epoch is null on all of them — none has consulted a
+        // build yet.
+        string Refuse(string message) => json ? JsonWire.RenderError(message, null) : "error: " + message;
+
+        // ---- LANE: the three destinations are mutually exclusive, and a dropped one is named ------------
+        // (SPEC §2.1 LANE, identical to housecarl_apply's — a parameter is honored or refused BY NAME, never
+        //  accepted-and-ignored. 1.x silently ignored patch_name= under into=.)
+        var patchName = string.IsNullOrWhiteSpace(patch) ? null : patch.Trim();
+        bool hasPatch = patchName is not null;
+        bool hasInto = !string.IsNullOrWhiteSpace(into);
+        bool hasInPlace = !string.IsNullOrWhiteSpace(in_place);
+        if (hasInto && hasInPlace)
+            return Refuse("into= and in_place= are different lanes — into= ADDS to a houseCARL patch, in_place= writes the records into an existing plugin's own file. Name one.");
+        if (hasPatch && hasInto)
+            return Refuse($"patch='{patch}' names a NEW patch to write, but into='{into}' extends an existing one — the two lanes are exclusive. Drop patch= to extend, or drop into= to write fresh.");
+        if (hasPatch && hasInPlace)
+            return Refuse($"patch='{patch}' names a NEW patch to write, but in_place='{in_place}' writes into that plugin's own file — the two lanes are exclusive. Drop patch= to create in place, or drop in_place= to write a patch.");
+        if (acknowledge && !hasInPlace)
+            return Refuse("acknowledge= confirms the in-place trade-off and is meaningless without in_place=<plugin filename>. Drop it, or name the file to write into.");
+
+        // ---- records= -----------------------------------------------------------------------------------
+        if (records is not { } recEl || recEl.ValueKind is JsonValueKind.Null)
+            return Refuse("nothing to create. Pass records=[{record_type, editorid, ops?, parent?, collection?}, …] " +
+                          "(or records=\"@<absolute path>\") — one record is a set of one.");
+        var (specs, rerr) = ListParams.Read<CreateRecordSpec>(recEl, "records", "{record_type, editorid, ops?, parent?, collection?, grid?}");
+        if (rerr is not null) return Refuse(rerr);
+
+        // ---- Map the 2.0 shapes onto the proven cleave --------------------------------------------------
+        // A rename over the same engine inputs: ops -> operations, op -> verb. The 1.x wire records (CreateOp /
+        // BulkOp) are reused deliberately so their published schemas stay untouched through the build waves.
+        var wire = new List<CreateOp>(specs!.Length);
+        var origins = new List<string?>(specs.Length);
+        for (int i = 0; i < specs.Length; i++)
+        {
+            var s = specs[i];
+            wire.Add(new CreateOp
+            {
+                RecordType = s.RecordType, Editorid = s.Editorid, Parent = s.Parent,
+                Collection = s.Collection, Grid = s.Grid,
+                Operations = s.Ops?.Select(o => new BulkOp
+                {
+                    FieldPath = o.FieldPath, Verb = o.Op ?? "Set", Value = o.Value, Key = o.Key,
+                    Values = o.Values, Entries = o.Entries, Compose = o.Compose, Composes = o.Composes,
+                }).ToArray(),
+            });
+            // The caller's OWN spelling for this spec. The 1.x batch labels its problems "record[i]" (its parameter
+            // is records=, singular label); this tool's element refusals say "records[i]", and a refusal must not
+            // point at a spelling the caller never wrote — so the engine label is carried, not left to drift.
+            origins.Add($"records[{i}]");
+        }
+
+        var outcome = svc.CreateRecordsBatch(wire, patchName, into, readback, in_place, hasInPlace, acknowledge, origins);
+        return json
+            ? JsonWire.RenderCreateOutcome(outcome, max_chars, readback)
+            : WriteTools.RenderCreate(outcome, max_chars, readback);
+    });
+}
+
+// ---- wire DTOs (the 2.0 create shapes) -----------------------------------------------------------------
+
+/// <summary>One brand-new record off the 2.0 wire (housecarl_create). The 1.x <see cref="CreateOp"/> with the SPEC
+/// §5.1 vocabulary — <c>operations</c> is <c>ops</c>, and each op is a <see cref="CreateFieldOp"/> whose verb member
+/// is <c>op</c>. Its own record rather than a reshaped CreateOp so the 1.x tools' published schemas stay untouched
+/// through the build waves.</summary>
+public sealed record CreateRecordSpec
+{
+    [JsonPropertyName("record_type"), Description("The kind of record to create: a catalog name ('Keyword', 'Spell', 'Weapon', 'DialogTopic', 'PlacedObject') or a 4-char signature ('KYWD'). For an abstract group name the concrete subtype ('GlobalFloat', 'GameSettingInt').")]
+    public string? RecordType { get; init; }
+
+    [JsonPropertyName("editorid"), Description("REQUIRED. The EditorID the new record is referenced by. A nested child's parent= can name this editorid (a same-call sibling parent), and a FormLink value can reference it as '@<editorid>'.")]
+    public string? Editorid { get; init; }
+
+    [JsonPropertyName("ops"), Description("The new record's fields: [{field_path, op?, value?, key?, values?, entries?, compose?, composes?}, …] — the same op shape housecarl_apply takes, minus formid. Omit to create a bare record (type + editorid only).")]
+    public CreateFieldOp[]? Ops { get; init; }
+
+    [JsonPropertyName("parent"), Description("For a NESTED record: the parent it nests under — an EXISTING parent's FormID 'XXXXXX:Plugin.esp', OR the editorid of a record declared EARLIER in this same records= array (a same-call sibling). Omit for a flat top-level record.")]
+    public string? Parent { get; init; }
+
+    [JsonPropertyName("collection"), Description("Which of the parent's child-collections to add into, BY NAME (e.g. a cell's 'Persistent') — needed only when more than one fits. Omit when unique or when parent is omitted.")]
+    public string? Collection { get; init; }
+
+    [JsonPropertyName("grid"), Description("For an EXTERIOR cell only (record_type 'Cell' with parent= a Worldspace): the cell's grid as \"X,Y\" (e.g. \"5,-12\"). A 'Cell' with NO parent and NO grid is an INTERIOR cell. Ignored for non-Cell types.")]
+    public string? Grid { get; init; }
+}
+
+/// <summary>One field op on a record being CREATED (housecarl_create). The <see cref="ApplyOp"/> shape minus the
+/// members a create has no meaning for: no <c>formid</c> (the id is auto-allocated), and no copy pole — copying a
+/// field FROM another version needs a record that already exists. Each of those is refused BY NAME by the strict
+/// reader, with the correction <see cref="ListParams"/> carries.</summary>
+public sealed record CreateFieldOp
+{
+    [JsonPropertyName("field_path"), Description("Dotted field path on the new record, e.g. 'Name' or 'BasicStats.Damage'. Step into a list/dict element mid-path with brackets ('Effects[0].Data.Magnitude'); at the LEAF use op + key, not brackets.")]
+    public string? FieldPath { get; init; }
+
+    [JsonPropertyName("op"), Description("Set (default) | Add | Remove | SetAtIndex | ReplaceAll | Merge. On a [Flags] enum, Add sets one bit and Remove clears one, leaving the others untouched.")]
+    public string? Op { get; init; }
+
+    [JsonPropertyName("value"), Description("The value, coerced to the field's type — a number, an enum name, a FormID 'XXXXXX:Plugin.esp', or '@<editorid>' for a same-call sibling on a FormLink field.")]
+    public string? Value { get; init; }
+
+    [JsonPropertyName("key"), Description("Dict key or list index at the leaf.")]
+    public string? Key { get; init; }
+
+    [JsonPropertyName("values"), Description("The whole new list for a list ReplaceAll.")]
+    public string[]? Values { get; init; }
+
+    [JsonPropertyName("entries"), Description("Key->value pairs for a dict Merge or dict ReplaceAll.")]
+    public Dictionary<string, string>? Entries { get; init; }
+
+    [JsonPropertyName("compose"), Description("Build a modeled struct: the arm for a polymorphic Set, or the element for a struct-element Add (e.g. 'LeveledItemEntry'; for a polymorphic list, the element's CONCRETE arm type such as 'ScriptObjectProperty').")]
+    public StructInput? Compose { get; init; }
+
+    [JsonPropertyName("composes"), Description("Build MANY modeled list elements in ONE op — the batch sibling of compose. With Add, appends each in order; with ReplaceAll, clears the list then appends each. Mutually exclusive with compose/value/values.")]
+    public StructInput[]? Composes { get; init; }
+}

--- a/src/housecarl-mcp/ForwardTools.cs
+++ b/src/housecarl-mcp/ForwardTools.cs
@@ -124,7 +124,7 @@ public static class ForwardTools
         var outcome = svc.ForwardRecords(targets, source.Trim(), patchName, into, readback, in_place, hasInPlace, acknowledge, dry_run);
         // The lane the CALL named — stated, not derived from the outcome's flags (PR #311 review [medium]).
         return json
-            ? JsonWire.RenderForwardOutcome(outcome, max_chars, readback, hasInPlace ? "in_place" : hasInto ? "extend" : "patch")
-            : WriteTools.RenderForward(outcome, max_chars);
+            ? JsonWire.RenderForwardOutcome(outcome, max_chars, readback, hasInPlace ? "in_place" : hasInto ? "into" : "patch")
+            : WriteTools.RenderForward(outcome, max_chars, laneAsName: true);
     });
 }

--- a/src/housecarl-mcp/ForwardTools.cs
+++ b/src/housecarl-mcp/ForwardTools.cs
@@ -82,7 +82,7 @@ public static class ForwardTools
             bool readback = false,
         [Description("TRANSPORT: 'text' (default) | 'json' (the same data, machine-readable, accounting in-band).")]
             string? format = null,
-        [Description("TRANSPORT: character ceiling on the render; past it the read-back is cut with an explicit notice (never silent). 0 = a safe default kept under the host's per-response limit; raise it to widen a readback=true dump.")]
+        [Description("TRANSPORT: character ceiling on the WHOLE render — the forwarded-record rows (each naming its source and the winner it out-ranks) and then the read-back. Past it, trailing rows are dropped with an explicit notice (never silent); the WRITE is unaffected. 0 = a safe default kept under the host's per-response limit.")]
             int max_chars = 0) => Guard.Tool("housecarl_forward", () =>
     {
         // format first, so the unconfigured-MO2 prompt answers a json caller as a DOCUMENT (PR #311 review 5 [low]).

--- a/src/housecarl-mcp/ForwardTools.cs
+++ b/src/housecarl-mcp/ForwardTools.cs
@@ -1,0 +1,129 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// housecarl_forward — the 2.0 S1 whole-record override surface (tool-surface-2.0 W3 PR 2; SPEC §2.2 ACT,
+/// §5.1/§5.2, §6.1).
+///
+/// Absorbs <c>housecarl_forward_record</c> over the unchanged forward cleave
+/// (<see cref="LoadOrderService.ForwardRecords"/> → WritePatchBuilder.ForwardRecords / ForwardRecordsInPlace).
+/// Vocabulary: <c>from_plugin</c> becomes <c>source</c> (§5.3 — the SOURCE axis word: WHOSE version), the
+/// <c>target=</c>+<c>in_place=true</c> pair becomes <c>in_place="X.esp"</c> (§5.2), <c>patch_name</c> is
+/// <c>patch</c>, <c>full_readback</c> is <c>readback</c>; TRANSPORT gains <c>format=json</c> and the §2.1.1 epoch.
+///
+/// <para><b>The pole's bound, stated not narrowed.</b> §4.2's <c>source</c> pole resolves a plugin wherever it lives
+/// — active, or a file on disk out of the order. Forwarding resolves its bodies THROUGH the load-order index
+/// (<c>view.GetRecord</c>), so the off-order arm is not reachable on this lane: <c>source=</c> here means an ACTIVE
+/// plugin, and a non-active one is refused BY NAME with the reason rather than silently treated as "doesn't define
+/// the record". The lifter is the off-order copy-source seam PR #310 landed for <c>CopyFrom</c>
+/// (<c>ResolveOffOrderCopySources</c>) — carried as a declared bound, not a quiet narrowing of the axis.</para>
+/// </summary>
+[McpServerToolType]
+public static class ForwardTools
+{
+    [McpServerTool(Name = "housecarl_forward", Title = "Forward a plugin's version of records as an override"),
+     Description(
+         "Forward a SPECIFIC plugin's version of one-or-more records as an override — xEdit's \"copy as override " +
+         "into\", the INVERSE of housecarl_apply. apply edits the load-order WINNER; this copies source='s whole " +
+         "record VERBATIM, so SOURCE's version (not the winner) becomes the patch's content. ONE surface: what to " +
+         "copy (formids=) x WHOSE version (source=) x WHERE it lands (the LANE) x how it reads back (TRANSPORT).\n\n" +
+         "WHAT IT IS FOR: RE-ASSERT an earlier mod's version over a later override (a late total-overhaul " +
+         "re-architected a record an earlier list patch had balanced — forward the earlier plugin's version back on " +
+         "top), or REVERT a record to vanilla (name a master — Skyrim.esm/Update.esm/… — as source). This copies the " +
+         "record WHOLE: it does NOT edit fields (that's housecarl_apply) and needs no field pre-flight, because a " +
+         "complete source record is legal by construction.\n\n" +
+         "formids= is set-valued — one or more 'XXXXXX:Plugin.esp', ALL copied from the SAME source; call again with " +
+         "into= to forward from a different source into the same patch. It also accepts [\"@<absolute path>\"].\n\n" +
+         "source= is an ACTIVE plugin that DEFINES or overrides each record. Forwarding does NOT add source as a " +
+         "master: the patch overrides the record's ORIGIN FormKey with the copied body, so the header carries the " +
+         "origin master + whatever the body references (exactly xEdit's copy-as-override-into-a-new-patch). A plugin " +
+         "on disk but NOT in the load order is refused by name — the bodies here resolve through the load-order " +
+         "index, so an off-order version isn't reachable on this lane.\n\n" +
+         "LANE — where the write lands. Default: a NEW patch named patch= (auto-suffixed if taken). into='<an " +
+         "existing patch's filename>' EXTENDS that patch — and if it ALREADY carries a forwarded FormKey, its " +
+         "existing override is REPLACED by source's body (xEdit's copy-as-override overwrite, flagged per record). " +
+         "in_place='<plugin filename>' forwards INTO an existing plugin's OWN file (incl. one houseCARL didn't " +
+         "author) — same replace-on-collision semantics, your ORIGINAL rewritten, no houseCARL backup or undo, and " +
+         "the same one-time acknowledge= consent as the sibling write tools.\n\n" +
+         "THE STALE-WINNER BYPASS RECIPE (pinned): forward from the source you want, then housecarl_apply into= the " +
+         "same patch — the ops edit the patch's FORWARDED copy and never re-resolve the (stale) load-order winner, " +
+         "so you build on the forwarded body directly.\n\n" +
+         "ALL-OR-NOTHING (Q3): the whole call is refused with a named reason and NOTHING is written if source isn't " +
+         "in the load order, was excluded (unparseable), is the output artifact itself, names a target twice, or " +
+         "simply doesn't DEFINE/override a given record (nothing there to forward). dry_run=true resolves every " +
+         "record from source, copies each into the in-memory would-be artifact, and STOPS before anything touches " +
+         "disk — what WOULD be forwarded, or EXACTLY the refusal the real call would give.\n\n" +
+         "Returns, per record, what was copied and the current winner it will out-rank once enabled (a forward whose " +
+         "version is ALREADY winning is flagged redundant, never silently a no-op). readback=true additionally " +
+         "returns each forwarded record IN FULL off the written file — the pre-enable verification that the copy is " +
+         "exactly the source's, WITHOUT enabling the patch in MO2 (the written file's content, not load-order " +
+         "truth). format='json' returns the same data machine-readable; max_chars caps the render with an explicit " +
+         "notice. Every response carries epoch=<hex> — the identity of the index build the sources and the " +
+         "out-ranked winners were resolved from.")]
+    public static string Forward(
+        LoadOrderService svc,
+        [Description("The record(s) to forward, each 'XXXXXX:Plugin.esp' — ALL copied from the SAME source. Set-valued; also accepts [\"@<absolute path>\"] to read the same list from a file.")]
+            string[]? formids = null,
+        [Description("SOURCE: the plugin filename WHOSE version of the record(s) to copy (e.g. 'Authoria - ATweaks.esp', or a master like 'Skyrim.esm' to revert to vanilla). Must be ACTIVE in the load order and must DEFINE or override each formid.")]
+            string? source = null,
+        [Description("LANE: base filename for the NEW patch this call writes (default 'Patch'); auto-suffixed if taken, so a prior patch is never overwritten. Mutually exclusive with into= and in_place= — naming both lanes is refused, never silently ignored.")]
+            string? patch = null,
+        [Description("LANE: filename of an EXISTING houseCARL patch to ADD these forwards to instead of writing a fresh one (accumulate across calls — e.g. forward from a different source into the same patch). If the patch already carries a forwarded FormKey, its existing override is REPLACED by source's body.")]
+            string? into = null,
+        [Description("LANE (opt-in): the FILENAME OF THE FILE BEING OVERWRITTEN, e.g. \"MyHandmadePatch.esp\" — forward INTO that existing active plugin's own file (incl. one houseCARL didn't author). Your ORIGINAL file is rewritten; no houseCARL backup or undo. A FormKey the target already carries is REPLACED by source's body.")]
+            string? in_place = null,
+        [Description("Confirms the one-time in-place trade-off for the plugin named by in_place= — needed only on the FIRST in-place write to a given plugin (edit, create, remove, OR forward), never again for it. Waives the consent to touch your original ONLY; it NEVER skips the record verify. Meaningless without in_place=, and refused there rather than ignored.")]
+            bool acknowledge = false,
+        [Description("DRY RUN: run the whole real pipeline and STOP before anything touches disk. Returns what WOULD be forwarded (per record: source, the winner it would out-rank, replace/redundant flags) + the expected masters, or EXACTLY the refusal the real call would give. Works on every lane.")]
+            bool dry_run = false,
+        [Description("TRANSPORT: also return each forwarded record IN FULL, read back from the written file on disk (every field, deep) — the pre-enable verify that the copy is exactly the source's. The written file's content, not load-order truth.")]
+            bool readback = false,
+        [Description("TRANSPORT: 'text' (default) | 'json' (the same data, machine-readable, accounting in-band).")]
+            string? format = null,
+        [Description("TRANSPORT: character ceiling on the render; past it the read-back is cut with an explicit notice (never silent). 0 = a safe default kept under the host's per-response limit; raise it to widen a readback=true dump.")]
+            int max_chars = 0) => Guard.Tool("housecarl_forward", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+
+        bool json = Wire.WantsJson(format, out var ferr);
+        if (ferr is not null) return ferr;
+        string Refuse(string message) => json ? JsonWire.RenderError(message, null) : "error: " + message;
+
+        // ---- LANE: the three destinations are mutually exclusive, and a dropped one is named (SPEC §2.1) ----
+        var patchName = string.IsNullOrWhiteSpace(patch) ? null : patch.Trim();
+        bool hasPatch = patchName is not null;
+        bool hasInto = !string.IsNullOrWhiteSpace(into);
+        bool hasInPlace = !string.IsNullOrWhiteSpace(in_place);
+        if (hasInto && hasInPlace)
+            return Refuse("into= and in_place= are different lanes — into= EXTENDS a houseCARL patch, in_place= rewrites an existing plugin's own file. Name one.");
+        if (hasPatch && hasInto)
+            return Refuse($"patch='{patch}' names a NEW patch to write, but into='{into}' extends an existing one — the two lanes are exclusive. Drop patch= to extend, or drop into= to write fresh.");
+        if (hasPatch && hasInPlace)
+            return Refuse($"patch='{patch}' names a NEW patch to write, but in_place='{in_place}' rewrites that plugin's own file — the two lanes are exclusive. Drop patch= to forward in place, or drop in_place= to write a patch.");
+        if (acknowledge && !hasInPlace)
+            return Refuse("acknowledge= confirms the in-place trade-off and is meaningless without in_place=<plugin filename>. Drop it, or name the file to overwrite.");
+
+        // ---- SELECT + SOURCE ---------------------------------------------------------------------------
+        if (string.IsNullOrWhiteSpace(source))
+            return Refuse("source= is required — name the plugin WHOSE version of the record(s) to forward (an earlier override to re-assert, or a master like 'Skyrim.esm' to revert to vanilla).");
+        if (formids is null || formids.Length == 0)
+            return Refuse("formids= is empty — pass the FormID(s) to forward from source, e.g. formids=[\"0012AB:CoolMod.esp\"] (one is a set of one), or [\"@<absolute path>\"] to read the list from a file.");
+        var (tokens, demand, _, xerr) = Artifacts.ExpandListInput(formids, "formids");
+        if (xerr is not null) return Refuse(xerr.StartsWith("error: ", StringComparison.Ordinal) ? xerr[7..] : xerr);
+        if (demand is not null)
+            // Same bound as housecarl_remove's, for the same reason: an artifact's identity column is epoch-BOUND,
+            // and the check only means something inside the consuming call's own capture — which the write lanes
+            // take inside the engine. Refused by name rather than honored unchecked.
+            return Refuse($"formids= names a result ARTIFACT ('{demand.Path}'), whose identity column is only valid at the epoch it was captured at ({demand.Epoch}) — the write lanes don't re-check that yet, and an unchecked artifact must not drive a write. Pass the FormIDs inline, or a plain list file (one FormID per line).");
+        var targets = tokens!.Where(t => !string.IsNullOrWhiteSpace(t)).Select(t => t.Trim()).ToList();
+        if (targets.Count == 0)
+            return Refuse("formids= expanded to an empty list — nothing to forward.");
+
+        var outcome = svc.ForwardRecords(targets, source.Trim(), patchName, into, readback, in_place, hasInPlace, acknowledge, dry_run);
+        return json
+            ? JsonWire.RenderForwardOutcome(outcome, max_chars, readback)
+            : WriteTools.RenderForward(outcome, max_chars);
+    });
+}

--- a/src/housecarl-mcp/ForwardTools.cs
+++ b/src/housecarl-mcp/ForwardTools.cs
@@ -85,10 +85,11 @@ public static class ForwardTools
         [Description("TRANSPORT: character ceiling on the render; past it the read-back is cut with an explicit notice (never silent). 0 = a safe default kept under the host's per-response limit; raise it to widen a readback=true dump.")]
             int max_chars = 0) => Guard.Tool("housecarl_forward", () =>
     {
-        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-
+        // format first, so the unconfigured-MO2 prompt answers a json caller as a DOCUMENT (PR #311 review 5 [low]).
         bool json = Wire.WantsJson(format, out var ferr);
         if (ferr is not null) return ferr;
+        if (svc.ConfigPromptOrNull() is { } prompt)
+            return json ? JsonWire.RenderError(prompt, null) : prompt;
         string Refuse(string message) => json ? JsonWire.RenderError(message, null) : "error: " + message;
 
         // ---- LANE: the three destinations are mutually exclusive, and a dropped one is named (SPEC §2.1) ----

--- a/src/housecarl-mcp/ForwardTools.cs
+++ b/src/housecarl-mcp/ForwardTools.cs
@@ -121,7 +121,10 @@ public static class ForwardTools
         if (targets.Count == 0)
             return Refuse("formids= expanded to an empty list — nothing to forward.");
 
-        var outcome = svc.ForwardRecords(targets, source.Trim(), patchName, into, readback, in_place, hasInPlace, acknowledge, dry_run);
+        // sourceParam: the refusals that name the source pole render THIS tool's word (PR #311 review 4 [low]) — the
+        // engine's are shared with the 1.x forward_record, whose pole is still spelled from_plugin=.
+        var outcome = svc.ForwardRecords(targets, source.Trim(), patchName, into, readback, in_place, hasInPlace, acknowledge, dry_run,
+                                         sourceParam: "source=");
         // The lane the CALL named — stated, not derived from the outcome's flags (PR #311 review [medium]).
         return json
             ? JsonWire.RenderForwardOutcome(outcome, max_chars, readback, hasInPlace ? "in_place" : hasInto ? "into" : "patch")

--- a/src/housecarl-mcp/ForwardTools.cs
+++ b/src/housecarl-mcp/ForwardTools.cs
@@ -122,8 +122,9 @@ public static class ForwardTools
             return Refuse("formids= expanded to an empty list — nothing to forward.");
 
         var outcome = svc.ForwardRecords(targets, source.Trim(), patchName, into, readback, in_place, hasInPlace, acknowledge, dry_run);
+        // The lane the CALL named — stated, not derived from the outcome's flags (PR #311 review [medium]).
         return json
-            ? JsonWire.RenderForwardOutcome(outcome, max_chars, readback)
+            ? JsonWire.RenderForwardOutcome(outcome, max_chars, readback, hasInPlace ? "in_place" : hasInto ? "extend" : "patch")
             : WriteTools.RenderForward(outcome, max_chars);
     });
 }

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1592,4 +1592,200 @@ static class JsonWire
         }
         return Finish(ms);
     }
+
+    // ---- housecarl_create (W3 PR 2) -----------------------------------------------------------------
+    /// <summary>The machine-readable twin of <see cref="WriteTools.RenderCreate"/> — the SAME data the text render
+    /// states (decision D2), on the same contract <see cref="RenderPatchOutcome"/> established: a refusal is a
+    /// document (<c>ok:false</c> with the reason), the first-touch consent prompt is its own flag rather than an
+    /// error, the epoch rides on every response, and truncation drops trailing ROWS so the document stays valid JSON.
+    /// <para>The three post-write REPORTS ride as data, not prose: a silent line, an inert result script and an empty
+    /// cell are the Q3 hazards the text render shouts about, and a json consumer that could not see them would be
+    /// exactly the silently-degraded mode this project refuses.</para></summary>
+    public static string RenderCreateOutcome(WritePatchBuilder.CreateOutcome o, int maxChars, bool readback)
+    {
+        int cap = Cap(maxChars);
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            w.WriteBoolean("ok", o.Success);
+            w.WriteBoolean("needs_acknowledge", o.NeedsAcknowledge);
+            w.WriteString("lane", o.InPlace ? "in_place" : o.Extended ? "extend" : "patch");
+            WriteNullable(w, "epoch", o.Epoch);
+            if (!o.Success)
+            {
+                WriteNullable(w, o.NeedsAcknowledge ? "confirmation" : "error", o.Error);
+                w.WriteEndObject();
+                w.Flush();          // INSIDE the using — without it the buffered document is unwritten and the
+                return Finish(ms);  // caller gets an EMPTY string (the PR #306 class; PR #310 hit it again).
+            }
+
+            w.WriteString("path", o.OutputPath);
+            w.WriteString("file", Path.GetFileName(o.OutputPath));
+            w.WriteNumber("bytes", o.Bytes);
+            WriteStringArray(w, "masters", o.Masters.ToList());
+
+            w.WriteNumber("total_created", o.Created.Count);
+            w.WriteStartArray("created");
+            int rendered = 0;
+            bool truncated = false;
+            foreach (var c in o.Created)
+            {
+                if (ms.Length >= cap) { truncated = true; break; }
+                w.WriteStartObject();
+                w.WriteString("formid", c.FormKey.ToString());
+                w.WriteString("record_type", c.RecordType);
+                w.WriteString("editorid", c.EditorId);
+                // A replace is never silent (the CreatedRecord contract): the same fact the text render puts in
+                // brackets, as a flag a consumer can branch on.
+                w.WriteBoolean("replaced_existing", c.ReplacedExisting);
+                w.WriteStartArray("ops");
+                foreach (var op in c.Ops)
+                {
+                    w.WriteStartObject();
+                    w.WriteString("label", op.Label);
+                    w.WriteBoolean("applied", op.Applied);
+                    WriteNullable(w, "error", op.Error);
+                    WriteNullable(w, "after", op.After);
+                    w.WriteEndObject();
+                }
+                w.WriteEndArray();
+                w.WriteEndObject();
+                rendered++;
+            }
+            w.WriteEndArray();
+            w.WriteNumber("rendered_created", rendered);
+
+            WriteVoiceReport(w, o.Voice);
+            WriteScriptBindingReport(w, o.ScriptBinding);
+            WriteCellShellReport(w, o.CellShell);
+
+            if (o.ReadBack is { } rb)
+            {
+                w.WriteString("readback_source", "written_file");
+                w.WriteBoolean("readback_full", readback);
+                w.WriteStartArray("readback");
+                foreach (var r in rb)
+                {
+                    if (ms.Length >= cap) { truncated = true; break; }
+                    w.WriteStartObject();
+                    w.WriteString("formid", r.Target.ToString());
+                    if (r.Error is not null) w.WriteString("error", r.Error);
+                    else
+                    {
+                        var rec = r.Record!;
+                        w.WriteString("type", rec.Type);
+                        WriteNullable(w, "editorid", rec.EditorId);
+                        w.WriteNumber("field_count", rec.Fields.Count);
+                        w.WriteStartArray("fields");
+                        foreach (var f in rec.Fields)
+                        {
+                            if (ms.Length >= cap) { truncated = true; break; }
+                            w.WriteStartObject();
+                            w.WriteString("path", f.Path);
+                            if (f.HasValue) w.WriteString("value", f.Token); else w.WriteString("note", f.Note);
+                            w.WriteEndObject();
+                        }
+                        w.WriteEndArray();
+                    }
+                    w.WriteEndObject();
+                }
+                w.WriteEndArray();
+            }
+
+            WriteNullable(w, "note", o.Note);
+            w.WriteBoolean("truncated", truncated);
+            if (truncated)
+                w.WriteString("truncated_note", $"the render hit max_chars={cap} and dropped trailing rows — the WRITE is complete and unaffected; raise max_chars to see the rest.");
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
+    /// <summary>The voice-coverage report as data (a created dialogue line with no .fuz plays SILENT in game). The
+    /// text render's "[!] WILL BE SILENT" becomes <c>fuz_present:false</c> + the path to put the audio at.</summary>
+    static void WriteVoiceReport(Utf8JsonWriter w, VoiceReport? report)
+    {
+        if (report is null || report.IsEmpty) return;
+        w.WriteStartObject("voice_coverage");
+        WriteNullable(w, "check_error", report.CheckError);
+        w.WriteStartArray("lines");
+        foreach (var l in report.Lines)
+        {
+            w.WriteStartObject();
+            w.WriteString("info", l.Info.ToString());
+            WriteNullable(w, "topic_editorid", l.TopicEditorId);
+            w.WriteNumber("response", l.ResponseNumber);
+            w.WriteBoolean("fuz_present", l.FuzPresent);
+            w.WriteBoolean("lip_present", l.LipPresent);
+            WriteNullable(w, "fuz_path", l.FuzPath);
+            WriteNullable(w, "lip_path", l.LipPath);
+            WriteNullable(w, "fuz_winner", l.FuzWinner);
+            w.WriteBoolean("fuz_contended", l.FuzAmbiguous);
+            // An "absent" that merely went unscanned is not the same claim as an absent that was looked for and
+            // not found — the text render says so in a note; here it is per-line data.
+            w.WriteBoolean("read_incomplete", l.ReadIncomplete);
+            w.WriteEndObject();
+        }
+        w.WriteEndArray();
+        w.WriteStartArray("undetermined");
+        foreach (var u in report.Undetermined)
+        {
+            w.WriteStartObject();
+            w.WriteString("info", u.Info.ToString());
+            WriteNullable(w, "topic_editorid", u.TopicEditorId);
+            w.WriteString("reason", u.Reason);
+            w.WriteEndObject();
+        }
+        w.WriteEndArray();
+        w.WriteEndObject();
+    }
+
+    /// <summary>The result-script binding report as data (a bound script that is unwired or uncompiled runs NOTHING
+    /// in game). <c>status</c> is the enum name the text render turns into "WILL NOT FIRE".</summary>
+    static void WriteScriptBindingReport(Utf8JsonWriter w, ScriptBindingReport? report)
+    {
+        if (report is null || report.IsEmpty) return;
+        w.WriteStartObject("result_script_coverage");
+        WriteNullable(w, "check_error", report.CheckError);
+        w.WriteStartArray("findings");
+        foreach (var f in report.Findings)
+        {
+            w.WriteStartObject();
+            w.WriteString("info", f.Info.ToString());
+            WriteNullable(w, "topic_editorid", f.TopicEditorId);
+            w.WriteString("status", f.Status.ToString());
+            w.WriteString("detail", f.Detail);
+            WriteStringArray(w, "missing_pex", f.MissingPex);
+            w.WriteBoolean("read_incomplete", f.ReadIncomplete);
+            w.WriteEndObject();
+        }
+        w.WriteEndArray();
+        w.WriteEndObject();
+    }
+
+    /// <summary>The cell-shell report as data (a created cell is a valid, correctly-placed record but EMPTY —
+    /// houseCARL does not author world content). <c>must_provide</c> is the Creation-Kit work list.</summary>
+    static void WriteCellShellReport(Utf8JsonWriter w, CellShellReport? report)
+    {
+        if (report is null || report.IsEmpty) return;
+        w.WriteStartObject("cell_shell");
+        WriteNullable(w, "check_error", report.CheckError);
+        w.WriteStartArray("cells");
+        foreach (var c in report.Cells)
+        {
+            w.WriteStartObject();
+            w.WriteString("cell", c.Cell.ToString());
+            w.WriteString("editorid", c.EditorId);
+            w.WriteBoolean("interior", c.Interior);
+            WriteStringArray(w, "must_provide", c.MustProvide);
+            w.WriteEndObject();
+        }
+        w.WriteEndArray();
+        // The grid-occupancy seam the text render declares — a json consumer must not read "cells: []" as "checked".
+        if (report.Cells.Any(c => !c.Interior))
+            w.WriteString("grid_occupancy_note",
+                "houseCARL does NOT check grid-occupancy — a NEW exterior cell at a grid your load order already fills collides. To change an existing cell, OVERRIDE it instead of creating a new one.");
+        w.WriteEndObject();
+    }
 }

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1951,10 +1951,12 @@ static class JsonWire
         if (report is null || report.IsEmpty) return;
         w.WriteStartObject("voice_coverage");
         WriteNullable(w, "check_error", report.CheckError);
+        int renderedLines = 0, renderedUndet = 0;
+        bool blockCut = false;
         w.WriteStartArray("lines");
         foreach (var l in report.Lines)
         {
-            if (Over(w, ms, cap)) { truncated = true; break; }
+            if (Over(w, ms, cap)) { truncated = true; blockCut = true; break; }
             w.WriteStartObject();
             w.WriteString("info", l.Info.ToString());
             WriteNullable(w, "topic_editorid", l.TopicEditorId);
@@ -1969,20 +1971,57 @@ static class JsonWire
             // not found — the text render says so in a note; here it is per-line data.
             w.WriteBoolean("read_incomplete", l.ReadIncomplete);
             w.WriteEndObject();
+            renderedLines++;
         }
         w.WriteEndArray();
         w.WriteStartArray("undetermined");
         foreach (var u in report.Undetermined)
         {
-            if (Over(w, ms, cap)) { truncated = true; break; }
+            if (Over(w, ms, cap)) { truncated = true; blockCut = true; break; }
             w.WriteStartObject();
             w.WriteString("info", u.Info.ToString());
             WriteNullable(w, "topic_editorid", u.TopicEditorId);
             w.WriteString("reason", u.Reason);
             w.WriteEndObject();
+            renderedUndet++;
         }
         w.WriteEndArray();
+        WriteBlockCensus(w, blockCut, ("lines", renderedLines, report.Lines.Count),
+                                      ("undetermined", renderedUndet, report.Undetermined.Count),
+            "voice coverage", cap,
+            "a created voiced response with NO .fuz plays SILENT in game — an empty or short list here is a RENDER cut, not a clean bill of health");
         w.WriteEndObject();
+    }
+
+    /// <summary>The per-BLOCK truncation census the three post-write reports carry (PR #311 review 5 [medium]).
+    /// <para>Without it a cut block renders as <c>lines: []</c> — indistinguishable from "nothing to report", which
+    /// is the exact inversion of what these blocks exist to say: an empty voice list reads as "every created line
+    /// is voiced" when it may mean "150 silent lines were dropped by the budget". The text renders have said so
+    /// since they were written (<c>AppendVoiceTrunc</c>); only the json twins were silent. And it is not an edge —
+    /// <see cref="RenderCreateOutcome"/>'s created rows budget against the SAME <c>cap</c> and run first, so
+    /// whenever they truncate, <c>Over</c> is already true at each report's first row and every block renders
+    /// empty, deterministically. The document-level <c>truncated</c> flag is a weaker claim: it does not say WHICH
+    /// block lost rows.</para>
+    /// <para>Counts ride even when nothing was cut — <c>rendered == total</c> is the positive statement that the
+    /// list IS complete, so a consumer never has to infer completeness from the absence of a marker.</para></summary>
+    static void WriteBlockCensus(Utf8JsonWriter w, bool cut, (string name, int rendered, int total) a,
+                                 (string name, int rendered, int total)? b, string blockLabel, int cap, string stakes)
+    {
+        w.WriteNumber($"total_{a.name}", a.total);
+        w.WriteNumber($"rendered_{a.name}", a.rendered);
+        if (b is { } bb)
+        {
+            w.WriteNumber($"total_{bb.name}", bb.total);
+            w.WriteNumber($"rendered_{bb.name}", bb.rendered);
+        }
+        w.WriteBoolean("truncated", cut);
+        // Deliberately NOT "raise max_chars": these blocks ride the WRITE renders, and re-issuing a create or an
+        // apply on the default lane auto-suffixes a second patch (the class this PR has now been told about three
+        // times). The note states the cut and the stakes and stops there — the write is done, the report is only a
+        // render of it, and the counts above are what a consumer branches on.
+        if (cut)
+            w.WriteString("truncated_note",
+                $"the {blockLabel} block hit max_chars={cap} and its rows were CUT — {stakes}. The WRITE is complete and unaffected; this block is only a render of it, so compare rendered_* against total_* rather than reading the array as the whole answer. Do NOT re-issue the write to widen this.");
     }
 
     /// <summary>The result-script binding report as data (a bound script that is unwired or uncompiled runs NOTHING
@@ -1992,10 +2031,12 @@ static class JsonWire
         if (report is null || report.IsEmpty) return;
         w.WriteStartObject("result_script_coverage");
         WriteNullable(w, "check_error", report.CheckError);
+        int renderedFindings = 0;
+        bool blockCut = false;
         w.WriteStartArray("findings");
         foreach (var f in report.Findings)
         {
-            if (Over(w, ms, cap)) { truncated = true; break; }
+            if (Over(w, ms, cap)) { truncated = true; blockCut = true; break; }
             w.WriteStartObject();
             w.WriteString("info", f.Info.ToString());
             WriteNullable(w, "topic_editorid", f.TopicEditorId);
@@ -2004,8 +2045,12 @@ static class JsonWire
             WriteStringArray(w, "missing_pex", f.MissingPex);
             w.WriteBoolean("read_incomplete", f.ReadIncomplete);
             w.WriteEndObject();
+            renderedFindings++;
         }
         w.WriteEndArray();
+        WriteBlockCensus(w, blockCut, ("findings", renderedFindings, report.Findings.Count), null,
+            "result-script coverage", cap,
+            "a bound script that is unwired or uncompiled runs NOTHING in game — an empty or short list here is a RENDER cut, not a clean bill of health");
         w.WriteEndObject();
     }
 
@@ -2016,18 +2061,23 @@ static class JsonWire
         if (report is null || report.IsEmpty) return;
         w.WriteStartObject("cell_shell");
         WriteNullable(w, "check_error", report.CheckError);
+        int renderedCells = 0;
+        bool blockCut = false;
         w.WriteStartArray("cells");
         foreach (var c in report.Cells)
         {
-            if (Over(w, ms, cap)) { truncated = true; break; }
+            if (Over(w, ms, cap)) { truncated = true; blockCut = true; break; }
             w.WriteStartObject();
             w.WriteString("cell", c.Cell.ToString());
             w.WriteString("editorid", c.EditorId);
             w.WriteBoolean("interior", c.Interior);
             WriteStringArray(w, "must_provide", c.MustProvide);
             w.WriteEndObject();
+            renderedCells++;
         }
         w.WriteEndArray();
+        WriteBlockCensus(w, blockCut, ("cells", renderedCells, report.Cells.Count), null, "cell shell", cap,
+            "a created cell is a valid record but EMPTY, and each dropped row is Creation-Kit work this response was supposed to name");
         // The grid-occupancy seam the text render declares — a json consumer must not read "cells: []" as "checked".
         if (report.Cells.Any(c => !c.Interior))
             w.WriteString("grid_occupancy_note",

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1714,8 +1714,17 @@ static class JsonWire
 
             WriteNullable(w, "note", o.Note);
             w.WriteBoolean("truncated", truncated);
+            // NOT the sibling renders' "raise max_chars to see the rest" (PR #311 review 4 [medium]). That remedy is
+            // safe on remove/forward/apply — a repeated remove is refused, a repeated forward re-copies identical
+            // bodies — but a repeated CREATE allocates the records AGAIN, and the trap does not care which transport
+            // asked: the text twin was moved off this wording one fold earlier and the json document kept it, so a
+            // json client raising max_chars and re-issuing walked into exactly what the fix existed to prevent.
             if (truncated)
-                w.WriteString("truncated_note", $"the render hit max_chars={cap} and dropped trailing rows — the WRITE is complete and unaffected; raise max_chars to see the rest.");
+                w.WriteString("truncated_note",
+                    $"the render hit max_chars={cap} and dropped trailing rows — the WRITE is complete and unaffected; every record WAS created. " +
+                    $"Read them back with {WriteTools.ReadBackCall(o, Path.GetFileName(o.OutputPath))} — do NOT re-issue this call to see the rest: a repeated create " +
+                    "allocates the records AGAIN (on the default lane patch= auto-suffixes into a second full patch; under into= each record is " +
+                    "re-created at its old FormID with its prior contents discarded).");
             w.WriteEndObject();
         }
         return Finish(ms);

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1490,13 +1490,19 @@ static class JsonWire
     // ---- housecarl_apply (W3 — the 2.0 write surface) -----------------------------------------------
     /// <summary>The machine-readable twin of <see cref="WriteTools.Render"/>: ONE write outcome, the SAME data the
     /// text render states (decision D2 — one write path, two renders). Everything the text lane treats as prose is a
-    /// typed field here: the lane taken, whether it was a dry run, the epoch of the build the winners resolved from,
+    /// typed field here: the lane the CALL NAMED (see below), whether it was a dry run, the epoch of the build the winners resolved from,
     /// per-op results, and the read-back. A REFUSAL is a document too (<c>ok:false</c> with the reason), not an empty
     /// body — a json caller must never have to parse "error: …" out of a string to learn the call failed. The
     /// first-touch in-place CONSENT prompt is its own flag: it is a required confirmation, not a failure (Q3).
     /// Budget handling matches every other json render — trailing ROWS drop and <c>truncated</c> says so, so the
-    /// document is always valid JSON rather than a string cut mid-token.</summary>
-    public static string RenderPatchOutcome(WritePatchBuilder.PatchOutcome o, int maxChars, bool readback)
+    /// document is always valid JSON rather than a string cut mid-token.
+    /// <para><b><paramref name="lane"/> is passed in, not derived from the outcome</b> (PR #311 review [medium]).
+    /// <c>Fail</c> and <c>NeedsAck</c> construct their outcome with <c>InPlace</c>/<c>Extended</c> at their
+    /// defaults, so deriving the lane from those flags reported <c>"patch"</c> for a refusal on an <c>into=</c>
+    /// call and — worse — for the first-touch in-place CONSENT PROMPT, a response that exists ONLY because the
+    /// caller asked to rewrite their own file. The tool layer knows which lane the call named; it says so, and the
+    /// value agrees with the outcome's flags on every success.</para></summary>
+    public static string RenderPatchOutcome(WritePatchBuilder.PatchOutcome o, int maxChars, bool readback, string lane)
     {
         int cap = Cap(maxChars);
         using var ms = new MemoryStream();
@@ -1506,7 +1512,7 @@ static class JsonWire
             w.WriteBoolean("ok", o.Success);
             w.WriteBoolean("needs_acknowledge", o.NeedsAcknowledge);
             w.WriteBoolean("dry_run", o.DryRun);
-            w.WriteString("lane", o.InPlace ? "in_place" : o.Extended ? "extend" : "patch");
+            w.WriteString("lane", lane);
             WriteNullable(w, "epoch", o.Epoch);
             if (!o.Success)
             {
@@ -1601,7 +1607,7 @@ static class JsonWire
     /// <para>The three post-write REPORTS ride as data, not prose: a silent line, an inert result script and an empty
     /// cell are the Q3 hazards the text render shouts about, and a json consumer that could not see them would be
     /// exactly the silently-degraded mode this project refuses.</para></summary>
-    public static string RenderCreateOutcome(WritePatchBuilder.CreateOutcome o, int maxChars, bool readback)
+    public static string RenderCreateOutcome(WritePatchBuilder.CreateOutcome o, int maxChars, bool readback, string lane)
     {
         int cap = Cap(maxChars);
         using var ms = new MemoryStream();
@@ -1610,7 +1616,7 @@ static class JsonWire
             w.WriteStartObject();
             w.WriteBoolean("ok", o.Success);
             w.WriteBoolean("needs_acknowledge", o.NeedsAcknowledge);
-            w.WriteString("lane", o.InPlace ? "in_place" : o.Extended ? "extend" : "patch");
+            w.WriteString("lane", lane);
             WriteNullable(w, "epoch", o.Epoch);
             if (!o.Success)
             {
@@ -1764,7 +1770,7 @@ static class JsonWire
     /// on <see cref="RenderPatchOutcome"/>'s contract: a refusal is a document, the consent prompt is its own flag,
     /// the epoch rides on every response. <c>remaining_records:0</c> is the "this file is now an inert shell" fact
     /// the text render spells out in a sentence.</summary>
-    public static string RenderRemovalOutcome(WritePatchBuilder.RemovalOutcome o, int maxChars)
+    public static string RenderRemovalOutcome(WritePatchBuilder.RemovalOutcome o, int maxChars, string lane)
     {
         int cap = Cap(maxChars);
         using var ms = new MemoryStream();
@@ -1773,7 +1779,7 @@ static class JsonWire
             w.WriteStartObject();
             w.WriteBoolean("ok", o.Success);
             w.WriteBoolean("needs_acknowledge", o.NeedsAcknowledge);
-            w.WriteString("lane", o.InPlace ? "in_place" : "into");
+            w.WriteString("lane", lane);
             WriteNullable(w, "epoch", o.Epoch);
             if (!o.Success)
             {
@@ -1821,7 +1827,7 @@ static class JsonWire
     /// flags here: <c>replaced_existing</c> (an override this artifact already carried is GONE) and
     /// <c>was_already_winner</c> (the forward re-asserts content that already wins — a no-op in effect, reported
     /// rather than silent).</summary>
-    public static string RenderForwardOutcome(WritePatchBuilder.ForwardOutcome o, int maxChars, bool readback)
+    public static string RenderForwardOutcome(WritePatchBuilder.ForwardOutcome o, int maxChars, bool readback, string lane)
     {
         int cap = Cap(maxChars);
         using var ms = new MemoryStream();
@@ -1831,7 +1837,7 @@ static class JsonWire
             w.WriteBoolean("ok", o.Success);
             w.WriteBoolean("needs_acknowledge", o.NeedsAcknowledge);
             w.WriteBoolean("dry_run", o.DryRun);
-            w.WriteString("lane", o.InPlace ? "in_place" : o.Extended ? "extend" : "patch");
+            w.WriteString("lane", lane);
             WriteNullable(w, "epoch", o.Epoch);
             if (!o.Success)
             {

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1702,6 +1702,63 @@ static class JsonWire
         return Finish(ms);
     }
 
+    // ---- housecarl_write_seq (W3 PR 2) --------------------------------------------------------------
+    /// <summary>The machine-readable twin of <see cref="SeqTools.Render"/>. Two Q3 facts the text render states in
+    /// prose are typed here: <c>written:false</c> with <c>quest_count:0</c> is the "no SGE quests, so no .seq is
+    /// needed" no-op (never a silent empty file), and <c>epoch:null</c> carries its own reason — this call consults
+    /// no load-order build, so an absent stamp is a fact rather than a missing field.</summary>
+    public static string RenderSeqOutcome(SeqOutcome o, int maxChars)
+    {
+        int cap = Cap(maxChars);
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            w.WriteBoolean("ok", o.Success);
+            w.WriteNull("epoch");
+            w.WriteString("epoch_note", "a .seq is derived from the plugin FILE alone (its FormID encoding is load-order-independent), so this call consulted no load-order build — the absent stamp is a fact, not a dropped field.");
+            if (!o.Success)
+            {
+                WriteNullable(w, "error", o.Error);
+                w.WriteEndObject();
+                w.Flush();          // INSIDE the using — see RenderPatchOutcome (an unflushed refusal renders EMPTY).
+                return Finish(ms);
+            }
+
+            w.WriteString("plugin", o.PluginFileName);
+            WriteNullable(w, "source_read_from", o.ResolvedFrom);
+            WriteNullable(w, "source_path", o.PluginPath);
+            w.WriteBoolean("written", o.SeqPath is not null);
+            WriteNullable(w, "seq_path", o.SeqPath);
+            WriteNullable(w, "mod_folder", o.ModFolder);
+            w.WriteBoolean("wrote_into_plugin_folder", o.WroteIntoPluginFolder);
+            w.WriteNumber("quest_count", o.Quests.Count);
+            if (o.Quests.Count == 0)
+                w.WriteString("note", "no start-game-enabled quests in this plugin — a .seq lists only SGE quests, so none is needed and NOTHING was written.");
+
+            w.WriteStartArray("quests");
+            int rendered = 0;
+            bool truncated = false;
+            foreach (var q in o.Quests)
+            {
+                if (ms.Length >= cap) { truncated = true; break; }
+                w.WriteStartObject();
+                WriteNullable(w, "editorid", q.EditorId is { Length: > 0 } e ? e : null);
+                w.WriteString("on_disk_formid", $"0x{q.OnDiskFormId:X8}");
+                w.WriteEndObject();
+                rendered++;
+            }
+            w.WriteEndArray();
+            w.WriteNumber("rendered_quests", rendered);
+            w.WriteBoolean("truncated", truncated);
+            if (truncated)
+                w.WriteString("truncated_note", $"the render hit max_chars={cap} and dropped trailing quest rows — the .seq is complete and unaffected; raise max_chars to see the rest.");
+            w.WriteString("standing_limit", "this makes the quest(s) START at game start; it does not verify the quest or its dialogue is otherwise well-formed.");
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
     // ---- housecarl_remove (W3 PR 2) -----------------------------------------------------------------
     /// <summary>The machine-readable twin of <see cref="WriteTools.RenderRemoval"/> — the SAME data (decision D2),
     /// on <see cref="RenderPatchOutcome"/>'s contract: a refusal is a document, the consent prompt is its own flag,

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -191,6 +191,15 @@ static class JsonWire
         return Finish(ms);
     }
 
+    /// <summary>Is the document already at its char ceiling? The writer BUFFERS, so <c>ms.Length</c> lags what has
+    /// been written — the row loops that budget by stream length flush first for exactly this reason. Shared by the
+    /// post-write report writers so all three judge the budget the same way.</summary>
+    static bool Over(Utf8JsonWriter w, MemoryStream ms, int cap)
+    {
+        w.Flush();
+        return ms.Length >= cap;
+    }
+
     static void WriteStringArray(Utf8JsonWriter w, string name, IReadOnlyList<string> items)
     {
         w.WriteStartArray(name);
@@ -1540,7 +1549,7 @@ static class JsonWire
             bool truncated = false;
             foreach (var op in o.Ops)
             {
-                if (ms.Length >= cap) { truncated = true; break; }
+                if (Over(w, ms, cap)) { truncated = true; break; }
                 w.WriteStartObject();
                 w.WriteString("formid", op.Target.ToString());
                 w.WriteString("record_type", op.RecordType);
@@ -1564,7 +1573,7 @@ static class JsonWire
                 w.WriteStartArray("readback");
                 foreach (var r in rb)
                 {
-                    if (ms.Length >= cap) { truncated = true; break; }
+                    if (Over(w, ms, cap)) { truncated = true; break; }
                     w.WriteStartObject();
                     w.WriteString("formid", r.Target.ToString());
                     if (r.Error is not null) w.WriteString("error", r.Error);
@@ -1577,7 +1586,7 @@ static class JsonWire
                         w.WriteStartArray("fields");
                         foreach (var f in rec.Fields)
                         {
-                            if (ms.Length >= cap) { truncated = true; break; }
+                            if (Over(w, ms, cap)) { truncated = true; break; }
                             w.WriteStartObject();
                             w.WriteString("path", f.Path);
                             if (f.HasValue) w.WriteString("value", f.Token); else w.WriteString("note", f.Note);
@@ -1637,7 +1646,7 @@ static class JsonWire
             bool truncated = false;
             foreach (var c in o.Created)
             {
-                if (ms.Length >= cap) { truncated = true; break; }
+                if (Over(w, ms, cap)) { truncated = true; break; }
                 w.WriteStartObject();
                 w.WriteString("formid", c.FormKey.ToString());
                 w.WriteString("record_type", c.RecordType);
@@ -1662,9 +1671,13 @@ static class JsonWire
             w.WriteEndArray();
             w.WriteNumber("rendered_created", rendered);
 
-            WriteVoiceReport(w, o.Voice);
-            WriteScriptBindingReport(w, o.ScriptBinding);
-            WriteCellShellReport(w, o.CellShell);
+            // The three post-write reports are INSIDE the budget (PR #311 round-2 review [low-medium]): the TEXT
+            // twin already stops each with an explicit notice, so leaving them unguarded here both blew the
+            // document past max_chars and closed it with truncated:false — the silent cut max_chars exists to
+            // prevent, and a D2 divergence in the direction that matters.
+            WriteVoiceReport(w, o.Voice, ms, cap, ref truncated);
+            WriteScriptBindingReport(w, o.ScriptBinding, ms, cap, ref truncated);
+            WriteCellShellReport(w, o.CellShell, ms, cap, ref truncated);
 
             if (o.ReadBack is { } rb)
             {
@@ -1673,7 +1686,7 @@ static class JsonWire
                 w.WriteStartArray("readback");
                 foreach (var r in rb)
                 {
-                    if (ms.Length >= cap) { truncated = true; break; }
+                    if (Over(w, ms, cap)) { truncated = true; break; }
                     w.WriteStartObject();
                     w.WriteString("formid", r.Target.ToString());
                     if (r.Error is not null) w.WriteString("error", r.Error);
@@ -1686,7 +1699,7 @@ static class JsonWire
                         w.WriteStartArray("fields");
                         foreach (var f in rec.Fields)
                         {
-                            if (ms.Length >= cap) { truncated = true; break; }
+                            if (Over(w, ms, cap)) { truncated = true; break; }
                             w.WriteStartObject();
                             w.WriteString("path", f.Path);
                             if (f.HasValue) w.WriteString("value", f.Token); else w.WriteString("note", f.Note);
@@ -1747,7 +1760,7 @@ static class JsonWire
             bool truncated = false;
             foreach (var q in o.Quests)
             {
-                if (ms.Length >= cap) { truncated = true; break; }
+                if (Over(w, ms, cap)) { truncated = true; break; }
                 w.WriteStartObject();
                 WriteNullable(w, "editorid", q.EditorId is { Length: > 0 } e ? e : null);
                 w.WriteString("on_disk_formid", $"0x{q.OnDiskFormId:X8}");
@@ -1801,7 +1814,7 @@ static class JsonWire
             bool truncated = false;
             foreach (var r in o.Removed)
             {
-                if (ms.Length >= cap) { truncated = true; break; }
+                if (Over(w, ms, cap)) { truncated = true; break; }
                 w.WriteStartObject();
                 w.WriteString("formid", r.Target.ToString());
                 w.WriteString("record_type", r.RecordType);
@@ -1858,7 +1871,7 @@ static class JsonWire
             bool truncated = false;
             foreach (var f in o.Forwarded)
             {
-                if (ms.Length >= cap) { truncated = true; break; }
+                if (Over(w, ms, cap)) { truncated = true; break; }
                 w.WriteStartObject();
                 w.WriteString("formid", f.Target.ToString());
                 w.WriteString("record_type", f.RecordType);
@@ -1880,7 +1893,7 @@ static class JsonWire
                 w.WriteStartArray("readback");
                 foreach (var r in rb)
                 {
-                    if (ms.Length >= cap) { truncated = true; break; }
+                    if (Over(w, ms, cap)) { truncated = true; break; }
                     w.WriteStartObject();
                     w.WriteString("formid", r.Target.ToString());
                     if (r.Error is not null) w.WriteString("error", r.Error);
@@ -1893,7 +1906,7 @@ static class JsonWire
                         w.WriteStartArray("fields");
                         foreach (var fl in rec.Fields)
                         {
-                            if (ms.Length >= cap) { truncated = true; break; }
+                            if (Over(w, ms, cap)) { truncated = true; break; }
                             w.WriteStartObject();
                             w.WriteString("path", fl.Path);
                             if (fl.HasValue) w.WriteString("value", fl.Token); else w.WriteString("note", fl.Note);
@@ -1917,7 +1930,7 @@ static class JsonWire
 
     /// <summary>The voice-coverage report as data (a created dialogue line with no .fuz plays SILENT in game). The
     /// text render's "[!] WILL BE SILENT" becomes <c>fuz_present:false</c> + the path to put the audio at.</summary>
-    static void WriteVoiceReport(Utf8JsonWriter w, VoiceReport? report)
+    static void WriteVoiceReport(Utf8JsonWriter w, VoiceReport? report, MemoryStream ms, int cap, ref bool truncated)
     {
         if (report is null || report.IsEmpty) return;
         w.WriteStartObject("voice_coverage");
@@ -1925,6 +1938,7 @@ static class JsonWire
         w.WriteStartArray("lines");
         foreach (var l in report.Lines)
         {
+            if (Over(w, ms, cap)) { truncated = true; break; }
             w.WriteStartObject();
             w.WriteString("info", l.Info.ToString());
             WriteNullable(w, "topic_editorid", l.TopicEditorId);
@@ -1944,6 +1958,7 @@ static class JsonWire
         w.WriteStartArray("undetermined");
         foreach (var u in report.Undetermined)
         {
+            if (Over(w, ms, cap)) { truncated = true; break; }
             w.WriteStartObject();
             w.WriteString("info", u.Info.ToString());
             WriteNullable(w, "topic_editorid", u.TopicEditorId);
@@ -1956,7 +1971,7 @@ static class JsonWire
 
     /// <summary>The result-script binding report as data (a bound script that is unwired or uncompiled runs NOTHING
     /// in game). <c>status</c> is the enum name the text render turns into "WILL NOT FIRE".</summary>
-    static void WriteScriptBindingReport(Utf8JsonWriter w, ScriptBindingReport? report)
+    static void WriteScriptBindingReport(Utf8JsonWriter w, ScriptBindingReport? report, MemoryStream ms, int cap, ref bool truncated)
     {
         if (report is null || report.IsEmpty) return;
         w.WriteStartObject("result_script_coverage");
@@ -1964,6 +1979,7 @@ static class JsonWire
         w.WriteStartArray("findings");
         foreach (var f in report.Findings)
         {
+            if (Over(w, ms, cap)) { truncated = true; break; }
             w.WriteStartObject();
             w.WriteString("info", f.Info.ToString());
             WriteNullable(w, "topic_editorid", f.TopicEditorId);
@@ -1979,7 +1995,7 @@ static class JsonWire
 
     /// <summary>The cell-shell report as data (a created cell is a valid, correctly-placed record but EMPTY —
     /// houseCARL does not author world content). <c>must_provide</c> is the Creation-Kit work list.</summary>
-    static void WriteCellShellReport(Utf8JsonWriter w, CellShellReport? report)
+    static void WriteCellShellReport(Utf8JsonWriter w, CellShellReport? report, MemoryStream ms, int cap, ref bool truncated)
     {
         if (report is null || report.IsEmpty) return;
         w.WriteStartObject("cell_shell");
@@ -1987,6 +2003,7 @@ static class JsonWire
         w.WriteStartArray("cells");
         foreach (var c in report.Cells)
         {
+            if (Over(w, ms, cap)) { truncated = true; break; }
             w.WriteStartObject();
             w.WriteString("cell", c.Cell.ToString());
             w.WriteString("editorid", c.EditorId);

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1601,8 +1601,13 @@ static class JsonWire
 
             WriteNullable(w, "note", o.Note);
             w.WriteBoolean("truncated", truncated);
+            // Lane-aware, shared with forward (PR #311 review 6): this document budgets the `ops` array, and a
+            // re-issue to widen it is safe on into=/dry-run but cuts a second patch on the default lane and
+            // re-serializes the caller's own file on in_place.
             if (truncated)
-                w.WriteString("truncated_note", $"the render hit max_chars={cap} and dropped trailing rows — the WRITE is complete and unaffected; raise max_chars to see the rest.");
+                w.WriteString("truncated_note",
+                    $"the render hit max_chars={cap} and dropped trailing rows — the WRITE is complete and unaffected; "
+                    + WriteTools.ApplyAgainRemedy(o, Path.GetFileName(o.OutputPath)) + ".");
             w.WriteEndObject();
         }
         return Finish(ms);

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1569,7 +1569,15 @@ static class JsonWire
                 // The read-back is the WRITTEN FILE's content, not load-order truth — stated as data (`source`) so a
                 // json consumer cannot lose the distinction the text render spells out in a sentence.
                 w.WriteString("readback_source", o.DryRun ? "in_memory_would_be_content" : "written_file");
-                w.WriteBoolean("readback_full", readback);
+                // Two DIFFERENT facts, told apart (PR #311 review 7 [nit]). `readback_full` describes THIS
+                // DOCUMENT: the json renders emit every field of every read-back row, so a present read-back
+                // is always the full one. It used to carry the caller's ASK, which the in-place lanes override
+                // (the service forces fullReadback), so `false` sat next to a complete field dump and a
+                // consumer branching on "are these fields complete?" got the opposite of the truth.
+                // `readback_requested` keeps the ask, which is what answers "why did I get one I did not ask
+                // for?" — the in-place lane forced it.
+                w.WriteBoolean("readback_full", true);
+                w.WriteBoolean("readback_requested", readback);
                 w.WriteStartArray("readback");
                 foreach (var r in rb)
                 {
@@ -1687,7 +1695,15 @@ static class JsonWire
             if (o.ReadBack is { } rb)
             {
                 w.WriteString("readback_source", "written_file");
-                w.WriteBoolean("readback_full", readback);
+                // Two DIFFERENT facts, told apart (PR #311 review 7 [nit]). `readback_full` describes THIS
+                // DOCUMENT: the json renders emit every field of every read-back row, so a present read-back
+                // is always the full one. It used to carry the caller's ASK, which the in-place lanes override
+                // (the service forces fullReadback), so `false` sat next to a complete field dump and a
+                // consumer branching on "are these fields complete?" got the opposite of the truth.
+                // `readback_requested` keeps the ask, which is what answers "why did I get one I did not ask
+                // for?" — the in-place lane forced it.
+                w.WriteBoolean("readback_full", true);
+                w.WriteBoolean("readback_requested", readback);
                 w.WriteStartArray("readback");
                 foreach (var r in rb)
                 {
@@ -1910,7 +1926,15 @@ static class JsonWire
             if (o.ReadBack is { } rb)
             {
                 w.WriteString("readback_source", o.DryRun ? "in_memory_would_be_content" : "written_file");
-                w.WriteBoolean("readback_full", readback);
+                // Two DIFFERENT facts, told apart (PR #311 review 7 [nit]). `readback_full` describes THIS
+                // DOCUMENT: the json renders emit every field of every read-back row, so a present read-back
+                // is always the full one. It used to carry the caller's ASK, which the in-place lanes override
+                // (the service forces fullReadback), so `false` sat next to a complete field dump and a
+                // consumer branching on "are these fields complete?" got the opposite of the truth.
+                // `readback_requested` keeps the ask, which is what answers "why did I get one I did not ask
+                // for?" — the in-place lane forced it.
+                w.WriteBoolean("readback_full", true);
+                w.WriteBoolean("readback_requested", readback);
                 w.WriteStartArray("readback");
                 foreach (var r in rb)
                 {

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1839,8 +1839,12 @@ static class JsonWire
 
             WriteNullable(w, "note", o.Note);
             w.WriteBoolean("truncated", truncated);
+            // Same remedy as the text twin, from the same constant (PR #311 review 6 [medium]): a repeated remove
+            // is REFUSED, so "raise max_chars" named the one call guaranteed to fail.
             if (truncated)
-                w.WriteString("truncated_note", $"the render hit max_chars={cap} and dropped trailing rows — the REMOVAL is complete and unaffected; raise max_chars to see the rest.");
+                w.WriteString("truncated_note",
+                    $"the render hit max_chars={cap} and dropped trailing rows — the REMOVAL is complete and unaffected; "
+                    + WriteTools.RemovedRowsRemedy + ".");
             w.WriteEndObject();
         }
         return Finish(ms);

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1702,6 +1702,156 @@ static class JsonWire
         return Finish(ms);
     }
 
+    // ---- housecarl_remove (W3 PR 2) -----------------------------------------------------------------
+    /// <summary>The machine-readable twin of <see cref="WriteTools.RenderRemoval"/> — the SAME data (decision D2),
+    /// on <see cref="RenderPatchOutcome"/>'s contract: a refusal is a document, the consent prompt is its own flag,
+    /// the epoch rides on every response. <c>remaining_records:0</c> is the "this file is now an inert shell" fact
+    /// the text render spells out in a sentence.</summary>
+    public static string RenderRemovalOutcome(WritePatchBuilder.RemovalOutcome o, int maxChars)
+    {
+        int cap = Cap(maxChars);
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            w.WriteBoolean("ok", o.Success);
+            w.WriteBoolean("needs_acknowledge", o.NeedsAcknowledge);
+            w.WriteString("lane", o.InPlace ? "in_place" : "into");
+            WriteNullable(w, "epoch", o.Epoch);
+            if (!o.Success)
+            {
+                WriteNullable(w, o.NeedsAcknowledge ? "confirmation" : "error", o.Error);
+                w.WriteEndObject();
+                w.Flush();          // INSIDE the using — see RenderPatchOutcome (an unflushed refusal renders EMPTY).
+                return Finish(ms);
+            }
+
+            w.WriteString("path", o.OutputPath);
+            w.WriteString("file", Path.GetFileName(o.OutputPath));
+            w.WriteNumber("bytes", o.Bytes);
+            w.WriteNumber("remaining_records", o.RemainingRecords);
+            WriteStringArray(w, "masters", o.Masters.ToList());
+
+            w.WriteNumber("total_removed", o.Removed.Count);
+            w.WriteStartArray("removed");
+            int rendered = 0;
+            bool truncated = false;
+            foreach (var r in o.Removed)
+            {
+                if (ms.Length >= cap) { truncated = true; break; }
+                w.WriteStartObject();
+                w.WriteString("formid", r.Target.ToString());
+                w.WriteString("record_type", r.RecordType);
+                WriteNullable(w, "editorid", r.EditorId);
+                w.WriteEndObject();
+                rendered++;
+            }
+            w.WriteEndArray();
+            w.WriteNumber("rendered_removed", rendered);
+
+            WriteNullable(w, "note", o.Note);
+            w.WriteBoolean("truncated", truncated);
+            if (truncated)
+                w.WriteString("truncated_note", $"the render hit max_chars={cap} and dropped trailing rows — the REMOVAL is complete and unaffected; raise max_chars to see the rest.");
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
+    // ---- housecarl_forward (W3 PR 2) ----------------------------------------------------------------
+    /// <summary>The machine-readable twin of <see cref="WriteTools.RenderForward"/> — the SAME data (decision D2),
+    /// on <see cref="RenderPatchOutcome"/>'s contract. The two per-record facts the text render puts in brackets are
+    /// flags here: <c>replaced_existing</c> (an override this artifact already carried is GONE) and
+    /// <c>was_already_winner</c> (the forward re-asserts content that already wins — a no-op in effect, reported
+    /// rather than silent).</summary>
+    public static string RenderForwardOutcome(WritePatchBuilder.ForwardOutcome o, int maxChars, bool readback)
+    {
+        int cap = Cap(maxChars);
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            w.WriteBoolean("ok", o.Success);
+            w.WriteBoolean("needs_acknowledge", o.NeedsAcknowledge);
+            w.WriteBoolean("dry_run", o.DryRun);
+            w.WriteString("lane", o.InPlace ? "in_place" : o.Extended ? "extend" : "patch");
+            WriteNullable(w, "epoch", o.Epoch);
+            if (!o.Success)
+            {
+                WriteNullable(w, o.NeedsAcknowledge ? "confirmation" : "error", o.Error);
+                w.WriteEndObject();
+                w.Flush();          // INSIDE the using — see RenderPatchOutcome (an unflushed refusal renders EMPTY).
+                return Finish(ms);
+            }
+
+            w.WriteString("path", o.OutputPath);
+            w.WriteString("file", Path.GetFileName(o.OutputPath));
+            w.WriteNumber("bytes", o.Bytes);
+            WriteStringArray(w, "masters", o.Masters.ToList());
+
+            w.WriteNumber("total_forwarded", o.Forwarded.Count);
+            w.WriteStartArray("forwarded");
+            int rendered = 0;
+            bool truncated = false;
+            foreach (var f in o.Forwarded)
+            {
+                if (ms.Length >= cap) { truncated = true; break; }
+                w.WriteStartObject();
+                w.WriteString("formid", f.Target.ToString());
+                w.WriteString("record_type", f.RecordType);
+                WriteNullable(w, "editorid", f.EditorId);
+                w.WriteString("source", f.FromPlugin);
+                w.WriteBoolean("replaced_existing", f.ReplacedExisting);
+                w.WriteBoolean("was_already_winner", f.WasAlreadyWinner);
+                WriteNullable(w, "prior_winner", f.PriorWinner);
+                w.WriteEndObject();
+                rendered++;
+            }
+            w.WriteEndArray();
+            w.WriteNumber("rendered_forwarded", rendered);
+
+            if (o.ReadBack is { } rb)
+            {
+                w.WriteString("readback_source", o.DryRun ? "in_memory_would_be_content" : "written_file");
+                w.WriteBoolean("readback_full", readback);
+                w.WriteStartArray("readback");
+                foreach (var r in rb)
+                {
+                    if (ms.Length >= cap) { truncated = true; break; }
+                    w.WriteStartObject();
+                    w.WriteString("formid", r.Target.ToString());
+                    if (r.Error is not null) w.WriteString("error", r.Error);
+                    else
+                    {
+                        var rec = r.Record!;
+                        w.WriteString("type", rec.Type);
+                        WriteNullable(w, "editorid", rec.EditorId);
+                        w.WriteNumber("field_count", rec.Fields.Count);
+                        w.WriteStartArray("fields");
+                        foreach (var fl in rec.Fields)
+                        {
+                            if (ms.Length >= cap) { truncated = true; break; }
+                            w.WriteStartObject();
+                            w.WriteString("path", fl.Path);
+                            if (fl.HasValue) w.WriteString("value", fl.Token); else w.WriteString("note", fl.Note);
+                            w.WriteEndObject();
+                        }
+                        w.WriteEndArray();
+                    }
+                    w.WriteEndObject();
+                }
+                w.WriteEndArray();
+            }
+
+            WriteNullable(w, "note", o.Note);
+            w.WriteBoolean("truncated", truncated);
+            if (truncated)
+                w.WriteString("truncated_note", $"the render hit max_chars={cap} and dropped trailing rows — the WRITE is complete and unaffected; raise max_chars to see the rest.");
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
     /// <summary>The voice-coverage report as data (a created dialogue line with no .fuz plays SILENT in game). The
     /// text render's "[!] WILL BE SILENT" becomes <c>fuz_present:false</c> + the path to put the audio at.</summary>
     static void WriteVoiceReport(Utf8JsonWriter w, VoiceReport? report)

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1779,8 +1779,11 @@ static class JsonWire
             w.WriteEndArray();
             w.WriteNumber("rendered_quests", rendered);
             w.WriteBoolean("truncated", truncated);
+            // Not "raise max_chars to see the rest" (PR #311 review 5 [medium]): widening the ceiling means
+            // re-issuing a WRITE. This PR moved SeqTools.Render off exactly this wording and left its json twin on
+            // it — the same D2 divergence, in the same fold that fixed it one renderer up.
             if (truncated)
-                w.WriteString("truncated_note", $"the render hit max_chars={cap} and dropped trailing quest rows — the .seq is complete and unaffected; raise max_chars to see the rest.");
+                w.WriteString("truncated_note", $"the render hit max_chars={cap} and dropped trailing quest rows — the .seq itself carries ALL of them; nothing is missing from the FILE. Re-run only if you need this LIST widened: that writes the .seq again (into= the folder named here to keep it in one).");
             w.WriteString("standing_limit", "this makes the quest(s) START at game start; it does not verify the quest or its dialogue is otherwise well-formed.");
             w.WriteEndObject();
         }
@@ -1930,8 +1933,12 @@ static class JsonWire
 
             WriteNullable(w, "note", o.Note);
             w.WriteBoolean("truncated", truncated);
+            // Lane-aware, same rule and same helper as the text twin (PR #311 review 5 [low]): a re-issue is
+            // idempotent on in_place=/into= and free on a dry run, but on the DEFAULT lane it cuts a second patch.
             if (truncated)
-                w.WriteString("truncated_note", $"the render hit max_chars={cap} and dropped trailing rows — the WRITE is complete and unaffected; raise max_chars to see the rest.");
+                w.WriteString("truncated_note",
+                    $"the render hit max_chars={cap} and dropped trailing rows — the WRITE is complete and unaffected; "
+                    + WriteTools.ForwardAgainRemedy(o, Path.GetFileName(o.OutputPath)) + ".");
             w.WriteEndObject();
         }
         return Finish(ms);

--- a/src/housecarl-mcp/ListParams.cs
+++ b/src/housecarl-mcp/ListParams.cs
@@ -1,0 +1,179 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// The shared reader behind every 2.0 typed list input (SPEC §5.1's <c>@file</c> convention): an inline JSON array,
+/// a bare <c>"@&lt;absolute path&gt;"</c>, or the one-element <c>["@&lt;path&gt;"]</c> spelling that matches how
+/// <c>formids=</c> writes it.
+///
+/// <para>ONE implementation, deliberately: the convention has to read the same on <c>apply</c>'s <c>ops=</c>, its
+/// <c>assignments=</c> zip, and <c>create</c>'s <c>records=</c>, and a second copy is how the three drift. It also
+/// keeps the STRICTNESS in one place — every lane deserializes with <see cref="Strict"/>, so an undeclared member is
+/// refused BY NAME inline too, where the SDK's own binder silently DROPS one (in a large generated batch a
+/// misspelled member would otherwise surface as a downstream refusal pointing away from the typo).</para>
+///
+/// <para>Lifted out of <c>ApplyTools</c> in W3 PR 2 unchanged — the wording of every refusal is what
+/// <c>apply-guard</c> pins, and this move is not the place to reword any of it.</para>
+/// </summary>
+internal static class ListParams
+{
+    /// <summary>Read a list parameter: inline array | "@path" | ["@path"]. Every failure (unreadable, not JSON, not
+    /// an array, empty, a null element, an undeclared member) names itself and its element (Q3).
+    /// <paramref name="shape"/> is the element shape as the caller writes it, e.g.
+    /// <c>{formid, field_path, op?, …}</c> — it appears verbatim in the refusals.</summary>
+    internal static (T[]? Items, string? Error) Read<T>(JsonElement el, string param, string shape)
+    {
+        string json;
+        string origin;
+        if (el.ValueKind is JsonValueKind.String)
+        {
+            var (text, err) = ReadAtFile(el.GetString(), param);
+            if (err is not null) return (null, err);
+            json = text!; origin = $"the file named by {param}";
+        }
+        else if (el.ValueKind is JsonValueKind.Array)
+        {
+            // The one-element ["@path"] spelling — the same shape formids= uses. An @-string anywhere else in the
+            // array is a mixed inline/file list, which has no meaning: refuse it by name rather than half-honor it.
+            var atIndexes = new List<int>();
+            int count = 0;
+            foreach (var item in el.EnumerateArray())
+            {
+                if (item.ValueKind is JsonValueKind.String && item.GetString()?.TrimStart().StartsWith('@') == true)
+                    atIndexes.Add(count);
+                count++;
+            }
+            if (atIndexes.Count > 0)
+            {
+                if (count != 1)
+                    return (null, $"{param}: \"@<path>\" reads the WHOLE list from a file, so it cannot be mixed with inline elements " +
+                                  $"(found {atIndexes.Count} @-element(s) among {count}). Pass either the inline array or a single \"@<absolute path>\".");
+                var (text, err) = ReadAtFile(el[0].GetString(), param);
+                if (err is not null) return (null, err);
+                json = text!; origin = $"the file named by {param}";
+            }
+            else { json = el.GetRawText(); origin = param; }
+        }
+        else
+            return (null, $"{param} must be an ARRAY of {shape} elements, or \"@<absolute path>\" naming a JSON file holding that array (got {el.ValueKind}).");
+
+        T[]? items;
+        try { items = JsonSerializer.Deserialize<T[]>(json, Strict); }
+        catch (JsonException ex)
+        {
+            // "byte N in the line", not "column": BytePositionInLine is a UTF-8 byte offset, which skews from the
+            // visual column on a non-ASCII line. STJ appends its own 0-based position block to the message, which
+            // would contradict the 1-based position stated here — shear it; the element path is surfaced separately.
+            string at = ex.LineNumber is { } ln ? $" at line {ln + 1}, byte {(ex.BytePositionInLine ?? 0) + 1} in the line" : "";
+            string element = ex.Path is { Length: > 2 } p ? $" (element {p})" : "";
+            var msg = ShearStjPosition(Guard.Flatten(ex.Message));
+            return (null, $"{origin} could not be parsed{at}{element}: {msg} " +
+                          $"Expected a JSON ARRAY of {shape} elements.{ElementVocabularyHint(msg)}");
+        }
+        if (items is null) return (null, $"{origin} parsed to JSON null — expected a JSON array of {shape} elements.");
+        if (items.Length == 0) return (null, $"{param} is an empty array — give at least one {shape}.");
+        for (int i = 0; i < items.Length; i++)
+            if (items[i] is null) return (null, $"{param}: element [{i}] is null — every element must be an object.");
+        return (items, null);
+    }
+
+    /// <summary>Read a list-input's <c>@&lt;path&gt;</c> target off disk. Absolute-path-only, for the reason the
+    /// message states: the server's working directory is not the caller's, so a relative path silently resolves
+    /// somewhere neither of them meant.</summary>
+    internal static (string? Text, string? Error) ReadAtFile(string? spelling, string param)
+    {
+        var raw = spelling?.Trim().Trim('"', '\'') ?? "";
+        var path = raw.StartsWith('@') ? raw[1..].Trim() : raw;
+        if (path.Length == 0)
+            return (null, $"{param}: \"@\" names no file — give the manifest's absolute path, e.g. \"@C:\\\\jobs\\\\ops.json\".");
+        if (!Path.IsPathRooted(path))
+            return (null, $"{param}: '{path}' must be an ABSOLUTE path — the server resolves relative paths against its OWN working directory, not yours.");
+        string text;
+        try { text = File.ReadAllText(path); }
+        catch (Exception ex) { return (null, $"{param}: could not read '{path}' — {ex.GetType().Name}: {ex.Message}"); }
+        if (string.IsNullOrWhiteSpace(text))
+            return (null, $"{param}: '{path}' is empty. Expected a JSON array.");
+        return (text, null);
+    }
+
+    /// <summary>STJ appends its own position block (" Path: $[0].x | LineNumber: 0 | BytePositionInLine: 89.") to a
+    /// JsonException message — 0-based, contradicting the 1-based position the refusal already leads with. Shear it.</summary>
+    internal static string ShearStjPosition(string msg)
+    {
+        int i = msg.IndexOf(" Path: ", StringComparison.Ordinal);
+        return i < 0 ? msg : msg[..i].TrimEnd();
+    }
+
+    /// <summary>Strict list-element options: property names case-insensitive like the SDK's inline binder, comments +
+    /// trailing commas tolerated (hand-generated files), and an undeclared member REFUSED by name.</summary>
+    internal static readonly JsonSerializerOptions Strict = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+    };
+
+    /// <summary>The §5.3 vocabulary correction for a rejected element member. The alias layer rewrites TOP-LEVEL
+    /// arguments only (<see cref="ToolCallShim"/> works off the published schema, and these members are inside a
+    /// list value), so a caller carrying 1.x habits — <c>verb</c>, <c>from_plugin</c>, <c>operations</c> — gets the
+    /// strict reader's unmapped-member refusal with no way to learn the new word. That refusal is correct and stays;
+    /// this appends the one-hop correction to it.
+    /// <para>Matched on the member name AND the DECLARING TYPE, both of which STJ already quotes. The type half is
+    /// load-bearing, not belt-and-braces: the same word means different things per shape — <c>verb</c> is a rename
+    /// on an op but a LEGAL member on a <see cref="NestedSet"/>, and <c>op</c> is legal on an op but a mistake in
+    /// two different ways on a nested set and on an <see cref="Assignment"/>. Matching the name alone would answer
+    /// a stray <c>op</c> inside an assignment by lecturing about `compose=`, a construct that caller never used
+    /// (PR #310 round-5 review). Unmatched pairs simply get no hint — the refusal still names the member and its
+    /// type.</para></summary>
+    static string ElementVocabularyHint(string stjMessage)
+    {
+        foreach (var (old, declaringType, correction) in ElementRenames)
+            if (stjMessage.Contains($"'{old}'", StringComparison.Ordinal) &&
+                stjMessage.Contains($".{declaringType}'", StringComparison.Ordinal))
+                return $" ('{old}' was the 1.x spelling — {correction})";
+        return "";
+    }
+
+    /// <summary>(old spelling, the type that REJECTED it, the correction). One row per (member, shape) pair,
+    /// because the same word is a different mistake — or no mistake — depending on which shape it landed in.</summary>
+    static readonly (string Old, string DeclaringType, string Correction)[] ElementRenames =
+    {
+        // AT THE OP LEVEL the rename is verb -> op. A nested set inside compose= is a NestedSet, shared verbatim
+        // with the 1.x wire shape, and legitimately still spells `verb` — hence the type gate, and the two
+        // opposite corrections below it.
+        ("verb", "ApplyOp", "at the OP level the verb member is now op — op=\"Add\". (A nested set inside compose= is unchanged and still takes verb.)"),
+        ("op", "NestedSet", "a nested set inside compose= still spells its verb `verb` — only the top-level op member was renamed to op"),
+        // An assignment names RECORDS, never a verb: the zip is a copy by construction. Answering this one with
+        // the NestedSet correction would lecture about compose=, which such a caller never used.
+        ("op", "Assignment", "an assignment pairs records and carries no verb — the zip is always a copy. Per-op verbs live in ops=[{…, op: \"…\"}]"),
+        ("verb", "Assignment", "an assignment pairs records and carries no verb — the zip is always a copy. Per-op verbs live in ops=[{…, op: \"…\"}]"),
+
+        ("from_plugin", "ApplyOp", "it split in two: from_source names the PLUGIN to copy from, from names a different source RECORD"),
+        ("fromplugin", "ApplyOp", "it split in two: from_source names the PLUGIN to copy from, from names a different source RECORD"),
+        ("from_plugin", "Assignment", "an assignment's source pole is from_source=, and its source RECORD is from="),
+
+        ("target_formid", "Assignment", "a copy's destination record is the assignments= zip's target="),
+        ("source_formid", "Assignment", "a copy's source record is the assignments= zip's from="),
+        ("source_plugin", "Assignment", "a copy's source pole is from_source="),
+        // The same three, typed into an OP instead — the zip's members do not exist there; an op copies with
+        // from=/from_source= and names its own record in formid=.
+        ("target_formid", "ApplyOp", "an op names its own record in formid=; a copy's DESTINATION only has a separate spelling inside the assignments= zip (target=)"),
+        ("source_formid", "ApplyOp", "an op's source record is from="),
+        ("source_plugin", "ApplyOp", "an op's source pole is from_source="),
+
+        // ---- W3 PR 2: housecarl_create's record specs + their field ops -------------------------------------
+        // The 1.x batch element spelled its field list `operations` and each op's verb `verb`; both are the same
+        // renames the op level took, so they get the same corrections in this shape's own words.
+        ("operations", "CreateRecordSpec", "a record spec's field list is now ops — ops=[{field_path, value}] (the §5.1 name, the same word housecarl_apply takes)"),
+        ("verb", "CreateFieldOp", "at the OP level the verb member is now op — op=\"Add\". (A nested set inside compose= is unchanged and still takes verb.)"),
+        // A create op sets a field on a record that does not exist yet, so three op members are not merely renamed
+        // — they have no meaning here at all, and the engine refuses each of them by name too. Say which is which.
+        ("formid", "CreateFieldOp", "a create op sets a field on the NEW record, whose FormID is auto-allocated and reported back — there is nothing to name here. The record's own identity is record_type + editorid on the spec"),
+        ("from_plugin", "CreateFieldOp", "copying a field FROM another version needs an existing record — a create has none yet. Set the field with value= / compose=, or create first and copy with housecarl_apply into= the same patch"),
+        ("from_source", "CreateFieldOp", "copying a field FROM another version needs an existing record — a create has none yet. Set the field with value= / compose=, or create first and copy with housecarl_apply into= the same patch"),
+        ("from", "CreateFieldOp", "copying a field FROM another record needs an existing target — a create has none yet. Set the field with value= / compose=, or create first and copy with housecarl_apply into= the same patch"),
+    };
+}

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4927,14 +4927,17 @@ public sealed class LoadOrderService : IDisposable
         if (targetPath is null)
             return WritePatchBuilder.RemovalOutcome.Fail(
                 $"in-place target '{target}' is not an active plugin in the load order — name a plugin enabled in MO2, by its " +
-                "plugin filename (e.g. 'CoolWeapons.esp'). in-place removes from the file the game actually loads. Nothing was written.");
+                "plugin filename (e.g. 'CoolWeapons.esp'). in-place removes from the file the game actually loads. Nothing was written.")
+                with { Epoch = view.Epoch };   // decided off the capture above — stamped like every post-capture outcome
 
         // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared
         //     with the edit + create lanes: acknowledging a plugin once covers editing, creating into, AND removing from
         //     it in place — it's the same "touch your original" trade-off).
         bool already = _store.IsInPlaceAcknowledged(targetPath);
         if (!already && !acknowledge)
-            return WritePatchBuilder.RemovalOutcome.NeedsAck(InPlaceHandshakeText(targetName, targetPath));
+            // Stamped for the reason the edit lane's twin states (the most common in-place response shape).
+            return WritePatchBuilder.RemovalOutcome.NeedsAck(InPlaceHandshakeText(targetName, targetPath))
+                with { Epoch = view.Epoch };
         string? ackNote = null;
         if (!already && acknowledge)
         {
@@ -4944,7 +4947,7 @@ public sealed class LoadOrderService : IDisposable
 
         // (3) Writable, same-volume parent pre-flight — refuse rather than degrade (the swap stages a sibling temp here).
         if (InPlaceParentUnwritable(targetPath, out var why))
-            return WritePatchBuilder.RemovalOutcome.Fail(why);
+            return WritePatchBuilder.RemovalOutcome.Fail(why) with { Epoch = view.Epoch };
 
         // (4) The write — absence verify forced ON (the model-C substitute for the dropped whole-plugin floor).
         var outcome = WritePatchBuilder.RemoveRecordsInPlace(resolver, keys, targetPath, targetName);
@@ -5054,7 +5057,8 @@ public sealed class LoadOrderService : IDisposable
         if (targetPath is null)
             return WritePatchBuilder.ForwardOutcome.Fail(
                 $"in-place target '{target}' is not an active plugin in the load order — name a plugin enabled in MO2, by its " +
-                "plugin filename (e.g. 'CoolWeapons.esp'). in-place forwards into the file the game actually loads. Nothing was written.");
+                "plugin filename (e.g. 'CoolWeapons.esp'). in-place forwards into the file the game actually loads. Nothing was written.")
+                with { Epoch = view.Epoch };   // decided off the capture above — stamped like every post-capture outcome
 
         // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared
         //     with the edit/create/remove lanes: it's the same "touch your original" trade-off).
@@ -5071,7 +5075,9 @@ public sealed class LoadOrderService : IDisposable
         else
         {
             if (!already && !acknowledge)
-                return WritePatchBuilder.ForwardOutcome.NeedsAck(InPlaceHandshakeText(targetName, targetPath));
+                // Stamped for the reason the edit lane's twin states (the most common in-place response shape).
+                return WritePatchBuilder.ForwardOutcome.NeedsAck(InPlaceHandshakeText(targetName, targetPath))
+                    with { Epoch = view.Epoch };
             if (!already && acknowledge)
             {
                 var (ok, err) = _store.RecordInPlaceAcknowledged(targetPath);
@@ -5082,7 +5088,7 @@ public sealed class LoadOrderService : IDisposable
         // (3) Writable, same-volume parent pre-flight — refuse rather than degrade. Kept in the dry run (it predicts
         //     exactly what the real write would refuse on).
         if (InPlaceParentUnwritable(targetPath, out var why))
-            return WritePatchBuilder.ForwardOutcome.Fail(why);
+            return WritePatchBuilder.ForwardOutcome.Fail(why) with { Epoch = view.Epoch };
 
         // (4) The write — touched-record verify forced ON (the model-C substitute for the dropped whole-plugin floor).
         var outcome = WritePatchBuilder.ForwardRecordsInPlace(resolver, specs, targetPath, targetName, fullReadback: true, dryRun);
@@ -6067,14 +6073,19 @@ public sealed class LoadOrderService : IDisposable
         if (targetPath is null)
             return WritePatchBuilder.CreateOutcome.Fail(
                 $"in-place target '{target}' is not an active plugin in the load order — name a plugin enabled in MO2, by its " +
-                "plugin filename (e.g. 'CoolWeapons.esp'). in-place creates into the file the game actually loads. Nothing was written.");
+                "plugin filename (e.g. 'CoolWeapons.esp'). in-place creates into the file the game actually loads. Nothing was written.")
+                with { Epoch = view.Epoch };   // decided off the capture above — stamped like every post-capture outcome
 
         // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared with
         //     the edit lane: acknowledging a plugin once covers BOTH editing and creating into it in place — it's the same
         //     "touch your original" trade-off).
         bool already = _store.IsInPlaceAcknowledged(targetPath);
         if (!already && !acknowledge)
-            return WritePatchBuilder.CreateOutcome.NeedsAck(InPlaceHandshakeText(targetName, targetPath));
+            // Stamped for the reason the edit lane's twin states: this branch is reached only after the view above
+            // resolved the target, and it is the MOST COMMON in-place response shape — an unstamped one would make
+            // "every write response carries an epoch" false exactly where a caller most often meets it.
+            return WritePatchBuilder.CreateOutcome.NeedsAck(InPlaceHandshakeText(targetName, targetPath))
+                with { Epoch = view.Epoch };
         string? ackNote = null;
         if (!already && acknowledge)
         {
@@ -6084,7 +6095,7 @@ public sealed class LoadOrderService : IDisposable
 
         // (3) Writable, same-volume parent pre-flight — refuse rather than degrade (the swap stages a sibling temp here).
         if (InPlaceParentUnwritable(targetPath, out var why))
-            return WritePatchBuilder.CreateOutcome.Fail(why);
+            return WritePatchBuilder.CreateOutcome.Fail(why) with { Epoch = view.Epoch };
 
         // (4) The write — created-record verify forced ON (the model-C substitute for the dropped whole-plugin floor).
         var outcome = WritePatchBuilder.CreateRecordsInPlace(resolver, rulebook, specs, targetPath, targetName, fullReadback: true);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -5929,7 +5929,7 @@ public sealed class LoadOrderService : IDisposable
     /// spec refuses the whole call (with per-record reasons) and the core <see cref="WritePatchBuilder.CreateRecords"/>
     /// likewise refuses the whole batch on any creatability/parent problem. One serialize for the lot.</summary>
     public WritePatchBuilder.CreateOutcome CreateRecordsBatch(IReadOnlyList<CreateOp> records, string? patchName, string? into, bool fullReadback = false,
-        string? target = null, bool inPlace = false, bool acknowledge = false)
+        string? target = null, bool inPlace = false, bool acknowledge = false, IReadOnlyList<string?>? origins = null)
     {
         if (records is null || records.Count == 0)
             return WritePatchBuilder.CreateOutcome.Fail("no records to create supplied — pass one or more {record_type, editorid, operations?, parent?, collection?} specs.");
@@ -5939,7 +5939,11 @@ public sealed class LoadOrderService : IDisposable
         for (int r = 0; r < records.Count; r++)
         {
             var rec = records[r];
-            var spec = BuildCreateSpec(rec.RecordType, rec.Editorid, rec.Operations ?? Array.Empty<BulkOp>(), rec.Parent, rec.Collection, rec.Grid, $"record[{r}]", problems);
+            // origins[r] is the CALLER's own spelling for this spec (housecarl_create passes "records[r]"; the 1.x
+            // batch passes none and keeps its own "record[r]"). Carried parallel to the list for the same reason
+            // ApplyEdits carries opOrigins: a refusal must never name an index shape the caller did not write.
+            var where = origins is not null && r < origins.Count && origins[r] is { } o ? o : $"record[{r}]";
+            var spec = BuildCreateSpec(rec.RecordType, rec.Editorid, rec.Operations ?? Array.Empty<BulkOp>(), rec.Parent, rec.Collection, rec.Grid, where, problems);
             if (spec is not null) specs.Add(spec);
         }
         if (problems.Count > 0)

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -5924,7 +5924,7 @@ public sealed class LoadOrderService : IDisposable
         string? target = null, bool inPlace = false, bool acknowledge = false)
     {
         var problems = new List<string>();
-        var spec = BuildCreateSpec(recordType, editorid, operations, parent, collection, grid, where: null, problems);
+        var spec = BuildCreateSpec(recordType, editorid, operations, parent, collection, grid, where: null, problems, CreateOpNaming.Legacy);
         if (spec is null)
             return WritePatchBuilder.CreateOutcome.Fail(
                 $"refused — {problems.Count} problem(s) creating the record; NOTHING created:\n  - " + string.Join("\n  - ", problems));
@@ -5938,7 +5938,8 @@ public sealed class LoadOrderService : IDisposable
     /// spec refuses the whole call (with per-record reasons) and the core <see cref="WritePatchBuilder.CreateRecords"/>
     /// likewise refuses the whole batch on any creatability/parent problem. One serialize for the lot.</summary>
     public WritePatchBuilder.CreateOutcome CreateRecordsBatch(IReadOnlyList<CreateOp> records, string? patchName, string? into, bool fullReadback = false,
-        string? target = null, bool inPlace = false, bool acknowledge = false, IReadOnlyList<string?>? origins = null)
+        string? target = null, bool inPlace = false, bool acknowledge = false, IReadOnlyList<string?>? origins = null,
+        CreateOpNaming? naming = null)
     {
         if (records is null || records.Count == 0)
             return WritePatchBuilder.CreateOutcome.Fail("no records to create supplied — pass one or more {record_type, editorid, operations?, parent?, collection?} specs.");
@@ -5952,7 +5953,7 @@ public sealed class LoadOrderService : IDisposable
             // batch passes none and keeps its own "record[r]"). Carried parallel to the list for the same reason
             // ApplyEdits carries opOrigins: a refusal must never name an index shape the caller did not write.
             var where = origins is not null && r < origins.Count && origins[r] is { } o ? o : $"record[{r}]";
-            var spec = BuildCreateSpec(rec.RecordType, rec.Editorid, rec.Operations ?? Array.Empty<BulkOp>(), rec.Parent, rec.Collection, rec.Grid, where, problems);
+            var spec = BuildCreateSpec(rec.RecordType, rec.Editorid, rec.Operations ?? Array.Empty<BulkOp>(), rec.Parent, rec.Collection, rec.Grid, where, problems, naming ?? CreateOpNaming.Legacy);
             if (spec is not null) specs.Add(spec);
         }
         if (problems.Count > 0)
@@ -5968,7 +5969,7 @@ public sealed class LoadOrderService : IDisposable
     /// through (a nested child) — null ⇒ a flat top-level record. Every problem (with the optional <paramref name="where"/>
     /// label) is APPENDED to <paramref name="problems"/>; returns null iff this record contributed any (all-or-nothing).</summary>
     WritePatchBuilder.CreateSpec? BuildCreateSpec(string? recordType, string? editorid, IReadOnlyList<BulkOp> operations,
-        string? parent, string? collection, string? grid, string? where, List<string> problems)
+        string? parent, string? collection, string? grid, string? where, List<string> problems, CreateOpNaming naming)
     {
         var prefix = where is null ? "" : where + ": ";
         int before = problems.Count;
@@ -5995,7 +5996,7 @@ public sealed class LoadOrderService : IDisposable
         if (catalogName is not null)
             for (int i = 0; i < operations.Count; i++)
             {
-                var req = MapCreateEdit(operations[i], i, catalogName, out var err);
+                var req = MapCreateEdit(operations[i], i, catalogName, naming, out var err);
                 if (err is not null) problems.Add($"{prefix}{err}"); else edits.Add(req!);
             }
 
@@ -6187,10 +6188,24 @@ public sealed class LoadOrderService : IDisposable
     /// derived), and a create op carries NO formid (it sets a field on the new record, whose id is auto-allocated) — a
     /// stray formid is refused loud (Q3) rather than silently ignored. Builds the composition <see cref="StructSpec"/> the
     /// same way <see cref="MapEdit"/> does (so a created Spell's Effects / LeveledItem's Entries compose identically).</summary>
-    WriteRequest? MapCreateEdit(BulkOp op, int index, string recordType, out string? error)
+    /// <summary>The CALLING tool's vocabulary for a create op, threaded down so a refusal never names a spelling the
+    /// caller cannot see (PR #311 review 6 [low]; the same rule as <c>origins</c>, <c>sourceParam</c>,
+    /// <c>offerModParam</c> and <c>InPlaceAgainHint</c>). <paramref name="Element"/> is the ops-list member word;
+    /// <paramref name="CopySubject"/> is how the copy refusal refers to what the caller asked for — the 2.0 surface
+    /// declares no <c>from_plugin</c>, so it can only have arrived via <c>op="CopyFrom"</c>.</summary>
+    public readonly record struct CreateOpNaming(string Element, string CopySubject)
+    {
+        /// <summary>1.x housecarl_create_record / housecarl_bulk_create — unchanged wording.</summary>
+        public static readonly CreateOpNaming Legacy = new("op", "CopyFrom / from_plugin");
+    }
+
+    WriteRequest? MapCreateEdit(BulkOp op, int index, string recordType, CreateOpNaming naming, out string? error)
     {
         error = null;
-        var where = $"op[{index}]";
+        // The caller's own element word (PR #311 review 6 [low]) — the same thread as `origins` one level up, for the
+        // same reason: `records[0]` was already the caller's spelling while `op[0]` was nobody's. On housecarl_create
+        // the member is ops=, so the navigational handle a caller must act on is ops[0].
+        var where = $"{naming.Element}[{index}]";
         if (!string.IsNullOrWhiteSpace(op.Formid))
         {
             error = $"{where}: a create operation sets a field on the NEW record, so it takes no formid (the new record's id is auto-allocated). Remove formid='{op.Formid}'.";
@@ -6211,7 +6226,11 @@ public sealed class LoadOrderService : IDisposable
 
         if (string.Equals(op.Verb, "CopyFrom", StringComparison.Ordinal) || !string.IsNullOrWhiteSpace(op.FromPlugin))
         {
-            error = $"{where}: CopyFrom / from_plugin copies from an EXISTING record's other version — it isn't valid when CREATING a record (there is no other version yet). Set the new field with value= / compose= instead.";
+            // Named in the CALLING surface's vocabulary (PR #311 review 6 [low]). This is reachable from
+            // housecarl_create — the strict reader only gates undeclared MEMBERS and `op` is declared, so
+            // ops:[{op:"CopyFrom"}] arrives here — where the old text answered with `from_plugin`, a member
+            // CreateFieldOp does not declare and the caller therefore cannot remove.
+            error = $"{where}: {naming.CopySubject} copies from an EXISTING record's other version — it isn't valid when CREATING a record (there is no other version yet). Set the new field with value= / compose= instead.";
             return null;
         }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -6669,11 +6669,34 @@ public sealed class LoadOrderService : IDisposable
     public SeqOutcome WriteSeq(string plugin, string? patchName, string? into)
     {
         if (string.IsNullOrWhiteSpace(plugin))
-            return SeqOutcome.Fail("no plugin given. Pass plugin= the path to the .esp/.esm/.esl whose start-game-enabled quests need a .seq.");
+            return SeqOutcome.Fail("no source given. Pass source= the plugin whose start-game-enabled quests need a .seq — its filename (e.g. 'MyQuestMod.esp') or an absolute path.");
         plugin = plugin.Trim().Trim('"');
-        if (!File.Exists(plugin))
-            return SeqOutcome.Fail($"no such plugin file: '{plugin}'. Pass the full path to the plugin (the path housecarl_create_record reported, or any .esp/.esm/.esl).");
-        var pluginPath = Path.GetFullPath(plugin);
+
+        // SOURCE resolution (§4.2's pole, W3 PR 2): a bare FILENAME is located across the MO2 folders — enabled,
+        // disabled, not-yet-listed, overwrite, and game Data — exactly as read_plugin_file and the copy donor lane
+        // locate one, through the SAME shared contract so two tools can never find different files for one name. An
+        // absolute path is still used verbatim (the 1.x spelling, and the "any file on disk" case). The arm that
+        // resolved is REPORTED, never silent: which copy was read decides which .seq you get.
+        string pluginPath, resolvedFrom;
+        try
+        {
+            string modsDir, dataDir, overwriteDir, profileDir;
+            lock (_gate) { EnsurePathsDerived(); modsDir = _modsDir; dataDir = _dataDir; overwriteDir = _overwriteDir; profileDir = _profileDir; }
+            var comp = Mo2LoadOrder.ReadComposition(profileDir);        // cheap text parse — no index build
+            var loc = LocatePluginFileOnDisk(comp, modsDir, dataDir, overwriteDir, plugin, null, offerModParam: false);
+            // The locate contract's own refusal names WHAT it couldn't find; this adds what THIS tool wants
+            // instead, so the caller isn't left to infer that a filename is allowed at all (the 1.x refusal said
+            // "pass the full path", which is now only one of the two accepted spellings).
+            if (loc.Error is not null)
+                return SeqOutcome.Fail($"{loc.Error} Pass source= the plugin's FILENAME (located across your MO2 mod folders, the overwrite folder and game Data) or an ABSOLUTE path to the .esp/.esm/.esl.");
+            if (loc.Ambiguous is { } hits)
+                return SeqOutcome.Fail($"'{Path.GetFileName(plugin)}' is provided by {hits.Count} locations — name the one you mean by absolute path: "
+                                     + string.Join("; ", hits.Select(h => $"{h.Where} -> {h.Path}")));
+            pluginPath = loc.Path!;
+            resolvedFrom = loc.Where;
+        }
+        catch (Exception ex) { return SeqOutcome.Fail(ex.Message); }
+
         if (!PluginExts.Contains(Path.GetExtension(pluginPath), StringComparer.OrdinalIgnoreCase))
             return SeqOutcome.Fail($"'{Path.GetFileName(pluginPath)}' is not a plugin (.esp/.esm/.esl).");
 
@@ -6690,7 +6713,7 @@ public sealed class LoadOrderService : IDisposable
 
             // No SGE quests → no .seq needed; write nothing, cut no folder (Q3: a clean, explicit "nothing to do").
             if (built.Quests.Count == 0)
-                return new SeqOutcome(true, null, null, null, built.Quests, built.PluginFileName, false);
+                return new SeqOutcome(true, null, null, null, built.Quests, built.PluginFileName, false) { ResolvedFrom = resolvedFrom, PluginPath = pluginPath };
 
             // Output folder: default into the plugin's OWN houseCARL folder; else fresh / explicit into=/patch_name.
             string? autoInto = (string.IsNullOrWhiteSpace(into) && string.IsNullOrWhiteSpace(patchName))
@@ -6715,7 +6738,8 @@ public sealed class LoadOrderService : IDisposable
             if (size != built.Bytes.Length)
                 return SeqOutcome.Fail($"wrote '{seqName}' but its on-disk size ({size}) does not match the {built.Bytes.Length} expected byte(s) — verify before relying on it.");
 
-            return new SeqOutcome(true, null, dest, rf.ModFolder, built.Quests, built.PluginFileName, autoInto is not null);
+            return new SeqOutcome(true, null, dest, rf.ModFolder, built.Quests, built.PluginFileName, autoInto is not null)
+                { ResolvedFrom = resolvedFrom, PluginPath = pluginPath };
         }
     }
 
@@ -7287,9 +7311,13 @@ public sealed class LoadOrderService : IDisposable
     /// direct PATH (rooted / has a separator) is used verbatim ("inspect ANY plugin file"); otherwise the argument
     /// is a FILENAME found across the whole install (enabled + disabled mod folders, overwrite, Data), with
     /// <paramref name="mod"/> narrowing a name several folders provide. Ambiguity comes back structured — each
-    /// caller renders its own remedy.</summary>
+    /// caller renders its own remedy.
+    /// <para><paramref name="offerModParam"/> (W3 PR 2): the not-found refusal ends by offering <c>mod=</c> as the
+    /// disambiguator, which is only true for callers that HAVE that parameter. A caller without one passes false and
+    /// the clause is omitted — a refusal must never send someone to a parameter their tool does not expose.</para></summary>
     internal static PluginLocateResult LocatePluginFileOnDisk(
-        Mo2Composition comp, string modsDir, string dataDir, string overwriteDir, string plugin, string? mod)
+        Mo2Composition comp, string modsDir, string dataDir, string overwriteDir, string plugin, string? mod,
+        bool offerModParam = true)
     {
         // A plugin's TICK state is a DIFFERENT fact from its mod folder's switch: a plugin can sit in an enabled mod
         // and be unchecked in MO2's right pane, and the game then does not load it. Every lane below returns the pair
@@ -7339,7 +7367,8 @@ public sealed class LoadOrderService : IDisposable
         var hits = Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, plugin);
         if (hits.Count == 0)
             return new(null, "", ServedStanding.NotAnInstallCopy, TickStanding.Unregistered, null, false, null,
-                $"'{Path.GetFileName(plugin)}' is in no mod folder (enabled, disabled, or not-yet-listed in MO2), the overwrite folder, or the game Data folder. Check the filename, pass an absolute path, or (if it's an MO2 mod) the exact folder via mod=.");
+                $"'{Path.GetFileName(plugin)}' is in no mod folder (enabled, disabled, or not-yet-listed in MO2), the overwrite folder, or the game Data folder. Check the filename, pass an absolute path"
+                + (offerModParam ? ", or (if it's an MO2 mod) the exact folder via mod=." : "."));
         if (hits.Count > 1) return new(null, "", ServedStanding.NotAnInstallCopy, TickStanding.Unregistered, null, false, hits, null);
         var (oneServed, oneDetail) = JudgeServed(comp, hits, hits[0].Path);
         // WhereNamesLayer: TRUE — Where IS the located hit's own label, folder and state both.
@@ -8009,6 +8038,17 @@ public sealed record SeqOutcome(
     bool Success, string? Error, string? SeqPath, string? ModFolder,
     IReadOnlyList<HousecarlCore.SeqFile.SeqQuest> Quests, string PluginFileName, bool WroteIntoPluginFolder)
 {
+    /// <summary>WHERE the source plugin resolved from (W3 PR 2, SPEC §4.2's "the response states which arm
+    /// resolved"): "direct path", or the located hit's own label (its mod folder and state). A .seq is derived from
+    /// ONE file's records, so which copy was read is load-bearing — a disabled folder's older copy yields a
+    /// different quest set than the served one, silently, unless the arm is stated. Null on a refusal taken before
+    /// the source resolved.</summary>
+    public string? ResolvedFrom { get; init; }
+
+    /// <summary>The absolute path the source resolved TO — the second half of the arm statement (the label says
+    /// which layer, this says which file).</summary>
+    public string? PluginPath { get; init; }
+
     public static SeqOutcome Fail(string error)
         => new(false, error, null, null, Array.Empty<HousecarlCore.SeqFile.SeqQuest>(), "", false);
 }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4981,13 +4981,16 @@ public sealed class LoadOrderService : IDisposable
     /// is written); <paramref name="target"/>+<paramref name="inPlace"/> is the explicit opt-in third route (in-place
     /// write lane; HCBR-2026-07-08-01 F4) — forward INTO an existing plugin's own file, consent-gated like the sibling
     /// write tools — see <see cref="ForwardRecordsInPlace"/>.</summary>
+    /// <param name="sourceParam">The SPELLING the calling tool exposes for the source pole — 1.x <c>from_plugin=</c>,
+    /// or <c>source=</c> on housecarl_forward (PR #311 review 4 [low]). Every refusal that names the parameter at all
+    /// renders the CALLING surface's word; a caller cannot fix a parameter its tool does not expose.</param>
     public WritePatchBuilder.ForwardOutcome ForwardRecords(IReadOnlyList<string> formids, string fromPlugin, string? patchName, string? into,
         bool fullReadback = false, string? target = null, bool inPlace = false, bool acknowledge = false,
-        bool dryRun = false)
+        bool dryRun = false, string sourceParam = "from_plugin")
     {
         if (string.IsNullOrWhiteSpace(fromPlugin))
             return WritePatchBuilder.ForwardOutcome.Fail(
-                "from_plugin is required — name the plugin whose version of the record(s) to forward (the earlier override, or a master to revert to vanilla).");
+                $"{sourceParam} is required — name the plugin whose version of the record(s) to forward (the earlier override, or a master to revert to vanilla).");
         if (formids is null || formids.Count == 0)
             return WritePatchBuilder.ForwardOutcome.Fail("no formids supplied — pass the FormID(s) to forward from the source plugin.");
 
@@ -5024,14 +5027,14 @@ public sealed class LoadOrderService : IDisposable
             var resolver = Resolver;                                      // builds/refreshes the index (Overlays for the source fetch + serialize)
 
             if (inPlace)
-                return ForwardRecordsInPlace(resolver, specs, target!.Trim(), acknowledge, dryRun);
+                return ForwardRecordsInPlace(resolver, specs, target!.Trim(), acknowledge, dryRun, sourceParam);
 
             // #225: a dry run resolves the would-be output path WITHOUT creating the mod folder (see ApplyEdits).
             string outPath; bool extend, created;
             try { outPath = ResolveOutputPath(patchName, into, out extend, out created, create: !dryRun); }
             catch (Exception ex) { return WritePatchBuilder.ForwardOutcome.Fail(ex.Message); }
 
-            var outcome = WritePatchBuilder.ForwardRecords(resolver, specs, outPath, extend, fullReadback, dryRun);
+            var outcome = WritePatchBuilder.ForwardRecords(resolver, specs, outPath, extend, fullReadback, dryRun, sourceParam);
             if (!outcome.Success && created) RemoveFolderCreatedThisCall(outPath);   // hunt F4: a refused forward leaves no orphan
             return outcome;
         }
@@ -5048,7 +5051,7 @@ public sealed class LoadOrderService : IDisposable
     /// fact no acknowledgement overrides.</summary>
     WritePatchBuilder.ForwardOutcome ForwardRecordsInPlace(
         LoadOrderResolver resolver, IReadOnlyList<WritePatchBuilder.ForwardSpec> specs, string target, bool acknowledge,
-        bool dryRun = false)
+        bool dryRun = false, string sourceParam = "from_plugin")
     {
         // (1) Resolve target -> real on-disk path via the load order (by plugin FILENAME). Refuse loud if it isn't a
         //     real active plugin. Same resolver as the edit + create + remove lanes.
@@ -5091,7 +5094,7 @@ public sealed class LoadOrderService : IDisposable
             return WritePatchBuilder.ForwardOutcome.Fail(why) with { Epoch = view.Epoch };
 
         // (4) The write — touched-record verify forced ON (the model-C substitute for the dropped whole-plugin floor).
-        var outcome = WritePatchBuilder.ForwardRecordsInPlace(resolver, specs, targetPath, targetName, fullReadback: true, dryRun);
+        var outcome = WritePatchBuilder.ForwardRecordsInPlace(resolver, specs, targetPath, targetName, fullReadback: true, dryRun, sourceParam);
 
         // (5-dry) #225: a successful dry run stamps NOTHING (no editedInPlace marker, no .seq note).
         if (dryRun)

--- a/src/housecarl-mcp/RemoveTools.cs
+++ b/src/housecarl-mcp/RemoveTools.cs
@@ -66,10 +66,11 @@ public static class RemoveTools
         [Description("TRANSPORT: character ceiling on the render; past it trailing rows are dropped with an explicit notice (never silent). 0 = a safe default kept under the host's per-response limit.")]
             int max_chars = 0) => Guard.Tool("housecarl_remove", () =>
     {
-        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-
+        // format first, so the unconfigured-MO2 prompt answers a json caller as a DOCUMENT (PR #311 review 5 [low]).
         bool json = Wire.WantsJson(format, out var ferr);
         if (ferr is not null) return ferr;
+        if (svc.ConfigPromptOrNull() is { } prompt)
+            return json ? JsonWire.RenderError(prompt, null) : prompt;
         string Refuse(string message) => json ? JsonWire.RenderError(message, null) : "error: " + message;
 
         // ---- LANE: exactly one destination, and a dropped one is named (SPEC §2.1) ---------------------

--- a/src/housecarl-mcp/RemoveTools.cs
+++ b/src/housecarl-mcp/RemoveTools.cs
@@ -104,6 +104,6 @@ public static class RemoveTools
         // The lane the CALL named — stated, not derived from the outcome's flags (PR #311 review [medium]).
         return json
             ? JsonWire.RenderRemovalOutcome(outcome, max_chars, hasInPlace ? "in_place" : "into")
-            : WriteTools.RenderRemoval(outcome, max_chars);
+            : WriteTools.RenderRemoval(outcome, max_chars, laneAsName: true);
     });
 }

--- a/src/housecarl-mcp/RemoveTools.cs
+++ b/src/housecarl-mcp/RemoveTools.cs
@@ -1,0 +1,108 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// housecarl_remove — the 2.0 S1 record-removal surface (tool-surface-2.0 W3 PR 2; SPEC §2.2 ACT, §5.1/§5.2, §6.1).
+///
+/// Absorbs <c>housecarl_remove_record</c> over the unchanged removal cleave
+/// (<see cref="LoadOrderService.RemoveRecords"/> → WritePatchBuilder.RemoveRecords / RemoveRecordsInPlace). Two
+/// things change beyond the vocabulary:
+/// <list type="bullet">
+/// <item><b>Plural by construction</b> — <c>formids=</c> is set-valued (§5.1: one is a degenerate set). The engine
+/// has ALWAYS taken a list (present-check + all-or-nothing over every target, one re-serialize); the 1.x tool
+/// exposed a single <c>formid=</c>, so dropping ten overrides cost ten rewrites of the same file. This is the
+/// "unreachable engine capability recovered" §6.1 names — no engine change, a reachable one.</item>
+/// <item><b>The lane is <c>into=</c>, not <c>patch=</c></b> — SPEC §5.1 defines <c>patch</c> as the NEW artifact a
+/// write creates, and a removal never creates one: it edits an artifact that already exists, which is exactly what
+/// <c>into=</c> names. (§5.3's row folded 1.x's bare <c>patch=</c> in with the <c>patch_name</c> drift instances —
+/// a spelling merge, not a role decision; taking it literally would re-create the one-word-two-meanings collision
+/// §5.2 exists to kill. The alias layer maps the old <c>patch=</c> onto <c>into=</c> by name.)</item>
+/// </list>
+/// </summary>
+[McpServerToolType]
+public static class RemoveTools
+{
+    [McpServerTool(Name = "housecarl_remove", Title = "Remove whole records (the 2.0 removal surface)"),
+     Description(
+         "Remove WHOLE records — a literal drop-from-plugin, NOT a flag-as-deleted stub. The counterpart to " +
+         "housecarl_apply: where apply ADDS an override into a patch, this drops one OUT of it. ONE surface: what to " +
+         "drop (formids=) x WHERE from (the LANE: into= a houseCARL patch | in_place=\"X.esp\") x how it reads back " +
+         "(TRANSPORT).\n\n" +
+         "WHAT CAN BE REMOVED. Only a record the named file ITSELF carries — one houseCARL created, or an override " +
+         "the patch accumulated via a prior apply/forward into= it. You CANNOT remove a record that lives in a " +
+         "master or another mod; you can only drop THIS file's override of it, which makes the load-order winner " +
+         "revert (the file stops touching that record). A FormID the file doesn't carry is REFUSED loud with " +
+         "nothing written (Q3). Reaches records in ANY group (cells, placed references, dialogue, navmesh).\n\n" +
+         "formids= is SET-VALUED — drop many records in ONE re-serialize (one is a set of one). ALL-OR-NOTHING " +
+         "(Q3): if ANY target isn't carried, the whole call is refused with per-record reasons and NOTHING is " +
+         "written. It also accepts [\"@<absolute path>\"] — the same list from a file, one FormID per line.\n\n" +
+         "LANE — where the removal happens. into='<a houseCARL patch's filename>' drops the records from that patch " +
+         "(the same name you pass to housecarl_apply's into=); it must be a patch houseCARL created. " +
+         "in_place='<plugin filename>' is the opt-in lane for ANY existing active plugin, including one houseCARL " +
+         "didn't author: your ORIGINAL file is rewritten — no houseCARL backup or undo (keep your own). The FIRST " +
+         "in-place write to a given plugin returns a one-time confirmation prompt (re-call with acknowledge=true); " +
+         "that consent covers touching your original ONLY — it NEVER skips the absence verify, which confirms on the " +
+         "re-opened file that every record you dropped is actually gone. Exactly one lane per call.\n\n" +
+         "Unused masters are pruned automatically: if a removed record held the file's last reference to a master, " +
+         "that master drops from the header on the re-write. Returns what was removed, the remaining masters, and " +
+         "how many records remain (0 = the file is an inert shell). Every response carries epoch=<hex> — the " +
+         "identity of the index build this removal's master context came from.\n\n" +
+         "To remove a list ENTRY (a keyword, an item, a leveled-list line) rather than a whole record, use " +
+         "housecarl_apply with op='Remove' instead. Read first with housecarl_records.")]
+    public static string Remove(
+        LoadOrderService svc,
+        [Description("The record(s) to drop, each 'XXXXXX:Plugin.esp' (6 hex digits, the defining master's filename) — set-valued, so many records drop in ONE re-serialize. Also accepts [\"@<absolute path>\"] to read the same list from a file.")]
+            string[]? formids = null,
+        [Description("LANE: filename of the houseCARL patch to remove the records FROM (e.g. 'MyMerge.esp') — a patch houseCARL created that carries them. Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead. Mutually exclusive with in_place=.")]
+            string? into = null,
+        [Description("LANE (opt-in): the FILENAME OF THE FILE BEING REWRITTEN, e.g. \"CoolWeapons.esp\" — drop the records straight out of that existing active plugin (incl. one houseCARL didn't author). Your ORIGINAL file is rewritten; no houseCARL backup or undo. It drops only a record the file itself defines or overrides. Mutually exclusive with into=.")]
+            string? in_place = null,
+        [Description("Confirms the one-time in-place trade-off for the plugin named by in_place= — needed only on the FIRST in-place write to a given plugin (edit, create, remove, OR forward), never again for it. Waives the consent to touch your original ONLY; it NEVER skips the absence verify. Meaningless without in_place=, and refused there rather than ignored.")]
+            bool acknowledge = false,
+        [Description("TRANSPORT: 'text' (default) | 'json' (the same data, machine-readable, accounting in-band).")]
+            string? format = null,
+        [Description("TRANSPORT: character ceiling on the render; past it trailing rows are dropped with an explicit notice (never silent). 0 = a safe default kept under the host's per-response limit.")]
+            int max_chars = 0) => Guard.Tool("housecarl_remove", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+
+        bool json = Wire.WantsJson(format, out var ferr);
+        if (ferr is not null) return ferr;
+        string Refuse(string message) => json ? JsonWire.RenderError(message, null) : "error: " + message;
+
+        // ---- LANE: exactly one destination, and a dropped one is named (SPEC §2.1) ---------------------
+        bool hasInto = !string.IsNullOrWhiteSpace(into);
+        bool hasInPlace = !string.IsNullOrWhiteSpace(in_place);
+        if (hasInto && hasInPlace)
+            return Refuse($"into='{into}' and in_place='{in_place}' are different lanes — into= drops the records from a houseCARL patch, in_place= rewrites an existing plugin's own file. Name one.");
+        if (!hasInto && !hasInPlace)
+            return Refuse("no lane named. Removal never creates a new artifact — it edits one that exists: pass into=<a houseCARL patch's filename> to drop the records from that patch, or in_place=<plugin filename> to drop them straight out of an existing plugin (opt-in, rewrites your original).");
+        if (acknowledge && !hasInPlace)
+            return Refuse("acknowledge= confirms the in-place trade-off and is meaningless without in_place=<plugin filename>. Drop it, or name the file to rewrite.");
+
+        // ---- formids= (set-valued; the @file spelling shared with every other list input) ---------------
+        if (formids is null || formids.Length == 0)
+            return Refuse("formids= is empty — pass the FormID(s) to drop, e.g. formids=[\"0012AB:CoolMod.esp\"] (one is a set of one), or [\"@<absolute path>\"] to read the list from a file.");
+        var (tokens, demand, _, xerr) = Artifacts.ExpandListInput(formids, "formids");
+        if (xerr is not null) return Refuse(xerr.StartsWith("error: ", StringComparison.Ordinal) ? xerr[7..] : xerr);
+        if (demand is not null)
+            // An artifact's identity column is epoch-BOUND (SPEC §2.1.1): the read tools check it inside the
+            // consuming call's own capture, which is the only place the comparison means anything. The write lanes
+            // capture inside the engine, so that check has no home here yet — refuse by name rather than honor a
+            // list whose freshness nothing verified (a stale identity column driving a REMOVAL is the worst place
+            // to find out). A plain list file (one FormID per line) is unaffected.
+            return Refuse($"formids= names a result ARTIFACT ('{demand.Path}'), whose identity column is only valid at the epoch it was captured at ({demand.Epoch}) — the write lanes don't re-check that yet, and an unchecked artifact must not drive a removal. Pass the FormIDs inline, or a plain list file (one FormID per line).");
+        var targets = tokens!.Where(t => !string.IsNullOrWhiteSpace(t)).Select(t => t.Trim()).ToList();
+        if (targets.Count == 0)
+            return Refuse("formids= expanded to an empty list — nothing to remove.");
+
+        // LANE-as-name maps onto the 1.x service contract: into= IS the patch lane's artifact, in_place= the
+        // target+bool pair (§5.2). The service's own exclusivity checks stay as the second line of defence.
+        var outcome = svc.RemoveRecords(targets, hasInto ? into : null, in_place, hasInPlace, acknowledge);
+        return json
+            ? JsonWire.RenderRemovalOutcome(outcome, max_chars)
+            : WriteTools.RenderRemoval(outcome);
+    });
+}

--- a/src/housecarl-mcp/RemoveTools.cs
+++ b/src/housecarl-mcp/RemoveTools.cs
@@ -101,8 +101,9 @@ public static class RemoveTools
         // LANE-as-name maps onto the 1.x service contract: into= IS the patch lane's artifact, in_place= the
         // target+bool pair (§5.2). The service's own exclusivity checks stay as the second line of defence.
         var outcome = svc.RemoveRecords(targets, hasInto ? into : null, in_place, hasInPlace, acknowledge);
+        // The lane the CALL named — stated, not derived from the outcome's flags (PR #311 review [medium]).
         return json
-            ? JsonWire.RenderRemovalOutcome(outcome, max_chars)
-            : WriteTools.RenderRemoval(outcome);
+            ? JsonWire.RenderRemovalOutcome(outcome, max_chars, hasInPlace ? "in_place" : "into")
+            : WriteTools.RenderRemoval(outcome, max_chars);
     });
 }

--- a/src/housecarl-mcp/SeqTools.cs
+++ b/src/housecarl-mcp/SeqTools.cs
@@ -13,6 +13,17 @@ namespace HousecarlMcp;
 /// reviewable houseCARL mod folder (originals untouched — same folder-per-patch model as every other write). The byte
 /// format and FormID encoding are load-order-independent (see <see cref="HousecarlCore.SeqFile"/>), so the .seq is correct
 /// the moment it's written and travels with the mod.
+///
+/// <para><b>The 2.0 surface (tool-surface-2.0 W3 PR 2).</b> The tool NAME is kept (SPEC §6.1: an S1 selection with a
+/// declared S2 file output, tiny, and its teaching — when a .seq is needed at all — is real), so this is a
+/// parameter migration rather than a new tool: <c>plugin</c> → <c>source</c> (the SOURCE pole, §5.3, now resolving a
+/// bare FILENAME across the MO2 folders instead of demanding a full path), <c>patch_name</c> → <c>patch</c>, plus
+/// TRANSPORT (<c>format=json</c>, <c>max_chars</c>). The alias layer maps the old spellings by name.</para>
+///
+/// <para><b>No epoch, stated rather than omitted</b> (SPEC §2.1.1): every other write response carries the
+/// fingerprint of the index build it resolved against. This call consults NO build — the .seq is derived from one
+/// plugin FILE, and its FormID encoding is load-order-independent by design — so a stamp here would name evidence
+/// that was never read. The render says so instead of leaving a caller to wonder which of the two it is.</para>
 /// </summary>
 [McpServerToolType]
 public static class SeqTools
@@ -21,25 +32,39 @@ public static class SeqTools
      Description(
          "Write the SEQ file (Data\\SEQ\\<plugin>.seq) a plugin needs for its START-GAME-ENABLED quests to actually run. " +
          "Ticking 'Start Game Enabled' on a quest does NOTHING on its own — without the .seq the quest, and any dialogue or " +
-         "change gated on it, silently never starts. Pass plugin= the path to the .esp/.esm/.esl (e.g. the path " +
-         "housecarl_create_record reported for your patch); houseCARL reads its start-game-enabled quests and writes the " +
-         ".seq into a houseCARL mod folder you enable in MO2. If the plugin is itself in a houseCARL patch folder, the .seq " +
-         "defaults into THAT same folder (so enabling the one mod deploys both .esp and .seq); otherwise it lands in a fresh " +
-         "folder (pass into= an existing houseCARL patch to keep them together). A plugin with no start-game-enabled quests " +
-         "needs no .seq — that's reported, nothing is written. The .seq makes the quest START; it does not verify the quest " +
-         "or its dialogue is otherwise correct. Needs houseCARL pointed at your MO2 instance (for the output folder).")]
+         "change gated on it, silently never starts. Pass source= the plugin: its FILENAME (e.g. 'MyQuestMod.esp' — " +
+         "located across your MO2 mod folders, enabled or not, the overwrite folder and game Data) or an ABSOLUTE PATH " +
+         "(e.g. the path housecarl_create reported for a fresh patch, which is not in the load order yet). The response " +
+         "states WHICH copy it read: with the same filename in several folders the call is refused, naming them, rather " +
+         "than picking one. houseCARL reads that plugin's start-game-enabled quests and writes the .seq into a houseCARL " +
+         "mod folder you enable in MO2. If the plugin is itself in a houseCARL patch folder, the .seq defaults into THAT " +
+         "same folder (so enabling the one mod deploys both .esp and .seq); otherwise it lands in a fresh folder (pass " +
+         "into= an existing houseCARL patch to keep them together, or patch= to name the new folder). A plugin with no " +
+         "start-game-enabled quests needs no .seq — that's reported, nothing is written. The .seq makes the quest START; " +
+         "it does not verify the quest or its dialogue is otherwise correct. format='json' returns the same data " +
+         "machine-readable. No epoch on this call, and that is a fact not an omission: a .seq is derived from the plugin " +
+         "FILE alone (its encoding is load-order-independent), so this call consults no load-order build. Needs houseCARL " +
+         "pointed at your MO2 instance (for the output folder).")]
     public static string WriteSeq(
         LoadOrderService svc,
-        [Description("Full path to the plugin (.esp/.esm/.esl) whose start-game-enabled quests need a .seq.")]
-            string plugin,
-        [Description("Optional. Base name for a NEW patch-mod folder the .seq lands in (default: the plugin's own houseCARL folder if it's in one, else 'houseCARL_SEQ'); auto-suffixed if taken.")]
-            string? patch_name = null,
-        [Description("Optional. Filename of an existing houseCARL patch mod to write the .seq into (e.g. the patch that holds the .esp, so one mod deploys both).")]
-            string? into = null) => Guard.Tool("housecarl_write_seq", () =>
+        [Description("SOURCE: the plugin whose start-game-enabled quests need a .seq — a FILENAME ('MyQuestMod.esp', located across enabled, disabled and not-yet-listed mod folders, overwrite, and game Data) or an ABSOLUTE path to the .esp/.esm/.esl. A filename provided by several locations is refused, naming them.")]
+            string source,
+        [Description("LANE: base name for a NEW patch-mod folder the .seq lands in (default: the plugin's own houseCARL folder if it's in one, else 'houseCARL_SEQ'); auto-suffixed if taken.")]
+            string? patch = null,
+        [Description("LANE: filename of an existing houseCARL patch mod to write the .seq into (e.g. the patch that holds the .esp, so one mod deploys both).")]
+            string? into = null,
+        [Description("TRANSPORT: 'text' (default) | 'json' (the same data, machine-readable).")]
+            string? format = null,
+        [Description("TRANSPORT: character ceiling on the render; past it trailing quest rows are dropped with an explicit notice (never silent). 0 = a safe default kept under the host's per-response limit.")]
+            int max_chars = 0) => Guard.Tool("housecarl_write_seq", () =>
     {
-        if (svc.ConfigPromptOrNull() is { } cfgPrompt) return cfgPrompt;
+        bool json = Wire.WantsJson(format, out var ferr);
+        if (ferr is not null) return ferr;
+        if (svc.ConfigPromptOrNull() is { } cfgPrompt)
+            return json ? JsonWire.RenderError(cfgPrompt, null) : cfgPrompt;
 
-        var o = svc.WriteSeq(plugin, patch_name, into);
+        var o = svc.WriteSeq(source, patch, into);
+        if (json) return JsonWire.RenderSeqOutcome(o, max_chars);
         if (!o.Success) return "error: " + o.Error;
         return Render(o);
     });
@@ -48,7 +73,7 @@ public static class SeqTools
     {
         // No SGE quests → a clean, explicit no-op (Q3: never a silent empty .seq, never a misleading "done").
         if (o.Quests.Count == 0)
-            return $"no start-game-enabled quests in {o.PluginFileName} — no .seq is needed (a .seq lists only quests with the " +
+            return $"no start-game-enabled quests in {o.PluginFileName}{ReadFrom(o)} — no .seq is needed (a .seq lists only quests with the " +
                    "Start Game Enabled flag). Nothing written. If a quest SHOULD start at game start, set its Start Game Enabled " +
                    "flag first, then write the .seq.";
 
@@ -59,6 +84,11 @@ public static class SeqTools
         foreach (var q in o.Quests)
             sb.Append("  ").Append(q.EditorId is { Length: > 0 } e ? e : "(no EditorID)")
               .Append("  →  0x").AppendFormat("{0:X8}", q.OnDiskFormId).Append('\n');
+        // WHICH copy of the source was read (§4.2 — the arm is always stated): a filename can be provided by more
+        // than one layer, and the quests came from exactly one of them.
+        if (o.ResolvedFrom is { Length: > 0 })
+            sb.Append("source: ").Append(o.PluginFileName).Append(" — read from ").Append(o.ResolvedFrom)
+              .Append(o.PluginPath is { Length: > 0 } p ? $" ({p})" : "").Append('\n');
         sb.Append("path: ").Append(o.SeqPath).Append('\n');
         sb.Append(o.WroteIntoPluginFolder
             ? "the .seq is in the plugin's OWN houseCARL folder — enabling that one mod in MO2 deploys both the .esp and its .seq."
@@ -68,4 +98,10 @@ public static class SeqTools
                   "well-formed (use housecarl_validate_dialogue for the dialogue graph).");
         return sb.ToString();
     }
+
+    /// <summary>The read-from clause for the nothing-to-do render — "no SGE quests" is a claim ABOUT a specific file,
+    /// so it names which one (a stale copy in a disabled folder has a different quest set, and reporting that as
+    /// "nothing to do" without saying whose is the silent-wrong-answer class Q3 refuses).</summary>
+    static string ReadFrom(SeqOutcome o)
+        => o.ResolvedFrom is { Length: > 0 } w ? $" (read from {w}{(o.PluginPath is { Length: > 0 } p ? $": {p}" : "")})" : "";
 }

--- a/src/housecarl-mcp/SeqTools.cs
+++ b/src/housecarl-mcp/SeqTools.cs
@@ -128,6 +128,12 @@ public static class SeqTools
         sb.Append(o.WroteIntoPluginFolder
             ? "the .seq is in the plugin's OWN houseCARL folder — enabling that one mod in MO2 deploys both the .esp and its .seq."
             : "the .seq is in a houseCARL mod folder — enable it in MO2 (AND make sure the plugin itself is enabled) so the game reads Data\\SEQ\\.");
+        // The ABSENT epoch, stated on the DEFAULT transport too (PR #311 review 6 [low]). The json twin has carried
+        // `epoch_note` since it was written; the text render said nothing — so a caller on the transport most of
+        // them use saw a response with no epoch= line, which is the same observable a DROPPED stamp would produce.
+        // The class-doc paragraph above claimed "the render says so"; it was true of one render out of two.
+        sb.Append("\nno epoch on this call, and that is a fact rather than an omission: a .seq is derived from the plugin " +
+                  "FILE alone (its FormID encoding is load-order-independent), so nothing here consulted a load-order build.");
         // Q3 standing limit: a written .seq makes the quest START; it is not a guarantee the quest/dialogue is otherwise correct.
         sb.Append("\nnote: this makes the quest(s) START at game start; it does not verify the quest or its dialogue is otherwise " +
                   "well-formed (use housecarl_validate_dialogue for the dialogue graph).");

--- a/src/housecarl-mcp/SeqTools.cs
+++ b/src/housecarl-mcp/SeqTools.cs
@@ -66,10 +66,10 @@ public static class SeqTools
         var o = svc.WriteSeq(source, patch, into);
         if (json) return JsonWire.RenderSeqOutcome(o, max_chars);
         if (!o.Success) return "error: " + o.Error;
-        return Render(o);
+        return Render(o, max_chars);
     });
 
-    internal static string Render(SeqOutcome o)
+    internal static string Render(SeqOutcome o, int maxChars = 0)
     {
         // No SGE quests → a clean, explicit no-op (Q3: never a silent empty .seq, never a misleading "done").
         if (o.Quests.Count == 0)
@@ -81,9 +81,25 @@ public static class SeqTools
         var seqName = Path.GetFileName(o.SeqPath);
         sb.Append("wrote ").Append(seqName).Append(": ").Append(o.Quests.Count)
           .Append(o.Quests.Count == 1 ? " start-game-enabled quest" : " start-game-enabled quests").Append('\n');
-        foreach (var q in o.Quests)
+        // Budgeted like the sibling write renders (PR #311 review [low-medium]): max_chars= promises "past it
+        // trailing quest rows are dropped with an explicit notice (never silent)", and a plugin with hundreds of
+        // start-game-enabled quests would otherwise render every row and let the HOST cut the response with no
+        // in-band signal. The path/next-step lines below stay outside the budget — a truncated list still needs
+        // to say where the file landed.
+        int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        for (int i = 0; i < o.Quests.Count; i++)
+        {
+            if (sb.Length >= cap)
+            {
+                sb.Append("  ... [truncated: ").Append(i).Append(" of ").Append(o.Quests.Count)
+                  .Append(" quest(s) listed at max_chars=").Append(cap)
+                  .Append("; the .seq itself carries ALL of them — raise max_chars to see the rest]\n");
+                break;
+            }
+            var q = o.Quests[i];
             sb.Append("  ").Append(q.EditorId is { Length: > 0 } e ? e : "(no EditorID)")
               .Append("  →  0x").AppendFormat("{0:X8}", q.OnDiskFormId).Append('\n');
+        }
         // WHICH copy of the source was read (§4.2 — the arm is always stated): a filename can be provided by more
         // than one layer, and the quests came from exactly one of them.
         if (o.ResolvedFrom is { Length: > 0 })

--- a/src/housecarl-mcp/SeqTools.cs
+++ b/src/housecarl-mcp/SeqTools.cs
@@ -63,6 +63,18 @@ public static class SeqTools
         if (svc.ConfigPromptOrNull() is { } cfgPrompt)
             return json ? JsonWire.RenderError(cfgPrompt, null) : cfgPrompt;
 
+        // LANE exclusivity, the same rule the sibling write tools enforce (PR #311 review 4 [low]). This PR is what
+        // renamed the pair onto the 2.0 words and labelled BOTH "LANE:", and a LANE that can be named alongside
+        // another and silently lose is the accepted-and-ignored class the grammar exists to close:
+        // ResolvePatchModFolder returns from the into= branch before patch= is ever read, so the .seq landed in
+        // into='s folder and the response said nothing about the folder patch= asked for.
+        if (!string.IsNullOrWhiteSpace(patch) && !string.IsNullOrWhiteSpace(into))
+        {
+            var laneErr = $"patch='{patch}' names a NEW mod folder for the .seq, but into='{into}' writes it into an existing houseCARL "
+                        + "patch — the two lanes are exclusive. Drop patch= to write into that patch, or drop into= to make a new folder.";
+            return json ? JsonWire.RenderError(laneErr, null) : "error: " + laneErr;
+        }
+
         var o = svc.WriteSeq(source, patch, into);
         if (json) return JsonWire.RenderSeqOutcome(o, max_chars);
         if (!o.Success) return "error: " + o.Error;
@@ -91,9 +103,16 @@ public static class SeqTools
         {
             if (sb.Length >= cap)
             {
+                // Not "raise max_chars to see the rest" — the same class as create's notice (PR #311 review 3
+                // round-2 / review 4), one tool over: re-running write_seq with a wider ceiling WRITES THE .seq
+                // AGAIN, and with no lane named for a plugin outside a houseCARL folder that is a second
+                // auto-suffixed mod folder holding a duplicate. Nothing is missing from the FILE, so the honest
+                // notice says so and prices the re-run instead of prescribing it. (Not a review-4 finding — a
+                // sibling spotted while folding one; declared on the PR rather than folded silently.)
                 sb.Append("  ... [truncated: ").Append(i).Append(" of ").Append(o.Quests.Count)
                   .Append(" quest(s) listed at max_chars=").Append(cap)
-                  .Append("; the .seq itself carries ALL of them — raise max_chars to see the rest]\n");
+                  .Append("; the .seq itself carries ALL of them — nothing is missing from the FILE. Re-run only if you need this "
+                        + "LIST widened: that writes the .seq again (into= the folder named below to keep it in one)]\n");
                 break;
             }
             var q = o.Quests[i];

--- a/src/housecarl-mcp/ToolSchemas.cs
+++ b/src/housecarl-mcp/ToolSchemas.cs
@@ -42,6 +42,11 @@ internal static class ToolSchemas
     {
         new("housecarl_apply", "ops", typeof(ApplyOp[])),
         new("housecarl_apply", "assignments", typeof(Assignment[])),
+        // W3 PR 2 — the chartered carry from PR #310's decision 1: create's records= is the same JsonElement-typed
+        // @file union, so it publishes the same anyOf. Its element type reaches StructInput/NestedSet through
+        // CreateFieldOp, which is why the $defs hoist below is first-wins BY NAME and sound here: those are
+        // literally the same C# types apply's rows generate, so a duplicate name is a duplicate schema.
+        new("housecarl_create", "records", typeof(CreateRecordSpec[])),
     };
 
     /// <summary>Register the rewrite. It runs as a POST-configure over <c>McpServerOptions</c>, which is the one

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -525,7 +525,7 @@ public static class WriteTools
 
     /// <summary>Compact, parseable confirmation (rulebook: short mutation confirmation + the IDs needed for follow-up).
     /// On refusal, the full reason (every malformed/rejected op) so the caller can fix and retry.</summary>
-    internal static string Render(WritePatchBuilder.PatchOutcome o, int maxChars = 0, bool fullDump = false)   // internal: the compact-readback guard renders one outcome three ways
+    internal static string Render(WritePatchBuilder.PatchOutcome o, int maxChars = 0, bool fullDump = false, bool laneAsName = false)   // internal: the compact-readback guard renders one outcome three ways
     {
         if (o.NeedsAcknowledge) return o.Error! + Epoch(o);  // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
         if (!o.Success) return "error: " + o.Error + Epoch(o);
@@ -569,7 +569,7 @@ public static class WriteTools
         }
         if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
         sb.Append(o.InPlace
-            ? $"to make more in-place edits to this plugin, pass target=\"{file}\" in_place=true (no further confirmation needed for it)."
+            ? InPlaceAgainHint("to make more in-place edits to this plugin", file, laneAsName)
             : $"to add more edits to THIS patch, pass into=\"{file}\".");
         sb.Append(Epoch(o));
         return sb.ToString();
@@ -588,6 +588,19 @@ public static class WriteTools
     static string Epoch(WritePatchBuilder.CreateOutcome o) => o.Epoch is null ? "" : $"\nepoch={o.Epoch}";
     static string Epoch(WritePatchBuilder.RemovalOutcome o) => o.Epoch is null ? "" : $"\nepoch={o.Epoch}";
     static string Epoch(WritePatchBuilder.ForwardOutcome o) => o.Epoch is null ? "" : $"\nepoch={o.Epoch}";
+
+    /// <summary>The "how to keep going on this plugin" line for a completed IN-PLACE write. The spelling differs
+    /// by surface and MUST match what the CALLING tool declares (PR #311 round-2 review [medium]): the 1.x tools
+    /// take the <c>target=</c> + <c>in_place=true</c> PAIR, while the 2.0 tools (apply / create / remove /
+    /// forward) declare a single STRING <c>in_place="X.esp"</c> and no <c>target=</c> at all — so the old text
+    /// told a 2.0 caller to send an undeclared parameter plus a BOOLEAN into a string parameter, which fails to
+    /// bind or goes looking for a plugin named "true". Same rule the locate contract's <c>offerModParam</c>
+    /// encodes on the refusal side, now applied to the success path: a response must never send someone to a
+    /// parameter their tool does not expose.</summary>
+    static string InPlaceAgainHint(string verb, string file, bool laneAsName) =>
+        laneAsName
+            ? $"{verb}, pass in_place=\"{file}\" again (no further confirmation needed for it)."
+            : $"{verb}, pass target=\"{file}\" in_place=true (no further confirmation needed for it).";
 
     /// <summary>#225 — the dry_run=true confirmation: the SAME pipeline ran (winner resolve, pre-flight, every verb
     /// applied in memory, the reference-resolution check) and stopped AT the point of no return, so this reports what
@@ -699,7 +712,7 @@ public static class WriteTools
 
     /// <summary>Confirmation for housecarl_remove_record: what was dropped, the patch's now-lean masters, and how many
     /// records remain (0 ⇒ inert). On refusal, the named reason (Q3) so the caller can fix and retry.</summary>
-    internal static string RenderRemoval(WritePatchBuilder.RemovalOutcome o, int maxChars = 0)   // internal: housecarl_remove renders the same outcome
+    internal static string RenderRemoval(WritePatchBuilder.RemovalOutcome o, int maxChars = 0, bool laneAsName = false)   // internal: housecarl_remove renders the same outcome
     {
         if (o.NeedsAcknowledge) return o.Error! + Epoch(o);  // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
         if (!o.Success) return "error: " + o.Error + Epoch(o);
@@ -744,7 +757,7 @@ public static class WriteTools
         if (o.InPlace)
             sb.Append(o.RemainingRecords == 0
                 ? "this plugin now carries no records — it's an inert shell; disable or delete the mod in MO2 if you don't need it."
-                : $"to remove more records from this plugin in place, pass target=\"{file}\" in_place=true (no further confirmation needed for it).");
+                : InPlaceAgainHint("to remove more records from this plugin in place", file, laneAsName));
         else
             sb.Append(o.RemainingRecords == 0
                 ? "this patch now carries no records — it's inert; disable or delete the mod folder in MO2 if you don't need it."
@@ -757,7 +770,7 @@ public static class WriteTools
     /// source it was copied FROM, and the current winner it out-ranks once enabled — with a redundant-forward NOTE when
     /// the copied version was already winning (Q3 — never silently a no-op). On refusal, the named reason so the caller
     /// can fix and retry. Optional full read-back rides along (the pre-enable verify that the copy is the source's).</summary>
-    internal static string RenderForward(WritePatchBuilder.ForwardOutcome o, int maxChars = 0)   // internal: the dry-run guard asserts the would-be phrasing
+    internal static string RenderForward(WritePatchBuilder.ForwardOutcome o, int maxChars = 0, bool laneAsName = false)   // internal: the dry-run guard asserts the would-be phrasing
     {
         if (o.NeedsAcknowledge) return o.Error! + Epoch(o);  // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
         if (!o.Success) return "error: " + o.Error + Epoch(o);
@@ -813,7 +826,7 @@ public static class WriteTools
             ? "every record resolved from its source; to forward for real, repeat the call without dry_run. " +
               "(A real write can still fail at serialize/commit — disk faults surface only there.)"
             : o.InPlace
-                ? $"to forward more into this plugin, pass target=\"{file}\" in_place=true (no further confirmation needed for it)."
+                ? InPlaceAgainHint("to forward more into this plugin", file, laneAsName)
                 : $"to forward more into THIS patch (incl. from a different source plugin), pass into=\"{file}\".");
         sb.Append(Epoch(o));
         return sb.ToString();
@@ -1045,7 +1058,7 @@ public static class WriteTools
     /// <summary>Confirmation for housecarl_create_record: the new record's ALLOCATED FormID + editorid + type (the FormID
     /// is the key output — the caller references the new record by it), the patch path + its (derived) masters, and the
     /// fields applied. On refusal, the named reason (Q3) so the caller can fix and retry.</summary>
-    internal static string RenderCreate(WritePatchBuilder.CreateOutcome o, int maxChars = 0, bool fullDump = false)   // internal: housecarl_create renders the same outcome
+    internal static string RenderCreate(WritePatchBuilder.CreateOutcome o, int maxChars = 0, bool fullDump = false, bool laneAsName = false)   // internal: housecarl_create renders the same outcome
     {
         if (o.NeedsAcknowledge) return o.Error! + Epoch(o);  // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
         if (!o.Success) return "error: " + o.Error + Epoch(o);
@@ -1092,7 +1105,7 @@ public static class WriteTools
         if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
         sb.Append("the new FormID above is how you reference this record (SkyPatcher/SPID, or a follow-up edit). ");
         sb.Append(o.InPlace
-            ? $"To create more records in this plugin, pass target=\"{file}\" in_place=true (no further confirmation needed for it)."
+            ? InPlaceAgainHint("To create more records in this plugin", file, laneAsName)
             : $"To add more to THIS patch, pass into=\"{file}\".");
         sb.Append(Epoch(o));
         return sb.ToString();

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -699,7 +699,7 @@ public static class WriteTools
 
     /// <summary>Confirmation for housecarl_remove_record: what was dropped, the patch's now-lean masters, and how many
     /// records remain (0 ⇒ inert). On refusal, the named reason (Q3) so the caller can fix and retry.</summary>
-    internal static string RenderRemoval(WritePatchBuilder.RemovalOutcome o)   // internal: housecarl_remove renders the same outcome
+    internal static string RenderRemoval(WritePatchBuilder.RemovalOutcome o, int maxChars = 0)   // internal: housecarl_remove renders the same outcome
     {
         if (o.NeedsAcknowledge) return o.Error! + Epoch(o);  // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
         if (!o.Success) return "error: " + o.Error + Epoch(o);
@@ -719,9 +719,26 @@ public static class WriteTools
               .Append(o.RemainingRecords).Append(o.RemainingRecords == 1 ? " record remains)\n" : " records remain)\n");
             sb.Append("mod folder: ").Append(modFolder).Append('\n');
         }
-        foreach (var r in o.Removed)
+        // Budgeted like every other write render (PR #311 review [medium]): removal is SET-VALUED now, so the
+        // unbounded case — a few hundred dropped overrides — is the expected one, not an edge, and max_chars=
+        // promises "past it trailing rows are dropped with an explicit notice (never silent)". Without this the
+        // rows all rendered and the HOST cut the oversized response out-of-band: exactly the silent cut the
+        // parameter's own description says never happens. The masters line and the closing guidance below are
+        // outside the budget deliberately — they are the accounting a truncated report still needs.
+        int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        for (int i = 0; i < o.Removed.Count; i++)
+        {
+            if (sb.Length >= cap)
+            {
+                sb.Append("  ... [truncated: ").Append(i).Append(" of ").Append(o.Removed.Count)
+                  .Append(" removed record(s) listed at max_chars=").Append(cap)
+                  .Append("; every one WAS removed — raise max_chars to see the rest]\n");
+                break;
+            }
+            var r = o.Removed[i];
             sb.Append("  - ").Append(r.RecordType).Append(' ').Append(r.Target).Append("  ")
               .Append(r.EditorId ?? "<no editorid>").Append('\n');
+        }
         sb.Append("masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters)).Append('\n');
         if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
         if (o.InPlace)

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -699,7 +699,7 @@ public static class WriteTools
 
     /// <summary>Confirmation for housecarl_remove_record: what was dropped, the patch's now-lean masters, and how many
     /// records remain (0 ⇒ inert). On refusal, the named reason (Q3) so the caller can fix and retry.</summary>
-    static string RenderRemoval(WritePatchBuilder.RemovalOutcome o)
+    internal static string RenderRemoval(WritePatchBuilder.RemovalOutcome o)   // internal: housecarl_remove renders the same outcome
     {
         if (o.NeedsAcknowledge) return o.Error! + Epoch(o);  // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
         if (!o.Success) return "error: " + o.Error + Epoch(o);

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -743,9 +743,14 @@ public static class WriteTools
         {
             if (sb.Length >= cap)
             {
+                // NOT "raise max_chars to see the rest" (PR #311 review 6 [medium]). RenderCreate's comment cited
+                // "a repeated remove is refused" as the reason that wording was SAFE here — which is also exactly
+                // why it is a dead end: re-issuing the call answers "not carried by patch '<file>'; NOTHING
+                // removed", because the records are already gone. Nothing is actually lost, though, and saying so
+                // is the honest remedy: removal is all-or-nothing, so the rows ARE the formids= the caller passed.
                 sb.Append("  ... [truncated: ").Append(i).Append(" of ").Append(o.Removed.Count)
                   .Append(" removed record(s) listed at max_chars=").Append(cap)
-                  .Append("; every one WAS removed — raise max_chars to see the rest]\n");
+                  .Append("; every one WAS removed — ").Append(RemovedRowsRemedy).Append("]\n");
                 break;
             }
             var r = o.Removed[i];
@@ -1155,6 +1160,15 @@ public static class WriteTools
         return sb.ToString();
     }
 
+    /// <summary>What a truncated REMOVE render tells the caller (PR #311 review 6 [medium]). The one lane where the
+    /// dropped rows carry no information the caller lacks: removal is ALL-OR-NOTHING over the <c>formids=</c> they
+    /// passed, so the listed set and the passed set are the same set. Re-issuing to widen the render is not merely
+    /// wasteful here — it is REFUSED, because the records no longer exist to be found, so the old
+    /// "raise max_chars to see the rest" pointed at the one call guaranteed to fail.</summary>
+    internal const string RemovedRowsRemedy =                       // internal: the json twin says the same thing (D2)
+        "removal is all-or-nothing, so these rows are exactly the formids= you passed — nothing here is unrecoverable. "
+      + "Do NOT re-issue to widen this: the records are gone, so a repeat is refused as 'not carried by' the file";
+
     /// <summary>What a truncated FORWARD render tells the caller to do — and it depends on the LANE (PR #311
     /// review 5 [low]). "raise max_chars and re-issue" was justified here on the grounds that a repeated forward
     /// re-copies identical bodies; that holds on <c>in_place=</c> and on <c>into=</c> (replace-on-collision, so the
@@ -1162,11 +1176,19 @@ public static class WriteTools
     /// the DEFAULT lane — the one a caller reaches by naming no lane — where <c>ResolveOutputPath</c>'s
     /// <c>UniqueStem</c> allocates a fresh stem, so the re-issue is a SECOND full patch mod carrying the same
     /// overrides. Quieter than create's duplicate (no new FormIDs), not absent. The remedy names the lane that
-    /// makes the re-issue safe rather than leaving the caller to discover the second folder.</summary>
+    /// makes the re-issue safe rather than leaving the caller to discover the second folder.
+    /// <para>IN_PLACE is its own case (PR #311 review 6 [low]) and the first pass got it wrong by lumping it with
+    /// <c>into=</c>. A re-issue there is content-idempotent, but it re-serializes the caller's OWN plugin end to
+    /// end — the file this same render just said has "no houseCARL backup or undo" — purely to widen a display.
+    /// It is the only lane of the four where the re-run touches something houseCARL does not own, so it gets the
+    /// read-back remedy instead: the target is active by definition of the lane, so <c>housecarl_records</c>
+    /// reaches it, and the FormIDs to name are the ones the caller passed.</para></summary>
     internal static string ForwardAgainRemedy(WritePatchBuilder.ForwardOutcome o, string file)   // internal: the json twin says the same thing (D2)
-        => o.DryRun || o.InPlace || o.Extended
+        => o.DryRun || o.Extended
             ? "raise max_chars to see the rest"
-            : $"to see the rest, raise max_chars AND pass into=\"{file}\" — a bare re-issue on the default patch= lane writes a SECOND patch mod carrying the same overrides";
+            : o.InPlace
+                ? $"to see the rest, read the rows back with housecarl_records source=\"{file}\" formids=[the ids you passed] — re-issuing would re-serialize your ORIGINAL file a second time just to widen this render"
+                : $"to see the rest, raise max_chars AND pass into=\"{file}\" — a bare re-issue on the default patch= lane writes a SECOND patch mod carrying the same overrides";
 
     /// <summary>The read-back call a truncated create render points the caller at — a call that actually RESOLVES,
     /// which is the whole point of pointing away from re-issuing the create (PR #311 review 4 [medium]).

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -1279,10 +1279,22 @@ public static class WriteTools
     }
 
     /// <summary>The explicit voice-coverage truncation notice (Q3 — the same convention as the read-back's): how many
-    /// of the total voice entries were rendered before the char budget was hit, and how to see the rest.</summary>
+    /// of the total voice entries were rendered before the char budget was hit, and what that does and does not mean.
+    /// <para>Shares its closing clause with the result-script notice and with the json <c>WriteBlockCensus</c>
+    /// (PR #311 review 7 [medium]): these blocks ride the CREATE render, so "raise max_chars to see the rest" meant
+    /// re-issuing a create — a second auto-suffixed patch on the default lane, or re-creation at the same FormID
+    /// with prior contents discarded under <c>into=</c>. The json twin added this round already said "Do NOT
+    /// re-issue the write to widen this", so the two transports were giving opposite advice about one call.</para></summary>
     static void AppendVoiceTrunc(StringBuilder sb, int rendered, int total, int cap)
         => sb.Append("  ... [voice coverage truncated: rendered ").Append(rendered).Append(" of ").Append(total)
-             .Append(" line(s) at max_chars=").Append(cap).Append("; raise max_chars to see the rest]\n");
+             .Append(" line(s) at max_chars=").Append(cap).Append(ReportBlockCutClause).Append("]\n");
+
+    /// <summary>The closing clause every post-write REPORT truncation notice shares, text and json alike. Names the
+    /// stakes (a cut list is not a clean bill of health) and refuses to prescribe the one action that would widen it
+    /// at the cost of a duplicate write.</summary>
+    internal const string ReportBlockCutClause =
+        "; the records WERE created and this block is only a render of them — compare rendered vs total above rather than "
+      + "reading the list as the whole answer. Do NOT re-issue the create to widen it: that allocates the records again";
 
     /// <summary>Render the coordinate-keyed §4-(b) structural-shell report (a cell create). The enforced Q3 teeth against
     /// a created-but-EMPTY cell: a created cell is a valid, correctly-placed RECORD, but houseCARL does NOT author world
@@ -1326,7 +1338,7 @@ public static class WriteTools
             if (sb.Length >= cap)
             {
                 sb.Append("  ... [result-script coverage truncated: rendered ").Append(rendered).Append(" of ").Append(total)
-                  .Append(" line(s) at max_chars=").Append(cap).Append("; raise max_chars to see the rest]\n");
+                  .Append(" line(s) at max_chars=").Append(cap).Append(ReportBlockCutClause).Append("]\n");
                 return;
             }
             var who = string.IsNullOrEmpty(f.TopicEditorId) ? f.Info.ToString() : $"{f.TopicEditorId} ({f.Info})";

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -1184,11 +1184,26 @@ public static class WriteTools
     /// read-back remedy instead: the target is active by definition of the lane, so <c>housecarl_records</c>
     /// reaches it, and the FormIDs to name are the ones the caller passed.</para></summary>
     internal static string ForwardAgainRemedy(WritePatchBuilder.ForwardOutcome o, string file)   // internal: the json twin says the same thing (D2)
-        => o.DryRun || o.Extended
+        => WriteAgainRemedy(o.DryRun, o.InPlace, o.Extended, file, "patch mod carrying the same overrides");
+
+    /// <summary>The lane rule generalized (PR #311 review 6): every WRITE render's row budget faces the same
+    /// question — is re-issuing this call to widen a display safe? — and the answer is a property of the LANE, not
+    /// of the verb. A dry run wrote nothing; <c>into=</c> lands on the same artifact; <c>in_place=</c> re-serializes
+    /// the caller's own file; the DEFAULT lane auto-suffixes a second patch. `apply` shares this with `forward`
+    /// because it shares the lane axis — the alternative was fixing three of four write tools and shipping the
+    /// fourth on wording the reviewer has now flagged in four consecutive rounds.</summary>
+    static string WriteAgainRemedy(bool dryRun, bool inPlace, bool extended, string file, string duplicateNoun)
+        => dryRun || extended
             ? "raise max_chars to see the rest"
-            : o.InPlace
+            : inPlace
                 ? $"to see the rest, read the rows back with housecarl_records source=\"{file}\" formids=[the ids you passed] — re-issuing would re-serialize your ORIGINAL file a second time just to widen this render"
-                : $"to see the rest, raise max_chars AND pass into=\"{file}\" — a bare re-issue on the default patch= lane writes a SECOND patch mod carrying the same overrides";
+                : $"to see the rest, raise max_chars AND pass into=\"{file}\" — a bare re-issue on the default patch= lane writes a SECOND {duplicateNoun}";
+
+    /// <summary>The <c>apply</c> lane's wording of <see cref="WriteAgainRemedy"/> (PR #311 review 6, declared as an
+    /// unrequested sibling): apply's json render budgets its <c>ops</c> array, and its notice carried the same
+    /// "raise max_chars" the forward/remove/create/write_seq notices were all moved off.</summary>
+    internal static string ApplyAgainRemedy(WritePatchBuilder.PatchOutcome o, string file)
+        => WriteAgainRemedy(o.DryRun, o.InPlace, o.Extended, file, "patch mod carrying the same edits");
 
     /// <summary>The read-back call a truncated create render points the caller at — a call that actually RESOLVES,
     /// which is the whole point of pointing away from re-issuing the create (PR #311 review 4 [medium]).

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -806,8 +806,22 @@ public static class WriteTools
             sb.Append("masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters)).Append('\n');
         sb.Append(o.DryRun ? "would forward " : "forwarded ").Append(o.Forwarded.Count)
           .Append(o.Forwarded.Count == 1 ? " record:\n" : " records:\n");
-        foreach (var f in o.Forwarded)
+        // Budgeted for the same reason as the created-records block: formids= is set-valued, each row is long (type +
+        // FormKey + editorid + the source clause + a REPLACED / redundant / out-ranks bracket), and the json twin
+        // already truncates the identical array (PR #311 review 3 [medium]).
+        int fwdCap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        for (int fi = 0; fi < o.Forwarded.Count; fi++)
         {
+            if (sb.Length >= fwdCap)
+            {
+                sb.Append("  ... [truncated: ").Append(fi).Append(" of ").Append(o.Forwarded.Count)
+                  .Append(" record(s) listed at max_chars=").Append(fwdCap)
+                  .Append(o.DryRun ? "; the dry run covered every one — raise max_chars to see the rest]"
+                                   : "; every one WAS forwarded — raise max_chars to see the rest]")
+                  .Append('\n');
+                break;
+            }
+            var f = o.Forwarded[fi];
             sb.Append("  ").Append(f.RecordType).Append(' ').Append(f.Target).Append("  ").Append(f.EditorId ?? "<no editorid>")
               .Append(o.DryRun ? "  — would be copied from " : "  — copied from ").Append(f.FromPlugin);
             if (f.ReplacedExisting)
@@ -1083,8 +1097,23 @@ public static class WriteTools
             sb.Append(" (").Append(replacedCount).Append(replacedCount == 1 ? " REPLACED an existing record" : " REPLACED existing records")
               .Append(" — same FormID kept, prior contents discarded)");
         sb.Append(":\n");
-        foreach (var c in o.Created)
+        // Budgeted (PR #311 review 3 [medium]): this is the render's LARGEST block and it is SET-VALUED — a 500-record
+        // authoring job from records="@<manifest>" is the case this tool exists for, not an edge. The json twin
+        // already budgets the same array and closes truncated:true, so leaving this one unbounded made text and json
+        // disagree about the same call, with the text lane taking a silent host-side cut. (The round-1 fold filed this
+        // as a follow-up on the grounds that max_chars' description scoped the ceiling to the read-back; the D2
+        // divergence is the stronger argument and it wins.)
+        int createCap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        for (int ci = 0; ci < o.Created.Count; ci++)
         {
+            if (sb.Length >= createCap)
+            {
+                sb.Append("  ... [truncated: ").Append(ci).Append(" of ").Append(o.Created.Count)
+                  .Append(" created record(s) listed at max_chars=").Append(createCap)
+                  .Append("; every one WAS created — raise max_chars to see the rest]").Append('\n');
+                break;
+            }
+            var c = o.Created[ci];
             sb.Append("  ").Append(c.RecordType).Append(' ').Append(c.FormKey).Append("  ").Append(c.EditorId);
             if (c.ReplacedExisting) sb.Append("  [REPLACED: this patch already defined this editorid — re-created fresh at the same FormID; prior contents, including any set_field edits since, were discarded]");
             sb.Append('\n');

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -816,8 +816,8 @@ public static class WriteTools
             {
                 sb.Append("  ... [truncated: ").Append(fi).Append(" of ").Append(o.Forwarded.Count)
                   .Append(" record(s) listed at max_chars=").Append(fwdCap)
-                  .Append(o.DryRun ? "; the dry run covered every one — raise max_chars to see the rest]"
-                                   : "; every one WAS forwarded — raise max_chars to see the rest]")
+                  .Append(o.DryRun ? "; the dry run covered every one — " : "; every one WAS forwarded — ")
+                  .Append(ForwardAgainRemedy(o, file)).Append(']')
                   .Append('\n');
                 break;
             }
@@ -1154,6 +1154,19 @@ public static class WriteTools
         sb.Append(Epoch(o));
         return sb.ToString();
     }
+
+    /// <summary>What a truncated FORWARD render tells the caller to do — and it depends on the LANE (PR #311
+    /// review 5 [low]). "raise max_chars and re-issue" was justified here on the grounds that a repeated forward
+    /// re-copies identical bodies; that holds on <c>in_place=</c> and on <c>into=</c> (replace-on-collision, so the
+    /// second call lands on the same FormKeys), and on a dry run, which writes nothing at all. It does NOT hold on
+    /// the DEFAULT lane — the one a caller reaches by naming no lane — where <c>ResolveOutputPath</c>'s
+    /// <c>UniqueStem</c> allocates a fresh stem, so the re-issue is a SECOND full patch mod carrying the same
+    /// overrides. Quieter than create's duplicate (no new FormIDs), not absent. The remedy names the lane that
+    /// makes the re-issue safe rather than leaving the caller to discover the second folder.</summary>
+    internal static string ForwardAgainRemedy(WritePatchBuilder.ForwardOutcome o, string file)   // internal: the json twin says the same thing (D2)
+        => o.DryRun || o.InPlace || o.Extended
+            ? "raise max_chars to see the rest"
+            : $"to see the rest, raise max_chars AND pass into=\"{file}\" — a bare re-issue on the default patch= lane writes a SECOND patch mod carrying the same overrides";
 
     /// <summary>The read-back call a truncated create render points the caller at — a call that actually RESOLVES,
     /// which is the whole point of pointing away from re-issuing the create (PR #311 review 4 [medium]).

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -1118,8 +1118,8 @@ public static class WriteTools
                 // walks into it.
                 sb.Append("  ... [truncated: ").Append(ci).Append(" of ").Append(o.Created.Count)
                   .Append(" created record(s) listed at max_chars=").Append(createCap)
-                  .Append("; every one WAS created — read them back with housecarl_records source=\"").Append(file)
-                  .Append("\" (re-calling this tool would create them AGAIN)]").Append('\n');
+                  .Append("; every one WAS created — read them back with ").Append(ReadBackCall(o, file))
+                  .Append(" (re-calling this tool would create them AGAIN)]").Append('\n');
                 break;
             }
             var c = o.Created[ci];
@@ -1147,12 +1147,34 @@ public static class WriteTools
         // printed. Say where to get them instead.
         sb.Append(listed > 0
             ? "the new FormID above is how you reference this record (SkyPatcher/SPID, or a follow-up edit). "
-            : $"no records are listed above — the char budget cut the whole list, though all {o.Created.Count} WERE created. Read them back with housecarl_records source=\"{file}\" to get their FormIDs. ");
+            : $"no records are listed above — the char budget cut the whole list, though all {o.Created.Count} WERE created. Read them back with {ReadBackCall(o, file)} to get their FormIDs. ");
         sb.Append(o.InPlace
             ? InPlaceAgainHint("To create more records in this plugin", file, laneAsName)
             : $"To add more to THIS patch, pass into=\"{file}\".");
         sb.Append(Epoch(o));
         return sb.ToString();
+    }
+
+    /// <summary>The read-back call a truncated create render points the caller at — a call that actually RESOLVES,
+    /// which is the whole point of pointing away from re-issuing the create (PR #311 review 4 [medium]).
+    /// <para>Two ways the shorter spellings fail. <c>source=</c> is records' SOURCE pole (WHOSE version), not a SELECT
+    /// term, so a source-only call dies on "select something — formids= …, or a scan scope". And a <c>plugins=</c>
+    /// scope names ACTIVE plugins, so it cannot select the headline case at all: a patch this very call just wrote is
+    /// not enabled in MO2 yet (the render's own next line says to enable it), and over an off-order file the scope is
+    /// refused by name. <c>types=</c> is the SELECT term that carries on BOTH arms — active, where the named pole's
+    /// records are the scan universe; off-order, where the pole is enumerated from the file directly — and the created
+    /// records' own <c>RecordType</c>s are catalog names, exactly what <c>types=</c> resolves.</para></summary>
+    internal static string ReadBackCall(WritePatchBuilder.CreateOutcome o, string file)   // internal: the json twin points at the SAME call (D2)
+    {
+        var types = o.Created.Select(c => c.RecordType).Where(t => !string.IsNullOrWhiteSpace(t))
+                             .Distinct(StringComparer.OrdinalIgnoreCase)
+                             .OrderBy(t => t, StringComparer.OrdinalIgnoreCase).ToList();
+        // Every distinct type, never a sampled head: a partial types= would select a partial answer while reading like
+        // the whole one. (Unreachable-empty — a successful create has at least one created record — but a bare
+        // source= call is the refused shape, so the clause is not silently dropped either.)
+        return types.Count > 0
+            ? $"housecarl_records source=\"{file}\" types=[{string.Join(", ", types.Select(t => $"\"{t}\""))}]"
+            : $"housecarl_records source=\"{file}\" types=[<the record types you created>]";
     }
 
     /// <summary>Render the Layer B unit B voice-coverage report (a dialogue-line create). The enforced Q3 teeth against a

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -1104,16 +1104,26 @@ public static class WriteTools
         // as a follow-up on the grounds that max_chars' description scoped the ceiling to the read-back; the D2
         // divergence is the stronger argument and it wins.)
         int createCap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        int listed = 0;
         for (int ci = 0; ci < o.Created.Count; ci++)
         {
             if (sb.Length >= createCap)
             {
+                // The remedy points at a READ, never at re-issuing this call (PR #311 review 3 round-2 [medium]).
+                // The sibling renders' "raise max_chars to see the rest" is safe on THEIR lanes — a repeated remove
+                // is refused, a repeated forward re-copies identical bodies — but a repeated CREATE allocates the
+                // records AGAIN: on the default lane patch= auto-suffixes into a second full patch, and under into=
+                // each record is re-created at its old FormID with its prior contents discarded. That is the
+                // duplicate-write trap ReadBackInFull's own doc names, and an agent following the notice literally
+                // walks into it.
                 sb.Append("  ... [truncated: ").Append(ci).Append(" of ").Append(o.Created.Count)
                   .Append(" created record(s) listed at max_chars=").Append(createCap)
-                  .Append("; every one WAS created — raise max_chars to see the rest]").Append('\n');
+                  .Append("; every one WAS created — read them back with housecarl_records source=\"").Append(file)
+                  .Append("\" (re-calling this tool would create them AGAIN)]").Append('\n');
                 break;
             }
             var c = o.Created[ci];
+            listed++;
             sb.Append("  ").Append(c.RecordType).Append(' ').Append(c.FormKey).Append("  ").Append(c.EditorId);
             if (c.ReplacedExisting) sb.Append("  [REPLACED: this patch already defined this editorid — re-created fresh at the same FormID; prior contents, including any set_field edits since, were discarded]");
             sb.Append('\n');
@@ -1132,7 +1142,12 @@ public static class WriteTools
             else AppendCompactReadback(sb, Array.Empty<WritePatchBuilder.OpResult>(), rb, maxChars);
         }
         if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
-        sb.Append("the new FormID above is how you reference this record (SkyPatcher/SPID, or a follow-up edit). ");
+        // Gated on rows having actually rendered (same review finding): with a small max_chars the header alone can
+        // exceed the cap and drop EVERY row, and "the new FormID above" then asserts a referent this render never
+        // printed. Say where to get them instead.
+        sb.Append(listed > 0
+            ? "the new FormID above is how you reference this record (SkyPatcher/SPID, or a follow-up edit). "
+            : $"no records are listed above — the char budget cut the whole list, though all {o.Created.Count} WERE created. Read them back with housecarl_records source=\"{file}\" to get their FormIDs. ");
         sb.Append(o.InPlace
             ? InPlaceAgainHint("To create more records in this plugin", file, laneAsName)
             : $"To add more to THIS patch, pass into=\"{file}\".");

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -581,6 +581,14 @@ public static class WriteTools
     /// what landed in the FILE, never what wins in the ORDER. Empty when the outcome consulted no build.</summary>
     static string Epoch(WritePatchBuilder.PatchOutcome o) => o.Epoch is null ? "" : $"\nepoch={o.Epoch}";
 
+    /// <summary>The same §2.1.1 stamp for the other three write outcomes (W3 PR 2 — create / remove / forward
+    /// carry the fingerprint on exactly the contract <see cref="WritePatchBuilder.PatchOutcome.Epoch"/> defines).
+    /// Separate overloads rather than one interface: the outcome records are deliberately independent shapes, and
+    /// a shared marker interface would be more machinery than one property read per lane.</summary>
+    static string Epoch(WritePatchBuilder.CreateOutcome o) => o.Epoch is null ? "" : $"\nepoch={o.Epoch}";
+    static string Epoch(WritePatchBuilder.RemovalOutcome o) => o.Epoch is null ? "" : $"\nepoch={o.Epoch}";
+    static string Epoch(WritePatchBuilder.ForwardOutcome o) => o.Epoch is null ? "" : $"\nepoch={o.Epoch}";
+
     /// <summary>#225 — the dry_run=true confirmation: the SAME pipeline ran (winner resolve, pre-flight, every verb
     /// applied in memory, the reference-resolution check) and stopped AT the point of no return, so this reports what
     /// WOULD change with NOTHING on disk. The header says so first (Q3 — a dry run must never read like a write);
@@ -693,8 +701,8 @@ public static class WriteTools
     /// records remain (0 ⇒ inert). On refusal, the named reason (Q3) so the caller can fix and retry.</summary>
     static string RenderRemoval(WritePatchBuilder.RemovalOutcome o)
     {
-        if (o.NeedsAcknowledge) return o.Error!;            // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
-        if (!o.Success) return "error: " + o.Error;
+        if (o.NeedsAcknowledge) return o.Error! + Epoch(o);  // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
+        if (!o.Success) return "error: " + o.Error + Epoch(o);
         var file = Path.GetFileName(o.OutputPath);
         var modFolder = Path.GetFileName(Path.GetDirectoryName(o.OutputPath) ?? "");
         var sb = new StringBuilder();
@@ -724,6 +732,7 @@ public static class WriteTools
             sb.Append(o.RemainingRecords == 0
                 ? "this patch now carries no records — it's inert; disable or delete the mod folder in MO2 if you don't need it."
                 : "re-sort in MO2 if dropping this override changes a conflict winner.");
+        sb.Append(Epoch(o));
         return sb.ToString();
     }
 
@@ -733,8 +742,8 @@ public static class WriteTools
     /// can fix and retry. Optional full read-back rides along (the pre-enable verify that the copy is the source's).</summary>
     internal static string RenderForward(WritePatchBuilder.ForwardOutcome o, int maxChars = 0)   // internal: the dry-run guard asserts the would-be phrasing
     {
-        if (o.NeedsAcknowledge) return o.Error!;            // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
-        if (!o.Success) return "error: " + o.Error;
+        if (o.NeedsAcknowledge) return o.Error! + Epoch(o);  // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
+        if (!o.Success) return "error: " + o.Error + Epoch(o);
         var file = Path.GetFileName(o.OutputPath);
         var modFolder = Path.GetFileName(Path.GetDirectoryName(o.OutputPath) ?? "");
         var sb = new StringBuilder();
@@ -789,6 +798,7 @@ public static class WriteTools
             : o.InPlace
                 ? $"to forward more into this plugin, pass target=\"{file}\" in_place=true (no further confirmation needed for it)."
                 : $"to forward more into THIS patch (incl. from a different source plugin), pass into=\"{file}\".");
+        sb.Append(Epoch(o));
         return sb.ToString();
     }
 
@@ -1018,10 +1028,10 @@ public static class WriteTools
     /// <summary>Confirmation for housecarl_create_record: the new record's ALLOCATED FormID + editorid + type (the FormID
     /// is the key output — the caller references the new record by it), the patch path + its (derived) masters, and the
     /// fields applied. On refusal, the named reason (Q3) so the caller can fix and retry.</summary>
-    static string RenderCreate(WritePatchBuilder.CreateOutcome o, int maxChars = 0, bool fullDump = false)
+    internal static string RenderCreate(WritePatchBuilder.CreateOutcome o, int maxChars = 0, bool fullDump = false)   // internal: housecarl_create renders the same outcome
     {
-        if (o.NeedsAcknowledge) return o.Error!;            // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
-        if (!o.Success) return "error: " + o.Error;
+        if (o.NeedsAcknowledge) return o.Error! + Epoch(o);  // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
+        if (!o.Success) return "error: " + o.Error + Epoch(o);
         var file = Path.GetFileName(o.OutputPath);
         var modFolder = Path.GetFileName(Path.GetDirectoryName(o.OutputPath) ?? "");
         var sb = new StringBuilder();
@@ -1067,6 +1077,7 @@ public static class WriteTools
         sb.Append(o.InPlace
             ? $"To create more records in this plugin, pass target=\"{file}\" in_place=true (no further confirmation needed for it)."
             : $"To add more to THIS patch, pass into=\"{file}\".");
+        sb.Append(Epoch(o));
         return sb.ToString();
     }
 

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -1137,7 +1137,7 @@ public static class WriteTools
         }
         AppendVoiceReport(sb, o.Voice, maxChars);
         AppendScriptBindingReport(sb, o.ScriptBinding, maxChars);
-        AppendCellShellReport(sb, o.CellShell);
+        AppendCellShellReport(sb, o.CellShell, maxChars);
         // Same compact-by-default verify as the edit lane (HCBR-2026-06-28-01): the forced create-in-place re-read still
         // runs; full_readback=true gives the deep dump, the default reports it compactly (per created record: re-read clean
         // + field count, or a named failure). The created records' set fields are already listed above.
@@ -1301,16 +1301,36 @@ public static class WriteTools
     /// content — so per created cell this lists, by kind, what the author must still provide in the Creation Kit
     /// (lighting / terrain / water / navmesh). "Created" must never read as "looks right in game". No-op unless the call
     /// created cells.</summary>
-    static void AppendCellShellReport(StringBuilder sb, CellShellReport? report)
+    static void AppendCellShellReport(StringBuilder sb, CellShellReport? report, int maxChars)
     {
         if (report is null || report.IsEmpty) return;
+        // Budgeted like its two siblings (PR #311 review 7 [low-medium], Aaron-go). This was the last unbudgeted
+        // block on the write renders: the json twin already stopped at `cap` and closed with a census, so one
+        // create authoring a batch of cells rendered every row in TEXT and took the SILENT host-side cut — the
+        // divergence the created-rows / forwarded-rows / removed-rows folds each closed in turn. The inner
+        // MustProvide loop is bounded too: one cell with a long work list could blow the budget by itself.
+        int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        int total = report.Cells.Count, rendered = 0;
+        bool cut = false;
         sb.Append("cell shell — created cells are valid, correctly-placed records but EMPTY; houseCARL does not author world content (provide these in the Creation Kit):\n");
         foreach (var c in report.Cells)
         {
+            if (sb.Length >= cap) { cut = true; break; }
             sb.Append("  ").Append(c.Interior ? "INTERIOR " : "EXTERIOR ").Append(c.EditorId).Append(" (").Append(c.Cell).Append("):\n");
             foreach (var m in c.MustProvide)
+            {
+                if (sb.Length >= cap) { cut = true; break; }
                 sb.Append("      - ").Append(m).Append('\n');
+            }
+            if (cut) break;
+            rendered++;
         }
+        // The notice, then the two Q3 notes below it — which stay OUTSIDE the budget on purpose, the same rule the
+        // removal render states: they are the accounting a truncated report still needs, and the grid-occupancy
+        // seam in particular must not be the thing a cut swallows.
+        if (cut)
+            sb.Append("  ... [cell shell truncated: rendered ").Append(rendered).Append(" of ").Append(total)
+              .Append(" cell(s) at max_chars=").Append(cap).Append(ReportBlockCutClause).Append("]\n");
         // Q3 — declare the un-checked grid-occupancy seam (full load-order occupancy detection is a follow-up; never a
         // silent omission). Only an EXTERIOR cell collides on a grid; an interior cell has no grid identity.
         if (report.Cells.Any(c => !c.Interior))


### PR DESCRIPTION
**W3 PR 2 of 4** — the rest of the 2.0 S1 write surface. PR 1 (#310) landed `housecarl_apply`; this lands
**`housecarl_create`**, **`housecarl_remove`**, **`housecarl_forward`**, and migrates **`housecarl_write_seq`**
to the 2.0 vocabulary. `copy` and `check` are PRs 3 and 4 (see *Decomposition* below).

Every tool rides its existing, unchanged cleave — this is consolidation of the surface, not a re-implementation
of the engine. The 1.x tools stay registered and unchanged through the build waves; they retire at 2.0.0's clean
cut (CHARTER_PHASE4 §3.4a).

`Refs #237` — not `Fixes`: milestone issues close at 2.0.0's shipped surface, never on a construction proof
(CHARTER_PHASE4 §6).

---

## What landed

**`housecarl_create`** (absorbs `create_record` + `bulk_create`). `records=[{record_type, editorid, ops?,
parent?, collection?, grid?}]`, inline or `"@<absolute path>"` — **one record is a set of one**, which is why the
scalar tool dissolves *and* why the nested one-shot needs no second tool. `ops=` is `apply`'s op shape minus
`formid`; the three members a create cannot have (`formid`, `from`, `from_source`) are refused **BY NAME** at
their element with their own corrections, where the SDK binder would silently drop them. Per-record refusals name
`records[i]` — the caller's own spelling — via an origin list threaded to the service the way `ApplyEdits`
threads `opOrigins`.

**`housecarl_remove`** (absorbs `remove_record`), now **plural**: the engine always took a list (present-check,
all-or-nothing, one re-serialize); only the tool surface didn't, so dropping ten overrides cost ten rewrites of
one file. §6.1's "unreachable engine capability recovered", with no engine change.

**`housecarl_forward`** (absorbs `forward_record`): `from_plugin=` → `source=`, plus the LANE/TRANSPORT grammar.

**`housecarl_write_seq`** keeps its name (§6.1 keeps the tool), so this is a parameter migration: `plugin=` →
`source=`, which now **resolves a bare filename** across the MO2 folders through the same shared locate contract
`read_plugin_file` and the copy donor lane use — and **states which copy it read**, because a stale copy in a
disabled folder answering "no SGE quests" without saying whose is the silent-wrong-answer class.

**Engine seams.** `CreateOutcome` / `RemovalOutcome` / `ForwardOutcome` gain `Epoch`, stamped from one place per
entry point via a `*Core` split (the `Apply`/`ApplyInPlace` pattern), plus the three **service-side** in-place
sites — the consent prompt and the post-capture refusals — which is where the guard found a real defect (below).

**Guards.** New `write-surface-guard` (**40 checks, 5 arms**, real tool path on a synthetic order) in `ci-all`;
`seq-write-guard` +2 arms; `codex-umbrella-coverage-guard` 9 → 11. Alias CENSUS **130 → 158**. **ci-all
116/116, ALL PASS.**

---

## Two calls that want a reviewer's eye

**1. Decomposition (conductor call, W1/W2/W3-PR1 precedent): `copy` moved out of PR 2 into its own PR.**
The handoff chartered PR 2 as `create · remove · forward · copy · write_seq`. `copy` is not a rename — it is the
§3.3 closure-copy *generalization* of `NpcAppearanceCopy` (604 + 328 lines of core) into a walk driven by
skill-supplied data, and it carries a real zero-capability-loss question: the facegen/voice **asset carry** and
the **strip report** are not expressible as walk data. PR 1 took five review rounds on one tool; bundling that
design risk behind four mechanical tools would have sunk both. Sequence is now PR 2 (this) → **PR 3 `copy`** →
**PR 4 `check`**.

**2. `remove`'s existing-patch lane is `into=`, not `patch=` — a §4-protocol (a) resolution.**
SPEC §5.3 folds 1.x `remove_record`'s bare `patch=` into the one `patch` name; but §5.1 defines `patch` as *the
NEW artifact a write creates*, and a removal never creates one. Taking §5.3 literally re-creates exactly the
one-word-two-meanings class §5.2 exists to kill. Resolution respecting both: the houseCARL-patch lane is
**`into=`** ("an existing one" — §5.1's own words), `in_place="X.esp"` otherwise, and the alias layer maps the
old `patch=` onto `into=` by name. §5.3's row was a spelling-drift merge — its own provenance note calls that
`patch` "one more live drift instance" — not a role decision. **If you read §5.3 as binding on the role too,
this is the line to push back on.**

---

## The defect the new guard found

The in-place **CONSENT PROMPT** and the service-side in-place refusals of create/remove/forward carried **no
epoch**, though each is decided *after* the service captured a build to resolve the target. This is PR #310
round 1's own finding, unfixed on the three lanes `apply` never touched — and the consent prompt is the response
shape a caller meets most often, so "every write response carries an epoch" was false exactly there. Fixed at
all three sites; the three arms were **RED-checked against the pre-fix code** and fail with exactly the predicted
observables (37/40 pre-fix, and *only* those three).

## Decisions and bounds, stated rather than narrowed

- **`forward`'s `source=` is ACTIVE-only, declared not narrowed.** §4.2's pole resolves a plugin wherever it
  lives, but forwarding resolves bodies *through the load-order index*, so the off-order arm isn't reachable on
  this lane. A non-active source is refused **by name** with the reason (never read as "doesn't define the
  record"), the doc comment names the lifter (PR #310's `ResolveOffOrderCopySources` seam), and the guard pins
  the refusal. **Candidate GAP issue if you'd rather it were filed than carried.**
- **A result ARTIFACT in `formids=` is refused by name on both write tools.** An artifact's identity column is
  epoch-bound and the check only means anything inside the consuming call's own capture — which the write lanes
  take inside the engine. Refused rather than honored unchecked; a plain list file is unaffected.
- **`create` has no `dry_run=`** — 1.x `create_record` had none either, so no capability is lost; the engine
  seam doesn't exist yet. Named here rather than left to be noticed.
- **`remove` has no `dry_run=` either**, and for the same reason: 1.x `remove_record` has none, so nothing is
  lost in the consolidation. Added on the round-7 review's prompt — `forward` documents one, so the silence
  reads as an oversight unless it is stated. The two that never had one are `create` and `remove`; `apply` and
  `forward` keep theirs.
- **`write_seq` carries no epoch, and says so** with its reason (a `.seq` is derived from the plugin FILE alone;
  the encoding is load-order-independent). An absent stamp is a fact, not a dropped field.
- **`RenderError` still has no `ok` discriminant** — the known, reviewer-scoped-out backlog item (~39 call
  sites, W3 PR 3). The guard pins the *reason* on pre-engine refusals instead of `ok`, with a comment saying the
  arms tighten when the sweep lands.
- **`LocatePluginFileOnDisk`'s not-found refusal** offered `mod=` unconditionally — a parameter `write_seq`
  doesn't expose. Now opt-out per caller.

## §6.1 description-harvest ledger

Each merged description was diffed against **every** source description; anything present in exactly one was
kept or its drop recorded. Two were folded back in: `create_record`'s "any flat top-level record" enumeration,
and the recipe for referencing a freshly created record from a later call (`into=` + the reported FormID).
**One deliberate drop:** `create_record`'s parenthetical that an EXTERIOR cell "nests under FormKey-less
worldspace structs — a separate capability". That clause contradicts the same tool's own `grid=` parameter,
which documents the working coordinate-keyed path; `create`'s `grid=` carries that path, and the stale
refusal-side clause is not reproduced.

## The chartered PR-2 carries, both done

- `create`'s `records=` gets the `anyOf[<generated array>, string]` publish (PR #310 decision 1);
  `binding-shim-guard`'s SCHEMA arm still reports **0 dangling `$ref`s** across every published schema.
- `apply`'s description cross-references now point at the shipped successors (`housecarl_create` /
  `_remove` / `_forward`) instead of the 1.x names.

## Drive-by

`codex-umbrella-coverage-guard`'s own GUARD-SELF arm predicted this PR: the 2.0 tools are **prefixes** of the
1.x names they absorb (`housecarl_create` ⊂ `housecarl_create_record`, same for remove/forward), which its bare
`Contains` match would false-pass — silently leaving all three unrouted. Matching is now identifier-boundary
aware, with the teeth moved to a RED arm plus its GREEN twin.

---

## Review notes

- 8 commits, each a single logical change.
- `dev/` is gitignored — the sub-project's STATUS/handoffs are local-only and not in this diff.
- Guard: `dotnet run --project src/housecarl-generator write-surface-guard` (or `ci-all` for all 116).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


