### PR TITLE
fix: an UNOPENABLE active plugin no longer breaks every write (Fixes #314)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,15 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**Fixed: one broken plugin in your load order no longer breaks every write.** If a plugin houseCARL cannot open
+sat in your active order — a truncated download, a half-copied mod folder, an interrupted xEdit save — then
+*every* write failed, including writes that had nothing to do with it, with an opaque message that read like a
+disk fault. Reads were never affected. Now writes that don't reference that plugin's records just work.
+
+A write that genuinely *does* need it (its records can still be reached through a plugin that overrides them) is
+refused **naming it as the cause**, with what to do — instead of the previous engine-level error. One such write
+now succeeds that didn't before: a patch whose header needs only that single master.
+
 **New tools: `housecarl_create`, `housecarl_remove`, `housecarl_forward` — the rest of the 2.0 write surface
 (W3 PR 2).** The same shape `housecarl_apply` introduced — *what changes* × *where it lands* × *how it reads
 back* — now covers authoring, removal and whole-record overrides.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -14,8 +14,9 @@ sat in your active order — a truncated download, a half-copied mod folder, an 
 disk fault. Reads were never affected. Now writes that don't reference that plugin's records just work.
 
 A write that genuinely *does* need it (its records can still be reached through a plugin that overrides them) is
-refused **naming it as the cause**, with what to do — instead of the previous engine-level error. One such write
-now succeeds that didn't before: a patch whose header needs only that single master.
+refused **naming it as the cause**, with what to do — instead of the previous engine-level error. And if the
+unopenable plugin is `Skyrim.esm` or `Update.esm` — the two masters every written plugin must list — nothing is
+written at all until you repair it, rather than a plugin landing on disk without them.
 
 **New tools: `housecarl_create`, `housecarl_remove`, `housecarl_forward` — the rest of the 2.0 write surface
 (W3 PR 2).** The same shape `housecarl_apply` introduced — *what changes* × *where it lands* × *how it reads

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -83,9 +83,9 @@ public sealed class UnopenableBaselineMasterException : Exception
         // no write can resolve against a master it cannot open.
         : base($"'{pluginName}' is a BASELINE master (Skyrim.esm / Update.esm) and is ACTIVE in your load order, but " +
                "houseCARL cannot open it — see load_order_status for the reason. Nothing can be written while that is " +
-               "true: no write can resolve references against a master it cannot read, and a new patch must list the " +
-               "baselines in its header, so emitting one without them would produce a plugin the game treats as " +
-               "malformed. Repair or replace that plugin in MO2 and retry. Nothing was written.")
+               "true, for either reason alone: a new patch must list the baselines in its header (emitting one without " +
+               "them produces a plugin the game treats as malformed), and no write can resolve references against a " +
+               "master it cannot read. Repair or replace that plugin in MO2 and retry. Nothing was written.")
         => PluginName = pluginName;
 }
 

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -127,6 +127,12 @@ public sealed class LoadOrderResolver : IDisposable
     /// <see cref="ExcludedPlugins"/>, formatted "name: reason" for log/harness display.</summary>
     public IReadOnlyList<string> LoadFailures => _snap.LoadFailures;
 
+    /// <summary>#314 — is this plugin ACTIVE but impossible to OPEN? The resolver-level twin of
+    /// <see cref="IndexView.IsUnopenable"/>, for callers holding the resolver rather than a captured view (the dry-run
+    /// master preview). Reads the current snapshot, which is what a dry run should predict against.</summary>
+    public bool IsUnopenable(string pluginName)
+        => _nameToIdx.TryGetValue(pluginName, out int i) && _snap.Unopenable.Contains(i);
+
     /// <summary>Plugins EXCLUDED from this build (name → why): unopenable, or carrying a record Mutagen can't parse.
     /// Their records are not in the index and no path will re-touch them; load_order_status reports them so the user
     /// can fix/remove the upstream plugin (Q3 — the exclusion is visible, not silent).</summary>
@@ -260,7 +266,10 @@ public sealed class LoadOrderResolver : IDisposable
         /// <summary>The plugins this session's master-set builds skipped as unopenable (#314). Empty in the normal case.
         /// Non-empty ⇒ a serialize failure naming a missing master is very likely one of THESE, and the write lane says
         /// so instead of reporting an opaque engine fault.</summary>
-        public IReadOnlyCollection<string> SkippedUnopenable => _skippedUnopenable;
+        /// <remarks>Exposed as a SET, not a collection: consumers ask "is this name in it?", and the backing
+        /// comparer is OrdinalIgnoreCase — a LINQ Contains over a collection would have compared ordinally and missed a
+        /// case difference between the profile's spelling and a ModKey's.</remarks>
+        public IReadOnlySet<string> SkippedUnopenable => _skippedUnopenable;
 
         /// <summary>Dispose and forget any overlay this session holds on <paramref name="fileName"/> — the file the caller
         /// is about to serialize to. The SECOND half of the active-patch write fix (with <see cref="AllMastersExcept"/>):
@@ -574,6 +583,12 @@ public sealed class LoadOrderResolver : IDisposable
         public int MaxDepth => _s.MaxDepth;
         public IReadOnlyList<string> LoadFailures => _s.LoadFailures;
         public IReadOnlyDictionary<string, string> ExcludedPlugins => _s.ExcludedPlugins;
+
+        /// <summary>#314 — is this plugin the could-not-be-OPENED exclusion class? A caller that is ABOUT to open a
+        /// plugin file itself (rather than going through the master-set builders) asks this first, so an unopenable one
+        /// becomes a named refusal instead of an exception escaping from a bare CreateFromBinaryOverlay.</summary>
+        public bool IsUnopenable(string pluginName)
+            => _r._nameToIdx.TryGetValue(pluginName, out int i) && _s.Unopenable.Contains(i);
 
         /// <summary>THIS captured build's epoch fingerprint — the stamp a bulk response computed off this view
         /// must carry (SPEC §2.1.1). Immutable with the snapshot: a concurrent rebuild changes nothing here.</summary>

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -70,6 +70,21 @@ public readonly record struct WinnerInfo(FormKey FormKey, string WinnerPlugin, i
 public readonly record struct RecordStatus(
     FormKey FormKey, string RecordType, bool PluginWins, int OverrideDepth, IReadOnlyList<string> TouchingPlugins);
 
+/// <summary>#314 / PR #315 review 2 — a BASELINE master (Skyrim.esm / Update.esm) is active but cannot be opened.
+/// Every written plugin force-includes the baselines (Aaron-locked 2026-06-02) and that force-include is derived from
+/// the known-master list, so quietly omitting one would emit a plugin missing a mandatory master. Thrown from the
+/// master-set builders — the single point every write lane funnels through — so no lane can forget the check.</summary>
+public sealed class UnopenableBaselineMasterException : Exception
+{
+    public string PluginName { get; }
+    public UnopenableBaselineMasterException(string pluginName)
+        : base($"'{pluginName}' is a BASELINE master (every written plugin must list it) and is ACTIVE in your load " +
+               "order, but houseCARL cannot open it — see load_order_status for the reason. No plugin can be written " +
+               "until it is repaired or replaced: writing one without it would produce a plugin the game treats as " +
+               "malformed. Nothing was written.")
+        => PluginName = pluginName;
+}
+
 public sealed class LoadOrderResolver : IDisposable
 {
     readonly string[] _paths;                          // every active plugin's path, priority order (masters → … → winner)
@@ -257,7 +272,18 @@ public sealed class LoadOrderResolver : IDisposable
         bool SkipUnopenable(int i)
         {
             if (!_r._snap.Unopenable.Contains(i)) return false;
-            _skippedUnopenable.Add(_r._names[i]);
+            var name = _r._names[i];
+            // A BASELINE master (Skyrim.esm / Update.esm) must never be skipped. WriteEngine.WritePatch derives its
+            // CK-mandated force-include FROM the list returned here, filtered to baselines present in it — a filter
+            // whose stated purpose is tolerating a degenerate order or a single-master harness. Skipping an unopenable
+            // baseline makes a REAL order look degenerate to it, and a plugin lands on disk missing a master Aaron
+            // locked as mandatory (2026-06-02) with no warning: a SILENT degradation where this PR found a loud
+            // failure, which is the one trade Q3 never allows (PR #315 review 2). A baseline is never legitimately
+            // absent, so this refuses instead — thrown from the single chokepoint every write lane funnels through,
+            // rather than re-checked per lane.
+            if (Array.Exists(WriteEngine.BaselineMasters, bm => string.Equals(bm.FileName.String, name, StringComparison.OrdinalIgnoreCase)))
+                throw new UnopenableBaselineMasterException(name);
+            _skippedUnopenable.Add(name);
             return true;
         }
 

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -261,9 +261,11 @@ public sealed class LoadOrderResolver : IDisposable
         /// Records the name, because the skip is NOT free and the guard proved exactly where:
         /// <list type="bullet">
         /// <item>a patch whose header needs only ONE master still writes, even when that master is the skipped plugin —
-        /// Mutagen derives the entry from the record's own FormKey, not from list membership;</item>
+        /// Mutagen derives the entry from the record's own FormKey, not from list membership. NOTE this is reachable
+        /// only in an order WITHOUT the baselines (a test harness): a real order force-includes Skyrim.esm + Update.esm,
+        /// so a patch-lane header always carries two or more and always takes the second case (PR #315 review 3);</item>
         /// <item>a patch whose header must be SORTED (two or more masters) does NOT: the serializer refuses with
-        /// <c>MissingModException</c> naming the skipped plugin.</item>
+        /// <c>MissingModException</c> naming the skipped plugin. In practice this is the case that fires.</item>
         /// </list>
         /// That second case is a real, reachable failure, and it must be named rather than surfaced as a generic
         /// "serialize or commit" fault (Q3) — which is what <see cref="SkippedUnopenable"/> is for. The first draft of

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -78,13 +78,23 @@ public sealed class UnopenableBaselineMasterException : Exception
 {
     public string PluginName { get; }
     public UnopenableBaselineMasterException(string pluginName)
-        : base($"'{pluginName}' is a BASELINE master (every written plugin must list it) and is ACTIVE in your load " +
-               "order, but houseCARL cannot open it — see load_order_status for the reason. No plugin can be written " +
-               "until it is repaired or replaced: writing one without it would produce a plugin the game treats as " +
-               "malformed. Nothing was written.")
+        // Worded to hold on BOTH write lanes (PR #315 review 4): "every written plugin must list it" is the PATCH
+        // lane's reason — WriteInPlace force-includes no baselines — while the fact that covers both is simply that
+        // no write can resolve against a master it cannot open.
+        : base($"'{pluginName}' is a BASELINE master (Skyrim.esm / Update.esm) and is ACTIVE in your load order, but " +
+               "houseCARL cannot open it — see load_order_status for the reason. Nothing can be written while that is " +
+               "true: no write can resolve references against a master it cannot read, and a new patch must list the " +
+               "baselines in its header, so emitting one without them would produce a plugin the game treats as " +
+               "malformed. Repair or replace that plugin in MO2 and retry. Nothing was written.")
         => PluginName = pluginName;
 }
 
+/// <remarks>LAYERING NOTE (#314 / PR #315 review 4): this file's master-set builders reference
+/// <see cref="WriteEngine.BaselineMasters"/> and throw <see cref="UnopenableBaselineMasterException"/> — a WRITE policy,
+/// and the first write dependency here. Deliberate, not drift: the builders are the single point every write lane
+/// funnels through, so enforcing it there is what makes "no lane can forget the check" true, where a per-lane check is
+/// something the next lane forgets. Kept on the chokepoint argument over the purity one; recorded so a later tidy-up
+/// re-litigates it rather than silently reverting it.</remarks>
 public sealed class LoadOrderResolver : IDisposable
 {
     readonly string[] _paths;                          // every active plugin's path, priority order (masters → … → winner)

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -104,13 +104,20 @@ public sealed class LoadOrderResolver : IDisposable
         public readonly Dictionary<FormKey, int[]> Overriders;                // MULTI keys only — ordered touching overlay indices
         public readonly List<string> LoadFailures;                            // per-plugin index-build failures (open OR parse), surfaced (Q3)
         public readonly HashSet<int> Excluded;                                // overlay indices excluded this build — never re-touched by any path
+        /// <summary>#314 — the SUBSET of <see cref="Excluded"/> whose file could not be OPENED at all, as opposed to
+        /// opening fine and failing on a record body. The distinction is invisible to reads (both are "never touch
+        /// this plugin") and load-bearing for WRITES: the master set retains excluded plugins on purpose, which is
+        /// only possible for the ones that can be opened. Kept as its own set rather than derived from the reason
+        /// STRING — a message is display prose that can be reworded, membership is a fact.</summary>
+        public readonly HashSet<int> Unopenable;
         public readonly Dictionary<string, string> ExcludedPlugins;           // excluded plugin name → reason (Q3)
         public readonly int MaxDepth;
         public readonly string Epoch;                                         // this build's fingerprint (SPEC §2.1.1) — immutable with the snapshot
 
         public IndexSnapshot(Dictionary<FormKey, (int winner, int count)> index, Dictionary<FormKey, int[]> overriders,
-                             List<string> loadFailures, HashSet<int> excluded, Dictionary<string, string> excludedPlugins, int maxDepth, string epoch)
-        { Index = index; Overriders = overriders; LoadFailures = loadFailures; Excluded = excluded; ExcludedPlugins = excludedPlugins; MaxDepth = maxDepth; Epoch = epoch; }
+                             List<string> loadFailures, HashSet<int> excluded, HashSet<int> unopenable,
+                             Dictionary<string, string> excludedPlugins, int maxDepth, string epoch)
+        { Index = index; Overriders = overriders; LoadFailures = loadFailures; Excluded = excluded; Unopenable = unopenable; ExcludedPlugins = excludedPlugins; MaxDepth = maxDepth; Epoch = epoch; }
     }
 
     volatile IndexSnapshot _snap;
@@ -177,16 +184,24 @@ public sealed class LoadOrderResolver : IDisposable
         /// Tier-2 perf idea above.</summary>
         public IReadOnlyList<ISkyrimModGetter> AllMasters()
         {
-            // Excluded plugins (BuildIndex couldn't fully parse) are INTENTIONALLY retained here — NOT filtered by
-            // the snapshot's Excluded set. A clean plugin can override a record whose ORIGIN master is an excluded one, and that master
-            // must still appear in the patch's output header for FormID resolution; dropping it would corrupt the
-            // header. Safe: Overlay() opens lazily (no parse, no enumeration → no throw), and the serializer parses a
-            // master's bodies ONLY when the patch references them — and an excluded plugin's OWN records can't be
-            // referenced (they're unreadable). So this is the one read-path that touches excluded plugins on purpose,
-            // and it cannot re-throw. (If a future change enumerates or link-caches over this full set, it must
-            // re-introduce the Excluded skip — the per-read "single choke point" is BuildIndex, not this method.)
-            var arr = new ISkyrimModGetter[_r._paths.Length];
-            for (int i = 0; i < arr.Length; i++) arr[i] = Overlay(i);
+            // Excluded plugins that OPEN are INTENTIONALLY retained here — NOT filtered by the snapshot's Excluded
+            // set. A clean plugin can override a record whose ORIGIN master is an excluded one, and that master must
+            // still appear in the patch's output header for FormID resolution; dropping it would corrupt the header.
+            // Safe for THAT class: Overlay() opens lazily (no parse, no enumeration → no throw), and the serializer
+            // parses a master's bodies ONLY when the patch references them.
+            //
+            // #314 — but the OTHER exclusion class cannot be retained, because retaining it is impossible: a plugin
+            // excluded BECAUSE OpenOverlay threw makes Overlay(i) throw again here, on EVERY write, including writes
+            // that never touch it. The old comment's "it cannot re-throw" was true of the parse-failure class and
+            // false of this one. Skipping loses nothing the retention argument was protecting — an overlay we cannot
+            // open contributes no header entry either way — and the names are recorded so a write that genuinely
+            // NEEDED one can say so instead of dying as a raw serializer fault.
+            var arr = new List<ISkyrimModGetter>(_r._paths.Length);
+            for (int i = 0; i < _r._paths.Length; i++)
+            {
+                if (SkipUnopenable(i)) continue;
+                arr.Add(Overlay(i));
+            }
             return arr;
         }
 
@@ -213,10 +228,39 @@ public sealed class LoadOrderResolver : IDisposable
         {
             var list = new List<ISkyrimModGetter>(_r._paths.Length);
             for (int i = 0; i < _r._paths.Length; i++)
-                if (!string.Equals(_r._names[i], excludeFileName, StringComparison.OrdinalIgnoreCase))
-                    list.Add(Overlay(i));   // SKIP the target's index — never map the file we're about to overwrite
+            {
+                if (string.Equals(_r._names[i], excludeFileName, StringComparison.OrdinalIgnoreCase)) continue;  // never map the file we're about to overwrite
+                if (SkipUnopenable(i)) continue;                                                                 // #314 — and never try to map one that cannot be opened
+                list.Add(Overlay(i));
+            }
             return list;
         }
+
+        /// <summary>#314 — is this index the could-not-be-OPENED exclusion class, which no master set can contain?
+        /// Records the name, because the skip is NOT free and the guard proved exactly where:
+        /// <list type="bullet">
+        /// <item>a patch whose header needs only ONE master still writes, even when that master is the skipped plugin —
+        /// Mutagen derives the entry from the record's own FormKey, not from list membership;</item>
+        /// <item>a patch whose header must be SORTED (two or more masters) does NOT: the serializer refuses with
+        /// <c>MissingModException</c> naming the skipped plugin.</item>
+        /// </list>
+        /// That second case is a real, reachable failure, and it must be named rather than surfaced as a generic
+        /// "serialize or commit" fault (Q3) — which is what <see cref="SkippedUnopenable"/> is for. The first draft of
+        /// this fix asserted the skip cost the output nothing and deleted this; the multi-master guard arm disproved
+        /// it.</summary>
+        bool SkipUnopenable(int i)
+        {
+            if (!_r._snap.Unopenable.Contains(i)) return false;
+            _skippedUnopenable.Add(_r._names[i]);
+            return true;
+        }
+
+        readonly SortedSet<string> _skippedUnopenable = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>The plugins this session's master-set builds skipped as unopenable (#314). Empty in the normal case.
+        /// Non-empty ⇒ a serialize failure naming a missing master is very likely one of THESE, and the write lane says
+        /// so instead of reporting an opaque engine fault.</summary>
+        public IReadOnlyCollection<string> SkippedUnopenable => _skippedUnopenable;
 
         /// <summary>Dispose and forget any overlay this session holds on <paramref name="fileName"/> — the file the caller
         /// is about to serialize to. The SECOND half of the active-patch write fix (with <see cref="AllMastersExcept"/>):
@@ -386,6 +430,7 @@ public sealed class LoadOrderResolver : IDisposable
         var overriders = new Dictionary<FormKey, List<int>>();        // multi keys only
         var failures = new List<string>();
         var excluded = new HashSet<int>();
+        var unopenable = new HashSet<int>();                          // #314 — the could-not-be-OPENED subset
         var excludedPlugins = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         int maxDepth = 0;
 
@@ -396,6 +441,7 @@ public sealed class LoadOrderResolver : IDisposable
             catch (Exception ex)
             {
                 Exclude(i, $"could not be opened — {Concise(ex)}", failures, excluded, excludedPlugins);
+                unopenable.Add(i);   // #314 — this one cannot serve as a master overlay either; the write path must skip it
                 continue;
             }
 
@@ -437,7 +483,7 @@ public sealed class LoadOrderResolver : IDisposable
         return new IndexSnapshot(
             index,
             overriders.ToDictionary(kv => kv.Key, kv => kv.Value.ToArray()),  // trim List overhead → int[]
-            failures, excluded, excludedPlugins, maxDepth, ComputeEpoch(_names, _paths, _mtimes, excludedPlugins));
+            failures, excluded, unopenable, excludedPlugins, maxDepth, ComputeEpoch(_names, _paths, _mtimes, excludedPlugins));
     }
 
     /// <summary>The epoch fingerprint: a compact, deterministic identity for ONE index build, derived from the

