### PR TITLE
ci: add Dependabot config for NuGet and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # NuGet packages referenced by the four .csproj files under src/.
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Actions pinned in .github/workflows/*.yml (actions/checkout, actions/setup-dotnet, actions/cache).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- houseCARL had no `.github/dependabot.yml` — the repo's Dependencies tab and automated update PRs weren't wired up.
- Adds weekly checks for the two ecosystems actually in use: NuGet (via `housecarl.sln` at repo root, which pulls in all four `.csproj` project references) and GitHub Actions (the pinned actions in `ci.yml`).

## Test plan
- [x] Config-only change (13-line YAML, no code) — pre-PR review rounds skipped per CLAUDE.md §5#11.
- [ ] Confirm GitHub picks up the config and the Dependencies/Insights tab reflects it after merge.
- [ ] Confirm the first scheduled Dependabot run opens sane update PRs (if any updates are available) that CI still gates correctly.