### PR TITLE
fix: #321 CopyFrom source paths, #308 in-place verify honesty, #300 nested parent hosting (+ generator mode refusal)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -44,8 +44,8 @@ time rather than discovered in game.
 matches a filename — so `from_source=C:\…\SomeMod\Bar.esp` pointing at a plugin your order is actively serving read
 the file directly and described the source as not in your load order. Usually that was only a wrong label; under a
 profile switch, where the same filename is served by a different mod folder, it was a wrong *body*. `housecarl_forward` has had the rule since its own fix — a path that names the exact file your
-order loads is that plugin — and `CopyFrom` now shares it. A path to a same-named *backup* still reads off-order,
-as it should: the test is the file, not the name.
+order loads is that plugin — and `CopyFrom` now shares it. A path to a same-named *backup* still reads
+off-order, as it should: the test is the file, not the name.
 
 **`housecarl_write_seq` can finally put the `.seq` in the mod's own folder — `output_dir=` (#312).** Editing a
 plugin **in place** left the two halves in different mods: the `.esp` in the mod's own folder, the `.seq` in a

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -48,17 +48,20 @@ the cell record losing, so nothing about it needed the winner. Which plugin host
 created record (`parent: …`, `parent_host` in JSON) — including the two cases where the definer genuinely can't
 answer (an injected record, or a plugin this session had to exclude), where the winner is still used and says so.
 
-**You keep the choice — that is the point.** The host is a full record override and still conflicts at record level, so
-wherever your patch out-ranks the mod that currently wins that cell or topic, the parent resolves to the *defining*
-plugin's fields rather than that mod's. That is the **residual** shape: your patch carries your child and a host lean
-enough to lose harmlessly. It is the right default because the alternative — copying the winner — silently inlines
-another mod's content into your plugin and costs a master your reference never needed, and only you know whether this
-patch is meant to win or to feed one that does.
+**Which shape you get is a decision, and houseCARL no longer makes it for you.** The host is a full record override and
+still conflicts at record level, so wherever your patch out-ranks the mod that currently wins that cell or topic, the
+parent resolves to the *defining* plugin's fields rather than that mod's. That is the **residual** shape: your patch
+carries your child and a host lean enough to lose harmlessly.
 
-xEdit copies the winner because a person is deciding, record by record, in the moment. houseCARL doesn't decide for
-you: it writes the residual and **tells you** which mod currently wins that parent and which way the record will
-resolve. Sort below that mod to keep the residual shape, sort above it to assert your host, or forward that mod's
-version in deliberately when inlining is what you actually want. The new child is carried either way.
+Both shapes are legitimate and which one is right depends entirely on what the patch is for. A patch meant to *win* —
+"patch this mod for my load order" — wants the winner's content carried forward, resolved. A patch meant to **feed**
+one — "make this sit before the Reqtificator / Synthesis output" — must not master those, must not forward their
+records, and must not bake in what they would regenerate. Same call, opposite right answers.
+
+So this is now the base you build from rather than an answer imposed on you: the residual is what you get when nothing
+else is said, because you can add the winner's version deliberately on top, and you cannot cleanly subtract it once it
+is baked in. The response **tells you** which mod currently wins that parent and which way the record will resolve, so
+the choice is in front of you at write time. The new child is carried either way.
 
 **Fixed: a full path to an *active* plugin is no longer treated as an off-order file (#321).** `housecarl_apply`'s
 `CopyFrom` decided "is this source in the load order?" by looking up the name it was given, and a full path never

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -15,11 +15,16 @@ serializes to nothing — a Faction `Rank` composed with no fields is the report
 list stayed empty, and the call still reported the addition as landed; it cost the reporter three more debugging
 rounds on a live mod. That clause now comes off the re-opened file — for the op that last touched a given field in
 the call; an earlier op on the same field is marked as the applied edit's own reading, because the file holds the
-state after all of them and cannot answer for a middle one. If the file and the applied edit disagree, the
-response says so **loudly** on its own line and tells you to treat the op as not landed, instead of leaving you to
-notice a count. In JSON the two are separate facts: `landed` (what the edit did in memory), `landed_on_disk` (what
-the file carries), `divergence`, and `landed_verification` (`verified` / `diverged` / `superseded` / `no_answer` / `not_comparable` /
-`not_checked`). And the specific call that caused it is now
+state after all of them and cannot answer for a middle one.
+
+**houseCARL shows you both readings; it does not rule on them.** You get what the edit did in memory and what the file
+says, and where the file could not answer, the response tells you which reading you are looking at. It deliberately
+stops short of declaring "this op did not land" — deciding that means telling a real difference from a harmless one
+(a percentage that rounds when saved, an internal type name, an empty field versus a missing one), and every version
+of that judgement we built ended up accusing writes that had in fact landed. In JSON: `landed` (memory),
+`landed_on_disk` (the file), and `landed_source` — `written_file`, `superseded` (a later op in the same call wrote
+that field), `no_answer` (the file was re-read and didn't yield it), or `not_checked` (this lane runs no per-op file
+check), plus `verify_ran` on the response. And the specific call that caused the bug is now
 **refused before anything is written**, naming the fields that would give the structure content — a compose you gave
 nothing to, whose every settable field is empty, cannot land, so houseCARL no longer pretends it did. **One shape that
 used to work is refused with it:** composing an empty value and then filling its fields in a *later op of the same

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -30,12 +30,19 @@ the cell record losing, so nothing about it needed the winner. Which plugin host
 created record (`parent: …`, `parent_host` in JSON) — including the two cases where the definer genuinely can't
 answer (an injected record, or a plugin this session had to exclude), where the winner is still used and says so.
 
+**Know the trade this makes.** The host is a full record override, and it still conflicts at record level. So wherever
+your patch out-ranks the mod that currently wins that cell or topic, the parent record now resolves to the *defining*
+plugin's fields — usually vanilla — instead of that mod's. Before, it resolved to a frozen copy of that mod's fields,
+which was right until the mod updated and then silently wrong forever. Neither is what you want from a patch that only
+added a reference: **sort the patch before the mod that owns the parent**, and the new child is carried either way.
+The `parent:` line now says which mod that is and which way it will resolve, so the choice is in front of you at write
+time rather than discovered in game.
+
 **Fixed: a full path to an *active* plugin is no longer treated as an off-order file (#321).** `housecarl_apply`'s
 `CopyFrom` decided "is this source in the load order?" by looking up the name it was given, and a full path never
 matches a filename — so `from_source=C:\…\SomeMod\Bar.esp` pointing at a plugin your order is actively serving read
-the file directly, skipped the excluded-plugin refusal, and described the source as not in your load order. Usually
-that was only a wrong label; under a profile switch, where the same filename is served by a different mod folder, it
-was a wrong *body*. `housecarl_forward` has had the rule since its own fix — a path that names the exact file your
+the file directly and described the source as not in your load order. Usually that was only a wrong label; under a
+profile switch, where the same filename is served by a different mod folder, it was a wrong *body*. `housecarl_forward` has had the rule since its own fix — a path that names the exact file your
 order loads is that plugin — and `CopyFrom` now shares it. A path to a same-named *backup* still reads off-order, as
 it should: the test is the file, not the name.
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -18,7 +18,7 @@ the call; an earlier op on the same field is marked as the applied edit's own re
 state after all of them and cannot answer for a middle one. If the file and the applied edit disagree, the
 response says so **loudly** on its own line and tells you to treat the op as not landed, instead of leaving you to
 notice a count. In JSON the two are separate facts: `landed` (what the edit did in memory), `landed_on_disk` (what
-the file carries), `divergence`, and `landed_verification` (`verified` / `diverged` / `superseded` / `no_answer` /
+the file carries), `divergence`, and `landed_verification` (`verified` / `diverged` / `superseded` / `no_answer` / `not_comparable` /
 `not_checked`). And the specific call that caused it is now
 **refused before anything is written**, naming the fields that would give the structure content — a compose you gave
 nothing to, whose every settable field is empty, cannot land, so houseCARL no longer pretends it did. **One shape that

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -19,7 +19,11 @@ notice a count. In JSON the two are separate facts: `landed` (what the edit did 
 the file carries), `divergence`, and `landed_verification` (`verified` / `diverged` / `superseded` / `no_answer` /
 `not_checked`). And the specific call that caused it is now
 **refused before anything is written**, naming the fields that would give the structure content — a compose you gave
-nothing to, whose every settable field is empty, cannot land, so houseCARL no longer pretends it did.
+nothing to, whose every settable field is empty, cannot land, so houseCARL no longer pretends it did. **One shape that
+used to work is refused with it:** composing an empty value and then filling its fields in a *later op of the same
+call*. The check runs as the value is built and cannot see the ops after it, and the lane is all-or-nothing, so the
+whole call is refused — the message says so and points at the one-op form (compose it *with* its fields), which cannot
+half-land either way.
 
 **Fixed: adding a record inside an existing cell (or topic) no longer drags in the mod that wins it (#300).** Placing
 a new reference into a vanilla cell pulled the cell's *load-order winner* into your patch — so a lighting overhaul

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -48,13 +48,17 @@ the cell record losing, so nothing about it needed the winner. Which plugin host
 created record (`parent: …`, `parent_host` in JSON) — including the two cases where the definer genuinely can't
 answer (an injected record, or a plugin this session had to exclude), where the winner is still used and says so.
 
-**Know the trade this makes.** The host is a full record override, and it still conflicts at record level. So wherever
-your patch out-ranks the mod that currently wins that cell or topic, the parent record now resolves to the *defining*
-plugin's fields — usually vanilla — instead of that mod's. Before, it resolved to a frozen copy of that mod's fields,
-which was right until the mod updated and then silently wrong forever. Neither is what you want from a patch that only
-added a reference: **sort the patch before the mod that owns the parent**, and the new child is carried either way.
-The `parent:` line now says which mod that is and which way it will resolve, so the choice is in front of you at write
-time rather than discovered in game.
+**You keep the choice — that is the point.** The host is a full record override and still conflicts at record level, so
+wherever your patch out-ranks the mod that currently wins that cell or topic, the parent resolves to the *defining*
+plugin's fields rather than that mod's. That is the **residual** shape: your patch carries your child and a host lean
+enough to lose harmlessly. It is the right default because the alternative — copying the winner — silently inlines
+another mod's content into your plugin and costs a master your reference never needed, and only you know whether this
+patch is meant to win or to feed one that does.
+
+xEdit copies the winner because a person is deciding, record by record, in the moment. houseCARL doesn't decide for
+you: it writes the residual and **tells you** which mod currently wins that parent and which way the record will
+resolve. Sort below that mod to keep the residual shape, sort above it to assert your host, or forward that mod's
+version in deliberately when inlining is what you actually want. The new child is carried either way.
 
 **Fixed: a full path to an *active* plugin is no longer treated as an off-order file (#321).** `housecarl_apply`'s
 `CopyFrom` decided "is this source in the load order?" by looking up the name it was given, and a full path never

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -59,9 +59,18 @@ one — "make this sit before the Reqtificator / Synthesis output" — must not 
 records, and must not bake in what they would regenerate. Same call, opposite right answers.
 
 So this is now the base you build from rather than an answer imposed on you: the residual is what you get when nothing
-else is said, because you can add the winner's version deliberately on top, and you cannot cleanly subtract it once it
-is baked in. The response **tells you** which mod currently wins that parent and which way the record will resolve, so
-the choice is in front of you at write time. The new child is carried either way.
+else is said, because you can build the inlined shape deliberately, and you cannot cleanly subtract the winner's content
+once it is baked in. The response **tells you** which mod currently wins that parent and which way the record will
+resolve, so the choice is in front of you at write time. Whichever way you sort, the new child is carried.
+
+**Building the inlined shape: the order matters, and only one order is safe today.** Forward the winner's version into
+a patch **first**, then create into that patch — your new record is hosted in the forwarded body, and you get both.
+Doing it the other way round — creating first, then forwarding the winner into the same patch — **deletes the record you
+just created**, and reports success. That is a pre-existing `housecarl_forward` bug rather than anything specific to
+this feature: forwarding onto a record the destination already carries drops that whole record before re-copying it,
+and the child group — placed references under a cell, dialogue lines under a topic — goes with the drop. It affects
+`into=` and `in_place=` alike, so it can take content out of your own plugin on the in-place lane. It is tracked as
+**#324** and is not fixed in this release; until it is, use the safe order. The write response names the safe order too.
 
 **Fixed: a full path to an *active* plugin is no longer treated as an off-order file (#321).** `housecarl_apply`'s
 `CopyFrom` decided "is this source in the load order?" by looking up the name it was given, and a full path never

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,7 +13,9 @@ banner saying every edited record was re-read off the file on disk — but the p
 now 1 (+1)`") was read from memory *before* the file was written. When a composed structure exists in memory and
 serializes to nothing — a Faction `Rank` composed with no fields is the reported case — the plugin didn't grow, the
 list stayed empty, and the call still reported the addition as landed; it cost the reporter three more debugging
-rounds on a live mod. That clause now comes off the re-opened file. If the file and the applied edit disagree, the
+rounds on a live mod. That clause now comes off the re-opened file — for the op that last touched a given field in
+the call; an earlier op on the same field is marked as the applied edit's own reading, because the file holds the
+state after all of them and cannot answer for a middle one. If the file and the applied edit disagree, the
 response says so **loudly** on its own line and tells you to treat the op as not landed, instead of leaving you to
 notice a count. In JSON the two are separate facts: `landed` (what the edit did in memory), `landed_on_disk` (what
 the file carries), `divergence`, and `landed_verification` (`verified` / `diverged` / `superseded` / `no_answer` /
@@ -24,6 +26,12 @@ used to work is refused with it:** composing an empty value and then filling its
 call*. The check runs as the value is built and cannot see the ops after it, and the lane is all-or-nothing, so the
 whole call is refused — the message says so and points at the one-op form (compose it *with* its fields), which cannot
 half-land either way.
+
+**Reads show the modelled type name for a sub-structure, never Mutagen's internal one.** A field like a weapon's
+`BasicStats` read off a plugin on disk rendered as `[WeaponBasicStatsBinaryOverlay]` — the class houseCARL happens to
+load — while the same field read from a record being edited said `[WeaponBasicStats]`. Same field, two names, and one
+of them is an implementation detail. It now always reads `[WeaponBasicStats]`, in every read tool and in the in-place
+write verify (where the two used to appear in a single response, two lines apart, looking like a disagreement).
 
 **Fixed: adding a record inside an existing cell (or topic) no longer drags in the mod that wins it (#300).** Placing
 a new reference into a vanilla cell pulled the cell's *load-order winner* into your patch — so a lighting overhaul

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,37 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**Fixed: an in-place edit's "what landed" line is now read off the written file (#308).** The verify prints under a
+banner saying every edited record was re-read off the file on disk — but the per-op half of each line ("`Add Ranks:
+now 1 (+1)`") was read from memory *before* the file was written. When a composed structure exists in memory and
+serializes to nothing — a Faction `Rank` composed with no fields is the reported case — the plugin didn't grow, the
+list stayed empty, and the call still reported the addition as landed; it cost the reporter three more debugging
+rounds on a live mod. That clause now comes off the re-opened file. If the file and the applied edit disagree, the
+response says so **loudly** on its own line and tells you to treat the op as not landed, instead of leaving you to
+notice a count. In JSON the two are separate facts: `landed` (what the edit did in memory), `landed_on_disk` (what
+the file carries), `divergence`, and `landed_verified_on_disk`. And the specific call that caused it is now
+**refused before anything is written**, naming the fields that would give the structure content — a compose you gave
+nothing to, whose every settable field is empty, cannot land, so houseCARL no longer pretends it did.
+
+**Fixed: adding a record inside an existing cell (or topic) no longer drags in the mod that wins it (#300).** Placing
+a new reference into a vanilla cell pulled the cell's *load-order winner* into your patch — so a lighting overhaul
+became a master your two new refs never needed, and the patch carried a frozen copy of that mod's lighting. Sorted
+below the lighting mod, your patch then re-asserted those stale values, and would keep re-asserting them after the
+mod updated. houseCARL now hosts the new child in the parent's **defining** plugin's version: no extra master, no
+copied-in content from a mod you weren't patching. A placed reference lives in the cell's child group and survives
+the cell record losing, so nothing about it needed the winner. Which plugin hosted the child is now reported per
+created record (`parent: …`, `parent_host` in JSON) — including the two cases where the definer genuinely can't
+answer (an injected record, or a plugin this session had to exclude), where the winner is still used and says so.
+
+**Fixed: a full path to an *active* plugin is no longer treated as an off-order file (#321).** `housecarl_apply`'s
+`CopyFrom` decided "is this source in the load order?" by looking up the name it was given, and a full path never
+matches a filename — so `from_source=C:\…\SomeMod\Bar.esp` pointing at a plugin your order is actively serving read
+the file directly, skipped the excluded-plugin refusal, and described the source as not in your load order. Usually
+that was only a wrong label; under a profile switch, where the same filename is served by a different mod folder, it
+was a wrong *body*. `housecarl_forward` has had the rule since its own fix — a path that names the exact file your
+order loads is that plugin — and `CopyFrom` now shares it. A path to a same-named *backup* still reads off-order, as
+it should: the test is the file, not the name.
+
 **`housecarl_write_seq` can finally put the `.seq` in the mod's own folder — `output_dir=` (#312).** Editing a
 plugin **in place** left the two halves in different mods: the `.esp` in the mod's own folder, the `.seq` in a
 freshly cut `houseCARL - houseCARL_SEQ_00N`, with `into=` unable to name a folder houseCARL didn't create. Every

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -16,7 +16,8 @@ list stayed empty, and the call still reported the addition as landed; it cost t
 rounds on a live mod. That clause now comes off the re-opened file. If the file and the applied edit disagree, the
 response says so **loudly** on its own line and tells you to treat the op as not landed, instead of leaving you to
 notice a count. In JSON the two are separate facts: `landed` (what the edit did in memory), `landed_on_disk` (what
-the file carries), `divergence`, and `landed_verified_on_disk`. And the specific call that caused it is now
+the file carries), `divergence`, and `landed_verification` (`verified` / `diverged` / `superseded` / `no_answer` /
+`not_checked`). And the specific call that caused it is now
 **refused before anything is written**, naming the fields that would give the structure content — a compose you gave
 nothing to, whose every settable field is empty, cannot land, so houseCARL no longer pretends it did.
 
@@ -43,8 +44,8 @@ time rather than discovered in game.
 matches a filename — so `from_source=C:\…\SomeMod\Bar.esp` pointing at a plugin your order is actively serving read
 the file directly and described the source as not in your load order. Usually that was only a wrong label; under a
 profile switch, where the same filename is served by a different mod folder, it was a wrong *body*. `housecarl_forward` has had the rule since its own fix — a path that names the exact file your
-order loads is that plugin — and `CopyFrom` now shares it. A path to a same-named *backup* still reads off-order, as
-it should: the test is the file, not the name.
+order loads is that plugin — and `CopyFrom` now shares it. A path to a same-named *backup* still reads off-order,
+as it should: the test is the file, not the name.
 
 **`housecarl_write_seq` can finally put the `.seq` in the mod's own folder — `output_dir=` (#312).** Editing a
 plugin **in place** left the two halves in different mods: the `.esp` in the mod's own folder, the `.seq` in a

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -103,6 +103,12 @@ public sealed class LoadOrderResolver : IDisposable
     DateTime[] _mtimes;                                // last-write at the last index build, per path (freshness baseline)
     readonly string? _dataDir;                         // real game-Data folder (Skyrim.esm's dir) — localized-strings fallback source (OpenOverlay)
 
+    /// <summary>The real game-Data folder this order resolved, for callers OUTSIDE the session that must open a plugin
+    /// through <see cref="OpenOverlay"/> and get the same strings resolution the index reads with — the in-place write's
+    /// post-serialize verify being the one that needs it, since it now COMPARES what it reads (#308) rather than only
+    /// printing it, and a strings-less read of a localized field would otherwise look like a lost write.</summary>
+    internal string? DataDir => _dataDir;
+
     /// <summary>Optional: given a plugin filename this index does NOT contain, a clause saying WHY it isn't in the
     /// active order — or null if the injector can't say. Every "not in the load order" refusal below is a dead end for
     /// the reader as it stands: the commonest cause by far is a plugin that IS installed and IS in an enabled mod but

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -32,8 +32,10 @@ namespace HousecarlCore;
 /// that vanished as "verified".</param>
 /// <param name="Count">Element count for a container leaf (0 = present but EMPTY); null for a value or a substruct,
 /// neither of which has one. Surfaced from <c>LeafRead.ContainerCount</c>, which already carried it.</param>
+/// <param name="Readable">False when the read FAILED (a throw, or no such field) rather than finding nothing — an
+/// unreadable leaf looks absent and is not evidence of absence.</param>
 public sealed record FieldValue(string Path, bool HasValue, string? Token, string? Note, string? Display = null, ResolvedRef? Link = null,
-                                bool Present = true, int? Count = null);
+                                bool Present = true, int? Count = null, bool Readable = true);
 
 /// <summary>The resolved identity of a form reference — the shared contract behind housecarl_resolve (P3, a full
 /// row) and the resolve_names field annotation (P7). <see cref="Resolved"/> false ⇒ the FormKey is valid but not
@@ -86,7 +88,7 @@ public static class ReadEngine
     /// (named bits → "Body"; an unnamed modder slot → "8388608"). The <see cref="Token"/> is unchanged — the
     /// round-trip oracle still drives the same display token — so this is invisible to read/write/diff.</para></summary>
     internal readonly record struct LeafRead(bool HasValue, string Token, string? Note, FlagBits? Flags = null, int? ContainerCount = null,
-                                             bool Present = true)
+                                             bool Present = true, bool Readable = true)
     {
         public static LeafRead Value(string token) => new(true, token, null);
         public static LeafRead FlagsValue(string token, FlagBits bits) => new(true, token, null, bits);
@@ -95,6 +97,11 @@ public static class ReadEngine
         /// deciding presence: both render as a parenthesised note, so telling them apart from the note text alone
         /// means parsing prose (the #308 divergence detector did, and missed a vanished substruct entirely).</summary>
         public static LeafRead None(string note) => new(false, "", note, null, null, Present: false);
+
+        /// <summary>The read FAILED — a throw at navigation, or a field the type does not have. Absent-looking, but
+        /// not evidence of ABSENCE: a caller deciding whether content vanished must not read "I could not look" as
+        /// "there is nothing there" (#308's verify did, and told the caller a correct write was lost).</summary>
+        public static LeafRead Unreadable(string note) => new(false, "", note, null, null, Present: false, Readable: false);
         /// <summary>A no-value CONTAINER/substruct summary carrying its element <paramref name="count"/>: null for a
         /// substruct (present by being non-null — no element count), a number for a list/dict (0 = present-but-EMPTY).
         /// The count is additive metadata for the presence predicate (<c>exists</c>/<c>missing</c>), which must tell
@@ -217,7 +224,8 @@ public static class ReadEngine
                 // FieldsDiff runs never sees the hint (it reads at expansion depth, a different summary path).
                 // The hint text is the caller's (containerHint): depth=2 is only a real knob on some surfaces.
                 if (note is { Length: > 0 } && note[0] == '[' && !string.IsNullOrEmpty(containerHint)) note += containerHint;
-                fields.Add(new FieldValue(p, r.HasValue, r.HasValue ? r.Token : null, note, FlagDisplay(r), Present: r.Present, Count: r.ContainerCount));
+                fields.Add(new FieldValue(p, r.HasValue, r.HasValue ? r.Token : null, note, FlagDisplay(r),
+                                          Present: r.Present, Count: r.ContainerCount, Readable: r.Readable));
             }
         }
         else
@@ -246,7 +254,7 @@ public static class ReadEngine
             {
                 var (segName, segKey) = WriteEngine.ParseSegment(path[i]);
                 var p = WriteEngine.ResolveProperty(current!.GetType(), segName);
-                if (p is null) return LeafRead.None(NoFieldNote(current, segName, i > 0 ? WriteEngine.ParseSegment(path[i - 1]).name : null));
+                if (p is null) return LeafRead.Unreadable(NoFieldNote(current, segName, i > 0 ? WriteEngine.ParseSegment(path[i - 1]).name : null));
                 current = segKey is null
                     ? p.GetValue(current)                                  // descend a substruct (read-only)
                     : WriteEngine.StepIntoElement(current, p, segName, segKey); // collnav (handles IReadOnly*)
@@ -255,7 +263,7 @@ public static class ReadEngine
 
             var (leafName, leafKey) = WriteEngine.ParseSegment(path[^1]);
             var leaf = WriteEngine.ResolveProperty(current!.GetType(), leafName);
-            if (leaf is null) return LeafRead.None(NoFieldNote(current, leafName, path.Length >= 2 ? WriteEngine.ParseSegment(path[^2]).name : null));
+            if (leaf is null) return LeafRead.Unreadable(NoFieldNote(current, leafName, path.Length >= 2 ? WriteEngine.ParseSegment(path[^2]).name : null));
             if (leafKey is not null)
             {
                 // The leaf brackets a collection element (Keywords[0]) — step in and emit the element.
@@ -264,7 +272,7 @@ public static class ReadEngine
             }
             return EmitToken(leaf.GetValue(current), leaf.PropertyType, current);
         }
-        catch (Exception ex) { return LeafRead.None($"(unreadable: {ex.Message})"); }
+        catch (Exception ex) { return LeafRead.Unreadable($"(unreadable: {ex.Message})"); }
     }
 
     /// <summary>The FormKeys on a record's <c>Keywords</c> list — the ONE keyword walk (previously

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -952,7 +952,7 @@ public static class ReadEngine
         bool? useAliases = ReflectBool(parent, "UseAliases");
         bool? usePackData = ReflectBool(parent, "UsePackageData");
         if (useAliases is null || usePackData is null)
-            return LeafRead.None($"(floi: parent {parent.GetType().Name} has no UseAliases/UsePackageData discriminator)");
+            return LeafRead.Unreadable($"(floi: parent {parent.GetType().Name} has no UseAliases/UsePackageData discriminator)");
 
         if (useAliases == false && usePackData == false)
         {
@@ -961,12 +961,12 @@ public static class ReadEngine
             // A present-but-null link stays a note, matching plain FormLink leaves (HCBR-2026-06-09-02).
             if (val is IFormLinkGetter fl) return LeafRead.Value(fl.FormKey.ToString());
             if (WriteEngine.ReadFloiFormKey(val) is { } fk) return LeafRead.Value(fk.ToString());
-            return LeafRead.None($"(floi: form mode, null or unreadable FormKey on {val.GetType().Name})");
+            return LeafRead.Unreadable($"(floi: form mode, null or unreadable FormKey on {val.GetType().Name})");
         }
 
         // index mode — read the numeric index defensively (FormLinkOrIndex carries it alongside the link).
         var idx = ReflectUInt(val, "Index", "RawIndex", "FormKeyOrIndex");
-        if (idx is null) return LeafRead.None("(floi: index mode, index accessor unresolved — refined in oracle)");
+        if (idx is null) return LeafRead.Unreadable("(floi: index mode, index accessor unresolved — refined in oracle)");
         return LeafRead.Value(useAliases == true ? $"alias {idx}" : $"packdata {idx}");
     }
 

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -421,7 +421,10 @@ public static class ReadEngine
                    || WriteEngine.ClosedInterface(val.GetType(), typeof(IReadOnlyDictionary<,>)) is not null;
 
         // a container or substruct — summarise (with an element identity where we can), then maybe open it.
-        if (!Emit(sink, ref budget, new FieldValue(path, false, null, ElementSummary(val, isDict)))) return;
+        // Present/Count on the DEEP path too (review [nit]): these exist so a consumer never parses a note to decide
+        // presence, and leaving them at their defaults here made a depth-2 read of an EMPTY list claim content.
+        int? deepCount = val is System.Collections.IEnumerable de and not string ? de.Cast<object?>().Count() : null;
+        if (!Emit(sink, ref budget, new FieldValue(path, false, null, ElementSummary(val, isDict), Present: true, Count: deepCount))) return;
 
         // Two POLYMORPHIC-ARM families normally stop here at their identity summary, hiding their VALUE, and both
         // surface it ONE bounded level deeper even at the depth floor so a read reaches parity with the write

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -25,7 +25,15 @@ namespace HousecarlCore;
 /// part of the round-trip <see cref="Token"/>, so it is invisible to write, read-proof, and diff. Populated by the
 /// service (which holds the resolver), never by the core read (which reads one record's bytes and cannot resolve a
 /// target). Null unless resolve_names was requested and the leaf carries a resolvable FormKey.</para></summary>
-public sealed record FieldValue(string Path, bool HasValue, string? Token, string? Note, string? Display = null, ResolvedRef? Link = null);
+/// <param name="Present">Is anything THERE? True for a value and for a present container/substruct (whose own
+/// <paramref name="Count"/> says how much); false only when the leaf holds nothing — absent, no such field,
+/// unreadable. Carried structurally because the two render alike (both are parenthesised notes) and a consumer that
+/// decides presence from the note text is parsing prose: #308's write verify did exactly that and reported a write
+/// that vanished as "verified".</param>
+/// <param name="Count">Element count for a container leaf (0 = present but EMPTY); null for a value or a substruct,
+/// neither of which has one. Surfaced from <c>LeafRead.ContainerCount</c>, which already carried it.</param>
+public sealed record FieldValue(string Path, bool HasValue, string? Token, string? Note, string? Display = null, ResolvedRef? Link = null,
+                                bool Present = true, int? Count = null);
 
 /// <summary>The resolved identity of a form reference — the shared contract behind housecarl_resolve (P3, a full
 /// row) and the resolve_names field annotation (P7). <see cref="Resolved"/> false ⇒ the FormKey is valid but not
@@ -77,11 +85,16 @@ public static class ReadEngine
     /// numerically WITHOUT tripping over the name/number rendering split that <c>[Flags].ToString()</c> produces
     /// (named bits → "Body"; an unnamed modder slot → "8388608"). The <see cref="Token"/> is unchanged — the
     /// round-trip oracle still drives the same display token — so this is invisible to read/write/diff.</para></summary>
-    internal readonly record struct LeafRead(bool HasValue, string Token, string? Note, FlagBits? Flags = null, int? ContainerCount = null)
+    internal readonly record struct LeafRead(bool HasValue, string Token, string? Note, FlagBits? Flags = null, int? ContainerCount = null,
+                                             bool Present = true)
     {
         public static LeafRead Value(string token) => new(true, token, null);
         public static LeafRead FlagsValue(string token, FlagBits bits) => new(true, token, null, bits);
-        public static LeafRead None(string note) => new(false, "", note);
+        /// <summary>NOTHING is there — an absent optional substruct, a field the type does not have, an unreadable
+        /// leaf. The ONE no-value shape that is not <see cref="Container"/>, and the difference matters to any caller
+        /// deciding presence: both render as a parenthesised note, so telling them apart from the note text alone
+        /// means parsing prose (the #308 divergence detector did, and missed a vanished substruct entirely).</summary>
+        public static LeafRead None(string note) => new(false, "", note, null, null, Present: false);
         /// <summary>A no-value CONTAINER/substruct summary carrying its element <paramref name="count"/>: null for a
         /// substruct (present by being non-null — no element count), a number for a list/dict (0 = present-but-EMPTY).
         /// The count is additive metadata for the presence predicate (<c>exists</c>/<c>missing</c>), which must tell
@@ -204,7 +217,7 @@ public static class ReadEngine
                 // FieldsDiff runs never sees the hint (it reads at expansion depth, a different summary path).
                 // The hint text is the caller's (containerHint): depth=2 is only a real knob on some surfaces.
                 if (note is { Length: > 0 } && note[0] == '[' && !string.IsNullOrEmpty(containerHint)) note += containerHint;
-                fields.Add(new FieldValue(p, r.HasValue, r.HasValue ? r.Token : null, note, FlagDisplay(r)));
+                fields.Add(new FieldValue(p, r.HasValue, r.HasValue ? r.Token : null, note, FlagDisplay(r), Present: r.Present, Count: r.ContainerCount));
             }
         }
         else
@@ -370,10 +383,10 @@ public static class ReadEngine
         {
             var seg = path.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
             var nav = NavigateValue(record, seg);
-            if (!nav.ok) { Emit(sink, ref budget, new FieldValue(path, false, null, nav.note)); return; }
+            if (!nav.ok) { Emit(sink, ref budget, new FieldValue(path, false, null, nav.note, Present: false)); return; }
             Expand(nav.val, nav.type, nav.parent, path, depth, sink, ref budget);
         }
-        catch (Exception ex) { Emit(sink, ref budget, new FieldValue(path, false, null, $"(unreadable: {ex.Message})")); }
+        catch (Exception ex) { Emit(sink, ref budget, new FieldValue(path, false, null, $"(unreadable: {ex.Message})", Present: false)); }
     }
 
     /// <summary>Recursively emit <paramref name="val"/> at <paramref name="path"/>: a value leaf → its token;
@@ -384,7 +397,7 @@ public static class ReadEngine
         if (budget < 0) return;
         var leaf = EmitToken(val, declaredType, parent);
         if (leaf.HasValue) { Emit(sink, ref budget, new FieldValue(path, true, leaf.Token, null, FlagDisplay(leaf))); return; }
-        if (val is null) { Emit(sink, ref budget, new FieldValue(path, false, null, leaf.Note)); return; }
+        if (val is null) { Emit(sink, ref budget, new FieldValue(path, false, null, leaf.Note, Present: false)); return; }
         // a link (incl. a null FormKey, or an FLOI) is a note, not an openable container/substruct.
         if (val is IFormLinkGetter || WriteEngine.IsFormLinkOrIndex(Nullable.GetUnderlyingType(declaredType) ?? declaredType))
         { Emit(sink, ref budget, new FieldValue(path, false, null, leaf.Note)); return; }

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -400,7 +400,7 @@ public static class ReadEngine
         if (val is null) { Emit(sink, ref budget, new FieldValue(path, false, null, leaf.Note, Present: false)); return; }
         // a link (incl. a null FormKey, or an FLOI) is a note, not an openable container/substruct.
         if (val is IFormLinkGetter || WriteEngine.IsFormLinkOrIndex(Nullable.GetUnderlyingType(declaredType) ?? declaredType))
-        { Emit(sink, ref budget, new FieldValue(path, false, null, leaf.Note)); return; }
+        { Emit(sink, ref budget, new FieldValue(path, false, null, leaf.Note, Present: leaf.Present)); return; }
 
         // Classify dict-vs-list the SAME way the navigation does (StepIntoElement) — by the GENERIC dictionary
         // interfaces via ClosedInterface, not a separate non-generic System.Collections.IDictionary cast — so the
@@ -1096,7 +1096,12 @@ public static class ReadEngine
             count = n;
             return $"[{(isDict ? "dict" : "list")}: {n} {(isDict ? "pair(s)" : "item(s)")}]";
         }
-        return $"[{RecordNaming.StripGetterInterface(val.GetType().Name)}]";
+        // StripOverlay as well as StripGetterInterface, matching ElementSummary (review [medium]): a binary overlay
+        // loads WeaponBasicStatsBinaryOverlay for the same type a mutable record calls WeaponBasicStats, and this
+        // summary is what the in-place verify prints for a substruct leaf read off the WRITTEN FILE. Without it the
+        // response says "-> [WeaponBasicStats]" in its edit list and "[WeaponBasicStatsBinaryOverlay]" two lines
+        // below, which reads as two halves disagreeing, and leaks an implementation name into a user-facing line.
+        return $"[{RecordNaming.StripGetterInterface(RecordNaming.StripOverlay(val.GetType().Name))}]";
     }
 
     /// <summary>The modeled field names for the whole-record dump. Prefer the CORPUS — the authoritative

--- a/src/housecarl-core/SchemaClassifier.cs
+++ b/src/housecarl-core/SchemaClassifier.cs
@@ -116,7 +116,13 @@ public static class SchemaClassifier
     /// its plain-value Set, never re-routed to compose-only); and that <see cref="WriteEngine.IsPlainComposableStruct"/>
     /// can instantiate — which EXCLUDES the composition-residuals <c>GenderedItem&lt;T&gt;</c>/<c>Array2d&lt;T&gt;</c> (no
     /// parameterless ctor; BuildStruct would throw). The last two guards keep the accept in lock-step with what
-    /// <c>ApplyScalarVerb</c> req.Struct → <c>BuildStruct</c> can actually build (gate==apply). Gendered leaves never reach
+    /// <c>ApplyScalarVerb</c> req.Struct → <c>BuildStruct</c> can actually build (gate==apply — with ONE declared
+    /// exception since #308: a compose the caller gave NOTHING to, whose built object has no settable value at all, is
+    /// accepted here and refused at apply. It cannot be decided from the schema — emptiness is a property of the
+    /// INSTANCE, and the corpus models types — so the check lives where the object exists. The refusal is still
+    /// pre-serialize and all-or-nothing on every lane, so the guarantee the parity exists to protect (never
+    /// accept-then-throw mid-write) holds; what it costs is that the gate no longer predicts this one refusal).
+    /// Gendered leaves never reach
     /// the compose gate — <c>CorpusRulebook</c> diverts them to their [0]/[1] halves upstream. Corpus-derived, no per-type
     /// wiring (cornerstone): the set of composable substructs IS the set of modeled build-from-parts struct/arm types.</summary>
     public static bool IsComposableSubstructLeaf(FieldSchema f, Corpus corpus)

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -2089,10 +2089,14 @@ public static class WriteEngine
         // `Count: > 0` on ctor_args too (review [nit]): an EMPTY array is "the 0-arg ctor", not a supplied
         // discriminator, so reading it as one let the empty compose through the check it should meet.
         if (spec.CtorArgs is { Length: > 0 } || spec.Fields is { Count: > 0 } || spec.Sets is { Count: > 0 }) return null;
-        // Instance properties ONLY (review [nit]): the default flags include public STATICS, and one of those with a
-        // value would suppress the refusal entirely while being listed as something a compose could set.
+        // Instance, non-indexed properties ONLY, in a STABLE order (reviews): the default flags include public
+        // STATICS — one with a value would suppress the refusal entirely while being listed as something a compose
+        // could set — an INDEXER throws TargetParameterCountException in GetValue below, whose catch would bail the
+        // whole check out, and GetProperties' order is unspecified by the CLR, so the worked example could name a
+        // different field between runtimes.
         var settable = type.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
-                           .Where(p => p is { CanRead: true, CanWrite: true }).ToList();
+                           .Where(p => p is { CanRead: true, CanWrite: true } && p.GetIndexParameters().Length == 0)
+                           .OrderBy(p => p.Name, StringComparer.Ordinal).ToList();
         if (settable.Count == 0) return null;                      // nothing to advise; not this check's case
         foreach (var p in settable)
         {
@@ -2100,14 +2104,16 @@ public static class WriteEngine
             try { v = p.GetValue(instance); } catch { return null; }   // unreadable ⇒ can't claim emptiness (Q3)
             if (v is not null) return null;                        // it carries something — let the write proceed
         }
+        // Worded for ANY compose, not just a list Add (review [low]): BuildStruct also serves a polymorphic-arm Set
+        // and SetAtIndex, and a caller who hit this on `Set Archetype compose={…}` was given advice about a list.
         return $"compose type='{spec.Type}' was given no fields, and a {spec.Type} built from nothing has no " +
-               "serializable content: it would be added in memory and written as ZERO bytes, leaving the list " +
+               "serializable content: it would exist in memory and be written as ZERO bytes, so the field would be " +
                "unchanged on disk while the call reported success (#308). Name at least one field — e.g. " +
                $"compose={{\"type\":\"{spec.Type}\",\"fields\":{{\"{settable[0].Name}\":\"<value>\"}}}}. Settable " +
                $"fields on {spec.Type}: {string.Join(", ", settable.Select(p => p.Name))}. " +
-               "(This also refuses the two-step shape — add an empty element, then set its fields in a LATER op of " +
-               "the same call — which did work: the check runs as the element is built and cannot see the ops after " +
-               "it. Compose the element WITH its fields instead; one op, and it cannot half-land.)";
+               "(This also refuses the two-step shape — compose an empty value, then set its fields in a LATER op of " +
+               "the same call — which did work: the check runs as the value is built and cannot see the ops after " +
+               "it. Compose it WITH its fields instead; one op, and it cannot half-land.)";
     }
 
     /// <summary>Resolve a struct catalog name to its concrete settable type. Most modeled structs live in

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -2111,12 +2111,23 @@ public static class WriteEngine
             try { v = p.GetValue(instance); } catch { return null; }   // unreadable ⇒ can't claim emptiness (Q3)
             if (v is not null) return null;                        // it carries something — let the write proceed
         }
+        // The worked example is the line a caller COPIES, so it names a field they can actually pass as a string —
+        // a scalar, never plumbing (review [low]: the ordinal sort that made the choice deterministic also made it
+        // `FemaleTitle` for a Rank, where `Number` is the obvious field). The full list below is unchanged.
+        static bool IsSimple(Type t)
+        {
+            var u = Nullable.GetUnderlyingType(t) ?? t;
+            return u.IsPrimitive || u.IsEnum || u == typeof(string) || u == typeof(decimal);
+        }
+        var usable = settable.Where(p => !p.Name.StartsWith("Unknown", StringComparison.Ordinal)
+                                      && !p.Name.Equals("Versioning", StringComparison.Ordinal)).ToList();
+        var example = usable.FirstOrDefault(p => IsSimple(p.PropertyType)) ?? usable.FirstOrDefault() ?? settable[0];
         // Worded for ANY compose, not just a list Add (review [low]): BuildStruct also serves a polymorphic-arm Set
         // and SetAtIndex, and a caller who hit this on `Set Archetype compose={…}` was given advice about a list.
         return $"compose type='{spec.Type}' was given no fields, and a {spec.Type} built from nothing has no " +
                "serializable content: it would exist in memory and be written as ZERO bytes, so the field would be " +
                "unchanged on disk while the call reported success (#308). Name at least one field — e.g. " +
-               $"compose={{\"type\":\"{spec.Type}\",\"fields\":{{\"{settable[0].Name}\":\"<value>\"}}}}. Settable " +
+               $"compose={{\"type\":\"{spec.Type}\",\"fields\":{{\"{example.Name}\":\"<value>\"}}}}. Settable " +
                $"fields on {spec.Type}: {string.Join(", ", settable.Select(p => p.Name))}. " +
                "(This also refuses the two-step shape — compose an empty value, then set its fields in a LATER op of " +
                "the same call — which did work: the check runs as the value is built and cannot see the ops after " +

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -2082,8 +2082,11 @@ public static class WriteEngine
     /// it and it is not content. What is NOT an exemption, though an earlier draft of this paragraph said so: the
     /// TYPE itself. A polymorphic arm survives because Mutagen's arm types carry a non-nullable member, not because
     /// naming the arm counts as content — so an arm whose whole settable surface is nullable references WOULD be
-    /// refused here, with advice to name a field, when the type was the content (review [low]). No such arm is
-    /// modelled today; if one appears, that is the fix, not a wider exemption. The general case — a struct that serializes to less than the caller believes — is
+    /// refused here, with advice to name a field, when the type was the content (review [low]). I have NOT found such
+    /// an arm, and I have not proven there is none — that is an assertion about the whole modelled universe with no
+    /// probe behind it, in a codebase whose cornerstone is that coverage claims are derived (review [low], round 9).
+    /// The by-construction form is cheap and worth adding: an arm asserting every <see cref="IsPlainComposableStruct"/>
+    /// type carries at least one non-nullable settable property. Until then this paragraph is a bound, not a fact. The general case — a struct that serializes to less than the caller believes — is
     /// caught from the other end: <c>WritePatchBuilder.VerifyLandedAgainstFile</c> reports content that is GONE (a
     /// count that moved, a leaf that now holds nothing), which is where an unserializable struct usually lands — but
     /// NOT an element that lands with fewer fields than supplied, because that cannot be told from the format

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -2079,8 +2079,15 @@ public static class WriteEngine
     /// non-nullable member (an enum, a number, a struct) never trips it, because that member has a value and
     /// serializes; a ctor-arg or discriminator compose never trips it, because the caller supplied the discriminator;
     /// and read-only reflection surface (Loqui's <c>StaticRegistration</c>) is excluded, because a compose cannot set
-    /// it and it is not content. The general case — a struct that serializes to less than the caller believes — is
-    /// caught after the fact, and loudly, by <c>WritePatchBuilder.VerifyLandedAgainstFile</c>.</para>
+    /// it and it is not content. What is NOT an exemption, though an earlier draft of this paragraph said so: the
+    /// TYPE itself. A polymorphic arm survives because Mutagen's arm types carry a non-nullable member, not because
+    /// naming the arm counts as content — so an arm whose whole settable surface is nullable references WOULD be
+    /// refused here, with advice to name a field, when the type was the content (review [low]). No such arm is
+    /// modelled today; if one appears, that is the fix, not a wider exemption. The general case — a struct that serializes to less than the caller believes — is
+    /// caught from the other end: <c>WritePatchBuilder.VerifyLandedAgainstFile</c> reports content that is GONE (a
+    /// count that moved, a leaf that now holds nothing), which is where an unserializable struct usually lands — but
+    /// NOT an element that lands with fewer fields than supplied, because that cannot be told from the format
+    /// representing a value its own way. Claimed here as more than that until a review proved the probe inert.</para>
     ///
     /// <para>Names what to set from the TYPE itself (settable properties, reflection-derived), never a hand-kept list
     /// per struct — the same by-construction rule the rest of the write surface follows.</para></summary>

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -2064,7 +2064,42 @@ public static class WriteEngine
         }
         foreach (var req in spec.Sets ?? new())
             ApplyVerb(instance, req);     // general nested writes — reuse the verb engine; recurses on struct-element Adds
+        if (EmptyComposeRefusal(spec, type, instance) is { } why) throw new ExpectedApplyRejectionException(why);
         return instance;
+    }
+
+    /// <summary>#308 — refuse a compose the caller gave NOTHING to, whose built object carries nothing to serialize.
+    /// The reported case: <c>Add Ranks compose={"type":"Rank"}</c>. Mutagen builds the Rank, the list holds it, and
+    /// the writer emits ZERO bytes for it — so the plugin does not grow, every later read shows the list still empty,
+    /// and (before this) the write reported it as landed. Q3: a write that cannot land must be refused, not reported.
+    ///
+    /// <para>Deliberately NARROW, because "would this serialize?" is Mutagen's question and not one this engine can
+    /// answer in general. It fires only when the caller supplied literally nothing — no <c>fields</c>, no nested
+    /// <c>sets</c>, no <c>ctor_args</c> — AND every SETTABLE property of the built object is null. A type with a
+    /// non-nullable member (an enum, a number, a struct) never trips it, because that member has a value and
+    /// serializes; a ctor-arg or discriminator compose never trips it, because the caller supplied the discriminator;
+    /// and read-only reflection surface (Loqui's <c>StaticRegistration</c>) is excluded, because a compose cannot set
+    /// it and it is not content. The general case — a struct that serializes to less than the caller believes — is
+    /// caught after the fact, and loudly, by <c>WritePatchBuilder.VerifyLandedAgainstFile</c>.</para>
+    ///
+    /// <para>Names what to set from the TYPE itself (settable properties, reflection-derived), never a hand-kept list
+    /// per struct — the same by-construction rule the rest of the write surface follows.</para></summary>
+    static string? EmptyComposeRefusal(StructSpec spec, Type type, object instance)
+    {
+        if (spec.CtorArgs is not null || spec.Fields is { Count: > 0 } || spec.Sets is { Count: > 0 }) return null;
+        var settable = type.GetProperties().Where(p => p is { CanRead: true, CanWrite: true }).ToList();
+        if (settable.Count == 0) return null;                      // nothing to advise; not this check's case
+        foreach (var p in settable)
+        {
+            object? v;
+            try { v = p.GetValue(instance); } catch { return null; }   // unreadable ⇒ can't claim emptiness (Q3)
+            if (v is not null) return null;                        // it carries something — let the write proceed
+        }
+        return $"compose type='{spec.Type}' was given no fields, and a {spec.Type} built from nothing has no " +
+               "serializable content: it would be added in memory and written as ZERO bytes, leaving the list " +
+               "unchanged on disk while the call reported success (#308). Name at least one field — e.g. " +
+               $"compose={{\"type\":\"{spec.Type}\",\"fields\":{{\"{settable[0].Name}\":\"<value>\"}}}}. Settable " +
+               $"fields on {spec.Type}: {string.Join(", ", settable.Select(p => p.Name))}.";
     }
 
     /// <summary>Resolve a struct catalog name to its concrete settable type. Most modeled structs live in

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -2086,7 +2086,9 @@ public static class WriteEngine
     /// per struct — the same by-construction rule the rest of the write surface follows.</para></summary>
     static string? EmptyComposeRefusal(StructSpec spec, Type type, object instance)
     {
-        if (spec.CtorArgs is not null || spec.Fields is { Count: > 0 } || spec.Sets is { Count: > 0 }) return null;
+        // `Count: > 0` on ctor_args too (review [nit]): an EMPTY array is "the 0-arg ctor", not a supplied
+        // discriminator, so reading it as one let the empty compose through the check it should meet.
+        if (spec.CtorArgs is { Length: > 0 } || spec.Fields is { Count: > 0 } || spec.Sets is { Count: > 0 }) return null;
         var settable = type.GetProperties().Where(p => p is { CanRead: true, CanWrite: true }).ToList();
         if (settable.Count == 0) return null;                      // nothing to advise; not this check's case
         foreach (var p in settable)
@@ -2099,7 +2101,10 @@ public static class WriteEngine
                "serializable content: it would be added in memory and written as ZERO bytes, leaving the list " +
                "unchanged on disk while the call reported success (#308). Name at least one field — e.g. " +
                $"compose={{\"type\":\"{spec.Type}\",\"fields\":{{\"{settable[0].Name}\":\"<value>\"}}}}. Settable " +
-               $"fields on {spec.Type}: {string.Join(", ", settable.Select(p => p.Name))}.";
+               $"fields on {spec.Type}: {string.Join(", ", settable.Select(p => p.Name))}. " +
+               "(This also refuses the two-step shape — add an empty element, then set its fields in a LATER op of " +
+               "the same call — which did work: the check runs as the element is built and cannot see the ops after " +
+               "it. Compose the element WITH its fields instead; one op, and it cannot half-land.)";
     }
 
     /// <summary>Resolve a struct catalog name to its concrete settable type. Most modeled structs live in

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -2089,7 +2089,10 @@ public static class WriteEngine
         // `Count: > 0` on ctor_args too (review [nit]): an EMPTY array is "the 0-arg ctor", not a supplied
         // discriminator, so reading it as one let the empty compose through the check it should meet.
         if (spec.CtorArgs is { Length: > 0 } || spec.Fields is { Count: > 0 } || spec.Sets is { Count: > 0 }) return null;
-        var settable = type.GetProperties().Where(p => p is { CanRead: true, CanWrite: true }).ToList();
+        // Instance properties ONLY (review [nit]): the default flags include public STATICS, and one of those with a
+        // value would suppress the refusal entirely while being listed as something a compose could set.
+        var settable = type.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
+                           .Where(p => p is { CanRead: true, CanWrite: true }).ToList();
         if (settable.Count == 0) return null;                      // nothing to advise; not this check's case
         foreach (var p in settable)
         {

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -71,8 +71,8 @@ public static class WritePatchBuilder
     /// <para><see cref="After"/> and <see cref="Landed"/> are read from the IN-MEMORY record, during apply and BEFORE
     /// the serialize. That is not a defect — they are what the edit did — but it is the whole of #308: the in-place
     /// verify rendered them under a banner claiming every line was re-read off the written file, so a composed struct
-    /// that exists in memory and serializes to NOTHING was reported as landed. <see cref="LandedOnDisk"/> and
-    /// <see cref="Divergence"/> below are the file's own answer.</para></summary>
+    /// that exists in memory and serializes to NOTHING was reported as landed. <see cref="LandedOnDisk"/> below is
+    /// the file's own answer, and the render says which of the two a clause came from.</para></summary>
     public sealed record OpResult(FormKey Target, string RecordType, string Label, bool Applied, string? Error, string? After, string? Landed = null)
     {
         /// <summary>#308 — the same descriptor as <see cref="Landed"/>, re-derived from the record as it was RE-READ
@@ -82,13 +82,6 @@ public static class WritePatchBuilder
         /// applied edit's claim rather than the file's content, never silently substitute one for the other.</summary>
         public string? LandedOnDisk { get; init; }
 
-        /// <summary>#308 — set when the edited leaf's in-memory state and the WRITTEN FILE's state disagree: the write
-        /// reported success and the file does not corroborate what the op claims to have put there. The canonical case
-        /// is a modeled struct with no serializable content (a Faction <c>Rank</c> composed with no fields): the list
-        /// holds one element in memory and zero on disk, the plugin does not grow, and every later read shows it
-        /// empty. Q3: the forced in-place verify exists to catch exactly this, so it is stated loudly rather than left
-        /// to a caller to notice. Null = checked and consistent, or not checkable (see <see cref="LandedOnDisk"/>).</summary>
-        public string? Divergence { get; init; }
 
         /// <summary>#308 — a LATER op in the same call wrote into this op's leaf, so the written file cannot answer
         /// for this one: <see cref="After"/>/<see cref="Landed"/> were read the instant it applied, and the file holds
@@ -104,30 +97,6 @@ public static class WritePatchBuilder
         /// synced marker reported as unanswered rather than unchecked.</summary>
         public bool VerifyAttempted { get; init; }
 
-        /// <summary>#308 — what the edited leaf HELD in memory when <see cref="After"/> was read: a value, a present
-        /// container/substruct (with its element count), or nothing. The presence half of the comparison, carried
-        /// structurally because a value, a container summary, a substruct summary and an absent leaf differ only in
-        /// display text — deciding "the file carries nothing there" from that text keys a Q3 verdict on wording, and
-        /// did miss real cases twice (an absent leaf reads "(absent)", never the empty string the first rule looked
-        /// for; a vanished SUBSTRUCT reads "[Rank]" in memory, which no count parser recognises).</summary>
-        public LeafPresence AfterPresence { get; init; }
-    }
-
-    /// <summary>#308 — what a leaf HOLDS, structurally, as the reader reported it: a value, a present
-    /// container/substruct (with its element count where it has one), or nothing at all. The three render as a token
-    /// or a parenthesised note and are not tellable apart from that text, which is why the write verify carries this
-    /// instead of parsing prose — it missed a vanished scalar and then a vanished substruct doing the latter.</summary>
-    /// <param name="HasValue">The leaf holds a scalar/link VALUE.</param>
-    /// <param name="Present">Something is there — a value, or a container/substruct that exists.</param>
-    /// <param name="Count">Elements, for a container leaf (0 = present but EMPTY); null for a value or a substruct.</param>
-    /// <param name="Readable">False when the read FAILED rather than found nothing — "I could not look" is not
-    /// evidence of absence, and treating it as such told a caller a correct write was lost (review [low]).</param>
-    public readonly record struct LeafPresence(bool HasValue, bool Present, int? Count, bool Readable = true)
-    {
-        /// <summary>Is there CONTENT? A value, a non-empty container, or a present substruct. An EMPTY container is
-        /// deliberately not content: an emptied list and a dropped subrecord say the same thing, so a call that
-        /// legitimately cleared a list must not be told its write vanished.</summary>
-        public bool HasContent => HasValue || (Present && (Count is null || Count > 0));
     }
 
     /// <summary>One record read back IN FULL from the WRITTEN patch file (opt-in — the pre-enable verify loop,
@@ -580,8 +549,8 @@ public static class WritePatchBuilder
                     WriteEngine.CopyField(srcBody!, ov, req.Path);
                 else
                     WriteEngine.ApplyVerb(ov, req);
-                var (after, landed, presence) = DescribeApplied(ov, req);
-                ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, after, landed) { AfterPresence = presence });
+                var (after, landed, _) = DescribeApplied(ov, req);
+                ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, after, landed));
             }
             catch (ExpectedApplyRejectionException ex)
             {
@@ -987,8 +956,8 @@ public static class WritePatchBuilder
                         ov, req.Path);
                 else
                     WriteEngine.ApplyVerb(ov, req);
-                var (after, landed, presence) = DescribeApplied(ov, req);
-                ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, after, landed) { AfterPresence = presence });
+                var (after, landed, _) = DescribeApplied(ov, req);
+                ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, after, landed));
             }
             catch (ExpectedApplyRejectionException ex)
             {
@@ -3406,7 +3375,7 @@ public static class WritePatchBuilder
             // then reaches for — re-issue the op — is the duplicate-Add trap this codebase already warns about.
             // The file has ONE final state, so only the LAST op touching a leaf is answerable by it.
             if (LaterOpTouchesSameLeaf(perOp, i)) { verified.Add(op with { SupersededInCall = true, VerifyAttempted = true }); continue; }
-            var (afterDisk, landedDisk, diskPresence) = DescribeApplied(rec, perOp[i].Req);
+            var (_, landedDisk, diskReadable) = DescribeApplied(rec, perOp[i].Req);
             // ONE comparison, on the leaf. An earlier round added a second pass over `Landed` (the touched ELEMENT) to
             // catch a struct that lands but serializes with fewer fields than supplied — and a later review proved it
             // INERT (review [medium]): `Landed` differs from `After` only for a container leaf, and for a container
@@ -3422,8 +3391,10 @@ public static class WritePatchBuilder
                 // text printed as the file's content. Leaving it null routes it to the state that already exists for
                 // this: attempted, no answer. The comparator meanwhile stays silent on it, which is correct and is
                 // why nothing else caught it.
-                LandedOnDisk = diskPresence.Readable ? landedDisk : null,
-                Divergence = LeafDivergence(op.After, op.AfterPresence, afterDisk, diskPresence),
+                // A file side that could NOT BE READ is not the file's answer: DescribeApplied hands back the note
+                // ("(unreadable: …)"), which is non-null, so presenting it would print a read failure as the file's
+                // content. Null routes it to the label that says the clause is the applied edit's own reading.
+                LandedOnDisk = diskReadable ? landedDisk : null,
                 VerifyAttempted = true,
             });
         }
@@ -3494,59 +3465,14 @@ public static class WritePatchBuilder
         }
     }
 
-    /// <summary>#308's comparator: does the WRITTEN FILE fail to carry what the applied edit put there? Null = it
-    /// carries it, or there is nothing to compare (either side unreadable — an absent answer is never evidence).
-    ///
-    /// <para>DELIBERATELY NOT "the two tokens differ" (review [high], reproduced): a difference in TEXT is not a lost
-    /// write. <c>Percent</c> is byte-quantised on serialize, so a routine <c>Set ChanceNone value="0.123"</c> reads
-    /// back <c>0.12</c> off the file — correct, and the format's own resolution. Calling that "NOT landed" tells the
-    /// caller to re-issue an op that will diverge identically every time, which is the same wrong-answer class this
-    /// detector exists to close, pointed the other way. Any lossy or normalising serialize (floats, colors, string
-    /// forms) is the same story.</para>
-    ///
-    /// <para>What IS evidence, and all this claims: the content is GONE. Two shapes carry that — a container whose
-    /// count moved (the #308 case: a composed struct that serialized to nothing, so the list is shorter on disk than
-    /// in memory), and a leaf that held something in memory and holds NOTHING in the file. Everything else is
-    /// reported by the ordinary clause, which prints the file's own reading anyway, so a caller who cares about the
-    /// exact value can see both without being told a correct write failed.</para></summary>
-    internal static string? LeafDivergence(string? inMemory, LeafPresence memory, string? onDisk, LeafPresence disk)
-    {
-        if (inMemory is null || onDisk is null) return null;
-        // An UNREADABLE side is not evidence either — which is what this method's own doc has always said, while the
-        // code counted it as absence (review [low]): a leaf whose read threw, or a field the type does not have,
-        // reads valueless and would have produced "a lost write … check it in xEdit".
-        if (!memory.Readable || !disk.Readable) return null;
-        if (string.Equals(inMemory, onDisk, StringComparison.Ordinal)) return null;
-        if (memory.Count is { } memCount && disk.Count is { } diskCount)
-            return memCount == diskCount
-                ? null                                     // same count, different summary text — not a content claim
-                : $"the applied edit left {memCount} element(s) in memory, but the WRITTEN FILE carries {diskCount}";
-        // The shape that is still evidence, judged on PRESENCE and never on a note's wording: the leaf held CONTENT in
-        // memory and holds none in the file. Content = a value, or a container with at least one element — so a
-        // nullable list whose subrecord never got written (it reads "(absent)", not "[list: 0 item(s)]", which is why
-        // the count arm above cannot see it) is caught, while a list the call legitimately EMPTIED is not, since an
-        // emptied list and a dropped subrecord say the same thing. An absent leaf reads "(absent)", never "", which is
-        // why an empty-string test found nothing and reported such a write "verified" (review [high], twice).
-        if (memory.HasContent && !disk.HasContent)
-            // Qualified, because ONE other thing reads a field as valueless — a localized plugin whose strings this
-            // session cannot resolve — and a caller who re-issues on that reading gets the same read forever.
-            return "the applied edit read back '" + inMemory + "', but the WRITTEN FILE carries no value there "
-                 + $"(it reads {onDisk}) — a lost write, or, on a LOCALIZED plugin whose strings this session cannot "
-                 + "resolve, a field houseCARL cannot read back; check it in xEdit before re-issuing";
-        return null;
-    }
-
-    static (string? After, string? Landed, LeafPresence Presence) DescribeApplied(IMajorRecordGetter ov, WriteRequest req)
+    static (string? After, string? Landed, bool Readable) DescribeApplied(IMajorRecordGetter ov, WriteRequest req)
     {
         try
         {
             var leaf = string.Join('.', req.Path);
             var read = ReadEngine.ReadFields(ov, new[] { leaf }, containerHint: null);   // same: no depth= on the write surface, don't hint it
             var f = read.Fields.FirstOrDefault(x => x.Path == leaf) ?? read.Fields.FirstOrDefault();
-            // `default` is deliberate and load-bearing: it gives Readable=false ("could not look"), NOT the
-            // primary constructor's Readable=true. Writing `new LeafPresence(false, false, null)` here would silently
-            // turn an unreadable memory side into "content vanished" (review [nit]).
-            if (f is null) return (null, null, default);
+            if (f is null) return (null, null, false);
             var after = f.HasValue ? f.Token : f.Note;
             // Scalar: Landed reuses the token just read. List/dict: name the touched element (+ new count); else the
             // summary. An Add carries how many elements it appended (composes= → Structs.Count, else 1) so a batch
@@ -3556,8 +3482,8 @@ public static class WritePatchBuilder
             // The presence PAIR rides along because it is the structural fact the tokens hide: a container summary, a
             // substruct summary and an ABSENT leaf all render as notes, and the divergence detector must not read
             // prose to decide whether anything is there.
-            return (after, landed, new LeafPresence(f.HasValue, f.Present, f.Count, f.Readable));
+            return (after, landed, f.Readable);
         }
-        catch { return (null, null, default); }   // default => Readable:false — see the note above
+        catch { return (null, null, false); }
     }
 }

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -1089,7 +1089,14 @@ public static class WritePatchBuilder
             // A pass that THREW is not "this lane ran no file check" (review [low]) — the verify ran and produced no
             // answer, which is the state that says so. Under-reporting a failed verification as an absent one is the
             // quieter half of the same wrong-answer class.
-            catch { reported = ops.Select(o => o with { VerifyAttempted = true }).ToList(); }
+            // Only the ops the pass would have ASKED about (review [nit]): the SNAM-sync ops appended past the
+            // resolved edits were never candidates, and marking them attempted made them claim the file was re-opened
+            // and could not answer for them — the state their own doc calls a claim about a read that did not happen.
+            catch
+            {
+                int asked = resolved.Count;
+                reported = ops.Select((o, k) => k < asked ? o with { VerifyAttempted = true } : o).ToList();
+            }
         }
         catch (Exception ex)
             { return PatchOutcome.Fail($"'{fileName}' was edited in place but could not be re-opened to verify: {ex.Message}"); }
@@ -3370,7 +3377,7 @@ public static class WritePatchBuilder
     /// through it would entangle this with its careful per-record error accounting — and because the walk is lazy
     /// header parsing over a file the call has just fully re-serialized, which dominates it. Worth merging if a
     /// large in-place target ever measures badly; not worth entangling on argument alone.</para></summary>
-    static IReadOnlyList<OpResult> VerifyLandedAgainstFile(
+    internal static IReadOnlyList<OpResult> VerifyLandedAgainstFile(   // internal: wire-pinned by apply-guard arm 8
         ISkyrimModGetter back, IReadOnlyList<(FormKey Target, WriteRequest Req)> perOp, IReadOnlyList<OpResult> ops)
     {
         if (ops.Count == 0) return ops;

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -240,7 +240,17 @@ public static class WritePatchBuilder
     /// original create — discarded and rebuilt from this call's spec. MUST be surfaced to the user (Q3 — a replace
     /// is never silent).</summary>
     public sealed record CreatedRecord(FormKey FormKey, string RecordType, string EditorId, IReadOnlyList<OpResult> Ops,
-        bool ReplacedExisting = false);
+        bool ReplacedExisting = false)
+    {
+        /// <summary>#300 — for a NESTED create under an EXISTING load-order parent: which record was overridden into
+        /// the artifact to host this child, and WHOSE version of it was copied. Null for a flat create, a same-call
+        /// sibling parent, and a parent the destination already carried (nothing was chosen in those cases).
+        /// <para>Reported because the choice is invisible afterwards and it is not the obvious one: the host is the
+        /// parent's DEFINING plugin's version, deliberately not the load-order winner's — see the parent-resolution
+        /// comment in <see cref="CreateRecords"/>. When the definer cannot answer (an injected parent, an excluded
+        /// plugin) the winner IS used, and this says so rather than letting the two cases look alike.</para></summary>
+        public string? ParentHost { get; init; }
+    }
 
     /// <summary>The outcome of a <see cref="CreateRecords"/> call. <see cref="Error"/> non-null ⇒ the whole call was
     /// refused (no file written) with a named, recoverable reason (Q3 — missing editorid, an un-createable type, a rejected
@@ -2717,6 +2727,9 @@ public static class WritePatchBuilder
         // LATER sibling still rejects loud.
         var priorEditorIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var parentPlans = new List<(IMajorRecordGetter? body, string? winnerPlugin, string? sibling, IMajorRecord? patchParent)?>(specs.Count);
+        // #300 — per-spec provenance of the parent override this create had to host the child in. Reported (Q3): which
+        // plugin's version was copied is a decision the caller did not make and cannot see in the record afterwards.
+        var parentHosts = new string?[specs.Count];
         var cellKinds = new CellCreate[specs.Count];   // coordinate-keyed §4-(b) routing per spec (None / Exterior / Interior)
         for (int i = 0; i < specs.Count; i++)
         {
@@ -2759,10 +2772,29 @@ public static class WritePatchBuilder
                         // in Phase 3. In place, this is the FOREIGN-parent case — the parent the target doesn't own — and
                         // overriding it in to host the child is exactly what the patch lane does into a new patch (correct,
                         // necessary nesting, NOT injection: the user explicitly named the parent; the override is reported).
-                        var parentBody = view.GetRecord(session, w.WinnerPlugin, parentFk);
+                        //
+                        // #300 — the version copied in is the parent's DEFINING plugin's, not its load-order WINNER's. The
+                        // override exists to HOST the child: a child lives in the parent's child GROUP and survives the
+                        // parent record losing, so nothing about the child needs the winner's fields. Taking them cost a
+                        // master the child never needed AND froze a snapshot of another mod's content — so a patch sorted
+                        // below that mod silently re-asserted its OLD values after it updated (the Q3 half of the report).
+                        // The definer's version is the leanest host that still carries a valid record.
+                        // An INJECTED parent (a FormKey in a master's ModKey but defined by a mod) is why the winner
+                        // remains a fallback rather than a refusal: the definer genuinely does not carry it. Same for a
+                        // definer this session EXCLUDED. Both are reported per record, never silently substituted.
+                        var definer = parentFk.ModKey.FileName.String;
+                        var fromDefiner = view.ContainsPlugin(definer) && !view.ExcludedPlugins.ContainsKey(definer)
+                            ? view.GetRecord(session, definer, parentFk) : null;
+                        var parentBody = fromDefiner ?? view.GetRecord(session, w.WinnerPlugin, parentFk);
                         if (parentBody is null) { problems.Add($"{s.RecordType} '{s.EditorId}': parent {parentFk} winner '{w.WinnerPlugin}' did not yield it on fetch (a load-order inconsistency)."); continue; }
+                        var readFrom = fromDefiner is not null ? definer : w.WinnerPlugin;
                         parentType = WriteEngine.ResolveConcreteRecordType(RecordNaming.StripOverlay(parentBody.GetType().Name));
-                        parentPlans[i] = (parentBody, w.WinnerPlugin, null, null);
+                        parentPlans[i] = (parentBody, readFrom, null, null);
+                        parentHosts[i] = $"{RecordNaming.StripOverlay(parentBody.GetType().Name)} {parentFk} hosted from '{readFrom}'"
+                            + (fromDefiner is not null
+                                ? " (its DEFINING plugin — the lean host; the load-order winner"
+                                  + (string.Equals(readFrom, w.WinnerPlugin, StringComparison.OrdinalIgnoreCase) ? " is this same plugin)" : $" '{w.WinnerPlugin}' is deliberately NOT copied, and is not a master of this write)")
+                                : $" (the load-order WINNER — its defining plugin '{definer}' does not carry it: an injected or excluded parent)");
                     }
                     else if (patchMod.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == parentFk) is { } patchParent)
                     {
@@ -2994,7 +3026,7 @@ public static class WritePatchBuilder
                 foreach (var fill in DialogueCkParity.ApplyQuestDefaults(questRec))
                     ops.Add(new OpResult(rec.FormKey, s.RecordType, fill.Label, true, null, fill.Reason));
             }
-            created.Add(new CreatedRecord(rec.FormKey, s.RecordType, s.EditorId, ops, replaced));
+            created.Add(new CreatedRecord(rec.FormKey, s.RecordType, s.EditorId, ops, replaced) { ParentHost = parentHosts[i] });
         }
 
         // --- Phase 4: serialize ONCE with the full known-master set. A created record referencing existing content pulls

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -96,6 +96,13 @@ public static class WritePatchBuilder
         /// covers the leaf's final state — but the two are not comparable, and comparing them reported a correct
         /// multi-op write (two Adds to one list; a value set then corrected) as NOT landed.</summary>
         public bool SupersededInCall { get; init; }
+
+        /// <summary>#308 — the file-verify actually examined this op. False means it was never asked: a lane that runs
+        /// no verify (patch, dry run), or an op APPENDED after the resolved edits (the SNAM topic-marker sync), which
+        /// has no request to re-read. Without it a renderer has to infer the state from the lane and gets it wrong in
+        /// both directions — an in-place dry run claiming a file was re-opened and could not answer (review), and a
+        /// synced marker reported as unanswered rather than unchecked.</summary>
+        public bool VerifyAttempted { get; init; }
     }
 
     /// <summary>One record read back IN FULL from the WRITTEN patch file (opt-in — the pre-enable verify loop,
@@ -249,9 +256,10 @@ public static class WritePatchBuilder
     public sealed record CreatedRecord(FormKey FormKey, string RecordType, string EditorId, IReadOnlyList<OpResult> Ops,
         bool ReplacedExisting = false)
     {
-        /// <summary>#300 — for a NESTED create under an EXISTING load-order parent: which record was overridden into
-        /// the artifact to host this child, and WHOSE version of it was copied. Null for a flat create, a same-call
-        /// sibling parent, and a parent the destination already carried (nothing was chosen in those cases).
+        /// <summary>#300 — for a NESTED create: which record hosts this child in the artifact, and WHOSE version of
+        /// it was copied in (when one was). Null for a flat create and for a same-call sibling parent — there the
+        /// host is this call's own new record and nothing was chosen. A parent the destination ALREADY carried says
+        /// so rather than reporting null, since "nothing was copied" is itself the fact worth stating.
         /// <para>Reported because the choice is invisible afterwards and it is not the obvious one: the host is the
         /// parent's DEFINING plugin's version, deliberately not the load-order winner's — see the parent-resolution
         /// comment in <see cref="CreateRecords"/>. When the definer cannot answer (an injected parent, an excluded
@@ -2742,6 +2750,15 @@ public static class WritePatchBuilder
         // #300 — per-spec provenance of the parent override this create had to host the child in. Reported (Q3): which
         // plugin's version was copied is a decision the caller did not make and cannot see in the record afterwards.
         var parentHosts = new string?[specs.Count];
+        // The destination's own records, indexed ONCE (review [low]): the "does the artifact already carry this
+        // parent?" probe runs per parented spec, and enumerating the whole patch each time is O(specs x records) on a
+        // bulk_create into a large into= patch. Lazy — a call with no parented spec builds nothing.
+        Dictionary<FormKey, IMajorRecord>? carried = null;
+        IMajorRecord? AlreadyCarried(FormKey fk)
+        {
+            carried ??= patchMod.EnumerateMajorRecords().GroupBy(r => r.FormKey).ToDictionary(g => g.Key, g => g.First());
+            return carried.TryGetValue(fk, out var rec) ? rec : null;
+        }
         var cellKinds = new CellCreate[specs.Count];   // coordinate-keyed §4-(b) routing per spec (None / Exterior / Interior)
         for (int i = 0; i < specs.Count; i++)
         {
@@ -2777,8 +2794,9 @@ public static class WritePatchBuilder
                     {
                         parentType = WriteEngine.ResolveConcreteRecordType(RecordNaming.StripOverlay(ownParent.GetType().Name));
                         parentPlans[i] = (null, null, null, ownParent);
+                        parentHosts[i] = $"{RecordNaming.StripOverlay(ownParent.GetType().Name)} {parentFk} is the target plugin's OWN record — it hosts the child directly (nothing copied in, no master added)";
                     }
-                    else if (patchMod.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == parentFk) is { } already)
+                    else if (AlreadyCarried(parentFk) is { } already)
                     {
                         // The DESTINATION already carries this parent — a prior into= call created it (the former N9
                         // gap, resolvable because Phase 0 opens the patch BEFORE this loop), forwarded it, or edited
@@ -3281,10 +3299,12 @@ public static class WritePatchBuilder
     /// null — the renderer then says the clause is the applied edit's claim, which is the honest reading and the one
     /// the old banner silently skipped.</para>
     ///
-    /// <para>Its own enumeration pass, deliberately: <see cref="ReadBackInFull"/> materialises RecordFields and hands
-    /// back values, and threading a second output through it to save one lazy header walk of ONE already-open file —
-    /// on a lane that has just re-serialized that whole file — would buy nothing and cost the read-back's careful
-    /// per-record error accounting.</para></summary>
+    /// <para>Its own enumeration pass, and the cost is real rather than nil (review [low]): on the in-place lane the
+    /// read-back is forced, so a write now walks the re-opened file TWICE. Kept separate because
+    /// <see cref="ReadBackInFull"/> materialises RecordFields and hands back values — threading a second output
+    /// through it would entangle this with its careful per-record error accounting — and because the walk is lazy
+    /// header parsing over a file the call has just fully re-serialized, which dominates it. Worth merging if a
+    /// large in-place target ever measures badly; not worth entangling on argument alone.</para></summary>
     static IReadOnlyList<OpResult> VerifyLandedAgainstFile(
         ISkyrimModGetter back, IReadOnlyList<(FormKey Target, WriteRequest Req)> perOp, IReadOnlyList<OpResult> ops)
     {
@@ -3302,14 +3322,15 @@ public static class WritePatchBuilder
         for (int i = 0; i < ops.Count; i++)
         {
             var op = ops[i];
-            if (i >= perOp.Count || !found.TryGetValue(perOp[i].Target, out var rec)) { verified.Add(op); continue; }
+            if (i >= perOp.Count) { verified.Add(op); continue; }                       // appended past the edits — never asked
+            if (!found.TryGetValue(perOp[i].Target, out var rec)) { verified.Add(op with { VerifyAttempted = true }); continue; }
             // SUPERSEDED ops are not comparable, and comparing them was a false alarm (review [high], reproduced):
             // `After`/`Landed` are read the instant op i applies — mid-sequence — while the file holds the state after
             // ALL of them. Two ops on one leaf (two Adds to one list; a value set then corrected) therefore always
             // "disagreed", and the response told the caller to treat a landed op as NOT landed. The remedy an agent
             // then reaches for — re-issue the op — is the duplicate-Add trap this codebase already warns about.
             // The file has ONE final state, so only the LAST op touching a leaf is answerable by it.
-            if (LaterOpTouchesSameLeaf(perOp, i)) { verified.Add(op with { SupersededInCall = true }); continue; }
+            if (LaterOpTouchesSameLeaf(perOp, i)) { verified.Add(op with { SupersededInCall = true, VerifyAttempted = true }); continue; }
             var (afterDisk, landedDisk) = DescribeApplied(rec, perOp[i].Req);
             // BOTH descriptors, not just the leaf summary (review [medium]): `After` is the container
             // (`[list: N item(s)]`), `Landed` is the touched ELEMENT. A struct that lands as an element but serializes
@@ -3320,6 +3341,7 @@ public static class WritePatchBuilder
             {
                 LandedOnDisk = landedDisk,
                 Divergence = LeafDivergence(op.After, afterDisk) ?? LeafDivergence(op.Landed, landedDisk),
+                VerifyAttempted = true,
             });
         }
         return verified;
@@ -3344,25 +3366,41 @@ public static class WritePatchBuilder
     /// suffix stripped? Equal paths count (a prefix of itself).</summary>
     static bool PathFamiliesOverlap(string[] a, string[] b)
     {
+        if (a.Length == 0 || b.Length == 0) return false;   // no leaf to share; a 0-segment path would otherwise
+                                                           // "overlap" everything and silently drop the verify
         int n = Math.Min(a.Length, b.Length);
         for (int k = 0; k < n; k++)
-            if (!string.Equals(BareSegment(a[k]), BareSegment(b[k]), StringComparison.OrdinalIgnoreCase)) return false;
+            if (!SameSegment(a[k], b[k])) return false;
         return true;
 
-        static string BareSegment(string s)
+        // Two segments that BOTH carry an index/key are compared whole, so Ranks[0] and Ranks[1] stay independent
+        // elements and each keeps its own file verification (review [low]); the suffix is stripped only when one side
+        // names the container itself, which is what makes Ranks[0].Number recognisably a write inside Ranks.
+        static bool SameSegment(string x, string y)
         {
-            int bracket = s.IndexOf('[');
-            return bracket < 0 ? s : s[..bracket];
+            int bx = x.IndexOf('['), by = y.IndexOf('[');
+            return bx >= 0 && by >= 0
+                ? string.Equals(x, y, StringComparison.OrdinalIgnoreCase)
+                : string.Equals(Bare(x), Bare(y), StringComparison.OrdinalIgnoreCase);
+            static string Bare(string s) { int b = s.IndexOf('['); return b < 0 ? s : s[..b]; }
         }
     }
 
-    /// <summary>#308's comparator: does the edited leaf's in-memory state disagree with the WRITTEN FILE's? Null =
-    /// they agree, or there is nothing to compare (either side unreadable — an absent answer is never evidence of a
-    /// divergence). Both sides come from one read path, so equal content compares equal.
-    /// <para>Counts are compared as COUNTS when both sides are container summaries — the class this exists for moves a
-    /// count, and "[list: 1 item(s)]" vs "[list: 0 item(s)]" is a clearer sentence as "1 in memory, 0 in the file".
-    /// Everything else is compared as text and reported as the two readings, not as an accusation about which is
-    /// right: the file is what the game loads, and that is what the wording says.</para></summary>
+    /// <summary>#308's comparator: does the WRITTEN FILE fail to carry what the applied edit put there? Null = it
+    /// carries it, or there is nothing to compare (either side unreadable — an absent answer is never evidence).
+    ///
+    /// <para>DELIBERATELY NOT "the two tokens differ" (review [high], reproduced): a difference in TEXT is not a lost
+    /// write. <c>Percent</c> is byte-quantised on serialize, so a routine <c>Set ChanceNone value="0.123"</c> reads
+    /// back <c>0.12</c> off the file — correct, and the format's own resolution. Calling that "NOT landed" tells the
+    /// caller to re-issue an op that will diverge identically every time, which is the same wrong-answer class this
+    /// detector exists to close, pointed the other way. Any lossy or normalising serialize (floats, colors, string
+    /// forms) is the same story.</para>
+    ///
+    /// <para>What IS evidence, and all this claims: the content is GONE. Two shapes carry that — a container whose
+    /// count moved (the #308 case: a composed struct that serialized to nothing, so the list is shorter on disk than
+    /// in memory), and a leaf that held something in memory and holds NOTHING in the file. Everything else is
+    /// reported by the ordinary clause, which prints the file's own reading anyway, so a caller who cares about the
+    /// exact value can see both without being told a correct write failed.</para></summary>
     internal static string? LeafDivergence(string? inMemory, string? onDisk)   // internal: unit-pinned by apply-guard arm 6
     {
         if (inMemory is null || onDisk is null) return null;
@@ -3371,7 +3409,14 @@ public static class WritePatchBuilder
             return mem == disk
                 ? null                                     // same count, different summary text — not a content claim
                 : $"the applied edit left {mem} element(s) in memory, but the WRITTEN FILE carries {disk}";
-        return $"the applied edit read back '{inMemory}', but the WRITTEN FILE carries '{onDisk}'";
+        if (inMemory.Trim().Length > 0 && onDisk.Trim().Length == 0)
+            // The one scalar shape that is still evidence: something became nothing. Qualified, because ONE other
+            // thing reads a field as empty — a localized plugin whose strings this session cannot resolve — and a
+            // caller who re-issues on that reading gets the same empty read forever.
+            return "the applied edit read back '" + inMemory + "', but the WRITTEN FILE carries nothing there "
+                 + "(a lost write — or, on a LOCALIZED plugin whose strings this session cannot resolve, a field "
+                 + "houseCARL cannot read back; check it in xEdit before re-issuing)";
+        return null;
     }
 
     /// <summary>The element count out of a container summary token (<c>[list: N item(s)]</c>, <c>[dict: N …]</c>);

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -3369,7 +3369,10 @@ public static class WritePatchBuilder
         try
         {
             foreach (var rec in back.EnumerateMajorRecords())
+            {
                 if (want.Contains(rec.FormKey) && !found.ContainsKey(rec.FormKey)) found[rec.FormKey] = rec;
+                if (found.Count == want.Count) break;    // every target in hand — the rest of the file is not ours
+            }
         }
         catch { /* leave every op unverified — the render says so, and ReadBackInFull names the walk failure itself */ }
 
@@ -3517,6 +3520,9 @@ public static class WritePatchBuilder
             var leaf = string.Join('.', req.Path);
             var read = ReadEngine.ReadFields(ov, new[] { leaf }, containerHint: null);   // same: no depth= on the write surface, don't hint it
             var f = read.Fields.FirstOrDefault(x => x.Path == leaf) ?? read.Fields.FirstOrDefault();
+            // `default` is deliberate and load-bearing: it gives Readable=false ("could not look"), NOT the
+            // primary constructor's Readable=true. Writing `new LeafPresence(false, false, null)` here would silently
+            // turn an unreadable memory side into "content vanished" (review [nit]).
             if (f is null) return (null, null, default);
             var after = f.HasValue ? f.Token : f.Note;
             // Scalar: Landed reuses the token just read. List/dict: name the touched element (+ new count); else the
@@ -3529,6 +3535,6 @@ public static class WritePatchBuilder
             // prose to decide whether anything is there.
             return (after, landed, new LeafPresence(f.HasValue, f.Present, f.Count, f.Readable));
         }
-        catch { return (null, null, default); }
+        catch { return (null, null, default); }   // default => Readable:false — see the note above
     }
 }

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -3412,8 +3412,16 @@ public static class WritePatchBuilder
     static bool LaterOpTouchesSameLeaf(IReadOnlyList<(FormKey Target, WriteRequest Req)> perOp, int i)
     {
         for (int j = i + 1; j < perOp.Count; j++)
-            if (perOp[j].Target == perOp[i].Target && PathFamiliesOverlap(perOp[i].Req.Path, perOp[j].Req.Path))
-                return true;
+        {
+            if (perOp[j].Target != perOp[i].Target || !PathFamiliesOverlap(perOp[i].Req.Path, perOp[j].Req.Path)) continue;
+            // A key-addressed pair on ONE path is two different elements (review [low]): SetAtIndex Ranks key=0 and
+            // key=1 — or a dict Set on key A then key B — carry the container as Path and the element in Key, so the
+            // bracketed rule above cannot tell them apart and the earlier op was marked superseded by an op that
+            // never touched it (losing its verification, and saying so untruthfully). Different keys = independent.
+            if (perOp[i].Req.Key is { } a && perOp[j].Req.Key is { } b
+                && !string.Equals(a, b, StringComparison.OrdinalIgnoreCase)) continue;
+            return true;
+        }
         return false;
     }
 

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -120,7 +120,9 @@ public static class WritePatchBuilder
     /// <param name="HasValue">The leaf holds a scalar/link VALUE.</param>
     /// <param name="Present">Something is there — a value, or a container/substruct that exists.</param>
     /// <param name="Count">Elements, for a container leaf (0 = present but EMPTY); null for a value or a substruct.</param>
-    public readonly record struct LeafPresence(bool HasValue, bool Present, int? Count)
+    /// <param name="Readable">False when the read FAILED rather than found nothing — "I could not look" is not
+    /// evidence of absence, and treating it as such told a caller a correct write was lost (review [low]).</param>
+    public readonly record struct LeafPresence(bool HasValue, bool Present, int? Count, bool Readable = true)
     {
         /// <summary>Is there CONTENT? A value, a non-empty container, or a present substruct. An EMPTY container is
         /// deliberately not content: an emptied list and a dropped subrecord say the same thing, so a call that
@@ -2776,7 +2778,7 @@ public static class WritePatchBuilder
         // createdByEditorId before applying its edits, so the substitution timing already holds). A forward-ref to a
         // LATER sibling still rejects loud.
         var priorEditorIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var parentPlans = new List<(IMajorRecordGetter? body, string? winnerPlugin, string? sibling, IMajorRecord? patchParent)?>(specs.Count);
+        var parentPlans = new List<(IMajorRecordGetter? body, string? sourcePlugin, string? sibling, IMajorRecord? patchParent)?>(specs.Count);
         // #300 — per-spec provenance of the parent override this create had to host the child in. Reported (Q3): which
         // plugin's version was copied is a decision the caller did not make and cannot see in the record afterwards.
         var parentHosts = new string?[specs.Count];
@@ -2974,8 +2976,8 @@ public static class WritePatchBuilder
                 Mutagen.Bethesda.Plugins.Cache.ILinkCache? cache = null;
                 if (WriteEngine.RecordNeedsSourceCache(plan.body))
                 {
-                    if (!linkCacheByPlugin.TryGetValue(plan.winnerPlugin!, out cache))
-                        linkCacheByPlugin[plan.winnerPlugin!] = (cache = session.LinkCacheFor(plan.winnerPlugin!))!;
+                    if (!linkCacheByPlugin.TryGetValue(plan.sourcePlugin!, out cache))
+                        linkCacheByPlugin[plan.sourcePlugin!] = (cache = session.LinkCacheFor(plan.sourcePlugin!))!;
                 }
                 return (WriteEngine.GenericGetOrAddAsOverride(patchMod, plan.body, cache), null);
             }
@@ -3467,6 +3469,10 @@ public static class WritePatchBuilder
     internal static string? LeafDivergence(string? inMemory, LeafPresence memory, string? onDisk, LeafPresence disk)
     {
         if (inMemory is null || onDisk is null) return null;
+        // An UNREADABLE side is not evidence either — which is what this method's own doc has always said, while the
+        // code counted it as absence (review [low]): a leaf whose read threw, or a field the type does not have,
+        // reads valueless and would have produced "a lost write … check it in xEdit".
+        if (!memory.Readable || !disk.Readable) return null;
         if (string.Equals(inMemory, onDisk, StringComparison.Ordinal)) return null;
         if (memory.Count is { } memCount && disk.Count is { } diskCount)
             return memCount == diskCount
@@ -3504,7 +3510,7 @@ public static class WritePatchBuilder
             // The presence PAIR rides along because it is the structural fact the tokens hide: a container summary, a
             // substruct summary and an ABSENT leaf all render as notes, and the divergence detector must not read
             // prose to decide whether anything is there.
-            return (after, landed, new LeafPresence(f.HasValue, f.Present, f.Count));
+            return (after, landed, new LeafPresence(f.HasValue, f.Present, f.Count, f.Readable));
         }
         catch { return (null, null, default); }
     }

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -290,6 +290,13 @@ public static class WritePatchBuilder
         /// comment in <see cref="CreateRecords"/>. When the definer cannot answer (an injected parent, an excluded
         /// plugin) the winner IS used, and this says so rather than letting the two cases look alike.</para></summary>
         public string? ParentHost { get; init; }
+
+        /// <summary>#300 — the parent this child was hosted in is CONTESTED: another plugin currently wins that
+        /// record, and this artifact will out-rank it wherever it sorts later. The renders hoist a warning for
+        /// exactly these, and they select on THIS, not by substring-matching <see cref="ParentHost"/>'s prose —
+        /// display text gets reworded, and a reword would have silently switched both hoists off with the guard
+        /// still green (review [low]; the same posture <c>IndexSnapshot.Unopenable</c> documents).</summary>
+        public bool ParentContested { get; init; }
     }
 
     /// <summary>The outcome of a <see cref="CreateRecords"/> call. <see cref="Error"/> non-null ⇒ the whole call was
@@ -2782,6 +2789,7 @@ public static class WritePatchBuilder
         // #300 — per-spec provenance of the parent override this create had to host the child in. Reported (Q3): which
         // plugin's version was copied is a decision the caller did not make and cannot see in the record afterwards.
         var parentHosts = new string?[specs.Count];
+        var parentContested = new bool[specs.Count];
         // The destination's own records, indexed ONCE (review [low]): the "does the artifact already carry this
         // parent?" probe runs per parented spec, and enumerating the whole destination each time is O(specs x records)
         // — on a bulk_create into a large into= patch, and equally on the IN-PLACE lane, where the destination is the
@@ -2883,6 +2891,7 @@ public static class WritePatchBuilder
                         parentType = WriteEngine.ResolveConcreteRecordType(RecordNaming.StripOverlay(parentBody.GetType().Name));
                         parentPlans[i] = (parentBody, readFrom, null, null);
                         bool overWinner = fromDefiner is not null && !string.Equals(readFrom, w.WinnerPlugin, StringComparison.OrdinalIgnoreCase);
+                        parentContested[i] = overWinner;
                         parentHosts[i] = $"{RecordNaming.StripOverlay(parentBody.GetType().Name)} {parentFk} hosted from '{readFrom}'"
                             + (fromDefiner is null
                                 ? $" (the load-order WINNER — its defining plugin '{definer}' does not carry it: an injected or excluded parent)"
@@ -3122,7 +3131,8 @@ public static class WritePatchBuilder
                 foreach (var fill in DialogueCkParity.ApplyQuestDefaults(questRec))
                     ops.Add(new OpResult(rec.FormKey, s.RecordType, fill.Label, true, null, fill.Reason));
             }
-            created.Add(new CreatedRecord(rec.FormKey, s.RecordType, s.EditorId, ops, replaced) { ParentHost = parentHosts[i] });
+            created.Add(new CreatedRecord(rec.FormKey, s.RecordType, s.EditorId, ops, replaced)
+            { ParentHost = parentHosts[i], ParentContested = parentContested[i] });
         }
 
         // --- Phase 4: serialize ONCE with the full known-master set. A created record referencing existing content pulls
@@ -3399,7 +3409,13 @@ public static class WritePatchBuilder
             // the bound is now stated where it is claimed instead of implied away.
             verified.Add(op with
             {
-                LandedOnDisk = landedDisk,
+                // A file side that could NOT BE READ is not the file's answer (review [medium]): DescribeApplied
+                // hands back the note ("(unreadable: …)"), which is non-null, and the state word derives from
+                // LandedOnDisk being non-null — so an op whose re-read THREW was stamped "verified" with the failure
+                // text printed as the file's content. Leaving it null routes it to the state that already exists for
+                // this: attempted, no answer. The comparator meanwhile stays silent on it, which is correct and is
+                // why nothing else caught it.
+                LandedOnDisk = diskPresence.Readable ? landedDisk : null,
                 Divergence = LeafDivergence(op.After, op.AfterPresence, afterDisk, diskPresence),
                 VerifyAttempted = true,
             });

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -2873,17 +2873,25 @@ public static class WritePatchBuilder
                                 ? $" (the load-order WINNER — its defining plugin '{definer}' does not carry it: an injected or excluded parent)"
                                 : !overWinner
                                     ? " (its DEFINING plugin, which is also the load-order winner)"
-                                    // The trade-off, stated where the choice is made (review [high], both rounds): the
-                                    // override is a FULL record copy and still conflicts at record level, so wherever
-                                    // this artifact out-ranks the winner it asserts the DEFINER's fields over that
-                                    // mod's. Nothing about the child needs the winner — the child sits in the parent's
-                                    // child group and survives the parent record losing — but the caller must be told
-                                    // which way the parent record itself will now resolve. "Not copied here" and not
-                                    // "not a master of this write": masters are derived at serialize, and another spec
-                                    // or a created record's own links can still pull that plugin in.
-                                    : $" (its DEFINING plugin — the lean host: '{w.WinnerPlugin}' currently WINS this record and its version is deliberately not copied here, "
-                                      + $"so wherever this artifact out-ranks '{w.WinnerPlugin}' the parent record resolves to '{readFrom}'s fields. "
-                                      + $"Sort this artifact BEFORE '{w.WinnerPlugin}' to keep that mod's version of the parent — the new child is carried either way.)");
+                                    // THE RESIDUAL IS THE DEFAULT, AND IT IS A CONTROL DECISION (Aaron, 2026-08-11).
+                                    // houseCARL does not resolve the conflict for the caller the way a human does in
+                                    // xEdit — xEdit copies the winner because a person is deciding in the moment. Here
+                                    // the two shapes are both legitimate and only the caller knows which they want:
+                                    // a LOGICAL patch that carries the residual (the child, and a host lean enough to
+                                    // lose harmlessly), or an INLINED one that carries another mod's content forward
+                                    // because this artifact feeds a patch that will win. Copying the winner by default
+                                    // silently picks the second, drags that mod's fields into the caller's plugin, and
+                                    // costs a master the child never needed. So the default is the lean host and the
+                                    // choice is REPORTED — a statement, not a warning: the caller sorts, or forwards
+                                    // the winner's version deliberately when inlining is what they meant.
+                                    // "Not copied here" and not "not a master of this write": masters are derived at
+                                    // serialize, and another spec or a created record's own links can still pull that
+                                    // plugin in.
+                                    : $" (its DEFINING plugin — the LEAN host, carrying the residual only: '{w.WinnerPlugin}' currently WINS this record "
+                                      + $"and its version is deliberately NOT inlined here, so wherever this artifact out-ranks '{w.WinnerPlugin}' the parent "
+                                      + $"record resolves to '{readFrom}'s fields. That is the control this lane gives you: sort below '{w.WinnerPlugin}' to "
+                                      + $"keep the residual shape, sort above it to assert this host, or forward '{w.WinnerPlugin}'s version in explicitly if "
+                                      + "you want its content inlined. The new child is carried either way.)");
                     }
                     else
                     {

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -3416,16 +3416,33 @@ public static class WritePatchBuilder
         for (int j = i + 1; j < perOp.Count; j++)
         {
             if (perOp[j].Target != perOp[i].Target || !PathFamiliesOverlap(perOp[i].Req.Path, perOp[j].Req.Path)) continue;
-            // A key-addressed pair on ONE path is two different elements (review [low]): SetAtIndex Ranks key=0 and
-            // key=1 — or a dict Set on key A then key B — carry the container as Path and the element in Key, so the
-            // bracketed rule above cannot tell them apart and the earlier op was marked superseded by an op that
-            // never touched it (losing its verification, and saying so untruthfully). Different keys = independent.
+            // A key-addressed pair on ONE path can be two different ELEMENTS: SetAtIndex Ranks key=0 and key=1 carry
+            // the container as Path and the element in Key, so the bracketed rule above cannot tell them apart and
+            // the earlier op was marked superseded by an op that never touched it (losing its verification, and
+            // saying so untruthfully).
+            //
+            // But ONLY when neither op can move the container's COUNT (review [high], reproduced): the first draft of
+            // this exemption asked about the keys alone, which turned the superseded rule off for the count-CHANGING
+            // keyed verbs — a list Remove by index, a dict Add/Remove/Set. Two `Remove Ranks[i]` in one call then
+            // compared op 1's mid-sequence count against the file's final one and printed "treat this op as NOT
+            // landed" for a write where BOTH removes landed; the remedy that invites deletes a third element.
+            // SetAtIndex is the one keyed verb that replaces in place, so it is the whole exemption — anything else
+            // falls back to superseded, which is silent rather than wrong.
             if (perOp[i].Req.Key is { } a && perOp[j].Req.Key is { } b
-                && !string.Equals(a, b, StringComparison.OrdinalIgnoreCase)) continue;
+                && !string.Equals(a, b, StringComparison.OrdinalIgnoreCase)
+                && CountNeutralKeyedVerb(perOp[i].Req.Verb) && CountNeutralKeyedVerb(perOp[j].Req.Verb)) continue;
             return true;
         }
         return false;
     }
+
+    /// <summary>Does this KEY-addressed verb leave the container's element count alone? Only <c>SetAtIndex</c>, which
+    /// overwrites the element at a position. <c>Remove</c> by index and every dict <c>Add</c>/<c>Set</c>/<c>Remove</c>
+    /// move the count, so two of them on one container are NOT independent for verification purposes — the earlier
+    /// one's in-memory count is a step behind the file's, and comparing it produces a false "NOT landed" on a write
+    /// that landed (review [high]). Named as a predicate rather than inlined so the exemption's bound is greppable
+    /// from the verb side, where the next keyed verb will be added.</summary>
+    static bool CountNeutralKeyedVerb(string verb) => string.Equals(verb, "SetAtIndex", StringComparison.Ordinal);
 
     /// <summary>Is one dotted path a prefix of the other, comparing segments with any <c>[index]</c>/<c>[key]</c>
     /// suffix stripped? Equal paths count (a prefix of itself).</summary>

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -1023,7 +1023,12 @@ public static class WritePatchBuilder
         ISkyrimModGetter? back = null;
         try
         {
-            back = SkyrimMod.CreateFromBinaryOverlay(targetPath, SkyrimRelease.SkyrimSE);
+            // The strings-aware factory, not a bare open (#308 review): a LOCALIZED plugin whose own folder carries no
+            // strings source reads every TranslatedString EMPTY (the HCBR-2026-06-24 class OpenOverlay exists for). That
+            // used to make only the read-back DUMP look empty; the verify below now COMPARES what it reads, so a bare
+            // open would report a correct in-place `Set Name` on such a plugin as "the file does not carry it" — the
+            // same wrong-answer class this fix exists to close, in the mirror direction.
+            back = LoadOrderResolver.OpenOverlay(targetPath, resolver.DataDir);
             masters = back.ModHeader.MasterReferences.Select(m => m.Master.FileName.ToString()).ToList();
             bytes = new FileInfo(targetPath).Length;
             if (fullReadback) readBack = ReadBackInFull(back, resolved.Select(r => r.edit.Target));
@@ -2783,18 +2788,32 @@ public static class WritePatchBuilder
                         // remains a fallback rather than a refusal: the definer genuinely does not carry it. Same for a
                         // definer this session EXCLUDED. Both are reported per record, never silently substituted.
                         var definer = parentFk.ModKey.FileName.String;
-                        var fromDefiner = view.ContainsPlugin(definer) && !view.ExcludedPlugins.ContainsKey(definer)
-                            ? view.GetRecord(session, definer, parentFk) : null;
+                        // GetRecord answers null for a plugin the order doesn't contain AND for one this session
+                        // EXCLUDED, so the two cases need no separate test here (review [nit]) — both fall to the
+                        // winner below, which is the behaviour an injected or unparseable definer should get.
+                        var fromDefiner = view.GetRecord(session, definer, parentFk);
                         var parentBody = fromDefiner ?? view.GetRecord(session, w.WinnerPlugin, parentFk);
                         if (parentBody is null) { problems.Add($"{s.RecordType} '{s.EditorId}': parent {parentFk} winner '{w.WinnerPlugin}' did not yield it on fetch (a load-order inconsistency)."); continue; }
                         var readFrom = fromDefiner is not null ? definer : w.WinnerPlugin;
                         parentType = WriteEngine.ResolveConcreteRecordType(RecordNaming.StripOverlay(parentBody.GetType().Name));
                         parentPlans[i] = (parentBody, readFrom, null, null);
+                        bool overWinner = fromDefiner is not null && !string.Equals(readFrom, w.WinnerPlugin, StringComparison.OrdinalIgnoreCase);
                         parentHosts[i] = $"{RecordNaming.StripOverlay(parentBody.GetType().Name)} {parentFk} hosted from '{readFrom}'"
-                            + (fromDefiner is not null
-                                ? " (its DEFINING plugin — the lean host; the load-order winner"
-                                  + (string.Equals(readFrom, w.WinnerPlugin, StringComparison.OrdinalIgnoreCase) ? " is this same plugin)" : $" '{w.WinnerPlugin}' is deliberately NOT copied, and is not a master of this write)")
-                                : $" (the load-order WINNER — its defining plugin '{definer}' does not carry it: an injected or excluded parent)");
+                            + (fromDefiner is null
+                                ? $" (the load-order WINNER — its defining plugin '{definer}' does not carry it: an injected or excluded parent)"
+                                : !overWinner
+                                    ? " (its DEFINING plugin, which is also the load-order winner)"
+                                    // The trade-off, stated where the choice is made (review [high], both rounds): the
+                                    // override is a FULL record copy and still conflicts at record level, so wherever
+                                    // this artifact out-ranks the winner it asserts the DEFINER's fields over that
+                                    // mod's. Nothing about the child needs the winner — the child sits in the parent's
+                                    // child group and survives the parent record losing — but the caller must be told
+                                    // which way the parent record itself will now resolve. "Not copied here" and not
+                                    // "not a master of this write": masters are derived at serialize, and another spec
+                                    // or a created record's own links can still pull that plugin in.
+                                    : $" (its DEFINING plugin — the lean host: '{w.WinnerPlugin}' currently WINS this record and its version is deliberately not copied here, "
+                                      + $"so wherever this artifact out-ranks '{w.WinnerPlugin}' the parent record resolves to '{readFrom}'s fields. "
+                                      + $"Sort this artifact BEFORE '{w.WinnerPlugin}' to keep that mod's version of the parent — the new child is carried either way.)");
                     }
                     else if (patchMod.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == parentFk) is { } patchParent)
                     {
@@ -3236,14 +3255,6 @@ public static class WritePatchBuilder
         catch { return null; }
     }
 
-    /// <summary>Read the edited leaf ONCE and derive BOTH best-effort descriptors an edit-lane <see cref="OpResult"/>
-    /// carries (PR #127 review #1 — previously two identical reflective reads of the same leaf per op, doubling the very
-    /// readback cost on the large-list records the report was about). <c>After</c> = the leaf read-back (xEdit remains
-    /// the authority). <c>Landed</c> = the compact "what landed" line the in-place verify renders by default
-    /// (HCBR-2026-06-28-01): a SCALAR leaf reuses the value just read (names exactly what was set); a LIST/DICT leaf names
-    /// the touched element + new count via <see cref="ReadEngine.TouchedElement"/> (the element you Added/Set, NOT the
-    /// whole list), falling back to the container summary. Read-only; NEVER throws into the write result (both null on any
-    /// difficulty). The create lane keeps <see cref="TryReadAfter"/> (it needs only <c>After</c>, never <c>Landed</c>).</summary>
     /// <summary>#308 — re-derive every op's "what landed" descriptor from the RE-OPENED WRITTEN FILE and compare it
     /// with the in-memory one the apply produced. The in-place verify's banner claims every line was re-read off the
     /// written file; before this, the record-level half was (<see cref="ReadBackInFull"/>) and the per-op half was
@@ -3278,7 +3289,16 @@ public static class WritePatchBuilder
             var op = ops[i];
             if (i >= perOp.Count || !found.TryGetValue(perOp[i].Target, out var rec)) { verified.Add(op); continue; }
             var (afterDisk, landedDisk) = DescribeApplied(rec, perOp[i].Req);
-            verified.Add(op with { LandedOnDisk = landedDisk, Divergence = LeafDivergence(op.After, afterDisk) });
+            // BOTH descriptors, not just the leaf summary (#308 review [medium]): `After` is the container
+            // (`[list: N item(s)]`), `Landed` is the touched ELEMENT. A struct that lands as an element but serializes
+            // to less than the caller supplied leaves the COUNT equal on both sides — so comparing summaries alone
+            // would answer "verified" while the two element renderings visibly disagreed in the same response, which
+            // is the general case this detector is documented to catch.
+            verified.Add(op with
+            {
+                LandedOnDisk = landedDisk,
+                Divergence = LeafDivergence(op.After, afterDisk) ?? LeafDivergence(op.Landed, landedDisk),
+            });
         }
         return verified;
     }
@@ -3315,6 +3335,17 @@ public static class WritePatchBuilder
         return i > start && int.TryParse(token.AsSpan(start, i - start), out var n) ? n : null;
     }
 
+    /// <summary>Read the edited leaf ONCE and derive BOTH best-effort descriptors an edit-lane <see cref="OpResult"/>
+    /// carries (PR #127 review #1 — previously two identical reflective reads of the same leaf per op, doubling the very
+    /// readback cost on the large-list records the report was about). <c>After</c> = the leaf read-back (xEdit remains
+    /// the authority). <c>Landed</c> = the compact "what landed" line the in-place verify renders by default
+    /// (HCBR-2026-06-28-01): a SCALAR leaf reuses the value just read (names exactly what was set); a LIST/DICT leaf names
+    /// the touched element + new count via <see cref="ReadEngine.TouchedElement"/> (the element you Added/Set, NOT the
+    /// whole list), falling back to the container summary. Read-only; NEVER throws into the write result (both null on any
+    /// difficulty). The create lane keeps <see cref="TryReadAfter"/> (it needs only <c>After</c>, never <c>Landed</c>).
+    /// <para>Takes a GETTER, not the mutable record, since #308: the same call reads the in-memory override during apply
+    /// AND the re-opened file's record afterwards, and one code path for both is what makes a difference between them a
+    /// difference in the DATA rather than in two renderings.</para></summary>
     static (string? After, string? Landed) DescribeApplied(IMajorRecordGetter ov, WriteRequest req)
     {
         try

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -626,7 +626,13 @@ public static class WritePatchBuilder
     /// projects, kept in step by a comment asking the reader to check — is the hand-wiring shape CLAUDE.md §3 argues
     /// against. It matters concretely: the next fix named for this lane is the <c>ActiveNameForPath</c> rule
     /// <c>forward</c> already has, and a clause added to one copy would silently stop matching the other. One
-    /// predicate, so a clause can only be added to both.</para></summary>
+    /// predicate, so a clause can only be added to both.</para>
+    /// <para>That fix landed as #321, and it deliberately did NOT become a clause here. A PATH is re-spelled to the
+    /// plugin NAME by the service before this predicate runs (<c>RespellActiveCopySourcePaths</c>), so what both ends
+    /// test is the order's own vocabulary. Testing membership here is therefore still a plain name lookup — and the
+    /// re-spelling reaches the engine, the winner comparison and the report at the same time, which a predicate-only
+    /// clause could not have done (it would have routed the body correctly while every rendered sentence still called
+    /// an active plugin off-order).</para></summary>
     public static bool IsOffOrderCopySource(PatchEdit e, LoadOrderResolver.IndexView view)
         => string.Equals(e.Verb, "CopyFrom", StringComparison.Ordinal)
            && !string.IsNullOrWhiteSpace(e.FromPlugin)
@@ -1585,13 +1591,11 @@ public static class WritePatchBuilder
     /// rather than the race repairs they were filed as. The argument is stated ONCE, on
     /// <see cref="TryOffOrderCopyBody"/> — read it there rather than re-deriving it from a second copy here
     /// (PR #318 review [nit]: this correction and its twin were saying the same thing twice).</para>
-    /// <para>NOT parity, and worth knowing before assuming it: this lane additionally carries the
-    /// <c>ActiveNameForPath</c> full-path identity rule (PR #313 [medium]), so a <c>source=</c> PATH naming an ACTIVE
-    /// plugin takes the in-order arm. The <c>CopyFrom</c> lane has no such rule at either end, so a
-    /// <c>from_source=</c> path to an active plugin still routes off-order and is described as not in the load
-    /// order — the same defect this lane fixed, still open on that one. Recorded here rather than filed: the sweep
-    /// that found it does not own the issue lane (CLAUDE.md §2), and a comment beside the code is a better pointer
-    /// than a stale reference if it is fixed first. Whoever fixes it should file it, then delete this paragraph.</para></summary>
+    /// <para>PARITY, since #321: both lanes carry the <c>ActiveNameForPath</c> full-path identity rule, so a
+    /// <c>source=</c> / <c>from_source=</c> PATH naming an ACTIVE plugin takes the in-order arm on either. The
+    /// <c>CopyFrom</c> twin applies it one step EARLIER — it re-spells the edit to the plugin NAME before
+    /// <see cref="IsOffOrderCopySource"/> is ever consulted — because that predicate is shared with the service's
+    /// pre-locate and a per-end rule could land on one side only.</para></summary>
     static bool IsOffOrderSource(OffOrderForwardSource? offOrder, ForwardSpec s, LoadOrderResolver.IndexView view) =>
         offOrder is not null
         && string.Equals(offOrder.Plugin, s.FromPlugin, StringComparison.OrdinalIgnoreCase)

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -2882,16 +2882,28 @@ public static class WritePatchBuilder
                                     // because this artifact feeds a patch that will win. Copying the winner by default
                                     // silently picks the second, drags that mod's fields into the caller's plugin, and
                                     // costs a master the child never needed. So the default is the lean host and the
-                                    // choice is REPORTED — a statement, not a warning: the caller sorts, or forwards
-                                    // the winner's version deliberately when inlining is what they meant.
+                                    // choice is REPORTED — a statement, not a warning: the caller sorts, or builds the
+                                    // inlined shape deliberately when inlining is what they meant.
                                     // "Not copied here" and not "not a master of this write": masters are derived at
                                     // serialize, and another spec or a created record's own links can still pull that
                                     // plugin in.
+                                    // THE INLINING LEVER NAMES AN ORDER, AND THE ORDER IS LOAD-BEARING (PR #323
+                                    // review [medium]). The first wording — "forward the winner's version in
+                                    // explicitly" — was measured FALSE: forwarding into the patch that already holds
+                                    // the child DELETES the child, because forward's extend/in-place path drops the
+                                    // whole record before re-copying it and the child group goes with the drop. That
+                                    // is a `forward` defect on both those lanes, filed as #324 and not fixed here.
+                                    // The order asserted safe in WriteSurfaceGuardProbe.NestedParentHostArm — forward
+                                    // first, then create into that patch — is what this now prints. Both halves are
+                                    // said: the safe order, and the destructive one named as destructive, because a
+                                    // caller who only reads "forward the winner in" will reach for the wrong one.
                                     : $" (its DEFINING plugin — the LEAN host, carrying the residual only: '{w.WinnerPlugin}' currently WINS this record "
                                       + $"and its version is deliberately NOT inlined here, so wherever this artifact out-ranks '{w.WinnerPlugin}' the parent "
                                       + $"record resolves to '{readFrom}'s fields. That is the control this lane gives you: sort below '{w.WinnerPlugin}' to "
-                                      + $"keep the residual shape, sort above it to assert this host, or forward '{w.WinnerPlugin}'s version in explicitly if "
-                                      + "you want its content inlined. The new child is carried either way.)");
+                                      + $"keep the residual shape, sort above it to assert this host, or inline '{w.WinnerPlugin}'s content deliberately: "
+                                      + $"forward its version into a patch FIRST, then create into THAT patch — the child hosts in the forwarded body. Not "
+                                      + "the other order: forwarding into a patch that ALREADY holds the child deletes the child (a known housecarl_forward "
+                                      + "bug, #324). Whichever way you sort, the new child is carried.)");
                     }
                     else
                     {

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -103,6 +103,13 @@ public static class WritePatchBuilder
         /// both directions — an in-place dry run claiming a file was re-opened and could not answer (review), and a
         /// synced marker reported as unanswered rather than unchecked.</summary>
         public bool VerifyAttempted { get; init; }
+
+        /// <summary>#308 — did the edited leaf hold a VALUE in memory when <see cref="After"/> was read? The presence
+        /// half of the comparison, carried structurally: an absent leaf and a container summary are both no-value
+        /// reads that differ only in a display note, so deciding "the file carries nothing there" from the note text
+        /// would key a Q3 verdict on wording (and, before this, missed the case entirely — an absent leaf reads
+        /// "(absent)", never the empty string the check was looking for).</summary>
+        public bool AfterHadValue { get; init; }
     }
 
     /// <summary>One record read back IN FULL from the WRITTEN patch file (opt-in — the pre-enable verify loop,
@@ -548,8 +555,8 @@ public static class WritePatchBuilder
                     WriteEngine.CopyField(srcBody!, ov, req.Path);
                 else
                     WriteEngine.ApplyVerb(ov, req);
-                var (after, landed) = DescribeApplied(ov, req);
-                ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, after, landed));
+                var (after, landed, hadValue) = DescribeApplied(ov, req);
+                ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, after, landed) { AfterHadValue = hadValue });
             }
             catch (ExpectedApplyRejectionException ex)
             {
@@ -955,8 +962,8 @@ public static class WritePatchBuilder
                         ov, req.Path);
                 else
                     WriteEngine.ApplyVerb(ov, req);
-                var (after, landed) = DescribeApplied(ov, req);
-                ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, after, landed));
+                var (after, landed, hadValue) = DescribeApplied(ov, req);
+                ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, after, landed) { AfterHadValue = hadValue });
             }
             catch (ExpectedApplyRejectionException ex)
             {
@@ -1050,7 +1057,11 @@ public static class WritePatchBuilder
             // #308 — the per-op half of the same verify. Unconditional, unlike the read-back above: the "what landed"
             // clause is rendered on EVERY in-place response (the compact default is the one a caller reads to confirm
             // an edit), so it is exactly the half that must not be a memory-derived claim wearing a file's authority.
-            reported = VerifyLandedAgainstFile(back, resolved.Select(r => (r.edit.Target, r.req)).ToList(), ops);
+            // Its own try: the file is already written and re-opened by this point, so a fault in the COMPARE pass is
+            // not "could not be re-opened to verify" and must not be reported as one (review [nit]). Ops then stay
+            // unverified, which the render states per op rather than turning a completed write into a failure.
+            try { reported = VerifyLandedAgainstFile(back, resolved.Select(r => (r.edit.Target, r.req)).ToList(), ops); }
+            catch { reported = ops; }
         }
         catch (Exception ex)
             { return PatchOutcome.Fail($"'{fileName}' was edited in place but could not be re-opened to verify: {ex.Message}"); }
@@ -2751,8 +2762,10 @@ public static class WritePatchBuilder
         // plugin's version was copied is a decision the caller did not make and cannot see in the record afterwards.
         var parentHosts = new string?[specs.Count];
         // The destination's own records, indexed ONCE (review [low]): the "does the artifact already carry this
-        // parent?" probe runs per parented spec, and enumerating the whole patch each time is O(specs x records) on a
-        // bulk_create into a large into= patch. Lazy — a call with no parented spec builds nothing.
+        // parent?" probe runs per parented spec, and enumerating the whole destination each time is O(specs x records)
+        // — on a bulk_create into a large into= patch, and equally on the IN-PLACE lane, where the destination is the
+        // user's own plugin and is the bigger of the two. Both branches read it. Lazy: a call with no parented spec
+        // builds nothing.
         Dictionary<FormKey, IMajorRecord>? carried = null;
         IMajorRecord? AlreadyCarried(FormKey fk)
         {
@@ -2790,7 +2803,7 @@ public static class WritePatchBuilder
                     // parent content + just add the child. The winner-source path below would instead override the load-order
                     // WINNER in, clobbering the user's content for a parent they own but don't win. (Patch lane: inPlace false
                     // => skips this; the prior-into= patchMod-carries branch still serves it, unchanged.)
-                    if (inPlace && patchMod.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == parentFk) is { } ownParent)
+                    if (inPlace && AlreadyCarried(parentFk) is { } ownParent)
                     {
                         parentType = WriteEngine.ResolveConcreteRecordType(RecordNaming.StripOverlay(ownParent.GetType().Name));
                         parentPlans[i] = (null, null, null, ownParent);
@@ -3331,7 +3344,7 @@ public static class WritePatchBuilder
             // then reaches for — re-issue the op — is the duplicate-Add trap this codebase already warns about.
             // The file has ONE final state, so only the LAST op touching a leaf is answerable by it.
             if (LaterOpTouchesSameLeaf(perOp, i)) { verified.Add(op with { SupersededInCall = true, VerifyAttempted = true }); continue; }
-            var (afterDisk, landedDisk) = DescribeApplied(rec, perOp[i].Req);
+            var (afterDisk, landedDisk, diskHasValue) = DescribeApplied(rec, perOp[i].Req);
             // BOTH descriptors, not just the leaf summary (review [medium]): `After` is the container
             // (`[list: N item(s)]`), `Landed` is the touched ELEMENT. A struct that lands as an element but serializes
             // to less than the caller supplied leaves the COUNT equal on both sides — so comparing summaries alone
@@ -3340,7 +3353,8 @@ public static class WritePatchBuilder
             verified.Add(op with
             {
                 LandedOnDisk = landedDisk,
-                Divergence = LeafDivergence(op.After, afterDisk) ?? LeafDivergence(op.Landed, landedDisk),
+                Divergence = LeafDivergence(op.After, op.AfterHadValue, afterDisk, diskHasValue)
+                             ?? LeafDivergence(op.Landed, op.AfterHadValue, landedDisk, diskHasValue),
                 VerifyAttempted = true,
             });
         }
@@ -3401,7 +3415,7 @@ public static class WritePatchBuilder
     /// in memory), and a leaf that held something in memory and holds NOTHING in the file. Everything else is
     /// reported by the ordinary clause, which prints the file's own reading anyway, so a caller who cares about the
     /// exact value can see both without being told a correct write failed.</para></summary>
-    internal static string? LeafDivergence(string? inMemory, string? onDisk)   // internal: unit-pinned by apply-guard arm 6
+    internal static string? LeafDivergence(string? inMemory, bool memoryHasValue, string? onDisk, bool diskHasValue)
     {
         if (inMemory is null || onDisk is null) return null;
         if (string.Equals(inMemory, onDisk, StringComparison.Ordinal)) return null;
@@ -3409,13 +3423,20 @@ public static class WritePatchBuilder
             return mem == disk
                 ? null                                     // same count, different summary text — not a content claim
                 : $"the applied edit left {mem} element(s) in memory, but the WRITTEN FILE carries {disk}";
-        if (inMemory.Trim().Length > 0 && onDisk.Trim().Length == 0)
-            // The one scalar shape that is still evidence: something became nothing. Qualified, because ONE other
-            // thing reads a field as empty — a localized plugin whose strings this session cannot resolve — and a
-            // caller who re-issues on that reading gets the same empty read forever.
-            return "the applied edit read back '" + inMemory + "', but the WRITTEN FILE carries nothing there "
-                 + "(a lost write — or, on a LOCALIZED plugin whose strings this session cannot resolve, a field "
-                 + "houseCARL cannot read back; check it in xEdit before re-issuing)";
+        // The shape that is still evidence, judged on PRESENCE and never on a note's wording: the leaf held CONTENT in
+        // memory and holds none in the file. Content = a value, or a container with at least one element — so a
+        // nullable list whose subrecord never got written (it reads "(absent)", not "[list: 0 item(s)]", which is why
+        // the count arm above cannot see it) is caught, while a list the call legitimately EMPTIED is not, since an
+        // emptied list and a dropped subrecord say the same thing. An absent leaf reads "(absent)", never "", which is
+        // why an empty-string test found nothing and reported such a write "verified" (review [high], twice).
+        bool memoryHasContent = memoryHasValue || ContainerCount(inMemory) > 0;
+        bool diskHasContent = diskHasValue || ContainerCount(onDisk) > 0;
+        if (memoryHasContent && !diskHasContent)
+            // Qualified, because ONE other thing reads a field as valueless — a localized plugin whose strings this
+            // session cannot resolve — and a caller who re-issues on that reading gets the same read forever.
+            return "the applied edit read back '" + inMemory + "', but the WRITTEN FILE carries no value there "
+                 + $"(it reads {onDisk}) — a lost write, or, on a LOCALIZED plugin whose strings this session cannot "
+                 + "resolve, a field houseCARL cannot read back; check it in xEdit before re-issuing";
         return null;
     }
 
@@ -3449,22 +3470,25 @@ public static class WritePatchBuilder
     /// <para>Takes a GETTER, not the mutable record, since #308: the same call reads the in-memory override during apply
     /// AND the re-opened file's record afterwards, and one code path for both is what makes a difference between them a
     /// difference in the DATA rather than in two renderings.</para></summary>
-    static (string? After, string? Landed) DescribeApplied(IMajorRecordGetter ov, WriteRequest req)
+    static (string? After, string? Landed, bool HasValue) DescribeApplied(IMajorRecordGetter ov, WriteRequest req)
     {
         try
         {
             var leaf = string.Join('.', req.Path);
             var read = ReadEngine.ReadFields(ov, new[] { leaf }, containerHint: null);   // same: no depth= on the write surface, don't hint it
             var f = read.Fields.FirstOrDefault(x => x.Path == leaf) ?? read.Fields.FirstOrDefault();
-            if (f is null) return (null, null);
+            if (f is null) return (null, null, false);
             var after = f.HasValue ? f.Token : f.Note;
             // Scalar: Landed reuses the token just read. List/dict: name the touched element (+ new count); else the
             // summary. An Add carries how many elements it appended (composes= → Structs.Count, else 1) so a batch
             // compose reports the whole appended run, never "(+1)" for N (#259).
             int added = req.Verb == "Add" ? (req.Structs?.Count ?? 1) : 1;
             var landed = f.HasValue ? f.Token : (ReadEngine.TouchedElement(ov, req.Path, req.Verb, req.Key, added) ?? f.Note);
-            return (after, landed);
+            // HasValue rides along because it is the ONE structural fact that separates "the leaf holds a value" from
+            // "it holds nothing" — a container summary and an ABSENT leaf are both no-value reads whose difference
+            // lives only in a display note, and the divergence detector must not read notes to decide presence.
+            return (after, landed, f.HasValue);
         }
-        catch { return (null, null); }
+        catch { return (null, null, false); }
     }
 }

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -104,12 +104,28 @@ public static class WritePatchBuilder
         /// synced marker reported as unanswered rather than unchecked.</summary>
         public bool VerifyAttempted { get; init; }
 
-        /// <summary>#308 — did the edited leaf hold a VALUE in memory when <see cref="After"/> was read? The presence
-        /// half of the comparison, carried structurally: an absent leaf and a container summary are both no-value
-        /// reads that differ only in a display note, so deciding "the file carries nothing there" from the note text
-        /// would key a Q3 verdict on wording (and, before this, missed the case entirely — an absent leaf reads
-        /// "(absent)", never the empty string the check was looking for).</summary>
-        public bool AfterHadValue { get; init; }
+        /// <summary>#308 — what the edited leaf HELD in memory when <see cref="After"/> was read: a value, a present
+        /// container/substruct (with its element count), or nothing. The presence half of the comparison, carried
+        /// structurally because a value, a container summary, a substruct summary and an absent leaf differ only in
+        /// display text — deciding "the file carries nothing there" from that text keys a Q3 verdict on wording, and
+        /// did miss real cases twice (an absent leaf reads "(absent)", never the empty string the first rule looked
+        /// for; a vanished SUBSTRUCT reads "[Rank]" in memory, which no count parser recognises).</summary>
+        public LeafPresence AfterPresence { get; init; }
+    }
+
+    /// <summary>#308 — what a leaf HOLDS, structurally, as the reader reported it: a value, a present
+    /// container/substruct (with its element count where it has one), or nothing at all. The three render as a token
+    /// or a parenthesised note and are not tellable apart from that text, which is why the write verify carries this
+    /// instead of parsing prose — it missed a vanished scalar and then a vanished substruct doing the latter.</summary>
+    /// <param name="HasValue">The leaf holds a scalar/link VALUE.</param>
+    /// <param name="Present">Something is there — a value, or a container/substruct that exists.</param>
+    /// <param name="Count">Elements, for a container leaf (0 = present but EMPTY); null for a value or a substruct.</param>
+    public readonly record struct LeafPresence(bool HasValue, bool Present, int? Count)
+    {
+        /// <summary>Is there CONTENT? A value, a non-empty container, or a present substruct. An EMPTY container is
+        /// deliberately not content: an emptied list and a dropped subrecord say the same thing, so a call that
+        /// legitimately cleared a list must not be told its write vanished.</summary>
+        public bool HasContent => HasValue || (Present && (Count is null || Count > 0));
     }
 
     /// <summary>One record read back IN FULL from the WRITTEN patch file (opt-in — the pre-enable verify loop,
@@ -555,8 +571,8 @@ public static class WritePatchBuilder
                     WriteEngine.CopyField(srcBody!, ov, req.Path);
                 else
                     WriteEngine.ApplyVerb(ov, req);
-                var (after, landed, hadValue) = DescribeApplied(ov, req);
-                ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, after, landed) { AfterHadValue = hadValue });
+                var (after, landed, presence) = DescribeApplied(ov, req);
+                ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, after, landed) { AfterPresence = presence });
             }
             catch (ExpectedApplyRejectionException ex)
             {
@@ -962,8 +978,8 @@ public static class WritePatchBuilder
                         ov, req.Path);
                 else
                     WriteEngine.ApplyVerb(ov, req);
-                var (after, landed, hadValue) = DescribeApplied(ov, req);
-                ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, after, landed) { AfterHadValue = hadValue });
+                var (after, landed, presence) = DescribeApplied(ov, req);
+                ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, after, landed) { AfterPresence = presence });
             }
             catch (ExpectedApplyRejectionException ex)
             {
@@ -1941,7 +1957,7 @@ public static class WritePatchBuilder
     /// does not contain (a disabled mod, an unticked plugin, a folder MO2 never registered). The whole call shares ONE
     /// source, so this is locate-once / open-once / fetch-N: the caller (the SERVICE, which owns the MO2 on-disk locate)
     /// pre-fetches every wanted body through the file's own overlay and hands them here, and the forward engine uses them
-    /// instead of the load-order index. The sibling of the <c>CopyFrom</c> lane's <c>ResolveOffOrderCopySources</c>.
+    /// instead of the load-order index. The sibling of the <c>CopyFrom</c> lane's <c>PrepareCopyFromSources</c>.
     /// <para><b>Lifetime.</b> The caller OWNS the overlay these bodies came from and must keep it open until the write's
     /// serialize has returned (the bodies are deep-copied during the write), then dispose it — the same contract the
     /// CopyFrom lane's <c>offOrderOverlays</c> carries. Nothing here disposes anything.</para></summary>
@@ -2766,6 +2782,12 @@ public static class WritePatchBuilder
         // — on a bulk_create into a large into= patch, and equally on the IN-PLACE lane, where the destination is the
         // user's own plugin and is the bigger of the two. Both branches read it. Lazy: a call with no parented spec
         // builds nothing.
+        var parentBodies = new Dictionary<(string Plugin, FormKey Key), IMajorRecordGetter?>();
+        IMajorRecordGetter? ParentBodyFrom(string plugin, FormKey fk)
+        {
+            if (parentBodies.TryGetValue((plugin, fk), out var hit)) return hit;
+            return parentBodies[(plugin, fk)] = view.GetRecord(session, plugin, fk);
+        }
         Dictionary<FormKey, IMajorRecord>? carried = null;
         IMajorRecord? AlreadyCarried(FormKey fk)
         {
@@ -2842,8 +2864,13 @@ public static class WritePatchBuilder
                         // GetRecord answers null for a plugin the order doesn't contain AND for one this session
                         // EXCLUDED, so the two cases need no separate test here (review [nit]) — both fall to the
                         // winner below, which is the behaviour an injected or unparseable definer should get.
-                        var fromDefiner = view.GetRecord(session, definer, parentFk);
-                        var parentBody = fromDefiner ?? view.GetRecord(session, w.WinnerPlugin, parentFk);
+                        // Memoised per (plugin, record): GetRecord is a full EnumerateMajorRecords scan, this sits in
+                        // the per-spec loop, and #300 pointed it at the DEFINER — usually Skyrim.esm — where it used
+                        // to hit the (small) winner. A bulk_create fanning N refs into vanilla cells would otherwise
+                        // pay N scans of a ~250k-record file (review [medium]). Specs commonly share a parent, so the
+                        // memo is usually one scan for the whole call.
+                        var fromDefiner = ParentBodyFrom(definer, parentFk);
+                        var parentBody = fromDefiner ?? ParentBodyFrom(w.WinnerPlugin, parentFk);
                         if (parentBody is null) { problems.Add($"{s.RecordType} '{s.EditorId}': parent {parentFk} winner '{w.WinnerPlugin}' did not yield it on fetch (a load-order inconsistency)."); continue; }
                         var readFrom = fromDefiner is not null ? definer : w.WinnerPlugin;
                         parentType = WriteEngine.ResolveConcreteRecordType(RecordNaming.StripOverlay(parentBody.GetType().Name));
@@ -3312,8 +3339,9 @@ public static class WritePatchBuilder
     /// null — the renderer then says the clause is the applied edit's claim, which is the honest reading and the one
     /// the old banner silently skipped.</para>
     ///
-    /// <para>Its own enumeration pass, and the cost is real rather than nil (review [low]): on the in-place lane the
-    /// read-back is forced, so a write now walks the re-opened file TWICE. Kept separate because
+    /// <para>The cost, stated in full rather than partly (reviews [low], twice): on the in-place lane the read-back is
+    /// forced, so a write walks the re-opened file TWICE, pays a second reflective <c>ReadFields</c> PER OP against
+    /// the overlay, and runs an O(ops²) scan for superseded leaves. Unconditional on every in-place write. Kept separate because
     /// <see cref="ReadBackInFull"/> materialises RecordFields and hands back values — threading a second output
     /// through it would entangle this with its careful per-record error accounting — and because the walk is lazy
     /// header parsing over a file the call has just fully re-serialized, which dominates it. Worth merging if a
@@ -3344,7 +3372,7 @@ public static class WritePatchBuilder
             // then reaches for — re-issue the op — is the duplicate-Add trap this codebase already warns about.
             // The file has ONE final state, so only the LAST op touching a leaf is answerable by it.
             if (LaterOpTouchesSameLeaf(perOp, i)) { verified.Add(op with { SupersededInCall = true, VerifyAttempted = true }); continue; }
-            var (afterDisk, landedDisk, diskHasValue) = DescribeApplied(rec, perOp[i].Req);
+            var (afterDisk, landedDisk, diskPresence) = DescribeApplied(rec, perOp[i].Req);
             // BOTH descriptors, not just the leaf summary (review [medium]): `After` is the container
             // (`[list: N item(s)]`), `Landed` is the touched ELEMENT. A struct that lands as an element but serializes
             // to less than the caller supplied leaves the COUNT equal on both sides — so comparing summaries alone
@@ -3353,8 +3381,8 @@ public static class WritePatchBuilder
             verified.Add(op with
             {
                 LandedOnDisk = landedDisk,
-                Divergence = LeafDivergence(op.After, op.AfterHadValue, afterDisk, diskHasValue)
-                             ?? LeafDivergence(op.Landed, op.AfterHadValue, landedDisk, diskHasValue),
+                Divergence = LeafDivergence(op.After, op.AfterPresence, afterDisk, diskPresence)
+                             ?? LeafDivergence(op.Landed, op.AfterPresence, landedDisk, diskPresence),
                 VerifyAttempted = true,
             });
         }
@@ -3415,23 +3443,21 @@ public static class WritePatchBuilder
     /// in memory), and a leaf that held something in memory and holds NOTHING in the file. Everything else is
     /// reported by the ordinary clause, which prints the file's own reading anyway, so a caller who cares about the
     /// exact value can see both without being told a correct write failed.</para></summary>
-    internal static string? LeafDivergence(string? inMemory, bool memoryHasValue, string? onDisk, bool diskHasValue)
+    internal static string? LeafDivergence(string? inMemory, LeafPresence memory, string? onDisk, LeafPresence disk)
     {
         if (inMemory is null || onDisk is null) return null;
         if (string.Equals(inMemory, onDisk, StringComparison.Ordinal)) return null;
-        if (ContainerCount(inMemory) is { } mem && ContainerCount(onDisk) is { } disk)
-            return mem == disk
+        if (memory.Count is { } memCount && disk.Count is { } diskCount)
+            return memCount == diskCount
                 ? null                                     // same count, different summary text — not a content claim
-                : $"the applied edit left {mem} element(s) in memory, but the WRITTEN FILE carries {disk}";
+                : $"the applied edit left {memCount} element(s) in memory, but the WRITTEN FILE carries {diskCount}";
         // The shape that is still evidence, judged on PRESENCE and never on a note's wording: the leaf held CONTENT in
         // memory and holds none in the file. Content = a value, or a container with at least one element — so a
         // nullable list whose subrecord never got written (it reads "(absent)", not "[list: 0 item(s)]", which is why
         // the count arm above cannot see it) is caught, while a list the call legitimately EMPTIED is not, since an
         // emptied list and a dropped subrecord say the same thing. An absent leaf reads "(absent)", never "", which is
         // why an empty-string test found nothing and reported such a write "verified" (review [high], twice).
-        bool memoryHasContent = memoryHasValue || ContainerCount(inMemory) > 0;
-        bool diskHasContent = diskHasValue || ContainerCount(onDisk) > 0;
-        if (memoryHasContent && !diskHasContent)
+        if (memory.HasContent && !disk.HasContent)
             // Qualified, because ONE other thing reads a field as valueless — a localized plugin whose strings this
             // session cannot resolve — and a caller who re-issues on that reading gets the same read forever.
             return "the applied edit read back '" + inMemory + "', but the WRITTEN FILE carries no value there "
@@ -3440,55 +3466,25 @@ public static class WritePatchBuilder
         return null;
     }
 
-    /// <summary>The element count out of a container summary token (<c>[list: N item(s)]</c>, <c>[dict: N …]</c>);
-    /// null when the token is not a counted container — a scalar, a formlink, or a shape this doesn't recognise, all
-    /// of which fall back to a text comparison rather than being read as "0".
-    /// <para>The prefix is checked against the two shapes ReadEngine actually emits, not "starts with '[' and has a
-    /// colon" (review [low]): a STRING field whose value happens to read <c>[Boss: 3 guards]</c> would otherwise be
-    /// compared as a count, so <c>[Boss: 3 guards]</c> vs <c>[Boss: 3 dragons]</c> — a real change — would compare
-    /// equal and the divergence would be missed silently, in a detector whose whole job is not to miss one.</para></summary>
-    static int? ContainerCount(string token)
-    {
-        if (!token.StartsWith("[list:", StringComparison.Ordinal) && !token.StartsWith("[dict:", StringComparison.Ordinal))
-            return null;
-        int colon = token.IndexOf(':');
-        int i = colon + 1;
-        while (i < token.Length && token[i] == ' ') i++;
-        int start = i;
-        while (i < token.Length && char.IsAsciiDigit(token[i])) i++;
-        return i > start && int.TryParse(token.AsSpan(start, i - start), out var n) ? n : null;
-    }
-
-    /// <summary>Read the edited leaf ONCE and derive BOTH best-effort descriptors an edit-lane <see cref="OpResult"/>
-    /// carries (PR #127 review #1 — previously two identical reflective reads of the same leaf per op, doubling the very
-    /// readback cost on the large-list records the report was about). <c>After</c> = the leaf read-back (xEdit remains
-    /// the authority). <c>Landed</c> = the compact "what landed" line the in-place verify renders by default
-    /// (HCBR-2026-06-28-01): a SCALAR leaf reuses the value just read (names exactly what was set); a LIST/DICT leaf names
-    /// the touched element + new count via <see cref="ReadEngine.TouchedElement"/> (the element you Added/Set, NOT the
-    /// whole list), falling back to the container summary. Read-only; NEVER throws into the write result (both null on any
-    /// difficulty). The create lane keeps <see cref="TryReadAfter"/> (it needs only <c>After</c>, never <c>Landed</c>).
-    /// <para>Takes a GETTER, not the mutable record, since #308: the same call reads the in-memory override during apply
-    /// AND the re-opened file's record afterwards, and one code path for both is what makes a difference between them a
-    /// difference in the DATA rather than in two renderings.</para></summary>
-    static (string? After, string? Landed, bool HasValue) DescribeApplied(IMajorRecordGetter ov, WriteRequest req)
+    static (string? After, string? Landed, LeafPresence Presence) DescribeApplied(IMajorRecordGetter ov, WriteRequest req)
     {
         try
         {
             var leaf = string.Join('.', req.Path);
             var read = ReadEngine.ReadFields(ov, new[] { leaf }, containerHint: null);   // same: no depth= on the write surface, don't hint it
             var f = read.Fields.FirstOrDefault(x => x.Path == leaf) ?? read.Fields.FirstOrDefault();
-            if (f is null) return (null, null, false);
+            if (f is null) return (null, null, default);
             var after = f.HasValue ? f.Token : f.Note;
             // Scalar: Landed reuses the token just read. List/dict: name the touched element (+ new count); else the
             // summary. An Add carries how many elements it appended (composes= → Structs.Count, else 1) so a batch
             // compose reports the whole appended run, never "(+1)" for N (#259).
             int added = req.Verb == "Add" ? (req.Structs?.Count ?? 1) : 1;
             var landed = f.HasValue ? f.Token : (ReadEngine.TouchedElement(ov, req.Path, req.Verb, req.Key, added) ?? f.Note);
-            // HasValue rides along because it is the ONE structural fact that separates "the leaf holds a value" from
-            // "it holds nothing" — a container summary and an ABSENT leaf are both no-value reads whose difference
-            // lives only in a display note, and the divergence detector must not read notes to decide presence.
-            return (after, landed, f.HasValue);
+            // The presence PAIR rides along because it is the structural fact the tokens hide: a container summary, a
+            // substruct summary and an ABSENT leaf all render as notes, and the divergence detector must not read
+            // prose to decide whether anything is there.
+            return (after, landed, new LeafPresence(f.HasValue, f.Present, f.Count));
         }
-        catch { return (null, null, false); }
+        catch { return (null, null, default); }
     }
 }

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -1077,7 +1077,10 @@ public static class WritePatchBuilder
             // not "could not be re-opened to verify" and must not be reported as one (review [nit]). Ops then stay
             // unverified, which the render states per op rather than turning a completed write into a failure.
             try { reported = VerifyLandedAgainstFile(back, resolved.Select(r => (r.edit.Target, r.req)).ToList(), ops); }
-            catch { reported = ops; }
+            // A pass that THREW is not "this lane ran no file check" (review [low]) — the verify ran and produced no
+            // answer, which is the state that says so. Under-reporting a failed verification as an absent one is the
+            // quieter half of the same wrong-answer class.
+            catch { reported = ops.Select(o => o with { VerifyAttempted = true }).ToList(); }
         }
         catch (Exception ex)
             { return PatchOutcome.Fail($"'{fileName}' was edited in place but could not be re-opened to verify: {ex.Message}"); }
@@ -2867,8 +2870,10 @@ public static class WritePatchBuilder
                         // Memoised per (plugin, record): GetRecord is a full EnumerateMajorRecords scan, this sits in
                         // the per-spec loop, and #300 pointed it at the DEFINER — usually Skyrim.esm — where it used
                         // to hit the (small) winner. A bulk_create fanning N refs into vanilla cells would otherwise
-                        // pay N scans of a ~250k-record file (review [medium]). Specs commonly share a parent, so the
-                        // memo is usually one scan for the whole call.
+                        // pay N scans of a ~250k-record file (review [medium]). The memo is keyed (plugin, record), so
+                        // it collapses the SHARED-parent fan-out to one scan; N specs naming N DISTINCT parents still
+                        // pay N, and against the definer those are now the bigger file, not the smaller one (review
+                        // [low]: said plainly rather than left implied — the honest fix is an index, not a memo).
                         var fromDefiner = ParentBodyFrom(definer, parentFk);
                         var parentBody = fromDefiner ?? ParentBodyFrom(w.WinnerPlugin, parentFk);
                         if (parentBody is null) { problems.Add($"{s.RecordType} '{s.EditorId}': parent {parentFk} winner '{w.WinnerPlugin}' did not yield it on fetch (a load-order inconsistency)."); continue; }
@@ -3331,6 +3336,13 @@ public static class WritePatchBuilder
     /// not, so a struct that exists in memory and serializes to nothing rendered as landed under a file-authority
     /// claim while the file was byte-unchanged.
     ///
+    /// <para>WHAT IT CATCHES, and what it does not, stated because three places used to claim more: content that is
+    /// GONE — a container whose count moved, or a leaf that held something and now holds nothing. NOT a value the
+    /// format represents differently (a byte-quantised Percent, an overlay's type name), and NOT an element that
+    /// landed but serialized with fewer fields than the caller supplied. That last one is bounded from the other end
+    /// instead: <c>WriteEngine.EmptyComposeRefusal</c> refuses the case where nothing was supplied at all, and the
+    /// per-op clause prints the FILE's own reading, so a caller comparing it against what they asked for can see the
+    /// difference — they are simply not told it is a failure, because this cannot tell that from a representation.</para>
     /// <para>One READER both sides (<see cref="DescribeApplied"/>), so a difference is a difference in the DATA, not
     /// in how two renderers phrase it. Not one OPEN, though, and the asymmetry is deliberate (review [low]): the
     /// memory side is the record this call authored, while the file side is re-opened through
@@ -3373,16 +3385,17 @@ public static class WritePatchBuilder
             // The file has ONE final state, so only the LAST op touching a leaf is answerable by it.
             if (LaterOpTouchesSameLeaf(perOp, i)) { verified.Add(op with { SupersededInCall = true, VerifyAttempted = true }); continue; }
             var (afterDisk, landedDisk, diskPresence) = DescribeApplied(rec, perOp[i].Req);
-            // BOTH descriptors, not just the leaf summary (review [medium]): `After` is the container
-            // (`[list: N item(s)]`), `Landed` is the touched ELEMENT. A struct that lands as an element but serializes
-            // to less than the caller supplied leaves the COUNT equal on both sides — so comparing summaries alone
-            // would answer "verified" while the two element renderings visibly disagreed in the same response, which
-            // is the general case this detector is documented to catch.
+            // ONE comparison, on the leaf. An earlier round added a second pass over `Landed` (the touched ELEMENT) to
+            // catch a struct that lands but serializes with fewer fields than supplied — and a later review proved it
+            // INERT (review [medium]): `Landed` differs from `After` only for a container leaf, and for a container
+            // both presences carry counts, so the count arm decides and returns null whenever the counts agree. The
+            // element strings were never judged. It is removed rather than repaired because repairing it means
+            // comparing element TEXT, which is exactly what produced the Percent and overlay-type false alarms — and
+            // the bound is now stated where it is claimed instead of implied away.
             verified.Add(op with
             {
                 LandedOnDisk = landedDisk,
-                Divergence = LeafDivergence(op.After, op.AfterPresence, afterDisk, diskPresence)
-                             ?? LeafDivergence(op.Landed, op.AfterPresence, landedDisk, diskPresence),
+                Divergence = LeafDivergence(op.After, op.AfterPresence, afterDisk, diskPresence),
                 VerifyAttempted = true,
             });
         }

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -67,8 +67,29 @@ public static class WritePatchBuilder
     /// <summary>Per-edit result. On a successful call every op has <see cref="Applied"/>=true (all-or-nothing);
     /// <see cref="After"/> is a best-effort read-back of the edited leaf (xEdit remains the authority).
     /// <see cref="Landed"/> is the compact "what landed" descriptor the in-place verify renders by default
-    /// (HCBR-2026-06-28-01) — the new scalar value, or the touched list element + new count; null when not derivable.</summary>
-    public sealed record OpResult(FormKey Target, string RecordType, string Label, bool Applied, string? Error, string? After, string? Landed = null);
+    /// (HCBR-2026-06-28-01) — the new scalar value, or the touched list element + new count; null when not derivable.
+    /// <para><see cref="After"/> and <see cref="Landed"/> are read from the IN-MEMORY record, during apply and BEFORE
+    /// the serialize. That is not a defect — they are what the edit did — but it is the whole of #308: the in-place
+    /// verify rendered them under a banner claiming every line was re-read off the written file, so a composed struct
+    /// that exists in memory and serializes to NOTHING was reported as landed. <see cref="LandedOnDisk"/> and
+    /// <see cref="Divergence"/> below are the file's own answer.</para></summary>
+    public sealed record OpResult(FormKey Target, string RecordType, string Label, bool Applied, string? Error, string? After, string? Landed = null)
+    {
+        /// <summary>#308 — the same descriptor as <see cref="Landed"/>, re-derived from the record as it was RE-READ
+        /// off the written file (same code path, different universe). This is the one a file-authoritative render may
+        /// print. Null when the file could not answer for this op — the re-opened file did not yield the record, the
+        /// walk failed, or the lane never wrote one (a dry run) — and a renderer must then say the clause is the
+        /// applied edit's claim rather than the file's content, never silently substitute one for the other.</summary>
+        public string? LandedOnDisk { get; init; }
+
+        /// <summary>#308 — set when the edited leaf's in-memory state and the WRITTEN FILE's state disagree: the write
+        /// reported success and the file does not corroborate what the op claims to have put there. The canonical case
+        /// is a modeled struct with no serializable content (a Faction <c>Rank</c> composed with no fields): the list
+        /// holds one element in memory and zero on disk, the plugin does not grow, and every later read shows it
+        /// empty. Q3: the forced in-place verify exists to catch exactly this, so it is stated loudly rather than left
+        /// to a caller to notice. Null = checked and consistent, or not checkable (see <see cref="LandedOnDisk"/>).</summary>
+        public string? Divergence { get; init; }
+    }
 
     /// <summary>One record read back IN FULL from the WRITTEN patch file (opt-in — the pre-enable verify loop,
     /// wishlist #3 re-scoped / HCBR-2026-06-11-02 wave (b)): every modeled field, deep, read off the re-opened
@@ -987,6 +1008,7 @@ public static class WritePatchBuilder
         //     the dropped whole-plugin floor — confirm what you TOUCHED landed; Mutagen is trusted for the rest). ---
         IReadOnlyList<string> masters = Array.Empty<string>();
         IReadOnlyList<FullReadback>? readBack = null;
+        IReadOnlyList<OpResult> reported = ops;
         long bytes = 0;
         ISkyrimModGetter? back = null;
         try
@@ -995,12 +1017,16 @@ public static class WritePatchBuilder
             masters = back.ModHeader.MasterReferences.Select(m => m.Master.FileName.ToString()).ToList();
             bytes = new FileInfo(targetPath).Length;
             if (fullReadback) readBack = ReadBackInFull(back, resolved.Select(r => r.edit.Target));
+            // #308 — the per-op half of the same verify. Unconditional, unlike the read-back above: the "what landed"
+            // clause is rendered on EVERY in-place response (the compact default is the one a caller reads to confirm
+            // an edit), so it is exactly the half that must not be a memory-derived claim wearing a file's authority.
+            reported = VerifyLandedAgainstFile(back, resolved.Select(r => (r.edit.Target, r.req)).ToList(), ops);
         }
         catch (Exception ex)
             { return PatchOutcome.Fail($"'{fileName}' was edited in place but could not be re-opened to verify: {ex.Message}"); }
         finally { (back as IDisposable)?.Dispose(); }
 
-        return new PatchOutcome(true, null, targetPath, false, masters, ops, bytes)
+        return new PatchOutcome(true, null, targetPath, false, masters, reported, bytes)
             { ReadBack = readBack, InPlace = true, Note = MasterGrowNote(fileName, mastersBefore, masters) };
     }
 
@@ -3186,7 +3212,78 @@ public static class WritePatchBuilder
     /// the touched element + new count via <see cref="ReadEngine.TouchedElement"/> (the element you Added/Set, NOT the
     /// whole list), falling back to the container summary. Read-only; NEVER throws into the write result (both null on any
     /// difficulty). The create lane keeps <see cref="TryReadAfter"/> (it needs only <c>After</c>, never <c>Landed</c>).</summary>
-    static (string? After, string? Landed) DescribeApplied(IMajorRecord ov, WriteRequest req)
+    /// <summary>#308 — re-derive every op's "what landed" descriptor from the RE-OPENED WRITTEN FILE and compare it
+    /// with the in-memory one the apply produced. The in-place verify's banner claims every line was re-read off the
+    /// written file; before this, the record-level half was (<see cref="ReadBackInFull"/>) and the per-op half was
+    /// not, so a struct that exists in memory and serializes to nothing rendered as landed under a file-authority
+    /// claim while the file was byte-unchanged.
+    ///
+    /// <para>Same code path both sides (<see cref="DescribeApplied"/>), so a difference is a difference in the DATA,
+    /// not in how two renderers phrase it. A record the file does not yield leaves both fields null — the renderer
+    /// then says the clause is the applied edit's claim, which is the honest reading and the one the old banner
+    /// silently skipped.</para>
+    ///
+    /// <para>Its own enumeration pass, deliberately: <see cref="ReadBackInFull"/> materialises RecordFields and hands
+    /// back values, and threading a second output through it to save one lazy header walk of ONE already-open file —
+    /// on a lane that has just re-serialized that whole file — would buy nothing and cost the read-back's careful
+    /// per-record error accounting.</para></summary>
+    static IReadOnlyList<OpResult> VerifyLandedAgainstFile(
+        ISkyrimModGetter back, IReadOnlyList<(FormKey Target, WriteRequest Req)> perOp, IReadOnlyList<OpResult> ops)
+    {
+        if (ops.Count == 0) return ops;
+        var want = new HashSet<FormKey>(perOp.Select(p => p.Target));
+        var found = new Dictionary<FormKey, IMajorRecordGetter>();
+        try
+        {
+            foreach (var rec in back.EnumerateMajorRecords())
+                if (want.Contains(rec.FormKey) && !found.ContainsKey(rec.FormKey)) found[rec.FormKey] = rec;
+        }
+        catch { /* leave every op unverified — the render says so, and ReadBackInFull names the walk failure itself */ }
+
+        var verified = new List<OpResult>(ops.Count);
+        for (int i = 0; i < ops.Count; i++)
+        {
+            var op = ops[i];
+            if (i >= perOp.Count || !found.TryGetValue(perOp[i].Target, out var rec)) { verified.Add(op); continue; }
+            var (afterDisk, landedDisk) = DescribeApplied(rec, perOp[i].Req);
+            verified.Add(op with { LandedOnDisk = landedDisk, Divergence = LeafDivergence(op.After, afterDisk) });
+        }
+        return verified;
+    }
+
+    /// <summary>#308's comparator: does the edited leaf's in-memory state disagree with the WRITTEN FILE's? Null =
+    /// they agree, or there is nothing to compare (either side unreadable — an absent answer is never evidence of a
+    /// divergence). Both sides come from one read path, so equal content compares equal.
+    /// <para>Counts are compared as COUNTS when both sides are container summaries — the class this exists for moves a
+    /// count, and "[list: 1 item(s)]" vs "[list: 0 item(s)]" is a clearer sentence as "1 in memory, 0 in the file".
+    /// Everything else is compared as text and reported as the two readings, not as an accusation about which is
+    /// right: the file is what the game loads, and that is what the wording says.</para></summary>
+    internal static string? LeafDivergence(string? inMemory, string? onDisk)   // internal: unit-pinned by apply-guard arm 6
+    {
+        if (inMemory is null || onDisk is null) return null;
+        if (string.Equals(inMemory, onDisk, StringComparison.Ordinal)) return null;
+        if (ContainerCount(inMemory) is { } mem && ContainerCount(onDisk) is { } disk)
+            return mem == disk
+                ? null                                     // same count, different summary text — not a content claim
+                : $"the applied edit left {mem} element(s) in memory, but the WRITTEN FILE carries {disk}";
+        return $"the applied edit read back '{inMemory}', but the WRITTEN FILE carries '{onDisk}'";
+    }
+
+    /// <summary>The element count out of a container summary token (<c>[list: N item(s)]</c>, <c>[dict: N …]</c>);
+    /// null when the token is not a counted container — a scalar, a formlink, or a shape this doesn't recognise, all
+    /// of which fall back to a text comparison rather than being read as "0".</summary>
+    static int? ContainerCount(string token)
+    {
+        int colon = token.IndexOf(':');
+        if (!token.StartsWith('[') || colon < 0) return null;
+        int i = colon + 1;
+        while (i < token.Length && token[i] == ' ') i++;
+        int start = i;
+        while (i < token.Length && char.IsAsciiDigit(token[i])) i++;
+        return i > start && int.TryParse(token.AsSpan(start, i - start), out var n) ? n : null;
+    }
+
+    static (string? After, string? Landed) DescribeApplied(IMajorRecordGetter ov, WriteRequest req)
     {
         try
         {

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -89,6 +89,13 @@ public static class WritePatchBuilder
         /// empty. Q3: the forced in-place verify exists to catch exactly this, so it is stated loudly rather than left
         /// to a caller to notice. Null = checked and consistent, or not checkable (see <see cref="LandedOnDisk"/>).</summary>
         public string? Divergence { get; init; }
+
+        /// <summary>#308 — a LATER op in the same call wrote into this op's leaf, so the written file cannot answer
+        /// for this one: <see cref="After"/>/<see cref="Landed"/> were read the instant it applied, and the file holds
+        /// the state after every op. Not a problem with the op — it applied, and the later op's own verified clause
+        /// covers the leaf's final state — but the two are not comparable, and comparing them reported a correct
+        /// multi-op write (two Adds to one list; a value set then corrected) as NOT landed.</summary>
+        public bool SupersededInCall { get; init; }
     }
 
     /// <summary>One record read back IN FULL from the WRITTEN patch file (opt-in — the pre-enable verify loop,
@@ -2771,6 +2778,19 @@ public static class WritePatchBuilder
                         parentType = WriteEngine.ResolveConcreteRecordType(RecordNaming.StripOverlay(ownParent.GetType().Name));
                         parentPlans[i] = (null, null, null, ownParent);
                     }
+                    else if (patchMod.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == parentFk) is { } already)
+                    {
+                        // The DESTINATION already carries this parent — a prior into= call created it (the former N9
+                        // gap, resolvable because Phase 0 opens the patch BEFORE this loop), forwarded it, or edited
+                        // it. Use that record: it is already patch-local and settable, and overriding a body in on top
+                        // of it would be discarded anyway (GenericGetOrAddAsOverride has get-semantics).
+                        // Ordered BEFORE the load-order branch since #300 (review [low]): that branch used to win
+                        // whenever the parent was also in the order, so the definer's body was fetched, silently
+                        // dropped, and then REPORTED as the host — the one place the provenance line could lie.
+                        parentType = WriteEngine.ResolveConcreteRecordType(RecordNaming.StripOverlay(already.GetType().Name));
+                        parentPlans[i] = (null, null, null, already);
+                        parentHosts[i] = $"{RecordNaming.StripOverlay(already.GetType().Name)} {parentFk} was already carried by this artifact — its existing record hosts the child (nothing copied in)";
+                    }
                     else if (view.ResolveWinner(parentFk) is { } w)
                     {
                         // An EXISTING load-order parent (a topic/cell from a master or mod): override it INTO the destination
@@ -2814,14 +2834,6 @@ public static class WritePatchBuilder
                                     : $" (its DEFINING plugin — the lean host: '{w.WinnerPlugin}' currently WINS this record and its version is deliberately not copied here, "
                                       + $"so wherever this artifact out-ranks '{w.WinnerPlugin}' the parent record resolves to '{readFrom}'s fields. "
                                       + $"Sort this artifact BEFORE '{w.WinnerPlugin}' to keep that mod's version of the parent — the new child is carried either way.)");
-                    }
-                    else if (patchMod.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == parentFk) is { } patchParent)
-                    {
-                        // A parent created in a PRIOR into= call — it lives in the patch being extended, not the load order
-                        // (the former N9 gap, now resolvable because Phase 0 opens the patch BEFORE this loop). It's already
-                        // a settable patch-local record, so Phase 3 uses it directly (no override needed).
-                        parentType = WriteEngine.ResolveConcreteRecordType(RecordNaming.StripOverlay(patchParent.GetType().Name));
-                        parentPlans[i] = (null, null, null, patchParent);
                     }
                     else
                     {
@@ -3261,10 +3273,13 @@ public static class WritePatchBuilder
     /// not, so a struct that exists in memory and serializes to nothing rendered as landed under a file-authority
     /// claim while the file was byte-unchanged.
     ///
-    /// <para>Same code path both sides (<see cref="DescribeApplied"/>), so a difference is a difference in the DATA,
-    /// not in how two renderers phrase it. A record the file does not yield leaves both fields null — the renderer
-    /// then says the clause is the applied edit's claim, which is the honest reading and the one the old banner
-    /// silently skipped.</para>
+    /// <para>One READER both sides (<see cref="DescribeApplied"/>), so a difference is a difference in the DATA, not
+    /// in how two renderers phrase it. Not one OPEN, though, and the asymmetry is deliberate (review [low]): the
+    /// memory side is the record this call authored, while the file side is re-opened through
+    /// <c>LoadOrderResolver.OpenOverlay</c> so a localized plugin's strings resolve — without which a value this call
+    /// just wrote would read back empty and be reported as lost. A record the file does not yield leaves both fields
+    /// null — the renderer then says the clause is the applied edit's claim, which is the honest reading and the one
+    /// the old banner silently skipped.</para>
     ///
     /// <para>Its own enumeration pass, deliberately: <see cref="ReadBackInFull"/> materialises RecordFields and hands
     /// back values, and threading a second output through it to save one lazy header walk of ONE already-open file —
@@ -3288,8 +3303,15 @@ public static class WritePatchBuilder
         {
             var op = ops[i];
             if (i >= perOp.Count || !found.TryGetValue(perOp[i].Target, out var rec)) { verified.Add(op); continue; }
+            // SUPERSEDED ops are not comparable, and comparing them was a false alarm (review [high], reproduced):
+            // `After`/`Landed` are read the instant op i applies — mid-sequence — while the file holds the state after
+            // ALL of them. Two ops on one leaf (two Adds to one list; a value set then corrected) therefore always
+            // "disagreed", and the response told the caller to treat a landed op as NOT landed. The remedy an agent
+            // then reaches for — re-issue the op — is the duplicate-Add trap this codebase already warns about.
+            // The file has ONE final state, so only the LAST op touching a leaf is answerable by it.
+            if (LaterOpTouchesSameLeaf(perOp, i)) { verified.Add(op with { SupersededInCall = true }); continue; }
             var (afterDisk, landedDisk) = DescribeApplied(rec, perOp[i].Req);
-            // BOTH descriptors, not just the leaf summary (#308 review [medium]): `After` is the container
+            // BOTH descriptors, not just the leaf summary (review [medium]): `After` is the container
             // (`[list: N item(s)]`), `Landed` is the touched ELEMENT. A struct that lands as an element but serializes
             // to less than the caller supplied leaves the COUNT equal on both sides — so comparing summaries alone
             // would answer "verified" while the two element renderings visibly disagreed in the same response, which
@@ -3301,6 +3323,37 @@ public static class WritePatchBuilder
             });
         }
         return verified;
+    }
+
+    /// <summary>Does a LATER op in the same call write into the same leaf family as op <paramref name="i"/> — the same
+    /// record, and a path that is equal to, contains, or is contained by this op's? Then op i's in-memory reading was
+    /// taken before that op ran and the written file cannot speak to it.
+    /// <para>Containment, not equality: <c>Set BasicStats</c> followed by <c>Set BasicStats.Damage</c> leaves the
+    /// first op's whole-struct reading stale too. Index/key suffixes are stripped before comparing, so
+    /// <c>Ranks[0].Number</c> is recognised as writing inside <c>Ranks</c>; sibling paths under one parent
+    /// (<c>BasicStats.Damage</c> vs <c>BasicStats.Reach</c>) stay independent and both remain checkable.</para></summary>
+    static bool LaterOpTouchesSameLeaf(IReadOnlyList<(FormKey Target, WriteRequest Req)> perOp, int i)
+    {
+        for (int j = i + 1; j < perOp.Count; j++)
+            if (perOp[j].Target == perOp[i].Target && PathFamiliesOverlap(perOp[i].Req.Path, perOp[j].Req.Path))
+                return true;
+        return false;
+    }
+
+    /// <summary>Is one dotted path a prefix of the other, comparing segments with any <c>[index]</c>/<c>[key]</c>
+    /// suffix stripped? Equal paths count (a prefix of itself).</summary>
+    static bool PathFamiliesOverlap(string[] a, string[] b)
+    {
+        int n = Math.Min(a.Length, b.Length);
+        for (int k = 0; k < n; k++)
+            if (!string.Equals(BareSegment(a[k]), BareSegment(b[k]), StringComparison.OrdinalIgnoreCase)) return false;
+        return true;
+
+        static string BareSegment(string s)
+        {
+            int bracket = s.IndexOf('[');
+            return bracket < 0 ? s : s[..bracket];
+        }
     }
 
     /// <summary>#308's comparator: does the edited leaf's in-memory state disagree with the WRITTEN FILE's? Null =
@@ -3323,11 +3376,16 @@ public static class WritePatchBuilder
 
     /// <summary>The element count out of a container summary token (<c>[list: N item(s)]</c>, <c>[dict: N …]</c>);
     /// null when the token is not a counted container — a scalar, a formlink, or a shape this doesn't recognise, all
-    /// of which fall back to a text comparison rather than being read as "0".</summary>
+    /// of which fall back to a text comparison rather than being read as "0".
+    /// <para>The prefix is checked against the two shapes ReadEngine actually emits, not "starts with '[' and has a
+    /// colon" (review [low]): a STRING field whose value happens to read <c>[Boss: 3 guards]</c> would otherwise be
+    /// compared as a count, so <c>[Boss: 3 guards]</c> vs <c>[Boss: 3 dragons]</c> — a real change — would compare
+    /// equal and the divergence would be missed silently, in a detector whose whole job is not to miss one.</para></summary>
     static int? ContainerCount(string token)
     {
+        if (!token.StartsWith("[list:", StringComparison.Ordinal) && !token.StartsWith("[dict:", StringComparison.Ordinal))
+            return null;
         int colon = token.IndexOf(':');
-        if (!token.StartsWith('[') || colon < 0) return null;
         int i = colon + 1;
         while (i < token.Length && token[i] == ' ') i++;
         int start = i;

--- a/src/housecarl-generator/ApplyGuardProbe.cs
+++ b/src/housecarl-generator/ApplyGuardProbe.cs
@@ -129,42 +129,71 @@ public static class ApplyGuardProbe
             && op0.TryGetProperty("landed_verification", out var lv) && lv.GetString() == "verified"
             && op0.TryGetProperty("divergence", out var dv) && dv.ValueKind == JsonValueKind.Null, withField);
 
-        // The comparator's own semantics (unit). The tokens below are the ones ReadEngine really emits — an absent
-        // leaf reads "(absent)", NEVER "", which is the whole reason an earlier draft's vanish check could not fire.
-        // Two of these pin the detector against WIDENING (a text difference must not become a verdict) and say so;
-        // the rest pin the two rules it does claim.
-        string? Div(string? mem, bool memHas, string? disk, bool diskHas) => WritePatchBuilder.LeafDivergence(mem, memHas, disk, diskHas);
+        // The comparator's own semantics (unit), fed the PRESENCE the reader reports rather than tokens a parser has
+        // to interpret. Two of these pin the detector against WIDENING (a text difference must not become a verdict)
+        // and say so; the rest pin the two rules it claims. Shorthands: a scalar value, a list of N, a present
+        // substruct, and nothing at all.
+        static WritePatchBuilder.LeafPresence Val() => new(true, true, null);
+        static WritePatchBuilder.LeafPresence List(int n) => new(false, true, n);
+        static WritePatchBuilder.LeafPresence Sub() => new(false, true, null);
+        static WritePatchBuilder.LeafPresence Gone() => new(false, false, null);
+        string? Div(string? mem, WritePatchBuilder.LeafPresence memP, string? disk, WritePatchBuilder.LeafPresence diskP)
+            => WritePatchBuilder.LeafDivergence(mem, memP, disk, diskP);
+
         Check("comparator: 1 element in memory vs 0 in the file is a divergence, reported as counts",
-            Div("[list: 1 item(s)]", false, "[list: 0 item(s)]", false) is { } d
+            Div("[list: 1 item(s)]", List(1), "[list: 0 item(s)]", List(0)) is { } d
             && d.Contains("1 element(s) in memory", StringComparison.Ordinal) && d.Contains("carries 0", StringComparison.Ordinal),
-            Div("[list: 1 item(s)]", false, "[list: 0 item(s)]", false));
+            Div("[list: 1 item(s)]", List(1), "[list: 0 item(s)]", List(0)));
         Check("comparator: identical readings are NOT a divergence, and an unanswered side never is either",
-            Div("[list: 1 item(s)]", false, "[list: 1 item(s)]", false) is null
-            && Div("99", true, null, false) is null
-            && Div(null, false, "99", true) is null);
+            Div("[list: 1 item(s)]", List(1), "[list: 1 item(s)]", List(1)) is null
+            && Div("99", Val(), null, default) is null
+            && Div(null, default, "99", Val()) is null);
         // A substruct leaf renders its TYPE name, and the mutable record and the binary overlay name it differently
         // ([WeaponBasicStats] vs [WeaponBasicStatsBinaryOverlay]) — a text compare accused every `Set <substruct>` of
-        // not landing. Both sides HAVE content, so the presence rule is silent: this pins that, against widening.
+        // not landing. Both sides are PRESENT, so the rule is silent: this pins that, against widening.
         Check("comparator: a substruct leaf the overlay names differently is NOT a divergence",
-            Div("[WeaponBasicStats]", false, "[WeaponBasicStatsBinaryOverlay]", false) is null,
-            Div("[WeaponBasicStats]", false, "[WeaponBasicStatsBinaryOverlay]", false));
+            Div("[WeaponBasicStats]", Sub(), "[WeaponBasicStatsBinaryOverlay]", Sub()) is null,
+            Div("[WeaponBasicStats]", Sub(), "[WeaponBasicStatsBinaryOverlay]", Sub()));
         // Percent is byte-quantised, so a correct `Set ChanceNone value="0.123"` reads back 0.12 off the file.
         // Calling that "NOT landed" instructs a re-issue that diverges identically forever.
         Check("comparator: a value the FORMAT rounds (0.123 -> 0.12, a byte-quantised Percent) is NOT a divergence",
-            Div("0.123", true, "0.12", true) is null, Div("0.123", true, "0.12", true));
-        // THE VANISH RULE, on the tokens the reader actually produces: a value that became nothing, and a nullable
-        // LIST whose subrecord never got written (it reads "(absent)", not "[list: 0 item(s)]", so the count arm
-        // cannot see it — the case the first draft of this rule missed for every leaf but a non-nullable list).
+            Div("0.123", Val(), "0.12", Val()) is null, Div("0.123", Val(), "0.12", Val()));
+        // THE VANISH RULE, on all three leaf kinds — each one a case an earlier draft missed. The scalar arm looked
+        // for an empty string the reader never emits; the count arm cannot see a nullable list that reads "(absent)";
+        // and neither could see a SUBSTRUCT, whose summary carries no count at all.
         Check("comparator: a scalar that became NOTHING is a divergence, with the localized-strings caveat named",
-            Div("Winner Sword", true, "(absent)", false) is { } gone
+            Div("Winner Sword", Val(), "(absent)", Gone()) is { } gone
             && gone.Contains("carries no value there", StringComparison.Ordinal)
-            && gone.Contains("LOCALIZED", StringComparison.Ordinal), Div("Winner Sword", true, "(absent)", false));
+            && gone.Contains("LOCALIZED", StringComparison.Ordinal), Div("Winner Sword", Val(), "(absent)", Gone()));
         Check("comparator: a nullable LIST that reads (absent) on disk is a divergence too",
-            Div("[list: 1 item(s)]", false, "(absent)", false) is not null,
-            Div("[list: 1 item(s)]", false, "(absent)", false));
+            Div("[list: 1 item(s)]", List(1), "(absent)", Gone()) is not null);
+        Check("comparator: a SUBSTRUCT that vanished on serialize is a divergence — the case with no count to compare",
+            Div("[VirtualMachineAdapter]", Sub(), "(absent)", Gone()) is not null,
+            Div("[VirtualMachineAdapter]", Sub(), "(absent)", Gone()));
         Check("comparator: a list the call legitimately EMPTIED is not — an emptied list and a dropped subrecord agree",
-            Div("[list: 0 item(s)]", false, "(absent)", false) is null,
-            Div("[list: 0 item(s)]", false, "(absent)", false));
+            Div("[list: 0 item(s)]", List(0), "(absent)", Gone()) is null,
+            Div("[list: 0 item(s)]", List(0), "(absent)", Gone()));
+
+        // THE REPORT, not just the detector (review [medium]): a reviewer showed that deleting AppendDivergences, the
+        // full-dump call site, and the json "diverged" word left every check green — the guard covered the finding and
+        // not the sentence a caller reads. Driven at the render boundary with a hand-built outcome, since the fixture
+        // can no longer produce a real divergence (the empty-compose refusal removed its only producer).
+        var diverged = new WritePatchBuilder.PatchOutcome(
+            true, null, fx.ReplacerPath, false, new[] { fx.MasterName },
+            new[] { new WritePatchBuilder.OpResult(fx.SubjectKey, "Weapon", "Add Ranks", true, null, "[list: 1 item(s)]", "now 1 (+1)")
+                        { LandedOnDisk = "[list: 0 item(s)]", Divergence = "the applied edit left 1 element(s) in memory, but the WRITTEN FILE carries 0", VerifyAttempted = true } },
+            123L)
+            { InPlace = true, ReadBack = new[] { new WritePatchBuilder.FullReadback(fx.SubjectKey, null, "re-read failed") } };
+        var compactRender = WriteTools.Render(diverged);
+        var fullRender = WriteTools.Render(diverged, fullDump: true);
+        Check("the COMPACT render states a divergence as NOT landed, even when that record's read-back failed",
+            compactRender.Contains("treat this op as NOT landed", StringComparison.Ordinal), compactRender);
+        Check("…and the FULL-dump render states it too (the lane that used to drop it silently)",
+            fullRender.Contains("treat this op as NOT landed", StringComparison.Ordinal), fullRender);
+        var divergedJson = JsonWire.RenderPatchOutcome(diverged, 0, false, "in_place");
+        Check("…and json says landed_verification=diverged with the divergence text",
+            divergedJson.Contains("\"landed_verification\": \"diverged\"", StringComparison.Ordinal)
+            && divergedJson.Contains("WRITTEN FILE carries 0", StringComparison.Ordinal), divergedJson);
 
         // MULTI-OP, end-to-end: two Adds to ONE list in ONE in-place call. Both land; the file carries both. The
         // earlier op's reading was taken between them, so comparing it against the final file state accused a correct

--- a/src/housecarl-generator/ApplyGuardProbe.cs
+++ b/src/housecarl-generator/ApplyGuardProbe.cs
@@ -26,7 +26,7 @@ namespace HousecarlGenerator;
 /// <item><b>TRANSPORT</b> — format=json is valid JSON carrying the same data, refusals are documents too, and every
 /// response (both renders) carries the §2.1.1 epoch.</item>
 /// <item><b>the in-place verify's own honesty</b> (#308) — the per-op "what landed" clause is re-derived from the
-/// WRITTEN FILE (json: <c>landed_on_disk</c> + <c>landed_verified_on_disk</c>), a compose with nothing to serialize
+/// WRITTEN FILE (json: <c>landed_on_disk</c> + <c>landed_verification</c>), a compose with nothing to serialize
 /// is refused before the file is touched instead of reported as landed, and the memory-vs-file comparator's own
 /// semantics are pinned as a unit.</item>
 /// </list>
@@ -139,11 +139,22 @@ public static class ApplyGuardProbe
             WritePatchBuilder.LeafDivergence("[list: 1 item(s)]", "[list: 1 item(s)]") is null
             && WritePatchBuilder.LeafDivergence("99", null) is null
             && WritePatchBuilder.LeafDivergence(null, "99") is null);
-        Check("comparator: a changed SCALAR is a divergence too, quoted as the two readings",
-            WritePatchBuilder.LeafDivergence("99", "10") is { } s && s.Contains("'99'", StringComparison.Ordinal)
-            && s.Contains("'10'", StringComparison.Ordinal), WritePatchBuilder.LeafDivergence("99", "10"));
-        Check("comparator: a SCALAR that merely looks like a container token is compared as text, not as a count",
-            WritePatchBuilder.LeafDivergence("[Boss: 3 guards]", "[Boss: 3 dragons]") is not null);
+        // A substruct leaf renders its TYPE name, and the mutable record and the binary overlay name it differently
+        // ([WeaponBasicStats] vs [WeaponBasicStatsBinaryOverlay]) — so a text compare accused every `Set <substruct>`
+        // of not landing. Same class as the Percent one below, found by a different reviewer in the same round.
+        Check("comparator: a substruct leaf the overlay names differently is NOT a divergence",
+            WritePatchBuilder.LeafDivergence("[WeaponBasicStats]", "[WeaponBasicStatsBinaryOverlay]") is null,
+            WritePatchBuilder.LeafDivergence("[WeaponBasicStats]", "[WeaponBasicStatsBinaryOverlay]"));
+        // The false-alarm bound, and the reason the scalar text compare was dropped: Percent is byte-quantised, so a
+        // correct `Set ChanceNone value="0.123"` reads back 0.12 off the file. Calling that "NOT landed" instructs a
+        // re-issue that diverges identically forever — the wrong-answer class this detector exists to close, mirrored.
+        Check("comparator: a value the FORMAT rounds (0.123 -> 0.12, a byte-quantised Percent) is NOT a divergence",
+            WritePatchBuilder.LeafDivergence("0.123", "0.12") is null,
+            WritePatchBuilder.LeafDivergence("0.123", "0.12"));
+        Check("comparator: content that VANISHED still is one, and the wording names the localized-strings caveat",
+            WritePatchBuilder.LeafDivergence("Winner Sword", "") is { } gone
+            && gone.Contains("carries nothing there", StringComparison.Ordinal)
+            && gone.Contains("LOCALIZED", StringComparison.Ordinal), WritePatchBuilder.LeafDivergence("Winner Sword", ""));
 
         // MULTI-OP, end-to-end: two Adds to ONE list in ONE in-place call. Both land; the file carries both. The
         // earlier op's reading was taken between them, so comparing it against the final file state accused a correct

--- a/src/housecarl-generator/ApplyGuardProbe.cs
+++ b/src/housecarl-generator/ApplyGuardProbe.cs
@@ -14,7 +14,7 @@ namespace HousecarlGenerator;
 ///
 /// Drives the REAL end-to-end tool path — a synthetic MO2 instance in temp + <see cref="LoadOrderService"/> +
 /// <see cref="ApplyTools.Apply"/> — so the wire reader, the LANE grammar, the alias-visible vocabulary, the corpus
-/// pre-flight and the apply engine are exercised exactly as a caller hits them. Six arms:
+/// pre-flight and the apply engine are exercised exactly as a caller hits them. EIGHT arms:
 /// <list type="number">
 /// <item><b>ops grammar</b> — the 2.0 vocabulary (op=, one op is a set of one), the @file spelling that retired
 /// from_file=, and the strict element reader's NAMED refusals (undeclared member, mixed inline/@file).</item>
@@ -29,6 +29,11 @@ namespace HousecarlGenerator;
 /// WRITTEN FILE (json: <c>landed_on_disk</c> + <c>landed_verification</c>), a compose with nothing to serialize
 /// is refused before the file is touched instead of reported as landed, and the memory-vs-file comparator's own
 /// semantics are pinned as a unit.</item>
+/// <item><b>keyed multi-op</b> (#308) — two COUNT-CHANGING key-addressed ops in one in-place call both land and
+/// neither is reported as not landed (the arm that would have caught the over-broad key exemption).</item>
+/// <item><b>the verify's wiring</b> (#308) — the keyed exemption's own purpose (two SetAtIndex on different elements
+/// each keep their verification) and the comparator's WIRE into the verify pass, both of which a review found
+/// deletable with every probe still green.</item>
 /// </list>
 ///
 /// Run: <c>dotnet run --project src/housecarl-generator apply-guard</c>
@@ -68,6 +73,7 @@ public static class ApplyGuardProbe
             TransportArm(fx);
             EmptyComposeArm(fx);
             KeyedMultiOpArm(fx);
+            VerifyWiringArm(fx);
 
             Console.WriteLine();
             Console.WriteLine($"=== apply-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
@@ -270,6 +276,69 @@ public static class ApplyGuardProbe
         Check("…and NEITHER is reported as not landed — the earlier op's count is behind the file's, not wrong",
             !twoRemoves.Contains("NOT landed", StringComparison.Ordinal)
             && !twoRemoves.Contains("NOT carried by the written file", StringComparison.Ordinal), twoRemoves);
+    }
+
+    /// <summary>ARM 8 (#308) — the two seams a review found INERT: nothing pinned the keyed exemption (deleting it
+    /// left every probe green, because arm 7 drives count-CHANGING removes which fall through anyway), and nothing
+    /// pinned the comparator's WIRE into the verify pass (deleting `Divergence = LeafDivergence(…)` left every probe
+    /// green too — the render checks are driven from a hand-built outcome, and the end-to-end assertions are all
+    /// negative). Both are driven here against the real written file.</summary>
+    static void VerifyWiringArm(Fixture fx)
+    {
+        Console.WriteLine("── ARM 8: #308 — the keyed exemption, and the comparator's wire into the verify ──");
+
+        // (a) THE EXEMPTION'S OWN PURPOSE: two SetAtIndex ops on DIFFERENT indices are independent, so each keeps its
+        //     own file verification rather than one being written off as superseded by the other.
+        var ranks = RanksIn(fx.ReplacerPath, fx.FactionFid);
+        if (ranks < 2)
+            ApplyTools.Apply(fx.Svc, in_place: fx.ReplacerName, acknowledge: true,
+                ops: Json("[" + string.Join(",", new[] { "1", "2" }
+                    .Select(n => ComposeRankOp(fx.FactionFid, "\"fields\":{\"Number\":\"" + n + "\"}")[1..^1])) + "]"));
+        // KEY-addressed SetAtIndex, not a bracketed path: the bracketed form takes the segment rule, and it was the
+        // KEY exemption a review found unpinned. `key=` is where the element lives for this verb, so this is the
+        // shape CountNeutralKeyedVerb actually decides. SetAtIndex on a struct list takes a compose spec.
+        string SetRankNumber(string idx, string val) =>
+            "{\"formid\":\"" + fx.FactionFid + "\",\"field_path\":\"Ranks\",\"op\":\"SetAtIndex\",\"key\":\"" + idx
+            + "\",\"compose\":{\"type\":\"Rank\",\"fields\":{\"Number\":\"" + val + "\"}}}";
+        var twoSets = ApplyTools.Apply(fx.Svc, in_place: fx.ReplacerName, acknowledge: true, format: "json",
+            ops: Json("[" + SetRankNumber("0", "41") + "," + SetRankNumber("1", "42") + "]"));
+        var states = new List<string>();
+        try
+        {
+            var doc = Json(twoSets);
+            if (doc.TryGetProperty("ops", out var arr))
+                foreach (var op in arr.EnumerateArray())
+                    states.Add(op.TryGetProperty("landed_verification", out var v) ? v.GetString() ?? "?" : "?");
+        }
+        catch { /* states stays empty — the check below fails with the render as evidence */ }
+        Check("two ops on DIFFERENT elements each keep their own file verification (neither is written off)",
+            states.Count == 2 && states.All(v => v == "verified"),
+            string.Join(",", states) + "\n" + twoSets);
+
+        // (b) THE WIRE: hand the REAL verify pass a claim the written file cannot corroborate — an op asserting a
+        //     5-element list for a leaf the file carries fewer of — and require that it comes back diverged. This is
+        //     what proves LeafDivergence is actually consulted by VerifyLandedAgainstFile; the fixture can no longer
+        //     produce a genuine vanishing write (the empty-compose refusal removed its only producer), so the claim
+        //     is synthesised while the FILE half stays real.
+        ISkyrimModGetter? back = null;
+        try
+        {
+            back = SkyrimMod.CreateFromBinaryOverlay(fx.ReplacerPath, SkyrimRelease.SkyrimSE);
+            var fk = FormKey.Factory(fx.FactionFid);
+            var req = new WriteRequest { RecordType = "Faction", Path = new[] { "Ranks" }, Verb = "Add" };
+            var claim = new WritePatchBuilder.OpResult(fk, "Faction", "Add Ranks", true, null,
+                                                      "[list: 5 item(s)]", "now 5 item(s)")
+                { AfterPresence = new WritePatchBuilder.LeafPresence(false, true, 5) };
+            var verified = WritePatchBuilder.VerifyLandedAgainstFile(
+                back, new[] { (fk, req) }, new[] { claim });
+            Check("the verify pass CONSULTS the comparator: a claim the file cannot corroborate comes back diverged",
+                verified.Count == 1 && verified[0].Divergence is { } d && d.Contains("5 element(s) in memory", StringComparison.Ordinal),
+                verified.Count == 1 ? verified[0].Divergence ?? "(no divergence)" : "(no result)");
+            Check("…and the same pass reports the FILE's own reading for that op, not the claim's",
+                verified.Count == 1 && verified[0].LandedOnDisk is { } lod && !lod.Contains("5", StringComparison.Ordinal),
+                verified.Count == 1 ? verified[0].LandedOnDisk ?? "(null)" : "(no result)");
+        }
+        finally { (back as IDisposable)?.Dispose(); }
     }
 
     /// <summary>How many Ranks the written faction carries on disk — the ground truth behind the multi-op check.</summary>

--- a/src/housecarl-generator/ApplyGuardProbe.cs
+++ b/src/housecarl-generator/ApplyGuardProbe.cs
@@ -67,6 +67,7 @@ public static class ApplyGuardProbe
             InPlaceCopyArm(fx);
             TransportArm(fx);
             EmptyComposeArm(fx);
+            KeyedMultiOpArm(fx);
 
             Console.WriteLine();
             Console.WriteLine($"=== apply-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
@@ -239,6 +240,36 @@ public static class ApplyGuardProbe
             twoAdds.Contains("a later op in this call wrote the same field", StringComparison.Ordinal), twoAdds);
         Check("…and the list really carries BOTH ranks on disk (the write the arm is defending was correct)",
             RanksIn(fx.ReplacerPath, fx.FactionFid) >= 2, $"ranks={RanksIn(fx.ReplacerPath, fx.FactionFid)}\n{twoAdds}");
+    }
+
+    /// <summary>#308 — two COUNT-CHANGING key-addressed ops in ONE in-place call. The multi-op checks in arm 6 use
+    /// two Adds, whose Key is null, so they take the superseded path and never exercised the key exemption; a review
+    /// then reproduced a false "NOT landed" here, on a call where BOTH removes landed and where the remedy that
+    /// advises would delete a third element. Driven end-to-end, and the disk count is asserted too, so the arm proves
+    /// the write was right rather than merely that the render stayed quiet.</summary>
+    static void KeyedMultiOpArm(Fixture fx)
+    {
+        Console.WriteLine("── ARM 7: #308 — two key-addressed REMOVES in one call are not slandered ──");
+
+        // Seed three ranks in one call, so the arm owns its own state regardless of what ran before it.
+        var seed = ApplyTools.Apply(fx.Svc, in_place: fx.ReplacerName, acknowledge: true,
+            ops: Json("[" + string.Join(",", new[] { "7", "8", "9" }
+                .Select(n => ComposeRankOp(fx.FactionFid, "\"fields\":{\"Number\":\"" + n + "\"}")[1..^1])) + "]"));
+        int before = RanksIn(fx.ReplacerPath, fx.FactionFid);
+        Check("seeded three ranks for the keyed-op arm",
+            seed.StartsWith("edited ", StringComparison.Ordinal) && before >= 3, $"ranks={before}\n{seed}");
+
+        // Two removes BY INDEX, high index first so the second index stays valid.
+        string RemoveRank(string key) =>
+            "{\"formid\":\"" + fx.FactionFid + "\",\"field_path\":\"Ranks\",\"op\":\"Remove\",\"key\":\"" + key + "\"}";
+        var twoRemoves = ApplyTools.Apply(fx.Svc, in_place: fx.ReplacerName, acknowledge: true,
+            ops: Json("[" + RemoveRank("2") + "," + RemoveRank("0") + "]"));
+        int after = RanksIn(fx.ReplacerPath, fx.FactionFid);
+        Check("two key-addressed Removes in one call: BOTH land (the count drops by two)",
+            after == before - 2, $"{before} -> {after}\n{twoRemoves}");
+        Check("…and NEITHER is reported as not landed — the earlier op's count is behind the file's, not wrong",
+            !twoRemoves.Contains("NOT landed", StringComparison.Ordinal)
+            && !twoRemoves.Contains("NOT carried by the written file", StringComparison.Ordinal), twoRemoves);
     }
 
     /// <summary>How many Ranks the written faction carries on disk — the ground truth behind the multi-op check.</summary>

--- a/src/housecarl-generator/ApplyGuardProbe.cs
+++ b/src/housecarl-generator/ApplyGuardProbe.cs
@@ -14,7 +14,7 @@ namespace HousecarlGenerator;
 ///
 /// Drives the REAL end-to-end tool path — a synthetic MO2 instance in temp + <see cref="LoadOrderService"/> +
 /// <see cref="ApplyTools.Apply"/> — so the wire reader, the LANE grammar, the alias-visible vocabulary, the corpus
-/// pre-flight and the apply engine are exercised exactly as a caller hits them. Five arms:
+/// pre-flight and the apply engine are exercised exactly as a caller hits them. Six arms:
 /// <list type="number">
 /// <item><b>ops grammar</b> — the 2.0 vocabulary (op=, one op is a set of one), the @file spelling that retired
 /// from_file=, and the strict element reader's NAMED refusals (undeclared member, mixed inline/@file).</item>
@@ -25,6 +25,10 @@ namespace HousecarlGenerator;
 /// <item><b>in-place CopyFrom</b> — the capability the lane never had (it died as an engine-inconsistency wrapper).</item>
 /// <item><b>TRANSPORT</b> — format=json is valid JSON carrying the same data, refusals are documents too, and every
 /// response (both renders) carries the §2.1.1 epoch.</item>
+/// <item><b>the in-place verify's own honesty</b> (#308) — the per-op "what landed" clause is re-derived from the
+/// WRITTEN FILE (json: <c>landed_on_disk</c> + <c>landed_verified_on_disk</c>), a compose with nothing to serialize
+/// is refused before the file is touched instead of reported as landed, and the memory-vs-file comparator's own
+/// semantics are pinned as a unit.</item>
 /// </list>
 ///
 /// Run: <c>dotnet run --project src/housecarl-generator apply-guard</c>
@@ -62,6 +66,7 @@ public static class ApplyGuardProbe
             ZipArm(fx);
             InPlaceCopyArm(fx);
             TransportArm(fx);
+            EmptyComposeArm(fx);
 
             Console.WriteLine();
             Console.WriteLine($"=== apply-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
@@ -75,6 +80,72 @@ public static class ApplyGuardProbe
         finally { try { Directory.Delete(root, recursive: true); } catch { } }
     }
 
+    /// <summary>ARM 6 (#308) — the in-place verify's per-op clause is the WRITTEN FILE's answer, and a compose with
+    /// nothing to serialize is refused instead of reported as landed.
+    /// <para>The end-to-end divergence RENDER has no synthesizable producer left once the refusal lands (that was the
+    /// only shape this fixture could build where memory and disk disagreed), so the two halves are pinned where each
+    /// actually lives: the refusal end-to-end through the tool, the file-derived clause through the json contract
+    /// (<c>landed_on_disk</c> + <c>landed_verified_on_disk</c>, which do not exist at all pre-fix), and the
+    /// comparator's own semantics as a unit. Stated rather than left as a gap: the detector is the general net for
+    /// every OTHER type that serializes to less than the caller believes, and that net is deliberately not
+    /// exercisable from a fixture built out of one.</para></summary>
+    /// <summary>One <c>Add Ranks</c> compose op, built by concatenation: the JSON's brace runs make a raw interpolated
+    /// literal ambiguous (the compiler says so), and escaping around that is less readable than this.</summary>
+    static string ComposeRankOp(string formid, string? extra) =>
+        "[{\"formid\":\"" + formid + "\",\"field_path\":\"Ranks\",\"op\":\"Add\",\"compose\":{\"type\":\"Rank\""
+        + (extra is null ? "" : "," + extra) + "}}]";
+
+    static void EmptyComposeArm(Fixture fx)
+    {
+        Console.WriteLine("── ARM 6: #308 — the verify's clause comes off the FILE, and an empty compose is refused ──");
+
+        var before = new FileInfo(fx.ReplacerPath).Length;
+        var empty = ApplyTools.Apply(fx.Svc,
+            ops: Json(ComposeRankOp(fx.FactionFid, null)),
+            in_place: fx.ReplacerName, acknowledge: true);
+        Check("a compose with NO fields whose struct serializes to nothing is REFUSED, not reported as landed",
+            empty.StartsWith("error:") && empty.Contains("no serializable content", StringComparison.Ordinal), empty);
+        Check("…and the refusal names the settable fields from the TYPE, so the caller knows what to set",
+            empty.Contains("Settable fields on Rank:", StringComparison.Ordinal)
+            && empty.Contains("Number", StringComparison.Ordinal), empty);
+        Check("…and it is a pre-serialize refusal: the in-place target is byte-untouched",
+            new FileInfo(fx.ReplacerPath).Length == before,
+            $"{before} -> {new FileInfo(fx.ReplacerPath).Length}");
+
+        // The same compose WITH content lands — the refusal is about emptiness, not about composing Ranks.
+        var withField = ApplyTools.Apply(fx.Svc,
+            ops: Json(ComposeRankOp(fx.FactionFid, "\"fields\":{\"Number\":\"0\"}")),
+            in_place: fx.ReplacerName, acknowledge: true, format: "json");
+        JsonElement op0 = default;
+        try
+        {
+            var doc = Json(withField);
+            if (doc.TryGetProperty("ops", out var opsArr) && opsArr.GetArrayLength() == 1) op0 = opsArr[0];
+        }
+        catch { /* op0 stays Undefined — every check below then fails with the render as evidence */ }
+        Check("the same compose WITH a field lands, and its clause is the FILE's (landed_on_disk present)",
+            op0.ValueKind == JsonValueKind.Object
+            && op0.TryGetProperty("landed_on_disk", out var lod) && lod.ValueKind == JsonValueKind.String, withField);
+        Check("…and it is declared VERIFIED against the written file, with no divergence",
+            op0.ValueKind == JsonValueKind.Object
+            && op0.TryGetProperty("landed_verified_on_disk", out var lv) && lv.ValueKind == JsonValueKind.True
+            && op0.TryGetProperty("divergence", out var dv) && dv.ValueKind == JsonValueKind.Null, withField);
+
+        // The comparator's own semantics (unit): a moved COUNT is a divergence and says so in counts; equal content
+        // is not; and an absent side is never evidence — the file failing to answer must not read as "it's wrong".
+        Check("comparator: 1 element in memory vs 0 in the file is a divergence, reported as counts",
+            WritePatchBuilder.LeafDivergence("[list: 1 item(s)]", "[list: 0 item(s)]") is { } d
+            && d.Contains("1 element(s) in memory", StringComparison.Ordinal) && d.Contains("carries 0", StringComparison.Ordinal),
+            WritePatchBuilder.LeafDivergence("[list: 1 item(s)]", "[list: 0 item(s)]"));
+        Check("comparator: identical readings are NOT a divergence, and an unanswered side never is either",
+            WritePatchBuilder.LeafDivergence("[list: 1 item(s)]", "[list: 1 item(s)]") is null
+            && WritePatchBuilder.LeafDivergence("99", null) is null
+            && WritePatchBuilder.LeafDivergence(null, "99") is null);
+        Check("comparator: a changed SCALAR is a divergence too, quoted as the two readings",
+            WritePatchBuilder.LeafDivergence("99", "10") is { } s && s.Contains("'99'", StringComparison.Ordinal)
+            && s.Contains("'10'", StringComparison.Ordinal), WritePatchBuilder.LeafDivergence("99", "10"));
+    }
+
     // ================= the shared synthetic order =================
 
     /// <summary>Master + replacer + an OFF-ORDER donor. The replacer WINS the subject weapon (so a copy from the
@@ -86,6 +157,8 @@ public static class ApplyGuardProbe
         public required string SubjectFid { get; init; }      // the weapon the replacer wins (Damage 99, no keywords)
         public required string DonorWeaponFid { get; init; }  // a DIFFERENT weapon (Damage 42, 2 keywords) — the zip source
         public required string ArmorFid { get; init; }        // a different record TYPE — the cross-type refusal source
+        public required string FactionFid { get; init; }      // #308: empty Ranks list, owned by the replacer
+        public required FormKey FactionKey { get; init; }
         public required string ModsDir { get; init; }
         public required string ReplacerPath { get; init; }   // the in-place target's real on-disk file
         public required FormKey DonorKey { get; init; }
@@ -149,6 +222,12 @@ public static class ApplyGuardProbe
             armor.EditorID = "ApArmor";
             armor.Name = "Some Cuirass";
 
+            // #308's fixture: a FACTION with an empty Ranks list. A Rank composed with NO fields is the canonical
+            // "exists in memory, serializes to nothing" struct — the shape the in-place verify used to report as
+            // landed under a banner claiming the line came off the written file.
+            var faction = m.Factions.AddNew();
+            faction.EditorID = "ApFaction";
+
             m.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
 
             // the replacer WINS the subject: Damage 99, and no keywords at all
@@ -166,6 +245,7 @@ public static class ApplyGuardProbe
             rd.BasicStats = new WeaponBasicStats { Damage = 7 };   // keywords carry over from the master (still 2)
             WriteEngine.GenericGetOrAddAsOverride(r, potA);        // the replacer OWNS both potions, so in-place may edit them
             WriteEngine.GenericGetOrAddAsOverride(r, potB);
+            WriteEngine.GenericGetOrAddAsOverride(r, faction);     // …and the faction, for the same reason (#308)
             r.BeginWrite.ToPath(replPath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
 
             File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + mKey.FileName + "\r\n" + rKey.FileName + "\r\n");
@@ -186,6 +266,8 @@ public static class ApplyGuardProbe
                 SubjectFid = $"{subject.FormKey.ID:X6}:{mKey.FileName}",
                 DonorWeaponFid = $"{donor.FormKey.ID:X6}:{mKey.FileName}",
                 ArmorFid = $"{armor.FormKey.ID:X6}:{mKey.FileName}",
+                FactionFid = $"{faction.FormKey.ID:X6}:{mKey.FileName}",
+                FactionKey = faction.FormKey,
                 ModsDir = mods,
                 ReplacerPath = replPath,
                 DonorKey = donor.FormKey,

--- a/src/housecarl-generator/ApplyGuardProbe.cs
+++ b/src/housecarl-generator/ApplyGuardProbe.cs
@@ -129,32 +129,42 @@ public static class ApplyGuardProbe
             && op0.TryGetProperty("landed_verification", out var lv) && lv.GetString() == "verified"
             && op0.TryGetProperty("divergence", out var dv) && dv.ValueKind == JsonValueKind.Null, withField);
 
-        // The comparator's own semantics (unit): a moved COUNT is a divergence and says so in counts; equal content
-        // is not; and an absent side is never evidence — the file failing to answer must not read as "it's wrong".
+        // The comparator's own semantics (unit). The tokens below are the ones ReadEngine really emits — an absent
+        // leaf reads "(absent)", NEVER "", which is the whole reason an earlier draft's vanish check could not fire.
+        // Two of these pin the detector against WIDENING (a text difference must not become a verdict) and say so;
+        // the rest pin the two rules it does claim.
+        string? Div(string? mem, bool memHas, string? disk, bool diskHas) => WritePatchBuilder.LeafDivergence(mem, memHas, disk, diskHas);
         Check("comparator: 1 element in memory vs 0 in the file is a divergence, reported as counts",
-            WritePatchBuilder.LeafDivergence("[list: 1 item(s)]", "[list: 0 item(s)]") is { } d
+            Div("[list: 1 item(s)]", false, "[list: 0 item(s)]", false) is { } d
             && d.Contains("1 element(s) in memory", StringComparison.Ordinal) && d.Contains("carries 0", StringComparison.Ordinal),
-            WritePatchBuilder.LeafDivergence("[list: 1 item(s)]", "[list: 0 item(s)]"));
+            Div("[list: 1 item(s)]", false, "[list: 0 item(s)]", false));
         Check("comparator: identical readings are NOT a divergence, and an unanswered side never is either",
-            WritePatchBuilder.LeafDivergence("[list: 1 item(s)]", "[list: 1 item(s)]") is null
-            && WritePatchBuilder.LeafDivergence("99", null) is null
-            && WritePatchBuilder.LeafDivergence(null, "99") is null);
+            Div("[list: 1 item(s)]", false, "[list: 1 item(s)]", false) is null
+            && Div("99", true, null, false) is null
+            && Div(null, false, "99", true) is null);
         // A substruct leaf renders its TYPE name, and the mutable record and the binary overlay name it differently
-        // ([WeaponBasicStats] vs [WeaponBasicStatsBinaryOverlay]) — so a text compare accused every `Set <substruct>`
-        // of not landing. Same class as the Percent one below, found by a different reviewer in the same round.
+        // ([WeaponBasicStats] vs [WeaponBasicStatsBinaryOverlay]) — a text compare accused every `Set <substruct>` of
+        // not landing. Both sides HAVE content, so the presence rule is silent: this pins that, against widening.
         Check("comparator: a substruct leaf the overlay names differently is NOT a divergence",
-            WritePatchBuilder.LeafDivergence("[WeaponBasicStats]", "[WeaponBasicStatsBinaryOverlay]") is null,
-            WritePatchBuilder.LeafDivergence("[WeaponBasicStats]", "[WeaponBasicStatsBinaryOverlay]"));
-        // The false-alarm bound, and the reason the scalar text compare was dropped: Percent is byte-quantised, so a
-        // correct `Set ChanceNone value="0.123"` reads back 0.12 off the file. Calling that "NOT landed" instructs a
-        // re-issue that diverges identically forever — the wrong-answer class this detector exists to close, mirrored.
+            Div("[WeaponBasicStats]", false, "[WeaponBasicStatsBinaryOverlay]", false) is null,
+            Div("[WeaponBasicStats]", false, "[WeaponBasicStatsBinaryOverlay]", false));
+        // Percent is byte-quantised, so a correct `Set ChanceNone value="0.123"` reads back 0.12 off the file.
+        // Calling that "NOT landed" instructs a re-issue that diverges identically forever.
         Check("comparator: a value the FORMAT rounds (0.123 -> 0.12, a byte-quantised Percent) is NOT a divergence",
-            WritePatchBuilder.LeafDivergence("0.123", "0.12") is null,
-            WritePatchBuilder.LeafDivergence("0.123", "0.12"));
-        Check("comparator: content that VANISHED still is one, and the wording names the localized-strings caveat",
-            WritePatchBuilder.LeafDivergence("Winner Sword", "") is { } gone
-            && gone.Contains("carries nothing there", StringComparison.Ordinal)
-            && gone.Contains("LOCALIZED", StringComparison.Ordinal), WritePatchBuilder.LeafDivergence("Winner Sword", ""));
+            Div("0.123", true, "0.12", true) is null, Div("0.123", true, "0.12", true));
+        // THE VANISH RULE, on the tokens the reader actually produces: a value that became nothing, and a nullable
+        // LIST whose subrecord never got written (it reads "(absent)", not "[list: 0 item(s)]", so the count arm
+        // cannot see it — the case the first draft of this rule missed for every leaf but a non-nullable list).
+        Check("comparator: a scalar that became NOTHING is a divergence, with the localized-strings caveat named",
+            Div("Winner Sword", true, "(absent)", false) is { } gone
+            && gone.Contains("carries no value there", StringComparison.Ordinal)
+            && gone.Contains("LOCALIZED", StringComparison.Ordinal), Div("Winner Sword", true, "(absent)", false));
+        Check("comparator: a nullable LIST that reads (absent) on disk is a divergence too",
+            Div("[list: 1 item(s)]", false, "(absent)", false) is not null,
+            Div("[list: 1 item(s)]", false, "(absent)", false));
+        Check("comparator: a list the call legitimately EMPTIED is not — an emptied list and a dropped subrecord agree",
+            Div("[list: 0 item(s)]", false, "(absent)", false) is null,
+            Div("[list: 0 item(s)]", false, "(absent)", false));
 
         // MULTI-OP, end-to-end: two Adds to ONE list in ONE in-place call. Both land; the file carries both. The
         // earlier op's reading was taken between them, so comparing it against the final file state accused a correct

--- a/src/housecarl-generator/ApplyGuardProbe.cs
+++ b/src/housecarl-generator/ApplyGuardProbe.cs
@@ -89,12 +89,6 @@ public static class ApplyGuardProbe
     /// comparator's own semantics as a unit. Stated rather than left as a gap: the detector is the general net for
     /// every OTHER type that serializes to less than the caller believes, and that net is deliberately not
     /// exercisable from a fixture built out of one.</para></summary>
-    /// <summary>One <c>Add Ranks</c> compose op, built by concatenation: the JSON's brace runs make a raw interpolated
-    /// literal ambiguous (the compiler says so), and escaping around that is less readable than this.</summary>
-    static string ComposeRankOp(string formid, string? extra) =>
-        "[{\"formid\":\"" + formid + "\",\"field_path\":\"Ranks\",\"op\":\"Add\",\"compose\":{\"type\":\"Rank\""
-        + (extra is null ? "" : "," + extra) + "}}]";
-
     static void EmptyComposeArm(Fixture fx)
     {
         Console.WriteLine("── ARM 6: #308 — the verify's clause comes off the FILE, and an empty compose is refused ──");
@@ -149,6 +143,12 @@ public static class ApplyGuardProbe
             && s.Contains("'10'", StringComparison.Ordinal), WritePatchBuilder.LeafDivergence("99", "10"));
     }
 
+    /// <summary>One <c>Add Ranks</c> compose op, built by concatenation: the JSON's brace runs make a raw interpolated
+    /// literal ambiguous (the compiler says so), and escaping around that is less readable than this.</summary>
+    static string ComposeRankOp(string formid, string? extra) =>
+        "[{\"formid\":\"" + formid + "\",\"field_path\":\"Ranks\",\"op\":\"Add\",\"compose\":{\"type\":\"Rank\""
+        + (extra is null ? "" : "," + extra) + "}}]";
+
     // ================= the shared synthetic order =================
 
     /// <summary>Master + replacer + an OFF-ORDER donor. The replacer WINS the subject weapon (so a copy from the
@@ -161,7 +161,6 @@ public static class ApplyGuardProbe
         public required string DonorWeaponFid { get; init; }  // a DIFFERENT weapon (Damage 42, 2 keywords) — the zip source
         public required string ArmorFid { get; init; }        // a different record TYPE — the cross-type refusal source
         public required string FactionFid { get; init; }      // #308: empty Ranks list, owned by the replacer
-        public required FormKey FactionKey { get; init; }
         public required string ModsDir { get; init; }
         public required string ReplacerPath { get; init; }   // the in-place target's real on-disk file
         public required FormKey DonorKey { get; init; }
@@ -270,7 +269,6 @@ public static class ApplyGuardProbe
                 DonorWeaponFid = $"{donor.FormKey.ID:X6}:{mKey.FileName}",
                 ArmorFid = $"{armor.FormKey.ID:X6}:{mKey.FileName}",
                 FactionFid = $"{faction.FormKey.ID:X6}:{mKey.FileName}",
-                FactionKey = faction.FormKey,
                 ModsDir = mods,
                 ReplacerPath = replPath,
                 DonorKey = donor.FormKey,

--- a/src/housecarl-generator/ApplyGuardProbe.cs
+++ b/src/housecarl-generator/ApplyGuardProbe.cs
@@ -80,15 +80,16 @@ public static class ApplyGuardProbe
         finally { try { Directory.Delete(root, recursive: true); } catch { } }
     }
 
-    /// <summary>ARM 6 (#308) — the in-place verify's per-op clause is the WRITTEN FILE's answer, and a compose with
-    /// nothing to serialize is refused instead of reported as landed.
-    /// <para>The end-to-end divergence RENDER has no synthesizable producer left once the refusal lands (that was the
-    /// only shape this fixture could build where memory and disk disagreed), so the two halves are pinned where each
-    /// actually lives: the refusal end-to-end through the tool, the file-derived clause through the json contract
-    /// (<c>landed_on_disk</c> + <c>landed_verified_on_disk</c>, which do not exist at all pre-fix), and the
-    /// comparator's own semantics as a unit. Stated rather than left as a gap: the detector is the general net for
-    /// every OTHER type that serializes to less than the caller believes, and that net is deliberately not
-    /// exercisable from a fixture built out of one.</para></summary>
+    /// <summary>ARM 6 (#308) — the in-place verify's per-op clause is the WRITTEN FILE's answer, a compose with
+    /// nothing to serialize is refused instead of reported as landed, and a MULTI-OP call is not slandered.
+    /// <para>The last of those is here because an earlier draft of this doc claimed the divergence render had "no
+    /// synthesizable producer left" — false, and a review found it by synthesizing one in this very fixture: two
+    /// Adds to one list, where op 1's mid-sequence reading was compared against the file's final state and a correct
+    /// write was reported as NOT landed. A guard that argues its way out of covering the one thing a caller sees is
+    /// how that shipped, so the multi-op case is now driven end-to-end here.</para>
+    /// <para>What stays unit-pinned is the comparator itself: with the refusal in place, a struct that lands as an
+    /// element and still serializes short is not buildable from this fixture — that is the general net for OTHER
+    /// types, and it is deliberately not synthesizable from one.</para></summary>
     static void EmptyComposeArm(Fixture fx)
     {
         Console.WriteLine("── ARM 6: #308 — the verify's clause comes off the FILE, and an empty compose is refused ──");
@@ -125,7 +126,7 @@ public static class ApplyGuardProbe
             && op0.TryGetProperty("landed_on_disk", out var lod) && lod.ValueKind == JsonValueKind.String, withField);
         Check("…and it is declared VERIFIED against the written file, with no divergence",
             op0.ValueKind == JsonValueKind.Object
-            && op0.TryGetProperty("landed_verified_on_disk", out var lv) && lv.ValueKind == JsonValueKind.True
+            && op0.TryGetProperty("landed_verification", out var lv) && lv.GetString() == "verified"
             && op0.TryGetProperty("divergence", out var dv) && dv.ValueKind == JsonValueKind.Null, withField);
 
         // The comparator's own semantics (unit): a moved COUNT is a divergence and says so in counts; equal content
@@ -141,6 +142,38 @@ public static class ApplyGuardProbe
         Check("comparator: a changed SCALAR is a divergence too, quoted as the two readings",
             WritePatchBuilder.LeafDivergence("99", "10") is { } s && s.Contains("'99'", StringComparison.Ordinal)
             && s.Contains("'10'", StringComparison.Ordinal), WritePatchBuilder.LeafDivergence("99", "10"));
+        Check("comparator: a SCALAR that merely looks like a container token is compared as text, not as a count",
+            WritePatchBuilder.LeafDivergence("[Boss: 3 guards]", "[Boss: 3 dragons]") is not null);
+
+        // MULTI-OP, end-to-end: two Adds to ONE list in ONE in-place call. Both land; the file carries both. The
+        // earlier op's reading was taken between them, so comparing it against the final file state accused a correct
+        // write of not landing — the defect a review reproduced in this fixture after the arm's own doc claimed it
+        // could not be built. Asserted on the RENDER, which is what a caller reads.
+        var twoAdds = ApplyTools.Apply(fx.Svc,
+            ops: Json("[" + ComposeRankOp(fx.FactionFid, "\"fields\":{\"Number\":\"1\"}")[1..^1] + ","
+                          + ComposeRankOp(fx.FactionFid, "\"fields\":{\"Number\":\"2\"}")[1..^1] + "]"),
+            in_place: fx.ReplacerName, acknowledge: true);
+        Check("two Adds to ONE list in one call: both land and NOTHING is reported as not landed",
+            twoAdds.StartsWith("edited ", StringComparison.Ordinal)
+            && !twoAdds.Contains("NOT landed", StringComparison.Ordinal), twoAdds);
+        Check("…and the superseded op says so — its clause is the applied edit's, not the later op's file reading",
+            twoAdds.Contains("a later op in this call wrote the same field", StringComparison.Ordinal), twoAdds);
+        Check("…and the list really carries BOTH ranks on disk (the write the arm is defending was correct)",
+            RanksIn(fx.ReplacerPath, fx.FactionFid) >= 2, $"ranks={RanksIn(fx.ReplacerPath, fx.FactionFid)}\n{twoAdds}");
+    }
+
+    /// <summary>How many Ranks the written faction carries on disk — the ground truth behind the multi-op check.</summary>
+    static int RanksIn(string espPath, string factionFid)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            var fk = FormKey.Factory(factionFid);
+            ov = SkyrimMod.CreateFromBinaryOverlay(espPath, SkyrimRelease.SkyrimSE);
+            return ov.Factions.FirstOrDefault(f => f.FormKey == fk)?.Ranks.Count ?? -1;
+        }
+        catch { return -1; }
+        finally { (ov as IDisposable)?.Dispose(); }
     }
 
     /// <summary>One <c>Add Ranks</c> compose op, built by concatenation: the JSON's brace runs make a raw interpolated

--- a/src/housecarl-generator/ApplyGuardProbe.cs
+++ b/src/housecarl-generator/ApplyGuardProbe.cs
@@ -87,9 +87,10 @@ public static class ApplyGuardProbe
     /// Adds to one list, where op 1's mid-sequence reading was compared against the file's final state and a correct
     /// write was reported as NOT landed. A guard that argues its way out of covering the one thing a caller sees is
     /// how that shipped, so the multi-op case is now driven end-to-end here.</para>
-    /// <para>What stays unit-pinned is the comparator itself: with the refusal in place, a struct that lands as an
-    /// element and still serializes short is not buildable from this fixture — that is the general net for OTHER
-    /// types, and it is deliberately not synthesizable from one.</para></summary>
+    /// <para>What stays unit-pinned is the comparator itself. And what it does NOT claim, since a review proved the
+    /// second probe inert: an element that lands but serializes with fewer fields than supplied is not reported —
+    /// telling that from the format representing a value its own way is what produced the earlier false alarms. The
+    /// unit checks below pin both the two rules it keeps and the two shapes it must stay silent about.</para></summary>
     static void EmptyComposeArm(Fixture fx)
     {
         Console.WriteLine("── ARM 6: #308 — the verify's clause comes off the FILE, and an empty compose is refused ──");
@@ -191,6 +192,14 @@ public static class ApplyGuardProbe
         Check("…and the FULL-dump render states it too (the lane that used to drop it silently)",
             fullRender.Contains("treat this op as NOT landed", StringComparison.Ordinal), fullRender);
         var divergedJson = JsonWire.RenderPatchOutcome(diverged, 0, false, "in_place");
+        // …and it survives a max_chars cut that drops the ops array, which is where the text render hoists its own
+        // lines to and the json twin did not (review [medium]): a document that cuts the only "did not land" row while
+        // saying "the WRITE is complete and unaffected" is worse than no verify at all.
+        var divergedTiny = JsonWire.RenderPatchOutcome(diverged, 400, false, "in_place");
+        Check("…and the json divergence rows survive a max_chars cut that truncates the ops array",
+            divergedTiny.Contains("\"divergences\"", StringComparison.Ordinal)
+            && divergedTiny.Contains("WRITTEN FILE carries 0", StringComparison.Ordinal)
+            && divergedTiny.Contains("\"diverged_ops\": 1", StringComparison.Ordinal), divergedTiny);
         Check("…and json says landed_verification=diverged with the divergence text",
             divergedJson.Contains("\"landed_verification\": \"diverged\"", StringComparison.Ordinal)
             && divergedJson.Contains("WRITTEN FILE carries 0", StringComparison.Ordinal), divergedJson);

--- a/src/housecarl-generator/ApplyGuardProbe.cs
+++ b/src/housecarl-generator/ApplyGuardProbe.cs
@@ -99,7 +99,10 @@ public static class ApplyGuardProbe
     {
         Console.WriteLine("── ARM 6: #308 — the verify's clause comes off the FILE, and an empty compose is refused ──");
 
-        var before = new FileInfo(fx.ReplacerPath).Length;
+        // The SIZE alone proves nothing here, and that is the whole point of the bug: pre-fix the call re-serialized
+        // the target and the file came out byte-identical, because the op contributed nothing. The discriminating
+        // observable is whether the file was WRITTEN AT ALL — so the timestamp is what this arm watches.
+        var before = (new FileInfo(fx.ReplacerPath).Length, File.GetLastWriteTimeUtc(fx.ReplacerPath));
         var empty = ApplyTools.Apply(fx.Svc,
             ops: Json(ComposeRankOp(fx.FactionFid, null)),
             in_place: fx.ReplacerName, acknowledge: true);
@@ -108,9 +111,9 @@ public static class ApplyGuardProbe
         Check("…and the refusal names the settable fields from the TYPE, so the caller knows what to set",
             empty.Contains("Settable fields on Rank:", StringComparison.Ordinal)
             && empty.Contains("Number", StringComparison.Ordinal), empty);
-        Check("…and it is a pre-serialize refusal: the in-place target is byte-untouched",
-            new FileInfo(fx.ReplacerPath).Length == before,
-            $"{before} -> {new FileInfo(fx.ReplacerPath).Length}");
+        var after = (new FileInfo(fx.ReplacerPath).Length, File.GetLastWriteTimeUtc(fx.ReplacerPath));
+        Check("…and it is a PRE-SERIALIZE refusal: the in-place target was never rewritten (size AND mtime)",
+            after == before, $"{before} -> {after}");
 
         // The same compose WITH content lands — the refusal is about emptiness, not about composing Ranks.
         var withField = ApplyTools.Apply(fx.Svc,

--- a/src/housecarl-generator/ApplyGuardProbe.cs
+++ b/src/housecarl-generator/ApplyGuardProbe.cs
@@ -26,7 +26,7 @@ namespace HousecarlGenerator;
 /// <item><b>TRANSPORT</b> — format=json is valid JSON carrying the same data, refusals are documents too, and every
 /// response (both renders) carries the §2.1.1 epoch.</item>
 /// <item><b>the in-place verify's own honesty</b> (#308) — the per-op "what landed" clause is re-derived from the
-/// WRITTEN FILE (json: <c>landed_on_disk</c> + <c>landed_verification</c>), a compose with nothing to serialize
+/// WRITTEN FILE (json: <c>landed_on_disk</c> + <c>landed_source</c>), a compose with nothing to serialize
 /// is refused before the file is touched instead of reported as landed, and the memory-vs-file comparator's own
 /// semantics are pinned as a unit.</item>
 /// <item><b>keyed multi-op</b> (#308) — two COUNT-CHANGING key-addressed ops in one in-place call both land and
@@ -132,84 +132,14 @@ public static class ApplyGuardProbe
         Check("the same compose WITH a field lands, and its clause is the FILE's (landed_on_disk present)",
             op0.ValueKind == JsonValueKind.Object
             && op0.TryGetProperty("landed_on_disk", out var lod) && lod.ValueKind == JsonValueKind.String, withField);
-        Check("…and it is declared VERIFIED against the written file, with no divergence",
+        Check("…and it is SOURCED as the file's reading rather than the applied edit's",
             op0.ValueKind == JsonValueKind.Object
-            && op0.TryGetProperty("landed_verification", out var lv) && lv.GetString() == "verified"
-            && op0.TryGetProperty("divergence", out var dv) && dv.ValueKind == JsonValueKind.Null, withField);
+            && op0.TryGetProperty("landed_source", out var lv) && lv.GetString() == "written_file", withField);
 
-        // The comparator's own semantics (unit), fed the PRESENCE the reader reports rather than tokens a parser has
-        // to interpret. Two of these pin the detector against WIDENING (a text difference must not become a verdict)
-        // and say so; the rest pin the two rules it claims. Shorthands: a scalar value, a list of N, a present
-        // substruct, and nothing at all.
-        static WritePatchBuilder.LeafPresence Val() => new(true, true, null);
-        static WritePatchBuilder.LeafPresence List(int n) => new(false, true, n);
-        static WritePatchBuilder.LeafPresence Sub() => new(false, true, null);
-        static WritePatchBuilder.LeafPresence Gone() => new(false, false, null);
-        string? Div(string? mem, WritePatchBuilder.LeafPresence memP, string? disk, WritePatchBuilder.LeafPresence diskP)
-            => WritePatchBuilder.LeafDivergence(mem, memP, disk, diskP);
-
-        Check("comparator: 1 element in memory vs 0 in the file is a divergence, reported as counts",
-            Div("[list: 1 item(s)]", List(1), "[list: 0 item(s)]", List(0)) is { } d
-            && d.Contains("1 element(s) in memory", StringComparison.Ordinal) && d.Contains("carries 0", StringComparison.Ordinal),
-            Div("[list: 1 item(s)]", List(1), "[list: 0 item(s)]", List(0)));
-        Check("comparator: identical readings are NOT a divergence, and an unanswered side never is either",
-            Div("[list: 1 item(s)]", List(1), "[list: 1 item(s)]", List(1)) is null
-            && Div("99", Val(), null, default) is null
-            && Div(null, default, "99", Val()) is null);
-        // A substruct leaf renders its TYPE name, and the mutable record and the binary overlay name it differently
-        // ([WeaponBasicStats] vs [WeaponBasicStatsBinaryOverlay]) — a text compare accused every `Set <substruct>` of
-        // not landing. Both sides are PRESENT, so the rule is silent: this pins that, against widening.
-        Check("comparator: a substruct leaf the overlay names differently is NOT a divergence",
-            Div("[WeaponBasicStats]", Sub(), "[WeaponBasicStatsBinaryOverlay]", Sub()) is null,
-            Div("[WeaponBasicStats]", Sub(), "[WeaponBasicStatsBinaryOverlay]", Sub()));
-        // Percent is byte-quantised, so a correct `Set ChanceNone value="0.123"` reads back 0.12 off the file.
-        // Calling that "NOT landed" instructs a re-issue that diverges identically forever.
-        Check("comparator: a value the FORMAT rounds (0.123 -> 0.12, a byte-quantised Percent) is NOT a divergence",
-            Div("0.123", Val(), "0.12", Val()) is null, Div("0.123", Val(), "0.12", Val()));
-        // THE VANISH RULE, on all three leaf kinds — each one a case an earlier draft missed. The scalar arm looked
-        // for an empty string the reader never emits; the count arm cannot see a nullable list that reads "(absent)";
-        // and neither could see a SUBSTRUCT, whose summary carries no count at all.
-        Check("comparator: a scalar that became NOTHING is a divergence, with the localized-strings caveat named",
-            Div("Winner Sword", Val(), "(absent)", Gone()) is { } gone
-            && gone.Contains("carries no value there", StringComparison.Ordinal)
-            && gone.Contains("LOCALIZED", StringComparison.Ordinal), Div("Winner Sword", Val(), "(absent)", Gone()));
-        Check("comparator: a nullable LIST that reads (absent) on disk is a divergence too",
-            Div("[list: 1 item(s)]", List(1), "(absent)", Gone()) is not null);
-        Check("comparator: a SUBSTRUCT that vanished on serialize is a divergence — the case with no count to compare",
-            Div("[VirtualMachineAdapter]", Sub(), "(absent)", Gone()) is not null,
-            Div("[VirtualMachineAdapter]", Sub(), "(absent)", Gone()));
-        Check("comparator: a list the call legitimately EMPTIED is not — an emptied list and a dropped subrecord agree",
-            Div("[list: 0 item(s)]", List(0), "(absent)", Gone()) is null,
-            Div("[list: 0 item(s)]", List(0), "(absent)", Gone()));
-
-        // THE REPORT, not just the detector (review [medium]): a reviewer showed that deleting AppendDivergences, the
-        // full-dump call site, and the json "diverged" word left every check green — the guard covered the finding and
-        // not the sentence a caller reads. Driven at the render boundary with a hand-built outcome, since the fixture
-        // can no longer produce a real divergence (the empty-compose refusal removed its only producer).
-        var diverged = new WritePatchBuilder.PatchOutcome(
-            true, null, fx.ReplacerPath, false, new[] { fx.MasterName },
-            new[] { new WritePatchBuilder.OpResult(fx.SubjectKey, "Weapon", "Add Ranks", true, null, "[list: 1 item(s)]", "now 1 (+1)")
-                        { LandedOnDisk = "[list: 0 item(s)]", Divergence = "the applied edit left 1 element(s) in memory, but the WRITTEN FILE carries 0", VerifyAttempted = true } },
-            123L)
-            { InPlace = true, ReadBack = new[] { new WritePatchBuilder.FullReadback(fx.SubjectKey, null, "re-read failed") } };
-        var compactRender = WriteTools.Render(diverged);
-        var fullRender = WriteTools.Render(diverged, fullDump: true);
-        Check("the COMPACT render states a divergence as NOT landed, even when that record's read-back failed",
-            compactRender.Contains("treat this op as NOT landed", StringComparison.Ordinal), compactRender);
-        Check("…and the FULL-dump render states it too (the lane that used to drop it silently)",
-            fullRender.Contains("treat this op as NOT landed", StringComparison.Ordinal), fullRender);
-        var divergedJson = JsonWire.RenderPatchOutcome(diverged, 0, false, "in_place");
-        // …and it survives a max_chars cut that drops the ops array, which is where the text render hoists its own
-        // lines to and the json twin did not (review [medium]): a document that cuts the only "did not land" row while
-        // saying "the WRITE is complete and unaffected" is worse than no verify at all.
-        var divergedTiny = JsonWire.RenderPatchOutcome(diverged, 400, false, "in_place");
-        Check("…and the json divergence rows survive a max_chars cut that truncates the ops array",
-            divergedTiny.Contains("\"divergences\"", StringComparison.Ordinal)
-            && divergedTiny.Contains("WRITTEN FILE carries 0", StringComparison.Ordinal)
-            && divergedTiny.Contains("\"diverged_ops\": 1", StringComparison.Ordinal), divergedTiny);
-        Check("…and json says landed_verification=diverged with the divergence text",
-            divergedJson.Contains("\"landed_verification\": \"diverged\"", StringComparison.Ordinal)
-            && divergedJson.Contains("WRITTEN FILE carries 0", StringComparison.Ordinal), divergedJson);
+        // The per-op clause REPORTS its source instead of judging (Aaron, 2026-08-11): the comparator that decided
+        // "this op did not land" is gone, with the eight unit checks that pinned its rules and the three render
+        // checks that pinned its sentence. What remains pinned is what survives it — the clause comes off the
+        // written FILE, and where it could not, the response says which reading it is showing instead.
 
         // THE READ-SURFACE HALF, pinned because reverting it left all 117 probes green (review [low]): a substruct
         // leaf read off a BINARY OVERLAY must render the modelled type name, not Mutagen's implementation class. This
@@ -280,9 +210,9 @@ public static class ApplyGuardProbe
 
     /// <summary>ARM 8 (#308) — the two seams a review found INERT: nothing pinned the keyed exemption (deleting it
     /// left every probe green, because arm 7 drives count-CHANGING removes which fall through anyway), and nothing
-    /// pinned the comparator's WIRE into the verify pass (deleting `Divergence = LeafDivergence(…)` left every probe
-    /// green too — the render checks are driven from a hand-built outcome, and the end-to-end assertions are all
-    /// negative). Both are driven here against the real written file.</summary>
+    /// pinned the verify's WIRE to the written file. Both are driven here against the real file. (The second half was
+    /// written when the pass also produced a divergence VERDICT; that verdict is gone, so it now pins the fact the
+    /// verdict rested on — that the clause is the file's reading and not the applied edit's passed through.)</summary>
     static void VerifyWiringArm(Fixture fx)
     {
         Console.WriteLine("── ARM 8: #308 — the keyed exemption, and the comparator's wire into the verify ──");
@@ -308,18 +238,17 @@ public static class ApplyGuardProbe
             var doc = Json(twoSets);
             if (doc.TryGetProperty("ops", out var arr))
                 foreach (var op in arr.EnumerateArray())
-                    states.Add(op.TryGetProperty("landed_verification", out var v) ? v.GetString() ?? "?" : "?");
+                    states.Add(op.TryGetProperty("landed_source", out var v) ? v.GetString() ?? "?" : "?");
         }
         catch { /* states stays empty — the check below fails with the render as evidence */ }
-        Check("two ops on DIFFERENT elements each keep their own file verification (neither is written off)",
-            states.Count == 2 && states.All(v => v == "verified"),
+        Check("two ops on DIFFERENT elements each keep their own file reading (neither is written off)",
+            states.Count == 2 && states.All(v => v == "written_file"),
             string.Join(",", states) + "\n" + twoSets);
 
-        // (b) THE WIRE: hand the REAL verify pass a claim the written file cannot corroborate — an op asserting a
-        //     5-element list for a leaf the file carries fewer of — and require that it comes back diverged. This is
-        //     what proves LeafDivergence is actually consulted by VerifyLandedAgainstFile; the fixture can no longer
-        //     produce a genuine vanishing write (the empty-compose refusal removed its only producer), so the claim
-        //     is synthesised while the FILE half stays real.
+        // (b) THE WIRE: drive the REAL verify pass against the REAL written file and require that the op comes back
+        //     carrying the FILE's reading — not the claim it was handed. This is what proves DescribeApplied is
+        //     actually consulted off the re-opened file rather than the clause being passed through from memory,
+        //     which is the whole of #308 now that the verdict is gone.
         ISkyrimModGetter? back = null;
         try
         {
@@ -327,16 +256,14 @@ public static class ApplyGuardProbe
             var fk = FormKey.Factory(fx.FactionFid);
             var req = new WriteRequest { RecordType = "Faction", Path = new[] { "Ranks" }, Verb = "Add" };
             var claim = new WritePatchBuilder.OpResult(fk, "Faction", "Add Ranks", true, null,
-                                                      "[list: 5 item(s)]", "now 5 item(s)")
-                { AfterPresence = new WritePatchBuilder.LeafPresence(false, true, 5) };
-            var verified = WritePatchBuilder.VerifyLandedAgainstFile(
-                back, new[] { (fk, req) }, new[] { claim });
-            Check("the verify pass CONSULTS the comparator: a claim the file cannot corroborate comes back diverged",
-                verified.Count == 1 && verified[0].Divergence is { } d && d.Contains("5 element(s) in memory", StringComparison.Ordinal),
-                verified.Count == 1 ? verified[0].Divergence ?? "(no divergence)" : "(no result)");
-            Check("…and the same pass reports the FILE's own reading for that op, not the claim's",
-                verified.Count == 1 && verified[0].LandedOnDisk is { } lod && !lod.Contains("5", StringComparison.Ordinal),
+                                                      "[list: 5 item(s)]", "now 5 item(s)");
+            var verified = WritePatchBuilder.VerifyLandedAgainstFile(back, new[] { (fk, req) }, new[] { claim });
+            Check("the verify pass reads the FILE: the op comes back with the file's own count, not the claim's",
+                verified.Count == 1 && verified[0].LandedOnDisk is { } lod2 && !lod2.Contains("5", StringComparison.Ordinal),
                 verified.Count == 1 ? verified[0].LandedOnDisk ?? "(null)" : "(no result)");
+            Check("...and the claim's own in-memory reading is preserved beside it, unchanged",
+                verified.Count == 1 && verified[0].Landed == "now 5 item(s)",
+                verified.Count == 1 ? verified[0].Landed ?? "(null)" : "(no result)");
         }
         finally { (back as IDisposable)?.Dispose(); }
     }

--- a/src/housecarl-generator/ApplyGuardProbe.cs
+++ b/src/housecarl-generator/ApplyGuardProbe.cs
@@ -204,6 +204,26 @@ public static class ApplyGuardProbe
             divergedJson.Contains("\"landed_verification\": \"diverged\"", StringComparison.Ordinal)
             && divergedJson.Contains("WRITTEN FILE carries 0", StringComparison.Ordinal), divergedJson);
 
+        // THE READ-SURFACE HALF, pinned because reverting it left all 117 probes green (review [low]): a substruct
+        // leaf read off a BINARY OVERLAY must render the modelled type name, not Mutagen's implementation class. This
+        // is what the verify prints for a `Set <substruct>`, and it is read straight off the written file — so
+        // without the strip the same response says "[WeaponBasicStats]" in its edit list and
+        // "[WeaponBasicStatsBinaryOverlay]" two lines below. Driven through the real reader on a real overlay.
+        ISkyrimModGetter? ovr = null;
+        try
+        {
+            ovr = SkyrimMod.CreateFromBinaryOverlay(fx.ReplacerPath, SkyrimRelease.SkyrimSE);
+            var subj = ovr.Weapons.FirstOrDefault(w => w.FormKey == fx.SubjectKey);
+            var token = subj is null ? null
+                : ReadEngine.ReadFields(subj, new[] { "BasicStats" }).Fields.FirstOrDefault()?.Note;
+            // Asserted on the TYPE NAME, not the whole note: the reader appends its own "pass depth=2" hint, and
+            // pinning that too would make this arm fail on an unrelated wording change.
+            Check("a SUBSTRUCT leaf read off the written file renders the modelled type, not the overlay class",
+                token is not null && token.StartsWith("[WeaponBasicStats]", StringComparison.Ordinal)
+                && !token.Contains("BinaryOverlay", StringComparison.Ordinal), token ?? "(no read)");
+        }
+        finally { (ovr as IDisposable)?.Dispose(); }
+
         // MULTI-OP, end-to-end: two Adds to ONE list in ONE in-place call. Both land; the file carries both. The
         // earlier op's reading was taken between them, so comparing it against the final file state accused a correct
         // write of not landing — the defect a review reproduced in this fixture after the arm's own doc claimed it

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -356,6 +356,10 @@ public static class CiAll
     /// drift out of sync with the CI set (a guard runnable locally but missing from CI — the Q3 coverage-gap
     /// class). Returns false if the name isn't a registry probe; the caller then tries its own dispatches (the
     /// cold freshness-capture-guard carve-out + the manual/exploratory probes).</summary>
+    /// <summary>Every CI probe's name, for the unknown-mode refusal's list and did-you-mean (Program.cs). Read off the
+    /// SAME registry the dispatch uses, so a probe can never be runnable and yet missing from the help.</summary>
+    public static IReadOnlyList<string> ProbeNames => Probes.Select(p => p.Name).ToArray();
+
     public static bool TryDispatch(string name, string[] args, out int rc)
     {
         foreach (var (n, run) in Probes)

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -351,17 +351,16 @@ public static class CiAll
         ("skypatcher-conflicts-guard", SkyPatcherConflictsProbe.RunGuard),
     };
 
+    /// <summary>Every CI probe's name, for the unknown-mode refusal's list and did-you-mean (Program.cs). Read off the
+    /// SAME registry the dispatch uses, so a probe can never be runnable and yet missing from the help. Materialised
+    /// once — the refusal path reads it twice and nothing mutates the registry.</summary>
+    public static IReadOnlyList<string> ProbeNames { get; } = Probes.Select(p => p.Name).ToArray();
+
     /// <summary>Dispatch a single CI guard by name through the registry — the ONE place a CI probe is listed, so
     /// Program.cs routes local single-probe runs here instead of keeping a parallel if-chain that could silently
     /// drift out of sync with the CI set (a guard runnable locally but missing from CI — the Q3 coverage-gap
     /// class). Returns false if the name isn't a registry probe; the caller then tries its own dispatches (the
     /// cold freshness-capture-guard carve-out + the manual/exploratory probes).</summary>
-    /// <summary>Every CI probe's name, for the unknown-mode refusal's list and did-you-mean (Program.cs). Read off the
-    /// SAME registry the dispatch uses, so a probe can never be runnable and yet missing from the help.</summary>
-    public static IReadOnlyList<string> ProbeNames => Probes.Select(p => p.Name).ToArray();
-
-    /// <summary>Run the ONE probe named, if the registry carries it — the single-probe dispatch Program.cs routes
-    /// through, so a guard cannot be runnable locally yet missing from the CI run.</summary>
     public static bool TryDispatch(string name, string[] args, out int rc)
     {
         foreach (var (n, run) in Probes)

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -360,6 +360,8 @@ public static class CiAll
     /// SAME registry the dispatch uses, so a probe can never be runnable and yet missing from the help.</summary>
     public static IReadOnlyList<string> ProbeNames => Probes.Select(p => p.Name).ToArray();
 
+    /// <summary>Run the ONE probe named, if the registry carries it — the single-probe dispatch Program.cs routes
+    /// through, so a guard cannot be runnable locally yet missing from the CI run.</summary>
     public static bool TryDispatch(string name, string[] args, out int rc)
     {
         foreach (var (n, run) in Probes)

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -262,14 +262,16 @@ if (args.Length > 0 && args[0] == "native-pairing-real") return NativePairingPro
 // Every dispatch above matched nothing, and the corpus fallthrough below reads args[0] as the OUTPUT DIRECTORY. So a
 // mistyped probe name generated the whole corpus into a folder of that name and exited 0: two of them put 13.5 MB of
 // generated files in the working tree, which `git add -A` then nearly committed. A mode and a directory ARE
-// distinguishable — a directory is rooted, carries a separator, or already exists — so anything else is refused BY
-// NAME, with the real modes listed and the near misses suggested (Q3: never a silent wrong action).
+// distinguishable — a directory is ROOTED or carries a SEPARATOR (or is "." / "..") — so anything else is refused BY
+// NAME, with the real modes listed and the near misses suggested (Q3: never a silent wrong action). Deliberately NOT
+// "…or it already exists": see IsDirectoryArgument, where that clause was removed after it let a mistyped mode write
+// into ./plugin (review [low] — this comment asserted it 25 lines above the one explaining why it is gone).
 if (args.Length > 0 && !IsDirectoryArgument(args[0]))
 {
     Console.Error.WriteLine($"unknown mode '{args[0]}' — nothing was generated and nothing was written.");
     // TrimStart, then skip an EMPTY suggestion entirely: DidYouMean returns "" when nothing is close, and a blank
     // line above the mode list reads like a truncated message.
-    if (HousecarlCore.PluginNameSuggest.DidYouMean(args[0], CiAll.ProbeNames).TrimStart(' ', '—') is { Length: > 0 } near)
+    if (HousecarlCore.PluginNameSuggest.DidYouMean(args[0], CiAll.ProbeNames).TrimStart(' ') is { Length: > 0 } near)
         Console.Error.WriteLine(near);
     Console.Error.WriteLine();
     Console.Error.WriteLine("CI guards in the registry (`ci-all` runs these; freshness-capture-guard is a CI step of its own):");

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -272,7 +272,7 @@ if (args.Length > 0 && !IsDirectoryArgument(args[0]))
     if (HousecarlCore.PluginNameSuggest.DidYouMean(args[0], CiAll.ProbeNames).TrimStart(' ', '—') is { Length: > 0 } near)
         Console.Error.WriteLine(near);
     Console.Error.WriteLine();
-    Console.Error.WriteLine("CI guards (the one registry — `ci-all` runs them all):");
+    Console.Error.WriteLine("CI guards in the registry (`ci-all` runs these; freshness-capture-guard is a CI step of its own):");
     foreach (var name in CiAll.ProbeNames) Console.Error.WriteLine("  " + name);
     Console.Error.WriteLine();
     Console.Error.WriteLine("Other modes are the manual/exploratory harnesses declared in src/housecarl-generator/Program.cs.");

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -265,13 +265,20 @@ if (args.Length > 0 && args[0] == "native-pairing-real") return NativePairingPro
 if (args.Length > 0 && !IsDirectoryArgument(args[0]))
 {
     Console.Error.WriteLine($"unknown mode '{args[0]}' — nothing was generated and nothing was written.");
-    Console.Error.WriteLine(HousecarlCore.PluginNameSuggest.DidYouMean(args[0], CiAll.ProbeNames).TrimStart(' ', '—'));
+    // TrimStart, then skip an EMPTY suggestion entirely: DidYouMean returns "" when nothing is close, and a blank
+    // line above the mode list reads like a truncated message.
+    if (HousecarlCore.PluginNameSuggest.DidYouMean(args[0], CiAll.ProbeNames).TrimStart(' ', '—') is { Length: > 0 } near)
+        Console.Error.WriteLine(near);
     Console.Error.WriteLine();
     Console.Error.WriteLine("CI guards (the one registry — `ci-all` runs them all):");
     foreach (var name in CiAll.ProbeNames) Console.Error.WriteLine("  " + name);
     Console.Error.WriteLine();
     Console.Error.WriteLine("Other modes are the manual/exploratory harnesses declared in src/housecarl-generator/Program.cs.");
-    Console.Error.WriteLine("To GENERATE the corpus, pass a directory path (or no argument at all, for ./generated).");
+    // State the RULE, not just the intent: a bare relative name that does not already exist is read as a mode, so
+    // "pass a directory path" alone would be advice the caller has already followed (review [low]).
+    Console.Error.WriteLine("To GENERATE the corpus into a directory, pass a path that is rooted (C:\\…), carries a");
+    Console.Error.WriteLine("separator (./out), or already exists — a bare name that does not exist is read as a mode.");
+    Console.Error.WriteLine("With no argument at all it generates into ./generated.");
     return 2;
 }
 

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -8,7 +8,7 @@ using HousecarlGenerator;
 //
 // Usage:  dotnet run --project src/housecarl-generator [outputDir]   (default: ./generated)
 //         An unrecognised FIRST argument is refused, not read as [outputDir] — so an output directory must be
-//         rooted, carry a separator, or already exist. Anything else is a mode name, and an unknown one exits 2.
+//         rooted, carry a separator, or be "." / "..". Anything else is a mode name, and an unknown one exits 2.
 
 // CI optimization Phase 2B: run EVERY CI probe in ONE process (the big Mutagen assembly loads + JITs once;
 // the schema corpus reflects once via CorpusGenerator's memoize). Replaces the per-probe ci.yml steps with one
@@ -275,11 +275,13 @@ if (args.Length > 0 && !IsDirectoryArgument(args[0]))
     Console.Error.WriteLine("CI guards in the registry (`ci-all` runs these; freshness-capture-guard is a CI step of its own):");
     foreach (var name in CiAll.ProbeNames) Console.Error.WriteLine("  " + name);
     Console.Error.WriteLine();
-    Console.Error.WriteLine("Other modes are the manual/exploratory harnesses declared in src/housecarl-generator/Program.cs.");
-    // State the RULE, not just the intent: a bare relative name that does not already exist is read as a mode, so
-    // "pass a directory path" alone would be advice the caller has already followed (review [low]).
-    Console.Error.WriteLine("To GENERATE the corpus into a directory, pass a path that is rooted (C:\\…), carries a");
-    Console.Error.WriteLine("separator (./out) — a BARE name is always read as a mode, even if a folder of that name exists.");
+    Console.Error.WriteLine("Other modes are the manual/exploratory harnesses declared in src/housecarl-generator/Program.cs");
+    Console.Error.WriteLine("(they are not in the suggestion pool above — only the CI registry is).");
+    // State the RULE, not just the intent: "pass a directory path" alone is advice a caller who typed one has
+    // already followed, and the accepted spellings are not guessable (reviews [low], twice).
+    Console.Error.WriteLine("To GENERATE the corpus into a directory, pass a path that is ROOTED (C:\\…), carries a");
+    Console.Error.WriteLine("SEPARATOR (./out), or is \".\" / \"..\" — a BARE name is always read as a mode, even if a");
+    Console.Error.WriteLine("folder of that name exists (that clause is what let a mistyped mode write into ./plugin).");
     Console.Error.WriteLine("With no argument at all it generates into ./generated.");
     return 2;
 }

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -279,19 +279,22 @@ if (args.Length > 0 && !IsDirectoryArgument(args[0]))
     // State the RULE, not just the intent: a bare relative name that does not already exist is read as a mode, so
     // "pass a directory path" alone would be advice the caller has already followed (review [low]).
     Console.Error.WriteLine("To GENERATE the corpus into a directory, pass a path that is rooted (C:\\…), carries a");
-    Console.Error.WriteLine("separator (./out), or already exists — a bare name that does not exist is read as a mode.");
+    Console.Error.WriteLine("separator (./out) — a BARE name is always read as a mode, even if a folder of that name exists.");
     Console.Error.WriteLine("With no argument at all it generates into ./generated.");
     return 2;
 }
 
-// A mode name is a bare token; an output directory is rooted, has a separator, or exists on disk. Deliberately
-// permissive toward directories: the cost of misreading a real output dir as a mode is a refusal the caller can
-// re-issue, while the cost the other way is the 13.5 MB write this check exists to stop.
+// A mode name is a BARE token; an output directory is rooted or carries a separator.
+//
+// "…or it already exists as a directory" was the obvious third clause, and it reopened the exact hole this check
+// closes (review [low], then reproduced): `plugin`, `src`, `scripts`, `standards`, `release` and `generated` are all
+// real folders at the repo root, so a mistyped mode that collided with one still generated the whole corpus into it —
+// `dotnet run --project src/housecarl-generator plugin` put 7.6 MB into plugin/ while this very fix was being
+// written. An output directory can always be spelled with a separator; a mistyped mode cannot be spelled back.
 static bool IsDirectoryArgument(string a)
 {
     if (a.Length == 0) return false;
-    if (Path.IsPathRooted(a) || a.Contains('\\') || a.Contains('/') || a is "." or "..") return true;
-    try { return Directory.Exists(a); } catch { return false; }
+    return Path.IsPathRooted(a) || a.Contains('\\') || a.Contains('/') || a is "." or "..";
 }
 
 var outputDir = Path.GetFullPath(args.Length > 0 ? args[0] : "generated");

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -7,6 +7,8 @@ using HousecarlGenerator;
 // type at full depth. Pure reflection over types — no plugin file required.
 //
 // Usage:  dotnet run --project src/housecarl-generator [outputDir]   (default: ./generated)
+//         An unrecognised FIRST argument is refused, not read as [outputDir] — so an output directory must be
+//         rooted, carry a separator, or already exist. Anything else is a mode name, and an unknown one exits 2.
 
 // CI optimization Phase 2B: run EVERY CI probe in ONE process (the big Mutagen assembly loads + JITs once;
 // the schema corpus reflects once via CorpusGenerator's memoize). Replaces the per-probe ci.yml steps with one

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -256,6 +256,35 @@ if (args.Length > 0 && args[0] == "skse-config-audit-real") return SkseConfigAud
 if (args.Length > 0 && args[0] == "native-pairing-guard") return NativePairingProbe.RunGuard(args[1..]);
 if (args.Length > 0 && args[0] == "native-pairing-real") return NativePairingProbe.RunReal(args[1..]);
 
+// UNKNOWN MODE — refused, not silently taken as an output directory (2.0 tidy-up scar, W3 PR 3 housekeeping).
+// Every dispatch above matched nothing, and the corpus fallthrough below reads args[0] as the OUTPUT DIRECTORY. So a
+// mistyped probe name generated the whole corpus into a folder of that name and exited 0: two of them put 13.5 MB of
+// generated files in the working tree, which `git add -A` then nearly committed. A mode and a directory ARE
+// distinguishable — a directory is rooted, carries a separator, or already exists — so anything else is refused BY
+// NAME, with the real modes listed and the near misses suggested (Q3: never a silent wrong action).
+if (args.Length > 0 && !IsDirectoryArgument(args[0]))
+{
+    Console.Error.WriteLine($"unknown mode '{args[0]}' — nothing was generated and nothing was written.");
+    Console.Error.WriteLine(HousecarlCore.PluginNameSuggest.DidYouMean(args[0], CiAll.ProbeNames).TrimStart(' ', '—'));
+    Console.Error.WriteLine();
+    Console.Error.WriteLine("CI guards (the one registry — `ci-all` runs them all):");
+    foreach (var name in CiAll.ProbeNames) Console.Error.WriteLine("  " + name);
+    Console.Error.WriteLine();
+    Console.Error.WriteLine("Other modes are the manual/exploratory harnesses declared in src/housecarl-generator/Program.cs.");
+    Console.Error.WriteLine("To GENERATE the corpus, pass a directory path (or no argument at all, for ./generated).");
+    return 2;
+}
+
+// A mode name is a bare token; an output directory is rooted, has a separator, or exists on disk. Deliberately
+// permissive toward directories: the cost of misreading a real output dir as a mode is a refusal the caller can
+// re-issue, while the cost the other way is the 13.5 MB write this check exists to stop.
+static bool IsDirectoryArgument(string a)
+{
+    if (a.Length == 0) return false;
+    if (Path.IsPathRooted(a) || a.Contains('\\') || a.Contains('/') || a is "." or "..") return true;
+    try { return Directory.Exists(a); } catch { return false; }
+}
+
 var outputDir = Path.GetFullPath(args.Length > 0 ? args[0] : "generated");
 // The slim reference tree ships INSIDE the skill (tracked); corpus.json + summary stay in generated/.
 // Default assumes the generator is run from the repo root (as `dotnet run --project src/housecarl-generator`).

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -177,6 +177,9 @@ public static class WriteSurfaceGuardProbe
             var topic = m.DialogTopics.AddNew();
             topic.EditorID = "W2Topic";
             topic.Name = "Master Topic";
+            // …carrying a CHILD of its own, so the arm can answer what the host override does to the parent's child
+            // list — not just its fields. The winner adds a second child below.
+            topic.Responses.Add(new DialogResponses(m.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "W2MasterLine" });
             m.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
 
             var r = new SkyrimMod(rKey, SkyrimRelease.SkyrimSE);
@@ -193,6 +196,7 @@ public static class WriteSurfaceGuardProbe
             var topicOverride = (IDialogTopic)WriteEngine.GenericGetOrAddAsOverride(r, topic);
             topicOverride.Name = "Winner Topic";
             topicOverride.Quest.SetTo(winnerQuest.FormKey);
+            topicOverride.Responses.Add(new DialogResponses(r.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "W2WinnerLine" });
             r.BeginWrite.ToPath(replPath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
 
             // --- W3 PR 2b: the OFF-ORDER source. A DISABLED mod folder (modlist '-W2Off'), absent from loadorder.txt
@@ -973,10 +977,36 @@ public static class WriteSurfaceGuardProbe
             path is not null && TopicNameIn(path!, fx.TopicKey) == "Master Topic",
             $"{made}  [topic name={(path is null ? "no artifact" : TopicNameIn(path, fx.TopicKey) ?? "unreadable")}]");
 
+        // WHAT THE HOST OVERRIDE DOES TO THE PARENT'S CHILD LIST — measured, not assumed, because a full-record copy
+        // that dragged the parent's children along would make "hosts from the definer" a far wider revert than fields
+        // alone (it would assert the DEFINER's child list wherever the artifact out-ranks the winner). It does not:
+        // the artifact's child group carries ONLY the new record, which is also why adding a line to a topic — or a
+        // ref to a cell — does not fight other mods' additions. This bounds the #300 trade to the parent's own FIELDS.
+        var children = ChildLinesIn(path!, fx.TopicKey);
+        Check("…and the host carries ONLY the new child — not the definer's existing lines, and not the winner's",
+            children.Count == 1 && children[0] == "W2HostedLine", string.Join(", ", children));
+
         Check("…and the render REPORTS which plugin's version hosted the child (the choice is invisible afterwards)",
             made.Contains("parent: ", StringComparison.Ordinal)
             && made.Contains("DEFINING plugin", StringComparison.Ordinal)
             && made.Contains(fx.MasterName, StringComparison.OrdinalIgnoreCase), made);
+    }
+
+    /// <summary>Every child line the written plugin's copy of the topic carries — #300's "whose CHILDREN did the host
+    /// copy" probe (a full-record override may bring the parent's child list with it, which widens the trade).</summary>
+    static List<string> ChildLinesIn(string espPath, FormKey fk)
+    {
+        var found = new List<string>();
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(espPath, SkyrimRelease.SkyrimSE);
+            foreach (var r in ov.DialogTopics.FirstOrDefault(d => d.FormKey == fk)?.Responses ?? Enumerable.Empty<IDialogResponsesGetter>())
+                found.Add(r.EditorID ?? r.FormKey.ToString());
+        }
+        catch { found.Add("(unreadable)"); }
+        finally { (ov as IDisposable)?.Dispose(); }
+        return found;
     }
 
     /// <summary>The topic's Name as the written plugin carries it — #300's "whose fields did the host copy" probe.</summary>

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -14,8 +14,10 @@ namespace HousecarlGenerator;
 /// <c>housecarl_write_seq</c> (tool-surface-2.0 W3 PR 2; SPEC §2.2 ACT, §5.1/§5.2, §6.1). Sibling of
 /// <c>apply-guard</c>, same posture: the REAL end-to-end tool path — a synthetic MO2 instance in temp +
 /// <see cref="LoadOrderService"/> + the tool methods themselves — so the wire readers, the LANE grammar, the
-/// alias-visible vocabulary and the engines are exercised exactly as a caller hits them. TEN arms (the two
-/// newest run before the off-order pair, which must go last — see RunGuard):
+/// alias-visible vocabulary and the engines are exercised exactly as a caller hits them. TEN arms, LISTED in the
+/// order they are declared below — which is NOT run order: the two off-order/in-place arms are run last by RunGuard
+/// because they rewrite a fixture file the others read as a known winner (review [nit]: the old wording implied the
+/// list itself was the schedule):
 /// <list type="number">
 /// <item><b>create grammar</b> — one record is a set of one, the nested one-shot (a same-call sibling parent +
 /// an '@editorid' link value), the @file spelling, and the strict element reader's NAMED refusals with the
@@ -990,6 +992,12 @@ public static class WriteSurfaceGuardProbe
             made.Contains("parent: ", StringComparison.Ordinal)
             && made.Contains("DEFINING plugin", StringComparison.Ordinal)
             && made.Contains(fx.MasterName, StringComparison.OrdinalIgnoreCase), made);
+        // …and the TRADE, not just the choice (review [low]): "DEFINING plugin" alone matches the benign branch where
+        // definer and winner are the same plugin, so the warning clause could have been reverted with this arm green.
+        Check("…and it names the mod that currently WINS the parent, and which way the record will resolve",
+            made.Contains(fx.ReplacerName, StringComparison.OrdinalIgnoreCase)
+            && made.Contains("currently WINS this record", StringComparison.Ordinal)
+            && made.Contains("out-ranks", StringComparison.Ordinal), made);
     }
 
     /// <summary>Every child line the written plugin's copy of the topic carries — #300's "whose CHILDREN did the host

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -176,7 +176,16 @@ public static class WriteSurfaceGuardProbe
             var rw = (IWeapon)WriteEngine.GenericGetOrAddAsOverride(r, subject);
             rw.Name = "Winner Sword";
             rw.BasicStats = new WeaponBasicStats { Damage = 99 };
-            ((IDialogTopic)WriteEngine.GenericGetOrAddAsOverride(r, topic)).Name = "Winner Topic";   // #300
+            // #300 — the winner's version both CHANGES a field and LINKS to a record the replacer owns. The link is
+            // what makes the master-growth check real: a copied body drags its referents' plugins into the header, so
+            // hosting from the winner would make the replacer a master of a patch that only added a child. Without it
+            // the masters assertion passes either way (a DIAL's own FormKey belongs to the master) — which is exactly
+            // how the reported CELL case cost a master: the winner's lighting fields linked into its own plugin.
+            var winnerQuest = r.Quests.AddNew();
+            winnerQuest.EditorID = "W2WinnerQuest";
+            var topicOverride = (IDialogTopic)WriteEngine.GenericGetOrAddAsOverride(r, topic);
+            topicOverride.Name = "Winner Topic";
+            topicOverride.Quest.SetTo(winnerQuest.FormKey);
             r.BeginWrite.ToPath(replPath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
 
             // --- W3 PR 2b: the OFF-ORDER source. A DISABLED mod folder (modlist '-W2Off'), absent from loadorder.txt

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -14,7 +14,7 @@ namespace HousecarlGenerator;
 /// <c>housecarl_write_seq</c> (tool-surface-2.0 W3 PR 2; SPEC §2.2 ACT, §5.1/§5.2, §6.1). Sibling of
 /// <c>apply-guard</c>, same posture: the REAL end-to-end tool path — a synthetic MO2 instance in temp +
 /// <see cref="LoadOrderService"/> + the tool methods themselves — so the wire readers, the LANE grammar, the
-/// alias-visible vocabulary and the engines are exercised exactly as a caller hits them. Seven arms:
+/// alias-visible vocabulary and the engines are exercised exactly as a caller hits them. Eight arms:
 /// <list type="number">
 /// <item><b>create grammar</b> — one record is a set of one, the nested one-shot (a same-call sibling parent +
 /// an '@editorid' link value), the @file spelling, and the strict element reader's NAMED refusals with the
@@ -34,6 +34,10 @@ namespace HousecarlGenerator;
 /// does not cover it, the overlay is released (the file stays movable), and the four refusals stay named:
 /// ambiguous filename, a file that doesn't define the record, a record whose ORIGIN plugin isn't active, and a
 /// self-forward caught by FILE IDENTITY when source= is a path to the artifact being written.</item>
+/// <item><b>CopyFrom source paths</b> (#321) — the same ACTIVE-copy-by-path rule on the <c>CopyFrom</c> lane: a
+/// <c>from_source=</c> path to the file the order serves is refused/resolved as IN-ORDER and named by its plugin
+/// name, the copy still lands from that plugin's own version, and a path to a same-NAMED different file keeps the
+/// off-order lane.</item>
 /// <item><b>the PR #313 review folds</b> — a <c>source=</c> PATH that names the file the order ACTUALLY LOADS is
 /// in-order (so the already-the-winner flag survives, and the epoch is not disclaimed) while a path to a
 /// same-NAMED different file stays off-order; a record ORIGINATING in the artifact being written forwards fine
@@ -78,6 +82,7 @@ public static class WriteSurfaceGuardProbe
             CopyFromViewArm(root);
             // LAST: it forwards into the replacer IN PLACE, which rewrites a fixture file the earlier arms read as a
             // known winner. Ordering it after them keeps every other arm reading the fixture it was written against.
+            CopySourcePathArm(fx, root);
             OffOrderForwardArm(fx);
             ReviewFoldArm(fx, root);
 
@@ -114,6 +119,8 @@ public static class WriteSurfaceGuardProbe
         public required string OffFolder { get; init; }
         /// <summary>A record the OFF-ORDER plugin ORIGINATES — forwarding it would need that plugin as a master.</summary>
         public required string OffOwnFid { get; init; }
+        /// <summary>A record ONLY the master carries (the replacer never touches it) — #321's discriminator.</summary>
+        public required string MasterOnlyFid { get; init; }
         /// <summary>One filename provided by TWO disabled mod folders — the ambiguity refusal's fixture.</summary>
         public required string AmbName { get; init; }
         /// <summary>A DISABLED plugin whose forwarded body links into ANOTHER disabled plugin — the missing-master
@@ -145,6 +152,12 @@ public static class WriteSurfaceGuardProbe
             subject.EditorID = "W2Subject";
             subject.Name = "Master Sword";
             subject.BasicStats = new WeaponBasicStats { Damage = 10 };
+            // #321's discriminator: a record the master defines and the replacer does NOT touch, so a CopyFrom naming
+            // the REPLACER has a source that is genuinely in the order and genuinely without a version to copy — the
+            // one shape whose refusal wording differs between the in-order and off-order arms.
+            var masterOnly = m.Weapons.AddNew();
+            masterOnly.EditorID = "W2MasterOnly";
+            masterOnly.BasicStats = new WeaponBasicStats { Damage = 3 };
             m.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
 
             var r = new SkyrimMod(rKey, SkyrimRelease.SkyrimSE);
@@ -227,6 +240,7 @@ public static class WriteSurfaceGuardProbe
                 OffPath = offPath,
                 OffFolder = "W2Off",
                 OffOwnFid = $"{ownWeapon.FormKey.ID:X6}:{oKey.FileName}",
+                MasterOnlyFid = $"{masterOnly.FormKey.ID:X6}:{mKey.FileName}",
                 AmbName = aKey.FileName.String,
                 ChainName = cKey.FileName.String,
             };
@@ -856,6 +870,61 @@ public static class WriteSurfaceGuardProbe
             && chain.Contains("Enable that plugin in MO2", StringComparison.Ordinal)
             && !chain.Contains("serialize or commit", StringComparison.Ordinal), chain);
     }
+
+    /// <summary>#321 — a <c>CopyFrom</c> <c>from_source=</c> PATH naming the ACTIVE copy of a plugin must take the
+    /// IN-ORDER arm, the rule <c>forward</c> has carried since PR #313. Driven through <c>housecarl_apply</c>, because
+    /// the fix lives in the SERVICE's pre-locate (the engine only ever sees the re-spelled edit).
+    ///
+    /// <para>Why the headline check is a REFUSAL rather than a copied value: the path names the very file the order
+    /// serves, so both arms read the same bytes and any value assertion passes pre-fix as well. The arms are
+    /// distinguishable exactly where they disagree about what the source IS — a plugin that is in the order but does
+    /// not carry the record answers "in the load order but does NOT define or override" in-order, and "source file
+    /// '&lt;path&gt;' does not define or override" off-order. The value checks below then bound the fix on both sides:
+    /// the copy still lands, and a path to a same-NAMED DIFFERENT file still reads off-order.</para></summary>
+    static void CopySourcePathArm(Fixture fx, string root)
+    {
+        Console.WriteLine("── ARM 8: #321 — a CopyFrom from_source= PATH to the ACTIVE copy takes the IN-ORDER arm ──");
+
+        var masterLive = Path.Combine(fx.ModsDir, "W2Master", fx.MasterName);
+        var replLive = Path.Combine(fx.ModsDir, "W2Repl", fx.ReplacerName);
+
+        // (a) THE DISCRIMINATOR — an ACTIVE plugin, addressed by path, that does not carry the record.
+        var missing = ApplyTools.Apply(fx.Svc, patch: "W2Cf321Miss",
+            ops: Json(CopyOps(fx.MasterOnlyFid, "BasicStats.Damage", replLive)));
+        Check("#321: a from_source= PATH to an ACTIVE plugin is refused as IN-ORDER (not as an off-order file read)",
+            missing.Contains("is in the load order but does NOT define or override", StringComparison.Ordinal), missing);
+        Check("…and the refusal speaks the order's vocabulary — the plugin NAME, not the path it was addressed by",
+            missing.Contains(fx.ReplacerName, StringComparison.OrdinalIgnoreCase)
+            && !missing.Contains(replLive, StringComparison.OrdinalIgnoreCase), missing);
+
+        // (b) The copy still happens, off the named plugin's own version: the master says 10 where the winner says 99.
+        var copied = ApplyTools.Apply(fx.Svc, patch: "W2Cf321Live",
+            ops: Json(CopyOps(fx.SubjectFid, "BasicStats.Damage", masterLive)));
+        var copiedPath = ArtifactPathFrom(fx, copied);
+        Check("…and the copy itself still lands from the named plugin's own version (10, not the winner's 99)",
+            copiedPath is not null && DamageIn(copiedPath, fx.SubjectKey) == 10,
+            $"{copied}  [damage={(copiedPath is null ? "no artifact" : DamageIn(copiedPath, fx.SubjectKey)?.ToString() ?? "unreadable")}]");
+
+        // (c) THE BOUND — identity, not filename. A DIFFERENT file that merely shares the active name keeps the
+        //     off-order lane, so its own body (77) is what gets copied. Same rule ActiveNameForPath states for
+        //     forward; asserted here so the re-spelling can never widen into a name match.
+        var shadowDir = Path.Combine(root, "cf321-shadow");
+        Directory.CreateDirectory(shadowDir);
+        var shadowMaster = Path.Combine(shadowDir, fx.MasterName);
+        File.Copy(masterLive, shadowMaster, overwrite: true);
+        BumpDamage(shadowMaster, 77);
+        var byShadow = ApplyTools.Apply(fx.Svc, patch: "W2Cf321Shadow",
+            ops: Json(CopyOps(fx.SubjectFid, "BasicStats.Damage", shadowMaster)));
+        var shadowPath = ArtifactPathFrom(fx, byShadow);
+        Check("a path to a DIFFERENT file sharing the active plugin's NAME still copies OFF-ORDER (77, its own body)",
+            shadowPath is not null && DamageIn(shadowPath, fx.SubjectKey) == 77,
+            $"{byShadow}  [damage={(shadowPath is null ? "no artifact" : DamageIn(shadowPath, fx.SubjectKey)?.ToString() ?? "unreadable")}]");
+    }
+
+    /// <summary>One CopyFrom op as the wire array <c>housecarl_apply</c> reads, with the Windows path escaped for
+    /// JSON (a raw backslash run is not a legal string body, and the failure would look like a locate miss).</summary>
+    static string CopyOps(string formid, string fieldPath, string fromSource) =>
+        $$"""[{"formid":"{{formid}}","field_path":"{{fieldPath}}","op":"CopyFrom","from_source":"{{fromSource.Replace("\\", "\\\\")}}"}]""";
 
     /// <summary>Set a weapon's damage in place (fixture surgery: move the LIVE patch on, so forwarding the parked
     /// copy's body back is a visible revert rather than a no-op).</summary>

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -14,7 +14,8 @@ namespace HousecarlGenerator;
 /// <c>housecarl_write_seq</c> (tool-surface-2.0 W3 PR 2; SPEC §2.2 ACT, §5.1/§5.2, §6.1). Sibling of
 /// <c>apply-guard</c>, same posture: the REAL end-to-end tool path — a synthetic MO2 instance in temp +
 /// <see cref="LoadOrderService"/> + the tool methods themselves — so the wire readers, the LANE grammar, the
-/// alias-visible vocabulary and the engines are exercised exactly as a caller hits them. Eight arms:
+/// alias-visible vocabulary and the engines are exercised exactly as a caller hits them. TEN arms (the two
+/// newest run before the off-order pair, which must go last — see RunGuard):
 /// <list type="number">
 /// <item><b>create grammar</b> — one record is a set of one, the nested one-shot (a same-call sibling parent +
 /// an '@editorid' link value), the @file spelling, and the strict element reader's NAMED refusals with the
@@ -34,6 +35,9 @@ namespace HousecarlGenerator;
 /// does not cover it, the overlay is released (the file stays movable), and the four refusals stay named:
 /// ambiguous filename, a file that doesn't define the record, a record whose ORIGIN plugin isn't active, and a
 /// self-forward caught by FILE IDENTITY when source= is a path to the artifact being written.</item>
+/// <item><b>nested parent hosting</b> (#300) — a nested create under an EXISTING load-order parent hosts the child
+/// in the parent's DEFINING plugin's version: the winner does not become a master, the hosted record does not carry
+/// a frozen copy of the winner's fields, and which plugin hosted it is reported.</item>
 /// <item><b>CopyFrom source paths</b> (#321) — the same ACTIVE-copy-by-path rule on the <c>CopyFrom</c> lane: a
 /// <c>from_source=</c> path to the file the order serves is refused/resolved as IN-ORDER and named by its plugin
 /// name, the copy still lands from that plugin's own version, and a path to a same-NAMED different file keeps the
@@ -907,7 +911,7 @@ public static class WriteSurfaceGuardProbe
     /// the copy still lands, and a path to a same-NAMED DIFFERENT file still reads off-order.</para></summary>
     static void CopySourcePathArm(Fixture fx, string root)
     {
-        Console.WriteLine("── ARM 8: #321 — a CopyFrom from_source= PATH to the ACTIVE copy takes the IN-ORDER arm ──");
+        Console.WriteLine("── #321: a CopyFrom from_source= PATH to the ACTIVE copy takes the IN-ORDER arm ──");
 
         var masterLive = Path.Combine(fx.ModsDir, "W2Master", fx.MasterName);
         var replLive = Path.Combine(fx.ModsDir, "W2Repl", fx.ReplacerName);
@@ -951,7 +955,7 @@ public static class WriteSurfaceGuardProbe
     /// silent-revert-on-update half), and the choice is REPORTED (it is invisible in the record afterwards).</summary>
     static void NestedParentHostArm(Fixture fx)
     {
-        Console.WriteLine("── ARM 9: #300 — a nested create hosts its child in the parent's DEFINING plugin's version ──");
+        Console.WriteLine("── #300: a nested create hosts its child in the parent's DEFINING plugin's version ──");
 
         var made = CreateTools.Create(fx.Svc, patch: "W2Host",
             records: Json($$"""[{"record_type":"DialogResponses","editorid":"W2HostedLine","parent":"{{fx.TopicFid}}"}]"""));

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -83,6 +83,7 @@ public static class WriteSurfaceGuardProbe
             // LAST: it forwards into the replacer IN PLACE, which rewrites a fixture file the earlier arms read as a
             // known winner. Ordering it after them keeps every other arm reading the fixture it was written against.
             CopySourcePathArm(fx, root);
+            NestedParentHostArm(fx);
             OffOrderForwardArm(fx);
             ReviewFoldArm(fx, root);
 
@@ -121,6 +122,9 @@ public static class WriteSurfaceGuardProbe
         public required string OffOwnFid { get; init; }
         /// <summary>A record ONLY the master carries (the replacer never touches it) — #321's discriminator.</summary>
         public required string MasterOnlyFid { get; init; }
+        /// <summary>#300: a nestable parent DEFINED by the master and WON by the replacer, at different content.</summary>
+        public required string TopicFid { get; init; }
+        public required FormKey TopicKey { get; init; }
         /// <summary>One filename provided by TWO disabled mod folders — the ambiguity refusal's fixture.</summary>
         public required string AmbName { get; init; }
         /// <summary>A DISABLED plugin whose forwarded body links into ANOTHER disabled plugin — the missing-master
@@ -158,12 +162,21 @@ public static class WriteSurfaceGuardProbe
             var masterOnly = m.Weapons.AddNew();
             masterOnly.EditorID = "W2MasterOnly";
             masterOnly.BasicStats = new WeaponBasicStats { Damage = 3 };
+
+            // #300's fixture: a NESTABLE parent the master DEFINES and the replacer WINS, at distinguishable content.
+            // A dialogue topic rather than a cell purely because a cell needs its block/subblock tree built by hand —
+            // the parent-resolution code under test is one branch for every nested create, and the topic exercises it
+            // with the same three-way distinction (definer's value, winner's value, which plugin becomes a master).
+            var topic = m.DialogTopics.AddNew();
+            topic.EditorID = "W2Topic";
+            topic.Name = "Master Topic";
             m.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
 
             var r = new SkyrimMod(rKey, SkyrimRelease.SkyrimSE);
             var rw = (IWeapon)WriteEngine.GenericGetOrAddAsOverride(r, subject);
             rw.Name = "Winner Sword";
             rw.BasicStats = new WeaponBasicStats { Damage = 99 };
+            ((IDialogTopic)WriteEngine.GenericGetOrAddAsOverride(r, topic)).Name = "Winner Topic";   // #300
             r.BeginWrite.ToPath(replPath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
 
             // --- W3 PR 2b: the OFF-ORDER source. A DISABLED mod folder (modlist '-W2Off'), absent from loadorder.txt
@@ -241,6 +254,8 @@ public static class WriteSurfaceGuardProbe
                 OffFolder = "W2Off",
                 OffOwnFid = $"{ownWeapon.FormKey.ID:X6}:{oKey.FileName}",
                 MasterOnlyFid = $"{masterOnly.FormKey.ID:X6}:{mKey.FileName}",
+                TopicFid = $"{topic.FormKey.ID:X6}:{mKey.FileName}",
+                TopicKey = topic.FormKey,
                 AmbName = aKey.FileName.String,
                 ChainName = cKey.FileName.String,
             };
@@ -919,6 +934,46 @@ public static class WriteSurfaceGuardProbe
         Check("a path to a DIFFERENT file sharing the active plugin's NAME still copies OFF-ORDER (77, its own body)",
             shadowPath is not null && DamageIn(shadowPath, fx.SubjectKey) == 77,
             $"{byShadow}  [damage={(shadowPath is null ? "no artifact" : DamageIn(shadowPath, fx.SubjectKey)?.ToString() ?? "unreadable")}]");
+    }
+
+    /// <summary>#300 — a NESTED create hosts its child in the parent's DEFINING plugin's version, not the load-order
+    /// WINNER's. Three observables, because the defect had three costs: the winner does not become a MASTER of the
+    /// patch (the child never needed it), the hosted record does not carry a frozen copy of the winner's FIELDS (the
+    /// silent-revert-on-update half), and the choice is REPORTED (it is invisible in the record afterwards).</summary>
+    static void NestedParentHostArm(Fixture fx)
+    {
+        Console.WriteLine("── ARM 9: #300 — a nested create hosts its child in the parent's DEFINING plugin's version ──");
+
+        var made = CreateTools.Create(fx.Svc, patch: "W2Host",
+            records: Json($$"""[{"record_type":"DialogResponses","editorid":"W2HostedLine","parent":"{{fx.TopicFid}}"}]"""));
+        var path = ArtifactPathFrom(fx, made);
+        Check("a nested create under an existing load-order parent succeeds", path is not null, made);
+
+        Check("…and the parent's load-order WINNER is NOT a master of the patch (the child never needed it)",
+            path is not null && !MastersLineOf(made).Contains(fx.ReplacerName, StringComparison.OrdinalIgnoreCase)
+            && MastersLineOf(made).Contains(fx.MasterName, StringComparison.OrdinalIgnoreCase), made);
+
+        Check("…and the hosted parent carries the DEFINER's fields, not a frozen copy of the winner's",
+            path is not null && TopicNameIn(path!, fx.TopicKey) == "Master Topic",
+            $"{made}  [topic name={(path is null ? "no artifact" : TopicNameIn(path, fx.TopicKey) ?? "unreadable")}]");
+
+        Check("…and the render REPORTS which plugin's version hosted the child (the choice is invisible afterwards)",
+            made.Contains("parent: ", StringComparison.Ordinal)
+            && made.Contains("DEFINING plugin", StringComparison.Ordinal)
+            && made.Contains(fx.MasterName, StringComparison.OrdinalIgnoreCase), made);
+    }
+
+    /// <summary>The topic's Name as the written plugin carries it — #300's "whose fields did the host copy" probe.</summary>
+    static string? TopicNameIn(string espPath, FormKey fk)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(espPath, SkyrimRelease.SkyrimSE);
+            return ov.DialogTopics.FirstOrDefault(d => d.FormKey == fk)?.Name?.String;
+        }
+        catch { return null; }
+        finally { (ov as IDisposable)?.Dispose(); }
     }
 
     /// <summary>One CopyFrom op as the wire array <c>housecarl_apply</c> reads, with the Windows path escaped for

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -991,12 +991,15 @@ public static class WriteSurfaceGuardProbe
             made.Contains("parent: ", StringComparison.Ordinal)
             && made.Contains("DEFINING plugin", StringComparison.Ordinal)
             && made.Contains(fx.MasterName, StringComparison.OrdinalIgnoreCase), made);
-        // …and the TRADE, not just the choice (review [low]): "DEFINING plugin" alone matches the benign branch where
-        // definer and winner are the same plugin, so the warning clause could have been reverted with this arm green.
-        Check("…and it names the mod that currently WINS the parent, and which way the record will resolve",
+        // …and the CHOICE, not just the label: "DEFINING plugin" alone matches the benign branch where definer and
+        // winner are the same plugin, so the contested clause could have been dropped with this arm green. What it
+        // must say is which mod currently wins, which way the record resolves, and what the caller can do about it —
+        // the lean residual is the default, and inlining the winner is a deliberate act, not an accident.
+        Check("…and it names the winning mod, how the record resolves, and the lever the caller has",
             made.Contains(fx.ReplacerName, StringComparison.OrdinalIgnoreCase)
             && made.Contains("currently WINS this record", StringComparison.Ordinal)
-            && made.Contains("out-ranks", StringComparison.Ordinal), made);
+            && made.Contains("out-ranks", StringComparison.Ordinal)
+            && made.Contains("inlined", StringComparison.Ordinal), made);
     }
 
     /// <summary>Every child line the written plugin's copy of the topic carries — #300's "whose CHILDREN did the host

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -1000,6 +1000,45 @@ public static class WriteSurfaceGuardProbe
             && made.Contains("currently WINS this record", StringComparison.Ordinal)
             && made.Contains("out-ranks", StringComparison.Ordinal)
             && made.Contains("inlined", StringComparison.Ordinal), made);
+
+        // THE PRINTED REMEDY, RUN RATHER THAN ARGUED (PR #323 review [medium]). The message above tells the caller to
+        // "forward '<winner>'s version in explicitly if you want its content inlined" — advice this branch shipped
+        // without ever executing it. It is not obviously safe: ForwardRecords on an EXTEND does drop-then-copy — the
+        // whole record is Remove()d, then the source body copied in (HCBR-2026-07-08-01 F1, where GetOrAdd's
+        // get-semantics silently SKIPPED the copy instead) — and the arm above establishes that
+        // GenericGetOrAddAsOverride does not carry children in. So if the drop takes the host's child GROUP with it,
+        // the copy cannot put it back and the printed advice DESTROYS the record the create just placed. One
+        // decidable question, one probe: create a child into a contested parent, forward the winner into the same
+        // patch, read the child group back. Both poles asserted, so a regression either way fails an arm.
+        var patchFile = Path.GetFileName(path!);
+        var inlined = ForwardTools.Forward(fx.Svc, formids: new[] { fx.TopicFid }, source: fx.ReplacerName, into: patchFile);
+        Check("…and the remedy the message prints — forward the winner into the same patch — is accepted",
+            inlined.StartsWith("extended ", StringComparison.Ordinal), inlined);
+
+        Check("…and it does what it says: the winner's FIELDS are now inlined in the host",
+            TopicNameIn(path!, fx.TopicKey) == "Winner Topic",
+            $"{inlined}  [topic name={TopicNameIn(path!, fx.TopicKey) ?? "unreadable"}]");
+
+        // THE ANSWER, AND IT IS THE BAD ONE — THIS ARM IS DEPLOYED RED ON PURPOSE. Measured 2026-08-11: after the
+        // forward the patch's child group is EMPTY and the whole file holds one record, the topic. `W2HostedLine` is
+        // not orphaned or re-parented — it is GONE, and the forward reported success ("extended …"). So the remedy
+        // the contested message prints destroys the record the create just placed.
+        //
+        // The destruction is NOT this branch's: the drop-then-copy landed 2026-07-09 (e8363de, HCBR-2026-07-08-01 F1)
+        // and the branch does not touch it. `forward into=` has always dropped the whole record before re-copying,
+        // and `GenericGetOrAddAsOverride` carries no children in (the arm above), so ANY forward into a patch that
+        // holds children under the forwarded record silently loses them — placed refs under a cell, INFOs under a
+        // topic. What #300 added is a signpost pointing callers straight at it.
+        //
+        // Left FAILING rather than re-pointed at the behaviour it found (which would pin data loss as correct) or
+        // quietly reworded (which would be folding an unverified answer into a message instead of fixing the
+        // engine). Which of those this becomes — a preserved child group in the extend path, a refusal when the
+        // dropped record has children, or a different remedy in the message — is an architecture call (§5 #5),
+        // escalated rather than taken here.
+        var afterInline = ChildLinesIn(path!, fx.TopicKey);
+        Check("…and the new child SURVIVES that forward — the drop-then-copy does not take the child group",
+            afterInline.Contains("W2HostedLine"),
+            $"child group after the forward: [{string.Join(", ", afterInline)}] · whole file: [{string.Join(", ", EditorIdsIn(path!))}]");
     }
 
     /// <summary>Every child line the written plugin's copy of the topic carries — #300's "whose CHILDREN did the host

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -14,10 +14,9 @@ namespace HousecarlGenerator;
 /// <c>housecarl_write_seq</c> (tool-surface-2.0 W3 PR 2; SPEC §2.2 ACT, §5.1/§5.2, §6.1). Sibling of
 /// <c>apply-guard</c>, same posture: the REAL end-to-end tool path — a synthetic MO2 instance in temp +
 /// <see cref="LoadOrderService"/> + the tool methods themselves — so the wire readers, the LANE grammar, the
-/// alias-visible vocabulary and the engines are exercised exactly as a caller hits them. TEN arms, LISTED in the
-/// order they are declared below — which is NOT run order: the two off-order/in-place arms are run last by RunGuard
-/// because they rewrite a fixture file the others read as a known winner (review [nit]: the old wording implied the
-/// list itself was the schedule):
+/// alias-visible vocabulary and the engines are exercised exactly as a caller hits them. TEN arms, listed BY SUBJECT
+/// — neither declaration nor run order, both of which live in RunGuard, where the off-order/in-place pair is
+/// deliberately last because it rewrites a fixture file the others read as a known winner:
 /// <list type="number">
 /// <item><b>create grammar</b> — one record is a set of one, the nested one-shot (a same-call sibling parent +
 /// an '@editorid' link value), the @file spelling, and the strict element reader's NAMED refusals with the

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -1000,45 +1000,50 @@ public static class WriteSurfaceGuardProbe
             && made.Contains("currently WINS this record", StringComparison.Ordinal)
             && made.Contains("out-ranks", StringComparison.Ordinal)
             && made.Contains("inlined", StringComparison.Ordinal), made);
+        // …and the ORDER, which is the load-bearing half of that lever (#324). The first wording said only "forward
+        // the winner's version in explicitly", which is the measured-DESTRUCTIVE operation; a future edit that
+        // trims back to it would ship data-loss advice again and every other assertion here would stay green. The
+        // safe order is proven below, but the SENTENCE is what a caller acts on, so the sentence gets its own pin.
+        Check("…and the inlining lever names the SAFE order and marks the other one destructive",
+            made.Contains("forward its version into a patch FIRST", StringComparison.Ordinal)
+            && made.Contains("deletes the child", StringComparison.Ordinal)
+            && made.Contains("#324", StringComparison.Ordinal), made);
 
-        // THE PRINTED REMEDY, RUN RATHER THAN ARGUED (PR #323 review [medium]). The message above tells the caller to
-        // "forward '<winner>'s version in explicitly if you want its content inlined" — advice this branch shipped
-        // without ever executing it. It is not obviously safe: ForwardRecords on an EXTEND does drop-then-copy — the
-        // whole record is Remove()d, then the source body copied in (HCBR-2026-07-08-01 F1, where GetOrAdd's
-        // get-semantics silently SKIPPED the copy instead) — and the arm above establishes that
-        // GenericGetOrAddAsOverride does not carry children in. So if the drop takes the host's child GROUP with it,
-        // the copy cannot put it back and the printed advice DESTROYS the record the create just placed. One
-        // decidable question, one probe: create a child into a contested parent, forward the winner into the same
-        // patch, read the child group back. Both poles asserted, so a regression either way fails an arm.
-        var patchFile = Path.GetFileName(path!);
-        var inlined = ForwardTools.Forward(fx.Svc, formids: new[] { fx.TopicFid }, source: fx.ReplacerName, into: patchFile);
-        Check("…and the remedy the message prints — forward the winner into the same patch — is accepted",
-            inlined.StartsWith("extended ", StringComparison.Ordinal), inlined);
-
-        Check("…and it does what it says: the winner's FIELDS are now inlined in the host",
-            TopicNameIn(path!, fx.TopicKey) == "Winner Topic",
-            $"{inlined}  [topic name={TopicNameIn(path!, fx.TopicKey) ?? "unreadable"}]");
-
-        // THE ANSWER, AND IT IS THE BAD ONE — THIS ARM IS DEPLOYED RED ON PURPOSE. Measured 2026-08-11: after the
-        // forward the patch's child group is EMPTY and the whole file holds one record, the topic. `W2HostedLine` is
-        // not orphaned or re-parented — it is GONE, and the forward reported success ("extended …"). So the remedy
-        // the contested message prints destroys the record the create just placed.
+        // THE REMEDY THE MESSAGE PRINTS, MEASURED RATHER THAN REASONED — because it is user-facing text telling a
+        // caller to run a write, and the FIRST wording of it was measured FALSE (PR #323 review [medium]).
         //
-        // The destruction is NOT this branch's: the drop-then-copy landed 2026-07-09 (e8363de, HCBR-2026-07-08-01 F1)
-        // and the branch does not touch it. `forward into=` has always dropped the whole record before re-copying,
-        // and `GenericGetOrAddAsOverride` carries no children in (the arm above), so ANY forward into a patch that
-        // holds children under the forwarded record silently loses them — placed refs under a cell, INFOs under a
-        // topic. What #300 added is a signpost pointing callers straight at it.
+        // What was measured false: create the child, THEN forward the winner into the SAME patch. That DESTROYS the
+        // child. `forward`'s extend path drops the whole record before re-copying it (drop-then-copy, so a collision
+        // can't silently skip the copy — HCBR-2026-07-08-01 F1) and the child group goes with the drop, while
+        // `GenericGetOrAddAsOverride` carries none back in (the arm above). The probe left the patch holding one
+        // record, the topic, with the forward reporting success. That is a `forward` defect on BOTH its into= and
+        // in_place= lanes — the in_place half deletes children out of the caller's own plugin, on the lane with no
+        // backup — and it is neither #300's nor this branch's: those lines are untouched here. Filed as #324, which
+        // carries that probe body verbatim as its RED. Deliberately NOT asserted here: #323 must not carry another
+        // lane's red, and re-pointing this arm at the destruction would assert data loss is correct.
         //
-        // Left FAILING rather than re-pointed at the behaviour it found (which would pin data loss as correct) or
-        // quietly reworded (which would be folding an unverified answer into a message instead of fixing the
-        // engine). Which of those this becomes — a preserved child group in the extend path, a refusal when the
-        // dropped record has children, or a different remedy in the message — is an architecture call (§5 #5),
-        // escalated rather than taken here.
-        var afterInline = ChildLinesIn(path!, fx.TopicKey);
-        Check("…and the new child SURVIVES that forward — the drop-then-copy does not take the child group",
-            afterInline.Contains("W2HostedLine"),
-            $"child group after the forward: [{string.Join(", ", afterInline)}] · whole file: [{string.Join(", ", EditorIdsIn(path!))}]");
+        // What IS asserted is the ordering the contested message now prints: forward the winner FIRST, then create
+        // the child into that patch. The create then resolves its parent from the record the patch ALREADY carries,
+        // so there is no drop for the child to survive. Both halves asserted together — the winner's FIELDS inlined
+        // and the child present — because either alone would pass on a shape the message must not recommend.
+        var pre = ForwardTools.Forward(fx.Svc, formids: new[] { fx.TopicFid }, source: fx.ReplacerName, patch: "W2Inline");
+        var prePath = ArtifactPathFrom(fx, pre);
+        Check("the SAFE ordering, step 1: the winner's version of the parent forwards into a patch of its own",
+            prePath is not null, pre);
+
+        var thenChild = CreateTools.Create(fx.Svc, into: Path.GetFileName(prePath!),
+            records: Json($$"""[{"record_type":"DialogResponses","editorid":"W2InlinedLine","parent":"{{fx.TopicFid}}"}]"""));
+        Check("…step 2: the child creates into THAT patch, hosting in the parent it already carries",
+            thenChild.StartsWith("extended ", StringComparison.Ordinal), thenChild);
+
+        // Both, on the file. (The winner's OWN child line is not here and is not expected to be: the forward copies
+        // the record, not its group, and the winner's INFOs still play from the winner's own plugin — a child group
+        // survives its parent record losing, which is the whole premise of the lean host above.)
+        var inlinedName = TopicNameIn(prePath!, fx.TopicKey);
+        var inlinedChildren = ChildLinesIn(prePath!, fx.TopicKey);
+        Check("…and BOTH land: the winner's FIELDS are inlined AND the new child is in the group",
+            inlinedName == "Winner Topic" && inlinedChildren.Contains("W2InlinedLine"),
+            $"{thenChild}  [topic name={inlinedName ?? "unreadable"} · children=[{string.Join(", ", inlinedChildren)}]]");
     }
 
     /// <summary>Every child line the written plugin's copy of the topic carries — #300's "whose CHILDREN did the host

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -35,6 +35,8 @@ namespace HousecarlGenerator;
 /// does not cover it, the overlay is released (the file stays movable), and the four refusals stay named:
 /// ambiguous filename, a file that doesn't define the record, a record whose ORIGIN plugin isn't active, and a
 /// self-forward caught by FILE IDENTITY when source= is a path to the artifact being written.</item>
+/// <item><b>the CopyFrom view arm</b> (#317) — a pre-fetched off-order body keyed to a source the ENGINE's own build
+/// says is ACTIVE is ignored, so the arm reported is the arm taken.</item>
 /// <item><b>nested parent hosting</b> (#300) — a nested create under an EXISTING load-order parent hosts the child
 /// in the parent's DEFINING plugin's version: the winner does not become a master, the hosted record does not carry
 /// a frozen copy of the winner's fields, and which plugin hosted it is reported.</item>
@@ -84,10 +86,11 @@ public static class WriteSurfaceGuardProbe
             ForwardArm(fx);
             TransportArm(fx);
             CopyFromViewArm(root);
-            // LAST: it forwards into the replacer IN PLACE, which rewrites a fixture file the earlier arms read as a
-            // known winner. Ordering it after them keeps every other arm reading the fixture it was written against.
             CopySourcePathArm(fx, root);
             NestedParentHostArm(fx);
+            // OffOrderForwardArm and ReviewFoldArm go LAST: they forward into the replacer IN PLACE, which rewrites a
+            // fixture file every earlier arm reads as a known winner. Ordering them after keeps every other arm
+            // reading the fixture it was written against.
             OffOrderForwardArm(fx);
             ReviewFoldArm(fx, root);
 

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1674,6 +1674,8 @@ static class JsonWire
                 // A replace is never silent (the CreatedRecord contract): the same fact the text render puts in
                 // brackets, as a flag a consumer can branch on.
                 w.WriteBoolean("replaced_existing", c.ReplacedExisting);
+                // #300 — the parent override this nested create hosted the child in, and whose version was copied.
+                WriteNullable(w, "parent_host", c.ParentHost);
                 w.WriteStartArray("ops");
                 foreach (var op in c.Ops)
                 {

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1564,11 +1564,16 @@ static class JsonWire
                 // disagree about what the edited leaf now holds — a success response that must not be read as landed.
                 WriteNullable(w, "landed_on_disk", op.LandedOnDisk);
                 WriteNullable(w, "divergence", op.Divergence);
-                // THREE-state, not two (review [low]): the file-verify runs on the in-place lane, so a patch-lane or
-                // dry-run op has not been checked at all — emitting `false` there would read as "checked and failed"
-                // and mark every ordinary patch write unverified. null = not attempted.
-                if (op.LandedOnDisk is null && op.Divergence is null) w.WriteNull("landed_verified_on_disk");
-                else w.WriteBoolean("landed_verified_on_disk", op.LandedOnDisk is not null && op.Divergence is null);
+                // The STATE of the file-check, as a word rather than a bool that cannot say why (review [low], twice):
+                // "verified" the file agreed · "diverged" it did not (see divergence) · "superseded" a later op in
+                // this call wrote the same field, so the file cannot answer for this one · "no_answer" the re-opened
+                // file did not yield this op's leaf · "not_checked" the lane runs no file-verify (patch, dry run).
+                // The text render's own suffixes are the D2 twin of these.
+                w.WriteString("landed_verification",
+                    op.Divergence is not null ? "diverged"
+                    : op.SupersededInCall ? "superseded"
+                    : op.LandedOnDisk is not null ? "verified"
+                    : lane == "in_place" ? "no_answer" : "not_checked");
                 w.WriteEndObject();
                 renderedOps++;
             }

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1705,9 +1705,8 @@ static class JsonWire
             // render's "!" lines, and the same rule the divergence rows follow: a statement that this artifact will
             // out-rank a mod on a parent record it only meant to host a child in must survive a max_chars cut. One
             // entry per distinct contested parent; empty when every host was uncontested.
-            var contestedHosts = o.Created.Select(c => c.ParentHost)
-                                  .Where(h => h is not null && h.Contains("currently WINS this record", StringComparison.Ordinal))
-                                  .Distinct(StringComparer.Ordinal).ToList();
+            var contestedHosts = o.Created.Where(c => c.ParentContested && c.ParentHost is not null)
+                                  .Select(c => c.ParentHost!).Distinct(StringComparer.Ordinal).ToList();
             w.WriteStartArray("contested_parent_hosts");
             foreach (var host in contestedHosts) w.WriteStringValue(host);
             w.WriteEndArray();
@@ -1728,6 +1727,7 @@ static class JsonWire
                 w.WriteBoolean("replaced_existing", c.ReplacedExisting);
                 // #300 — the parent override this nested create hosted the child in, and whose version was copied.
                 WriteNullable(w, "parent_host", c.ParentHost);
+                w.WriteBoolean("parent_contested", c.ParentContested);
                 w.WriteStartArray("ops");
                 foreach (var op in c.Ops)
                 {

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1681,10 +1681,18 @@ static class JsonWire
             // render's "!" lines, and the same rule the divergence rows follow: a statement that this artifact will
             // out-rank a mod on a parent record it only meant to host a child in must survive a max_chars cut. One
             // entry per distinct contested parent; empty when every host was uncontested.
+            // BOUNDED on the SAME constant as the text twin (PR #323 review [medium]): hoisting an UNBOUNDED
+            // set-valued block above the budget just moves the overflow — at ~600-700 chars per host, a bulk_create
+            // fanning children into many distinct contested cells spent the whole budget here and left `created`
+            // rendering "0 of N, truncated". The text side was capped for exactly this and the json side was missed,
+            // which made the two lanes disagree about the same call (D2). `total_contested_parent_hosts` carries the
+            // full distinct count regardless — the same total/list pair `created` uses below — so the cut is stated,
+            // never silent (Q3); each host past the cap is still named on its own record's `parent_host`.
             var contestedHosts = o.Created.Where(c => c.ParentContested && c.ParentHost is not null)
                                   .Select(c => c.ParentHost!).Distinct(StringComparer.Ordinal).ToList();
+            w.WriteNumber("total_contested_parent_hosts", contestedHosts.Count);
             w.WriteStartArray("contested_parent_hosts");
-            foreach (var host in contestedHosts) w.WriteStringValue(host);
+            foreach (var host in contestedHosts.Take(Wire.ContestedHostsShown)) w.WriteStringValue(host);
             w.WriteEndArray();
 
             w.WriteNumber("total_created", o.Created.Count);

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1549,6 +1549,11 @@ static class JsonWire
             // reassurance in the one case #308 exists to catch. These rows are few (one per un-landed op) and are the
             // json twin of a statement the text render already refuses to let a cut remove.
             var diverged = o.Ops.Where(op => op.Divergence is not null).ToList();
+            // `verify_ran` beside the count (review [low]): a patch-lane or dry-run document also carries
+            // "diverged_ops": 0, and a consumer branching on that alone reads "nothing diverged" where the truth is
+            // "nothing was checked". The per-op word says so too, but only past the max_chars cut this hoist exists
+            // to survive.
+            w.WriteBoolean("verify_ran", o.Ops.Any(op => op.VerifyAttempted));
             w.WriteNumber("diverged_ops", diverged.Count);
             w.WriteStartArray("divergences");
             foreach (var op in diverged)
@@ -1587,12 +1592,16 @@ static class JsonWire
                 // this call wrote the same field, so the file cannot answer for this one · "no_answer" the re-opened
                 // file did not yield this op's leaf · "not_checked" this op was never ASKED — a lane that runs no
                 // file-verify (patch, dry run), or an op appended after the resolved edits (the SNAM topic-marker
-                // sync) on a lane that did verify.
+                // sync) on a lane that did verify · "not_comparable" the file answered but the applied edit's own
+                // read did not, so there was nothing to compare it against.
                 // The text render's own suffixes are the D2 twin of these.
                 w.WriteString("landed_verification",
                     op.Divergence is not null ? "diverged"
                     : op.SupersededInCall ? "superseded"
-                    : op.LandedOnDisk is not null ? "verified"
+                    // "verified" needs BOTH sides: if the applied edit's own read failed (After null) nothing was
+                    // compared, and reporting the file as agreeing is the overclaim this PR exists to remove.
+                    : op.LandedOnDisk is not null && op.After is not null ? "verified"
+                    : op.LandedOnDisk is not null ? "not_comparable"
                     // From the OP's own fact, never inferred from the lane: an in-place dry run re-opens nothing, and an
                     // op appended after the edits (the SNAM sync) was never asked about — both were read as
                     // "no_answer", which asserts a file was re-opened and could not answer (review).

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1585,7 +1585,9 @@ static class JsonWire
                 // The STATE of the file-check, as a word rather than a bool that cannot say why (review [low], twice):
                 // "verified" the file agreed · "diverged" it did not (see divergence) · "superseded" a later op in
                 // this call wrote the same field, so the file cannot answer for this one · "no_answer" the re-opened
-                // file did not yield this op's leaf · "not_checked" the lane runs no file-verify (patch, dry run).
+                // file did not yield this op's leaf · "not_checked" this op was never ASKED — a lane that runs no
+                // file-verify (patch, dry run), or an op appended after the resolved edits (the SNAM topic-marker
+                // sync) on a lane that did verify.
                 // The text render's own suffixes are the D2 twin of these.
                 w.WriteString("landed_verification",
                     op.Divergence is not null ? "diverged"

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1598,9 +1598,11 @@ static class JsonWire
                 w.WriteString("landed_verification",
                     op.Divergence is not null ? "diverged"
                     : op.SupersededInCall ? "superseded"
-                    // "verified" needs BOTH sides: if the applied edit's own read failed (After null) nothing was
-                    // compared, and reporting the file as agreeing is the overclaim this PR exists to remove.
-                    : op.LandedOnDisk is not null && op.After is not null ? "verified"
+                    // "verified" needs BOTH sides READABLE (review [low]): a leaf whose read failed comes back as the
+                    // note "(unreadable: …)", which is non-null — so testing for a non-null After stamped exactly the
+                    // op nothing could be compared for. The presence pair carries the fact; the file side is gated
+                    // upstream by leaving LandedOnDisk null.
+                    : op.LandedOnDisk is not null && op.After is not null && op.AfterPresence.Readable ? "verified"
                     : op.LandedOnDisk is not null ? "not_comparable"
                     // From the OP's own fact, never inferred from the lane: an in-place dry run re-opens nothing, and an
                     // op appended after the edits (the SNAM sync) was never asked about — both were read as

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1564,7 +1564,11 @@ static class JsonWire
                 // disagree about what the edited leaf now holds — a success response that must not be read as landed.
                 WriteNullable(w, "landed_on_disk", op.LandedOnDisk);
                 WriteNullable(w, "divergence", op.Divergence);
-                w.WriteBoolean("landed_verified_on_disk", op.LandedOnDisk is not null && op.Divergence is null);
+                // THREE-state, not two (review [low]): the file-verify runs on the in-place lane, so a patch-lane or
+                // dry-run op has not been checked at all — emitting `false` there would read as "checked and failed"
+                // and mark every ordinary patch write unverified. null = not attempted.
+                if (op.LandedOnDisk is null && op.Divergence is null) w.WriteNull("landed_verified_on_disk");
+                else w.WriteBoolean("landed_verified_on_disk", op.LandedOnDisk is not null && op.Divergence is null);
                 w.WriteEndObject();
                 renderedOps++;
             }

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1701,6 +1701,17 @@ static class JsonWire
             w.WriteNumber("bytes", o.Bytes);
             WriteStringArray(w, "masters", o.Masters.ToList());
 
+            // #300's trade, hoisted ABOVE the budgeted `created` array (review [medium]) — the json twin of the text
+            // render's "!" lines, and the same rule the divergence rows follow: a statement that this artifact will
+            // out-rank a mod on a parent record it only meant to host a child in must survive a max_chars cut. One
+            // entry per distinct contested parent; empty when every host was uncontested.
+            var contestedHosts = o.Created.Select(c => c.ParentHost)
+                                  .Where(h => h is not null && h.Contains("currently WINS this record", StringComparison.Ordinal))
+                                  .Distinct(StringComparer.Ordinal).ToList();
+            w.WriteStartArray("contested_parent_hosts");
+            foreach (var host in contestedHosts) w.WriteStringValue(host);
+            w.WriteEndArray();
+
             w.WriteNumber("total_created", o.Created.Count);
             w.WriteStartArray("created");
             int rendered = 0;

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1543,28 +1543,10 @@ static class JsonWire
             foreach (var m in o.Masters) w.WriteStringValue(m);
             w.WriteEndArray();
 
-            // FIRST and OUTSIDE the budget, exactly as the text render hoists its ✗ lines (review [medium]): the ops
-            // array is cut by max_chars, so a diverged op past the cut vanished from the document while `ok:true`,
-            // `truncated:true` and a note reading "the WRITE is complete and unaffected" stayed — an actively wrong
-            // reassurance in the one case #308 exists to catch. These rows are few (one per un-landed op) and are the
-            // json twin of a statement the text render already refuses to let a cut remove.
-            var diverged = o.Ops.Where(op => op.Divergence is not null).ToList();
-            // `verify_ran` beside the count (review [low]): a patch-lane or dry-run document also carries
-            // "diverged_ops": 0, and a consumer branching on that alone reads "nothing diverged" where the truth is
-            // "nothing was checked". The per-op word says so too, but only past the max_chars cut this hoist exists
-            // to survive.
+            // Did the per-op file check RUN at all? A patch-lane or dry-run document has no per-op file readings in
+            // it, and a consumer needs to tell that from "it ran and everything came off the file". Outside the ops
+            // budget, because that is the one fact a max_chars cut must not remove.
             w.WriteBoolean("verify_ran", o.Ops.Any(op => op.VerifyAttempted));
-            w.WriteNumber("diverged_ops", diverged.Count);
-            w.WriteStartArray("divergences");
-            foreach (var op in diverged)
-            {
-                w.WriteStartObject();
-                w.WriteString("formid", op.Target.ToString());
-                w.WriteString("label", op.Label);
-                w.WriteString("divergence", op.Divergence!);
-                w.WriteEndObject();
-            }
-            w.WriteEndArray();
 
             w.WriteNumber("total_ops", o.Ops.Count);
             w.WriteStartArray("ops");
@@ -1581,32 +1563,24 @@ static class JsonWire
                 WriteNullable(w, "error", op.Error);
                 WriteNullable(w, "after", op.After);
                 WriteNullable(w, "landed", op.Landed);
-                // #308 — the D2 twin of the text render's file-vs-memory split. `landed` is the applied edit's own
-                // read (in memory, pre-serialize); `landed_on_disk` is the same descriptor re-derived from the WRITTEN
-                // FILE, null when the file could not answer for this op; `divergence` is non-null exactly when the two
-                // disagree about what the edited leaf now holds — a success response that must not be read as landed.
+                // #308 — the D2 twin of the text render's file-vs-memory split, and it REPORTS rather than judges.
+                // `landed` is the applied edit's own read (in memory, before the serialize); `landed_on_disk` is the
+                // same descriptor re-derived from the WRITTEN FILE, null when the file could not answer for this op.
                 WriteNullable(w, "landed_on_disk", op.LandedOnDisk);
-                WriteNullable(w, "divergence", op.Divergence);
-                // The STATE of the file-check, as a word rather than a bool that cannot say why (review [low], twice):
-                // "verified" the file agreed · "diverged" it did not (see divergence) · "superseded" a later op in
-                // this call wrote the same field, so the file cannot answer for this one · "no_answer" the re-opened
-                // file did not yield this op's leaf · "not_checked" this op was never ASKED — a lane that runs no
-                // file-verify (patch, dry run), or an op appended after the resolved edits (the SNAM topic-marker
-                // sync) on a lane that did verify · "not_comparable" the file answered but the applied edit's own
-                // read did not, so there was nothing to compare it against.
-                // The text render's own suffixes are the D2 twin of these.
-                w.WriteString("landed_verification",
-                    op.Divergence is not null ? "diverged"
-                    : op.SupersededInCall ? "superseded"
-                    // "verified" needs BOTH sides READABLE (review [low]): a leaf whose read failed comes back as the
-                    // note "(unreadable: …)", which is non-null — so testing for a non-null After stamped exactly the
-                    // op nothing could be compared for. The presence pair carries the fact; the file side is gated
-                    // upstream by leaving LandedOnDisk null.
-                    : op.LandedOnDisk is not null && op.After is not null && op.AfterPresence.Readable ? "verified"
-                    : op.LandedOnDisk is not null ? "not_comparable"
-                    // From the OP's own fact, never inferred from the lane: an in-place dry run re-opens nothing, and an
-                    // op appended after the edits (the SNAM sync) was never asked about — both were read as
-                    // "no_answer", which asserts a file was re-opened and could not answer (review).
+                // WHERE the clause came from, as a word rather than a verdict:
+                //   "written_file"  the file answered for this op — `landed_on_disk` is its reading
+                //   "superseded"    a later op in this call wrote the same field, so the file's final state is that
+                //                   op's result and cannot speak for this one
+                //   "no_answer"     the file was re-opened and did not yield this op's leaf (or the read failed)
+                //   "not_checked"   this op was never asked — a lane that runs no per-op file check (patch, dry run),
+                //                   or an op appended after the resolved edits (the SNAM topic-marker sync)
+                // Deliberately NOT a judgement about whether the write "landed": telling a real difference from a
+                // representational one (a byte-quantised Percent, an overlay's type name) is what nine review rounds
+                // showed cannot be done reliably, and every attempt told a caller to re-issue a write that HAD landed.
+                // The two readings are both here; a caller comparing them decides.
+                w.WriteString("landed_source",
+                    op.SupersededInCall ? "superseded"
+                    : op.LandedOnDisk is not null ? "written_file"
                     : op.VerifyAttempted ? "no_answer" : "not_checked");
                 w.WriteEndObject();
                 renderedOps++;

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1573,7 +1573,10 @@ static class JsonWire
                     op.Divergence is not null ? "diverged"
                     : op.SupersededInCall ? "superseded"
                     : op.LandedOnDisk is not null ? "verified"
-                    : lane == "in_place" ? "no_answer" : "not_checked");
+                    // From the OP's own fact, never inferred from the lane: an in-place dry run re-opens nothing, and an
+                    // op appended after the edits (the SNAM sync) was never asked about — both were read as
+                    // "no_answer", which asserts a file was re-opened and could not answer (review).
+                    : op.VerifyAttempted ? "no_answer" : "not_checked");
                 w.WriteEndObject();
                 renderedOps++;
             }

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1558,6 +1558,13 @@ static class JsonWire
                 WriteNullable(w, "error", op.Error);
                 WriteNullable(w, "after", op.After);
                 WriteNullable(w, "landed", op.Landed);
+                // #308 — the D2 twin of the text render's file-vs-memory split. `landed` is the applied edit's own
+                // read (in memory, pre-serialize); `landed_on_disk` is the same descriptor re-derived from the WRITTEN
+                // FILE, null when the file could not answer for this op; `divergence` is non-null exactly when the two
+                // disagree about what the edited leaf now holds — a success response that must not be read as landed.
+                WriteNullable(w, "landed_on_disk", op.LandedOnDisk);
+                WriteNullable(w, "divergence", op.Divergence);
+                w.WriteBoolean("landed_verified_on_disk", op.LandedOnDisk is not null && op.Divergence is null);
                 w.WriteEndObject();
                 renderedOps++;
             }

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1543,6 +1543,24 @@ static class JsonWire
             foreach (var m in o.Masters) w.WriteStringValue(m);
             w.WriteEndArray();
 
+            // FIRST and OUTSIDE the budget, exactly as the text render hoists its ✗ lines (review [medium]): the ops
+            // array is cut by max_chars, so a diverged op past the cut vanished from the document while `ok:true`,
+            // `truncated:true` and a note reading "the WRITE is complete and unaffected" stayed — an actively wrong
+            // reassurance in the one case #308 exists to catch. These rows are few (one per un-landed op) and are the
+            // json twin of a statement the text render already refuses to let a cut remove.
+            var diverged = o.Ops.Where(op => op.Divergence is not null).ToList();
+            w.WriteNumber("diverged_ops", diverged.Count);
+            w.WriteStartArray("divergences");
+            foreach (var op in diverged)
+            {
+                w.WriteStartObject();
+                w.WriteString("formid", op.Target.ToString());
+                w.WriteString("label", op.Label);
+                w.WriteString("divergence", op.Divergence!);
+                w.WriteEndObject();
+            }
+            w.WriteEndArray();
+
             w.WriteNumber("total_ops", o.Ops.Count);
             w.WriteStartArray("ops");
             int renderedOps = 0;

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4613,9 +4613,14 @@ public sealed class LoadOrderService : IDisposable
     /// <para>Why it is needed at all: off-order-ness is decided by <c>WritePatchBuilder.IsOffOrderCopySource</c>, a
     /// lookup in the plugin-NAME table. A full path is never a key there, so <c>from_source=C:\…\SomeMod\Bar.esp</c>
     /// answered "off-order" for a plugin the order is actively serving — the body was read off the file directly,
-    /// bypassing the build the rest of the call resolves against, an EXCLUDED-but-active plugin was read rather than
-    /// refused, and the response described the source as not in the load order. Usually a wrong LABEL; under a
-    /// profile switch, where a filename is served by a different mod folder, a wrong BODY.</para>
+    /// bypassing the build the rest of the call resolves against, and the response described the source as not in the
+    /// load order. Usually a wrong LABEL; under a profile switch, where a filename is served by a different mod
+    /// folder, a wrong BODY.</para>
+    ///
+    /// <para>NOT fixed here, deliberately, though #321 listed it as a symptom: a path to an EXCLUDED-but-active plugin
+    /// still reads the file directly rather than taking the exclusion refusal. That is <c>ActiveNameForPath</c>'s own
+    /// rule (it declines excluded plugins), and it is the read surface's deliberate escape hatch — records ahead of
+    /// the unparseable one still come back. <c>forward</c> made the same call in PR #313; parity is the point.</para>
     ///
     /// <para><see cref="ActiveNameForPath"/> is the rule <c>forward</c> already answers this with (PR #313 [medium]),
     /// reused rather than restated: a FULL-PATH identity compare, so a same-named backup keeps the off-order lane,

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4548,7 +4548,8 @@ public sealed class LoadOrderService : IDisposable
     /// That is a structural invariant, NOT the mid-call race #317 was filed as: a write pins one resolver instance and
     /// its name table is never rebuilt, so the two captures cannot disagree about membership today. The helper's own
     /// doc carries the full statement.</para>
-    /// <para>MUTATES <paramref name="edits"/> before doing anything else (#321): a CopyFrom source addressed by a PATH
+    /// <para>MUTATES <paramref name="edits"/> — after the no-CopyFrom early return and this helper's own capture,
+    /// and before anything READS an edit (#321): a CopyFrom source addressed by a PATH
     /// that names the very file the order LOADS is re-spelled to that plugin's NAME
     /// (<see cref="RespellActiveCopySourcePaths"/>). Stated here rather than left to the reader because a
     /// <c>Resolve…</c> helper rewriting its argument is a surprise — the alternative was a second

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4547,8 +4547,14 @@ public sealed class LoadOrderService : IDisposable
     /// engine's own build still agrees the source is off-order (<c>WritePatchBuilder.TryOffOrderCopyBody</c>, #317).
     /// That is a structural invariant, NOT the mid-call race #317 was filed as: a write pins one resolver instance and
     /// its name table is never rebuilt, so the two captures cannot disagree about membership today. The helper's own
-    /// doc carries the full statement.</para></summary>
-    string? ResolveOffOrderCopySources(LoadOrderResolver resolver, IReadOnlyList<WritePatchBuilder.PatchEdit> edits,
+    /// doc carries the full statement.</para>
+    /// <para>MUTATES <paramref name="edits"/> before doing anything else (#321): a CopyFrom source addressed by a PATH
+    /// that names the very file the order LOADS is re-spelled to that plugin's NAME
+    /// (<see cref="RespellActiveCopySourcePaths"/>). Stated here rather than left to the reader because a
+    /// <c>Resolve…</c> helper rewriting its argument is a surprise — the alternative was a second
+    /// <c>Capture()</c> at the call site purely to re-spell, and this list is the one both the pre-locate and the
+    /// ENGINE consume, which is exactly what makes one rewrite reach both.</para></summary>
+    string? ResolveOffOrderCopySources(LoadOrderResolver resolver, IList<WritePatchBuilder.PatchEdit> edits,
         ref Dictionary<WritePatchBuilder.PatchEdit, IMajorRecordGetter>? sources, ref List<IDisposable>? overlays,
         out string? epoch)
     {
@@ -4559,6 +4565,7 @@ public sealed class LoadOrderService : IDisposable
         if (!edits.Any(e => string.Equals(e.Verb, "CopyFrom", StringComparison.Ordinal))) return null;   // no CopyFrom → no source work
         var view = resolver.Capture();
         epoch = view.Epoch;
+        RespellActiveCopySourcePaths(view, edits);   // #321 — before the predicate, and before any key is taken
         string modsDir = "", dataDir = "", overwriteDir = "", profileDir = "";
         Mo2Composition? comp = null;
         var problems = new List<string>();
@@ -4598,6 +4605,40 @@ public sealed class LoadOrderService : IDisposable
         return problems.Count > 0
             ? $"refused — {problems.Count} CopyFrom source problem(s); NO patch written:\n  - " + string.Join("\n  - ", problems)
             : null;
+    }
+
+    /// <summary>#321 — re-spell every <c>CopyFrom</c> source that is a PATH to the ACTIVE copy of a plugin into that
+    /// plugin's NAME, in place, so the rest of the write speaks the load order's own vocabulary.
+    ///
+    /// <para>Why it is needed at all: off-order-ness is decided by <c>WritePatchBuilder.IsOffOrderCopySource</c>, a
+    /// lookup in the plugin-NAME table. A full path is never a key there, so <c>from_source=C:\…\SomeMod\Bar.esp</c>
+    /// answered "off-order" for a plugin the order is actively serving — the body was read off the file directly,
+    /// bypassing the build the rest of the call resolves against, an EXCLUDED-but-active plugin was read rather than
+    /// refused, and the response described the source as not in the load order. Usually a wrong LABEL; under a
+    /// profile switch, where a filename is served by a different mod folder, a wrong BODY.</para>
+    ///
+    /// <para><see cref="ActiveNameForPath"/> is the rule <c>forward</c> already answers this with (PR #313 [medium]),
+    /// reused rather than restated: a FULL-PATH identity compare, so a same-named backup keeps the off-order lane,
+    /// and a path to an EXCLUDED plugin does too — reading that one directly is the deliberate escape hatch.</para>
+    ///
+    /// <para>Applied BEFORE the pre-locate loop for two reasons. A <c>PatchEdit</c> is the KEY of the pre-fetched
+    /// source dictionary, so re-spelling one afterwards would leave a key the engine can never look up; and the same
+    /// list is handed to the engine, so one rewrite reaches the arm decision, the winner comparison and every
+    /// rendered sentence at once — where a clause inside the shared predicate would have routed the body correctly
+    /// while the report still called an active plugin off-order.</para></summary>
+    static void RespellActiveCopySourcePaths(LoadOrderResolver.IndexView view, IList<WritePatchBuilder.PatchEdit> edits)
+    {
+        for (int i = 0; i < edits.Count; i++)
+        {
+            var e = edits[i];
+            if (!string.Equals(e.Verb, "CopyFrom", StringComparison.Ordinal)) continue;
+            // LooksLikePath gate, matching ResolveDiffPole / ResolveOffOrderForwardSource — the convention those
+            // sites cite; harmless without it (a bare filename that is active never reaches the off-order arm
+            // anyway), but a convention with an exception is one someone has to re-derive.
+            if (string.IsNullOrWhiteSpace(e.FromPlugin) || !LooksLikePath(e.FromPlugin!)) continue;
+            if (ActiveNameForPath(view, e.FromPlugin!) is { } activeName)
+                edits[i] = e with { FromPlugin = activeName };
+        }
     }
 
     /// <summary>W3 PR 2b — locate the ONE <c>source=</c> plugin a forward call shares when the ACTIVE ORDER does not

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4496,7 +4496,7 @@ public sealed class LoadOrderService : IDisposable
                 // disposed only after ApplyEditsInPlace returns.
                 Dictionary<WritePatchBuilder.PatchEdit, IMajorRecordGetter>? ipSources = null;
                 List<IDisposable>? ipOverlays = null;
-                var ipError = ResolveOffOrderCopySources(resolver, edits, ref ipSources, ref ipOverlays, out var ipEpoch);
+                var ipError = PrepareCopyFromSources(resolver, edits, ref ipSources, ref ipOverlays, out var ipEpoch);
                 if (ipError is not null)
                 {
                     if (ipOverlays is not null) foreach (var d in ipOverlays) d.Dispose();
@@ -4519,7 +4519,7 @@ public sealed class LoadOrderService : IDisposable
             // their overlays must stay OPEN through the serialize (CopyField deep-copies through them) — disposed after.
             Dictionary<WritePatchBuilder.PatchEdit, IMajorRecordGetter>? copyFromSources = null;
             List<IDisposable>? offOrderOverlays = null;
-            var cfError = ResolveOffOrderCopySources(resolver, edits, ref copyFromSources, ref offOrderOverlays, out var cfEpoch);
+            var cfError = PrepareCopyFromSources(resolver, edits, ref copyFromSources, ref offOrderOverlays, out var cfEpoch);
             if (cfError is not null)
             {
                 if (offOrderOverlays is not null) foreach (var d in offOrderOverlays) d.Dispose();
@@ -4554,7 +4554,7 @@ public sealed class LoadOrderService : IDisposable
     /// <c>Resolve…</c> helper rewriting its argument is a surprise — the alternative was a second
     /// <c>Capture()</c> at the call site purely to re-spell, and this list is the one both the pre-locate and the
     /// ENGINE consume, which is exactly what makes one rewrite reach both.</para></summary>
-    string? ResolveOffOrderCopySources(LoadOrderResolver resolver, IList<WritePatchBuilder.PatchEdit> edits,
+    string? PrepareCopyFromSources(LoadOrderResolver resolver, IList<WritePatchBuilder.PatchEdit> edits,
         ref Dictionary<WritePatchBuilder.PatchEdit, IMajorRecordGetter>? sources, ref List<IDisposable>? overlays,
         out string? epoch)
     {
@@ -4648,7 +4648,7 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>W3 PR 2b — locate the ONE <c>source=</c> plugin a forward call shares when the ACTIVE ORDER does not
     /// contain it (a disabled mod, an unticked plugin, an unregistered folder, or a direct path), open it, and pre-fetch
-    /// every requested record's body off its own overlay. The forward twin of <see cref="ResolveOffOrderCopySources"/>,
+    /// every requested record's body off its own overlay. The forward twin of <see cref="PrepareCopyFromSources"/>,
     /// and simpler than it: every forward in a call names the same source, so this is locate-ONCE / open-ONCE / fetch-N
     /// rather than a per-edit loop. Uses the SAME on-disk locate as read_plugin_file / the copy-npc-appearance donor lane
     /// (<see cref="LocatePluginFileOnDisk"/>), so two tools can never disagree about which file a filename names.

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -632,6 +632,15 @@ static class Wire
     /// hit the same spill bug, and all want the same bound. A caller raises it per-call via max_chars.</summary>
     public const int ReadbackMaxChars = 24_000;
 
+    /// <summary>How many distinct contested parent HOSTS a create render names before it says "and N further"
+    /// (#300). Lives here, shared by the text render and its json twin, because the two ARE the same bound and a
+    /// second literal is how they drift: the text side was capped on review [medium] and the json side was not,
+    /// so a bulk_create fanning children into many contested cells wrote ~700 bytes per host AHEAD of the budgeted
+    /// `created` array and truncated it at "0 of N" — the HCBR-2026-06-28-01 shape the text cap exists to prevent
+    /// (PR #323 review [medium]). Both lanes still publish the FULL distinct count beside the capped list, so a
+    /// cut caller knows how many it is not seeing.</summary>
+    public const int ContestedHostsShown = 10;
+
     static int Cap(int maxChars) => maxChars > 0 ? maxChars : DefaultMaxChars;
 
     /// <summary>Parse the shared format= param (Wave 2 / P6): null/"text" ⇒ false (the default text render), "json" ⇒

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -747,8 +747,10 @@ public static class WriteTools
         : " [as applied — this lane ran no file check]";
 
     /// <summary>#308 — the "APPLIED but the file does not carry it" lines for the ops given. Its own method because
-    /// BOTH readback forms must emit it: the compact verify calls it once BEFORE its per-record loop (so a cut or a
-    /// failed read-back cannot suppress it), and the full-dump lane calls it once after the dump. A Q3 statement that appears in only one of two renders of the same call is the D2 divergence class
+    /// EXACTLY ONE call site — <see cref="Render"/>, ahead of both renderers and of the read-back block entirely — so
+    /// neither the compact budget, a record whose read-back errored, nor the absence of a read-back can suppress it.
+    /// (This doc previously described two call sites, one of them inside the full-dump renderer, where a reader
+    /// auditing "does the full dump emit this?" would have found nothing — review [low].) A Q3 statement that appears in only one of two renders of the same call is the D2 divergence class
     /// this PR's own reviews keep finding.</summary>
     static void AppendDivergences(StringBuilder sb, IEnumerable<WritePatchBuilder.OpResult> ops)
     {
@@ -1178,6 +1180,18 @@ public static class WriteTools
         // as a follow-up on the grounds that max_chars' description scoped the ceiling to the read-back; the D2
         // divergence is the stronger argument and it wins.)
         int createCap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        // #300's TRADE, hoisted out of the budget below (review [medium]) — the same reasoning that hoisted #308's
+        // divergence lines: a statement that the artifact will now out-rank a mod on a record it did not mean to
+        // touch must not be the thing a max_chars cut removes, and the per-record `parent:` lines live INSIDE the
+        // loop. One line per distinct contested parent, before the list, and only when the definer and the winner
+        // actually differ — the benign case (definer IS the winner, or the artifact already carried the parent) says
+        // nothing here. The truncation notice points at a read-back, and the host choice is not IN the record, so a
+        // cut caller could not recover this afterwards.
+        var contested = o.Created.Select(c => c.ParentHost)
+                         .Where(h => h is not null && h.Contains("currently WINS this record", StringComparison.Ordinal))
+                         .Distinct(StringComparer.Ordinal).ToList();
+        foreach (var host in contested)
+            sb.Append("  ! ").Append(host).Append('\n');
         int listed = 0;
         for (int ci = 0; ci < o.Created.Count; ci++)
         {

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -691,7 +691,10 @@ public static class WriteTools
         IReadOnlyList<WritePatchBuilder.FullReadback> rb, int maxChars)
     {
         int cap = maxChars > 0 ? maxChars : Wire.ReadbackMaxChars;
-        sb.Append("verified — every edited record re-read off the written file (compact; pass full_readback=true for the ")
+        // Never lead with "verified" over a ✗ (review [nit]): the divergence lines print immediately below this.
+        sb.Append(ops.Any(o => o.Divergence is not null)
+                ? "verify — every edited record was re-read off the written file, and AT LEAST ONE op is NOT carried by it (compact; pass full_readback=true for the "
+                : "verified — every edited record re-read off the written file (compact; pass full_readback=true for the ")
           .Append("full field-by-field dump):\n");
         // FIRST, and outside the budget (review [medium]): a "did not land" statement must not be the thing a
         // max_chars cut removes, and it must not ride on the per-record loop — that loop `continue`s past a record
@@ -716,7 +719,7 @@ public static class WriteTools
             // #308: the per-op clause is the FILE's answer when the file gave one (LandedOnDisk), and is marked as the
             // applied edit's claim when it did not — the banner above says "re-read off the written file", and this
             // line used to carry a memory-derived descriptor under it without saying so.
-            var mine = ops.Where(op => op.Target == r.Target).ToList();
+            var mine = ops.Where(op => op.Target == r.Target);
             var landed = mine.Where(op => (op.LandedOnDisk ?? op.Landed) is not null)
                              .Select(op => $"{op.Label}: {op.LandedOnDisk ?? op.Landed}" + LandedProvenance(op))
                              .ToList();
@@ -731,8 +734,12 @@ public static class WriteTools
     /// cannot corroborate — comparing it anyway is what reported correct multi-op writes as NOT landed).</summary>
     static string LandedProvenance(WritePatchBuilder.OpResult op) =>
         op.SupersededInCall ? " [as applied — a later op in this call wrote the same field; the file shows that op's result]"
-        : op.LandedOnDisk is null ? " [as applied — the re-opened file did not answer for this op]"
-        : "";
+        : op.LandedOnDisk is not null ? ""
+        // The same three-way split json makes, for the same reason (review [low], both rounds): asserting the file was
+        // re-opened and could not answer, on a call where the verify never ran, is a claim about a read that did not
+        // happen. Reachable — the compare pass has its own catch, which leaves every op unattempted.
+        : op.VerifyAttempted ? " [as applied — the re-opened file did not answer for this op]"
+        : " [as applied — this lane ran no file check]";
 
     /// <summary>#308 — the "APPLIED but the file does not carry it" lines for the ops given. Its own method because
     /// BOTH readback forms must emit it: the compact verify calls it once BEFORE its per-record loop (so a cut or a

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -693,6 +693,11 @@ public static class WriteTools
         int cap = maxChars > 0 ? maxChars : Wire.ReadbackMaxChars;
         sb.Append("verified — every edited record re-read off the written file (compact; pass full_readback=true for the ")
           .Append("full field-by-field dump):\n");
+        // FIRST, and outside the budget (review [medium]): a "did not land" statement must not be the thing a
+        // max_chars cut removes, and it must not ride on the per-record loop — that loop `continue`s past a record
+        // whose read-back errored, while the divergence pass is a separate walk that may well have an answer for it.
+        // These lines are few (one per genuinely un-landed op) and are the whole reason the verify is forced on.
+        AppendDivergences(sb, ops);
         for (int i = 0; i < rb.Count; i++)
         {
             if (sb.Length >= cap)
@@ -713,18 +718,21 @@ public static class WriteTools
             // line used to carry a memory-derived descriptor under it without saying so.
             var mine = ops.Where(op => op.Target == r.Target).ToList();
             var landed = mine.Where(op => (op.LandedOnDisk ?? op.Landed) is not null)
-                             .Select(op => $"{op.Label}: {op.LandedOnDisk ?? op.Landed}"
-                                         + (op.LandedOnDisk is null ? " [as applied — the re-opened file did not answer for this op]" : ""))
+                             .Select(op => $"{op.Label}: {op.LandedOnDisk ?? op.Landed}" + LandedProvenance(op))
                              .ToList();
             if (landed.Count > 0) sb.Append("; ").Append(string.Join("; ", landed));
             sb.Append('\n');
-            // #308 — LOUD, on its own line, and never folded into the ✓: the write succeeded and the file does NOT
-            // corroborate what an op claims to have put there (canonically a composed struct with nothing to
-            // serialize). This is the inconsistency the forced verify exists to catch, so it is stated, not implied by
-            // a count the caller would have to notice.
-            AppendDivergences(sb, mine);
         }
     }
+
+    /// <summary>#308 — where a per-op "what landed" clause CAME FROM, when it is not the plain file answer. Silence
+    /// means the file was re-read for this op and agreed; the two marked cases are a file that could not answer for
+    /// the op, and an op a later op in the same call superseded (whose reading is a mid-sequence one the final file
+    /// cannot corroborate — comparing it anyway is what reported correct multi-op writes as NOT landed).</summary>
+    static string LandedProvenance(WritePatchBuilder.OpResult op) =>
+        op.SupersededInCall ? " [as applied — a later op in this call wrote the same field; the file shows that op's result]"
+        : op.LandedOnDisk is null ? " [as applied — the re-opened file did not answer for this op]"
+        : "";
 
     /// <summary>#308 — the "APPLIED but the file does not carry it" lines for the ops given. Its own method because
     /// BOTH readback forms must emit it: the compact verify calls it per record, and the full-dump lane calls it once

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -719,8 +719,7 @@ public static class WriteTools
             // #308: the per-op clause is the FILE's answer when the file gave one (LandedOnDisk), and is marked as the
             // applied edit's claim when it did not — the banner above says "re-read off the written file", and this
             // line used to carry a memory-derived descriptor under it without saying so.
-            var mine = ops.Where(op => op.Target == r.Target);
-            var landed = mine.Where(op => (op.LandedOnDisk ?? op.Landed) is not null)
+            var landed = ops.Where(op => op.Target == r.Target && (op.LandedOnDisk ?? op.Landed) is not null)
                              .Select(op => $"{op.Label}: {op.LandedOnDisk ?? op.Landed}" + LandedProvenance(op))
                              .ToList();
             if (landed.Count > 0) sb.Append("; ").Append(string.Join("; ", landed));

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -738,9 +738,11 @@ public static class WriteTools
     static string LandedProvenance(WritePatchBuilder.OpResult op) =>
         op.SupersededInCall ? " [as applied — a later op in this call wrote the same field; the file shows that op's result]"
         : op.LandedOnDisk is not null ? ""
-        // The same three-way split json makes, for the same reason (review [low], both rounds): asserting the file was
-        // re-opened and could not answer, on a call where the verify never ran, is a claim about a read that did not
-        // happen. Reachable — the compare pass has its own catch, which leaves every op unattempted.
+        // The same split json makes, for the same reason: asserting the file was re-opened and could not answer, on a
+        // call where the verify never ran, is a claim about a read that did not happen. The first arm is the reachable
+        // one — the compare pass's own catch marks its ops ATTEMPTED-and-unanswered. The second is defensive: every
+        // in-place op the verify reached is attempted, and the ops it does not reach (the appended SNAM syncs) carry
+        // no Landed and are filtered out of this clause upstream, so no product path reaches it today (review [nit]).
         : op.VerifyAttempted ? " [as applied — the re-opened file did not answer for this op]"
         : " [as applied — this lane ran no file check]";
 
@@ -752,7 +754,12 @@ public static class WriteTools
     {
         foreach (var op in ops)
             if (op.Divergence is { } why)
-                sb.Append("  ✗ ").Append(op.Label).Append(" — the edit was APPLIED but the written file does not carry it: ")
+                // NAMES THE RECORD (review [medium]): op.Label is "{Verb} {path}" and nothing else, so a bulk in-place
+                // over 40 NPCs with a divergence on 3 of them printed three byte-identical lines and the caller could
+                // not tell which records to re-check. The json twin has carried formid since it was hoisted; this is
+                // that D2 gap closed on the side a human actually reads.
+                sb.Append("  ✗ ").Append(op.RecordType).Append(' ').Append(op.Target).Append("  ").Append(op.Label)
+                  .Append(" — the edit was APPLIED but the written file does not carry it: ")
                   .Append(why).Append(". The file is what the game loads: treat this op as NOT landed.\n");
     }
 

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -704,10 +704,24 @@ public static class WriteTools
             var rec = r.Record!;
             sb.Append("  ✓ ").Append(rec.Type).Append(' ').Append(rec.FormKey)
               .Append(" — re-read clean (").Append(rec.Fields.Count).Append(" field(s))");
-            var landed = ops.Where(op => op.Target == r.Target && op.Landed is not null)
-                            .Select(op => $"{op.Label}: {op.Landed}").ToList();
+            // #308: the per-op clause is the FILE's answer when the file gave one (LandedOnDisk), and is marked as the
+            // applied edit's claim when it did not — the banner above says "re-read off the written file", and this
+            // line used to carry a memory-derived descriptor under it without saying so.
+            var mine = ops.Where(op => op.Target == r.Target).ToList();
+            var landed = mine.Where(op => (op.LandedOnDisk ?? op.Landed) is not null)
+                             .Select(op => $"{op.Label}: {op.LandedOnDisk ?? op.Landed}"
+                                         + (op.LandedOnDisk is null ? " [as applied — the re-opened file did not answer for this op]" : ""))
+                             .ToList();
             if (landed.Count > 0) sb.Append("; ").Append(string.Join("; ", landed));
             sb.Append('\n');
+            // #308 — LOUD, on its own line, and never folded into the ✓: the write succeeded and the file does NOT
+            // corroborate what an op claims to have put there (canonically a composed struct with nothing to
+            // serialize). This is the inconsistency the forced verify exists to catch, so it is stated, not implied by
+            // a count the caller would have to notice.
+            foreach (var op in mine)
+                if (op.Divergence is { } why)
+                    sb.Append("  ✗ ").Append(op.Label).Append(" — the edit was APPLIED but the written file does not carry it: ")
+                      .Append(why).Append(". The file is what the game loads: treat this op as NOT landed.\n");
         }
     }
 

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -735,8 +735,8 @@ public static class WriteTools
         : "";
 
     /// <summary>#308 — the "APPLIED but the file does not carry it" lines for the ops given. Its own method because
-    /// BOTH readback forms must emit it: the compact verify calls it per record, and the full-dump lane calls it once
-    /// at the end. A Q3 statement that appears in only one of two renders of the same call is the D2 divergence class
+    /// BOTH readback forms must emit it: the compact verify calls it once BEFORE its per-record loop (so a cut or a
+    /// failed read-back cannot suppress it), and the full-dump lane calls it once after the dump. A Q3 statement that appears in only one of two renders of the same call is the D2 divergence class
     /// this PR's own reviews keep finding.</summary>
     static void AppendDivergences(StringBuilder sb, IEnumerable<WritePatchBuilder.OpResult> ops)
     {

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -1156,14 +1156,15 @@ public static class WriteTools
         // Selected on the FLAG, never by matching the sentence (review [low]). BOUNDED, too (review [medium]): one
         // line per contested parent is ~400 chars, and a bulk_create fanning children into many contested cells would
         // otherwise blow the whole response budget BEFORE the created list starts — which then truncates at "0 of N",
-        // the exact HCBR-2026-06-28-01 shape. Cap the block, and say how many were not shown.
-        const int contestedShown = 10;
+        // the exact HCBR-2026-06-28-01 shape. Cap the block, and say how many were not shown. The bound lives on
+        // Wire (PR #323 review [medium]) because the json twin needs the SAME one and a local literal here is how the
+        // two drifted apart in the first place — the json side shipped this block unbounded.
         var contested = o.Created.Where(c => c.ParentContested && c.ParentHost is not null)
                          .Select(c => c.ParentHost!).Distinct(StringComparer.Ordinal).ToList();
-        foreach (var host in contested.Take(contestedShown))
+        foreach (var host in contested.Take(Wire.ContestedHostsShown))
             sb.Append("  ! ").Append(host).Append('\n');
-        if (contested.Count > contestedShown)
-            sb.Append("  ! … and ").Append(contested.Count - contestedShown)
+        if (contested.Count > Wire.ContestedHostsShown)
+            sb.Append("  ! … and ").Append(contested.Count - Wire.ContestedHostsShown)
               .Append(" further contested parent(s) — each is named on its own record's `parent:` line below.\n");
         int listed = 0;
         for (int ci = 0; ci < o.Created.Count; ci++)

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -754,8 +754,15 @@ public static class WriteTools
     /// this PR's own reviews keep finding.</summary>
     static void AppendDivergences(StringBuilder sb, IEnumerable<WritePatchBuilder.OpResult> ops)
     {
+        // BOUNDED, though hoisted above the budget (review [medium]): a divergence line is ~350 chars and a bulk
+        // in-place with a systematic divergence emits one per op, which would push the whole response past the host's
+        // ceiling — the failure this render was reshaped to avoid. The cap is generous (a caller with 25 un-landed
+        // ops has a systemic problem, not 25 individual ones) and the remainder is counted, never dropped silently.
+        const int shown = 25;
+        int rendered = 0, total = 0;
+        foreach (var op in ops) if (op.Divergence is not null) total++;
         foreach (var op in ops)
-            if (op.Divergence is { } why)
+            if (op.Divergence is { } why && rendered++ < shown)
                 // NAMES THE RECORD (review [medium]): op.Label is "{Verb} {path}" and nothing else, so a bulk in-place
                 // over 40 NPCs with a divergence on 3 of them printed three byte-identical lines and the caller could
                 // not tell which records to re-check. The json twin has carried formid since it was hoisted; this is
@@ -763,6 +770,9 @@ public static class WriteTools
                 sb.Append("  ✗ ").Append(op.RecordType).Append(' ').Append(op.Target).Append("  ").Append(op.Label)
                   .Append(" — the edit was APPLIED but the written file does not carry it: ")
                   .Append(why).Append(". The file is what the game loads: treat this op as NOT landed.\n");
+        if (total > shown)
+            sb.Append("  ✗ … and ").Append(total - shown).Append(" further op(s) the written file does not carry")
+              .Append(" — every one is in format=\"json\" (`divergences`), which is not cut here.\n");
     }
 
     /// <summary>Confirmation for housecarl_remove_record: what was dropped, the patch's now-lean masters, and how many
@@ -1187,11 +1197,18 @@ public static class WriteTools
         // actually differ — the benign case (definer IS the winner, or the artifact already carried the parent) says
         // nothing here. The truncation notice points at a read-back, and the host choice is not IN the record, so a
         // cut caller could not recover this afterwards.
-        var contested = o.Created.Select(c => c.ParentHost)
-                         .Where(h => h is not null && h.Contains("currently WINS this record", StringComparison.Ordinal))
-                         .Distinct(StringComparer.Ordinal).ToList();
-        foreach (var host in contested)
+        // Selected on the FLAG, never by matching the sentence (review [low]). BOUNDED, too (review [medium]): one
+        // line per contested parent is ~400 chars, and a bulk_create fanning children into many contested cells would
+        // otherwise blow the whole response budget BEFORE the created list starts — which then truncates at "0 of N",
+        // the exact HCBR-2026-06-28-01 shape. Cap the block, and say how many were not shown.
+        const int contestedShown = 10;
+        var contested = o.Created.Where(c => c.ParentContested && c.ParentHost is not null)
+                         .Select(c => c.ParentHost!).Distinct(StringComparer.Ordinal).ToList();
+        foreach (var host in contested.Take(contestedShown))
             sb.Append("  ! ").Append(host).Append('\n');
+        if (contested.Count > contestedShown)
+            sb.Append("  ! … and ").Append(contested.Count - contestedShown)
+              .Append(" further contested parent(s) — each is named on its own record's `parent:` line below.\n");
         int listed = 0;
         for (int ci = 0; ci < o.Created.Count; ci++)
         {

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -549,11 +549,7 @@ public static class WriteTools
         sb.Append(o.Ops.Count).Append(o.Ops.Count == 1 ? " edit:\n" : " edits:\n");
         foreach (var op in o.Ops)
             sb.Append("  ").Append(op.RecordType).Append(' ').Append(op.Target).Append("  ").Append(op.Label)
-              .Append(op.After is not null ? "  -> " + op.After : "  -> applied")
-              // This row is the APPLIED edit's own reading. When the file does not carry it, mark it HERE too — this
-              // is the first place a caller looks, and the ✗ line arrives further down (review [nit]).
-              .Append(op.Divergence is not null ? "   [NOT carried by the written file — see below]" : "")
-              .Append('\n');
+              .Append(op.After is not null ? "  -> " + op.After : "  -> applied").Append('\n');
         // Make the dialogue-coverage scope boundary VISIBLE, not silent (Q3): the .fuz/.lip presence check (unit B) AND
         // the result-script binding check (unit C1) both run on CREATE of dialogue lines, not on EDITS to existing ones.
         // An edit that adds a spoken response or a result script to an existing INFO produces the same silent-line /
@@ -567,12 +563,6 @@ public static class WriteTools
         // lane) renders COMPACT by default and the full field-by-field dump only on full_readback=true (HCBR-2026-06-28-01):
         // the deep dump of N records with large list fields blew past the host token cap and spilled to a file, reading as
         // "only some ops applied". The verify itself is unchanged — this is its OUTPUT, not its detection.
-        // BEFORE the read-back, ONCE, for EVERY lane (reviews [medium] then [low]): a "did not land" statement must
-        // not be the thing a max_chars cut removes, must not ride on the per-record loop (which skips a record whose
-        // read-back errored), and must not be coupled to whether a read-back exists at all — it was reachable only
-        // through the compact block, so a lane that computed a divergence without one would print nothing here while
-        // json still said "diverged".
-        AppendDivergences(sb, o.Ops);
         if (o.ReadBack is { } rb)
         {
             if (fullDump) AppendFullReadback(sb, rb, maxChars);
@@ -697,14 +687,10 @@ public static class WriteTools
         IReadOnlyList<WritePatchBuilder.FullReadback> rb, int maxChars)
     {
         int cap = maxChars > 0 ? maxChars : Wire.ReadbackMaxChars;
-        // Never lead with "verified" over a ✗ (review [nit]): the divergence lines print immediately below this.
-        sb.Append(ops.Any(o => o.Divergence is not null)
-                ? "verify — every edited record was re-read off the written file, and AT LEAST ONE op is NOT carried by it (compact; pass full_readback=true for the "
-                : "verified — every edited record re-read off the written file (compact; pass full_readback=true for the ")
+        // The banner covers what it can now stand behind: every edited record WAS re-read off the written file, and
+        // each per-op clause below says whether it is the file's answer or the applied edit's own reading.
+        sb.Append("verified — every edited record re-read off the written file (compact; pass full_readback=true for the ")
           .Append("full field-by-field dump):\n");
-        // The divergence lines are NOT emitted here — Render emits them once for every lane, before this block, so
-        // they cannot be cut by the budget below, skipped with a record whose read-back errored, or lost on a lane
-        // that has no read-back at all.
         for (int i = 0; i < rb.Count; i++)
         {
             if (sb.Length >= cap)
@@ -745,35 +731,6 @@ public static class WriteTools
         // no Landed and are filtered out of this clause upstream, so no product path reaches it today (review [nit]).
         : op.VerifyAttempted ? " [as applied — the re-opened file did not answer for this op]"
         : " [as applied — this lane ran no file check]";
-
-    /// <summary>#308 — the "APPLIED but the file does not carry it" lines for the ops given. Its own method because
-    /// EXACTLY ONE call site — <see cref="Render"/>, ahead of both renderers and of the read-back block entirely — so
-    /// neither the compact budget, a record whose read-back errored, nor the absence of a read-back can suppress it.
-    /// (This doc previously described two call sites, one of them inside the full-dump renderer, where a reader
-    /// auditing "does the full dump emit this?" would have found nothing — review [low].) A Q3 statement that appears in only one of two renders of the same call is the D2 divergence class
-    /// this PR's own reviews keep finding.</summary>
-    static void AppendDivergences(StringBuilder sb, IEnumerable<WritePatchBuilder.OpResult> ops)
-    {
-        // BOUNDED, though hoisted above the budget (review [medium]): a divergence line is ~350 chars and a bulk
-        // in-place with a systematic divergence emits one per op, which would push the whole response past the host's
-        // ceiling — the failure this render was reshaped to avoid. The cap is generous (a caller with 25 un-landed
-        // ops has a systemic problem, not 25 individual ones) and the remainder is counted, never dropped silently.
-        const int shown = 25;
-        int rendered = 0, total = 0;
-        foreach (var op in ops) if (op.Divergence is not null) total++;
-        foreach (var op in ops)
-            if (op.Divergence is { } why && rendered++ < shown)
-                // NAMES THE RECORD (review [medium]): op.Label is "{Verb} {path}" and nothing else, so a bulk in-place
-                // over 40 NPCs with a divergence on 3 of them printed three byte-identical lines and the caller could
-                // not tell which records to re-check. The json twin has carried formid since it was hoisted; this is
-                // that D2 gap closed on the side a human actually reads.
-                sb.Append("  ✗ ").Append(op.RecordType).Append(' ').Append(op.Target).Append("  ").Append(op.Label)
-                  .Append(" — the edit was APPLIED but the written file does not carry it: ")
-                  .Append(why).Append(". The file is what the game loads: treat this op as NOT landed.\n");
-        if (total > shown)
-            sb.Append("  ✗ … and ").Append(total - shown).Append(" further op(s) the written file does not carry")
-              .Append(" — every one is in format=\"json\" (`divergences`), which is not cut here.\n");
-    }
 
     /// <summary>Confirmation for housecarl_remove_record: what was dropped, the patch's now-lean masters, and how many
     /// records remain (0 ⇒ inert). On refusal, the named reason (Q3) so the caller can fix and retry.</summary>

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -549,7 +549,11 @@ public static class WriteTools
         sb.Append(o.Ops.Count).Append(o.Ops.Count == 1 ? " edit:\n" : " edits:\n");
         foreach (var op in o.Ops)
             sb.Append("  ").Append(op.RecordType).Append(' ').Append(op.Target).Append("  ").Append(op.Label)
-              .Append(op.After is not null ? "  -> " + op.After : "  -> applied").Append('\n');
+              .Append(op.After is not null ? "  -> " + op.After : "  -> applied")
+              // This row is the APPLIED edit's own reading. When the file does not carry it, mark it HERE too — this
+              // is the first place a caller looks, and the ✗ line arrives further down (review [nit]).
+              .Append(op.Divergence is not null ? "   [NOT carried by the written file — see below]" : "")
+              .Append('\n');
         // Make the dialogue-coverage scope boundary VISIBLE, not silent (Q3): the .fuz/.lip presence check (unit B) AND
         // the result-script binding check (unit C1) both run on CREATE of dialogue lines, not on EDITS to existing ones.
         // An edit that adds a spoken response or a result script to an existing INFO produces the same silent-line /
@@ -563,15 +567,17 @@ public static class WriteTools
         // lane) renders COMPACT by default and the full field-by-field dump only on full_readback=true (HCBR-2026-06-28-01):
         // the deep dump of N records with large list fields blew past the host token cap and spilled to a file, reading as
         // "only some ops applied". The verify itself is unchanged — this is its OUTPUT, not its detection.
+        // BEFORE the read-back, ONCE, for EVERY lane (reviews [medium] then [low]): a "did not land" statement must
+        // not be the thing a max_chars cut removes, must not ride on the per-record loop (which skips a record whose
+        // read-back errored), and must not be coupled to whether a read-back exists at all — it was reachable only
+        // through the compact block, so a lane that computed a divergence without one would print nothing here while
+        // json still said "diverged".
+        AppendDivergences(sb, o.Ops);
         if (o.ReadBack is { } rb)
         {
             if (fullDump) AppendFullReadback(sb, rb, maxChars);
             else AppendCompactReadback(sb, o.Ops, rb, maxChars);
         }
-        // #308 review [medium] — the divergence lines live in the COMPACT verify, so asking for the FULL dump used to
-        // drop them: the caller who asked for the most verification was the only one never told an op had not landed.
-        // Rendered here for the full-dump lane, after the dump, so both forms carry the same Q3 statement.
-        if (fullDump) AppendDivergences(sb, o.Ops);
         if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
         sb.Append(o.InPlace
             ? InPlaceAgainHint("to make more in-place edits to this plugin", file, laneAsName)
@@ -696,11 +702,9 @@ public static class WriteTools
                 ? "verify — every edited record was re-read off the written file, and AT LEAST ONE op is NOT carried by it (compact; pass full_readback=true for the "
                 : "verified — every edited record re-read off the written file (compact; pass full_readback=true for the ")
           .Append("full field-by-field dump):\n");
-        // FIRST, and outside the budget (review [medium]): a "did not land" statement must not be the thing a
-        // max_chars cut removes, and it must not ride on the per-record loop — that loop `continue`s past a record
-        // whose read-back errored, while the divergence pass is a separate walk that may well have an answer for it.
-        // These lines are few (one per genuinely un-landed op) and are the whole reason the verify is forced on.
-        AppendDivergences(sb, ops);
+        // The divergence lines are NOT emitted here — Render emits them once for every lane, before this block, so
+        // they cannot be cut by the budget below, skipped with a record whose read-back errored, or lost on a lane
+        // that has no read-back at all.
         for (int i = 0; i < rb.Count; i++)
         {
             if (sb.Length >= cap)

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -568,6 +568,10 @@ public static class WriteTools
             if (fullDump) AppendFullReadback(sb, rb, maxChars);
             else AppendCompactReadback(sb, o.Ops, rb, maxChars);
         }
+        // #308 review [medium] — the divergence lines live in the COMPACT verify, so asking for the FULL dump used to
+        // drop them: the caller who asked for the most verification was the only one never told an op had not landed.
+        // Rendered here for the full-dump lane, after the dump, so both forms carry the same Q3 statement.
+        if (fullDump) AppendDivergences(sb, o.Ops);
         if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
         sb.Append(o.InPlace
             ? InPlaceAgainHint("to make more in-place edits to this plugin", file, laneAsName)
@@ -718,11 +722,20 @@ public static class WriteTools
             // corroborate what an op claims to have put there (canonically a composed struct with nothing to
             // serialize). This is the inconsistency the forced verify exists to catch, so it is stated, not implied by
             // a count the caller would have to notice.
-            foreach (var op in mine)
-                if (op.Divergence is { } why)
-                    sb.Append("  ✗ ").Append(op.Label).Append(" — the edit was APPLIED but the written file does not carry it: ")
-                      .Append(why).Append(". The file is what the game loads: treat this op as NOT landed.\n");
+            AppendDivergences(sb, mine);
         }
+    }
+
+    /// <summary>#308 — the "APPLIED but the file does not carry it" lines for the ops given. Its own method because
+    /// BOTH readback forms must emit it: the compact verify calls it per record, and the full-dump lane calls it once
+    /// at the end. A Q3 statement that appears in only one of two renders of the same call is the D2 divergence class
+    /// this PR's own reviews keep finding.</summary>
+    static void AppendDivergences(StringBuilder sb, IEnumerable<WritePatchBuilder.OpResult> ops)
+    {
+        foreach (var op in ops)
+            if (op.Divergence is { } why)
+                sb.Append("  ✗ ").Append(op.Label).Append(" — the edit was APPLIED but the written file does not carry it: ")
+                  .Append(why).Append(". The file is what the game loads: treat this op as NOT landed.\n");
     }
 
     /// <summary>Confirmation for housecarl_remove_record: what was dropped, the patch's now-lean masters, and how many

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -1163,6 +1163,9 @@ public static class WriteTools
             sb.Append("  ").Append(c.RecordType).Append(' ').Append(c.FormKey).Append("  ").Append(c.EditorId);
             if (c.ReplacedExisting) sb.Append("  [REPLACED: this patch already defined this editorid — re-created fresh at the same FormID; prior contents, including any set_field edits since, were discarded]");
             sb.Append('\n');
+            // #300 — a nested create had to override its parent in to host the child, and WHOSE version it copied is a
+            // choice the caller never made and cannot see in the record afterwards. One line, only when there was one.
+            if (c.ParentHost is { } host) sb.Append("      parent: ").Append(host).Append('\n');
             foreach (var op in c.Ops)
                 sb.Append("      ").Append(op.Label).Append(op.After is not null ? "  -> " + op.After : "  -> applied").Append('\n');
         }

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -1147,13 +1147,12 @@ public static class WriteTools
         // as a follow-up on the grounds that max_chars' description scoped the ceiling to the read-back; the D2
         // divergence is the stronger argument and it wins.)
         int createCap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
-        // #300's TRADE, hoisted out of the budget below (review [medium]) — the same reasoning that hoisted #308's
-        // divergence lines: a statement that the artifact will now out-rank a mod on a record it did not mean to
-        // touch must not be the thing a max_chars cut removes, and the per-record `parent:` lines live INSIDE the
-        // loop. One line per distinct contested parent, before the list, and only when the definer and the winner
-        // actually differ — the benign case (definer IS the winner, or the artifact already carried the parent) says
-        // nothing here. The truncation notice points at a read-back, and the host choice is not IN the record, so a
-        // cut caller could not recover this afterwards.
+        // #300's HOST CHOICE, hoisted out of the budget below: which version of a contested parent this artifact
+        // carries is a control decision the caller may want to act on (sort, or inline the winner deliberately), and
+        // the per-record `parent:` lines live INSIDE the loop where a max_chars cut removes them. It is a statement,
+        // not a warning — the lean residual is the right default; this just makes it visible. One line per distinct
+        // contested parent; the benign cases (definer IS the winner, or the artifact already carried the parent) say
+        // nothing. The host choice is not IN the record, so a cut caller could not recover it afterwards.
         // Selected on the FLAG, never by matching the sentence (review [low]). BOUNDED, too (review [medium]): one
         // line per contested parent is ~400 chars, and a bulk_create fanning children into many contested cells would
         // otherwise blow the whole response budget BEFORE the created list starts — which then truncates at "0 of N",


### PR DESCRIPTION
Three routed bug fixes from the W3 PR 3 charter, plus the generator housekeeping the 2.0 tidy-up left behind. `copy` itself is **not** in this PR — Aaron split it out so these could be reviewed on their own merits (PR 3b).

Fixes #321
Fixes #308
Fixes #300

---

## What landed

**#321 — a `from_source=` PATH to an ACTIVE plugin took the off-order arm.** Off-order-ness is a lookup in the plugin-NAME table and a full path is never a key there, so a path naming the very file the order serves read off disk directly and was described as not in the load order. Usually a wrong label; under a profile switch, a wrong body. `forward` has had `ActiveNameForPath` since PR #313 — the edit is now re-spelled to the plugin NAME before the shared predicate runs, so the arm decision, the winner comparison and every rendered sentence move together. A same-named backup and a path to an excluded plugin both keep the off-order lane, as on `forward`.

**#308 — the in-place verify's "what landed" clause is now read off the written file**, and a compose that cannot serialize is refused before anything is written. See "The #308 story" below: this shipped with a divergence *verdict* that was removed on Aaron's call after ten review rounds.

**#300 — a nested create hosts its child in the parent's DEFINING plugin's version**, not the load-order winner's. No unnecessary master, and no frozen copy of another mod's fields. Injected and excluded definers fall back to the winner and say so. Which plugin hosted the child is reported per record (`parent:`, `parent_host`).

**Generator** — an unknown first argument is refused (exit 2) instead of being read as an output directory. Two mistyped guard names wrote 13.5 MB into the working tree during the tidy-up; a bare name is now always a mode, even when a folder of that name exists (I reproduced the hole mid-review: `... src/housecarl-generator plugin` put 7.6 MB into `plugin/`).

## The #308 story, because the diff will not tell it

The fix shipped with a second half: a comparator that compared the in-memory reading against the file's and declared **"this op did not land"**. Across ten rounds that verdict produced a new false-accusation class each time — a byte-quantised `Percent` (`0.123` → `0.12`), an overlay's type name (`[WeaponBasicStatsBinaryOverlay]` vs `[WeaponBasicStats]`), `(absent)` vs `""`, a vanished substruct with no count to compare, two count-changing keyed ops in one call, and finally an unreadable read stamped `"verified"`. **Four of this branch's five high findings were that feature breaking under its own fixes.** Each version told a caller to re-issue a write that had landed; on a `Remove`, that deletes a further element.

Aaron's call (2026-08-11): **keep the honesty, drop the judgement.** Removed: the comparator, its presence plumbing, `OpResult.Divergence`, the `✗ … treat this op as NOT landed` lines, the JSON `divergences`/`diverged_ops` block, and the 12 checks that pinned them. Kept: the clause is re-derived from the re-opened written file; where the file could not answer (unreadable leaf, record not yielded, an op a later op superseded, a lane that runs no per-op check) the response says which reading it is showing — `landed`, `landed_on_disk`, `landed_source` (`written_file` | `superseded` | `no_answer` | `not_checked`), `verify_ran`. The pre-write refusal that stops the reported call is untouched.

The honesty half caused none of the regressions. The judgement caused all of them.

## On #300's shape — read this before judging the host choice

Four rounds flagged definer-hosting as a defect by comparing it to xEdit. xEdit copies the winner because a *person* is deciding, record by record. houseCARL is not making that decision: **the agent picks the shape from the request.** "Patch this mod for my list" wants a full resolution patch that wins and carries the resolved content. "Make this sit before the Reqtificator / Synthesis output" wants a feeder that masters neither, forwards neither, and does not bake in what those would regenerate. Same call, opposite right answers.

The residual is what you get when nothing is said, because it is the shape you can build up from and an inlined winner is the one you cannot cleanly subtract. Measured bound: the host carries **only** the new child — not the definer's existing children, not the winner's — so this touches the parent record's own fields, never other mods' child records.

**Open question for the next session** (Aaron: works when prompted, degrades with record count/complexity): is the inline path mechanically reachable — does forwarding the winner's version into a patch that already carries the host overwrite its fields while preserving the new child group, or does get-or-add semantics silently no-op it? If it no-ops, the composition argument does not hold and #300 is half-finished.

## Pre-PR review rounds (§5 #11)

**Ten rounds, twenty fresh unseeded agents.** Highs: round 1 (the #300 shape, escalated to Aaron rather than folded); rounds 2, 3, 4 and 8 — **all mine, every one introduced by a fold**, all in the #308 verdict now deleted. Rounds 5, 6, 7, 9 and 10 returned no highs.

Findings I refused, with reasons, are in the fold commits. Two rounds are worth calling out because they changed how the branch was guarded rather than what it does:

- **Round 9b** found two seams that could be **deleted with all 117 probes green** — the keyed-op exemption and the comparator's wire into the verify pass. Both got real arms, RED-verified.
- **Round 6** found my own guard doc arguing a case "could not be synthesised"; a reviewer synthesised it in minutes. That sentence is why a high shipped.

**Process failure worth recording:** §11 stops on severity, which cannot converge on a feature that generates a new true-but-benign finding per round. I should have invoked §4 at round three, when the same class recurred twice, instead of folding seven more times. Aaron and I have agreed §11 wants a convergence guard — if one subsystem draws findings in three consecutive rounds, stop and escalate the design. That edit is his to make.

I also repeated a scar from the previous session's handoff: RED-checking with the fix uncommitted, then `git checkout --` on the file, destroying it. Twice now.

## Known and NOT fixed (for the fresh session)

- #300's per-parent body fetch now scans the DEFINING master (usually `Skyrim.esm`) rather than the smaller winner; memoised per parent, so it bites on a bulk create fanning into many *distinct* cells. The honest fix is an index, not a memo.
- The empty-compose refusal's worked example can name a field that cannot be passed as a string (a reviewer enumerated 28 affected types, e.g. `LeveledItemEntry`).
- #300's contested line does not re-fire on a second `into=` call into the same cell.
- `parent_host` / `parent_contested` have no JSON-side probe; the text half is pinned.
- The empty-compose refusal also refuses a shape that used to work (compose empty, fill in a later op of the same call) — declared in the refusal text and the changelog.
- `ForwardTools.cs` still names `ResolveOffOrderCopySources` after the rename to `PrepareCopyFromSources`.
- The strings-aware re-open has no localized fixture; the CLI refusal has no probe.

## Verification

`ci-all` **117/117** · `apply-guard` **78/78** · `write-surface-guard` **129/129**, all in Release on the branch tip. Every new guard arm RED-verified against the pre-fix code; where a check passes in both directions the arm's own doc says so and calls it a bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