--- a/src/housecarl-core/NpcAppearanceCopy.cs
+++ b/src/housecarl-core/NpcAppearanceCopy.cs
@@ -505,7 +505,7 @@ public static class NpcAppearanceCopy
             // unopenable-master skip and the same residual refusal; without the caller's cause it reported an unnamed
             // engine fault while the identical failure from apply/create/forward named the plugin (PR #315 review).
             // Injected rather than reached for: this type takes a mastersFor closure, not a resolver session.
-            catch (Exception ex) { return NpcCopyOutcome.Fail($"serialize failed — {WriteEngine.Describe(ex)}{serializeCause?.Invoke(ex) ?? ""}. Nothing usable was written."); }
+            catch (Exception ex) { return NpcCopyOutcome.Fail($"serialize failed — {WriteEngine.Describe(ex)}.{serializeCause?.Invoke(ex) ?? ""} Nothing usable was written."); }
 
             // ---- post-commit read-back — the patch IS on disk from here; a read-back failure is a WARNING on a
             //      success, never a "nothing was written" (review finding: that mislabel invites a duplicate re-run).

--- a/src/housecarl-core/NpcAppearanceCopy.cs
+++ b/src/housecarl-core/NpcAppearanceCopy.cs
@@ -320,7 +320,8 @@ public static class NpcAppearanceCopy
         ActiveResolve resolvesActively,
         string outPath, bool extend,
         Func<string, IReadOnlyList<ISkyrimModGetter>> mastersFor,
-        string donorReadFrom, bool donorOutOfLoadOrder)
+        string donorReadFrom, bool donorOutOfLoadOrder,
+        Func<Exception, string>? serializeCause = null)
     {
         var patchFileName = Path.GetFileName(outPath);
         try
@@ -500,7 +501,11 @@ public static class NpcAppearanceCopy
 
             // ---- serialize (multi-master; the caller's mastersFor handles the active-patch self-lock) ----
             try { WriteEngine.WritePatch(patchMod, mastersFor(patchFileName), outPath); }
-            catch (Exception ex) { return NpcCopyOutcome.Fail($"serialize failed — {WriteEngine.Describe(ex)}. Nothing usable was written."); }
+            // #314 — this lane serializes through the caller's AllMastersExcept too, so it is subject to the same
+            // unopenable-master skip and the same residual refusal; without the caller's cause it reported an unnamed
+            // engine fault while the identical failure from apply/create/forward named the plugin (PR #315 review).
+            // Injected rather than reached for: this type takes a mastersFor closure, not a resolver session.
+            catch (Exception ex) { return NpcCopyOutcome.Fail($"serialize failed — {WriteEngine.Describe(ex)}{serializeCause?.Invoke(ex) ?? ""}. Nothing usable was written."); }
 
             // ---- post-commit read-back — the patch IS on disk from here; a read-back failure is a WARNING on a
             //      success, never a "nothing was written" (review finding: that mislabel invites a duplicate re-run).

--- a/src/housecarl-core/NpcAppearanceCopy.cs
+++ b/src/housecarl-core/NpcAppearanceCopy.cs
@@ -321,7 +321,7 @@ public static class NpcAppearanceCopy
         string outPath, bool extend,
         Func<string, IReadOnlyList<ISkyrimModGetter>> mastersFor,
         string donorReadFrom, bool donorOutOfLoadOrder,
-        Func<Exception, string>? serializeCause = null)
+        Func<Exception, string>? serializeFailure = null)
     {
         var patchFileName = Path.GetFileName(outPath);
         try
@@ -505,7 +505,16 @@ public static class NpcAppearanceCopy
             // unopenable-master skip and the same residual refusal; without the caller's cause it reported an unnamed
             // engine fault while the identical failure from apply/create/forward named the plugin (PR #315 review).
             // Injected rather than reached for: this type takes a mastersFor closure, not a resolver session.
-            catch (Exception ex) { return NpcCopyOutcome.Fail($"serialize failed — {WriteEngine.Describe(ex)}.{serializeCause?.Invoke(ex) ?? ""} Nothing usable was written."); }
+            //
+            // An OVERRIDE, not a suffix (PR #315 review 4): a suffix left the baseline refusal rendered behind
+            // "serialize failed" (it threw while the master-set ARGUMENT was built, so serialize never started) with
+            // the write status stated twice and a doubled period — the exact three complaints review 3 fixed
+            // everywhere else, surviving here because this was the one lane routed around SerializeFailure.
+            catch (Exception ex)
+            {
+                return NpcCopyOutcome.Fail(serializeFailure?.Invoke(ex)
+                    ?? $"serialize failed — {WriteEngine.Describe(ex)}. Nothing usable was written.");
+            }
 
             // ---- post-commit read-back — the patch IS on disk from here; a read-back failure is a WARNING on a
             //      success, never a "nothing was written" (review finding: that mislabel invites a duplicate re-run).

--- a/src/housecarl-core/RemapEngine.cs
+++ b/src/housecarl-core/RemapEngine.cs
@@ -903,7 +903,24 @@ public static class RemapEngine
                     return RepointResult.Fail(
                         $"cannot re-serialize '{pluginName}' in place: its declared master '{mfn}' is not active in the load order, " +
                         "so a faithful re-serialize can't resolve the references into it. Enable that master (or fix the masters in xEdit) first. The file is UNTOUCHED.");
-                var ov = SkyrimMod.CreateFromBinaryOverlay(mpath, SkyrimRelease.SkyrimSE);
+                // #314 / PR #315 review 2 — the same bare open WritePatchBuilder.ResolveOwnMasters had (this comment
+                // block's own sibling), and the same consequence: an unopenable declared master escaped as an
+                // unhandled exception. Worse here, because the caller reaches this only AFTER the compacted plugin is
+                // already on disk — the throw discards every per-plugin repoint result and skips the facegen/voice/SEQ
+                // carry that follows, on a half-completed compaction. Asked before opening, then wrapped.
+                if (view.IsUnopenable(mfn))
+                    return RepointResult.Fail(
+                        $"cannot re-serialize '{pluginName}' in place: its declared master '{mfn}' is ACTIVE but cannot be " +
+                        "opened by houseCARL (see load_order_status for the reason), so a faithful re-serialize can't " +
+                        "resolve the references into it. Repair or remove that plugin in MO2 and retry. The file is UNTOUCHED.");
+                ISkyrimModGetter ov;
+                try { ov = SkyrimMod.CreateFromBinaryOverlay(mpath, SkyrimRelease.SkyrimSE); }
+                catch (Exception ex)
+                {
+                    return RepointResult.Fail(
+                        $"cannot re-serialize '{pluginName}' in place: its declared master '{mfn}' could not be opened " +
+                        $"({WriteEngine.Describe(ex)}). Repair or remove that plugin in MO2 and retry. The file is UNTOUCHED.");
+                }
                 overlays.Add((IDisposable)ov);
                 resolved.Add(ov);
             }

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -559,7 +559,7 @@ public static class WritePatchBuilder
         session.ReleaseOverlay(patchMod.ModKey.FileName.String);
         try { WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath); }
         catch (Exception ex)
-            { return PatchOutcome.Fail($"writing the patch failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}{UnopenableMasterClause(ex, session)}"); }
+            { return PatchOutcome.Fail(SerializeFailure("writing the patch failed (serialize or commit; the existing file is untouched): ", ex, session)); }
 
         // --- Phase 5: re-open the written patch and report its master header — and, on request, each touched
         //     record's FULL read-back off that same re-opened file (the on-disk bytes, not the in-memory mod — the
