### PR TITLE
2.0 tidy-up sweep: guard the #315 fixes, close CopyFrom's arm drift, give write_seq output_dir=

### DIFF
--- a/.claude/skills/dialogue-authoring/SKILL.md
+++ b/.claude/skills/dialogue-authoring/SKILL.md
@@ -220,6 +220,10 @@ this skill's job.
    starts. (A plugin with no such quests needs no `.seq`; the tool reports that.) If a later **in-place** edit
    or removal prunes a master, the on-disk FormIDs shift and the existing `.seq` goes stale — houseCARL flags
    this in the write's read-back note so you re-run `housecarl_write_seq` (it flags, never silently rewrites).
+   After an **in-place** edit the `.esp` is in the mod's own folder — pass `output_dir=` that mod folder so the
+   `.seq` lands beside it rather than in a separate houseCARL mod you then have to enable. Re-running against a
+   lane-named destination is free: a byte-identical `.seq` is left alone (reported `unchanged`). See
+   `references/seq-file-format.md`.
 
 7. **Validate, then verify.** Run `housecarl_validate_dialogue` on the topic (a DIAL FormID) or the whole
    quest (a QUST FormID). It checks what it can — quest/branch wiring, `LinkTo` and PNAM resolve, voice

--- a/.claude/skills/dialogue-authoring/references/seq-file-format.md
+++ b/.claude/skills/dialogue-authoring/references/seq-file-format.md
@@ -56,5 +56,17 @@ that single mod deploys `.esp` and `.seq` together), otherwise a fresh one you e
 After an **in-place** edit the `.esp` is in the *mod's own* folder, so pass `output_dir=` that mod folder
 and the `.seq` lands in its `SEQ\`, where the mod's own copy already lives. `output_dir=` wins over
 `patch=` / `into=` (the response says so), and it never touches the `.esp` — a `.seq` is a new sidecar
-file, not an in-place record edit. If the destination already holds exactly the bytes houseCARL would
-write, nothing is written and the response says `unchanged` — so re-running after every edit is free.
+file, not an in-place record edit.
+
+When the destination is one a **lane names** — `output_dir=`, `into=`, or the plugin's own houseCARL
+folder — and it already holds exactly the bytes houseCARL would write, nothing is written and the
+response says `unchanged`, so re-running after every edit costs nothing. (With *no* lane named the
+destination is a freshly cut folder, empty by construction, so that call always writes — and cuts
+another folder each time. Name a lane if you regenerate repeatedly.) A `.seq` that is byte-identical
+but older than the plugin has its timestamp stamped forward, because `housecarl_validate_dialogue`'s
+SEQ staleness check reads mtime — otherwise a skipped write would leave that check calling a correct
+file stale. (That check lints the `.seq` your load order *serves*, so the refresh clears it only when
+the folder you wrote to is the one that wins the `SEQ\` conflict.)
+
+If a `.seq` is already at the path, it is **overwritten with no backup** and the response says
+`replaced` rather than `wrote` — on `output_dir=` that file can be the mod's own shipped copy.

--- a/.claude/skills/dialogue-authoring/references/seq-file-format.md
+++ b/.claude/skills/dialogue-authoring/references/seq-file-format.md
@@ -47,3 +47,14 @@ quest is meant to be running from game start, the quest must be Start-Game-Enabl
 in the `.seq`. Set the flag (a quest-record field write), then run `housecarl_write_seq` against the
 plugin. The `.seq` makes the quest START; it does not verify the quest or its dialogue is otherwise
 correct — that is `housecarl_validate_dialogue`'s job.
+
+## Where it lands
+
+By default the `.seq` goes into a houseCARL mod folder — the plugin's own if it lives in one (so enabling
+that single mod deploys `.esp` and `.seq` together), otherwise a fresh one you enable in MO2.
+
+After an **in-place** edit the `.esp` is in the *mod's own* folder, so pass `output_dir=` that mod folder
+and the `.seq` lands in its `SEQ\`, where the mod's own copy already lives. `output_dir=` wins over
+`patch=` / `into=` (the response says so), and it never touches the `.esp` — a `.seq` is a new sidecar
+file, not an in-place record edit. If the destination already holds exactly the bytes houseCARL would
+write, nothing is written and the response says `unchanged` — so re-running after every edit is free.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -19,10 +19,11 @@ mods folder, the overwrite folder, or the game's Data). It wins over `patch=`/`i
 quietly ignoring them. If a `.seq` was already at that path it is overwritten with no backup, and the response now
 says `replaced` rather than `wrote`.
 