@@ -934,7 +934,7 @@ public static class WritePatchBuilder
                   "Enable that plugin in MO2 (or reference an active one) and retry. The existing file is untouched.");
         }
         catch (Exception ex)
-            { return PatchOutcome.Fail($"writing '{fileName}' in place failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}{UnopenableMasterClause(ex, session)}"); }
+            { return PatchOutcome.Fail(SerializeFailure($"writing '{fileName}' in place failed (serialize or commit; the existing file is untouched): ", ex, session)); }
 
         // --- Phase 5: re-open the now-edited file and report its master header — and the touched-record verify (default
         //     ON for in-place): each edited record read back IN FULL off the on-disk bytes (the model-C substitute for
@@ -1222,7 +1222,7 @@ public static class WritePatchBuilder
         // keeps the target out of the master set. (writelock-probe / writelock-apply-probe; both halves guarded.)
         session.ReleaseOverlay(patchMod.ModKey.FileName.String);
         try { WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath); }
-        catch (Exception ex) { return RemovalOutcome.Fail($"writing the patch after removal failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}{UnopenableMasterClause(ex, session)}"); }
+        catch (Exception ex) { return RemovalOutcome.Fail(SerializeFailure("writing the patch after removal failed (serialize or commit; the existing file is untouched): ", ex, session)); }
 
         // Re-open: report the (possibly shrunk) master header + how many records remain (0 ⇒ the patch is now an inert
         // header-only plugin the user can disable/delete). Dispose the overlay so the file isn't left mmap'd for a later call.
@@ -1611,7 +1611,7 @@ public static class WritePatchBuilder
                   "Enable that plugin in MO2 and retry. The existing file is untouched.");
         }
         catch (Exception ex)
-            { return ForwardOutcome.Fail($"writing '{fileName}' in place failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}{UnopenableMasterClause(ex, session)}"); }
+            { return ForwardOutcome.Fail(SerializeFailure($"writing '{fileName}' in place failed (serialize or commit; the existing file is untouched): ", ex, session)); }
 
         // --- Phase 5: re-open + report masters/bytes + the touched-record verify (default ON for in-place). ---
         IReadOnlyList<string> masters = Array.Empty<string>();
@@ -1648,10 +1648,12 @@ public static class WritePatchBuilder
     /// included.</para></summary>
     public static string UnopenableMasterClause(Exception ex, LoadOrderResolver.OverlaySession session)
     {
-        // A baseline refusal is thrown, not skipped, so it can arrive with SkippedUnopenable still empty — check it
-        // first or the "serialize or commit failed" lead-in would stand alone in front of it.
+        // NOT the baseline class: WriteEngine.Describe already renders "{Type}: {Message}", and that exception's
+        // Message IS the whole refusal — appending it as a CAUSE printed the same ~60 words twice (PR #315 review 3).
+        // That branch is handled by SerializeFailure, which SUBSTITUTES rather than appends. Returning "" here also
+        // keeps the doubling out of the one lane that renders the clause without going through it (npc-copy).
         for (Exception? b = ex; b is not null; b = b.InnerException)
-            if (b is UnopenableBaselineMasterException ub) return " CAUSE: " + ub.Message;
+            if (b is UnopenableBaselineMasterException) return "";
         if (session.SkippedUnopenable.Count == 0) return "";
         var hit = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
         CollectMissingMods(ex, session, hit, depth: 0);
@@ -1662,6 +1664,19 @@ public static class WritePatchBuilder
                "houseCARL (see load_order_status for the reason), so the header this write needs cannot be sorted against " +
                $"{(one ? "it" : "them")}. Repair or remove {(one ? "that plugin" : "those plugins")} " +
                "in MO2 and retry — writes that do NOT reference their records are unaffected.";
+    }
+
+    /// <summary>Render a serialize-failure message. Normally <paramref name="lead"/> + the exception + the
+    /// unopenable-master CAUSE; but a BASELINE refusal SUBSTITUTES its own message for the lot, because every part of
+    /// the usual shape is wrong for it (PR #315 review 3): it is thrown while the master-set ARGUMENT is being built,
+    /// so "serialize or commit" names a phase that never started; the patch lanes' lead adds "the existing file is
+    /// untouched" when a fresh patch has no existing file; and the message would otherwise print twice, since
+    /// <see cref="WriteEngine.Describe"/> already carries it.</summary>
+    static string SerializeFailure(string lead, Exception ex, LoadOrderResolver.OverlaySession session)
+    {
+        for (Exception? b = ex; b is not null; b = b.InnerException)
+            if (b is UnopenableBaselineMasterException ub) return ub.Message;
+        return lead + WriteEngine.Describe(ex) + UnopenableMasterClause(ex, session);
     }
 
     /// <summary>Walk an exception chain (inner + aggregate branches) collecting the SKIPPED plugins a
@@ -1965,7 +1980,7 @@ public static class WritePatchBuilder
         session.ReleaseOverlay(patchMod.ModKey.FileName.String);
         try { WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath); }
         catch (Exception ex)
-            { return ForwardOutcome.Fail($"writing the patch failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}{UnopenableMasterClause(ex, session)}"); }
+            { return ForwardOutcome.Fail(SerializeFailure("writing the patch failed (serialize or commit; the existing file is untouched): ", ex, session)); }
 
         // --- Phase 5: re-open + report the (lean, derived) master header + bytes — and, on request, each forwarded
         //     record's FULL read-back off that same re-opened file (see Apply's Phase 5). Dispose the overlay after. ---
@@ -2720,7 +2735,7 @@ public static class WritePatchBuilder
             else
                 WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath);
         }
-        catch (Exception ex) { return CreateOutcome.Fail($"writing {(inPlace ? $"'{fileName}' in place" : "the patch")} after create failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}{UnopenableMasterClause(ex, session)}"); }
+        catch (Exception ex) { return CreateOutcome.Fail(SerializeFailure($"writing {(inPlace ? $"'{fileName}' in place" : "the patch")} after create failed (serialize or commit; the existing file is untouched): ", ex, session)); }
 
         // --- Phase 5: re-open + report the (derived) master header + bytes — and, on request, each created record's
         //     FULL read-back off that same re-opened file (see Apply's Phase 5). Dispose the overlay so the file isn't

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -1038,6 +1038,17 @@ public static class WritePatchBuilder
         // unopenable plugin (Mutagen derives the entry from the record's FormKey), and a header that must be SORTED —
         // two or more — refuses. Both sides are pinned by excluded-master-guard, so if that behaviour ever moves, the
         // guard says so rather than this prediction quietly going wrong in one direction or the other.
+        // The BASELINE case first, and WITHOUT the count threshold: the real write refuses it outright (the force-
+        // include is mandatory however small the header), and it is not in `set` at all when nothing references it —
+        // which is exactly the self-contained create the real call would otherwise emit missing a master.
+        foreach (var bm in WriteEngine.BaselineMasters)
+            if (resolver.PluginNames.Contains(bm.FileName.String, StringComparer.OrdinalIgnoreCase)
+                && resolver.IsUnopenable(bm.FileName.String))
+                return $"dry run caught what the real write would fail on: '{bm.FileName}' is a BASELINE master (every " +
+                       "written plugin must list it) and is ACTIVE in your load order, but houseCARL cannot open it — " +
+                       "see load_order_status for the reason. No plugin can be written until it is repaired or " +
+                       "replaced. Nothing was written.";
+
         var unopenable = set.Where(resolver.IsUnopenable).OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToList();
         if (unopenable.Count > 0 && set.Count > 1)
             return $"dry run caught what the real write would fail on: the would-be content references " +
@@ -1637,6 +1648,10 @@ public static class WritePatchBuilder
     /// included.</para></summary>
     public static string UnopenableMasterClause(Exception ex, LoadOrderResolver.OverlaySession session)
     {
+        // A baseline refusal is thrown, not skipped, so it can arrive with SkippedUnopenable still empty — check it
+        // first or the "serialize or commit failed" lead-in would stand alone in front of it.
+        for (Exception? b = ex; b is not null; b = b.InnerException)
+            if (b is UnopenableBaselineMasterException ub) return " CAUSE: " + ub.Message;
         if (session.SkippedUnopenable.Count == 0) return "";
         var hit = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
         CollectMissingMods(ex, session, hit, depth: 0);
@@ -2145,7 +2160,19 @@ public static class WritePatchBuilder
                     return CompactBuildResult.Fail(
                         $"cannot compact '{modKey.FileName}': its declared master '{mfn}' is not active in the load order, so a " +
                         "faithful re-serialize can't resolve the references into it. Enable that master (or fix the masters in xEdit) first. Nothing was written.");
-                var mov = SkyrimMod.CreateFromBinaryOverlay(mp, SkyrimRelease.SkyrimSE);
+                // Wrapped for the reason MergeBuild's twin states in its own catch: an open throw escaping HERE skips
+                // the caller's rider-folder cleanup, leaving an orphan houseCARL mod folder in the MO2 mods directory
+                // — plus an unnamed engine throw instead of a Fail result. CompactBuild had the same caller shape and
+                // no such catch, which #314's unopenable class makes reachable (PR #315 review 2).
+                ISkyrimModGetter mov;
+                try { mov = SkyrimMod.CreateFromBinaryOverlay(mp, SkyrimRelease.SkyrimSE); }
+                catch (Exception ex)
+                {
+                    return CompactBuildResult.Fail(
+                        $"cannot compact '{modKey.FileName}': its declared master '{mfn}' could not be opened for the " +
+                        $"serialize ({WriteEngine.Describe(ex)}) — if that plugin is active but unreadable, repair or " +
+                        "remove it in MO2 and retry. Nothing was written.");
+                }
                 overlays.Add((IDisposable)mov); resolved.Add(mov);
             }
             try { WriteEngine.WriteInPlace(pPrime, resolved, outPath); }

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -1051,10 +1051,12 @@ public static class WritePatchBuilder
             // IsUnopenable already returns false for a name absent from the order, so a membership pre-test would only
             // add an O(n) scan of every plugin name per baseline, on every dry run (PR #315 review 4).
             if (resolver.IsUnopenable(bm.FileName.String))
-                return $"dry run caught what the real write would fail on: '{bm.FileName}' is a BASELINE master (every " +
-                       "written plugin must list it) and is ACTIVE in your load order, but houseCARL cannot open it — " +
-                       "see load_order_status for the reason. No plugin can be written until it is repaired or " +
-                       "replaced. Nothing was written.";
+                // The REAL call's own message, constructed rather than paraphrased (PR #315 re-review). Finding 4 was
+                // folded in the exception and missed here, so the two immediately disagreed — this one still carried
+                // the patch-lane-only reason on a lane that reaches it in-place, and had lost the remedy. Sharing the
+                // string makes #225 parity a fact instead of two prose blocks somebody has to keep in step.
+                return "dry run caught what the real write would fail on: "
+                       + new UnopenableBaselineMasterException(bm.FileName.String).Message;
 
         var unopenable = set.Where(resolver.IsUnopenable).OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToList();
         if (unopenable.Count > 0 && set.Count > 1)
@@ -1688,7 +1690,12 @@ public static class WritePatchBuilder
     {
         for (Exception? b = ex; b is not null; b = b.InnerException)
             if (b is UnopenableBaselineMasterException ub) return ub.Message;
-        return lead + WriteEngine.Describe(ex) + UnopenableMasterClause(ex, session) + trailer;
+        var body = lead + WriteEngine.Describe(ex) + UnopenableMasterClause(ex, session);
+        if (trailer.Length == 0) return body;
+        // Exactly ONE terminator before a lane's tail. A fixed trailer cannot do this alone: the clause already ends
+        // in a full stop when it fires, and Describe(ex) does not when it doesn't — so a leading period doubles in one
+        // case and its absence runs two sentences together in the other (PR #315 re-review).
+        return body.TrimEnd().EndsWith('.') ? body + trailer : body + "." + trailer;
     }
 
     /// <summary>Walk an exception chain (inner + aggregate branches) collecting the SKIPPED plugins a

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -923,10 +923,15 @@ public static class WritePatchBuilder
         try { WriteEngine.WriteInPlace(targetMod, session.AllMastersExcept(fileName), targetPath); }
         catch (MissingModException ex)
         {
-            return PatchOutcome.Fail(
-                $"writing '{fileName}' in place failed: the edited records reference a plugin that is NOT active in " +
-                $"the load order ({ex.Message}) — a reference into an inactive plugin can't resolve in game. " +
-                "Enable that plugin in MO2 (or reference an active one) and retry. The existing file is untouched.");
+            // #314: this arm fires FIRST, so it is where the unopenable residual lands on this lane — and its
+            // "NOT active in the load order" reading is wrong for it (the plugin IS active, just unopenable), which
+            // would send the user to enable something already enabled. Prefer the named cause when it applies.
+            return PatchOutcome.Fail(UnopenableMasterClause(ex, session) is { Length: > 0 } why
+                ? $"writing '{fileName}' in place failed: the edited records reference a plugin the write cannot " +
+                  $"resolve ({ex.Message}).{why} The existing file is untouched."
+                : $"writing '{fileName}' in place failed: the edited records reference a plugin that is NOT active in " +
+                  $"the load order ({ex.Message}) — a reference into an inactive plugin can't resolve in game. " +
+                  "Enable that plugin in MO2 (or reference an active one) and retry. The existing file is untouched.");
         }
         catch (Exception ex)
             { return PatchOutcome.Fail($"writing '{fileName}' in place failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}{UnopenableMasterClause(ex, session)}"); }
@@ -1024,6 +1029,25 @@ public static class WritePatchBuilder
         if (patchLane)
             foreach (var bm in WriteEngine.BaselineMasters)
                 if (priority.ContainsKey(bm.FileName.String)) set.Add(bm.FileName.String);
+
+        // #314 — an UNOPENABLE referenced plugin is ACTIVE, so the membership test above passes it happily, and the
+        // dry run would predict success for a write the real call now refuses. That breaks this method's own contract
+        // ("a dry run must never say 'would apply' about a write that would fail"), which the #225 parity guard holds.
+        //
+        // The threshold is empirical, not assumed: a header carrying ONE master writes even when that master is the
+        // unopenable plugin (Mutagen derives the entry from the record's FormKey), and a header that must be SORTED —
+        // two or more — refuses. Both sides are pinned by excluded-master-guard, so if that behaviour ever moves, the
+        // guard says so rather than this prediction quietly going wrong in one direction or the other.
+        var unopenable = set.Where(resolver.IsUnopenable).OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToList();
+        if (unopenable.Count > 0 && set.Count > 1)
+            return $"dry run caught what the real write would fail on: the would-be content references " +
+                   $"{string.Join(", ", unopenable.Select(n => $"'{n}'"))}, which {(unopenable.Count == 1 ? "is" : "are")} " +
+                   "ACTIVE in your load order but cannot be opened by houseCARL (see load_order_status for the reason), " +
+                   "so the master header this write needs cannot be sorted against " +
+                   $"{(unopenable.Count == 1 ? "it" : "them")}. Repair or remove " +
+                   $"{(unopenable.Count == 1 ? "that plugin" : "those plugins")} in MO2 and retry — writes that do NOT " +
+                   "reference their records are unaffected. Nothing was written.";
+
         masters = set.OrderBy(n => priority[n]).ToList();
         return null;
     }
@@ -1050,7 +1074,30 @@ public static class WritePatchBuilder
                           "(or fix the target's masters in xEdit) first. The file is UNTOUCHED.";
                 return Array.Empty<ISkyrimModGetter>();
             }
-            var ov = SkyrimMod.CreateFromBinaryOverlay(mpath, SkyrimRelease.SkyrimSE);
+            // #314 — this lane does NOT go through AllMasters/AllMastersExcept: it opens the target's declared
+            // masters itself, with a bare CreateFromBinaryOverlay that sat outside every catch. An unopenable declared
+            // master therefore escaped as an unhandled exception rather than a Q3 refusal — the same failure class
+            // #314 filed, surviving in the one write lane the skip does not reach (PR #315 review). Asked BEFORE the
+            // open, so the refusal names the plugin and the remedy instead of relaying an engine throw.
+            if (view.IsUnopenable(mfn))
+            {
+                missing = $"cannot re-serialize '{targetMod.ModKey.FileName}' in place: its declared master '{mfn}' is ACTIVE " +
+                          "but cannot be opened by houseCARL (see load_order_status for the reason), so a faithful " +
+                          "re-serialize can't resolve the references into it. Repair or remove that plugin in MO2 and " +
+                          "retry. The file is UNTOUCHED.";
+                return Array.Empty<ISkyrimModGetter>();
+            }
+            ISkyrimModGetter ov;
+            try { ov = SkyrimMod.CreateFromBinaryOverlay(mpath, SkyrimRelease.SkyrimSE); }
+            catch (Exception ex)
+            {
+                // Belt to the check above's braces: a master that opens fine at index time can still fail here (the
+                // file changed since the build). Named, never an escaping throw.
+                missing = $"cannot re-serialize '{targetMod.ModKey.FileName}' in place: its declared master '{mfn}' could " +
+                          $"not be opened ({WriteEngine.Describe(ex)}) — a faithful re-serialize can't resolve the " +
+                          "references into it. Repair or remove that plugin in MO2 and retry. The file is UNTOUCHED.";
+                return Array.Empty<ISkyrimModGetter>();
+            }
             overlays.Add((IDisposable)ov);
             resolved.Add(ov);
         }
@@ -1330,7 +1377,7 @@ public static class WritePatchBuilder
             if (missing is not null) return RemovalOutcome.Fail(missing);
             try { WriteEngine.WriteInPlace(targetMod, ownMasters, targetPath); }
             catch (Exception ex)
-                { return RemovalOutcome.Fail($"writing '{fileName}' in place after removal failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}{UnopenableMasterClause(ex, session)}"); }
+                { return RemovalOutcome.Fail($"writing '{fileName}' in place after removal failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}"); }
         }
         finally { foreach (var d in masterOverlays) { try { d.Dispose(); } catch { /* best-effort; never mask the write result */ } } }
 
@@ -1544,10 +1591,13 @@ public static class WritePatchBuilder
         try { WriteEngine.WriteInPlace(targetMod, session.AllMastersExcept(fileName), targetPath); }
         catch (MissingModException ex)
         {
-            return ForwardOutcome.Fail(
-                $"writing '{fileName}' in place failed: the forwarded records reference a plugin that is NOT active in " +
-                $"the load order ({ex.Message}) — a reference into an inactive plugin can't resolve in game. " +
-                "Enable that plugin in MO2 and retry. The existing file is untouched.");
+            // Same shadowing as the apply twin — see there.
+            return ForwardOutcome.Fail(UnopenableMasterClause(ex, session) is { Length: > 0 } why
+                ? $"writing '{fileName}' in place failed: the forwarded records reference a plugin the write cannot " +
+                  $"resolve ({ex.Message}).{why} The existing file is untouched."
+                : $"writing '{fileName}' in place failed: the forwarded records reference a plugin that is NOT active in " +
+                  $"the load order ({ex.Message}) — a reference into an inactive plugin can't resolve in game. " +
+                  "Enable that plugin in MO2 and retry. The existing file is untouched.");
         }
         catch (Exception ex)
             { return ForwardOutcome.Fail($"writing '{fileName}' in place failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}{UnopenableMasterClause(ex, session)}"); }
@@ -1573,25 +1623,46 @@ public static class WritePatchBuilder
     }
 
 
-    /// <summary>#314 — the NAMED cause when a serialize failed because the header needed a master this session skipped
-    /// as unopenable. The plugin IS active, so the pre-existing "not active in the load order" wording is wrong for it,
-    /// and the generic "serialize or commit" wording reads as a disk fault. Empty string when this isn't that case, so
-    /// callers can append unconditionally.
-    /// <para>Matched on the exception TEXT naming one of the skipped plugins, which is why it is a suffix rather than a
-    /// replacement: Mutagen's message is the only thing that knows WHICH master the sort wanted, and a mismatch must
-    /// degrade to the ordinary description rather than to a confident wrong cause.</para></summary>
-    static string UnopenableMasterClause(Exception ex, LoadOrderResolver.OverlaySession session)
+    /// <summary>#314 — the NAMED cause when a serialize failed because the header needed a master this session
+    /// skipped as unopenable. The plugin IS active, so the "not active in the load order" wording the missing-master
+    /// arms use is wrong for it, and the generic "serialize or commit" wording reads as a disk fault. Empty string when
+    /// this isn't that case, so callers can append unconditionally.
+    ///
+    /// <para>Matched on the exception's TYPED <c>ModPaths</c>, never on its message text. Two review findings closed by
+    /// construction rather than patched: a substring match would fire when a skipped <c>Foo.esp</c> is a substring of
+    /// the <c>MyFoo.esp</c> the serializer actually wanted (Skyrim plugin names are heavily prefixed) — the confident
+    /// wrong cause this is supposed to degrade away from; and reading only <c>ex.Message</c> would miss a
+    /// <c>MissingModException</c> that arrives WRAPPED, which this codebase already documents happens (see
+    /// <see cref="RootNullArm"/>'s doubly-nested AggregateException). The whole chain is walked, aggregates
+    /// included.</para></summary>
+    public static string UnopenableMasterClause(Exception ex, LoadOrderResolver.OverlaySession session)
     {
         if (session.SkippedUnopenable.Count == 0) return "";
-        var hit = session.SkippedUnopenable
-            .Where(n => ex.Message.Contains(n, StringComparison.OrdinalIgnoreCase))
-            .ToList();
+        var hit = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+        CollectMissingMods(ex, session, hit, depth: 0);
         if (hit.Count == 0) return "";
         var names = string.Join(", ", hit.Select(n => $"'{n}'"));
-        return $" CAUSE: {names} {(hit.Count == 1 ? "is" : "are")} ACTIVE in your load order but cannot be opened by " +
+        bool one = hit.Count == 1;
+        return $" CAUSE: {names} {(one ? "is" : "are")} ACTIVE in your load order but cannot be opened by " +
                "houseCARL (see load_order_status for the reason), so the header this write needs cannot be sorted against " +
-               $"{(hit.Count == 1 ? "it" : "them")}. Repair or remove {(hit.Count == 1 ? "that plugin" : "those plugins")} " +
+               $"{(one ? "it" : "them")}. Repair or remove {(one ? "that plugin" : "those plugins")} " +
                "in MO2 and retry — writes that do NOT reference their records are unaffected.";
+    }
+
+    /// <summary>Walk an exception chain (inner + aggregate branches) collecting the SKIPPED plugins a
+    /// <see cref="MissingModException"/> names. Depth-capped because a malformed chain must never hang a refusal.</summary>
+    static void CollectMissingMods(Exception? ex, LoadOrderResolver.OverlaySession session, SortedSet<string> into, int depth)
+    {
+        if (ex is null || depth > 8) return;
+        if (ex is MissingModException mme)
+            foreach (var mp in mme.ModPaths)
+            {
+                var name = mp.ModKey.FileName.String;
+                if (session.SkippedUnopenable.Contains(name)) into.Add(name);
+            }
+        if (ex is AggregateException agg)
+            foreach (var inner in agg.InnerExceptions) CollectMissingMods(inner, session, into, depth + 1);
+        CollectMissingMods(ex.InnerException, session, into, depth + 1);
     }
 
     /// <summary>One record to FORWARD: take plugin <see cref="FromPlugin"/>'s version of <see cref="Target"/> and carry

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -559,7 +559,7 @@ public static class WritePatchBuilder
         session.ReleaseOverlay(patchMod.ModKey.FileName.String);
         try { WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath); }
         catch (Exception ex)
-            { return PatchOutcome.Fail($"writing the patch failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}"); }
+            { return PatchOutcome.Fail($"writing the patch failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}{UnopenableMasterClause(ex, session)}"); }
 
         // --- Phase 5: re-open the written patch and report its master header — and, on request, each touched
         //     record's FULL read-back off that same re-opened file (the on-disk bytes, not the in-memory mod — the
@@ -929,7 +929,7 @@ public static class WritePatchBuilder
                 "Enable that plugin in MO2 (or reference an active one) and retry. The existing file is untouched.");
         }
         catch (Exception ex)
-            { return PatchOutcome.Fail($"writing '{fileName}' in place failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}"); }
+            { return PatchOutcome.Fail($"writing '{fileName}' in place failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}{UnopenableMasterClause(ex, session)}"); }
 
         // --- Phase 5: re-open the now-edited file and report its master header — and the touched-record verify (default
         //     ON for in-place): each edited record read back IN FULL off the on-disk bytes (the model-C substitute for
@@ -1164,7 +1164,7 @@ public static class WritePatchBuilder
         // keeps the target out of the master set. (writelock-probe / writelock-apply-probe; both halves guarded.)
         session.ReleaseOverlay(patchMod.ModKey.FileName.String);
         try { WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath); }
-        catch (Exception ex) { return RemovalOutcome.Fail($"writing the patch after removal failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}"); }
+        catch (Exception ex) { return RemovalOutcome.Fail($"writing the patch after removal failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}{UnopenableMasterClause(ex, session)}"); }
 
         // Re-open: report the (possibly shrunk) master header + how many records remain (0 ⇒ the patch is now an inert
         // header-only plugin the user can disable/delete). Dispose the overlay so the file isn't left mmap'd for a later call.
@@ -1330,7 +1330,7 @@ public static class WritePatchBuilder
             if (missing is not null) return RemovalOutcome.Fail(missing);
             try { WriteEngine.WriteInPlace(targetMod, ownMasters, targetPath); }
             catch (Exception ex)
-                { return RemovalOutcome.Fail($"writing '{fileName}' in place after removal failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}"); }
+                { return RemovalOutcome.Fail($"writing '{fileName}' in place after removal failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}{UnopenableMasterClause(ex, session)}"); }
         }
         finally { foreach (var d in masterOverlays) { try { d.Dispose(); } catch { /* best-effort; never mask the write result */ } } }
 
@@ -1550,7 +1550,7 @@ public static class WritePatchBuilder
                 "Enable that plugin in MO2 and retry. The existing file is untouched.");
         }
         catch (Exception ex)
-            { return ForwardOutcome.Fail($"writing '{fileName}' in place failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}"); }
+            { return ForwardOutcome.Fail($"writing '{fileName}' in place failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}{UnopenableMasterClause(ex, session)}"); }
 
         // --- Phase 5: re-open + report masters/bytes + the touched-record verify (default ON for in-place). ---
         IReadOnlyList<string> masters = Array.Empty<string>();
@@ -1570,6 +1570,28 @@ public static class WritePatchBuilder
 
         return new ForwardOutcome(true, null, targetPath, false, forwarded, masters, bytes)
             { ReadBack = readBack, InPlace = true, Note = MasterGrowNote(fileName, mastersBefore, masters) };