-**The MO2 overwrite folder now counts as a place the game loads from.** `output_dir=` on both
-`housecarl_compile_script` and `housecarl_write_seq` warned that a file landing in your overwrite folder wouldn't
-deploy. It does — MO2 maps overwrite onto the game's Data at top priority, and it's where xEdit/CK/Synthesis
-output lands — so that warning was a false alarm. It no longer fires there. (The rule is otherwise unchanged and
+**The MO2 overwrite folder now counts as a place the game loads from.** `housecarl_compile_script`'s `output_dir=`
+warned that a `.pex` landing in your overwrite folder wouldn't deploy. It does — MO2 maps overwrite onto the game's
+Data at top priority, and it's where xEdit/CK/Synthesis output lands — so that warning was a false alarm. It no
+longer fires there, and `housecarl_write_seq`'s new `output_dir=` shares the corrected rule rather than inheriting
+the old one. (The rule is otherwise unchanged and
 still exact: a mod's own `Scripts\`/`SEQ\`, the overwrite folder, or the game's `Data\` — a *nested* path inside a
 mod still warns, because MO2 would deploy it to `Data\<Sub>\…` where nothing loads it.)
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -12,15 +12,26 @@ when it changes.
 plugin **in place** left the two halves in different mods: the `.esp` in the mod's own folder, the `.seq` in a
 freshly cut `houseCARL - houseCARL_SEQ_00N`, with `into=` unable to name a folder houseCARL didn't create. Every
 regeneration then meant hand-comparing the temp output against the mod's live `Seq\` copy and deleting the
-folder. `output_dir=` takes the mod-folder root and appends `SEQ\` — the same contract `housecarl_compile_script`
-and `housecarl_bsa_extract` already use, including the don't-double-it guard, no houseCARL folder cut, your
-folder never touched by cleanup, and a warning when the destination isn't somewhere the game actually reads SEQ
-files from. It wins over `patch=`/`into=`, and says so rather than quietly ignoring them.
+folder. `output_dir=` takes the mod-folder root and appends `SEQ\` — the same contract `housecarl_compile_script`'s
+`output_dir=` already uses, including the don't-double-it guard, no houseCARL folder cut, your folder never touched
+by cleanup, and a warning when the destination isn't somewhere the game actually reads SEQ files from (your MO2
+mods folder, the overwrite folder, or the game's Data). It wins over `patch=`/`into=`, and says so rather than
+quietly ignoring them. If a `.seq` was already at that path it is overwritten with no backup, and the response now
+says `replaced` rather than `wrote`.
 
-**…and regenerating an unchanged `.seq` now writes nothing.** If the destination already holds exactly the bytes
-houseCARL would write, the file is left alone and the response says `unchanged` (`written: false` in JSON) instead
-of reporting a write that only churned the file. Re-running after every in-place edit — which is the point of the
-tool — is now free.
+**The MO2 overwrite folder now counts as a place the game loads from.** `output_dir=` on both
+`housecarl_compile_script` and `housecarl_write_seq` warned that a file landing in your overwrite folder wouldn't
+deploy. It does — MO2 maps overwrite onto the game's Data at top priority, and it's where xEdit/CK/Synthesis
+output lands — so that warning was a false alarm. It no longer fires there. (The rule is otherwise unchanged and
+still exact: a mod's own `Scripts\`/`SEQ\`, the overwrite folder, or the game's `Data\` — a *nested* path inside a
+mod still warns, because MO2 would deploy it to `Data\<Sub>\…` where nothing loads it.)
+
+**…and regenerating an unchanged `.seq` now writes nothing.** When a lane names the destination (`output_dir=`,
+`into=`, or the plugin's own houseCARL folder) and it already holds exactly the bytes houseCARL would write, the
+file is left alone and the response says `unchanged` (`written: false` in JSON) instead of churning the file.
+Re-running after every in-place edit — which is the point of the tool — is now free. A skipped write still stamps
+the file's timestamp forward when it was older than the plugin, so `housecarl_validate_dialogue`'s SEQ staleness
+check keeps agreeing with it.
 
 **Fixed: one broken plugin in your load order no longer breaks every write.** If a plugin houseCARL cannot open
 sat in your active order — a truncated download, a half-copied mod folder, an interrupted xEdit save — then

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -23,7 +23,9 @@ says `replaced` rather than `wrote`.
 warned that a `.pex` landing in your overwrite folder wouldn't deploy. It does — MO2 maps overwrite onto the game's
 Data at top priority, and it's where xEdit/CK/Synthesis output lands — so that warning was a false alarm. It no
 longer fires there, and `housecarl_write_seq`'s new `output_dir=` shares the corrected rule rather than inheriting
-the old one. (The rule is otherwise unchanged and
+the old one. Sharing the rule also fixed a second `compile_script` bug on the way past: `output_dir=C:\` (a bare
+drive root) produced the drive-*relative* `C:Scripts`, so the `.pex` landed in whatever the working directory
+happened to be on that drive. (The rule is otherwise unchanged and
 still exact: a mod's own `Scripts\`/`SEQ\`, the overwrite folder, or the game's `Data\` — a *nested* path inside a
 mod still warns, because MO2 would deploy it to `Data\<Sub>\…` where nothing loads it.)
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,20 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**`housecarl_write_seq` can finally put the `.seq` in the mod's own folder — `output_dir=` (#312).** Editing a
+plugin **in place** left the two halves in different mods: the `.esp` in the mod's own folder, the `.seq` in a
+freshly cut `houseCARL - houseCARL_SEQ_00N`, with `into=` unable to name a folder houseCARL didn't create. Every
+regeneration then meant hand-comparing the temp output against the mod's live `Seq\` copy and deleting the
+folder. `output_dir=` takes the mod-folder root and appends `SEQ\` — the same contract `housecarl_compile_script`
+and `housecarl_bsa_extract` already use, including the don't-double-it guard, no houseCARL folder cut, your
+folder never touched by cleanup, and a warning when the destination isn't somewhere the game actually reads SEQ
+files from. It wins over `patch=`/`into=`, and says so rather than quietly ignoring them.
+
+**…and regenerating an unchanged `.seq` now writes nothing.** If the destination already holds exactly the bytes
+houseCARL would write, the file is left alone and the response says `unchanged` (`written: false` in JSON) instead
+of reporting a write that only churned the file. Re-running after every in-place edit — which is the point of the
+tool — is now free.
+
 **Fixed: one broken plugin in your load order no longer breaks every write.** If a plugin houseCARL cannot open
 sat in your active order — a truncated download, a half-copied mod folder, an interrupted xEdit save — then
 *every* write failed, including writes that had nothing to do with it, with an opaque message that read like a

--- a/plugin/codex/housecarl/SKILL.md
+++ b/plugin/codex/housecarl/SKILL.md
@@ -48,7 +48,7 @@ Beyond the core workflow, reach for the right group. Depth for the specialist ar
 - `housecarl_forward` — copy a specific plugin's whole record as an override: `source=` names whose version (any plugin — active, or one that is only on disk in a DISABLED mod; a master reverts to vanilla), and the response names the winner it will out-rank plus, for an off-order source, which copy on disk it read.
 - `housecarl_set_field`, `housecarl_bulk_apply`, `housecarl_create_record`, `housecarl_bulk_create`, `housecarl_create_plugin` (header-only trigger plugin), `housecarl_remove_record`, `housecarl_forward_record` (copy-as-override, or revert to another plugin's version), `housecarl_validate_scripts` (unbound script properties).
 
-**Dialogue** — `housecarl_validate_dialogue`, `housecarl_write_seq` (the start-game-enabled quest `.seq`; `source=` takes the plugin's filename or an absolute path). Depth: `dialogue-authoring`.
+**Dialogue** — `housecarl_validate_dialogue`, `housecarl_write_seq` (the start-game-enabled quest `.seq`; `source=` takes the plugin's filename or an absolute path; `output_dir=` lands it in the mod's own `SEQ\` after an in-place edit). Depth: `dialogue-authoring`.
 
 **Assets / NIF / facegen** — `housecarl_asset_status` (which mod/BSA wins a Data-relative path), `housecarl_place_asset` / `housecarl_bulk_place_asset` (make a chosen copy win MO2's VFS), `housecarl_nif_inspect` / `housecarl_nif_set` (read/write mesh data values). Depth: `facegen-diagnostics`.
 

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -434,7 +434,7 @@ public static class WritePatchBuilder
                 var srcPlugin = ResolveCopyPole(e, view, out var poleErr);
                 if (poleErr is not null) { problems.Add(poleErr); continue; }
 
-                if (copyFromSources is not null && copyFromSources.TryGetValue(e, out var offSrc))
+                if (TryOffOrderCopyBody(copyFromSources, e, view, out var offSrc))
                     srcBody = offSrc;
                 else if (string.IsNullOrWhiteSpace(srcPlugin))
                 { problems.Add($"{e.Target}: CopyFrom is missing from_plugin (internal — the mapper should have caught this)."); continue; }
@@ -591,6 +591,28 @@ public static class WritePatchBuilder
         e.FromTarget is null
             ? $"{e.Target}: CopyFrom source '{srcPlugin}' is in the load order but does NOT define or override this record — there is no version of it there to copy."
             : $"{e.Target}: CopyFrom source '{srcPlugin}' is in the load order but does NOT define or override the SOURCE record {e.CopySource} — there is no version of it there to copy from.";
+
+    /// <summary>Does this edit's CopyFrom source resolve through the service's OFF-ORDER pre-locate? A dictionary hit
+    /// alone is NOT the answer. The pre-locate takes its OWN capture (<c>ResolveOffOrderCopySources</c>), the engine
+    /// captures again, and <c>_snap</c> can be swapped by a concurrent read's freshness rebuild in between — inside
+    /// <c>_writeGate</c> too, which serialises writes but not index rebuilds. So a source that was off-order a moment
+    /// ago may be ACTIVE now, and using the pre-fetched bodies then reads the DISK copy of a live plugin. A profile
+    /// switch changes which mod folder serves a filename, so that copy can be a genuinely DIFFERENT file: a wrong
+    /// BODY, not merely a wrong label.
+    /// <para>Re-checking against <paramref name="view"/> — THIS call's capture — costs one dictionary lookup and
+    /// resolves the drift the right way round: the fresher build wins, the pre-fetched bodies go unused, and the
+    /// in-order arm below resolves the source correctly. #317; the <c>forward</c> twin is
+    /// <see cref="IsOffOrderSource"/> (PR #313), whose arm this mirrors deliberately.</para></summary>
+    static bool TryOffOrderCopyBody(
+        IReadOnlyDictionary<PatchEdit, IMajorRecordGetter>? copyFromSources, PatchEdit e,
+        LoadOrderResolver.IndexView view, out IMajorRecordGetter? body)
+    {
+        body = null;
+        return copyFromSources is not null
+            && !string.IsNullOrWhiteSpace(e.FromPlugin)          // the pre-locate only ever keys edits that named one
+            && !view.ContainsPlugin(e.FromPlugin!)
+            && copyFromSources.TryGetValue(e, out body);
+    }
 
     /// <summary>Resolve the PLUGIN a CopyFrom reads its source body from. Named <c>from_source</c> wins; when it is
     /// absent AND a source RECORD is named (the §4.5 zip's <c>from</c>), it defaults to that record's load-order
@@ -759,7 +781,7 @@ public static class WritePatchBuilder
                 var srcPlugin = ResolveCopyPole(e, view, out var poleErr);
                 if (poleErr is not null) { problems.Add(poleErr); continue; }
 
-                if (copyFromSources is not null && copyFromSources.TryGetValue(e, out var offSrc))
+                if (TryOffOrderCopyBody(copyFromSources, e, view, out var offSrc))
                     srcBody = offSrc;
                 else if (string.IsNullOrWhiteSpace(srcPlugin))
                 { problems.Add($"{e.Target}: CopyFrom is missing from_plugin (internal — the mapper should have caught this)."); continue; }
@@ -1538,8 +1560,8 @@ public static class WritePatchBuilder
     /// ACTIVE now. Matching on the name alone would then read the disk copy of a live plugin — and a profile switch can
     /// make that a DIFFERENT file, so it is a wrong body, not merely a wrong label. Re-checking costs one dictionary
     /// lookup and resolves the drift the right way round: the fresher build wins, the pre-fetched bodies go unused, and
-    /// the arm reported matches the arm taken (PR #313 review 3 [observation]). The <c>CopyFrom</c> twin has the same
-    /// window and is NOT fixed here — same-shaped change, different lane, its own PR.</para></summary>
+    /// the arm reported matches the arm taken (PR #313 review 3 [observation]). The <c>CopyFrom</c> twin closed the
+    /// same window in its own PR (#317) — <see cref="TryOffOrderCopyBody"/>, deliberately the same shape.</para></summary>
     static bool IsOffOrderSource(OffOrderForwardSource? offOrder, ForwardSpec s, LoadOrderResolver.IndexView view) =>
         offOrder is not null
         && string.Equals(offOrder.Plugin, s.FromPlugin, StringComparison.OrdinalIgnoreCase)

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -592,20 +592,25 @@ public static class WritePatchBuilder
             ? $"{e.Target}: CopyFrom source '{srcPlugin}' is in the load order but does NOT define or override this record — there is no version of it there to copy."
             : $"{e.Target}: CopyFrom source '{srcPlugin}' is in the load order but does NOT define or override the SOURCE record {e.CopySource} — there is no version of it there to copy from.";
 
-    /// <summary>Does this edit's CopyFrom source resolve through the service's OFF-ORDER pre-locate? A dictionary hit
-    /// alone is NOT the answer. The pre-locate takes its OWN capture (<c>ResolveOffOrderCopySources</c>), the engine
-    /// captures again, and <c>_snap</c> can be swapped by a concurrent read's freshness rebuild in between — inside
-    /// <c>_writeGate</c> too, which serialises writes but not index rebuilds. So a source that was off-order a moment
-    /// ago may be ACTIVE now, and using the pre-fetched bodies then reads the DISK copy of a live plugin. A profile
-    /// switch changes which mod folder serves a filename, so that copy can be a genuinely DIFFERENT file: a wrong
-    /// BODY, not merely a wrong label.
-    /// <para>Re-checking against <paramref name="view"/> — THIS call's capture — costs one dictionary lookup and
-    /// resolves the drift the right way round: the fresher build wins, the pre-fetched bodies go unused, and the
-    /// in-order arm below resolves the source correctly. #317; the <c>forward</c> twin is
-    /// <see cref="IsOffOrderSource"/> (PR #313), whose arm this mirrors deliberately.</para></summary>
+    /// <summary>Does this edit's CopyFrom source resolve through the service's OFF-ORDER pre-locate? The arm is decided
+    /// from <paramref name="view"/> — THIS call's capture — rather than from the dictionary alone, so the body used is
+    /// always the one the ENGINE's own build agrees is off-order.
+    /// <para>HOW FAR THAT ACTUALLY REACHES, stated precisely because #317 (and PR #313's <c>forward</c> twin, whose
+    /// shape this mirrors) was filed as a RACE fix and that framing is wrong. Membership lives in the resolver's
+    /// <c>_nameToIdx</c>, built once per resolver INSTANCE and never rebuilt; <c>RefreshIfStale</c> swaps only
+    /// <c>_snap</c> (winners, exclusions), and a changed plugin SET drops the whole resolver for a new one. A write
+    /// reads <c>Resolver</c> ONCE and hands that instance to both the pre-locate and the engine. So within one call the
+    /// two captures cannot disagree about MEMBERSHIP, and this re-check cannot currently change the arm.</para>
+    /// <para>It is kept, and kept cheap (one dictionary lookup), as a STRUCTURAL invariant rather than a race repair:
+    /// the arm follows the view the write actually resolves against, not a dictionary another component built against
+    /// another capture. If membership ever can move under a live resolver — an in-place profile refresh being the
+    /// obvious candidate — the right behaviour is already here rather than a silently wrong body. Pinned
+    /// deterministically by <c>CopyFromViewArm</c> in write-surface-guard, which hands the engine a pre-fetched body
+    /// keyed to an ACTIVE source and asserts the in-order arm still wins.</para></summary>
     static bool TryOffOrderCopyBody(
         IReadOnlyDictionary<PatchEdit, IMajorRecordGetter>? copyFromSources, PatchEdit e,
-        LoadOrderResolver.IndexView view, out IMajorRecordGetter? body)
+        LoadOrderResolver.IndexView view,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IMajorRecordGetter? body)
     {
         body = null;
         return copyFromSources is not null
@@ -1560,8 +1565,19 @@ public static class WritePatchBuilder
     /// ACTIVE now. Matching on the name alone would then read the disk copy of a live plugin — and a profile switch can
     /// make that a DIFFERENT file, so it is a wrong body, not merely a wrong label. Re-checking costs one dictionary
     /// lookup and resolves the drift the right way round: the fresher build wins, the pre-fetched bodies go unused, and
-    /// the arm reported matches the arm taken (PR #313 review 3 [observation]). The <c>CopyFrom</c> twin closed the
-    /// same window in its own PR (#317) — <see cref="TryOffOrderCopyBody"/>, deliberately the same shape.</para></summary>
+    /// the arm reported matches the arm taken (PR #313 review 3 [observation]). The <c>CopyFrom</c> twin took the same
+    /// shape in its own PR (#317) — <see cref="TryOffOrderCopyBody"/>.</para>
+    /// <para>CORRECTION (2026-08-07, 2.0 tidy-up review round 1): the premise above — "a concurrent rebuild can swap
+    /// membership mid-call" — is FALSE as written, here and on the twin. <c>_nameToIdx</c> is per-resolver-instance and
+    /// never rebuilt (<c>RefreshIfStale</c> swaps only <c>_snap</c>), and a write pins ONE instance for both the
+    /// pre-locate and the engine, so <c>ContainsPlugin</c> cannot answer differently between the two captures. Both
+    /// re-checks are kept as structural invariants — the arm follows the view the write resolves against — rather than
+    /// as the race repairs they were filed as. Full statement on <see cref="TryOffOrderCopyBody"/>.</para>
+    /// <para>NOT parity, and worth knowing before assuming it: this lane additionally carries the
+    /// <c>ActiveNameForPath</c> full-path identity rule (PR #313 [medium]), so a <c>source=</c> PATH naming an ACTIVE
+    /// plugin takes the in-order arm. The <c>CopyFrom</c> lane has no such rule at either end, so a
+    /// <c>from_source=</c> path to an active plugin still routes off-order and is described as not in the load
+    /// order — the same defect this lane fixed, still open on that one.</para></summary>
     static bool IsOffOrderSource(OffOrderForwardSource? offOrder, ForwardSpec s, LoadOrderResolver.IndexView view) =>
         offOrder is not null
         && string.Equals(offOrder.Plugin, s.FromPlugin, StringComparison.OrdinalIgnoreCase)

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -1577,7 +1577,9 @@ public static class WritePatchBuilder
     /// <c>ActiveNameForPath</c> full-path identity rule (PR #313 [medium]), so a <c>source=</c> PATH naming an ACTIVE
     /// plugin takes the in-order arm. The <c>CopyFrom</c> lane has no such rule at either end, so a
     /// <c>from_source=</c> path to an active plugin still routes off-order and is described as not in the load
-    /// order — the same defect this lane fixed, still open on that one.</para></summary>
+    /// order — the same defect this lane fixed, still open on that one. Recorded here rather than filed: the sweep
+    /// that found it does not own the issue lane (CLAUDE.md §2), and a comment beside the code is a better pointer
+    /// than a stale reference if it is fixed first. Whoever fixes it should file it, then delete this paragraph.</para></summary>
     static bool IsOffOrderSource(OffOrderForwardSource? offOrder, ForwardSpec s, LoadOrderResolver.IndexView view) =>
         offOrder is not null
         && string.Equals(offOrder.Plugin, s.FromPlugin, StringComparison.OrdinalIgnoreCase)

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -614,10 +614,23 @@ public static class WritePatchBuilder
     {
         body = null;
         return copyFromSources is not null
-            && !string.IsNullOrWhiteSpace(e.FromPlugin)          // the pre-locate only ever keys edits that named one
-            && !view.ContainsPlugin(e.FromPlugin!)
+            && IsOffOrderCopySource(e, view)
             && copyFromSources.TryGetValue(e, out body);
     }
+
+    /// <summary>Does this edit's CopyFrom source need the OFF-ORDER on-disk locate — i.e. is it a CopyFrom naming a
+    /// plugin the ACTIVE ORDER does not contain? The ONE rule, called by both sides: the service's pre-locate uses it
+    /// to decide what to fetch, and <see cref="TryOffOrderCopyBody"/> uses it to decide what to consume.
+    /// <para>Shared rather than restated (PR #318 review [low]): the whole point of the engine-side re-check is that
+    /// the two captures agree, and enforcing that agreement with two independent copies of the predicate — in two
+    /// projects, kept in step by a comment asking the reader to check — is the hand-wiring shape CLAUDE.md §3 argues
+    /// against. It matters concretely: the next fix named for this lane is the <c>ActiveNameForPath</c> rule
+    /// <c>forward</c> already has, and a clause added to one copy would silently stop matching the other. One
+    /// predicate, so a clause can only be added to both.</para></summary>
+    public static bool IsOffOrderCopySource(PatchEdit e, LoadOrderResolver.IndexView view)
+        => string.Equals(e.Verb, "CopyFrom", StringComparison.Ordinal)
+           && !string.IsNullOrWhiteSpace(e.FromPlugin)
+           && !view.ContainsPlugin(e.FromPlugin!);
 
     /// <summary>Resolve the PLUGIN a CopyFrom reads its source body from. Named <c>from_source</c> wins; when it is
     /// absent AND a source RECORD is named (the §4.5 zip's <c>from</c>), it defaults to that record's load-order
@@ -1568,11 +1581,10 @@ public static class WritePatchBuilder
     /// the arm reported matches the arm taken (PR #313 review 3 [observation]). The <c>CopyFrom</c> twin took the same
     /// shape in its own PR (#317) — <see cref="TryOffOrderCopyBody"/>.</para>
     /// <para>CORRECTION (2026-08-07, 2.0 tidy-up review round 1): the premise above — "a concurrent rebuild can swap
-    /// membership mid-call" — is FALSE as written, here and on the twin. <c>_nameToIdx</c> is per-resolver-instance and
-    /// never rebuilt (<c>RefreshIfStale</c> swaps only <c>_snap</c>), and a write pins ONE instance for both the
-    /// pre-locate and the engine, so <c>ContainsPlugin</c> cannot answer differently between the two captures. Both
-    /// re-checks are kept as structural invariants — the arm follows the view the write resolves against — rather than
-    /// as the race repairs they were filed as. Full statement on <see cref="TryOffOrderCopyBody"/>.</para>
+    /// membership mid-call" — is FALSE as written, here and on the twin, so both re-checks are structural invariants
+    /// rather than the race repairs they were filed as. The argument is stated ONCE, on
+    /// <see cref="TryOffOrderCopyBody"/> — read it there rather than re-deriving it from a second copy here
+    /// (PR #318 review [nit]: this correction and its twin were saying the same thing twice).</para>
     /// <para>NOT parity, and worth knowing before assuming it: this lane additionally carries the
     /// <c>ActiveNameForPath</c> full-path identity rule (PR #313 [medium]), so a <c>source=</c> PATH naming an ACTIVE
     /// plugin takes the in-order arm. The <c>CopyFrom</c> lane has no such rule at either end, so a

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -545,8 +545,13 @@ public static class BindingShimProbe
         "housecarl_validate_scripts: pluginnames -> plugins",
         "housecarl_validate_scripts: types -> type",
         "housecarl_write_seq: archivename -> patch",
+        // #312 gave write_seq the compile lane's output_dir=, so the same two rows activate here — the alias table
+        // needed no edit, which is the census's own evidence that the parameter was added as PARITY and not as a
+        // new spelling of its own.
+        "housecarl_write_seq: dest -> output_dir",
         "housecarl_write_seq: fromplugin -> source",
         "housecarl_write_seq: mod -> source",
+        "housecarl_write_seq: outpath -> output_dir",
         "housecarl_write_seq: output -> patch",
         "housecarl_write_seq: patchname -> patch",
         "housecarl_write_seq: plugin -> source",

--- a/src/housecarl-generator/CompileErgonomicsProbe.cs
+++ b/src/housecarl-generator/CompileErgonomicsProbe.cs
@@ -111,6 +111,16 @@ internal static class CompileErgonomicsProbe
               "a nested Data path (<data>\\Sub\\Scripts) WARNS — the game loads only <data>\\Scripts");
         Check(LoadOrderService.ScriptOutputContract(@"C:\MO2\modsX\Foo", mods, data).deployWarning is not null,
               "segment-boundary safe: C:\\MO2\\modsX is NOT 'under' C:\\MO2\\mods (still warns)");
+        // 2026-08-07 (#312's shared refactor): the MO2 OVERWRITE folder deploys too — it is mapped onto Data at top
+        // priority and is where xEdit/CK/Synthesis output lands, so warning about it was a false alarm. Pinned BOTH
+        // ways, because the overwrite root is a parameter: unknown root → the old warning still fires.
+        const string over = @"C:\MO2\overwrite";
+        Check(LoadOrderService.ScriptOutputContract(over, mods, data, over).deployWarning is null
+              && LoadOrderService.ScriptOutputContract(over, mods, data).deployWarning is not null,
+              "the MO2 overwrite folder deploys when its root is known, and is judged on that root (not by folder name)");
+        // …and a drive ROOT keeps its separator: "C:\" trimmed to "C:" yields the drive-RELATIVE "C:Scripts".
+        Check(LoadOrderService.ScriptOutputContract(@"C:\", mods, data).scriptsDir == @"C:\Scripts",
+              $"a drive root appends correctly — got [{LoadOrderService.ScriptOutputContract(@"C:\", mods, data).scriptsDir}] (want C:\\Scripts, never C:Scripts)");
 
         // ---------------------------------------------------------- B3: ResolveExplicitScriptFolder — no patch folder cut
         Console.WriteLine();

--- a/src/housecarl-generator/ExcludedMasterWriteProbe.cs
+++ b/src/housecarl-generator/ExcludedMasterWriteProbe.cs
@@ -382,7 +382,11 @@ public static class ExcludedMasterWriteProbe
         var p = Path.Combine(instance, "profiles", "Default");
         File.WriteAllText(Path.Combine(p, "loadorder.txt"), "# header\r\n" + string.Concat(order.Select(o => o.key.FileName + "\r\n")));
         File.WriteAllText(Path.Combine(p, "plugins.txt"), string.Concat(order.Select(o => "*" + o.key.FileName + "\r\n")));
-        File.WriteAllText(Path.Combine(p, "modlist.txt"), "# header\r\n" + string.Concat(order.Reverse().Select(o => "+" + o.folder + "\r\n")));
+        // Enumerable.Reverse SPELLED OUT: on an array, `order.Reverse()` binds to MemoryExtensions.Reverse<T>(Span<T>)
+        // — which reverses IN PLACE and returns void, so the LINQ-looking call does not compile (and where it does
+        // resolve, it would mutate the caller's array). CI caught this in Release; the local Debug build did not.
+        File.WriteAllText(Path.Combine(p, "modlist.txt"),
+            "# header\r\n" + string.Concat(Enumerable.Reverse(order).Select(o => "+" + o.folder + "\r\n")));
     }
 
     /// <summary>Write <paramref name="m"/> into <paramref name="mods"/>\<paramref name="folder"/> against

--- a/src/housecarl-generator/ExcludedMasterWriteProbe.cs
+++ b/src/housecarl-generator/ExcludedMasterWriteProbe.cs
@@ -159,6 +159,9 @@ public static class ExcludedMasterWriteProbe
 
             BaselineArm(Path.Combine(root, "bl"));
             RealOrderArm(Path.Combine(root, "ro"));
+            CompactMasterArm(Path.Combine(root, "cm"));
+            RepointArm(Path.Combine(root, "rp"));
+            InPlaceThresholdArm(Path.Combine(root, "ip"));
 
             Console.WriteLine();
             Console.WriteLine($"=== excluded-master-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
@@ -347,6 +350,252 @@ public static class ExcludedMasterWriteProbe
             && !npc.Contains("..", StringComparison.Ordinal)                         // …so no doubled period
             && !npc.Contains("serialize failed", StringComparison.Ordinal),          // …behind a phase never reached
             npc);
+    }
+
+    // ---- #316: the three PR #315 fixes that shipped proven only by READING -------------------------------------
+    //
+    // Each takes its OWN order, for the reason this whole file exists: an unopenable plugin poisons every write in
+    // the order it sits in. The two arms above predate them and are left as they are — retrofitting a working guard
+    // onto a shared harness is churn with a real chance of breaking what it was written to hold.
+
+    /// <summary>A synthetic MO2 instance skeleton (ini + profile dir + mods dir + game Data), shared by the #316 arms
+    /// so three near-identical setups don't drift apart in three different ways. Returns the instance root and its
+    /// mods dir; the caller writes the plugins, then calls <see cref="Profile"/>.</summary>
+    static (string instance, string mods) NewInstance(string dir)
+    {
+        string instance = Path.Combine(dir, "instance");
+        string mods = Path.Combine(instance, "mods");
+        Directory.CreateDirectory(Path.Combine(instance, "profiles", "Default"));
+        Directory.CreateDirectory(mods);
+        Directory.CreateDirectory(Path.Combine(dir, "game", "Data"));
+        File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(dir, "game").Replace(@"\", @"\\") + ")\r\n");
+        return (instance, mods);
+    }
+
+    /// <summary>Write the three profile files for an order given in LOAD order (folder, plugin key). modlist.txt is
+    /// MO2's reverse-priority list, so it is emitted reversed — getting that backwards silently inverts which copy of
+    /// a filename wins.</summary>
+    static void Profile(string instance, params (string folder, ModKey key)[] order)
+    {
+        var p = Path.Combine(instance, "profiles", "Default");
+        File.WriteAllText(Path.Combine(p, "loadorder.txt"), "# header\r\n" + string.Concat(order.Select(o => o.key.FileName + "\r\n")));
+        File.WriteAllText(Path.Combine(p, "plugins.txt"), string.Concat(order.Select(o => "*" + o.key.FileName + "\r\n")));
+        File.WriteAllText(Path.Combine(p, "modlist.txt"), "# header\r\n" + string.Concat(order.Reverse().Select(o => "+" + o.folder + "\r\n")));
+    }
+
+    /// <summary>Write <paramref name="m"/> into <paramref name="mods"/>\<paramref name="folder"/> against
+    /// <paramref name="lo"/>, returning the path.</summary>
+    static string WriteMod(string mods, string folder, ModKey k, SkyrimMod m, params ISkyrimModGetter[] lo)
+    {
+        var p = Path.Combine(mods, folder, k.FileName.String);
+        Directory.CreateDirectory(Path.GetDirectoryName(p)!);
+        m.BeginWrite.ToPath(p).WithLoadOrder(lo).NoNextFormIDProcessing().Write();
+        return p;
+    }
+
+    /// <summary>Break a written plugin into the could-not-be-OPENED exclusion class: a valid header followed by a
+    /// truncated body. Twelve bytes is what the fixtures above use and what reliably produces the class.</summary>
+    static void Truncate(string path)
+    {
+        var whole = File.ReadAllBytes(path);
+        File.WriteAllBytes(path, whole[..(whole.Length - 12)]);
+    }
+
+    /// <summary>#316 (1) — <c>CompactBuild</c>'s declared-master open. The <c>catch</c> added around
+    /// <c>CreateFromBinaryOverlay</c> to mirror <c>MergeBuild</c>'s twin shipped with no arm. Its whole reason for
+    /// existing is the CALLER's cleanup: <c>RemoveOrNameRiderResidue</c> runs on a <c>Fail</c> RETURN and never on a
+    /// throw, so an escaping exception leaves an orphan houseCARL mod folder in the MO2 mods directory — which is why
+    /// this arm asserts the folder count as hard as it asserts the message.</summary>
+    static void CompactMasterArm(string dir)
+    {
+        Console.WriteLine();
+        Console.WriteLine("   -- compact: an unopenable DECLARED master is a named refusal, and leaves no orphan folder --");
+
+        var (instance, mods) = NewInstance(dir);
+        var brkKey = new ModKey("HcXCmBroken", ModType.Plugin);
+        var subKey = new ModKey("HcXCmSubject", ModType.Plugin);
+
+        var brk = new SkyrimMod(brkKey, SkyrimRelease.SkyrimSE);
+        var brkOwn = brk.Weapons.AddNew(); brkOwn.EditorID = "CmBrokenOwn";
+        brkOwn.BasicStats = new WeaponBasicStats { Damage = 40 };
+        var brkPath = WriteMod(mods, "CmBroken", brkKey, brk);
+
+        // The compact SUBJECT: its own originating record (something to renumber) plus an override of the broken
+        // plugin's record — which is what puts the unopenable plugin in its DECLARED master header.
+        var sub = new SkyrimMod(subKey, SkyrimRelease.SkyrimSE);
+        if (sub.ModHeader.Stats.NextFormID < 0x800) sub.ModHeader.Stats.NextFormID = 0x800;
+        var subOwn = sub.Weapons.AddNew(); subOwn.EditorID = "CmSubjectOwn";
+        subOwn.BasicStats = new WeaponBasicStats { Damage = 15 };
+        ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(sub, brkOwn)).BasicStats = new WeaponBasicStats { Damage = 41 };
+        WriteMod(mods, "CmSubject", subKey, sub, brk);
+
+        Truncate(brkPath);                                   // …last, so the subject could be built against it
+        Profile(instance, ("CmBroken", brkKey), ("CmSubject", subKey));
+
+        using var svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(dir, "hc.user.json")));
+        svc.Stats();
+
+        int before = Directory.GetDirectories(mods).Length;
+        var outcome = svc.CompactPlugin(subKey.FileName.String, esl: true, inPlace: false, repointExternals: false,
+            acknowledge: false, patchName: null);
+        int after = Directory.GetDirectories(mods).Length;
+
+        Check("compact: an unopenable DECLARED master is a named Fail (not an escaping engine throw), naming the plugin and the remedy",
+            !outcome.Success && outcome.Error is { } cerr
+            && cerr.Contains(brkKey.FileName.String, StringComparison.OrdinalIgnoreCase)
+            && cerr.Contains("could not be opened for the serialize", StringComparison.Ordinal)
+            && cerr.Contains("Nothing was written", StringComparison.Ordinal),
+            outcome.Error ?? "(succeeded)");
+        // The REASON the wrap exists, and the half a message assertion cannot see: cleanup only runs on a Fail RETURN.
+        Check("…and the fresh mod folder it cut is REMOVED — the cleanup an escaping throw would have skipped",
+            after == before, $"mod folders {before} -> {after}");
+    }
+
+    /// <summary>#316 (2) — <c>RemapEngine.RepointInPlace</c>'s <c>IsUnopenable</c> pre-check + wrap. The one that
+    /// matters most: its caller reaches it only AFTER the compacted plugin is already on disk, so an escaping throw
+    /// discards every per-plugin repoint result and skips the facegen/voice/SEQ carry that follows — on a
+    /// half-completed compaction. Driven through the TOOL, because the difference this fix makes is precisely
+    /// "a named per-plugin failure" vs "Guard.Tool's generic internal-failure wrapper".</summary>
+    static void RepointArm(string dir)
+    {
+        Console.WriteLine();
+        Console.WriteLine("   -- compact + repoint: an external referencer whose OWN master is unopenable fails NAMED, mid-compaction --");
+
+        var (instance, mods) = NewInstance(dir);
+        var brkKey = new ModKey("HcXRpBroken", ModType.Plugin);
+        var tgtKey = new ModKey("HcXRpTarget", ModType.Plugin);
+        var extKey = new ModKey("HcXRpExternal", ModType.Plugin);
+
+        var brk = new SkyrimMod(brkKey, SkyrimRelease.SkyrimSE);
+        var brkOwn = brk.Weapons.AddNew(); brkOwn.EditorID = "RpBrokenOwn";
+        brkOwn.BasicStats = new WeaponBasicStats { Damage = 40 };
+        var brkPath = WriteMod(mods, "RpBroken", brkKey, brk);
+
+        // The compact TARGET declares NO unopenable master itself — otherwise CompactBuild refuses first and the
+        // repoint stage is never reached (which is the arm above, not this one).
+        var tgt = new SkyrimMod(tgtKey, SkyrimRelease.SkyrimSE);
+        if (tgt.ModHeader.Stats.NextFormID < 0x800) tgt.ModHeader.Stats.NextFormID = 0x800;
+        var tgtOwn = tgt.Weapons.AddNew(); tgtOwn.EditorID = "RpTargetOwn";
+        tgtOwn.BasicStats = new WeaponBasicStats { Damage = 15 };
+        var tgtPath = WriteMod(mods, "RpTarget", tgtKey, tgt);
+
+        // The EXTERNAL referencer: it points at the target's record (so the compaction must repoint it) AND declares
+        // the broken plugin as a master (so the repoint's own re-serialize hits the unopenable open).
+        // …and the reference must be a LINK, not an override: HasExternalReferencers counts FormLinks INTO the
+        // renumbered records (an override is reported separately and never gates the operation), so an override-only
+        // "referencer" produced "external referencers: none" and the repoint stage never ran at all.
+        var ext = new SkyrimMod(extKey, SkyrimRelease.SkyrimSE);
+        if (ext.ModHeader.Stats.NextFormID < 0x800) ext.ModHeader.Stats.NextFormID = 0x800;
+        var lvl = ext.LeveledItems.AddNew(); lvl.EditorID = "RpExtList";
+        lvl.Entries = new Noggog.ExtendedList<LeveledItemEntry>
+        {
+            new LeveledItemEntry { Data = new LeveledItemEntryData { Level = 1, Count = 1, Reference = tgtOwn.ToLink<IItemGetter>() } },
+        };
+        ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(ext, brkOwn)).BasicStats = new WeaponBasicStats { Damage = 41 };
+        WriteMod(mods, "RpExternal", extKey, ext, brk, tgt);
+
+        Truncate(brkPath);
+        Profile(instance, ("RpBroken", brkKey), ("RpTarget", tgtKey), ("RpExternal", extKey));
+
+        using var svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(dir, "hc.user.json")));
+        svc.Stats();
+
+        var targetBefore = File.ReadAllBytes(tgtPath);   // BYTES, not length: a renumber rewrites ids in place and the size is identical
+        var render = WriteTools.CompactPlugin(svc, plugin: tgtKey.FileName.String, esl: true, in_place: true,
+            repoint_externals: true, acknowledge: true);
+
+        Check("repoint: the per-plugin failure is NAMED — the unopenable master, the remedy, and the file left UNTOUCHED",
+            render.Contains(extKey.FileName.String, StringComparison.OrdinalIgnoreCase)
+            && render.Contains(brkKey.FileName.String, StringComparison.OrdinalIgnoreCase)
+            && render.Contains("cannot be opened by houseCARL", StringComparison.Ordinal)
+            && render.Contains("UNTOUCHED", StringComparison.Ordinal),
+            Trim(render));
+        // The consequence the pre-check exists for: a throw here escapes to Guard.Tool, which reports an INTERNAL
+        // failure — discarding the repoint results and skipping the asset carry, on an ALREADY-REWRITTEN target.
+        Check("…and it is a REPORTED result, not Guard.Tool's internal-failure wrapper (the throw would land after P′ is on disk)",
+            !render.Contains("internal failure", StringComparison.OrdinalIgnoreCase)
+            && !render.Contains("unexpected", StringComparison.OrdinalIgnoreCase),
+            Trim(render));
+        // …and the compaction is still REPORTED. P′ lands before the repoint either way, so "the file changed" alone
+        // proves nothing (its own RED check passed on that clause); what the throw destroys is the caller's RESULT —
+        // the compaction report, the other referencers' outcomes, and the asset carry that follows it.
+        Check("…and the compaction itself is still REPORTED — the failing repoint is one plugin's result, not the call's",
+            !File.ReadAllBytes(tgtPath).AsSpan().SequenceEqual(targetBefore)
+            && render.Contains("compacted", StringComparison.OrdinalIgnoreCase),
+            $"target rewritten={!File.ReadAllBytes(tgtPath).AsSpan().SequenceEqual(targetBefore)} :: {Trim(render)}");
+    }
+
+    /// <summary>#316 (3) — the IN-PLACE lane's single-master threshold. <c>DryRunMastersPreview(patchLane:false)</c>
+    /// predicts the same <c>set.Count > 1</c> rule the patch lane uses, and nothing verified it on THIS lane. The
+    /// patch-lane side is pinned both ways above (a one-master header writes; a two-master header refuses); this is
+    /// its twin, pinned the same two ways, and with the dry run agreeing on BOTH — a threshold verified in only one
+    /// direction is how a predictor drifts into over- or under-refusing without a guard noticing.</summary>
+    static void InPlaceThresholdArm(string dir)
+    {
+        Console.WriteLine();
+        Console.WriteLine("   -- in-place: the single-master threshold, pinned BOTH ways, real call and dry run --");
+
+        var (instance, mods) = NewInstance(dir);
+        var mstKey = new ModKey("HcXIpMaster", ModType.Master);
+        var brkKey = new ModKey("HcXIpBroken", ModType.Plugin);
+        var oneKey = new ModKey("HcXIpOne", ModType.Plugin);
+        var twoKey = new ModKey("HcXIpTwo", ModType.Plugin);
+
+        var mst = new SkyrimMod(mstKey, SkyrimRelease.SkyrimSE);
+        var mstOwn = mst.Weapons.AddNew(); mstOwn.EditorID = "IpMasterOwn";
+        mstOwn.BasicStats = new WeaponBasicStats { Damage = 10 };
+        WriteMod(mods, "IpMaster", mstKey, mst);
+
+        var brk = new SkyrimMod(brkKey, SkyrimRelease.SkyrimSE);
+        var brkOwn = brk.Weapons.AddNew(); brkOwn.EditorID = "IpBrokenOwn";
+        brkOwn.BasicStats = new WeaponBasicStats { Damage = 40 };
+        var brkPath = WriteMod(mods, "IpBroken", brkKey, brk);
+
+        // ONE master: overrides only the broken plugin's record, so its header is exactly {broken}.
+        var one = new SkyrimMod(oneKey, SkyrimRelease.SkyrimSE);
+        ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(one, brkOwn)).BasicStats = new WeaponBasicStats { Damage = 41 };
+        WriteMod(mods, "IpOne", oneKey, one, brk);
+
+        // TWO masters: the same override PLUS one of the openable master's, so the header must be SORTED.
+        var two = new SkyrimMod(twoKey, SkyrimRelease.SkyrimSE);
+        ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(two, brkOwn)).BasicStats = new WeaponBasicStats { Damage = 42 };
+        ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(two, mstOwn)).BasicStats = new WeaponBasicStats { Damage = 11 };
+        WriteMod(mods, "IpTwo", twoKey, two, mst, brk);
+
+        Truncate(brkPath);
+        Profile(instance, ("IpMaster", mstKey), ("IpBroken", brkKey), ("IpOne", oneKey), ("IpTwo", twoKey));
+
+        using var svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(dir, "hc.user.json")));
+        svc.Stats();
+
+        string brokenFid = $"{brkOwn.FormKey.ID:X6}:{brkKey.FileName}";
+        string Edit(string fid, string val) => $$"""[{"formid":"{{fid}}","field_path":"BasicStats.Damage","value":"{{val}}"}]""";
+        System.Text.Json.JsonElement Ops(string fid, string val)
+            => System.Text.Json.JsonDocument.Parse(Edit(fid, val)).RootElement.Clone();
+
+        // ONE master — WRITES. (The record it edits ORIGINATES in the unopenable plugin, so the header entry comes
+        // from the record's own FormKey; nothing has to be sorted against a plugin that cannot be opened.)
+        var oneReal = ApplyTools.Apply(svc, ops: Ops(brokenFid, "44"), in_place: oneKey.FileName.String, acknowledge: true);
+        Check("in_place, ONE-master header: the write LANDS even though that one master is unopenable",
+            !oneReal.StartsWith("error:"), oneReal);
+        var oneDry = ApplyTools.Apply(svc, ops: Ops(brokenFid, "45"), in_place: oneKey.FileName.String, acknowledge: true, dry_run: true);
+        Check("…and the dry run AGREES (no over-refusal — the predictor's threshold, on the lane that predicts it)",
+            oneDry.StartsWith("DRY RUN", StringComparison.Ordinal), oneDry);
+
+        // TWO masters — REFUSES, by CAUSE. This is the case a real order always takes.
+        var twoReal = ApplyTools.Apply(svc, ops: Ops(brokenFid, "46"), in_place: twoKey.FileName.String, acknowledge: true);
+        Check("in_place, TWO-master header: the write REFUSES, naming the unopenable plugin as the cause",
+            twoReal.StartsWith("error:")
+            && twoReal.Contains(brkKey.FileName.String, StringComparison.OrdinalIgnoreCase)
+            && twoReal.Contains("cannot be opened by houseCARL", StringComparison.Ordinal)
+            && !twoReal.Contains("is NOT active in", StringComparison.Ordinal), twoReal);
+        var twoDry = ApplyTools.Apply(svc, ops: Ops(brokenFid, "47"), in_place: twoKey.FileName.String, acknowledge: true, dry_run: true);
+        Check("…and the dry run predicts THAT refusal too (#225 parity on the in-place lane, both directions now pinned)",
+            twoDry.StartsWith("error:")
+            && twoDry.Contains(brkKey.FileName.String, StringComparison.OrdinalIgnoreCase)
+            && twoDry.Contains("cannot be opened by houseCARL", StringComparison.Ordinal), twoDry);
     }
 
     sealed class Fixture : IDisposable

--- a/src/housecarl-generator/ExcludedMasterWriteProbe.cs
+++ b/src/housecarl-generator/ExcludedMasterWriteProbe.cs
@@ -395,6 +395,19 @@ public static class ExcludedMasterWriteProbe
         return p;
     }
 
+    /// <summary>Read one weapon's Damage straight off a written plugin — the "did the edit actually land" witness for
+    /// the arms that assert a write HAPPENED rather than that it was refused. Null when the file or the record can't
+    /// be read (which fails the arm, correctly).</summary>
+    static ushort? DamageOnDisk(string espPath, FormKey fk)
+    {
+        try
+        {
+            using var ov = SkyrimMod.CreateFromBinaryOverlay(espPath, SkyrimRelease.SkyrimSE);
+            return ov.Weapons.FirstOrDefault(w => w.FormKey == fk)?.BasicStats?.Damage;
+        }
+        catch { return null; }
+    }
+
     /// <summary>Break a written plugin into the could-not-be-OPENED exclusion class: a valid header followed by a
     /// truncated body. Twelve bytes is what the fixtures above use and what reliably produces the class.</summary>
     static void Truncate(string path)
@@ -514,9 +527,13 @@ public static class ExcludedMasterWriteProbe
             Trim(render));
         // The consequence the pre-check exists for: a throw here escapes to Guard.Tool, which reports an INTERNAL
         // failure — discarding the repoint results and skipping the asset carry, on an ALREADY-REWRITTEN target.
+        // "internal failure" is NOT the string Guard.Named emits ("failed unexpectedly") — an inert clause reading as
+        // a second check (review round 1). Pinned on the words the wrapper actually uses, plus the positive: a
+        // per-plugin repoint REPORT exists at all.
         Check("…and it is a REPORTED result, not Guard.Tool's internal-failure wrapper (the throw would land after P′ is on disk)",
-            !render.Contains("internal failure", StringComparison.OrdinalIgnoreCase)
-            && !render.Contains("unexpected", StringComparison.OrdinalIgnoreCase),
+            !render.Contains("unexpectedly", StringComparison.OrdinalIgnoreCase)
+            && !render.Contains("internal houseCARL failure", StringComparison.OrdinalIgnoreCase)
+            && render.Contains("repointed in place", StringComparison.OrdinalIgnoreCase),
             Trim(render));
         // …and the compaction is still REPORTED. P′ lands before the repoint either way, so "the file changed" alone
         // proves nothing (its own RED check passed on that clause); what the throw destroys is the caller's RESULT —
@@ -531,7 +548,12 @@ public static class ExcludedMasterWriteProbe
     /// predicts the same <c>set.Count > 1</c> rule the patch lane uses, and nothing verified it on THIS lane. The
     /// patch-lane side is pinned both ways above (a one-master header writes; a two-master header refuses); this is
     /// its twin, pinned the same two ways, and with the dry run agreeing on BOTH — a threshold verified in only one
-    /// direction is how a predictor drifts into over- or under-refusing without a guard noticing.</summary>
+    /// direction is how a predictor drifts into over- or under-refusing without a guard noticing.
+    /// <para>SCOPE, carried from <c>RealOrderArm</c>'s lesson rather than re-learned (review round 1): this order has
+    /// no baselines, and the ONE-master case is only reachable without them. A real order's PATCH lane force-includes
+    /// Skyrim.esm + Update.esm, so it always has ≥2 and always takes the refusing side. The in-place lane force-
+    /// includes nothing, so a genuinely one-master in-place header IS reachable in the field (a plugin overriding one
+    /// mod's records) — but the arm pins the THRESHOLD, not a claim about how often each side is hit.</para></summary>
     static void InPlaceThresholdArm(string dir)
     {
         Console.WriteLine();
@@ -578,8 +600,12 @@ public static class ExcludedMasterWriteProbe
         // ONE master — WRITES. (The record it edits ORIGINATES in the unopenable plugin, so the header entry comes
         // from the record's own FormKey; nothing has to be sorted against a plugin that cannot be opened.)
         var oneReal = ApplyTools.Apply(svc, ops: Ops(brokenFid, "44"), in_place: oneKey.FileName.String, acknowledge: true);
-        Check("in_place, ONE-master header: the write LANDS even though that one master is unopenable",
-            !oneReal.StartsWith("error:"), oneReal);
+        // …asserted on the VALUE, not merely on the absence of "error:" (review round 1): a regression that returned a
+        // success render while applying nothing would have kept the weaker form green, on the one arm here whose job
+        // is to prove a write HAPPENS.
+        var oneBack = DamageOnDisk(Path.Combine(mods, "IpOne", oneKey.FileName.String), brkOwn.FormKey);
+        Check("in_place, ONE-master header: the write LANDS even though that one master is unopenable (value read back off the file)",
+            !oneReal.StartsWith("error:") && oneBack == 44, $"damage={oneBack} (want 44) :: {oneReal}");
         var oneDry = ApplyTools.Apply(svc, ops: Ops(brokenFid, "45"), in_place: oneKey.FileName.String, acknowledge: true, dry_run: true);
         Check("…and the dry run AGREES (no over-refusal — the predictor's threshold, on the lane that predicts it)",
             oneDry.StartsWith("DRY RUN", StringComparison.Ordinal), oneDry);

--- a/src/housecarl-generator/ExcludedMasterWriteProbe.cs
+++ b/src/housecarl-generator/ExcludedMasterWriteProbe.cs
@@ -531,13 +531,13 @@ public static class ExcludedMasterWriteProbe
             Trim(render));
         // The consequence the pre-check exists for: a throw here escapes to Guard.Tool, which reports an INTERNAL
         // failure — discarding the repoint results and skipping the asset carry, on an ALREADY-REWRITTEN target.
-        // "internal failure" is NOT the string Guard.Named emits ("failed unexpectedly") — an inert clause reading as
-        // a second check (review round 1). Pinned on the words the wrapper actually uses, plus the positive: a
-        // per-plugin repoint REPORT exists at all.
+        // The POSITIVE carries the signal — a per-plugin repoint report exists, which a throw out through Guard.Tool
+        // makes impossible. The negative is one DISTINCTIVE Guard string, not the generic "unexpectedly" an unrelated
+        // sentence elsewhere in the compact render could legitimately use (PR #318 review [nit]; the first draft of
+        // this clause searched for words Guard never emits at all).
         Check("…and it is a REPORTED result, not Guard.Tool's internal-failure wrapper (the throw would land after P′ is on disk)",
-            !render.Contains("unexpectedly", StringComparison.OrdinalIgnoreCase)
-            && !render.Contains("internal houseCARL failure", StringComparison.OrdinalIgnoreCase)
-            && render.Contains("repointed in place", StringComparison.OrdinalIgnoreCase),
+            render.Contains("repointed in place", StringComparison.OrdinalIgnoreCase)
+            && !render.Contains("internal houseCARL failure", StringComparison.OrdinalIgnoreCase),
             Trim(render));
         // …and the compaction is still REPORTED. P′ lands before the repoint either way, so "the file changed" alone
         // proves nothing (its own RED check passed on that clause); what the throw destroys is the caller's RESULT —

--- a/src/housecarl-generator/SeqWriteGuardProbe.cs
+++ b/src/housecarl-generator/SeqWriteGuardProbe.cs
@@ -430,6 +430,14 @@ internal static class SeqWriteGuardProbe
             var oFresh = svc.WriteSeq(svcPlugin, null, null, userMod);
             Check(oFresh.Success && !oFresh.Replaced && SeqTools.Render(oFresh).StartsWith("wrote ", StringComparison.Ordinal),
                 $"REPLACED-NEG a first write to an empty destination is 'wrote', not 'replaced' — replaced={oFresh.Replaced}");
+            // …and the json twin of the replaced state, which had no arm (PR #318 review [nit]).
+            File.WriteAllBytes(expectedUserSeq, new byte[] { 9, 9, 9, 9, 9, 9 });
+            var jsonRepl = SeqTools.WriteSeq(svc, source: Path.GetFileName(svcPlugin), output_dir: userMod, format: "json");
+            Check(jsonRepl.Contains("\"replaced\": true", StringComparison.Ordinal)
+                  && jsonRepl.Contains("\"replaced_same_bytes\": false", StringComparison.Ordinal)
+                  && jsonRepl.Contains("replaced_note", StringComparison.Ordinal)
+                  && jsonRepl.Contains("no backup", StringComparison.Ordinal),
+                $"REPLACED-JSON the replaced state and its note are on the json transport too — render=[{Trim(jsonRepl)}]");
 
             // LANE-ORDER: output_dir= + patch= + into= together is NOT refused. The pair-exclusivity check used to run
             // first, so naming all three was rejected over two parameters output_dir='s own contract promises to
@@ -452,6 +460,19 @@ internal static class SeqWriteGuardProbe
             Check(toolEmptyNote.Contains("no start-game-enabled quests", StringComparison.Ordinal)
                   && toolEmptyNote.Contains("output_dir= was given", StringComparison.Ordinal),
                 $"NOOP-LANE-NOTE the nothing-to-do render states the ignored lane too — render=[{Trim(toolEmptyNote)}]");
+
+            // WRITE-FAIL-FOLDER: the output_dir lane's write-failure clause, which had no arm (PR #318 review [nit]).
+            // A directory sitting where the .seq must go makes the write throw with the folder already resolved, so
+            // the message has to say the folder is left alone — cleanup is bypassed on a user-owned destination.
+            var blocked = Path.Combine(root, "blocked");
+            Directory.CreateDirectory(Path.Combine(blocked, "SEQ", "HcSeqSvc.seq"));   // a DIRECTORY where the file goes
+            var oBlocked = svc.WriteSeq(svcPlugin, null, null, blocked);
+            Check(!oBlocked.Success && oBlocked.Error is { } be
+                  && be.Contains("could not write", StringComparison.Ordinal)
+                  && be.Contains("is left in place", StringComparison.Ordinal)
+                  && be.Contains("never removes a folder you named", StringComparison.Ordinal)
+                  && Directory.Exists(Path.Combine(blocked, "SEQ")),
+                $"WRITE-FAIL-FOLDER a failed output_dir write names the folder it leaves behind, and leaves it — err=[{oBlocked.Error}]");
 
             // LANE-NOTE-ON-REFUSAL: an ignored lane stays stated when the call FAILS. A refusal is exactly when a
             // caller re-reads their parameters, and "patch= was ignored" is still true (review round 2).

--- a/src/housecarl-generator/SeqWriteGuardProbe.cs
+++ b/src/housecarl-generator/SeqWriteGuardProbe.cs
@@ -37,6 +37,17 @@ namespace HousecarlGenerator;
 ///   SAME-FOLDER    — a plugin inside a houseCARL-owned folder defaults the .seq INTO that folder (WroteIntoPluginFolder).
 ///   EMPTY-NOOP     — a plugin with NO SGE quests writes nothing, cuts no folder (no orphan), reports the clean no-op.
 ///   REFUSE-NOFILE  — WriteSeq on a missing plugin path refuses, named (Q3).
+///
+/// #312 (output_dir= + the byte-identical no-op):
+///   PURE-SEQ-CONTRACT / PURE-SEQ-DEPLOY — the pure path contract: SEQ\ appended once (double-SEQ guard), and the
+///                    deployability rule with a warning worded for a .seq's own consequence (silently dead quests).
+///   OUTPUT-DIR / -DEPLOYS / -OUTSIDE    — the .seq lands in the USER's folder, no houseCARL folder cut and no owner
+///                    marker stamped; a deployable folder carries no warning, an off-tree one does.
+///   USER-OWNED-SURVIVES — residue cleanup never deletes a folder the user named.
+///   UNCHANGED / -DIFFERS — a byte-identical destination is left ALONE (proved by mtime, not by the flag), while a
+///                    stale one is rewritten (the compare is on BYTES, never existence).
+///   TOOL-LANE      — output_dir= wins over patch=/into= and the ignored lane is STATED (Q3).
+///   RENDER-UNCHANGED / JSON-UNCHANGED — the no-op renders as its own state on both transports (written=false).
 /// </summary>
 internal static class SeqWriteGuardProbe
 {
@@ -254,6 +265,105 @@ internal static class SeqWriteGuardProbe
                   && oByName.ResolvedFrom is { Length: > 0 }
                   && string.Equals(oByName.PluginPath, Path.GetFullPath(svcPlugin), StringComparison.OrdinalIgnoreCase),
                 $"FILENAME-LANE source= by filename resolves to the same file and states its arm — from=[{oByName.ResolvedFrom}] path=[{oByName.PluginPath}] err=[{oByName.Error}]");
+
+            // ====================== #312 — output_dir= and the byte-identical no-op ======================
+
+            // PURE-CONTRACT: the SEQ twin of the compile lane's path contract. Pure, so it is provable without an
+            // instance, and it is the piece the resolve arms below cannot distinguish from a lucky Path.Combine.
+            const string pcMods = @"C:\MO2\mods", pcData = @"C:\Game\Skyrim Special Edition\Data";
+            var pcBare = LoadOrderService.SeqOutputContract(@"C:\MyMod", pcMods, pcData);
+            var pcAlready = LoadOrderService.SeqOutputContract(@"C:\MyMod\SEQ", pcMods, pcData);
+            var pcLower = LoadOrderService.SeqOutputContract(@"C:\MyMod\seq\", pcMods, pcData);
+            Check(pcBare.seqDir == @"C:\MyMod\SEQ" && pcBare.appendedSeq
+                  && pcAlready.seqDir == @"C:\MyMod\SEQ" && !pcAlready.appendedSeq
+                  && pcLower.seqDir == @"C:\MyMod\seq" && !pcLower.appendedSeq,
+                $"PURE-SEQ-CONTRACT SEQ\\ appended once, double-SEQ guard case-insensitive + trailing-separator tolerant — [{pcBare.seqDir}] [{pcAlready.seqDir}] [{pcLower.seqDir}]");
+            // Deployability is the .pex rule one segment over — and the WARNING is worded for what a mis-placed .seq
+            // costs (silently dead quests), not the milder "won't deploy on its own" the compile lane can afford.
+            Check(LoadOrderService.SeqOutputContract(@"C:\MO2\mods\MyMod", pcMods, pcData).deployWarning is null
+                  && LoadOrderService.SeqOutputContract(pcData, pcMods, pcData).deployWarning is null
+                  && LoadOrderService.SeqOutputContract(@"C:\MO2\mods", pcMods, pcData).deployWarning is not null
+                  && LoadOrderService.SeqOutputContract(@"C:\MO2\mods\X\Sub", pcMods, pcData).deployWarning is not null
+                  && LoadOrderService.SeqOutputContract(@"C:\Elsewhere\MyMod", pcMods, pcData).deployWarning is { } w312
+                     && w312.Contains("silently", StringComparison.Ordinal),
+                "PURE-SEQ-DEPLOY <mods>\\<mod>\\SEQ and <data>\\SEQ deploy; the mods root, a nested path and an outside path warn — and the warning names the silent-death consequence");
+
+            // OUTPUT-DIR: a third-party mod's OWN folder — the #312 case (in-place .esp edit, .seq belongs beside it).
+            // The folder is USER-owned: no houseCARL mod folder is cut, and no ownership marker is stamped into it.
+            string userMod = Path.Combine(mods, "SomeoneElsesQuestMod");
+            Directory.CreateDirectory(userMod);
+            int cutBefore = Directory.GetDirectories(mods).Length;
+            var oOut = svc.WriteSeq(svcPlugin, null, null, userMod);
+            string expectedUserSeq = Path.Combine(userMod, "SEQ", "HcSeqSvc.seq");
+            Check(oOut.Success && File.Exists(expectedUserSeq)
+                  && string.Equals(oOut.SeqPath, expectedUserSeq, StringComparison.OrdinalIgnoreCase)
+                  && oOut.UserChoseOutput && !oOut.WroteIntoPluginFolder
+                  && Directory.GetDirectories(mods).Length == cutBefore
+                  && !File.Exists(Path.Combine(userMod, "meta.ini")),
+                $"OUTPUT-DIR .seq lands in <output_dir>\\SEQ, no houseCARL folder cut, no ownership marker stamped — path=[{oOut.SeqPath}] chose={oOut.UserChoseOutput} err=[{oOut.Error}]");
+            // …and a mod folder directly under mods\ DEPLOYS, so no warning. (The arm above is the case a user hits;
+            // this is the half that proves the warning is a real discriminator rather than always-on.)
+            Check(oOut.DeployWarning is null, $"OUTPUT-DIR-DEPLOYS <mods>\\<mod>\\SEQ carries no deploy warning — got [{oOut.DeployWarning}]");
+
+            // OUTPUT-DIR-OUTSIDE: the same call to a folder the game never reads is written and WARNED, never a clean
+            // "done" — a .seq the engine can't see leaves every SGE quest silently dead (Q3).
+            string offTree = Path.Combine(root, "elsewhere", "NotAMod");
+            var oOff = svc.WriteSeq(svcPlugin, null, null, offTree);
+            Check(oOff.Success && File.Exists(Path.Combine(offTree, "SEQ", "HcSeqSvc.seq"))
+                  && oOff.DeployWarning is not null,
+                $"OUTPUT-DIR-OUTSIDE written but WARNED (never a clean done for a .seq the game won't read) — warn=[{oOff.DeployWarning}]");
+
+            // USER-OWNED-SURVIVES: residue cleanup must never delete a folder the user named (CreatedFresh=false).
+            var userRf = svc.ResolveExplicitSeqFolder(userMod, out _);
+            Check(!userRf.CreatedFresh && svc.RemoveOrNameRiderResidue(userRf) is null && Directory.Exists(userRf.OutputDir),
+                "USER-OWNED-SURVIVES residue cleanup never deletes an output_dir folder (CreatedFresh=false; the folder survives)");
+
+            // UNCHANGED: re-running against a destination that already holds these bytes writes NOTHING. Proved by the
+            // file's TIMESTAMP, not by the flag alone — the flag is what a broken short-circuit would set while still
+            // rewriting the file, so a mtime sentinel is what makes this arm mean "no write happened".
+            var sentinel = new DateTime(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+            File.SetLastWriteTimeUtc(expectedUserSeq, sentinel);
+            var oSame = svc.WriteSeq(svcPlugin, null, null, userMod);
+            Check(oSame.Success && oSame.Unchanged
+                  && File.GetLastWriteTimeUtc(expectedUserSeq) == sentinel
+                  && string.Equals(oSame.SeqPath, expectedUserSeq, StringComparison.OrdinalIgnoreCase),
+                $"UNCHANGED byte-identical destination → nothing written (mtime untouched), reported as its own state — unchanged={oSame.Unchanged} err=[{oSame.Error}]");
+
+            // UNCHANGED-DIFFERS: the negative half. A destination holding DIFFERENT bytes is rewritten — a
+            // short-circuit that fired on mere existence would leave the stale file and report success.
+            File.WriteAllBytes(expectedUserSeq, new byte[] { 0xDE, 0xAD, 0xBE, 0xEF });
+            File.SetLastWriteTimeUtc(expectedUserSeq, sentinel);
+            var oDiff = svc.WriteSeq(svcPlugin, null, null, userMod);
+            Check(oDiff.Success && !oDiff.Unchanged
+                  && File.GetLastWriteTimeUtc(expectedUserSeq) != sentinel
+                  && File.ReadAllBytes(expectedUserSeq).Length == 4
+                  && File.ReadAllBytes(expectedUserSeq)[0] != 0xDE,
+                $"UNCHANGED-DIFFERS a stale destination IS rewritten (the short-circuit compares BYTES, not existence) — unchanged={oDiff.Unchanged}");
+
+            // TOOL-LANE: output_dir= WINS over patch=/into=, and says so (Q3 — an ignored parameter is stated, never
+            // silently dropped). Asserted through the TOOL, because the note is composed there.
+            var toolBoth = SeqTools.WriteSeq(svc, source: Path.GetFileName(svcPlugin), patch: "HcSeqIgnored", output_dir: userMod);
+            Check(toolBoth.Contains("output_dir= was given", StringComparison.Ordinal)
+                  && toolBoth.Contains("ignored", StringComparison.Ordinal)
+                  && !Directory.EnumerateDirectories(mods, "houseCARL - HcSeqIgnored*").Any(),
+                $"TOOL-LANE output_dir= wins over patch= and the ignored lane is STATED, with no folder cut for it — render=[{Trim(toolBoth)}]");
+
+            // RENDER-UNCHANGED: the no-op's text render leads with it. "wrote" on a call that wrote nothing is the
+            // silent-success shape Q3 refuses, and the first line is what a caller reads.
+            var toolSame = SeqTools.WriteSeq(svc, source: Path.GetFileName(svcPlugin), output_dir: userMod);
+            Check(toolSame.StartsWith("unchanged", StringComparison.Ordinal)
+                  && toolSame.Contains("NOTHING was written", StringComparison.Ordinal)
+                  && !toolSame.Contains("houseCARL mod folder — enable it", StringComparison.Ordinal),
+                $"RENDER-UNCHANGED the no-op renders as 'unchanged … NOTHING was written', and an output_dir destination is NOT called a houseCARL mod folder — render=[{Trim(toolSame)}]");
+
+            // JSON-UNCHANGED: written=false with unchanged=true and a seq_path — the machine twin of the same fact
+            // (the pre-#312 `written` was "a path exists", which would now report a write that never happened).
+            var jsonSame = SeqTools.WriteSeq(svc, source: Path.GetFileName(svcPlugin), output_dir: userMod, format: "json");
+            Check(jsonSame.Contains("\"written\": false", StringComparison.Ordinal)
+                  && jsonSame.Contains("\"unchanged\": true", StringComparison.Ordinal)
+                  && jsonSame.Contains("\"user_chose_output_dir\": true", StringComparison.Ordinal)
+                  && jsonSame.Contains("\"seq_path\"", StringComparison.Ordinal),
+                $"JSON-UNCHANGED json reports written=false + unchanged=true + the path — render=[{Trim(jsonSame)}]");
         }
         catch (Exception ex)
         {
@@ -272,6 +382,10 @@ internal static class SeqWriteGuardProbe
 
     static bool PathUnder(string? path, string folder)
         => path is not null && Path.GetFullPath(path).StartsWith(Path.GetFullPath(folder), StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>One-line, bounded echo of a render for a FAIL line (the arms below assert on multi-line output).</summary>
+    static string Trim(string s)
+        => (s.Length <= 300 ? s : s[..300] + " …").Replace("\r", "").Replace("\n", " | ");
 
     // ---- raw on-disk FormID parse (independent of Mutagen's overlay decode) — to verify the computed encoding ----
 

--- a/src/housecarl-generator/SeqWriteGuardProbe.cs
+++ b/src/housecarl-generator/SeqWriteGuardProbe.cs
@@ -303,7 +303,12 @@ internal static class SeqWriteGuardProbe
                 $"OUTPUT-DIR .seq lands in <output_dir>\\SEQ, no houseCARL folder cut, no ownership marker stamped — path=[{oOut.SeqPath}] chose={oOut.UserChoseOutput} err=[{oOut.Error}]");
             // …and a mod folder directly under mods\ DEPLOYS, so no warning. (The arm above is the case a user hits;
             // this is the half that proves the warning is a real discriminator rather than always-on.)
-            Check(oOut.DeployWarning is null, $"OUTPUT-DIR-DEPLOYS <mods>\\<mod>\\SEQ carries no deploy warning — got [{oOut.DeployWarning}]");
+            // …and it asserts WHERE THE FILE WENT alongside the null warning: on its own, "no warning" is also what
+            // every houseCARL-folder lane produces, so the arm passed unchanged with output_dir= routing disabled
+            // (its own RED check found that, twice — the flag alone was no better, since it reports what the CALLER
+            // asked for, not which lane ran). The path is the only witness that cannot be faked by intent.
+            Check(PathUnder(oOut.SeqPath, userMod) && oOut.DeployWarning is null,
+                $"OUTPUT-DIR-DEPLOYS the .seq is IN the named folder AND <mods>\\<mod>\\SEQ carries no deploy warning — path=[{oOut.SeqPath}] got [{oOut.DeployWarning}]");
 
             // OUTPUT-DIR-OUTSIDE: the same call to a folder the game never reads is written and WARNED, never a clean
             // "done" — a .seq the engine can't see leaves every SGE quest silently dead (Q3).
@@ -322,7 +327,11 @@ internal static class SeqWriteGuardProbe
             // file's TIMESTAMP, not by the flag alone — the flag is what a broken short-circuit would set while still
             // rewriting the file, so a mtime sentinel is what makes this arm mean "no write happened".
             var sentinel = new DateTime(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc);
-            File.SetLastWriteTimeUtc(expectedUserSeq, sentinel);
+            // Stamped only if the arm above actually produced the file: a missing destination is a FAILURE of that
+            // arm, and stamping it blind turns it into an exception that takes the rest of this section with it
+            // (which is exactly what the OUTPUT-DIR RED check produced).
+            if (File.Exists(expectedUserSeq)) File.SetLastWriteTimeUtc(expectedUserSeq, sentinel);
+            else Check(false, "UNCHANGED prerequisite: the OUTPUT-DIR arm left no file to re-run against");
             var oSame = svc.WriteSeq(svcPlugin, null, null, userMod);
             Check(oSame.Success && oSame.Unchanged
                   && File.GetLastWriteTimeUtc(expectedUserSeq) == sentinel
@@ -331,6 +340,7 @@ internal static class SeqWriteGuardProbe
 
             // UNCHANGED-DIFFERS: the negative half. A destination holding DIFFERENT bytes is rewritten — a
             // short-circuit that fired on mere existence would leave the stale file and report success.
+            Directory.CreateDirectory(Path.GetDirectoryName(expectedUserSeq)!);
             File.WriteAllBytes(expectedUserSeq, new byte[] { 0xDE, 0xAD, 0xBE, 0xEF });
             File.SetLastWriteTimeUtc(expectedUserSeq, sentinel);
             var oDiff = svc.WriteSeq(svcPlugin, null, null, userMod);

--- a/src/housecarl-generator/SeqWriteGuardProbe.cs
+++ b/src/housecarl-generator/SeqWriteGuardProbe.cs
@@ -280,6 +280,17 @@ internal static class SeqWriteGuardProbe
                 $"PURE-SEQ-CONTRACT SEQ\\ appended once, double-SEQ guard case-insensitive + trailing-separator tolerant — [{pcBare.seqDir}] [{pcAlready.seqDir}] [{pcLower.seqDir}]");
             // Deployability is the .pex rule one segment over — and the WARNING is worded for what a mis-placed .seq
             // costs (silently dead quests), not the milder "won't deploy on its own" the compile lane can afford.
+            // …including MO2's OVERWRITE folder, which is VFS-mapped onto Data at top priority and is where xEdit /
+            // CK / Synthesis output normally lands. Omitting it made the feature's own headline case — an in-place
+            // edit of a plugin living in overwrite — warn "the game will NOT see this .seq" about a folder the game
+            // does read (review round 1).
+            const string pcOver = @"C:\MO2\overwrite";
+            Check(LoadOrderService.SeqOutputContract(pcOver, pcMods, pcData, pcOver).deployWarning is null
+                  && LoadOrderService.SeqOutputContract(pcOver, pcMods, pcData).deployWarning is not null,
+                "PURE-SEQ-OVERWRITE <overwrite>\\SEQ deploys when the overwrite root is known, and is judged only on that root (not by name)");
+            // …and a drive ROOT keeps its separator: "C:\" trimmed to "C:" yields the drive-RELATIVE "C:SEQ".
+            Check(LoadOrderService.SeqOutputContract(@"C:\", pcMods, pcData).seqDir == @"C:\SEQ",
+                $"PURE-SEQ-ROOT a drive root appends correctly — got [{LoadOrderService.SeqOutputContract(@"C:\", pcMods, pcData).seqDir}] (want C:\\SEQ, never the drive-relative C:SEQ)");
             Check(LoadOrderService.SeqOutputContract(@"C:\MO2\mods\MyMod", pcMods, pcData).deployWarning is null
                   && LoadOrderService.SeqOutputContract(pcData, pcMods, pcData).deployWarning is null
                   && LoadOrderService.SeqOutputContract(@"C:\MO2\mods", pcMods, pcData).deployWarning is not null
@@ -326,17 +337,21 @@ internal static class SeqWriteGuardProbe
             // UNCHANGED: re-running against a destination that already holds these bytes writes NOTHING. Proved by the
             // file's TIMESTAMP, not by the flag alone — the flag is what a broken short-circuit would set while still
             // rewriting the file, so a mtime sentinel is what makes this arm mean "no write happened".
-            var sentinel = new DateTime(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+            // The PLUGIN is stamped OLDER than the sentinel deliberately: an identical .seq that is older than its
+            // plugin is stamped forward (the MTIME-REFRESH arm below), so "no write" is only observable as a preserved
+            // mtime when the file is already the newer of the two.
+            var sentinel = new DateTime(2005, 5, 5, 5, 5, 5, DateTimeKind.Utc);
             // Stamped only if the arm above actually produced the file: a missing destination is a FAILURE of that
             // arm, and stamping it blind turns it into an exception that takes the rest of this section with it
             // (which is exactly what the OUTPUT-DIR RED check produced).
+            File.SetLastWriteTimeUtc(svcPlugin, new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc));
             if (File.Exists(expectedUserSeq)) File.SetLastWriteTimeUtc(expectedUserSeq, sentinel);
             else Check(false, "UNCHANGED prerequisite: the OUTPUT-DIR arm left no file to re-run against");
             var oSame = svc.WriteSeq(svcPlugin, null, null, userMod);
-            Check(oSame.Success && oSame.Unchanged
+            Check(oSame.Success && oSame.Unchanged && !oSame.TimestampRefreshed
                   && File.GetLastWriteTimeUtc(expectedUserSeq) == sentinel
                   && string.Equals(oSame.SeqPath, expectedUserSeq, StringComparison.OrdinalIgnoreCase),
-                $"UNCHANGED byte-identical destination → nothing written (mtime untouched), reported as its own state — unchanged={oSame.Unchanged} err=[{oSame.Error}]");
+                $"UNCHANGED byte-identical destination → nothing written (mtime untouched), reported as its own state — unchanged={oSame.Unchanged} touched={oSame.TimestampRefreshed} err=[{oSame.Error}]");
 
             // UNCHANGED-DIFFERS: the negative half. A destination holding DIFFERENT bytes is rewritten — a
             // short-circuit that fired on mere existence would leave the stale file and report success.
@@ -349,6 +364,38 @@ internal static class SeqWriteGuardProbe
                   && File.ReadAllBytes(expectedUserSeq).Length == 4
                   && File.ReadAllBytes(expectedUserSeq)[0] != 0xDE,
                 $"UNCHANGED-DIFFERS a stale destination IS rewritten (the short-circuit compares BYTES, not existence) — unchanged={oDiff.Unchanged}");
+
+            // MTIME-REFRESH: the no-op must not leave the file looking STALE to the sibling lint, which reads MTIME
+            // and not content (validate_dialogue's SeqNewerThanPlugin). Without this, the exact loop the feature
+            // exists for — edit in place, regenerate — would leave a permanent "your .seq is older than the plugin"
+            // advisory on a byte-perfect file, with two houseCARL tools contradicting each other (review round 1).
+            File.SetLastWriteTimeUtc(expectedUserSeq, new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+            var pluginStamp = new DateTime(2020, 6, 6, 6, 6, 6, DateTimeKind.Utc);
+            File.SetLastWriteTimeUtc(svcPlugin, pluginStamp);
+            var oStale = svc.WriteSeq(svcPlugin, null, null, userMod);
+            Check(oStale.Success && oStale.Unchanged && oStale.TimestampRefreshed
+                  && File.GetLastWriteTimeUtc(expectedUserSeq) > pluginStamp
+                  && File.ReadAllBytes(expectedUserSeq).Length == 4,
+                $"MTIME-REFRESH a byte-identical but OLDER .seq is stamped forward, not rewritten — unchanged={oStale.Unchanged} touched={oStale.TimestampRefreshed} seq={File.GetLastWriteTimeUtc(expectedUserSeq):O} plugin={pluginStamp:O}");
+            var renderStale = SeqTools.Render(oStale);
+            Check(renderStale.Contains("timestamp was refreshed", StringComparison.Ordinal)
+                  && renderStale.Contains("validate_dialogue", StringComparison.Ordinal)
+                  // …and it does NOT promise that tool's verdict: the lint reads the .seq the VFS SERVES, which is
+                  // this file only when this folder wins the SEQ\ conflict (review round 2).
+                  && renderStale.Contains("provided this is the copy your load order actually serves", StringComparison.Ordinal),
+                $"MTIME-REFRESH-RENDER the stamp is STATED and its scope is bounded — render=[{Trim(renderStale)}]");
+
+            // MTIME-FUTURE: a plugin stamped in the FUTURE (restored backup, skewed clock) cannot be beaten by
+            // stamping UtcNow — the old code would have mutated the file, claimed a refresh, and left the comparison
+            // exactly as it was. The stamp now targets past the plugin and VERIFIES, so the file really is newer.
+            var future = DateTime.UtcNow.AddDays(30);
+            File.SetLastWriteTimeUtc(svcPlugin, future);
+            File.SetLastWriteTimeUtc(expectedUserSeq, new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+            var oFuture = svc.WriteSeq(svcPlugin, null, null, userMod);
+            Check(oFuture.Success
+                  && File.GetLastWriteTimeUtc(expectedUserSeq) >= File.GetLastWriteTimeUtc(svcPlugin),
+                $"MTIME-FUTURE a future-stamped plugin still ends up OLDER than its .seq (the refresh is verified, not assumed) — seq={File.GetLastWriteTimeUtc(expectedUserSeq):O} plugin={future:O} unchanged={oFuture.Unchanged} touched={oFuture.TimestampRefreshed}");
+            File.SetLastWriteTimeUtc(svcPlugin, new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc));   // leave the fixture sane
 
             // TOOL-LANE: output_dir= WINS over patch=/into=, and says so (Q3 — an ignored parameter is stated, never
             // silently dropped). Asserted through the TOOL, because the note is composed there.
@@ -368,6 +415,56 @@ internal static class SeqWriteGuardProbe
 
             // JSON-UNCHANGED: written=false with unchanged=true and a seq_path — the machine twin of the same fact
             // (the pre-#312 `written` was "a path exists", which would now report a write that never happened).
+            // REPLACED: the write that overwrites an existing .seq says so. On the output_dir lane that file can be
+            // the mod's OWN shipped copy and houseCARL keeps no backup — the same "two different facts about the disk"
+            // argument that split the no-op out (review round 1).
+            File.WriteAllBytes(expectedUserSeq, new byte[] { 1, 2, 3, 4, 5, 6 });
+            var oRepl = svc.WriteSeq(svcPlugin, null, null, userMod);
+            var renderRepl = SeqTools.Render(oRepl);
+            Check(oRepl.Success && !oRepl.Unchanged && oRepl.Replaced
+                  && renderRepl.StartsWith("replaced ", StringComparison.Ordinal)
+                  && renderRepl.Contains("no backup is kept", StringComparison.Ordinal),
+                $"REPLACED overwriting an existing .seq reports 'replaced', not 'wrote' — replaced={oRepl.Replaced} render=[{Trim(renderRepl)}]");
+            // …and the fresh-file case is NOT reported as a replacement (the flag has to discriminate).
+            File.Delete(expectedUserSeq);
+            var oFresh = svc.WriteSeq(svcPlugin, null, null, userMod);
+            Check(oFresh.Success && !oFresh.Replaced && SeqTools.Render(oFresh).StartsWith("wrote ", StringComparison.Ordinal),
+                $"REPLACED-NEG a first write to an empty destination is 'wrote', not 'replaced' — replaced={oFresh.Replaced}");
+
+            // LANE-ORDER: output_dir= + patch= + into= together is NOT refused. The pair-exclusivity check used to run
+            // first, so naming all three was rejected over two parameters output_dir='s own contract promises to
+            // ignore — a tool contradicting itself (review round 1).
+            var toolAllThree = SeqTools.WriteSeq(svc, source: Path.GetFileName(svcPlugin),
+                patch: "HcSeqIgnoredA", into: "HcSeqIgnoredB.esp", output_dir: userMod);
+            Check(!toolAllThree.StartsWith("error:", StringComparison.Ordinal)
+                  && toolAllThree.Contains("output_dir= was given", StringComparison.Ordinal),
+                $"LANE-ORDER output_dir= + patch= + into= is accepted with the ignored-lane note, not refused — render=[{Trim(toolAllThree)}]");
+            // …while the pair WITHOUT output_dir is still the refusal it was.
+            var toolPair = SeqTools.WriteSeq(svc, source: Path.GetFileName(svcPlugin),
+                patch: "HcSeqIgnoredA", into: "HcSeqIgnoredB.esp");
+            Check(toolPair.StartsWith("error:", StringComparison.Ordinal)
+                  && toolPair.Contains("exclusive", StringComparison.Ordinal),
+                $"LANE-ORDER-NEG patch= + into= alone is still refused BY NAME — render=[{Trim(toolPair)}]");
+
+            // NOOP-LANE-NOTE: the no-SGE-quest early return carries the ignored-lane note too. It used to drop it
+            // while the json twin emitted one — the D2 divergence this file's epoch fold exists to close.
+            var toolEmptyNote = SeqTools.WriteSeq(svc, source: emptyPlugin, patch: "HcSeqIgnoredC", output_dir: userMod);
+            Check(toolEmptyNote.Contains("no start-game-enabled quests", StringComparison.Ordinal)
+                  && toolEmptyNote.Contains("output_dir= was given", StringComparison.Ordinal),
+                $"NOOP-LANE-NOTE the nothing-to-do render states the ignored lane too — render=[{Trim(toolEmptyNote)}]");
+
+            // LANE-NOTE-ON-REFUSAL: an ignored lane stays stated when the call FAILS. A refusal is exactly when a
+            // caller re-reads their parameters, and "patch= was ignored" is still true (review round 2).
+            var failNote = SeqTools.WriteSeq(svc, source: "HcSeqNoSuchPlugin.esp", patch: "HcSeqIgnoredD", output_dir: userMod);
+            Check(failNote.StartsWith("error:", StringComparison.Ordinal)
+                  && failNote.Contains("output_dir= was given", StringComparison.Ordinal),
+                $"LANE-NOTE-ON-REFUSAL a failed call still states the ignored lane — render=[{Trim(failNote)}]");
+            var failNoteJson = SeqTools.WriteSeq(svc, source: "HcSeqNoSuchPlugin.esp", patch: "HcSeqIgnoredD",
+                output_dir: userMod, format: "json");
+            Check(failNoteJson.Contains("\"lane_note\"", StringComparison.Ordinal)
+                  && failNoteJson.Contains("output_dir= was given", StringComparison.Ordinal),
+                $"LANE-NOTE-ON-REFUSAL-JSON …on the json transport too (D2) — render=[{Trim(failNoteJson)}]");
+
             var jsonSame = SeqTools.WriteSeq(svc, source: Path.GetFileName(svcPlugin), output_dir: userMod, format: "json");
             Check(jsonSame.Contains("\"written\": false", StringComparison.Ordinal)
                   && jsonSame.Contains("\"unchanged\": true", StringComparison.Ordinal)

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -75,6 +75,7 @@ public static class WriteSurfaceGuardProbe
             RemovePluralArm(fx);
             ForwardArm(fx);
             TransportArm(fx);
+            CopyFromViewArm(root);
             // LAST: it forwards into the replacer IN PLACE, which rewrites a fixture file the earlier arms read as a
             // known winner. Ordering it after them keeps every other arm reading the fixture it was written against.
             OffOrderForwardArm(fx);
@@ -277,6 +278,61 @@ public static class WriteSurfaceGuardProbe
         catch { /* the caller asserts on the contents, and an unreadable file fails those */ }
         finally { (ov as IDisposable)?.Dispose(); }
         return found;
+    }
+
+    /// <summary>#317 — the CopyFrom lane decides its off-order arm from the ENGINE's view, never from the presence of
+    /// a pre-fetched body. The race the issue described cannot be synthesised (a write pins one resolver instance and
+    /// its name table never moves), but the INVARIANT can be, deterministically: hand the engine a pre-fetched body
+    /// keyed to an edit whose source is ACTIVE — exactly what a drifted pre-locate would produce — and the in-order
+    /// arm must still win. Self-contained order, driven through the core so the dictionary can be hand-built (the
+    /// service only ever fills it for genuinely off-order sources, which is why nothing else can reach this).
+    /// <para>Three distinguishable values, so no outcome is ambiguous: the copy source (master, 10) is neither the
+    /// winner the patch starts from (replacer, 20) nor the decoy body (77). 20 would mean the copy never happened; 77
+    /// would mean the stale dictionary won.</para></summary>
+    static void CopyFromViewArm(string root)
+    {
+        var dir = Path.Combine(root, "cfview");
+        Directory.CreateDirectory(dir);
+
+        var mKey = new ModKey("HcCfMaster", ModType.Master);
+        var rKey = new ModKey("HcCfRepl", ModType.Plugin);
+        var mPath = Path.Combine(dir, mKey.FileName.String);
+        var rPath = Path.Combine(dir, rKey.FileName.String);
+
+        var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
+        var subject = m.Weapons.AddNew();
+        subject.EditorID = "CfSubject";
+        subject.BasicStats = new WeaponBasicStats { Damage = 10 };
+        m.BeginWrite.ToPath(mPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+        var r = new SkyrimMod(rKey, SkyrimRelease.SkyrimSE);
+        ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(r, subject)).BasicStats = new WeaponBasicStats { Damage = 20 };
+        r.BeginWrite.ToPath(rPath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
+
+        // The decoy carries the MASTER's ModKey, because that is the source the edit names — a pre-locate that
+        // resolved it off-order would have fetched exactly this shape, at whatever the disk copy said.
+        var decoy = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
+        ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(decoy, subject)).BasicStats = new WeaponBasicStats { Damage = 77 };
+        IMajorRecordGetter decoyBody = decoy.Weapons.First();
+
+        using var resolver = LoadOrderResolver.Build(new[] { mPath, rPath });
+        var rulebook = CorpusRulebook.Load();
+        var edit = new WritePatchBuilder.PatchEdit
+        {
+            Target = subject.FormKey,
+            Path = new[] { "BasicStats", "Damage" },
+            Verb = "CopyFrom",
+            FromPlugin = mKey.FileName.String,          // ACTIVE — so the dictionary entry must be ignored
+        };
+        var outPath = Path.Combine(dir, "HcCfPatch.esp");
+        var o = WritePatchBuilder.Apply(resolver, rulebook, new[] { edit }, outPath, extend: false, fullReadback: false,
+            copyFromSources: new Dictionary<WritePatchBuilder.PatchEdit, IMajorRecordGetter> { [edit] = decoyBody });
+        var back = o.Success ? DamageIn(outPath, subject.FormKey) : null;
+
+        Check("CopyFrom: a pre-fetched body keyed to an ACTIVE source is IGNORED — the in-order arm resolves it (#317)",
+            o.Success && back == 10,
+            $"success={o.Success} damage={back} (want 10 = the named source; 20 = no copy happened; 77 = the stale " +
+            $"pre-fetched body won) err={o.Error}");
     }
 
     static ushort? DamageIn(string espPath, FormKey fk)

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -99,7 +99,7 @@ public static class CompileTools
             string? patch_name = null,
         [Description("Optional. Filename of an existing houseCARL patch mod to add the .pex into instead of creating a fresh folder (accumulate compiled scripts). Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
             string? into = null,
-        [Description("Optional. Land the .pex in a folder of YOUR choosing instead of a fresh houseCARL patch folder — pass the mod-folder ROOT; houseCARL appends Scripts\\ (and won't double it if you already point at a ...\\Scripts folder). When set, patch_name=/into= are ignored. If the folder is under neither your MO2 mods folder nor the game's Data, the .pex still compiles but you're warned it won't deploy automatically.")]
+        [Description("Optional. Land the .pex in a folder of YOUR choosing instead of a fresh houseCARL patch folder — pass the mod-folder ROOT; houseCARL appends Scripts\\ (and won't double it if you already point at a ...\\Scripts folder). When set, patch_name=/into= are ignored. Scripts load from exactly <mods>\\<YourMod>\\Scripts, the MO2 overwrite folder, or <Data>\\Scripts — anywhere else (including a NESTED path under a mod) the .pex still compiles but you're warned it won't deploy automatically.")]
             string? output_dir = null) => Guard.Tool("housecarl_compile_script", () =>
     {
         // 1) MO2 must be configured — the .pex lands under the instance's mods folder.

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -199,7 +199,10 @@ public static class CompileTools
             if (!string.IsNullOrWhiteSpace(patch_name) || !string.IsNullOrWhiteSpace(into))
                 outputNote = "note: output_dir= was given, so patch_name=/into= are ignored (the .pex lands in output_dir, not a houseCARL patch folder).";
             try { rf = svc.ResolveExplicitScriptFolder(output_dir, out deployWarning); }
-            catch (InvalidOperationException ex) { return "error: " + ex.Message; }
+            // …carrying the ignored-lane note onto the REFUSAL, the parity write_seq's own fold argued for and this
+            // lane was missing (review round 3): a refusal is exactly when a caller re-reads their parameters, and
+            // "patch_name= was ignored" is still true of the call they are about to retype.
+            catch (InvalidOperationException ex) { return "error: " + ex.Message + (outputNote is null ? "" : "\n" + outputNote); }
         }
         else
         {

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1784,12 +1784,15 @@ static class JsonWire
             w.WriteBoolean("written", o.SeqPath is not null && !o.Unchanged);
             w.WriteBoolean("unchanged", o.Unchanged);
             w.WriteBoolean("replaced", o.Replaced);
+            w.WriteBoolean("replaced_same_bytes", o.ReplacedSameBytes);
             w.WriteBoolean("timestamp_refreshed", o.TimestampRefreshed);
             if (o.Unchanged)
                 w.WriteString("unchanged_note", "the destination already held EXACTLY these bytes, so nothing was written — seq_path names the file that was already current. Stated rather than reported as a write (Q3: a skipped write and a done one must not look alike)."
                     + (o.TimestampRefreshed ? " Its mtime was older than the plugin and has been stamped forward (contents untouched); validate_dialogue's SEQ staleness check compares those two mtimes, so this file no longer reads as stale — for the copy the load order actually serves, which is this one only if this folder wins the SEQ\\ conflict." : ""));
             if (o.Replaced)
-                w.WriteString("replaced_note", o.UserChoseOutput
+                w.WriteString("replaced_note", o.ReplacedSameBytes
+                    ? "the file already at seq_path held EXACTLY these bytes; it was rewritten only because its timestamp could not be refreshed in place, so nothing was lost."
+                    : o.UserChoseOutput
                     ? "a .seq already existed at seq_path and was OVERWRITTEN; houseCARL keeps no backup, and in a folder you named that file may have been the mod's own shipped .seq."
                     : "the previous .seq in that houseCARL folder was overwritten (houseCARL's own earlier output — the ordinary regenerate case).");
             WriteNullable(w, "seq_path", o.SeqPath);
@@ -1800,7 +1803,11 @@ static class JsonWire
             WriteNullable(w, "lane_note", outputNote);
             w.WriteNumber("quest_count", o.Quests.Count);
             if (o.Quests.Count == 0)
-                w.WriteString("note", "no start-game-enabled quests in this plugin — a .seq lists only SGE quests, so none is needed and NOTHING was written.");
+                w.WriteString("note", "no start-game-enabled quests in this plugin — a .seq lists only SGE quests, so none is needed and NOTHING was written."
+                    // The lane was ACKNOWLEDGED but never resolved on this path, and the json shape shows that more
+                    // starkly than the prose does: user_chose_output_dir true, no seq_path, no deploy_warning. Say
+                    // which of the two it is (PR #318 review [low]).
+                    + (o.UserChoseOutput ? " output_dir= was not resolved or checked either — no destination was touched, so an unusable one would not have been reported here." : ""));
 
             w.WriteStartArray("quests");
             int rendered = 0;

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1789,7 +1789,9 @@ static class JsonWire
                 w.WriteString("unchanged_note", "the destination already held EXACTLY these bytes, so nothing was written — seq_path names the file that was already current. Stated rather than reported as a write (Q3: a skipped write and a done one must not look alike)."
                     + (o.TimestampRefreshed ? " Its mtime was older than the plugin and has been stamped forward (contents untouched); validate_dialogue's SEQ staleness check compares those two mtimes, so this file no longer reads as stale — for the copy the load order actually serves, which is this one only if this folder wins the SEQ\\ conflict." : ""));
             if (o.Replaced)
-                w.WriteString("replaced_note", "a .seq already existed at seq_path and was OVERWRITTEN; houseCARL keeps no backup. On the output_dir lane that file can be the mod's own shipped .seq.");
+                w.WriteString("replaced_note", o.UserChoseOutput
+                    ? "a .seq already existed at seq_path and was OVERWRITTEN; houseCARL keeps no backup, and in a folder you named that file may have been the mod's own shipped .seq."
+                    : "the previous .seq in that houseCARL folder was overwritten (houseCARL's own earlier output — the ordinary regenerate case).");
             WriteNullable(w, "seq_path", o.SeqPath);
             WriteNullable(w, "mod_folder", o.ModFolder);
             w.WriteBoolean("wrote_into_plugin_folder", o.WroteIntoPluginFolder);
@@ -1819,7 +1821,7 @@ static class JsonWire
             // re-issuing a WRITE. This PR moved SeqTools.Render off exactly this wording and left its json twin on
             // it — the same D2 divergence, in the same fold that fixed it one renderer up.
             if (truncated)
-                w.WriteString("truncated_note", $"the render hit max_chars={cap} and dropped trailing quest rows — the .seq itself carries ALL of them; nothing is missing from the FILE. Re-run only if you need this LIST widened: with no lane named that writes the .seq again into ANOTHER fresh mod folder (name into=/output_dir= the folder named here to keep it in one — there a byte-identical destination is left untouched).");
+                w.WriteString("truncated_note", $"the render hit max_chars={cap} and dropped trailing quest rows — the .seq itself carries ALL of them; nothing is missing from the FILE. Re-run only if you need this LIST widened: for a plugin OUTSIDE a houseCARL folder with no lane named, that writes the .seq again into ANOTHER fresh mod folder (name into=/output_dir=, or let a plugin in its own houseCARL folder default there — at any named destination a byte-identical .seq is left untouched).");
             w.WriteString("standing_limit", "this makes the quest(s) START at game start; it does not verify the quest or its dialogue is otherwise well-formed.");
             w.WriteEndObject();
         }

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1755,8 +1755,11 @@ static class JsonWire
     /// <summary>The machine-readable twin of <see cref="SeqTools.Render"/>. Two Q3 facts the text render states in
     /// prose are typed here: <c>written:false</c> with <c>quest_count:0</c> is the "no SGE quests, so no .seq is
     /// needed" no-op (never a silent empty file), and <c>epoch:null</c> carries its own reason — this call consults
-    /// no load-order build, so an absent stamp is a fact rather than a missing field.</summary>
-    public static string RenderSeqOutcome(SeqOutcome o, int maxChars)
+    /// no load-order build, so an absent stamp is a fact rather than a missing field.
+    /// <para>#312 adds the third: <c>written:false</c> with <c>unchanged:true</c> and a non-null <c>seq_path</c> is
+    /// "the destination already held exactly these bytes". <c>written</c> is therefore the fact "this call wrote the
+    /// file", never merely "a path exists" — the two had been the same thing until a lane could decline to write.</para></summary>
+    public static string RenderSeqOutcome(SeqOutcome o, int maxChars, string? outputNote = null)
     {
         int cap = Cap(maxChars);
         using var ms = new MemoryStream();
@@ -1777,10 +1780,16 @@ static class JsonWire
             w.WriteString("plugin", o.PluginFileName);
             WriteNullable(w, "source_read_from", o.ResolvedFrom);
             WriteNullable(w, "source_path", o.PluginPath);
-            w.WriteBoolean("written", o.SeqPath is not null);
+            w.WriteBoolean("written", o.SeqPath is not null && !o.Unchanged);
+            w.WriteBoolean("unchanged", o.Unchanged);
+            if (o.Unchanged)
+                w.WriteString("unchanged_note", "the destination already held EXACTLY these bytes, so nothing was written — seq_path names the file that was already current. Stated rather than reported as a write (Q3: a skipped write and a done one must not look alike).");
             WriteNullable(w, "seq_path", o.SeqPath);
             WriteNullable(w, "mod_folder", o.ModFolder);
             w.WriteBoolean("wrote_into_plugin_folder", o.WroteIntoPluginFolder);
+            w.WriteBoolean("user_chose_output_dir", o.UserChoseOutput);
+            WriteNullable(w, "deploy_warning", o.DeployWarning);
+            WriteNullable(w, "lane_note", outputNote);
             w.WriteNumber("quest_count", o.Quests.Count);
             if (o.Quests.Count == 0)
                 w.WriteString("note", "no start-game-enabled quests in this plugin — a .seq lists only SGE quests, so none is needed and NOTHING was written.");
@@ -1804,7 +1813,7 @@ static class JsonWire
             // re-issuing a WRITE. This PR moved SeqTools.Render off exactly this wording and left its json twin on
             // it — the same D2 divergence, in the same fold that fixed it one renderer up.
             if (truncated)
-                w.WriteString("truncated_note", $"the render hit max_chars={cap} and dropped trailing quest rows — the .seq itself carries ALL of them; nothing is missing from the FILE. Re-run only if you need this LIST widened: that writes the .seq again (into= the folder named here to keep it in one).");
+                w.WriteString("truncated_note", $"the render hit max_chars={cap} and dropped trailing quest rows — the .seq itself carries ALL of them; nothing is missing from the FILE. Re-run only if you need this LIST widened: with no lane named that writes the .seq again into ANOTHER fresh mod folder (name into=/output_dir= the folder named here to keep it in one — there a byte-identical destination is left untouched).");
             w.WriteString("standing_limit", "this makes the quest(s) START at game start; it does not verify the quest or its dialogue is otherwise well-formed.");
             w.WriteEndObject();
         }

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1772,6 +1772,7 @@ static class JsonWire
             if (!o.Success)
             {
                 WriteNullable(w, "error", o.Error);
+                WriteNullable(w, "lane_note", outputNote);   // an ignored lane stays stated on a refusal too (review round 2)
                 w.WriteEndObject();
                 w.Flush();          // INSIDE the using — see RenderPatchOutcome (an unflushed refusal renders EMPTY).
                 return Finish(ms);
@@ -1782,8 +1783,13 @@ static class JsonWire
             WriteNullable(w, "source_path", o.PluginPath);
             w.WriteBoolean("written", o.SeqPath is not null && !o.Unchanged);
             w.WriteBoolean("unchanged", o.Unchanged);
+            w.WriteBoolean("replaced", o.Replaced);
+            w.WriteBoolean("timestamp_refreshed", o.TimestampRefreshed);
             if (o.Unchanged)
-                w.WriteString("unchanged_note", "the destination already held EXACTLY these bytes, so nothing was written — seq_path names the file that was already current. Stated rather than reported as a write (Q3: a skipped write and a done one must not look alike).");
+                w.WriteString("unchanged_note", "the destination already held EXACTLY these bytes, so nothing was written — seq_path names the file that was already current. Stated rather than reported as a write (Q3: a skipped write and a done one must not look alike)."
+                    + (o.TimestampRefreshed ? " Its mtime was older than the plugin and has been stamped forward (contents untouched); validate_dialogue's SEQ staleness check compares those two mtimes, so this file no longer reads as stale — for the copy the load order actually serves, which is this one only if this folder wins the SEQ\\ conflict." : ""));
+            if (o.Replaced)
+                w.WriteString("replaced_note", "a .seq already existed at seq_path and was OVERWRITTEN; houseCARL keeps no backup. On the output_dir lane that file can be the mod's own shipped .seq.");
             WriteNullable(w, "seq_path", o.SeqPath);
             WriteNullable(w, "mod_folder", o.ModFolder);
             w.WriteBoolean("wrote_into_plugin_folder", o.WroteIntoPluginFolder);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4544,8 +4544,10 @@ public sealed class LoadOrderService : IDisposable
     /// (all-or-nothing, before any write); null on success. Uses the SAME on-disk locate as read_plugin_file / the
     /// copy-npc-appearance donor lane, so the tools can never disagree on which file a filename names.
     /// <para>This capture is its OWN — the engine captures again — so a body pre-fetched here is only USED when the
-    /// engine's fresher build still agrees the source is off-order (<c>WritePatchBuilder.TryOffOrderCopyBody</c>,
-    /// #317). Pre-fetching a source that has since become active is wasted work, never a wrong body.</para></summary>
+    /// engine's own build still agrees the source is off-order (<c>WritePatchBuilder.TryOffOrderCopyBody</c>, #317).
+    /// That is a structural invariant, NOT the mid-call race #317 was filed as: a write pins one resolver instance and
+    /// its name table is never rebuilt, so the two captures cannot disagree about membership today. The helper's own
+    /// doc carries the full statement.</para></summary>
     string? ResolveOffOrderCopySources(LoadOrderResolver resolver, IReadOnlyList<WritePatchBuilder.PatchEdit> edits,
         ref Dictionary<WritePatchBuilder.PatchEdit, IMajorRecordGetter>? sources, ref List<IDisposable>? overlays,
         out string? epoch)
@@ -6725,15 +6727,17 @@ public sealed class LoadOrderService : IDisposable
     /// <see cref="ResolvePatchModFolder"/> (no houseCARL mod folder is cut under ModsDir), and the folder is USER-OWNED — the
     /// returned <see cref="RiderFolder"/> carries CreatedFresh=false, so <see cref="RemoveOrNameRiderResidue"/> never deletes
     /// it on a failed compile (it early-returns on !CreatedFresh). <paramref name="deployWarning"/> is a Q3 note (non-null)
-    /// when the final Scripts\ path is under neither the MO2 mods tree nor the game's Data — the .pex compiles but the game
+    /// when the final Scripts\ path is none of a mod's own Scripts\, the MO2 overwrite folder, or the game's Data — the .pex compiles but the game
     /// won't auto-load it from there, so a clean "done" is never reported for a .pex that won't deploy. Refuses loud (Q3) on
     /// an unusable output_dir (a malformed path, or a path that names an existing FILE).</summary>
     public RiderFolder ResolveExplicitScriptFolder(string outputDir, out string? deployWarning)
         => ResolveExplicitRiderFolder(outputDir, "Scripts", ScriptOutputContract, out deployWarning);
 
     /// <summary>#312 — the SAME output_dir= contract for the SEQ rider: the user names a mod-folder ROOT and houseCARL
-    /// appends <c>SEQ\</c>. Parity, not a new escape hatch — <c>compile_script</c> and <c>bsa_extract</c> have carried
-    /// output_dir= on this DECIDED contract (Aaron 2026-06-16) since 6.3, and <c>write_seq</c> was the odd one out: its
+    /// appends <c>SEQ\</c>. Parity, not a new escape hatch — <c>compile_script</c> has carried output_dir= on this
+    /// DECIDED contract (Aaron 2026-06-16) since 6.3 (<c>bsa_extract</c>'s <c>dest=</c> is a plain unpack folder — a
+    /// looser, different thing; this comment and the changelog both said otherwise, review round 1), and
+    /// <c>write_seq</c> was the odd one out: its
     /// output model assumed the plugin it serves lives in a houseCARL folder, which the opt-in IN-PLACE .esp lane
     /// inverted — the .esp in the mod's own folder, the .seq in a different mod entirely, left to the user to reunite.
     /// For a <c>.seq</c> that is the live Q3 footgun <see cref="OwnedPluginFolderStem"/> exists to prevent: one in an
@@ -6751,7 +6755,7 @@ public sealed class LoadOrderService : IDisposable
     /// One body rather than one per rider — the compile lane's rules are the rules, so they cannot drift per artifact.</summary>
     RiderFolder ResolveExplicitRiderFolder(
         string outputDir, string sub,
-        Func<string, string, string, (string dir, bool appended, string? deployWarning)> contract,
+        Func<string, string, string, string, (string dir, bool appended, string? deployWarning)> contract,
         out string? deployWarning)
     {
         lock (_gate)
@@ -6764,7 +6768,7 @@ public sealed class LoadOrderService : IDisposable
             if (File.Exists(root))
                 throw new InvalidOperationException($"output_dir '{root}' is a file, not a folder. Give a mod-folder root — houseCARL appends {sub}\\.");
 
-            var (outDir, appended, warn) = contract(root, _modsDir, _dataDir);
+            var (outDir, appended, warn) = contract(root, _modsDir, _dataDir, _overwriteDir);
             // Friendly Q3 message if the folder can't be created — e.g. <output_dir>\Scripts already exists AS A FILE, or
             // the path is read-only — instead of letting the IO/access exception reach Guard.Tool's generic "internal
             // failure" (which would wrongly read as a houseCARL bug, not bad input). The File.Exists(root) guard above
@@ -6784,13 +6788,18 @@ public sealed class LoadOrderService : IDisposable
     /// CI without an MO2 instance. Appends Scripts\ to a mod-folder root, with the DOUBLE-SCRIPTS GUARD (a root already ending
     /// in a Scripts segment — any case, trailing separator tolerated — is taken as-is, never doubled). <paramref name="outputDir"/>
     /// is expected absolute (the caller GetFullPaths it). Returns the final Scripts dir, whether Scripts\ was appended, and a
-    /// Q3 deployWarning when the result is under neither <paramref name="modsDir"/> (a mod's Scripts\ is VFS-deployed) nor
+    /// Q3 deployWarning when the result is none of <paramref name="modsDir"/> (a mod's Scripts\ is VFS-deployed), the overwrite folder, nor
     /// <paramref name="dataDir"/> (a direct game install) — the one "this won't load" case the contract can't fix by
-    /// construction, so it's surfaced rather than reported as a clean success.</summary>
+    /// construction, so it's surfaced rather than reported as a clean success.
+    /// <para>2026-08-07 (#312's shared refactor, review round 2): <paramref name="overwriteDir"/> counts as deployable
+    /// too. MO2 maps the overwrite folder's contents onto the Data root at top priority, and it is where xEdit / CK /
+    /// Synthesis output lands, so warning about it was a false alarm on both lanes. A BEHAVIOUR CHANGE for
+    /// compile_script, deliberately shared rather than special-cased for SEQ — a deployability rule that differs per
+    /// artifact is the drift this helper exists to prevent — and logged in the changelog as its own line.</para></summary>
     internal static (string scriptsDir, bool appendedScripts, string? deployWarning) ScriptOutputContract(
-        string outputDir, string modsDir, string dataDir)
+        string outputDir, string modsDir, string dataDir, string overwriteDir = "")
     {
-        var (scriptsDir, appended, deployable) = SubfolderOutputContract(outputDir, "Scripts", modsDir, dataDir);
+        var (scriptsDir, appended, deployable) = SubfolderOutputContract(outputDir, "Scripts", modsDir, dataDir, overwriteDir);
         string? warn = deployable ? null :
             $"note: '{scriptsDir}' isn't a folder MO2 (or the game) auto-loads scripts from, so the compiled .pex won't " +
             "deploy on its own — it compiled fine, but you must place it where the game loads scripts yourself: a mod's " +
@@ -6804,9 +6813,9 @@ public sealed class LoadOrderService : IDisposable
     /// start-game-enabled quest in that plugin SILENTLY not starting — the exact failure the tool exists to prevent, so
     /// the note says that rather than the milder "won't deploy on its own".</summary>
     internal static (string seqDir, bool appendedSeq, string? deployWarning) SeqOutputContract(
-        string outputDir, string modsDir, string dataDir)
+        string outputDir, string modsDir, string dataDir, string overwriteDir = "")
     {
-        var (seqDir, appended, deployable) = SubfolderOutputContract(outputDir, "SEQ", modsDir, dataDir);
+        var (seqDir, appended, deployable) = SubfolderOutputContract(outputDir, "SEQ", modsDir, dataDir, overwriteDir);
         string? warn = deployable ? null :
             $"note: '{seqDir}' isn't a folder MO2 (or the game) reads SEQ files from, so the game will NOT see this .seq — " +
             "the file is correct, but until it sits somewhere loaded the plugin's start-game-enabled quests stay silently " +
@@ -6824,12 +6833,27 @@ public sealed class LoadOrderService : IDisposable
     /// <c>&lt;data&gt;\&lt;sub&gt;</c>. <paramref name="outputDir"/> is expected absolute (the caller GetFullPaths it).
     /// The per-artifact SENTENCE stays with each caller — the RULE is shared, the consequence is not.</summary>
     static (string dir, bool appendedSub, bool deployable) SubfolderOutputContract(
-        string outputDir, string sub, string modsDir, string dataDir)
+        string outputDir, string sub, string modsDir, string dataDir, string overwriteDir = "")
     {
-        var root = outputDir.TrimEnd('\\', '/');
+        // A DRIVE ROOT keeps its separator: "C:\".TrimEnd() is "C:", and Path.Combine("C:", sub) yields the
+        // drive-RELATIVE "C:SEQ" — a path Windows resolves against the process's current directory on that drive,
+        // so the folder is created somewhere else entirely and reported under a name that looks absolute (review
+        // round 1). Inherited from the compile lane's contract; fixed here for both.
+        var root = IsRoot(outputDir) ? outputDir : outputDir.TrimEnd('\\', '/');
         bool already = Path.GetFileName(root).Equals(sub, StringComparison.OrdinalIgnoreCase);
         var dir = already ? root : Path.Combine(root, sub);
-        return (dir, !already, IsModDeployFolder(dir, modsDir) || IsDataDeployFolder(dir, dataDir));
+        return (dir, !already,
+            IsModDeployFolder(dir, modsDir) || IsDataDeployFolder(dir, dataDir) || IsDataDeployFolder(dir, overwriteDir));
+    }
+
+    /// <summary>Is this path a filesystem ROOT whose trailing separator is part of its MEANING — i.e. <c>C:\</c>,
+    /// where trimming yields the drive-RELATIVE <c>C:</c>? A UNC share deliberately answers false: <c>GetPathRoot</c>
+    /// returns it WITHOUT a trailing separator, and trimming <c>\\srv\share\</c> is harmless anyway (review round 2 —
+    /// an earlier version of this comment claimed the UNC case, which it does not have).</summary>
+    static bool IsRoot(string path)
+    {
+        try { return string.Equals(Path.GetPathRoot(path), path, StringComparison.OrdinalIgnoreCase); }
+        catch { return false; }
     }
 
     /// <summary>A deploy folder MO2 actually serves: <c>&lt;modsDir&gt;\&lt;modFolder&gt;\&lt;sub&gt;</c> exactly — the mod
@@ -6985,8 +7009,11 @@ public sealed class LoadOrderService : IDisposable
             { return SeqOutcome.Fail($"could not read '{Path.GetFileName(pluginPath)}' as a plugin: {ex.Message}"); }
 
             // No SGE quests → no .seq needed; write nothing, cut no folder (Q3: a clean, explicit "nothing to do").
+            // It still carries UserChoseOutput: the lane the caller named is a fact about the CALL, and reporting
+            // "you chose no output_dir" here made the json twin contradict its own lane note (review round 1).
             if (built.Quests.Count == 0)
-                return new SeqOutcome(true, null, null, null, built.Quests, built.PluginFileName, false) { ResolvedFrom = resolvedFrom, PluginPath = pluginPath };
+                return new SeqOutcome(true, null, null, null, built.Quests, built.PluginFileName, false)
+                    { ResolvedFrom = resolvedFrom, PluginPath = pluginPath, UserChoseOutput = !string.IsNullOrWhiteSpace(outputDir) };
 
             // Output folder: output_dir= (the USER's own mod folder, #312) wins; else the plugin's OWN houseCARL folder;
             // else fresh / explicit into=/patch_name. The output_dir arm cuts no houseCARL folder at all, so the
@@ -7012,10 +7039,24 @@ public sealed class LoadOrderService : IDisposable
             // output_dir=, a whole fresh mod folder) that changed nothing. Compared against the bytes already built in
             // memory, so this costs one read of a file that is typically a few hundred bytes. Reported as its OWN state
             // rather than folded into success (Q3): "nothing written" and "written" must not look alike.
-            if (SameBytesOnDisk(dest, built.Bytes))
+            // …with one thing the skip must NOT take with it: the TIMESTAMP. validate_dialogue's SEQ lint reads
+            // mtime, not content (`SeqNewerThanPlugin`, DialogueValidate) — a .seq older than its plugin is reported
+            // as stale even when it is byte-perfect. Skipping the write after an in-place edit (the exact loop this
+            // feature exists for) would therefore leave a permanent advisory no houseCARL tool could clear, with two
+            // tools contradicting each other about one file. So an identical-but-older file has its timestamp
+            // refreshed — no content churn, and the sibling lint stays true. If the touch fails, fall THROUGH to the
+            // real write rather than reporting a no-op that leaves the lint wrong (Q3).
+            bool identical = SameBytesOnDisk(dest, built.Bytes), touched = false;
+            if (identical && !RefreshSeqTimestamp(dest, pluginPath, out touched)) identical = false;
+            if (identical)
                 return new SeqOutcome(true, null, dest, rf.ModFolder, built.Quests, built.PluginFileName, autoInto is not null)
-                    { ResolvedFrom = resolvedFrom, PluginPath = pluginPath, Unchanged = true,
+                    { ResolvedFrom = resolvedFrom, PluginPath = pluginPath, Unchanged = true, TimestampRefreshed = touched,
                       UserChoseOutput = chosenOutput, DeployWarning = deployWarning };
+
+            // Is there something HERE already? An output_dir= destination is a folder houseCARL does not own, so the
+            // file being replaced may be the mod's OWN shipped .seq — "wrote" and "replaced yours" are different facts
+            // about the disk, and the same Q3 argument that split the no-op out applies to them (review round 1).
+            bool replaced = File.Exists(dest);
 
             // Crash-atomic write of <plugin>.seq under SEQ\ (originals untouched — a houseCARL-owned folder, or the
             // folder the caller named in output_dir=).
@@ -7024,7 +7065,14 @@ public sealed class LoadOrderService : IDisposable
             {
                 var residue = RemoveOrNameRiderResidue(rf);             // nothing landed → a fresh folder is an orphan
                 return SeqOutcome.Fail($"could not write '{seqName}': {ex.Message}"
-                    + (residue is null ? "" : $" The freshly created folder was left at '{residue}'."));
+                    + (residue is null ? "" : $" The freshly created folder was left at '{residue}'.")
+                    // …and on the output_dir lane cleanup is bypassed BY DESIGN (the folder is the user's), so the
+                    // SEQ\ directory this call created is still there. Say so — "nothing was written" is true of the
+                    // FILE and not of the disk (review round 1).
+                    // …worded for what is KNOWN: the folder is there and houseCARL will not remove it. Claiming this
+                    // call CREATED it would be false whenever the mod already ships a SEQ\ — the feature's own
+                    // headline case (review round 2).
+                    + (chosenOutput ? $" (the '{rf.OutputDir}' folder is left in place — it is inside the folder you named, which houseCARL never removes.)" : ""));
             }
 
             // Integrity (Q3: THIS run wrote it; on-disk size matches the bytes we built — no false success).
@@ -7033,9 +7081,37 @@ public sealed class LoadOrderService : IDisposable
                 return SeqOutcome.Fail($"wrote '{seqName}' but its on-disk size ({size}) does not match the {built.Bytes.Length} expected byte(s) — verify before relying on it.");
 
             return new SeqOutcome(true, null, dest, rf.ModFolder, built.Quests, built.PluginFileName, autoInto is not null)
-                { ResolvedFrom = resolvedFrom, PluginPath = pluginPath,
+                { ResolvedFrom = resolvedFrom, PluginPath = pluginPath, Replaced = replaced,
                   UserChoseOutput = chosenOutput, DeployWarning = deployWarning };
         }
+    }
+
+    /// <summary>#312 — keep a SKIPPED write honest against the mtime-based SEQ lint: if <paramref name="seqPath"/> is
+    /// byte-identical but OLDER than <paramref name="pluginPath"/>, stamp it now. <paramref name="touched"/> reports
+    /// whether a stamp was actually needed (so the response can say so rather than implying one silently happened).
+    /// Returns false when the stamp was needed and FAILED — the caller then does the real write instead of reporting a
+    /// no-op that leaves validate_dialogue calling the file stale (Q3: never trade a loud rewrite for a silent
+    /// inconsistency between two tools).</summary>
+    static bool RefreshSeqTimestamp(string seqPath, string pluginPath, out bool touched)
+    {
+        touched = false;
+        try
+        {
+            var seqTime = File.GetLastWriteTimeUtc(seqPath);
+            var pluginTime = File.GetLastWriteTimeUtc(pluginPath);
+            if (seqTime >= pluginTime) return true;                 // already newer — the lint is satisfied, leave it alone
+            // NOW is not necessarily enough: a plugin can be stamped in the FUTURE relative to this machine's clock
+            // (a restored backup, a synced share, a dual-boot local-vs-UTC BIOS clock), and stamping UtcNow there
+            // would mutate the file, report a refresh, and leave the comparison exactly as it was — a claim without a
+            // fact behind it (review round 2). Stamp past the plugin, then VERIFY, and let a stamp that did not
+            // achieve the predicate fall through to the real write.
+            var target = pluginTime > DateTime.UtcNow ? pluginTime.AddSeconds(1) : DateTime.UtcNow;
+            File.SetLastWriteTimeUtc(seqPath, target);
+            if (File.GetLastWriteTimeUtc(seqPath) < File.GetLastWriteTimeUtc(pluginPath)) return false;
+            touched = true;
+            return true;
+        }
+        catch { return false; }
     }
 
     /// <summary>Does <paramref name="path"/> already hold EXACTLY <paramref name="bytes"/>? Length first (the cheap
@@ -8364,6 +8440,17 @@ public sealed record SeqOutcome(
     /// different facts about the disk, and collapsing them would make a skipped write indistinguishable from a done
     /// one (Q3). False on every path that actually wrote.</summary>
     public bool Unchanged { get; init; }
+
+    /// <summary>#312 — the byte-identical destination was OLDER than the plugin, so its timestamp was stamped forward
+    /// without rewriting a byte. validate_dialogue's SEQ lint judges staleness by mtime, so a skipped write would
+    /// otherwise leave that lint permanently calling a byte-perfect file stale — two tools contradicting each other
+    /// about one file. False when no stamp was needed (the file was already newer) or nothing was skipped.</summary>
+    public bool TimestampRefreshed { get; init; }
+
+    /// <summary>#312 — the write REPLACED a file that was already there, rather than creating one. On the
+    /// <c>output_dir=</c> lane that file can be the mod's OWN shipped <c>.seq</c>, and houseCARL keeps no backup, so
+    /// "wrote" and "replaced yours" are different facts about the disk and are reported as such.</summary>
+    public bool Replaced { get; init; }
 
     /// <summary>#312 — the caller named <c>output_dir=</c>, so the .seq landed in a folder the USER owns and no
     /// houseCARL mod folder was cut. Drives the confirmation: "enable this houseCARL mod in MO2" is the wrong next

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -6729,6 +6729,30 @@ public sealed class LoadOrderService : IDisposable
     /// won't auto-load it from there, so a clean "done" is never reported for a .pex that won't deploy. Refuses loud (Q3) on
     /// an unusable output_dir (a malformed path, or a path that names an existing FILE).</summary>
     public RiderFolder ResolveExplicitScriptFolder(string outputDir, out string? deployWarning)
+        => ResolveExplicitRiderFolder(outputDir, "Scripts", ScriptOutputContract, out deployWarning);
+
+    /// <summary>#312 — the SAME output_dir= contract for the SEQ rider: the user names a mod-folder ROOT and houseCARL
+    /// appends <c>SEQ\</c>. Parity, not a new escape hatch — <c>compile_script</c> and <c>bsa_extract</c> have carried
+    /// output_dir= on this DECIDED contract (Aaron 2026-06-16) since 6.3, and <c>write_seq</c> was the odd one out: its
+    /// output model assumed the plugin it serves lives in a houseCARL folder, which the opt-in IN-PLACE .esp lane
+    /// inverted — the .esp in the mod's own folder, the .seq in a different mod entirely, left to the user to reunite.
+    /// For a <c>.seq</c> that is the live Q3 footgun <see cref="OwnedPluginFolderStem"/> exists to prevent: one in an
+    /// un-enabled or wrong folder leaves the quest SILENTLY DEAD.
+    /// <para>The <c>into=</c> ownership guard is deliberately untouched — loosening it (letting into= name a folder
+    /// houseCARL didn't create) would put houseCARL's own patch-folder machinery inside a third party's mod. This lane
+    /// is the <c>place_asset</c> posture instead: a NEW SIDECAR FILE written into a folder the USER owns, with no
+    /// houseCARL folder cut and residue cleanup bypassed (<see cref="RiderFolder.CreatedFresh"/> = false).</para></summary>
+    public RiderFolder ResolveExplicitSeqFolder(string outputDir, out string? deployWarning)
+        => ResolveExplicitRiderFolder(outputDir, "SEQ", SeqOutputContract, out deployWarning);
+
+    /// <summary>The shared body of the output_dir= lanes (6.3's contract, one artifact per caller): normalize the root,
+    /// refuse an unusable one LOUD, apply <paramref name="contract"/> (which appends <paramref name="sub"/> with the
+    /// double-segment guard and decides deployability), create the folder, and hand back a USER-OWNED RiderFolder.
+    /// One body rather than one per rider — the compile lane's rules are the rules, so they cannot drift per artifact.</summary>
+    RiderFolder ResolveExplicitRiderFolder(
+        string outputDir, string sub,
+        Func<string, string, string, (string dir, bool appended, string? deployWarning)> contract,
+        out string? deployWarning)
     {
         lock (_gate)
         {
@@ -6738,21 +6762,21 @@ public sealed class LoadOrderService : IDisposable
             try { root = Path.GetFullPath((outputDir ?? "").Trim().Trim('"')); }
             catch (Exception ex) { throw new InvalidOperationException($"output_dir '{outputDir}' is not a usable path ({ex.Message})."); }
             if (File.Exists(root))
-                throw new InvalidOperationException($"output_dir '{root}' is a file, not a folder. Give a mod-folder root — houseCARL appends Scripts\\.");
+                throw new InvalidOperationException($"output_dir '{root}' is a file, not a folder. Give a mod-folder root — houseCARL appends {sub}\\.");
 
-            var (scriptsDir, appended, warn) = ScriptOutputContract(root, _modsDir, _dataDir);
+            var (outDir, appended, warn) = contract(root, _modsDir, _dataDir);
             // Friendly Q3 message if the folder can't be created — e.g. <output_dir>\Scripts already exists AS A FILE, or
             // the path is read-only — instead of letting the IO/access exception reach Guard.Tool's generic "internal
             // failure" (which would wrongly read as a houseCARL bug, not bad input). The File.Exists(root) guard above
             // already catches the common "output_dir itself is a file" shape; this rounds out the rest.
-            try { Directory.CreateDirectory(scriptsDir); }
+            try { Directory.CreateDirectory(outDir); }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-            { throw new InvalidOperationException($"output_dir: couldn't create the output folder '{scriptsDir}' ({ex.Message}). Check the path and that it's writable."); }
+            { throw new InvalidOperationException($"output_dir: couldn't create the output folder '{outDir}' ({ex.Message}). Check the path and that it's writable."); }
             deployWarning = warn;
             // ModFolder = the mod-folder root (inert here — cleanup is bypassed by CreatedFresh=false — but kept honest):
             // when the user pointed AT a Scripts\ dir, the root is its parent; otherwise the path they gave IS the root.
-            var modRoot = appended ? root : (Path.GetDirectoryName(scriptsDir.TrimEnd('\\', '/')) ?? scriptsDir);
-            return new RiderFolder(scriptsDir, modRoot, CreatedFresh: false);   // user-owned: residue cleanup never touches it
+            var modRoot = appended ? root : (Path.GetDirectoryName(outDir.TrimEnd('\\', '/')) ?? outDir);
+            return new RiderFolder(outDir, modRoot, CreatedFresh: false);   // user-owned: residue cleanup never touches it
         }
     }
 
@@ -6766,39 +6790,66 @@ public sealed class LoadOrderService : IDisposable
     internal static (string scriptsDir, bool appendedScripts, string? deployWarning) ScriptOutputContract(
         string outputDir, string modsDir, string dataDir)
     {
-        var root = outputDir.TrimEnd('\\', '/');
-        bool alreadyScripts = Path.GetFileName(root).Equals("Scripts", StringComparison.OrdinalIgnoreCase);
-        var scriptsDir = alreadyScripts ? root : Path.Combine(root, "Scripts");
-        // Deployable = the .pex will ACTUALLY auto-load. MO2 overlays a mod folder's CONTENTS onto the game Data root, so a
-        // deployable mod Scripts\ is EXACTLY <mods>\<modFolder>\Scripts (mod folder a direct child of mods; Scripts directly
-        // under it). A bare <mods>\Scripts (no mod folder) and a nested <mods>\X\Sub\Scripts (lands at Data\Sub\Scripts, not
-        // Data\Scripts) do NOT load — so they correctly WARN (review nit: "under mods" alone was too loose). A direct game
-        // install loads exactly <data>\Scripts.
-        bool deployable = IsModScriptsFolder(scriptsDir, modsDir) || IsDataScriptsFolder(scriptsDir, dataDir);
+        var (scriptsDir, appended, deployable) = SubfolderOutputContract(outputDir, "Scripts", modsDir, dataDir);
         string? warn = deployable ? null :
             $"note: '{scriptsDir}' isn't a folder MO2 (or the game) auto-loads scripts from, so the compiled .pex won't " +
             "deploy on its own — it compiled fine, but you must place it where the game loads scripts yourself: a mod's " +
             "own Scripts\\ folder (<mods>\\<YourMod>\\Scripts) or the game's <Data>\\Scripts.";
-        return (scriptsDir, !alreadyScripts, warn);
+        return (scriptsDir, appended, warn);
     }
 
-    /// <summary>A Scripts\ folder MO2 actually deploys: <c>&lt;modsDir&gt;\&lt;modFolder&gt;\Scripts</c> exactly — the mod
-    /// folder a DIRECT child of the mods root, Scripts directly under it (MO2 maps a mod folder's contents onto the Data
-    /// root, so <c>&lt;mods&gt;\Scripts</c> has no mod and <c>&lt;mods&gt;\X\Sub\Scripts</c> lands at Data\Sub\Scripts). Empty
-    /// mods root (unconfigured) → false. Case-insensitive, normalized.</summary>
-    static bool IsModScriptsFolder(string scriptsDir, string modsDir)
+    /// <summary>#312 — <see cref="ScriptOutputContract"/>'s twin for the <c>.seq</c>: the same pure path contract with
+    /// <c>SEQ\</c> appended, and a warning worded for what a mis-placed .seq actually costs. The stakes differ from the
+    /// .pex's: a script that doesn't deploy leaves the OLD behaviour, while a .seq the engine never reads leaves every
+    /// start-game-enabled quest in that plugin SILENTLY not starting — the exact failure the tool exists to prevent, so
+    /// the note says that rather than the milder "won't deploy on its own".</summary>
+    internal static (string seqDir, bool appendedSeq, string? deployWarning) SeqOutputContract(
+        string outputDir, string modsDir, string dataDir)
+    {
+        var (seqDir, appended, deployable) = SubfolderOutputContract(outputDir, "SEQ", modsDir, dataDir);
+        string? warn = deployable ? null :
+            $"note: '{seqDir}' isn't a folder MO2 (or the game) reads SEQ files from, so the game will NOT see this .seq — " +
+            "the file is correct, but until it sits somewhere loaded the plugin's start-game-enabled quests stay silently " +
+            "dead. Put it in a mod's own SEQ\\ folder (<mods>\\<YourMod>\\SEQ — enabled in MO2) or the game's <Data>\\SEQ.";
+        return (seqDir, appended, warn);
+    }
+
+    /// <summary>The shared pure core of the output_dir= contracts: append <paramref name="sub"/> to a mod-folder root with
+    /// the DOUBLE-SEGMENT GUARD (a root already ending in that segment — any case, trailing separator tolerated — is taken
+    /// as-is, never doubled), and decide DEPLOYABILITY. MO2 overlays a mod folder's CONTENTS onto the game Data root, so a
+    /// deployable folder is EXACTLY <c>&lt;mods&gt;\&lt;modFolder&gt;\&lt;sub&gt;</c> (mod folder a direct child of mods;
+    /// the subfolder directly under it). A bare <c>&lt;mods&gt;\&lt;sub&gt;</c> (no mod folder) and a nested
+    /// <c>&lt;mods&gt;\X\Sub\&lt;sub&gt;</c> (which lands at Data\Sub\…, not Data\&lt;sub&gt;) do NOT load — so they
+    /// correctly warn (review nit: "under mods" alone was too loose). A direct game install loads exactly
+    /// <c>&lt;data&gt;\&lt;sub&gt;</c>. <paramref name="outputDir"/> is expected absolute (the caller GetFullPaths it).
+    /// The per-artifact SENTENCE stays with each caller — the RULE is shared, the consequence is not.</summary>
+    static (string dir, bool appendedSub, bool deployable) SubfolderOutputContract(
+        string outputDir, string sub, string modsDir, string dataDir)
+    {
+        var root = outputDir.TrimEnd('\\', '/');
+        bool already = Path.GetFileName(root).Equals(sub, StringComparison.OrdinalIgnoreCase);
+        var dir = already ? root : Path.Combine(root, sub);
+        return (dir, !already, IsModDeployFolder(dir, modsDir) || IsDataDeployFolder(dir, dataDir));
+    }
+
+    /// <summary>A deploy folder MO2 actually serves: <c>&lt;modsDir&gt;\&lt;modFolder&gt;\&lt;sub&gt;</c> exactly — the mod
+    /// folder a DIRECT child of the mods root, the subfolder directly under it (MO2 maps a mod folder's contents onto the
+    /// Data root, so <c>&lt;mods&gt;\Scripts</c> has no mod and <c>&lt;mods&gt;\X\Sub\Scripts</c> lands at Data\Sub\Scripts).
+    /// The rule is about SHAPE, not the segment's name, so the .pex and .seq lanes share it. Empty mods root
+    /// (unconfigured) → false. Case-insensitive, normalized.</summary>
+    static bool IsModDeployFolder(string outDir, string modsDir)
     {
         if (string.IsNullOrEmpty(modsDir)) return false;
-        var modFolder = Path.GetDirectoryName(scriptsDir.TrimEnd('\\', '/'));   // expect <mods>\<modFolder>
+        var modFolder = Path.GetDirectoryName(outDir.TrimEnd('\\', '/'));       // expect <mods>\<modFolder>
         return modFolder is not null && PathEquals(Path.GetDirectoryName(modFolder), modsDir);
     }
 
-    /// <summary>A direct game install loads exactly <c>&lt;dataDir&gt;\Scripts</c> (not Data\Sub\Scripts). Empty data dir →
+    /// <summary>A direct game install loads exactly <c>&lt;dataDir&gt;\&lt;sub&gt;</c> (not Data\Sub\…). Empty data dir →
     /// false. Case-insensitive, normalized.</summary>
-    static bool IsDataScriptsFolder(string scriptsDir, string dataDir)
+    static bool IsDataDeployFolder(string outDir, string dataDir)
     {
         if (string.IsNullOrEmpty(dataDir)) return false;
-        return PathEquals(Path.GetDirectoryName(scriptsDir.TrimEnd('\\', '/')), dataDir);
+        return PathEquals(Path.GetDirectoryName(outDir.TrimEnd('\\', '/')), dataDir);
     }
 
     /// <summary>Case-insensitive equality of two paths after full-path normalization + trailing-separator trim (no
@@ -6879,8 +6930,16 @@ public sealed class LoadOrderService : IDisposable
     /// riders). Output folder DEFAULTS to the plugin's OWN houseCARL folder when it lives in one (so the .seq deploys with
     /// the .esp); else a fresh folder, or <paramref name="into"/>/<paramref name="patchName"/> when given. A plugin with NO
     /// SGE quests writes NOTHING and cuts no folder (a .seq is only needed for SGE quests — Q3, not a silent empty file).
-    /// Serialized on the write gate (one write at a time), like its sibling writers.</summary>
-    public SeqOutcome WriteSeq(string plugin, string? patchName, string? into)
+    /// Serialized on the write gate (one write at a time), like its sibling writers.
+    /// <para><paramref name="outputDir"/> (#312) is the compile lane's output_dir= contract on this rider: the user names
+    /// a mod-folder ROOT — typically the plugin's OWN mod, after an IN-PLACE .esp edit — and the .seq lands in its
+    /// <c>SEQ\</c> where the mod's own copy already lives. It WINS over <paramref name="patchName"/>/<paramref name="into"/>
+    /// (the caller says so out loud) and cuts no houseCARL folder.</para>
+    /// <para>A destination already holding these EXACT bytes is reported as such and NOT rewritten (#312) — the reported
+    /// workflow regenerates the .seq after every in-place edit, and the answer is byte-identical nearly every time. The
+    /// no-op is stated explicitly, never as a bare success: an unstated skip is indistinguishable from a silent failure
+    /// (Q3).</para></summary>
+    public SeqOutcome WriteSeq(string plugin, string? patchName, string? into, string? outputDir = null)
     {
         if (string.IsNullOrWhiteSpace(plugin))
             return SeqOutcome.Fail("no source given. Pass source= the plugin whose start-game-enabled quests need a .seq — its filename (e.g. 'MyQuestMod.esp') or an absolute path.");
@@ -6929,16 +6988,37 @@ public sealed class LoadOrderService : IDisposable
             if (built.Quests.Count == 0)
                 return new SeqOutcome(true, null, null, null, built.Quests, built.PluginFileName, false) { ResolvedFrom = resolvedFrom, PluginPath = pluginPath };
 
-            // Output folder: default into the plugin's OWN houseCARL folder; else fresh / explicit into=/patch_name.
-            string? autoInto = (string.IsNullOrWhiteSpace(into) && string.IsNullOrWhiteSpace(patchName))
+            // Output folder: output_dir= (the USER's own mod folder, #312) wins; else the plugin's OWN houseCARL folder;
+            // else fresh / explicit into=/patch_name. The output_dir arm cuts no houseCARL folder at all, so the
+            // owned-folder default is not consulted there — the caller named the destination outright.
+            bool chosenOutput = !string.IsNullOrWhiteSpace(outputDir);
+            string? autoInto = (!chosenOutput && string.IsNullOrWhiteSpace(into) && string.IsNullOrWhiteSpace(patchName))
                 ? OwnedPluginFolderStem(pluginPath) : null;
             RiderFolder rf;
-            try { rf = ResolveSeqFolder(patchName, autoInto ?? into); }
+            string? deployWarning = null;
+            try
+            {
+                rf = chosenOutput
+                    ? ResolveExplicitSeqFolder(outputDir!, out deployWarning)
+                    : ResolveSeqFolder(patchName, autoInto ?? into);
+            }
             catch (InvalidOperationException ex) { return SeqOutcome.Fail(ex.Message); }
 
-            // Crash-atomic write of <plugin>.seq under SEQ\ (originals untouched — a houseCARL-owned folder only).
             var seqName = Path.GetFileNameWithoutExtension(pluginPath) + ".seq";
             var dest = Path.Combine(rf.OutputDir, seqName);
+
+            // #312 — the destination already holds EXACTLY these bytes: report it, write nothing. Every in-place edit
+            // regenerates the .seq and the answer rarely changes, so the common case was a file rewrite (and, before
+            // output_dir=, a whole fresh mod folder) that changed nothing. Compared against the bytes already built in
+            // memory, so this costs one read of a file that is typically a few hundred bytes. Reported as its OWN state
+            // rather than folded into success (Q3): "nothing written" and "written" must not look alike.
+            if (SameBytesOnDisk(dest, built.Bytes))
+                return new SeqOutcome(true, null, dest, rf.ModFolder, built.Quests, built.PluginFileName, autoInto is not null)
+                    { ResolvedFrom = resolvedFrom, PluginPath = pluginPath, Unchanged = true,
+                      UserChoseOutput = chosenOutput, DeployWarning = deployWarning };
+
+            // Crash-atomic write of <plugin>.seq under SEQ\ (originals untouched — a houseCARL-owned folder, or the
+            // folder the caller named in output_dir=).
             try { AtomicFile.WriteAllBytes(dest, built.Bytes); }
             catch (Exception ex)
             {
@@ -6953,8 +7033,24 @@ public sealed class LoadOrderService : IDisposable
                 return SeqOutcome.Fail($"wrote '{seqName}' but its on-disk size ({size}) does not match the {built.Bytes.Length} expected byte(s) — verify before relying on it.");
 
             return new SeqOutcome(true, null, dest, rf.ModFolder, built.Quests, built.PluginFileName, autoInto is not null)
-                { ResolvedFrom = resolvedFrom, PluginPath = pluginPath };
+                { ResolvedFrom = resolvedFrom, PluginPath = pluginPath,
+                  UserChoseOutput = chosenOutput, DeployWarning = deployWarning };
         }
+    }
+
+    /// <summary>Does <paramref name="path"/> already hold EXACTLY <paramref name="bytes"/>? Length first (the cheap
+    /// discriminator), then a full compare. Any IO problem answers FALSE — "I could not prove it is identical" must fall
+    /// through to the write, never skip one (Q3: the failure mode of a wrong TRUE here is a stale .seq reported as
+    /// current, which is precisely the silent failure this tool exists to prevent).</summary>
+    static bool SameBytesOnDisk(string path, byte[] bytes)
+    {
+        try
+        {
+            var fi = new FileInfo(path);
+            if (!fi.Exists || fi.Length != bytes.Length) return false;
+            return File.ReadAllBytes(path).AsSpan().SequenceEqual(bytes);
+        }
+        catch { return false; }
     }
 
     // ---- decompiler class hierarchy (lazy, cached for process lifetime) ----------------------------------------
@@ -8262,6 +8358,23 @@ public sealed record SeqOutcome(
     /// <summary>The absolute path the source resolved TO — the second half of the arm statement (the label says
     /// which layer, this says which file).</summary>
     public string? PluginPath { get; init; }
+
+    /// <summary>#312 — the destination already held EXACTLY these bytes, so NOTHING was written (<see cref="SeqPath"/>
+    /// names the file that was already correct). A success, and a DISTINCT one: "written" and "already current" are
+    /// different facts about the disk, and collapsing them would make a skipped write indistinguishable from a done
+    /// one (Q3). False on every path that actually wrote.</summary>
+    public bool Unchanged { get; init; }
+
+    /// <summary>#312 — the caller named <c>output_dir=</c>, so the .seq landed in a folder the USER owns and no
+    /// houseCARL mod folder was cut. Drives the confirmation: "enable this houseCARL mod in MO2" is the wrong next
+    /// step for a file written into the user's own mod.</summary>
+    public bool UserChoseOutput { get; init; }
+
+    /// <summary>#312 — the Q3 note for an <c>output_dir=</c> that neither MO2 nor the game reads SEQ files from. The
+    /// .seq is correct; the engine will never see it, and every start-game-enabled quest in the plugin stays silently
+    /// dead until it moves. Null when the destination deploys (and on every non-output_dir lane, which lands in a
+    /// houseCARL mod folder by construction).</summary>
+    public string? DeployWarning { get; init; }
 
     public static SeqOutcome Fail(string error)
         => new(false, error, null, null, Array.Empty<HousecarlCore.SeqFile.SeqQuest>(), "", false);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4542,7 +4542,10 @@ public sealed class LoadOrderService : IDisposable
     /// left for <see cref="WritePatchBuilder.Apply"/> to resolve via its shared view (so they read the winner's build).
     /// Returns a Q3 refusal string if any off-order source can't be located/opened/read or doesn't define the record
     /// (all-or-nothing, before any write); null on success. Uses the SAME on-disk locate as read_plugin_file / the
-    /// copy-npc-appearance donor lane, so the tools can never disagree on which file a filename names.</summary>
+    /// copy-npc-appearance donor lane, so the tools can never disagree on which file a filename names.
+    /// <para>This capture is its OWN — the engine captures again — so a body pre-fetched here is only USED when the
+    /// engine's fresher build still agrees the source is off-order (<c>WritePatchBuilder.TryOffOrderCopyBody</c>,
+    /// #317). Pre-fetching a source that has since become active is wasted work, never a wrong body.</para></summary>
     string? ResolveOffOrderCopySources(LoadOrderResolver resolver, IReadOnlyList<WritePatchBuilder.PatchEdit> edits,
         ref Dictionary<WritePatchBuilder.PatchEdit, IMajorRecordGetter>? sources, ref List<IDisposable>? overlays,
         out string? epoch)

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4564,8 +4564,9 @@ public sealed class LoadOrderService : IDisposable
         var problems = new List<string>();
         foreach (var e in edits)
         {
-            if (!string.Equals(e.Verb, "CopyFrom", StringComparison.Ordinal) || string.IsNullOrWhiteSpace(e.FromPlugin)) continue;
-            if (view.ContainsPlugin(e.FromPlugin)) continue;   // active — Apply resolves it (shared build)
+            // The SHARED predicate, not a restatement of it (PR #318 review [low]): the engine consumes what this
+            // fetches through the same rule, so a clause added to one can never fail to reach the other.
+            if (!WritePatchBuilder.IsOffOrderCopySource(e, view)) continue;   // not a CopyFrom, or active — Apply resolves it off the shared build
             if (comp is null)
             {
                 try { lock (_gate) { EnsurePathsDerived(); modsDir = _modsDir; dataDir = _dataDir; overwriteDir = _overwriteDir; profileDir = _profileDir; } }
@@ -7048,7 +7049,7 @@ public sealed class LoadOrderService : IDisposable
             // tools contradicting each other about one file. So an identical-but-older file has its timestamp
             // refreshed — no content churn, and the sibling lint stays true. If the touch fails, fall THROUGH to the
             // real write rather than reporting a no-op that leaves the lint wrong (Q3).
-            bool identical = SameBytesOnDisk(dest, built.Bytes), touched = false;
+            bool sameBytes = SameBytesOnDisk(dest, built.Bytes), identical = sameBytes, touched = false;
             if (identical && !RefreshSeqTimestamp(dest, pluginPath, out touched)) identical = false;
             if (identical)
                 return new SeqOutcome(true, null, dest, rf.ModFolder, built.Quests, built.PluginFileName, autoInto is not null)
@@ -7059,6 +7060,11 @@ public sealed class LoadOrderService : IDisposable
             // file being replaced may be the mod's OWN shipped .seq — "wrote" and "replaced yours" are different facts
             // about the disk, and the same Q3 argument that split the no-op out applies to them (review round 1).
             bool replaced = File.Exists(dest);
+            // …and WHETHER ANYTHING WAS LOST. The one path that reaches the write with sameBytes true is a timestamp
+            // refresh that failed (a share that accepts SetLastWriteTimeUtc without persisting it), and calling that
+            // "OVERWRITTEN, no backup is kept" is an alarm about a file whose bytes we just re-wrote identically
+            // (PR #318 review [low]). Same event, materially different fact.
+            bool replacedSameBytes = replaced && sameBytes;
 
             // Crash-atomic write of <plugin>.seq under SEQ\ (originals untouched — a houseCARL-owned folder, or the
             // folder the caller named in output_dir=).
@@ -7084,6 +7090,7 @@ public sealed class LoadOrderService : IDisposable
 
             return new SeqOutcome(true, null, dest, rf.ModFolder, built.Quests, built.PluginFileName, autoInto is not null)
                 { ResolvedFrom = resolvedFrom, PluginPath = pluginPath, Replaced = replaced,
+                  ReplacedSameBytes = replacedSameBytes,
                   UserChoseOutput = chosenOutput, DeployWarning = deployWarning };
         }
     }
@@ -8453,6 +8460,12 @@ public sealed record SeqOutcome(
     /// <c>output_dir=</c> lane that file can be the mod's OWN shipped <c>.seq</c>, and houseCARL keeps no backup, so
     /// "wrote" and "replaced yours" are different facts about the disk and are reported as such.</summary>
     public bool Replaced { get; init; }
+
+    /// <summary>#312 — the replaced file held EXACTLY the bytes just written, so nothing was lost. Only reachable when
+    /// the byte-identical short-circuit was taken and its timestamp refresh then FAILED, sending an unchanged file
+    /// down the write path (PR #318 review [low]): without this the response cries "OVERWRITTEN, no backup is kept"
+    /// about a file it re-wrote identically.</summary>
+    public bool ReplacedSameBytes { get; init; }
 
     /// <summary>#312 — the caller named <c>output_dir=</c>, so the .seq landed in a folder the USER owns and no
     /// houseCARL mod folder was cut. Drives the confirmation: "enable this houseCARL mod in MO2" is the wrong next

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -6803,7 +6803,7 @@ public sealed class LoadOrderService : IDisposable
         string? warn = deployable ? null :
             $"note: '{scriptsDir}' isn't a folder MO2 (or the game) auto-loads scripts from, so the compiled .pex won't " +
             "deploy on its own — it compiled fine, but you must place it where the game loads scripts yourself: a mod's " +
-            "own Scripts\\ folder (<mods>\\<YourMod>\\Scripts) or the game's <Data>\\Scripts.";
+            "own Scripts\\ folder (<mods>\\<YourMod>\\Scripts), the MO2 overwrite folder, or the game's <Data>\\Scripts.";
         return (scriptsDir, appended, warn);
     }
 
@@ -6819,7 +6819,7 @@ public sealed class LoadOrderService : IDisposable
         string? warn = deployable ? null :
             $"note: '{seqDir}' isn't a folder MO2 (or the game) reads SEQ files from, so the game will NOT see this .seq — " +
             "the file is correct, but until it sits somewhere loaded the plugin's start-game-enabled quests stay silently " +
-            "dead. Put it in a mod's own SEQ\\ folder (<mods>\\<YourMod>\\SEQ — enabled in MO2) or the game's <Data>\\SEQ.";
+            "dead. Put it in a mod's own SEQ\\ folder (<mods>\\<YourMod>\\SEQ — enabled in MO2), the MO2 overwrite folder, or the game's <Data>\\SEQ.";
         return (seqDir, appended, warn);
     }
 
@@ -6830,7 +6830,8 @@ public sealed class LoadOrderService : IDisposable
     /// the subfolder directly under it). A bare <c>&lt;mods&gt;\&lt;sub&gt;</c> (no mod folder) and a nested
     /// <c>&lt;mods&gt;\X\Sub\&lt;sub&gt;</c> (which lands at Data\Sub\…, not Data\&lt;sub&gt;) do NOT load — so they
     /// correctly warn (review nit: "under mods" alone was too loose). A direct game install loads exactly
-    /// <c>&lt;data&gt;\&lt;sub&gt;</c>. <paramref name="outputDir"/> is expected absolute (the caller GetFullPaths it).
+    /// <c>&lt;data&gt;\&lt;sub&gt;</c> — and, since #312's shared refactor, <c>&lt;overwriteDir&gt;\&lt;sub&gt;</c>, which MO2
+    /// maps onto Data at top priority. <paramref name="outputDir"/> is expected absolute (the caller GetFullPaths it).
     /// The per-artifact SENTENCE stays with each caller — the RULE is shared, the consequence is not.</summary>
     static (string dir, bool appendedSub, bool deployable) SubfolderOutputContract(
         string outputDir, string sub, string modsDir, string dataDir, string overwriteDir = "")
@@ -6847,9 +6848,10 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>Is this path a filesystem ROOT whose trailing separator is part of its MEANING — i.e. <c>C:\</c>,
-    /// where trimming yields the drive-RELATIVE <c>C:</c>? A UNC share deliberately answers false: <c>GetPathRoot</c>
-    /// returns it WITHOUT a trailing separator, and trimming <c>\\srv\share\</c> is harmless anyway (review round 2 —
-    /// an earlier version of this comment claimed the UNC case, which it does not have).</summary>
+    /// where trimming yields the drive-RELATIVE <c>C:</c>? A bare UNC share (<c>\\srv\share</c>) answers true as well,
+    /// since <c>GetPathRoot</c> returns it unchanged — harmlessly, because trimming it changes nothing either way. Two
+    /// earlier drafts of this comment got the UNC case wrong in OPPOSITE directions (review rounds 2 and 3); the case
+    /// this helper exists for is the drive root, and that is what it is worth stating.</summary>
     static bool IsRoot(string path)
     {
         try { return string.Equals(Path.GetPathRoot(path), path, StringComparison.OrdinalIgnoreCase); }
@@ -7072,7 +7074,7 @@ public sealed class LoadOrderService : IDisposable
                     // …worded for what is KNOWN: the folder is there and houseCARL will not remove it. Claiming this
                     // call CREATED it would be false whenever the mod already ships a SEQ\ — the feature's own
                     // headline case (review round 2).
-                    + (chosenOutput ? $" (the '{rf.OutputDir}' folder is left in place — it is inside the folder you named, which houseCARL never removes.)" : ""));
+                    + (chosenOutput ? $" (the '{rf.OutputDir}' folder is left in place — houseCARL never removes a folder you named.)" : ""));
             }
 
             // Integrity (Q3: THIS run wrote it; on-disk size matches the bytes we built — no false success).

--- a/src/housecarl-mcp/SeqTools.cs
+++ b/src/housecarl-mcp/SeqTools.cs
@@ -39,7 +39,10 @@ public static class SeqTools
          "than picking one. houseCARL reads that plugin's start-game-enabled quests and writes the .seq into a houseCARL " +
          "mod folder you enable in MO2. If the plugin is itself in a houseCARL patch folder, the .seq defaults into THAT " +
          "same folder (so enabling the one mod deploys both .esp and .seq); otherwise it lands in a fresh folder (pass " +
-         "into= an existing houseCARL patch to keep them together, or patch= to name the new folder). A plugin with no " +
+         "into= an existing houseCARL patch to keep them together, or patch= to name the new folder). After an IN-PLACE " +
+         "edit the .esp is in the MOD's own folder, so pass output_dir= that mod folder and the .seq lands beside it in " +
+         "its SEQ\\. If the destination already holds exactly these bytes, nothing is written and the response says so. " +
+         "A plugin with no " +
          "start-game-enabled quests needs no .seq — that's reported, nothing is written. The .seq makes the quest START; " +
          "it does not verify the quest or its dialogue is otherwise correct. format='json' returns the same data " +
          "machine-readable. No epoch on this call, and that is a fact not an omission: a .seq is derived from the plugin " +
@@ -53,6 +56,8 @@ public static class SeqTools
             string? patch = null,
         [Description("LANE: filename of an existing houseCARL patch mod to write the .seq into (e.g. the patch that holds the .esp, so one mod deploys both).")]
             string? into = null,
+        [Description("LANE: land the .seq in a folder of YOUR choosing instead of a houseCARL patch folder — pass the mod-folder ROOT (typically the plugin's own mod, after an in-place edit); houseCARL appends SEQ\\ (and won't double it if you already point at a ...\\SEQ folder). When set, patch=/into= are ignored. If the folder is under neither your MO2 mods folder nor the game's Data, the .seq is still written but you're warned the game won't read it.")]
+            string? output_dir = null,
         [Description("TRANSPORT: 'text' (default) | 'json' (the same data, machine-readable).")]
             string? format = null,
         [Description("TRANSPORT: character ceiling on the render; past it trailing quest rows are dropped with an explicit notice (never silent). 0 = a safe default kept under the host's per-response limit.")]
@@ -74,14 +79,21 @@ public static class SeqTools
                         + "patch — the two lanes are exclusive. Drop patch= to write into that patch, or drop into= to make a new folder.";
             return json ? JsonWire.RenderError(laneErr, null) : "error: " + laneErr;
         }
+        // output_dir= WINS over patch=/into= — the compile lane's decided contract (Aaron 2026-06-16), and the same
+        // ignored-lane rule it states out loud rather than silently applying (Q3). Not an error like the pair above:
+        // that pair is two ways of naming a houseCARL folder with no way to choose between them, while this is one
+        // lane superseding another — a note, and the .seq goes where output_dir says.
+        string? outputNote = null;
+        if (!string.IsNullOrWhiteSpace(output_dir) && (!string.IsNullOrWhiteSpace(patch) || !string.IsNullOrWhiteSpace(into)))
+            outputNote = "note: output_dir= was given, so patch=/into= are ignored (the .seq lands in output_dir, not a houseCARL patch folder).";
 
-        var o = svc.WriteSeq(source, patch, into);
-        if (json) return JsonWire.RenderSeqOutcome(o, max_chars);
+        var o = svc.WriteSeq(source, patch, into, output_dir);
+        if (json) return JsonWire.RenderSeqOutcome(o, max_chars, outputNote);
         if (!o.Success) return "error: " + o.Error;
-        return Render(o, max_chars);
+        return Render(o, max_chars, outputNote);
     });
 
-    internal static string Render(SeqOutcome o, int maxChars = 0)
+    internal static string Render(SeqOutcome o, int maxChars = 0, string? outputNote = null)
     {
         // No SGE quests → a clean, explicit no-op (Q3: never a silent empty .seq, never a misleading "done").
         if (o.Quests.Count == 0)
@@ -91,8 +103,11 @@ public static class SeqTools
 
         var sb = new StringBuilder();
         var seqName = Path.GetFileName(o.SeqPath);
-        sb.Append("wrote ").Append(seqName).Append(": ").Append(o.Quests.Count)
-          .Append(o.Quests.Count == 1 ? " start-game-enabled quest" : " start-game-enabled quests").Append('\n');
+        // #312 — "already current" is its own headline, not a "wrote" with a caveat further down: the first line is
+        // what a caller reads, and a skipped write reported as a write is the same observable as a silent failure (Q3).
+        sb.Append(o.Unchanged ? "unchanged — " : "wrote ").Append(seqName).Append(": ").Append(o.Quests.Count)
+          .Append(o.Quests.Count == 1 ? " start-game-enabled quest" : " start-game-enabled quests")
+          .Append(o.Unchanged ? "; the file on disk already holds exactly these bytes, so NOTHING was written." : "").Append('\n');
         // Budgeted like the sibling write renders (PR #311 review [low-medium]): max_chars= promises "past it
         // trailing quest rows are dropped with an explicit notice (never silent)", and a plugin with hundreds of
         // start-game-enabled quests would otherwise render every row and let the HOST cut the response with no
@@ -112,7 +127,9 @@ public static class SeqTools
                 sb.Append("  ... [truncated: ").Append(i).Append(" of ").Append(o.Quests.Count)
                   .Append(" quest(s) listed at max_chars=").Append(cap)
                   .Append("; the .seq itself carries ALL of them — nothing is missing from the FILE. Re-run only if you need this "
-                        + "LIST widened: that writes the .seq again (into= the folder named below to keep it in one)]\n");
+                        + "LIST widened: with no lane named that writes the .seq again into ANOTHER fresh mod folder (name "
+                        + "into=/output_dir= the folder below to keep it in one — there a byte-identical destination is left "
+                        + "untouched)]\n");
                 break;
             }
             var q = o.Quests[i];
@@ -125,9 +142,17 @@ public static class SeqTools
             sb.Append("source: ").Append(o.PluginFileName).Append(" — read from ").Append(o.ResolvedFrom)
               .Append(o.PluginPath is { Length: > 0 } p ? $" ({p})" : "").Append('\n');
         sb.Append("path: ").Append(o.SeqPath).Append('\n');
-        sb.Append(o.WroteIntoPluginFolder
-            ? "the .seq is in the plugin's OWN houseCARL folder — enabling that one mod in MO2 deploys both the .esp and its .seq."
-            : "the .seq is in a houseCARL mod folder — enable it in MO2 (AND make sure the plugin itself is enabled) so the game reads Data\\SEQ\\.");
+        // WHERE it is decides the NEXT STEP, so the three destinations get three different sentences. An output_dir=
+        // folder is the USER's own mod — telling them to "enable this houseCARL mod" would name a mod that doesn't
+        // exist (#312).
+        sb.Append(o.UserChoseOutput
+            ? "the .seq is in the folder you named (output_dir) — no houseCARL mod folder was created; make sure that mod is enabled in MO2 so the game reads Data\\SEQ\\."
+            : o.WroteIntoPluginFolder
+                ? "the .seq is in the plugin's OWN houseCARL folder — enabling that one mod in MO2 deploys both the .esp and its .seq."
+                : "the .seq is in a houseCARL mod folder — enable it in MO2 (AND make sure the plugin itself is enabled) so the game reads Data\\SEQ\\.");
+        // Q3: never a clean "done" for a .seq the engine will not read (the quests stay silently dead).
+        if (o.DeployWarning is { Length: > 0 } dw) sb.Append('\n').Append(dw);
+        if (outputNote is { Length: > 0 }) sb.Append('\n').Append(outputNote);
         // The ABSENT epoch, stated on the DEFAULT transport too (PR #311 review 6 [low]). The json twin has carried
         // `epoch_note` since it was written; the text render said nothing — so a caller on the transport most of
         // them use saw a response with no epoch= line, which is the same observable a DROPPED stamp would produce.

--- a/src/housecarl-mcp/SeqTools.cs
+++ b/src/housecarl-mcp/SeqTools.cs
@@ -125,8 +125,14 @@ public static class SeqTools
           .Append(o.Unchanged
               ? "; the file on disk already holds exactly these bytes, so NOTHING was written."
               // REPLACED is its own word for the same reason UNCHANGED is: on the output_dir lane the file that was
-              // there may be the mod's OWN .seq, and houseCARL keeps no backup of it (review round 1).
-              : o.Replaced ? "; a .seq was already at that path and has been OVERWRITTEN (no backup is kept)." : "")
+              // there may be the mod's OWN .seq, and houseCARL keeps no backup of it (review round 1). The
+              // no-backup ALARM is scoped to that lane (review round 3): re-generating over houseCARL's own previous
+              // output is the ordinary workflow, and dressing it as a loss would train the reader to ignore the word.
+              : o.Replaced
+                  ? (o.UserChoseOutput
+                      ? "; a .seq was already at that path and has been OVERWRITTEN (no backup is kept — in a folder you named, that may have been the mod's own)."
+                      : "; the previous .seq in that houseCARL folder was overwritten.")
+                  : "")
           .Append('\n');
         // Budgeted like the sibling write renders (PR #311 review [low-medium]): max_chars= promises "past it
         // trailing quest rows are dropped with an explicit notice (never silent)", and a plugin with hundreds of
@@ -147,9 +153,10 @@ public static class SeqTools
                 sb.Append("  ... [truncated: ").Append(i).Append(" of ").Append(o.Quests.Count)
                   .Append(" quest(s) listed at max_chars=").Append(cap)
                   .Append("; the .seq itself carries ALL of them — nothing is missing from the FILE. Re-run only if you need this "
-                        + "LIST widened: with no lane named that writes the .seq again into ANOTHER fresh mod folder (name "
-                        + "into=/output_dir= the folder below to keep it in one — there a byte-identical destination is left "
-                        + "untouched)]\n");
+                        + "LIST widened: for a plugin OUTSIDE a houseCARL folder with no lane named, that writes the .seq "
+                        + "again into ANOTHER fresh mod folder (name into=/output_dir= the folder below; a plugin in its own "
+                        + "houseCARL folder already defaults there — and at any named destination a byte-identical .seq is "
+                        + "left untouched)]\n");
                 break;
             }
             var q = o.Quests[i];

--- a/src/housecarl-mcp/SeqTools.cs
+++ b/src/housecarl-mcp/SeqTools.cs
@@ -114,7 +114,12 @@ public static class SeqTools
         if (o.Quests.Count == 0)
             return $"no start-game-enabled quests in {o.PluginFileName}{ReadFrom(o)} — no .seq is needed (a .seq lists only quests with the " +
                    "Start Game Enabled flag). Nothing written. If a quest SHOULD start at game start, set its Start Game Enabled " +
-                   "flag first, then write the .seq." + (outputNote is { Length: > 0 } n0 ? "\n" + n0 : "");
+                   "flag first, then write the .seq."
+                   // …and say that the destination was never looked at (PR #318 review [low]): this return happens
+                   // BEFORE any folder is resolved, so an unusable output_dir= would not have been diagnosed —
+                   // "your folder is fine" and "we never checked your folder" must not read the same.
+                   + (o.UserChoseOutput ? "\nnote: output_dir= was not resolved or checked — nothing needed writing, so no destination was touched." : "")
+                   + (outputNote is { Length: > 0 } n0 ? "\n" + n0 : "");
 
         var sb = new StringBuilder();
         var seqName = Path.GetFileName(o.SeqPath);
@@ -129,9 +134,13 @@ public static class SeqTools
               // no-backup ALARM is scoped to that lane (review round 3): re-generating over houseCARL's own previous
               // output is the ordinary workflow, and dressing it as a loss would train the reader to ignore the word.
               : o.Replaced
-                  ? (o.UserChoseOutput
-                      ? "; a .seq was already at that path and has been OVERWRITTEN (no backup is kept — in a folder you named, that may have been the mod's own)."
-                      : "; the previous .seq in that houseCARL folder was overwritten.")
+                  // Nothing was lost when the replaced bytes were the SAME bytes — the only way here is a byte-identical
+                  // destination whose timestamp refresh failed, and an alarm would be about nothing (review [low]).
+                  ? (o.ReplacedSameBytes
+                      ? "; the file already there held these exact bytes — it was rewritten only because its timestamp could not be refreshed in place, so nothing was lost."
+                      : o.UserChoseOutput
+                          ? "; a .seq was already at that path and has been OVERWRITTEN (no backup is kept — in a folder you named, that may have been the mod's own)."
+                          : "; the previous .seq in that houseCARL folder was overwritten.")
                   : "")
           .Append('\n');
         // Budgeted like the sibling write renders (PR #311 review [low-medium]): max_chars= promises "past it

--- a/src/housecarl-mcp/SeqTools.cs
+++ b/src/housecarl-mcp/SeqTools.cs
@@ -41,7 +41,9 @@ public static class SeqTools
          "same folder (so enabling the one mod deploys both .esp and .seq); otherwise it lands in a fresh folder (pass " +
          "into= an existing houseCARL patch to keep them together, or patch= to name the new folder). After an IN-PLACE " +
          "edit the .esp is in the MOD's own folder, so pass output_dir= that mod folder and the .seq lands beside it in " +
-         "its SEQ\\. If the destination already holds exactly these bytes, nothing is written and the response says so. " +
+         "its SEQ\\. When a LANE names the destination (output_dir=/into=, or the plugin's own houseCARL folder) and it " +
+         "already holds exactly these bytes, nothing is written and the response says so; with no lane named the fresh " +
+         "folder is empty by construction, so that re-run always writes. " +
          "A plugin with no " +
          "start-game-enabled quests needs no .seq — that's reported, nothing is written. The .seq makes the quest START; " +
          "it does not verify the quest or its dialogue is otherwise correct. format='json' returns the same data " +
@@ -56,7 +58,7 @@ public static class SeqTools
             string? patch = null,
         [Description("LANE: filename of an existing houseCARL patch mod to write the .seq into (e.g. the patch that holds the .esp, so one mod deploys both).")]
             string? into = null,
-        [Description("LANE: land the .seq in a folder of YOUR choosing instead of a houseCARL patch folder — pass the mod-folder ROOT (typically the plugin's own mod, after an in-place edit); houseCARL appends SEQ\\ (and won't double it if you already point at a ...\\SEQ folder). When set, patch=/into= are ignored. If the folder is under neither your MO2 mods folder nor the game's Data, the .seq is still written but you're warned the game won't read it.")]
+        [Description("LANE: land the .seq in a folder of YOUR choosing instead of a houseCARL patch folder — pass the mod-folder ROOT (typically the plugin's own mod, after an in-place edit); houseCARL appends SEQ\\ (and won't double it if you already point at a ...\\SEQ folder). When set, patch=/into= are ignored. An existing .seq at that path is OVERWRITTEN with no backup (the response says 'replaced'), and a byte-identical one is left alone with only its timestamp refreshed if it was older than the plugin. The game reads SEQ files from exactly <mods>\\<YourMod>\\SEQ, the MO2 overwrite folder, or <Data>\\SEQ — anywhere else the .seq is still written and you're warned it won't be read (a nested path like <mods>\\<YourMod>\\Sub is 'under mods' but does NOT deploy).")]
             string? output_dir = null,
         [Description("TRANSPORT: 'text' (default) | 'json' (the same data, machine-readable).")]
             string? format = null,
@@ -73,41 +75,59 @@ public static class SeqTools
         // another and silently lose is the accepted-and-ignored class the grammar exists to close:
         // ResolvePatchModFolder returns from the into= branch before patch= is ever read, so the .seq landed in
         // into='s folder and the response said nothing about the folder patch= asked for.
-        if (!string.IsNullOrWhiteSpace(patch) && !string.IsNullOrWhiteSpace(into))
+        // output_dir= WINS over patch=/into= — the compile lane's decided contract (Aaron 2026-06-16), and the same
+        // ignored-lane rule it states out loud rather than silently applying (Q3). Not an error like the pair below:
+        // that pair is two ways of naming a houseCARL folder with no way to choose between them, while this is one
+        // lane superseding another — a note, and the .seq goes where output_dir says.
+        //
+        // Order matters, and this order is the fix (review round 1): the pair check ran FIRST, so naming all three
+        // was REFUSED over two parameters output_dir='s own description promises to ignore — a tool contradicting its
+        // own contract. With output_dir= set there is nothing ambiguous left to refuse. (The compile lane it claims
+        // parity with resolves output_dir first too.)
+        string? outputNote = null;
+        if (!string.IsNullOrWhiteSpace(output_dir))
+        {
+            if (!string.IsNullOrWhiteSpace(patch) || !string.IsNullOrWhiteSpace(into))
+                outputNote = "note: output_dir= was given, so patch=/into= are ignored (the .seq lands in output_dir, not a houseCARL patch folder).";
+        }
+        else if (!string.IsNullOrWhiteSpace(patch) && !string.IsNullOrWhiteSpace(into))
         {
             var laneErr = $"patch='{patch}' names a NEW mod folder for the .seq, but into='{into}' writes it into an existing houseCARL "
                         + "patch — the two lanes are exclusive. Drop patch= to write into that patch, or drop into= to make a new folder.";
             return json ? JsonWire.RenderError(laneErr, null) : "error: " + laneErr;
         }
-        // output_dir= WINS over patch=/into= — the compile lane's decided contract (Aaron 2026-06-16), and the same
-        // ignored-lane rule it states out loud rather than silently applying (Q3). Not an error like the pair above:
-        // that pair is two ways of naming a houseCARL folder with no way to choose between them, while this is one
-        // lane superseding another — a note, and the .seq goes where output_dir says.
-        string? outputNote = null;
-        if (!string.IsNullOrWhiteSpace(output_dir) && (!string.IsNullOrWhiteSpace(patch) || !string.IsNullOrWhiteSpace(into)))
-            outputNote = "note: output_dir= was given, so patch=/into= are ignored (the .seq lands in output_dir, not a houseCARL patch folder).";
 
         var o = svc.WriteSeq(source, patch, into, output_dir);
         if (json) return JsonWire.RenderSeqOutcome(o, max_chars, outputNote);
-        if (!o.Success) return "error: " + o.Error;
+        // The ignored-lane note rides the REFUSAL too (review round 2): a call that named patch= alongside output_dir=
+        // and then failed was told nothing about patch= being ignored — the accepted-and-ignored class the note exists
+        // to close does not stop applying because the write failed.
+        if (!o.Success) return "error: " + o.Error + (outputNote is { Length: > 0 } ne ? "\n" + ne : "");
         return Render(o, max_chars, outputNote);
     });
 
     internal static string Render(SeqOutcome o, int maxChars = 0, string? outputNote = null)
     {
         // No SGE quests → a clean, explicit no-op (Q3: never a silent empty .seq, never a misleading "done").
+        // …carrying the ignored-lane note, which this early return used to drop while the json twin emitted it — the
+        // same D2 divergence this file's epoch-note fold closed one paragraph up (review round 1).
         if (o.Quests.Count == 0)
             return $"no start-game-enabled quests in {o.PluginFileName}{ReadFrom(o)} — no .seq is needed (a .seq lists only quests with the " +
                    "Start Game Enabled flag). Nothing written. If a quest SHOULD start at game start, set its Start Game Enabled " +
-                   "flag first, then write the .seq.";
+                   "flag first, then write the .seq." + (outputNote is { Length: > 0 } n0 ? "\n" + n0 : "");
 
         var sb = new StringBuilder();
         var seqName = Path.GetFileName(o.SeqPath);
         // #312 — "already current" is its own headline, not a "wrote" with a caveat further down: the first line is
         // what a caller reads, and a skipped write reported as a write is the same observable as a silent failure (Q3).
-        sb.Append(o.Unchanged ? "unchanged — " : "wrote ").Append(seqName).Append(": ").Append(o.Quests.Count)
+        sb.Append(o.Unchanged ? "unchanged — " : o.Replaced ? "replaced " : "wrote ").Append(seqName).Append(": ").Append(o.Quests.Count)
           .Append(o.Quests.Count == 1 ? " start-game-enabled quest" : " start-game-enabled quests")
-          .Append(o.Unchanged ? "; the file on disk already holds exactly these bytes, so NOTHING was written." : "").Append('\n');
+          .Append(o.Unchanged
+              ? "; the file on disk already holds exactly these bytes, so NOTHING was written."
+              // REPLACED is its own word for the same reason UNCHANGED is: on the output_dir lane the file that was
+              // there may be the mod's OWN .seq, and houseCARL keeps no backup of it (review round 1).
+              : o.Replaced ? "; a .seq was already at that path and has been OVERWRITTEN (no backup is kept)." : "")
+          .Append('\n');
         // Budgeted like the sibling write renders (PR #311 review [low-medium]): max_chars= promises "past it
         // trailing quest rows are dropped with an explicit notice (never silent)", and a plugin with hundreds of
         // start-game-enabled quests would otherwise render every row and let the HOST cut the response with no
@@ -150,6 +170,16 @@ public static class SeqTools
             : o.WroteIntoPluginFolder
                 ? "the .seq is in the plugin's OWN houseCARL folder — enabling that one mod in MO2 deploys both the .esp and its .seq."
                 : "the .seq is in a houseCARL mod folder — enable it in MO2 (AND make sure the plugin itself is enabled) so the game reads Data\\SEQ\\.");
+        // The stamp a skipped write still made, stated rather than left to be noticed: it is a real change to the
+        // file's metadata, and it is what keeps validate_dialogue's mtime-based SEQ lint agreeing with this call.
+        if (o.TimestampRefreshed)
+            // Careful with the claim (review round 2): what is established is that THIS FILE is now newer than the
+            // plugin. validate_dialogue lints the .seq the VFS serves for that plugin, which is this file only when
+            // this folder wins the SEQ\ conflict and is enabled — so the sentence says what was done and what it is
+            // for, and does not promise a verdict from a tool that resolves its input differently.
+            sb.Append("\nthe file was older than the plugin, so its timestamp was refreshed (contents untouched) — "
+                    + "housecarl_validate_dialogue's SEQ staleness check compares those two mtimes, so this .seq no longer "
+                    + "reads as stale (provided this is the copy your load order actually serves).");
         // Q3: never a clean "done" for a .seq the engine will not read (the quests stay silently dead).
         if (o.DeployWarning is { Length: > 0 } dw) sb.Append('\n').Append(dw);
         if (outputNote is { Length: > 0 }) sb.Append('\n').Append(outputNote);


### PR DESCRIPTION
The 2.0 tidy-up sweep (Aaron-go 2026-08-07: *"next session tidies up everything left over so far that is related to 2.0"*). Three issues, one branch, three rounds of independent review folded before this PR was opened.

Closes #316 · Fixes #317 · Fixes #312

---

## What is in it

### #316 — guard the three PR #315 fixes that shipped proven only by READING

Each was reviewed by reading and declared as such on that PR. #315 made the same declaration a fourth time and its round-4 review found *that* lane was wrong; both times the declared gap was where the defect was. Now pinned, each in its OWN order (an unopenable plugin poisons every write in the order it sits in):

- **`CompactBuild`'s declared-master open** — the named refusal **and** that the fresh mod folder is gone. The folder is the point: `RemoveOrNameRiderResidue` runs on a `Fail` return and never on a throw. RED: without the catch the throw escapes `CompactPlugin` entirely.
- **`RemapEngine.RepointInPlace`** — the one that matters most, because its caller reaches it only *after* P′ is on disk. Driven through the tool, since the difference the fix makes is "a named per-plugin result" vs Guard's internal-failure wrapper. RED: the open throws out through `Guard.Tool` with P′ already rewritten and every repoint result discarded.
- **The in-place single-master threshold**, both ways plus its dry run — a one-master header writes even when that master is unopenable, a two-master header refuses by cause, and the predictor agrees with each. RED in both directions (dropping `set.Count > 1` → over-refusal; removing the clause → under-refusal).

Two of these arms were repaired by their own RED checks: one asserted a file SIZE that a renumber leaves identical, and the "external referencer" was first an override — which `HasExternalReferencers` does not count, so the repoint stage never ran and the arm was green against *"external referencers: none"*.

### #317 — the CopyFrom lane's off-order arm

Fixed as filed (`TryOffOrderCopyBody`, mirroring #313's `IsOffOrderSource`) — **and then the premise turned out to be wrong**, which review round 1 caught. Membership lives in `_nameToIdx`, built once per resolver **instance** and never rebuilt (`RefreshIfStale` swaps only `_snap`), and a write reads `Resolver` once and hands that instance to both the pre-locate and the engine. So the mid-call race #317 *and PR #313* describe cannot occur, and neither re-check can currently change the arm.

Both are kept and re-documented for what they are: a structural invariant (the arm follows the view the write resolves against), not a race repair. The deterministic half is now pinned — `CopyFromViewArm` hands the engine a pre-fetched body keyed to an **active** source and asserts the in-order arm wins, on three distinguishable values so no outcome is ambiguous.

### #312 — `write_seq` gains `output_dir=`, plus a byte-identical no-op

Parity with `compile_script`'s decided contract (Aaron 2026-06-16), through one shared body so the two lanes cannot drift; `into=`'s ownership guard is untouched. A destination already holding these exact bytes is left alone and reported `unchanged`. The `.seq` is a new sidecar file into a folder the user owns — the `place_asset` posture, not an in-place record edit.

## Review before the PR (Aaron's trial, 2026-08-07)

Three rounds, fresh unseeded agents each time, folded between rounds. Round 3 returned **no high and no medium findings**, which is what opened this PR. What the rounds actually caught:

| Round | Findings | Sharpest |
|---|---|---|
| 1 | 3 medium, 8 low | #317's premise is false — and so is #313's |
| 2 | **1 high (mine)**, 3 medium, 5 low | 13.5 MB of generated corpus swept into a fold commit by `git add -A` |
| 3 | lows only | strings that describe a rule the code no longer follows |

Three that changed the shipped behaviour rather than the prose:

- **The no-op broke `validate_dialogue`.** Its SEQ lint reads **mtime**, not content, so skipping the write after an in-place edit — the exact loop #312 exists for — left a permanent "your .seq is older than the plugin" advisory on a byte-perfect file that no houseCARL tool could clear. An identical-but-older `.seq` now has its timestamp stamped **past the plugin** and verified; a stamp that fails, or that cannot beat a future-dated plugin, falls through to the real write.
- **The deployability rule omitted MO2's overwrite folder** — which is mapped onto Data at top priority and is where xEdit/CK/Synthesis output lands, so the feature's headline case warned about a folder the game reads. Fixed on **both** lanes, which is a behaviour change for `compile_script`: it has its own changelog line and is now pinned both ways in `compile-ergonomics-guard`, which had only ever exercised the 3-arg overload.
- **The high was mine.** Two mistyped probe names (the generator treats an unrecognised first argument as an output directory and exits 0) produced two 6.6 MB corpus dumps that `git add -A` committed. Stripped by rebuilding the commit, so no blob ever reached a pushed branch — but the silent mode→output-dir fallback that made it possible is pre-existing and worth its own issue.

## Verification

`ci-all` **117/117** · `write-surface-guard` **119/119** · `excluded-master-guard` **28/28** · `seq-write-guard` (42 arms) and `compile-ergonomics-guard` green. Every new arm RED-verified against the code it covers.

## Stated, not fixed

- `written` in `write_seq`'s json changed meaning (now "this call wrote the file", not "a path exists") — documented on the renderer; no in-repo consumer.
- The `CopyFrom` lane still lacks `forward`'s `ActiveNameForPath` rule, so a `from_source=` **path** naming an active plugin routes off-order and is described as not in the load order — the same defect PR #313 fixed for `forward`. Named in the code; worth its own issue.
- `output_dir=` can overwrite a third-party mod's own `.seq` with no backup and no `acknowledge` gate. Now disclosed in the parameter description and reported as `replaced`, and it matches `compile_script`'s shipped precedent — but whether this lane deserves a handshake is a product call.
- An unusable `output_dir=` is not diagnosed on the no-SGE-quests path (that lane returns before any folder is resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