+    }
+
+
+    /// <summary>#314 — the NAMED cause when a serialize failed because the header needed a master this session skipped
+    /// as unopenable. The plugin IS active, so the pre-existing "not active in the load order" wording is wrong for it,
+    /// and the generic "serialize or commit" wording reads as a disk fault. Empty string when this isn't that case, so
+    /// callers can append unconditionally.
+    /// <para>Matched on the exception TEXT naming one of the skipped plugins, which is why it is a suffix rather than a
+    /// replacement: Mutagen's message is the only thing that knows WHICH master the sort wanted, and a mismatch must
+    /// degrade to the ordinary description rather than to a confident wrong cause.</para></summary>
+    static string UnopenableMasterClause(Exception ex, LoadOrderResolver.OverlaySession session)
+    {
+        if (session.SkippedUnopenable.Count == 0) return "";
+        var hit = session.SkippedUnopenable
+            .Where(n => ex.Message.Contains(n, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (hit.Count == 0) return "";
+        var names = string.Join(", ", hit.Select(n => $"'{n}'"));
+        return $" CAUSE: {names} {(hit.Count == 1 ? "is" : "are")} ACTIVE in your load order but cannot be opened by " +
+               "houseCARL (see load_order_status for the reason), so the header this write needs cannot be sorted against " +
+               $"{(hit.Count == 1 ? "it" : "them")}. Repair or remove {(hit.Count == 1 ? "that plugin" : "those plugins")} " +
+               "in MO2 and retry — writes that do NOT reference their records are unaffected.";
     }
 
     /// <summary>One record to FORWARD: take plugin <see cref="FromPlugin"/>'s version of <see cref="Target"/> and carry
@@ -1857,7 +1879,7 @@ public static class WritePatchBuilder
         session.ReleaseOverlay(patchMod.ModKey.FileName.String);
         try { WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath); }
         catch (Exception ex)
-            { return ForwardOutcome.Fail($"writing the patch failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}"); }
+            { return ForwardOutcome.Fail($"writing the patch failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}{UnopenableMasterClause(ex, session)}"); }
 
         // --- Phase 5: re-open + report the (lean, derived) master header + bytes — and, on request, each forwarded
         //     record's FULL read-back off that same re-opened file (see Apply's Phase 5). Dispose the overlay after. ---
@@ -2600,7 +2622,7 @@ public static class WritePatchBuilder
             else
                 WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath);
         }
-        catch (Exception ex) { return CreateOutcome.Fail($"writing {(inPlace ? $"'{fileName}' in place" : "the patch")} after create failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}"); }
+        catch (Exception ex) { return CreateOutcome.Fail($"writing {(inPlace ? $"'{fileName}' in place" : "the patch")} after create failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}{UnopenableMasterClause(ex, session)}"); }
 
         // --- Phase 5: re-open + report the (derived) master header + bytes — and, on request, each created record's
         //     FULL read-back off that same re-opened file (see Apply's Phase 5). Dispose the overlay so the file isn't

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -1030,6 +1030,12 @@ public static class WritePatchBuilder
             foreach (var bm in WriteEngine.BaselineMasters)
                 if (priority.ContainsKey(bm.FileName.String)) set.Add(bm.FileName.String);
 
+        // SNAPSHOT NOTE (PR #315 review 4): resolver.IsUnopenable reads the CURRENT snapshot, while the write lanes
+        // resolve against a pinned IndexView — so a rebuild between this prediction and the write lets the two
+        // disagree, the class hunt-F5's one-view discipline exists to prevent. Inherited shape (this method takes a
+        // resolver, not a view) rather than introduced here, and the failure mode is a stale prediction, never a bad
+        // write; recorded so it is a known bound rather than an oversight.
+        //
         // #314 — an UNOPENABLE referenced plugin is ACTIVE, so the membership test above passes it happily, and the
         // dry run would predict success for a write the real call now refuses. That breaks this method's own contract
         // ("a dry run must never say 'would apply' about a write that would fail"), which the #225 parity guard holds.
@@ -1042,8 +1048,9 @@ public static class WritePatchBuilder
         // include is mandatory however small the header), and it is not in `set` at all when nothing references it —
         // which is exactly the self-contained create the real call would otherwise emit missing a master.
         foreach (var bm in WriteEngine.BaselineMasters)
-            if (resolver.PluginNames.Contains(bm.FileName.String, StringComparer.OrdinalIgnoreCase)
-                && resolver.IsUnopenable(bm.FileName.String))
+            // IsUnopenable already returns false for a name absent from the order, so a membership pre-test would only
+            // add an O(n) scan of every plugin name per baseline, on every dry run (PR #315 review 4).
+            if (resolver.IsUnopenable(bm.FileName.String))
                 return $"dry run caught what the real write would fail on: '{bm.FileName}' is a BASELINE master (every " +
                        "written plugin must list it) and is ACTIVE in your load order, but houseCARL cannot open it — " +
                        "see load_order_status for the reason. No plugin can be written until it is repaired or " +
@@ -1672,11 +1679,16 @@ public static class WritePatchBuilder
     /// so "serialize or commit" names a phase that never started; the patch lanes' lead adds "the existing file is
     /// untouched" when a fresh patch has no existing file; and the message would otherwise print twice, since
     /// <see cref="WriteEngine.Describe"/> already carries it.</summary>
-    static string SerializeFailure(string lead, Exception ex, LoadOrderResolver.OverlaySession session)
+    /// <para><paramref name="trailer"/> is a lane's own tail (npc-copy's "Nothing usable was written."). It is
+    /// DROPPED on the baseline branch, whose message already states the write status — appending it produced the
+    /// doubled status and doubled period that survived in the one lane routed around this helper (PR #315 review 4).
+    /// PUBLIC rather than the suggested internal: the calling lane lives in housecarl-mcp, and core only grants
+    /// InternalsVisibleTo to housecarl-generator, so internal would not have compiled at the call site.</para>
+    public static string SerializeFailure(string lead, Exception ex, LoadOrderResolver.OverlaySession session, string trailer = "")
     {
         for (Exception? b = ex; b is not null; b = b.InnerException)
             if (b is UnopenableBaselineMasterException ub) return ub.Message;
-        return lead + WriteEngine.Describe(ex) + UnopenableMasterClause(ex, session);
+        return lead + WriteEngine.Describe(ex) + UnopenableMasterClause(ex, session) + trailer;
     }
 
     /// <summary>Walk an exception chain (inner + aggregate branches) collecting the SKIPPED plugins a
@@ -1691,7 +1703,14 @@ public static class WritePatchBuilder
                 if (session.SkippedUnopenable.Contains(name)) into.Add(name);
             }
         if (ex is AggregateException agg)
+        {
+            // …and NOT the tail below as well: AggregateException.InnerException IS InnerExceptions[0], so visiting
+            // both walks that branch twice and burns two depth levels on one hop, roughly halving the effective cap
+            // along an aggregate chain (PR #315 review 4). Harmless — the set dedupes — but the cap should mean what
+            // it says.
             foreach (var inner in agg.InnerExceptions) CollectMissingMods(inner, session, into, depth + 1);
+            return;
+        }
         CollectMissingMods(ex.InnerException, session, into, depth + 1);
     }
 

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -95,6 +95,9 @@ public static class CiAll
         // plural capability, forward's renamed source= pole, and json/epoch TRANSPORT — including write_seq's
         // ABSENT epoch, stated as a fact with its reason.
         ("write-surface-guard", WriteSurfaceGuardProbe.RunGuard),
+        // #314 — an UNOPENABLE active plugin must not break every write. Its own probe because its fixture cannot be
+        // shared: the broken plugin poisons every write in whatever order it sits in, which IS the bug.
+        ("excluded-master-guard", ExcludedMasterWriteProbe.RunGuard),
         ("writelock-guard", WriteLockProbe.RunGuard),
         // #225 dry_run= on the write tools — the real pipeline HALTED before serialize, nothing written: refusal
         // parity with the real call, prediction parity (path/After/masters), the pre-empted missing-master failure,

--- a/src/housecarl-generator/ExcludedMasterWriteProbe.cs
+++ b/src/housecarl-generator/ExcludedMasterWriteProbe.cs
@@ -322,8 +322,14 @@ public static class ExcludedMasterWriteProbe
         var dry = ApplyTools.Apply(svc, patch: "BlDry", dry_run: true,
             ops: System.Text.Json.JsonDocument.Parse(
                 $$"""[{"formid":"{{subjectFid}}","field_path":"Name","value":"Bl"}]""").RootElement.Clone());
-        Check("…and dry_run predicts that same refusal, naming the baseline (#225 parity)",
-            dry.StartsWith("error:") && dry.Contains("BASELINE master", StringComparison.Ordinal), dry);
+        // …with the SAME words, not merely the same phrase. A Contains() on both sides cannot see the two drift
+        // apart, which is exactly what happened: review 4's rewording landed in the exception and not in the dry
+        // run's paraphrase (PR #315 re-review). The refusals now share one string, so the arm asserts that identity
+        // — the dry-run text must contain the real call's message verbatim.
+        var realBody = created["error: ".Length..].Trim();
+        Check("…and dry_run predicts that same refusal VERBATIM, not a paraphrase that can drift (#225 parity)",
+            dry.StartsWith("error:") && dry.Contains(realBody, StringComparison.Ordinal),
+            $"real=[{realBody}] dry=[{dry}]");
 
         // copy_npc_appearance is the one write lane that renders through an INJECTED renderer rather than calling
         // SerializeFailure directly, so it is the lane that silently kept the doubled tail and the wrong phase after

--- a/src/housecarl-generator/ExcludedMasterWriteProbe.cs
+++ b/src/housecarl-generator/ExcludedMasterWriteProbe.cs
@@ -41,6 +41,20 @@ public static class ExcludedMasterWriteProbe
     static string MastersLineOf(string render)
         => render.Split('\n').FirstOrDefault(l => l.StartsWith("masters:", StringComparison.Ordinal)) ?? "";
 
+    /// <summary>The written artifact's path out of a write render (mod folder + filename), so a following arm can
+    /// address it by name — e.g. as an in_place target.</summary>
+    static string? ArtifactPathFrom(Fixture fx, string render)
+    {
+        if (!render.StartsWith("wrote ", StringComparison.Ordinal)) return null;
+        var file = render[(render.IndexOf(' ') + 1)..];
+        file = file[..file.IndexOf(' ')];
+        const string marker = "mod folder: ";
+        int at = render.IndexOf(marker, StringComparison.Ordinal);
+        if (at < 0) return null;
+        var mod = render[(at + marker.Length)..].Split('\n')[0].Split("  ")[0].Trim();
+        return Path.Combine(fx.ModsDir, mod, file);
+    }
+
     const string MasterName = "HcXMaster.esm";
     const string CleanName = "HcXClean.esp";
     const string BrokenName = "HcXBroken.esp";
@@ -106,19 +120,56 @@ public static class ExcludedMasterWriteProbe
             var line = MastersLineOf(both);
             int iMaster = line.IndexOf(MasterName, StringComparison.OrdinalIgnoreCase);
             int iBroken = line.IndexOf(BrokenName, StringComparison.OrdinalIgnoreCase);
-            if (!both.StartsWith("error:"))
-                Check("a MULTI-master header still lists both masters in load order (the skip does not reorder it)",
-                    iMaster >= 0 && iBroken >= 0 && iMaster < iBroken, line.Length > 0 ? line : both);
-            else
-                // …and where it CANNOT be written, the refusal must name the real cause. This is the residual the skip
-                // leaves: with two or more masters the serializer sorts the header against the known set and refuses on
-                // the one it hasn't got. It was already failing before the fix (with a different exception), so nothing
-                // regressed — but "serialize or commit failed" sends the reader to their disk, and the plugin is not
-                // "not active" either, which is what the pre-existing MissingMod arms would have said.
-                Check("…or, where a sorted header cannot be built, the refusal NAMES the unopenable plugin as the cause",
-                    both.Contains(BrokenName, StringComparison.OrdinalIgnoreCase)
-                    && both.Contains("cannot be opened by houseCARL", StringComparison.Ordinal)
-                    && both.Contains("writes that do NOT reference their records are unaffected", StringComparison.Ordinal), both);
+            // PINNED, not branched. The earlier version asserted ordering on success and the CAUSE on failure with
+            // nothing asserting WHICH outcome was expected — so a behaviour flip in either direction would still have
+            // reported PASS while the clause silently lost all CI coverage (PR #315 review). The two-master header is
+            // the case that REFUSES; the one-master header above is the case that WRITES. Both sides are now facts the
+            // guard holds, which is also what licenses the dry-run predictor to use that threshold.
+            Check("a MULTI-master header REFUSES (the sorted-header residual the skip leaves) — pinned, not assumed",
+                both.StartsWith("error:"),
+                both.StartsWith("error:") ? both
+                    : "UPSTREAM BEHAVIOUR CHANGED: a two-master header now WRITES. Re-derive the residual — the "
+                      + "dry-run predictor's >1 threshold and UnopenableMasterClause both rest on this. Got: " + both);
+            Check("…and that refusal NAMES the unopenable plugin as the cause, with the remedy",
+                both.Contains(BrokenName, StringComparison.OrdinalIgnoreCase)
+                && both.Contains("cannot be opened by houseCARL", StringComparison.Ordinal)
+                && both.Contains("writes that do NOT reference their records are unaffected", StringComparison.Ordinal), both);
+
+            // The DRY RUN must predict that refusal rather than reporting a would-be success (#225 parity).
+            var dry = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid, fx.BrokenOwnFid }, source: CleanName,
+                patch: "X314DryBoth", dry_run: true);
+            Check("dry_run predicts the SAME refusal for the same call, naming the same cause (#225 parity)",
+                dry.StartsWith("error:") && dry.Contains(BrokenName, StringComparison.OrdinalIgnoreCase)
+                && dry.Contains("cannot be opened by houseCARL", StringComparison.Ordinal), dry);
+            var dryOk = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: MasterName,
+                patch: "X314DryOk", dry_run: true);
+            Check("…and a dry run of a write that does NOT reference it still predicts success (no over-refusal)",
+                dryOk.StartsWith("DRY RUN", StringComparison.Ordinal), dryOk);
+
+            // ---- The IN-PLACE lanes: their MissingModException arm fires BEFORE the generic catch, so it — not the
+            //      generic one — is where this residual lands, and its "NOT active in the load order" wording would
+            //      send the user to enable a plugin that IS enabled (PR #315 review). No new-patch arm can catch this.
+            //      The target must be an ACTIVE plugin (that lane's own contract), so it is the clean plugin — which
+            //      also declares the broken one as a master, giving the sorted header this residual needs.
+            //      One forwarded record is enough: an in-place write RE-SERIALIZES the whole target, and the clean
+            //      plugin's own header already needs both masters.
+            var ip = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid },
+                source: MasterName, in_place: CleanName, acknowledge: true);
+            Check("in_place: the residual is named by CAUSE, not as 'NOT active in the load order'",
+                ip.StartsWith("error:")
+                && ip.Contains("cannot be opened by houseCARL", StringComparison.Ordinal)
+                && !ip.Contains("is NOT active in", StringComparison.Ordinal), ip);
+
+            // ---- The remove-IN-PLACE lane does NOT use the master-set builders at all: it opens the target's own
+            //      declared masters directly, with a bare CreateFromBinaryOverlay that used to sit outside every catch,
+            //      so an unopenable declared master escaped as an unhandled exception rather than a refusal. The clean
+            //      plugin declares the broken one, so this reaches it (PR #315 review).
+            var rm = RemoveTools.Remove(fx.Svc, formids: new[] { fx.SubjectFid }, in_place: CleanName, acknowledge: true);
+            Check("remove in_place: an unopenable DECLARED master is a named refusal, not an escaping exception",
+                rm.StartsWith("error:")
+                && rm.Contains(BrokenName, StringComparison.OrdinalIgnoreCase)
+                && rm.Contains("cannot be opened by houseCARL", StringComparison.Ordinal)
+                && rm.Contains("UNTOUCHED", StringComparison.Ordinal), rm);
 
             Console.WriteLine();
             Console.WriteLine($"=== excluded-master-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
@@ -137,6 +188,7 @@ public static class ExcludedMasterWriteProbe
         public required LoadOrderService Svc { get; init; }
         public required string SubjectFid { get; init; }      // originates in the MASTER, overridden by the clean plugin
         public required string BrokenOwnFid { get; init; }    // ORIGINATES in the unopenable plugin, overridden by clean
+        public required string ModsDir { get; init; }
         public void Dispose() => Svc.Dispose();
 
         public static Fixture Build(string dir)
@@ -204,6 +256,7 @@ public static class ExcludedMasterWriteProbe
                 Svc = svc,
                 SubjectFid = $"{subject.FormKey.ID:X6}:{mKey.FileName}",
                 BrokenOwnFid = $"{brokenOwn.FormKey.ID:X6}:{bKey.FileName}",
+                ModsDir = mods,
             };
         }
     }

--- a/src/housecarl-generator/ExcludedMasterWriteProbe.cs
+++ b/src/housecarl-generator/ExcludedMasterWriteProbe.cs
@@ -286,6 +286,8 @@ public static class ExcludedMasterWriteProbe
         Directory.CreateDirectory(Path.GetDirectoryName(clnPath)!);
         var cln = new SkyrimMod(clnKey, SkyrimRelease.SkyrimSE);
         ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(cln, w)).BasicStats = new WeaponBasicStats { Damage = 20 };
+        var donor = cln.Npcs.AddNew();                 // the npc-copy lane's donor — it only has to reach the serialize
+        donor.EditorID = "BlDonor";
         cln.BeginWrite.ToPath(clnPath).WithLoadOrder(new ISkyrimModGetter[] { sky }).Write();
 
         File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + skyKey.FileName + "\r\n" + clnKey.FileName + "\r\n");
@@ -322,6 +324,23 @@ public static class ExcludedMasterWriteProbe
                 $$"""[{"formid":"{{subjectFid}}","field_path":"Name","value":"Bl"}]""").RootElement.Clone());
         Check("…and dry_run predicts that same refusal, naming the baseline (#225 parity)",
             dry.StartsWith("error:") && dry.Contains("BASELINE master", StringComparison.Ordinal), dry);
+
+        // copy_npc_appearance is the one write lane that renders through an INJECTED renderer rather than calling
+        // SerializeFailure directly, so it is the lane that silently kept the doubled tail and the wrong phase after
+        // review 3 fixed every other one (PR #315 review 4). It had no arm; that is why nothing caught it.
+        var npc = NpcCopyTools.CopyNpcAppearance(svc, source_formid: $"{donor.FormKey.ID:X6}:{clnKey.FileName}",
+            new_editorid: "BlDonorClone", patch_name: "BlNpc");
+        Check("npc-copy renders the baseline refusal through the SAME substituting renderer as its sibling lanes",
+            npc.StartsWith("error:")
+            && npc.Contains("BASELINE master", StringComparison.Ordinal)
+            // Pinned on the three things substitution actually guarantees. (An earlier draft counted the word
+            // "Nothing", which the reworded refusal legitimately uses twice — a false failure, and a reminder that a
+            // count is only as good as the token counted.)
+            && (npc.Split("BASELINE master").Length - 1) == 1                       // the refusal ONCE, not doubled
+            && !npc.Contains("Nothing usable was written", StringComparison.Ordinal) // the lane's trailer dropped
+            && !npc.Contains("..", StringComparison.Ordinal)                         // …so no doubled period
+            && !npc.Contains("serialize failed", StringComparison.Ordinal),          // …behind a phase never reached
+            npc);
     }
 
     sealed class Fixture : IDisposable

--- a/src/housecarl-generator/ExcludedMasterWriteProbe.cs
+++ b/src/housecarl-generator/ExcludedMasterWriteProbe.cs
@@ -41,20 +41,6 @@ public static class ExcludedMasterWriteProbe
     static string MastersLineOf(string render)
         => render.Split('\n').FirstOrDefault(l => l.StartsWith("masters:", StringComparison.Ordinal)) ?? "";
 
-    /// <summary>The written artifact's path out of a write render (mod folder + filename), so a following arm can
-    /// address it by name — e.g. as an in_place target.</summary>
-    static string? ArtifactPathFrom(Fixture fx, string render)
-    {
-        if (!render.StartsWith("wrote ", StringComparison.Ordinal)) return null;
-        var file = render[(render.IndexOf(' ') + 1)..];
-        file = file[..file.IndexOf(' ')];
-        const string marker = "mod folder: ";
-        int at = render.IndexOf(marker, StringComparison.Ordinal);
-        if (at < 0) return null;
-        var mod = render[(at + marker.Length)..].Split('\n')[0].Split("  ")[0].Trim();
-        return Path.Combine(fx.ModsDir, mod, file);
-    }
-
     const string MasterName = "HcXMaster.esm";
     const string CleanName = "HcXClean.esp";
     const string BrokenName = "HcXBroken.esp";
@@ -113,13 +99,11 @@ public static class ExcludedMasterWriteProbe
                 !needsIt.StartsWith("error:")
                 && MastersLineOf(needsIt).Contains(BrokenName, StringComparison.OrdinalIgnoreCase), needsIt);
 
-            // …and the ORDER of a multi-master header survives the skip: a patch touching a record from the master AND
-            // one originating in the broken plugin must list them in LOAD ORDER (master first), or the plugin is
-            // malformed in a way nothing else in this probe would catch.
+            // …and a MULTI-master header is the residual: it cannot be built at all, so there is no ordering to pin
+            // here (an earlier draft's comment claimed there was, over locals nothing read — the assertion had been
+            // replaced by the refusal check below and the prose was left behind, PR #315 review 2). Single-master
+            // ordering is trivially satisfied by the arm above, which asserts the master IS the header.
             var both = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid, fx.BrokenOwnFid }, source: CleanName, patch: "X314Both");
-            var line = MastersLineOf(both);
-            int iMaster = line.IndexOf(MasterName, StringComparison.OrdinalIgnoreCase);
-            int iBroken = line.IndexOf(BrokenName, StringComparison.OrdinalIgnoreCase);
             // PINNED, not branched. The earlier version asserted ordering on success and the CAUSE on failure with
             // nothing asserting WHICH outcome was expected — so a behaviour flip in either direction would still have
             // reported PASS while the clause silently lost all CI coverage (PR #315 review). The two-master header is
@@ -171,6 +155,8 @@ public static class ExcludedMasterWriteProbe
                 && rm.Contains("cannot be opened by houseCARL", StringComparison.Ordinal)
                 && rm.Contains("UNTOUCHED", StringComparison.Ordinal), rm);
 
+            BaselineArm(Path.Combine(root, "bl"));
+
             Console.WriteLine();
             Console.WriteLine($"=== excluded-master-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
             return _fail == 0 ? 0 : 1;
@@ -183,12 +169,75 @@ public static class ExcludedMasterWriteProbe
         finally { try { Directory.Delete(root, recursive: true); } catch { } }
     }
 
+    /// <summary>The BASELINE case, which the main fixture structurally cannot see: it has no Skyrim.esm/Update.esm, and
+    /// the defect is in the CK-mandated baseline force-include (PR #315 review 2). A baseline master that cannot be
+    /// opened must REFUSE the write — skipping it silently emits a plugin missing a master Aaron locked as mandatory,
+    /// which is a loud failure traded for a silent one. Its own order, because a broken Skyrim.esm poisons everything.</summary>
+    static void BaselineArm(string dir)
+    {
+        Console.WriteLine();
+        Console.WriteLine("   -- baseline masters: an unopenable Skyrim.esm must REFUSE, never be quietly dropped --");
+
+        string instance = Path.Combine(dir, "instance");
+        string profiles = Path.Combine(instance, "profiles", "Default");
+        string mods = Path.Combine(instance, "mods");
+        Directory.CreateDirectory(profiles); Directory.CreateDirectory(mods);
+        Directory.CreateDirectory(Path.Combine(dir, "game", "Data"));
+        File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(dir, "game").Replace(@"\", @"\\") + ")\r\n");
+
+        // A real baseline NAME, deliberately: the force-include matches on ModKey, so only this name reaches the bug.
+        var skyKey = new ModKey("Skyrim", ModType.Master);
+        var skyPath = Path.Combine(mods, "BlSky", skyKey.FileName.String);
+        Directory.CreateDirectory(Path.GetDirectoryName(skyPath)!);
+        var sky = new SkyrimMod(skyKey, SkyrimRelease.SkyrimSE);
+        var w = sky.Weapons.AddNew();
+        w.EditorID = "BlSubject";
+        w.BasicStats = new WeaponBasicStats { Damage = 10 };
+        sky.BeginWrite.ToPath(skyPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        var whole = File.ReadAllBytes(skyPath);
+        File.WriteAllBytes(skyPath, whole[..(whole.Length - 12)]);          // …and break it
+
+        // A clean plugin overriding it, so the dry-run arm has a resolvable record to aim at (create has no dry lane).
+        var clnKey = new ModKey("BlClean", ModType.Plugin);
+        var clnPath = Path.Combine(mods, "BlClean", clnKey.FileName.String);
+        Directory.CreateDirectory(Path.GetDirectoryName(clnPath)!);
+        var cln = new SkyrimMod(clnKey, SkyrimRelease.SkyrimSE);
+        ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(cln, w)).BasicStats = new WeaponBasicStats { Damage = 20 };
+        cln.BeginWrite.ToPath(clnPath).WithLoadOrder(new ISkyrimModGetter[] { sky }).Write();
+
+        File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + skyKey.FileName + "\r\n" + clnKey.FileName + "\r\n");
+        File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + skyKey.FileName + "\r\n*" + clnKey.FileName + "\r\n");
+        File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+BlClean\r\n+BlSky\r\n");
+
+        using var svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(dir, "hc.user.json")));
+        svc.Stats();
+
+        // A SELF-CONTAINED create references nothing, so its derived header is empty and the baseline force-include is
+        // the ONLY thing that would put Skyrim.esm in it — the exact write that used to land silently master-less.
+        var records = System.Text.Json.JsonDocument.Parse("""[{"record_type":"Keyword","editorid":"BlKw"}]""").RootElement.Clone();
+        var created = CreateTools.Create(svc, patch: "BlCreate", records: records);
+        Check("a self-contained create REFUSES when a baseline master is unopenable (never a silently master-less plugin)",
+            created.StartsWith("error:")
+            && created.Contains("BASELINE master", StringComparison.Ordinal)
+            && created.Contains(skyKey.FileName.String, StringComparison.OrdinalIgnoreCase), created);
+
+        // …and the dry run agrees with the real call, which it did NOT before: it added baselines by load-order
+        // membership and never asked whether they could be opened (#225 parity).
+        var subjectFid = $"{w.FormKey.ID:X6}:{skyKey.FileName}";
+        var dry = ApplyTools.Apply(svc, patch: "BlDry", dry_run: true,
+            ops: System.Text.Json.JsonDocument.Parse(
+                $$"""[{"formid":"{{subjectFid}}","field_path":"Name","value":"Bl"}]""").RootElement.Clone());
+        Check("…and dry_run predicts that same refusal, naming the baseline (#225 parity)",
+            dry.StartsWith("error:") && dry.Contains("BASELINE master", StringComparison.Ordinal), dry);
+    }
+
     sealed class Fixture : IDisposable
     {
         public required LoadOrderService Svc { get; init; }
         public required string SubjectFid { get; init; }      // originates in the MASTER, overridden by the clean plugin
         public required string BrokenOwnFid { get; init; }    // ORIGINATES in the unopenable plugin, overridden by clean
-        public required string ModsDir { get; init; }
         public void Dispose() => Svc.Dispose();
 
         public static Fixture Build(string dir)
@@ -256,7 +305,6 @@ public static class ExcludedMasterWriteProbe
                 Svc = svc,
                 SubjectFid = $"{subject.FormKey.ID:X6}:{mKey.FileName}",
                 BrokenOwnFid = $"{brokenOwn.FormKey.ID:X6}:{bKey.FileName}",
-                ModsDir = mods,
             };
         }
     }

--- a/src/housecarl-generator/ExcludedMasterWriteProbe.cs
+++ b/src/housecarl-generator/ExcludedMasterWriteProbe.cs
@@ -1,0 +1,210 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REGRESSION GUARD for #314 — ONE active plugin that Mutagen cannot OPEN must not break every write in the order.
+///
+/// <para><b>The bug.</b> <c>BuildIndex</c> excludes a plugin along two different paths: <c>OpenOverlay</c> throws
+/// (the file cannot be opened at all), or <c>EnumerateMajorRecords</c> throws (it opens, but a record body is
+/// unparseable). <c>OverlaySession.AllMasters</c>/<c>AllMastersExcept</c> then open EVERY plugin including excluded
+/// ones — deliberately, because a clean plugin can override a record whose ORIGIN master is excluded and that master
+/// must still appear in the patch header. Its stated safety argument is "Overlay() opens lazily (no parse, no
+/// enumeration → no throw)", which holds for the second class and is FALSE for the first: the class that exists
+/// precisely BECAUSE the file cannot be opened is the one the write path then tries to open, on every write.</para>
+///
+/// <para><b>Why its own probe.</b> The fixture cannot be shared. An unopenable plugin in the active order poisons
+/// every write in whatever order it sits in — which is exactly the bug, and is how this was found (it broke every
+/// unrelated arm of <c>write-surface-guard</c> when added there). So this order is built once, used only here, and
+/// deliberately contains the broken plugin.</para>
+///
+/// Run: <c>dotnet run --project src/housecarl-generator excluded-master-guard</c>
+/// </summary>
+public static class ExcludedMasterWriteProbe
+{
+    static int _pass, _fail;
+    static void Check(string label, bool ok, string? got = null)
+    {
+        Console.WriteLine($"   [{(ok ? "PASS" : "FAIL")}] {label}");
+        if (!ok && got is not null) Console.WriteLine($"          got: {Trim(got)}");
+        if (ok) _pass++; else _fail++;
+    }
+    static string Trim(string s) => s.Length <= 400 ? s.Replace("\n", " | ") : s[..400].Replace("\n", " | ") + " …";
+
+    /// <summary>The render's "masters:" line alone — a whole-render search would false-match the plugin names that
+    /// appear in the per-record rows, which is the assertion mistake this codebase has already paid for twice.</summary>
+    static string MastersLineOf(string render)
+        => render.Split('\n').FirstOrDefault(l => l.StartsWith("masters:", StringComparison.Ordinal)) ?? "";
+
+    const string MasterName = "HcXMaster.esm";
+    const string CleanName = "HcXClean.esp";
+    const string BrokenName = "HcXBroken.esp";
+
+    public static int RunGuard(string[] args)
+    {
+        _pass = _fail = 0;
+        Console.WriteLine("################  REGRESSION GUARD — #314: an UNOPENABLE active plugin must not break every write  ################");
+        Console.WriteLine();
+
+        var root = Path.Combine(Path.GetTempPath(), "hc_x314_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            using var fx = Fixture.Build(Path.Combine(root, "fx"));
+
+            // ---- The premise, asserted rather than assumed: the broken plugin IS excluded, and READS are unharmed. ----
+            var asBroken = ReadTools.ReadRecord(fx.Svc, formid: fx.SubjectFid, plugin: BrokenName);
+            Check("the truncated plugin is EXCLUDED from the index, refused BY NAME with the reason (the read side handles this)",
+                asBroken.StartsWith("error:") && asBroken.Contains("exclud", StringComparison.OrdinalIgnoreCase), asBroken);
+
+            var read = ReadTools.ReadRecord(fx.Svc, formid: fx.SubjectFid);
+            Check("reads are unaffected: the clean override still resolves as the winner",
+                !read.StartsWith("error:") && read.Contains($"winner={CleanName}", StringComparison.OrdinalIgnoreCase), read);
+
+            // ---- THE BUG: writes that have NOTHING to do with the broken plugin. ----
+            var fwd = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: MasterName, patch: "X314Fwd");
+            Check("forward into a NEW patch succeeds — the broken plugin is not this write's business",
+                !fwd.StartsWith("error:"), fwd);
+
+            var apply = ApplyTools.Apply(fx.Svc,
+                ops: System.Text.Json.JsonDocument.Parse(
+                    $$"""[{"formid":"{{fx.SubjectFid}}","field_path":"Name","value":"X314"}]""").RootElement.Clone(),
+                patch: "X314Apply");
+            Check("apply into a NEW patch succeeds",
+                !apply.StartsWith("error:"), apply);
+
+            var create = CreateTools.Create(fx.Svc, patch: "X314Create",
+                records: System.Text.Json.JsonDocument.Parse(
+                    """[{"record_type":"Keyword","editorid":"X314Kw"}]""").RootElement.Clone());
+            Check("create into a NEW patch succeeds",
+                !create.StartsWith("error:"), create);
+
+            // ---- The refusal that must NOT be softened: naming the broken plugin itself is still refused. ----
+            var fromBroken = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: BrokenName, patch: "X314Bad");
+            Check("naming the EXCLUDED plugin as a source is still refused (the skip must not become an escape hatch)",
+                fromBroken.StartsWith("error:"), fromBroken);
+
+            // ---- THE RISK the fix has to answer: does skipping corrupt the HEADER? The retention comment said
+            //      dropping an excluded master would, because a clean plugin can override a record ORIGINATING in it
+            //      and that master must appear in the output. It does appear — Mutagen derives the header from the
+            //      records' own FormKeys, not from membership of the known-master list. Asserted, because the whole
+            //      safety of this change rests on it. ----
+            var needsIt = ForwardTools.Forward(fx.Svc, formids: new[] { fx.BrokenOwnFid }, source: CleanName, patch: "X314Need");
+            Check("a patch whose record ORIGINATES in the unopenable plugin still WRITES, and still masters on it",
+                !needsIt.StartsWith("error:")
+                && MastersLineOf(needsIt).Contains(BrokenName, StringComparison.OrdinalIgnoreCase), needsIt);
+
+            // …and the ORDER of a multi-master header survives the skip: a patch touching a record from the master AND
+            // one originating in the broken plugin must list them in LOAD ORDER (master first), or the plugin is
+            // malformed in a way nothing else in this probe would catch.
+            var both = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid, fx.BrokenOwnFid }, source: CleanName, patch: "X314Both");
+            var line = MastersLineOf(both);
+            int iMaster = line.IndexOf(MasterName, StringComparison.OrdinalIgnoreCase);
+            int iBroken = line.IndexOf(BrokenName, StringComparison.OrdinalIgnoreCase);
+            if (!both.StartsWith("error:"))
+                Check("a MULTI-master header still lists both masters in load order (the skip does not reorder it)",
+                    iMaster >= 0 && iBroken >= 0 && iMaster < iBroken, line.Length > 0 ? line : both);
+            else
+                // …and where it CANNOT be written, the refusal must name the real cause. This is the residual the skip
+                // leaves: with two or more masters the serializer sorts the header against the known set and refuses on
+                // the one it hasn't got. It was already failing before the fix (with a different exception), so nothing
+                // regressed — but "serialize or commit failed" sends the reader to their disk, and the plugin is not
+                // "not active" either, which is what the pre-existing MissingMod arms would have said.
+                Check("…or, where a sorted header cannot be built, the refusal NAMES the unopenable plugin as the cause",
+                    both.Contains(BrokenName, StringComparison.OrdinalIgnoreCase)
+                    && both.Contains("cannot be opened by houseCARL", StringComparison.Ordinal)
+                    && both.Contains("writes that do NOT reference their records are unaffected", StringComparison.Ordinal), both);
+
+            Console.WriteLine();
+            Console.WriteLine($"=== excluded-master-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
+            return _fail == 0 ? 0 : 1;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"   FAIL (unexpected): {ex.GetType().Name}: {ex.Message}\n{ex.StackTrace}");
+            return 1;
+        }
+        finally { try { Directory.Delete(root, recursive: true); } catch { } }
+    }
+
+    sealed class Fixture : IDisposable
+    {
+        public required LoadOrderService Svc { get; init; }
+        public required string SubjectFid { get; init; }      // originates in the MASTER, overridden by the clean plugin
+        public required string BrokenOwnFid { get; init; }    // ORIGINATES in the unopenable plugin, overridden by clean
+        public void Dispose() => Svc.Dispose();
+
+        public static Fixture Build(string dir)
+        {
+            string instance = Path.Combine(dir, "instance");
+            string profiles = Path.Combine(instance, "profiles", "Default");
+            string mods = Path.Combine(instance, "mods");
+            Directory.CreateDirectory(profiles); Directory.CreateDirectory(mods);
+            Directory.CreateDirectory(Path.Combine(dir, "game", "Data"));
+            File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+                "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                + Path.Combine(dir, "game").Replace(@"\", @"\\") + ")\r\n");
+
+            var mKey = new ModKey("HcXMaster", ModType.Master);
+            var bKey = new ModKey("HcXBroken", ModType.Plugin);
+            var cKey = new ModKey("HcXClean", ModType.Plugin);
+            string P(string folder, ModKey k)
+            {
+                var p = Path.Combine(mods, folder, k.FileName.String);
+                Directory.CreateDirectory(Path.GetDirectoryName(p)!);
+                return p;
+            }
+
+            var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
+            var subject = m.Weapons.AddNew();
+            subject.EditorID = "XSubject";
+            subject.BasicStats = new WeaponBasicStats { Damage = 10 };
+            m.BeginWrite.ToPath(P("XMaster", mKey)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            // The broken plugin ORIGINATES a record of its own, so a patch can be made to need it as a master.
+            var b = new SkyrimMod(bKey, SkyrimRelease.SkyrimSE);
+            ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(b, subject)).BasicStats = new WeaponBasicStats { Damage = 30 };
+            var brokenOwn = b.Weapons.AddNew();
+            brokenOwn.EditorID = "XBrokenOwn";
+            brokenOwn.BasicStats = new WeaponBasicStats { Damage = 40 };
+            var brokenPath = P("XBroken", bKey);
+            b.BeginWrite.ToPath(brokenPath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
+
+            // The clean plugin wins the subject AND overrides the broken plugin's own record (so that record stays
+            // readable through a plugin that parses, which is the situation AllMasters' retention comment describes).
+            var c = new SkyrimMod(cKey, SkyrimRelease.SkyrimSE);
+            ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(c, subject)).BasicStats = new WeaponBasicStats { Damage = 20 };
+            ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(c, brokenOwn)).BasicStats = new WeaponBasicStats { Damage = 41 };
+            c.BeginWrite.ToPath(P("XClean", cKey)).WithLoadOrder(new ISkyrimModGetter[] { m, b }).Write();
+
+            // …and NOW break it: a valid header followed by a truncated body. The overlay open throws, which is the
+            // exclusion class this guard is about. Written last so both plugins above could be built against it.
+            var whole = File.ReadAllBytes(brokenPath);
+            File.WriteAllBytes(brokenPath, whole[..(whole.Length - 12)]);
+
+            File.WriteAllText(Path.Combine(profiles, "loadorder.txt"),
+                "# header\r\n" + mKey.FileName + "\r\n" + bKey.FileName + "\r\n" + cKey.FileName + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "plugins.txt"),
+                "*" + mKey.FileName + "\r\n*" + bKey.FileName + "\r\n*" + cKey.FileName + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+XClean\r\n+XBroken\r\n+XMaster\r\n");
+
+            var genDir = Path.Combine(dir, "corpus-gen");
+            try { _ = CorpusRulebook.LoadCorpus(); }
+            catch { CorpusGenerator.GenerateAll(genDir, Path.Combine(dir, "corpus-ref")); CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json"); }
+
+            var svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(dir, "houseCARL.user.json")));
+            svc.Stats();
+            return new Fixture
+            {
+                Svc = svc,
+                SubjectFid = $"{subject.FormKey.ID:X6}:{mKey.FileName}",
+                BrokenOwnFid = $"{brokenOwn.FormKey.ID:X6}:{bKey.FileName}",
+            };
+        }
+    }
+}

--- a/src/housecarl-generator/ExcludedMasterWriteProbe.cs
+++ b/src/housecarl-generator/ExcludedMasterWriteProbe.cs
@@ -94,8 +94,10 @@ public static class ExcludedMasterWriteProbe
             //      and that master must appear in the output. It does appear — Mutagen derives the header from the
             //      records' own FormKeys, not from membership of the known-master list. Asserted, because the whole
             //      safety of this change rests on it. ----
+            //      Reachable HERE only because this fixture carries no baselines to force-include, leaving a genuinely
+            //      single-entry header — see RealOrderArm for what a user's order actually does (PR #315 review 3).
             var needsIt = ForwardTools.Forward(fx.Svc, formids: new[] { fx.BrokenOwnFid }, source: CleanName, patch: "X314Need");
-            Check("a patch whose record ORIGINATES in the unopenable plugin still WRITES, and still masters on it",
+            Check("a baseline-less order: a patch whose record ORIGINATES in the unopenable plugin still WRITES, mastering on it",
                 !needsIt.StartsWith("error:")
                 && MastersLineOf(needsIt).Contains(BrokenName, StringComparison.OrdinalIgnoreCase), needsIt);
 
@@ -156,6 +158,7 @@ public static class ExcludedMasterWriteProbe
                 && rm.Contains("UNTOUCHED", StringComparison.Ordinal), rm);
 
             BaselineArm(Path.Combine(root, "bl"));
+            RealOrderArm(Path.Combine(root, "ro"));
 
             Console.WriteLine();
             Console.WriteLine($"=== excluded-master-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
@@ -167,6 +170,84 @@ public static class ExcludedMasterWriteProbe
             return 1;
         }
         finally { try { Directory.Delete(root, recursive: true); } catch { } }
+    }
+
+    /// <summary>The order a REAL user has: baselines present and openable, plus one broken plugin. The main fixture
+    /// carries no baselines, which made it report a single-master success that cannot happen in practice — every
+    /// patch-lane header force-includes Skyrim.esm + Update.esm, so it always has ≥2 entries and always has to be
+    /// SORTED, which is exactly the residual (PR #315 review 3). This arm is the one that describes reality; the
+    /// main fixture's single-master arm now documents itself as the baseline-less harness case.</summary>
+    static void RealOrderArm(string dir)
+    {
+        Console.WriteLine();
+        Console.WriteLine("   -- a REAL order (baselines present): the unrelated write lands, the referencing one refuses --");
+
+        string instance = Path.Combine(dir, "instance");
+        string profiles = Path.Combine(instance, "profiles", "Default");
+        string mods = Path.Combine(instance, "mods");
+        Directory.CreateDirectory(profiles); Directory.CreateDirectory(mods);
+        Directory.CreateDirectory(Path.Combine(dir, "game", "Data"));
+        File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(dir, "game").Replace(@"\", @"\\") + ")\r\n");
+
+        string Write(string folder, ModKey k, SkyrimMod m, params ISkyrimModGetter[] lo)
+        {
+            var p = Path.Combine(mods, folder, k.FileName.String);
+            Directory.CreateDirectory(Path.GetDirectoryName(p)!);
+            m.BeginWrite.ToPath(p).WithLoadOrder(lo).Write();
+            return p;
+        }
+
+        var skyKey = new ModKey("Skyrim", ModType.Master);
+        var updKey = new ModKey("Update", ModType.Master);
+        var brkKey = new ModKey("SxBroken", ModType.Plugin);
+        var clnKey = new ModKey("SxClean", ModType.Plugin);
+
+        var sky = new SkyrimMod(skyKey, SkyrimRelease.SkyrimSE);
+        var subject = sky.Weapons.AddNew();
+        subject.EditorID = "SxSubject";
+        subject.BasicStats = new WeaponBasicStats { Damage = 10 };
+        Write("SxSky", skyKey, sky);
+        Write("SxUpd", updKey, new SkyrimMod(updKey, SkyrimRelease.SkyrimSE), sky);
+
+        var brk = new SkyrimMod(brkKey, SkyrimRelease.SkyrimSE);
+        var brkOwn = brk.Weapons.AddNew();
+        brkOwn.EditorID = "SxBrokenOwn";
+        brkOwn.BasicStats = new WeaponBasicStats { Damage = 40 };
+        var brkPath = Write("SxBroken", brkKey, brk, sky);
+
+        var cln = new SkyrimMod(clnKey, SkyrimRelease.SkyrimSE);
+        ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(cln, brkOwn)).BasicStats = new WeaponBasicStats { Damage = 41 };
+        Write("SxClean", clnKey, cln, sky, brk);
+
+        var whole = File.ReadAllBytes(brkPath);
+        File.WriteAllBytes(brkPath, whole[..(whole.Length - 12)]);
+
+        File.WriteAllText(Path.Combine(profiles, "loadorder.txt"),
+            "# header\r\n" + skyKey.FileName + "\r\n" + updKey.FileName + "\r\n" + brkKey.FileName + "\r\n" + clnKey.FileName + "\r\n");
+        File.WriteAllText(Path.Combine(profiles, "plugins.txt"),
+            "*" + skyKey.FileName + "\r\n*" + updKey.FileName + "\r\n*" + brkKey.FileName + "\r\n*" + clnKey.FileName + "\r\n");
+        File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+SxClean\r\n+SxBroken\r\n+SxUpd\r\n+SxSky\r\n");
+
+        using var svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(dir, "hc.user.json")));
+        svc.Stats();
+
+        // THE HEADLINE FIX, in the shape a user actually has.
+        var unrelated = ForwardTools.Forward(svc, formids: new[] { $"{subject.FormKey.ID:X6}:{skyKey.FileName}" },
+            source: skyKey.FileName.String, patch: "SxOk");
+        Check("REAL order: a write that doesn't reference the broken plugin lands, with the baselines in its header",
+            !unrelated.StartsWith("error:")
+            && MastersLineOf(unrelated).Contains(skyKey.FileName.String, StringComparison.OrdinalIgnoreCase), unrelated);
+
+        // …and the case the changelog claimed "now succeeds". It does not, and cannot: the force-include guarantees
+        // ≥2 masters, so this header must be sorted and hits the residual.
+        var referencing = ForwardTools.Forward(svc, formids: new[] { $"{brkOwn.FormKey.ID:X6}:{brkKey.FileName}" },
+            source: clnKey.FileName.String, patch: "SxNeed");
+        Check("REAL order: a write REFERENCING the broken plugin's record refuses, naming the cause (never a single-master success)",
+            referencing.StartsWith("error:")
+            && referencing.Contains(brkKey.FileName.String, StringComparison.OrdinalIgnoreCase)
+            && referencing.Contains("cannot be opened by houseCARL", StringComparison.Ordinal), referencing);
     }
 
     /// <summary>The BASELINE case, which the main fixture structurally cannot see: it has no Skyrim.esm/Update.esm, and
@@ -222,6 +303,16 @@ public static class ExcludedMasterWriteProbe
             created.StartsWith("error:")
             && created.Contains("BASELINE master", StringComparison.Ordinal)
             && created.Contains(skyKey.FileName.String, StringComparison.OrdinalIgnoreCase), created);
+
+        // …ONCE. A Contains() is satisfied by a doubled render, and that is exactly what this arm used to hide: the
+        // clause appended the exception's own Message behind a Describe() that already printed it (PR #315 review 3).
+        // Counting is the difference between asserting the text exists and asserting the message is right.
+        int occurrences = created.Split("BASELINE master").Length - 1;
+        Check("…and renders that refusal exactly ONCE, without the serialize lead-in it never reached",
+            occurrences == 1
+            && !created.Contains("serialize or commit", StringComparison.Ordinal)
+            && !created.Contains("the existing file is untouched", StringComparison.Ordinal),
+            $"occurrences={occurrences} :: {created}");
 
         // …and the dry run agrees with the real call, which it did NOT before: it added baselines by load-order
         // membership and never asked whether they could be opened (#225 parity).

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -19,6 +19,7 @@ if (args.Length > 0 && args[0] == "ci-all") return CiAll.RunAll(args[1..]);
 if (args.Length > 0 && CiAll.TryDispatch(args[0], args[1..], out var ciRc)) return ciRc;
 
 // Maintenance diagnostic: re-verify the mutable-collection whitelist on a Mutagen bump.
+if (args.Length > 0 && args[0] == "excluded-master-guard") return ExcludedMasterWriteProbe.RunGuard(args[1..]);
 if (args.Length > 0 && args[0] == "vocab") return Probe.RunVocab();
 
 // SkyPatcher Wave-1 CRUX harness: one record's computed post-SkyPatcher state off a LIVE MO2 instance —

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -19,7 +19,6 @@ if (args.Length > 0 && args[0] == "ci-all") return CiAll.RunAll(args[1..]);
 if (args.Length > 0 && CiAll.TryDispatch(args[0], args[1..], out var ciRc)) return ciRc;
 
 // Maintenance diagnostic: re-verify the mutable-collection whitelist on a Mutagen bump.
-if (args.Length > 0 && args[0] == "excluded-master-guard") return ExcludedMasterWriteProbe.RunGuard(args[1..]);
 if (args.Length > 0 && args[0] == "vocab") return Probe.RunVocab();
 
 // SkyPatcher Wave-1 CRUX harness: one record's computed post-SkyPatcher state off a LIVE MO2 instance —

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -5861,7 +5861,8 @@ public sealed class LoadOrderService : IDisposable
                     active,
                     outPath, extend,
                     pf => { session.ReleaseOverlay(pf); return session.AllMastersExcept(pf); },   // active-patch self-lock fix
-                    donorReadFrom, outOfLoadOrder);
+                    donorReadFrom, outOfLoadOrder,
+                    ex => WritePatchBuilder.UnopenableMasterClause(ex, session));   // #314 — same named cause as the sibling write lanes
                 if (!outcome.Success)
                 {
                     if (created) RemoveFolderCreatedThisCall(outPath);   // hunt F4: a refused copy leaves no orphan

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -5862,7 +5862,8 @@ public sealed class LoadOrderService : IDisposable
                     outPath, extend,
                     pf => { session.ReleaseOverlay(pf); return session.AllMastersExcept(pf); },   // active-patch self-lock fix
                     donorReadFrom, outOfLoadOrder,
-                    ex => WritePatchBuilder.UnopenableMasterClause(ex, session));   // #314 — same named cause as the sibling write lanes
+                    // #314 — the SAME renderer the sibling write lanes use, so the baseline refusal substitutes here too.
+                    ex => WritePatchBuilder.SerializeFailure("serialize failed — ", ex, session, " Nothing usable was written."));
                 if (!outcome.Success)
                 {
                     if (created) RemoveFolderCreatedThisCall(outPath);   // hunt F4: a refused copy leaves no orphan


### PR DESCRIPTION
Fixes #314.

One plugin houseCARL cannot **open** sitting in the active load order made **every write fail** — `apply`, `create`, `remove`, `forward`, both lanes — including writes with nothing to do with it, with an opaque `ModGroupsMalformedException` that reads as a disk fault. Reads were never affected.

Found while building a guard fixture for a review finding on #313: adding a deliberately unparseable plugin to that probe's synthetic order broke every unrelated write arm in it. Filed rather than folded there (different lane, shipped behaviour, core seam), and this is that PR.

## The defect

`BuildIndex` excludes a plugin along two paths — `OpenOverlay` throws, or `EnumerateMajorRecords` throws. `AllMasters`/`AllMastersExcept` then opened **every** plugin including excluded ones, deliberately and with a stated safety argument:

> Safe: `Overlay()` opens lazily (no parse, no enumeration → no throw) […] and it cannot re-throw.

True of the enumerate-failure class. **False of the open-failure class** — the one that exists precisely because the file cannot be opened. `Overlay(idx)` calls `OpenOverlay` → `CreateFromBinaryOverlay`, which parses group structure eagerly enough to throw on a truncated file, so it threw again on every write.

The retention *rationale* was sound and is kept: a clean plugin can override a record whose origin master is excluded, and the header needs that master. It just cannot apply to a plugin that will not open.

## The fix

The snapshot carries the open-failure subset as its own `Unopenable` set — **a fact, not a substring of a display message** — populated only at the `OpenOverlay` catch. The two master-set builders skip it. Nothing outside `LoadOrderResolver` reads the `Excluded` int set (checked: external code sees only `ExcludedPlugins`), so nothing else changes behaviour.

## What the guard changed about the fix — worth reading

The first draft asserted that skipping **costs the output nothing**, on solid-looking evidence: a patch whose record *originates* in the skipped plugin still writes, because Mutagen derives that header entry from the record's own FormKey rather than from list membership. I verified that, and deleted the reporting machinery I'd built as unearned speculation.

Then the **multi-master** arm disproved it. Once a header must be *sorted* — two or more masters — the serializer refuses with `MissingModException` naming the skipped plugin. The residual failure is real and reachable, and the machinery came back because a test earned it.

That residual is now a named **CAUSE** appended at every serialize-failure render that has a session: which plugin, that it is **ACTIVE but unopenable** (so the pre-existing `"references a plugin that is NOT active"` wording would have been wrong for it), what to do, and that unrelated writes are unaffected. **Appended, not substituted**, and matched on the exception naming a skipped plugin — a mismatch degrades to the ordinary description rather than to a confident wrong cause.

**Nothing regresses.** That case failed before too, with a worse message.

*(An earlier version of this paragraph also claimed a single-master patch on the broken plugin now writes. Review 3 showed that is unreachable in a real order — `WritePatch` force-includes `Skyrim.esm` + `Update.esm`, so a patch-lane header always carries two or more and always takes the sorted-header residual. It happens only in a baseline-less harness, which is what the original fixture was. Corrected here, in the changelog, and in the code comment that repeated it; `RealOrderArm` now pins the real-order behaviour both ways.)*

## Its own probe, because the fixture cannot be shared

An unopenable plugin poisons every write in whatever order it sits in — that *is* the bug. `excluded-master-guard` builds its own MO2 instances (three: the main order, a baseline-bearing one, and a real order): a master, a clean plugin that wins the subject **and** overrides a record the broken plugin originates, and the broken plugin itself (valid header, truncated body), all active and ticked.

**Nineteen checks across three orders**, grown by the review rounds:

- **the baseline-less order** (the original): the plugin is excluded and reads are unaffected · forward / apply / create into a new patch all succeed · naming the excluded plugin as a source is still refused (the skip must not become an escape hatch) · a patch whose record originates in it still writes **and still masters on it** · a sorted multi-master header refuses, **pinned** as the expected outcome so an upstream flip fails loudly instead of passing · dry-run parity both ways · the in-place and remove-in-place lanes.
- **a baseline-bearing order** (review 2): an unopenable `Skyrim.esm` refuses a self-contained create rather than emitting a master-less plugin, renders that refusal **exactly once** without the phase it never reached, is predicted by `dry_run`, and reaches `copy_npc_appearance` through the same renderer (review 4).
- **a real order** (review 3): baselines present and openable. The unrelated write lands with them in its header; the write referencing the broken plugin's record refuses. This one exists because the original fixture's baseline-less shape taught me a claim about a case users cannot reach.

**RED-verified** each round against the behaviour being fixed — the skip, the baseline refusal, the doubling, the npc-copy override — with the pre-fix output quoted in the fold comments.

`ci-all` **117/117** (116 + this probe). That matters more than usual: this is a core seam every write path funnels through, so the existing suite passing unchanged is most of the safety argument.

**Not guarded**, stated rather than implied away: `RemapEngine.RepointInPlace` and `CompactBuild` (each needs a compact/merge fixture with an unopenable declared master), and the in-place lane's single-master threshold case (predicted, unverified).

## Note on sequencing

Branched from `main` while [#313](https://github.com/Avick3110/houseCARL/pull/313) is still open. The two are independent, but both touch `WritePatchBuilder`'s serialize-failure renders — #313 adds a named `MissingModException` arm to `forward`'s patch lane. Whichever merges second gets a small, mechanical rebase there; I'll take it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


