### PR TITLE
fix(#324): forward preserves the child group across its drop-then-copy

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,16 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**Fixed: forwarding a record no longer deletes the records nested under it (#324).** When `forward` targeted a record
+the destination *already carried*, it replaced it by dropping the whole record and copying the source body in — and
+the drop took the record's child group with it. Any dialogue line under a forwarded topic, or placed reference under
+a forwarded cell, was destroyed, and the call reported success. The `in_place=` lane was the worse half: it deleted
+those records out of your own plugin, on the lane that keeps no backup. The children are now lifted off before the
+replace and re-attached after it, so a forward changes the record's *fields* and leaves what is nested under it
+alone. Nothing about the forward semantic changes: the source's own children still stay in the source's plugin,
+which is what lets a patched topic not fight another mod's added lines. If houseCARL ever cannot account for every
+child across the replace, it refuses and writes nothing rather than emit a plugin it knows is short a record.
+
 **Fixed: an in-place edit's "what landed" line is now read off the written file (#308).** The verify prints under a
 banner saying every edited record was re-read off the file on disk — but the per-op half of each line ("`Add Ranks:
 now 1 (+1)`") was read from memory *before* the file was written. When a composed structure exists in memory and

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -73,14 +73,10 @@ else is said, because you can build the inlined shape deliberately, and you cann
 once it is baked in. The response **tells you** which mod currently wins that parent and which way the record will
 resolve, so the choice is in front of you at write time. Whichever way you sort, the new child is carried.
 
-**Building the inlined shape: the order matters, and only one order is safe today.** Forward the winner's version into
-a patch **first**, then create into that patch — your new record is hosted in the forwarded body, and you get both.
-Doing it the other way round — creating first, then forwarding the winner into the same patch — **deletes the record you
-just created**, and reports success. That is a pre-existing `housecarl_forward` bug rather than anything specific to
-this feature: forwarding onto a record the destination already carries drops that whole record before re-copying it,
-and the child group — placed references under a cell, dialogue lines under a topic — goes with the drop. It affects
-`into=` and `in_place=` alike, so it can take content out of your own plugin on the in-place lane. It is tracked as
-**#324** and is not fixed in this release; until it is, use the safe order. The write response names the safe order too.
+**Building the inlined shape.** Forward the winner's version of the parent into a patch, then create into that patch —
+your new record is hosted in the forwarded body, and you get both. Either order works: forwarding onto a parent a
+patch already holds keeps the records nested under it (that order used to destroy them, which is the `forward` fix
+above in this same release). The write response names the remedy too.
 
 **Fixed: a full path to an *active* plugin is no longer treated as an off-order file (#321).** `housecarl_apply`'s
 `CopyFrom` decided "is this source in the load order?" by looking up the name it was given, and a full path never

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -661,8 +661,9 @@ public static class WriteEngine
     public readonly record struct ChildGroupCarry(
         IReadOnlyList<(PropertyInfo Prop, object? Value)> Held, int Count, IReadOnlyList<string> Names)
     {
-        /// <summary>Nothing was held — the record owns no children (the overwhelmingly common case: every flat record
-        /// type but Cell / DialogTopic / Worldspace), so the restore is a no-op and the lanes skip it.</summary>
+        /// <summary>Nothing was held — the record owns no children (the overwhelmingly common case: every record type
+        /// but Cell / DialogTopic / Worldspace), so there is nothing to re-attach. NOT a licence to skip the arrival
+        /// tripwire in <see cref="RestoreChildGroup"/>: see the comment there.</summary>
         public bool IsEmpty => Count == 0;
     }
 
@@ -674,27 +675,56 @@ public static class WriteEngine
         var held = new List<(PropertyInfo, object?)>();
         foreach (var p in ChildBearingProperties(record.GetType()))
             held.Add((p, p.GetValue(record)));
-        var kids = ChildrenOf(record);
-        return new ChildGroupCarry(held, kids.Count, kids.Take(10).ToList());
+        return new ChildGroupCarry(held, ChildCountOf(record), ChildNamesOf(record, 10));
+    }
+
+    /// <summary>The capture, with a throw turned into a refusal naming the RIGHT operation (round-1 review [low]). The
+    /// lanes run this inside the try whose catch reports "the override-copy threw" — true of the copy, false of a
+    /// fault reading the destination's own existing record, which is what would send a caller debugging the wrong
+    /// file. Returns null on success, or the refusal.</summary>
+    public static string? TryCaptureChildGroup(IMajorRecord record, string untouchedClause, out ChildGroupCarry carry)
+    {
+        carry = default;
+        try { carry = CaptureChildGroup(record); return null; }
+        catch (Exception ex)
+        {
+            return $"cannot forward {record.FormKey}: reading the child records under the version the destination " +
+                   $"already carries threw ({ex.GetType().Name}: {ex.Message}) — surfaced, not swallowed (Q3). " +
+                   untouchedClause;
+        }
     }
 
     /// <summary>Re-attach a <see cref="CaptureChildGroup"/> carry onto the freshly copied record, AFTER the copy (#324).
     /// Returns null on success, or a refusal naming the cause — the caller fails the whole call with nothing
-    /// serialized, never a partial write.</summary>
-    public static string? RestoreChildGroup(IMajorRecord fresh, ChildGroupCarry carry)
+    /// serialized, never a partial write. <paramref name="untouchedClause"/> is the lane's own statement of what was
+    /// left alone, SUBSTITUTED into each message rather than appended by the caller (the <c>SerializeFailure</c>
+    /// precedent) so the reassurance lands before "please report it" instead of after it.</summary>
+    public static string? RestoreChildGroup(IMajorRecord fresh, ChildGroupCarry carry, string untouchedClause)
     {
-        if (carry.IsEmpty) return null;
+        // Gate on what the record TYPE can own, not on what the destination happened to hold. An empty carry is NOT a
+        // reason to skip the arrival tripwire below (round-1 review [low]): that case is the one where an arriving
+        // child set would be an INJECTION of the source's own children — a patch topic with no INFOs of its own
+        // silently acquiring the source mod's five — rather than a discard of the destination's. The memoized
+        // reflection lookup is what keeps this free for the 130 record types that can own nothing at all.
+        if (ChildBearingProperties(fresh.GetType()).Count == 0) return null;
 
-        // The copy is expected to arrive EMPTY (see the type doc). If it ever does not, the two child sets would have
-        // to be reconciled and there is no defensible way to guess which wins — so surface it instead of silently
-        // dropping one side. A Mutagen bump that starts carrying children in trips this in CI, loudly, by design.
-        var arrived = ChildrenOf(fresh);
-        if (arrived.Count > 0)
-            return $"cannot preserve the {carry.Count} child record(s) under {fresh.FormKey}: the forwarded copy " +
-                   $"arrived carrying {arrived.Count} child record(s) of its own ({string.Join(", ", arrived.Take(5))}" +
-                   $"{(arrived.Count > 5 ? ", …" : "")}), so re-attaching would discard one of the two sets. houseCARL " +
-                   "refuses rather than guess which (Q3) — this is an engine-level change in Mutagen's override-copy " +
-                   "semantics, not something the call did wrong; please report it.";
+        // The copy is expected to arrive EMPTY (see the type doc). If it ever does not, surface it instead of
+        // silently resolving it either way. A Mutagen bump that starts carrying children in trips this loudly.
+        var arrived = ChildCountOf(fresh);
+        if (arrived > 0)
+        {
+            var sample = string.Join(", ", ChildNamesOf(fresh, 5)) + (arrived > 5 ? ", …" : "");
+            return $"cannot forward {fresh.FormKey}: the forwarded copy arrived carrying {arrived} child record(s) of "
+                 + $"its own ({sample}), " + (carry.IsEmpty
+                     ? "which a forward does not mean — it asserts the source's FIELDS and leaves the source's own "
+                       + "children in the source's plugin, so houseCARL refuses rather than silently import them (Q3). "
+                     : $"while the destination held {carry.Count} of its own; re-attaching would discard one of the two "
+                       + "sets and there is no defensible way to guess which, so houseCARL refuses (Q3). ")
+                 + untouchedClause + " This is an engine-level change in Mutagen's override-copy semantics, not "
+                 + "something the call did wrong; please report it.";
+        }
+
+        if (carry.IsEmpty) return null;
 
         // A throw here is caught rather than left to the caller's catch: that one reports "the override-copy threw",
         // which would name the wrong operation for a fault in the re-attach. Same loudness, accurate sentence.
@@ -706,27 +736,34 @@ public static class WriteEngine
         catch (Exception ex)
         {
             return $"cannot preserve the {carry.Count} child record(s) under {fresh.FormKey}: re-attaching them to " +
-                   $"the forwarded copy threw ({ex.GetType().Name}: {ex.Message}) — surfaced, not swallowed (Q3).";
+                   $"the forwarded copy threw ({ex.GetType().Name}: {ex.Message}) — surfaced, not swallowed (Q3). " +
+                   untouchedClause;
         }
 
         // By-construction verification, off Mutagen's OWN containment enumeration rather than the reflected property
         // set that did the re-attach: if a containment path exists that ChildBearingProperties cannot see, the counts
         // disagree and the call refuses. A record type Mutagen grows a new child group on fails loud here instead of
         // quietly losing it — the same posture the coverage cornerstone takes on record types.
-        var after = ChildrenOf(fresh);
-        if (after.Count != carry.Count)
+        var after = ChildCountOf(fresh);
+        if (after != carry.Count)
             return $"cannot forward {fresh.FormKey}: it carries {carry.Count} child record(s) " +
-                   $"({string.Join(", ", carry.Names)}{(carry.Count > carry.Names.Count ? ", …" : "")}) and only " +
-                   $"{after.Count} survived the replace — houseCARL will not write a plugin it knows is missing " +
-                   "records (Q3). Nothing was serialized; the file is UNTOUCHED. Please report this with the record type.";
+                   $"({string.Join(", ", carry.Names)}{(carry.Count > carry.Names.Count ? ", …" : "")}) and {after} " +
+                   "are on the record after the replace — houseCARL will not write a plugin whose child records it " +
+                   $"cannot account for (Q3). {untouchedClause} Please report this with the record type.";
         return null;
     }
 
-    /// <summary>Every major record contained UNDER <paramref name="record"/>, by Mutagen's own containment walk — the
-    /// independent yardstick <see cref="RestoreChildGroup"/> checks the reflected re-attach against.</summary>
-    static List<string> ChildrenOf(IMajorRecordGetter record) =>
+    /// <summary>How many major records are contained UNDER <paramref name="record"/>, by Mutagen's own containment
+    /// walk — the independent yardstick <see cref="RestoreChildGroup"/> checks the reflected re-attach against. Count
+    /// only: the names cost a string per descendant, which on a worldspace is six figures, so they are materialized
+    /// by <see cref="ChildNamesOf"/> on the refusal paths and on capture (ten, for the message) alone.</summary>
+    static int ChildCountOf(IMajorRecordGetter record) =>
+        record is IMajorRecordGetterEnumerable e ? e.EnumerateMajorRecords().Count() : 0;
+
+    /// <summary>Up to <paramref name="max"/> child records of <paramref name="record"/>, named for a message.</summary>
+    static List<string> ChildNamesOf(IMajorRecordGetter record, int max) =>
         record is IMajorRecordGetterEnumerable e
-            ? e.EnumerateMajorRecords().Select(r => r.EditorID ?? r.FormKey.ToString()).ToList()
+            ? e.EnumerateMajorRecords().Take(max).Select(r => r.EditorID ?? r.FormKey.ToString()).ToList()
             : new List<string>();
 
     /// <summary>The settable properties of <paramref name="t"/> that can REACH an owned major record, MEMOIZED per type
@@ -738,8 +775,10 @@ public static class WriteEngine
     /// one-level "is this property a major record" test sees <c>Cell</c>/<c>DialogTopic</c> and misses every exterior
     /// cell in the game. <c>IFormLink</c>s are excluded — a link REFERENCES a record, it does not own one, and walking
     /// them would sweep in most of the schema. Against Mutagen 0.53.1 this answers: Cell (Landscape, NavigationMeshes,
-    /// Persistent, Temporary), DialogTopic (Responses), Worldspace (TopCell, SubCells) — and nothing else, which the
-    /// guard pins so a Mutagen bump that adds a container shows up as a failing arm rather than as lost records.</summary>
+    /// Persistent, Temporary), DialogTopic (Responses), Worldspace (TopCell, SubCells) — and nothing else. The guard
+    /// pins that over EVERY concrete record type Mutagen models, not a sample of them (round-1 review [low]: a pin on
+    /// six names leaves the other 127 free to grow a container silently), so a Mutagen bump that adds one shows up as
+    /// a failing arm rather than as a refusal in a caller's face.</summary>
     internal static IReadOnlyList<PropertyInfo> ChildBearingProperties(Type t) => _childProps.GetOrAdd(t, static ty =>
         ty.GetProperties(BindingFlags.Public | BindingFlags.Instance)
           .Where(p => p.CanRead && p.CanWrite && p.GetIndexParameters().Length == 0
@@ -749,7 +788,11 @@ public static class WriteEngine
 
     /// <summary>Can a value of <paramref name="t"/> hold an owned major record? See <see cref="ChildBearingProperties"/>
     /// for why this recurses and why links are cut. The depth bound and the visited set close the cycles Mutagen's
-    /// object graph has (a Cell reaches a Cell through a Worldspace).</summary>
+    /// object graph has (a Cell reaches a Cell through a Worldspace). The bound is a CONSTANT with one level of slack,
+    /// not a by-construction limit: the deepest real path is Worldspace.SubCells at 5 (ExtendedList → WorldspaceBlock
+    /// → Items → WorldspaceSubBlock → Items → Cell). A Mutagen bump that nests deeper than 6 degrades fail-closed —
+    /// the property drops out of the set, the count check in <see cref="RestoreChildGroup"/> refuses, and the guard's
+    /// all-types pin goes red first — so the constant is a tripwire, not a correctness assumption.</summary>
     static bool ReachesOwnedRecord(Type t, HashSet<Type> seen, int depth)
     {
         if (depth > 6 || !seen.Add(t)) return false;

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -637,6 +637,143 @@ public static class WriteEngine
         return true;
     }
 
+    // ======================================================================
+    //  CHILD-GROUP PRESERVATION ACROSS A DROP-THEN-COPY  (#324)
+    // ======================================================================
+
+    /// <summary>
+    /// The child records a record OWNS, lifted off it so a drop-then-copy can put them back (#324).
+    /// <para/>
+    /// <b>Why this exists.</b> Both <c>forward</c> lanes replace a FormKey the destination already carries by
+    /// <c>Remove</c>-ing the whole record and then copying the source body in (the F1 semantic — a collision must not
+    /// silently SKIP the copy, HCBR-2026-07-08-01). The drop takes the record's child GROUP with it, and
+    /// <see cref="GenericGetOrAddAsOverride"/> carries none back in, so every child under the replaced record was
+    /// silently destroyed while the call reported success: INFOs under a DIAL, placed refs under a CELL. Measured on
+    /// PR #323 and filed as #324; the <c>in_place=</c> half deleted them out of the caller's OWN plugin.
+    /// <para/>
+    /// <b>There is nothing to reconcile.</b> The copy brings no children in, so this is re-attach-what-was-there, not
+    /// a merge — and the forward semantic is unchanged by it (a forwarded parent asserts the source's FIELDS; the
+    /// source's own children stay in the source's plugin, which is what lets a DIAL override not fight other mods'
+    /// added lines). <see cref="RestoreChildGroup"/> nonetheless REFUSES rather than overwrites if the copy ever does
+    /// arrive carrying children — that assumption is Mutagen's, not ours, and a bump that changed it would otherwise
+    /// turn this preservation into a silent discard (Q3).
+    /// </summary>
+    public readonly record struct ChildGroupCarry(
+        IReadOnlyList<(PropertyInfo Prop, object? Value)> Held, int Count, IReadOnlyList<string> Names)
+    {
+        /// <summary>Nothing was held — the record owns no children (the overwhelmingly common case: every flat record
+        /// type but Cell / DialogTopic / Worldspace), so the restore is a no-op and the lanes skip it.</summary>
+        public bool IsEmpty => Count == 0;
+    }
+
+    /// <summary>Lift <paramref name="record"/>'s owned child records off it, BEFORE the drop (#324). The values are the
+    /// live collections — the record is on its way out of the mod and nothing else references it, so re-attaching them
+    /// by reference is lossless and needs no deep copy.</summary>
+    public static ChildGroupCarry CaptureChildGroup(IMajorRecord record)
+    {
+        var held = new List<(PropertyInfo, object?)>();
+        foreach (var p in ChildBearingProperties(record.GetType()))
+            held.Add((p, p.GetValue(record)));
+        var kids = ChildrenOf(record);
+        return new ChildGroupCarry(held, kids.Count, kids.Take(10).ToList());
+    }
+
+    /// <summary>Re-attach a <see cref="CaptureChildGroup"/> carry onto the freshly copied record, AFTER the copy (#324).
+    /// Returns null on success, or a refusal naming the cause — the caller fails the whole call with nothing
+    /// serialized, never a partial write.</summary>
+    public static string? RestoreChildGroup(IMajorRecord fresh, ChildGroupCarry carry)
+    {
+        if (carry.IsEmpty) return null;
+
+        // The copy is expected to arrive EMPTY (see the type doc). If it ever does not, the two child sets would have
+        // to be reconciled and there is no defensible way to guess which wins — so surface it instead of silently
+        // dropping one side. A Mutagen bump that starts carrying children in trips this in CI, loudly, by design.
+        var arrived = ChildrenOf(fresh);
+        if (arrived.Count > 0)
+            return $"cannot preserve the {carry.Count} child record(s) under {fresh.FormKey}: the forwarded copy " +
+                   $"arrived carrying {arrived.Count} child record(s) of its own ({string.Join(", ", arrived.Take(5))}" +
+                   $"{(arrived.Count > 5 ? ", …" : "")}), so re-attaching would discard one of the two sets. houseCARL " +
+                   "refuses rather than guess which (Q3) — this is an engine-level change in Mutagen's override-copy " +
+                   "semantics, not something the call did wrong; please report it.";
+
+        // A throw here is caught rather than left to the caller's catch: that one reports "the override-copy threw",
+        // which would name the wrong operation for a fault in the re-attach. Same loudness, accurate sentence.
+        try
+        {
+            foreach (var (prop, value) in carry.Held)
+                prop.SetValue(fresh, value);
+        }
+        catch (Exception ex)
+        {
+            return $"cannot preserve the {carry.Count} child record(s) under {fresh.FormKey}: re-attaching them to " +
+                   $"the forwarded copy threw ({ex.GetType().Name}: {ex.Message}) — surfaced, not swallowed (Q3).";
+        }
+
+        // By-construction verification, off Mutagen's OWN containment enumeration rather than the reflected property
+        // set that did the re-attach: if a containment path exists that ChildBearingProperties cannot see, the counts
+        // disagree and the call refuses. A record type Mutagen grows a new child group on fails loud here instead of
+        // quietly losing it — the same posture the coverage cornerstone takes on record types.
+        var after = ChildrenOf(fresh);
+        if (after.Count != carry.Count)
+            return $"cannot forward {fresh.FormKey}: it carries {carry.Count} child record(s) " +
+                   $"({string.Join(", ", carry.Names)}{(carry.Count > carry.Names.Count ? ", …" : "")}) and only " +
+                   $"{after.Count} survived the replace — houseCARL will not write a plugin it knows is missing " +
+                   "records (Q3). Nothing was serialized; the file is UNTOUCHED. Please report this with the record type.";
+        return null;
+    }
+
+    /// <summary>Every major record contained UNDER <paramref name="record"/>, by Mutagen's own containment walk — the
+    /// independent yardstick <see cref="RestoreChildGroup"/> checks the reflected re-attach against.</summary>
+    static List<string> ChildrenOf(IMajorRecordGetter record) =>
+        record is IMajorRecordGetterEnumerable e
+            ? e.EnumerateMajorRecords().Select(r => r.EditorID ?? r.FormKey.ToString()).ToList()
+            : new List<string>();
+
+    /// <summary>The settable properties of <paramref name="t"/> that can REACH an owned major record, MEMOIZED per type
+    /// (the <see cref="_flatGroupTypes"/> precedent — pure reflection metadata, constant for the process lifetime, and
+    /// this runs per replaced record).
+    /// <para/>
+    /// Reachability is RECURSIVE and that is load-bearing, not defensive: <c>Worldspace.SubCells</c> reaches its cells
+    /// through two non-record container types (<c>WorldspaceBlock</c> → <c>WorldspaceSubBlock</c> → <c>Cell</c>), so a
+    /// one-level "is this property a major record" test sees <c>Cell</c>/<c>DialogTopic</c> and misses every exterior
+    /// cell in the game. <c>IFormLink</c>s are excluded — a link REFERENCES a record, it does not own one, and walking
+    /// them would sweep in most of the schema. Against Mutagen 0.53.1 this answers: Cell (Landscape, NavigationMeshes,
+    /// Persistent, Temporary), DialogTopic (Responses), Worldspace (TopCell, SubCells) — and nothing else, which the
+    /// guard pins so a Mutagen bump that adds a container shows up as a failing arm rather than as lost records.</summary>
+    internal static IReadOnlyList<PropertyInfo> ChildBearingProperties(Type t) => _childProps.GetOrAdd(t, static ty =>
+        ty.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+          .Where(p => p.CanRead && p.CanWrite && p.GetIndexParameters().Length == 0
+                      && ReachesOwnedRecord(p.PropertyType, new HashSet<Type>(), 0))
+          .ToList());
+    static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, IReadOnlyList<PropertyInfo>> _childProps = new();
+
+    /// <summary>Can a value of <paramref name="t"/> hold an owned major record? See <see cref="ChildBearingProperties"/>
+    /// for why this recurses and why links are cut. The depth bound and the visited set close the cycles Mutagen's
+    /// object graph has (a Cell reaches a Cell through a Worldspace).</summary>
+    static bool ReachesOwnedRecord(Type t, HashSet<Type> seen, int depth)
+    {
+        if (depth > 6 || !seen.Add(t)) return false;
+        if (typeof(IFormLinkGetter).IsAssignableFrom(t)) return false;       // a reference, not a child
+        if (typeof(IMajorRecordGetter).IsAssignableFrom(t)) return true;
+        if (ElementTypeOf(t) is { } elem) return ReachesOwnedRecord(elem, seen, depth + 1);
+        if (!t.IsClass || t.Namespace?.StartsWith("Mutagen", StringComparison.Ordinal) != true) return false;
+        foreach (var p in t.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            if (ReachesOwnedRecord(p.PropertyType, seen, depth + 1)) return true;
+        return false;
+    }
+
+    /// <summary>The element type <paramref name="t"/> enumerates, or null if it is not a collection. <c>string</c> is
+    /// excluded explicitly — it enumerates chars and would otherwise recurse pointlessly on every text field.</summary>
+    static Type? ElementTypeOf(Type t)
+    {
+        if (t.IsArray) return t.GetElementType();
+        if (t == typeof(string) || !typeof(System.Collections.IEnumerable).IsAssignableFrom(t)) return null;
+        foreach (var i in new[] { t }.Concat(t.GetInterfaces()))
+            if (i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                return i.GetGenericArguments()[0];
+        return null;
+    }
+
     /// <summary>The Type to hand Mutagen's typed <c>Remove(FormKey, Type, throwIfUnknown)</c> for
     /// <paramref name="record"/>: the record's FLAT GROUP's <c>T</c> when one matches, else the runtime type (nested-group
     /// records — the shape the remove-record-probe proved reaches Cell/Placed*/INFO/Navmesh/Landscape). The flat-group

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -659,7 +659,7 @@ public static class WriteEngine
     /// turn this preservation into a silent discard (Q3).
     /// </summary>
     public readonly record struct ChildGroupCarry(
-        IReadOnlyList<(PropertyInfo Prop, object? Value)> Held, int Count, IReadOnlyList<string> Names)
+        IReadOnlyList<(PropertyInfo Prop, object? Value)> Held, int Count, IReadOnlyList<string> Names, bool Captured)
     {
         /// <summary>Nothing was held — the record owns no children (the overwhelmingly common case: every record type
         /// but Cell / DialogTopic / Worldspace), so there is nothing to re-attach. NOT a licence to skip the arrival
@@ -675,7 +675,11 @@ public static class WriteEngine
         var held = new List<(PropertyInfo, object?)>();
         foreach (var p in ChildBearingProperties(record.GetType()))
             held.Add((p, p.GetValue(record)));
-        return new ChildGroupCarry(held, ChildCountOf(record), ChildNamesOf(record, 10));
+        // Captured: true is written HERE and nowhere else — it is the fact "a drop-then-copy is happening to this
+        // record", and RestoreChildGroup keys off it rather than inferring the same thing from the carry's shape or
+        // the record's type. Both inferences were tried and both were wrong (rounds 1 and 2): emptiness cannot tell a
+        // childless replace from no replace at all, and a type test fires on records the call itself just created.
+        return new ChildGroupCarry(held, ChildCountOf(record), ChildNamesOf(record, 10), Captured: true);
     }
 
     /// <summary>The capture, with a throw turned into a refusal naming the RIGHT operation (round-1 review [low]). The
@@ -701,56 +705,58 @@ public static class WriteEngine
     /// precedent) so the reassurance lands before "please report it" instead of after it.</summary>
     public static string? RestoreChildGroup(IMajorRecord fresh, ChildGroupCarry carry, string untouchedClause)
     {
-        // Gate on what the record TYPE can own, not on what the destination happened to hold. An empty carry is NOT a
-        // reason to skip the arrival tripwire below (round-1 review [low]): that case is the one where an arriving
-        // child set would be an INJECTION of the source's own children — a patch topic with no INFOs of its own
-        // silently acquiring the source mod's five — rather than a discard of the destination's. The memoized
-        // reflection lookup is what keeps this free for the 130 record types that can own nothing at all.
-        if (ChildBearingProperties(fresh.GetType()).Count == 0) return null;
+        // THE ONE GATE: did a capture happen — i.e. is this record being replaced by a drop-then-copy? Nothing else.
+        // The lane knows that as a fact and CaptureChildGroup writes it; this method must not re-derive it. Both
+        // derivations were tried and both were wrong. Deriving it from the carry being EMPTY skipped the arrival
+        // tripwire in the case where an arriving set would be an INJECTION of the source's children into a
+        // destination that deliberately holds none (round 1). Deriving it from the record's TYPE fired on records the
+        // call had just created itself — forwarding an INFO and its DIAL in one call refused the whole write and
+        // blamed Mutagen — and short-circuited the count check for any type whose containers the walk cannot see,
+        // which is the silent-loss shape this whole function exists to prevent (round 2).
+        if (!carry.Captured) return null;
 
-        // The copy is expected to arrive EMPTY (see the type doc). If it ever does not, surface it instead of
-        // silently resolving it either way. A Mutagen bump that starts carrying children in trips this loudly.
-        var arrived = ChildCountOf(fresh);
-        if (arrived > 0)
-        {
-            var sample = string.Join(", ", ChildNamesOf(fresh, 5)) + (arrived > 5 ? ", …" : "");
-            return $"cannot forward {fresh.FormKey}: the forwarded copy arrived carrying {arrived} child record(s) of "
-                 + $"its own ({sample}), " + (carry.IsEmpty
-                     ? "which a forward does not mean — it asserts the source's FIELDS and leaves the source's own "
-                       + "children in the source's plugin, so houseCARL refuses rather than silently import them (Q3). "
-                     : $"while the destination held {carry.Count} of its own; re-attaching would discard one of the two "
-                       + "sets and there is no defensible way to guess which, so houseCARL refuses (Q3). ")
-                 + untouchedClause + " This is an engine-level change in Mutagen's override-copy semantics, not "
-                 + "something the call did wrong; please report it.";
-        }
-
-        if (carry.IsEmpty) return null;
-
-        // A throw here is caught rather than left to the caller's catch: that one reports "the override-copy threw",
-        // which would name the wrong operation for a fault in the re-attach. Same loudness, accurate sentence.
+        // The walks are INSIDE the try with the re-attach: a fault in Mutagen's containment enumeration is not the
+        // override-copy throwing, and the lane's catch would call it that.
         try
         {
+            // The copy is expected to arrive EMPTY (see the type doc). If it ever does not, surface it instead of
+            // silently resolving it either way. A Mutagen bump that starts carrying children in trips this loudly.
+            var arrived = ChildCountOf(fresh);
+            if (arrived > 0)
+            {
+                var sample = string.Join(", ", ChildNamesOf(fresh, 5)) + (arrived > 5 ? ", …" : "");
+                return $"cannot forward {fresh.FormKey}: the forwarded copy arrived carrying {arrived} child record(s) "
+                     + $"of its own ({sample}), " + (carry.IsEmpty
+                         ? "which a forward does not mean — it asserts the source's FIELDS and leaves the source's own "
+                           + "children in the source's plugin, so houseCARL refuses rather than silently import them (Q3). "
+                         : $"while the destination held {carry.Count} of its own; re-attaching would discard one of the two "
+                           + "sets and there is no defensible way to guess which, so houseCARL refuses (Q3). ")
+                     + untouchedClause + " This is an engine-level change in Mutagen's override-copy semantics, not "
+                     + "something the call did wrong; please report it.";
+            }
+
             foreach (var (prop, value) in carry.Held)
                 prop.SetValue(fresh, value);
+
+            // By-construction verification, off Mutagen's OWN containment enumeration rather than the reflected
+            // property set that did the re-attach: if a containment path exists that ChildBearingProperties cannot
+            // see, the counts disagree and the call refuses. This runs even when the carry held NOTHING to re-attach,
+            // because the two readings are independent — a carry can count children off Mutagen's walk while the
+            // reflected set that would restore them is empty, and that disagreement is exactly the silent loss.
+            var after = ChildCountOf(fresh);
+            if (after != carry.Count)
+                return $"cannot forward {fresh.FormKey}: it carries {carry.Count} child record(s) " +
+                       $"({string.Join(", ", carry.Names)}{(carry.Count > carry.Names.Count ? ", …" : "")}) and {after} " +
+                       "are on the record after the replace — houseCARL will not write a plugin whose child records it " +
+                       $"cannot account for (Q3). {untouchedClause} Please report this with the record type.";
+            return null;
         }
         catch (Exception ex)
         {
-            return $"cannot preserve the {carry.Count} child record(s) under {fresh.FormKey}: re-attaching them to " +
-                   $"the forwarded copy threw ({ex.GetType().Name}: {ex.Message}) — surfaced, not swallowed (Q3). " +
+            return $"cannot preserve the {carry.Count} child record(s) under {fresh.FormKey}: carrying them across " +
+                   $"the replace threw ({ex.GetType().Name}: {ex.Message}) — surfaced, not swallowed (Q3). " +
                    untouchedClause;
         }
-
-        // By-construction verification, off Mutagen's OWN containment enumeration rather than the reflected property
-        // set that did the re-attach: if a containment path exists that ChildBearingProperties cannot see, the counts
-        // disagree and the call refuses. A record type Mutagen grows a new child group on fails loud here instead of
-        // quietly losing it — the same posture the coverage cornerstone takes on record types.
-        var after = ChildCountOf(fresh);
-        if (after != carry.Count)
-            return $"cannot forward {fresh.FormKey}: it carries {carry.Count} child record(s) " +
-                   $"({string.Join(", ", carry.Names)}{(carry.Count > carry.Names.Count ? ", …" : "")}) and {after} " +
-                   "are on the record after the replace — houseCARL will not write a plugin whose child records it " +
-                   $"cannot account for (Q3). {untouchedClause} Please report this with the record type.";
-        return null;
     }
 
     /// <summary>How many major records are contained UNDER <paramref name="record"/>, by Mutagen's own containment

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -802,13 +802,21 @@ public static class WriteEngine
     static bool ReachesOwnedRecord(Type t, HashSet<Type> seen, int depth)
     {
         if (depth > 6 || !seen.Add(t)) return false;
-        if (typeof(IFormLinkGetter).IsAssignableFrom(t)) return false;       // a reference, not a child
-        if (typeof(IMajorRecordGetter).IsAssignableFrom(t)) return true;
-        if (ElementTypeOf(t) is { } elem) return ReachesOwnedRecord(elem, seen, depth + 1);
-        if (!t.IsClass || t.Namespace?.StartsWith("Mutagen", StringComparison.Ordinal) != true) return false;
-        foreach (var p in t.GetProperties(BindingFlags.Public | BindingFlags.Instance))
-            if (ReachesOwnedRecord(p.PropertyType, seen, depth + 1)) return true;
-        return false;
+        // `seen` is a PATH set, not a memo: the entry comes back out on the way up. Left in, a type first reached at
+        // the depth bound would be recorded as unreachable and then skipped when a shallower branch reaches it, which
+        // memoizes a depth-truncated answer as a depth-independent one. Cycles are still closed — a type on the
+        // CURRENT path is what the set holds (a Cell reaches a Cell through a Worldspace).
+        try
+        {
+            if (typeof(IFormLinkGetter).IsAssignableFrom(t)) return false;   // a reference, not a child
+            if (typeof(IMajorRecordGetter).IsAssignableFrom(t)) return true;
+            if (ElementTypeOf(t) is { } elem) return ReachesOwnedRecord(elem, seen, depth + 1);
+            if (!t.IsClass || t.Namespace?.StartsWith("Mutagen", StringComparison.Ordinal) != true) return false;
+            foreach (var p in t.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                if (ReachesOwnedRecord(p.PropertyType, seen, depth + 1)) return true;
+            return false;
+        }
+        finally { seen.Remove(t); }
     }
 
     /// <summary>The element type <paramref name="t"/> enumerates, or null if it is not a collection. <c>string</c> is

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -1721,6 +1721,12 @@ public static class WritePatchBuilder
         return epoch is null ? outcome : outcome with { Epoch = epoch };
     }
 
+    /// <summary>What each forward lane left alone, SUBSTITUTED into a child-group refusal rather than appended after
+    /// it (round-1 review [low]; the <c>SerializeFailure</c> precedent below). Appending doubled the reassurance and
+    /// landed it after "please report it" — the engine builds the whole sentence with the lane's clause in place.</summary>
+    const string InPlaceUntouched = "Nothing was serialized; your original is UNTOUCHED.";
+    const string ExtendUntouched = "Nothing was serialized; the extended patch's on-disk file is UNTOUCHED.";
+
     /// <summary>The body of <see cref="ForwardRecordsInPlace"/> — split for the same single-point epoch stamp as
     /// <see cref="ApplyCore"/> (SPEC §2.1.1).</summary>
     static ForwardOutcome ForwardRecordsInPlaceCore(
@@ -1780,7 +1786,8 @@ public static class WritePatchBuilder
                     // #324, and this is the worse half: the target is the caller's OWN plugin on the lane whose banner
                     // reads "no houseCARL backup or undo", so a child group the drop takes is gone for good. Lift it
                     // off before the Remove and re-attach after the copy.
-                    carriedChildren = WriteEngine.CaptureChildGroup(existing);
+                    if (WriteEngine.TryCaptureChildGroup(existing, InPlaceUntouched, out carriedChildren) is { } captureRefusal)
+                        return ForwardOutcome.Fail(captureRefusal);
                     ((IMajorRecordEnumerable)targetMod).Remove(spec.Target, WriteEngine.RemovalTypeFor(existing), throwIfUnknown: true);
                     if (targetMod.EnumerateMajorRecords().Any(x => x.FormKey == spec.Target))
                         return ForwardOutcome.Fail(
@@ -1790,8 +1797,8 @@ public static class WritePatchBuilder
                     replaced = true;
                 }
                 var fresh = WriteEngine.GenericGetOrAddAsOverride(targetMod, body, SourceCacheFor(session, spec, body, offOrderBody, offOrder));
-                if (WriteEngine.RestoreChildGroup(fresh, carriedChildren) is { } childRefusal)
-                    return ForwardOutcome.Fail($"{childRefusal} (nothing was serialized; your original is UNTOUCHED.)");
+                if (WriteEngine.RestoreChildGroup(fresh, carriedChildren, InPlaceUntouched) is { } childRefusal)
+                    return ForwardOutcome.Fail(childRefusal);
                 forwarded.Add(new ForwardedRecord(
                     spec.Target, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID, spec.FromPlugin, priorWinner, wasWinner,
                     ReplacedExisting: replaced));
@@ -2259,7 +2266,8 @@ public static class WritePatchBuilder
                     // #324: the drop below takes the record's CHILD GROUP with it and the copy carries none back in,
                     // so lift the children off FIRST and re-attach them after — a topic's INFOs, a cell's placed refs.
                     // Before the Remove, because afterwards the record is no longer reachable from the mod.
-                    carriedChildren = WriteEngine.CaptureChildGroup(existing);
+                    if (WriteEngine.TryCaptureChildGroup(existing, ExtendUntouched, out carriedChildren) is { } captureRefusal)
+                        return ForwardOutcome.Fail(captureRefusal);
                     ((IMajorRecordEnumerable)patchMod).Remove(spec.Target, WriteEngine.RemovalTypeFor(existing), throwIfUnknown: true);
                     // The typed Remove can no-op WITHOUT throwing (F3's sibling defect) — verify the slot is genuinely
                     // empty before the copy, else GetOrAdd would silently return the old record again (Q3).
@@ -2271,8 +2279,8 @@ public static class WritePatchBuilder
                     replaced = true;
                 }
                 var fresh = WriteEngine.GenericGetOrAddAsOverride(patchMod, body, SourceCacheFor(session, spec, body, offOrderBody, offOrder));
-                if (WriteEngine.RestoreChildGroup(fresh, carriedChildren) is { } childRefusal)
-                    return ForwardOutcome.Fail($"{childRefusal} (nothing was serialized; the extended patch's on-disk file is untouched.)");
+                if (WriteEngine.RestoreChildGroup(fresh, carriedChildren, ExtendUntouched) is { } childRefusal)
+                    return ForwardOutcome.Fail(childRefusal);
                 forwarded.Add(new ForwardedRecord(
                     spec.Target, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID, spec.FromPlugin, priorWinner, wasWinner,
                     ReplacedExisting: replaced));
@@ -2901,23 +2909,25 @@ public static class WritePatchBuilder
                                     // "Not copied here" and not "not a master of this write": masters are derived at
                                     // serialize, and another spec or a created record's own links can still pull that
                                     // plugin in.
-                                    // THE INLINING LEVER NAMES AN ORDER, AND THE ORDER IS LOAD-BEARING (PR #323
-                                    // review [medium]). The first wording — "forward the winner's version in
-                                    // explicitly" — was measured FALSE: forwarding into the patch that already holds
-                                    // the child DELETES the child, because forward's extend/in-place path drops the
-                                    // whole record before re-copying it and the child group goes with the drop. That
-                                    // is a `forward` defect on both those lanes, filed as #324 and not fixed here.
-                                    // The order asserted safe in WriteSurfaceGuardProbe.NestedParentHostArm — forward
-                                    // first, then create into that patch — is what this now prints. Both halves are
-                                    // said: the safe order, and the destructive one named as destructive, because a
-                                    // caller who only reads "forward the winner in" will reach for the wrong one.
+                                    // THE INLINING LEVER NAMES AN ORDER (PR #323 review [medium]). History, because
+                                    // the wording has been wrong in both directions: "forward the winner's version in
+                                    // explicitly" was measured FALSE while #324 was open — forwarding into a patch
+                                    // that already held the child DELETED the child, since forward's extend/in-place
+                                    // path drops the whole record before re-copying it and the child group went with
+                                    // the drop — so the message was changed to name one safe order and mark the other
+                                    // destructive. #324 is FIXED on this branch (the children are lifted off and
+                                    // re-attached across the replace), which makes that warning false in turn: both
+                                    // orders now land the same shape, measured in ForwardChildGroupArm, which runs
+                                    // exactly the sequence this sentence used to call destructive. The message states
+                                    // what happens and names no issue number — a sentence pinned to an OPEN bug is a
+                                    // sentence that goes stale the day it is fixed, and the guard arm holds it there.
                                     : $" (its DEFINING plugin — the LEAN host, carrying the residual only: '{w.WinnerPlugin}' currently WINS this record "
                                       + $"and its version is deliberately NOT inlined here, so wherever this artifact out-ranks '{w.WinnerPlugin}' the parent "
                                       + $"record resolves to '{readFrom}'s fields. That is the control this lane gives you: sort below '{w.WinnerPlugin}' to "
                                       + $"keep the residual shape, sort above it to assert this host, or inline '{w.WinnerPlugin}'s content deliberately: "
-                                      + $"forward its version into a patch FIRST, then create into THAT patch — the child hosts in the forwarded body. Not "
-                                      + "the other order: forwarding into a patch that ALREADY holds the child deletes the child (a known housecarl_forward "
-                                      + "bug, #324). Whichever way you sort, the new child is carried.)");
+                                      + $"forward '{w.WinnerPlugin}'s version of the parent into a patch and create into THAT patch — the child hosts in the "
+                                      + "forwarded body. Either order works: forwarding onto a parent a patch already holds keeps the children under it. "
+                                      + "Whichever way you sort, the new child is carried.)");
                     }
                     else
                     {

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -1774,8 +1774,13 @@ public static class WritePatchBuilder
             try
             {
                 bool replaced = false;
+                var carriedChildren = default(WriteEngine.ChildGroupCarry);
                 if (alreadyCarried.TryGetValue(spec.Target, out var existing))
                 {
+                    // #324, and this is the worse half: the target is the caller's OWN plugin on the lane whose banner
+                    // reads "no houseCARL backup or undo", so a child group the drop takes is gone for good. Lift it
+                    // off before the Remove and re-attach after the copy.
+                    carriedChildren = WriteEngine.CaptureChildGroup(existing);
                     ((IMajorRecordEnumerable)targetMod).Remove(spec.Target, WriteEngine.RemovalTypeFor(existing), throwIfUnknown: true);
                     if (targetMod.EnumerateMajorRecords().Any(x => x.FormKey == spec.Target))
                         return ForwardOutcome.Fail(
@@ -1784,7 +1789,9 @@ public static class WritePatchBuilder
                             "surfaced, not a silent skip (Q3); your original is UNTOUCHED.");
                     replaced = true;
                 }
-                WriteEngine.GenericGetOrAddAsOverride(targetMod, body, SourceCacheFor(session, spec, body, offOrderBody, offOrder));
+                var fresh = WriteEngine.GenericGetOrAddAsOverride(targetMod, body, SourceCacheFor(session, spec, body, offOrderBody, offOrder));
+                if (WriteEngine.RestoreChildGroup(fresh, carriedChildren) is { } childRefusal)
+                    return ForwardOutcome.Fail($"{childRefusal} (nothing was serialized; your original is UNTOUCHED.)");
                 forwarded.Add(new ForwardedRecord(
                     spec.Target, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID, spec.FromPlugin, priorWinner, wasWinner,
                     ReplacedExisting: replaced));
@@ -2246,8 +2253,13 @@ public static class WritePatchBuilder
             try
             {
                 bool replaced = false;
+                var carriedChildren = default(WriteEngine.ChildGroupCarry);
                 if (alreadyCarried.TryGetValue(spec.Target, out var existing))
                 {
+                    // #324: the drop below takes the record's CHILD GROUP with it and the copy carries none back in,
+                    // so lift the children off FIRST and re-attach them after — a topic's INFOs, a cell's placed refs.
+                    // Before the Remove, because afterwards the record is no longer reachable from the mod.
+                    carriedChildren = WriteEngine.CaptureChildGroup(existing);
                     ((IMajorRecordEnumerable)patchMod).Remove(spec.Target, WriteEngine.RemovalTypeFor(existing), throwIfUnknown: true);
                     // The typed Remove can no-op WITHOUT throwing (F3's sibling defect) — verify the slot is genuinely
                     // empty before the copy, else GetOrAdd would silently return the old record again (Q3).
@@ -2258,7 +2270,9 @@ public static class WritePatchBuilder
                             "surfaced, not a silent skip (Q3); nothing was serialized (the extended patch's on-disk file is untouched).");
                     replaced = true;
                 }
-                WriteEngine.GenericGetOrAddAsOverride(patchMod, body, SourceCacheFor(session, spec, body, offOrderBody, offOrder));
+                var fresh = WriteEngine.GenericGetOrAddAsOverride(patchMod, body, SourceCacheFor(session, spec, body, offOrderBody, offOrder));
+                if (WriteEngine.RestoreChildGroup(fresh, carriedChildren) is { } childRefusal)
+                    return ForwardOutcome.Fail($"{childRefusal} (nothing was serialized; the extended patch's on-disk file is untouched.)");
                 forwarded.Add(new ForwardedRecord(
                     spec.Target, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID, spec.FromPlugin, priorWinner, wasWinner,
                     ReplacedExisting: replaced));

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -1801,7 +1801,7 @@ public static class WritePatchBuilder
                     return ForwardOutcome.Fail(childRefusal);
                 forwarded.Add(new ForwardedRecord(
                     spec.Target, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID, spec.FromPlugin, priorWinner, wasWinner,
-                    ReplacedExisting: replaced));
+                    ReplacedExisting: replaced, PreservedChildren: carriedChildren.Count));
             }
             catch (Exception ex)
             {
@@ -2009,9 +2009,12 @@ public static class WritePatchBuilder
     /// this PR's self-origin path makes ordinary (a record originating in a patch that is not enabled yet). It used to
     /// be the sentinel "(none)", which the renders dropped straight into "out-ranks the current winner (none)" — a
     /// ranking asserted against a winner that does not exist (PR #313 review 3 [low]).</para>
+    /// <summary><paramref name="PreservedChildren"/> — how many records nested under <paramref name="Target"/> the
+    /// replace carried across (#324). Only ever non-zero with <paramref name="ReplacedExisting"/>, and it is what
+    /// stops the render saying "the old body is gone" over a cell whose forty placed refs are still there.</summary>
     public sealed record ForwardedRecord(
         FormKey Target, string RecordType, string? EditorId, string FromPlugin, string? PriorWinner, bool WasAlreadyWinner,
-        bool ReplacedExisting = false);
+        bool ReplacedExisting = false, int PreservedChildren = 0);
 
     /// <summary>The outcome of a <see cref="ForwardRecords"/> call. <see cref="Error"/> non-null ⇒ the whole call was
     /// refused (no file written) with a named, recoverable reason (Q3 — a source plugin found nowhere / excluded /
@@ -2283,7 +2286,7 @@ public static class WritePatchBuilder
                     return ForwardOutcome.Fail(childRefusal);
                 forwarded.Add(new ForwardedRecord(
                     spec.Target, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID, spec.FromPlugin, priorWinner, wasWinner,
-                    ReplacedExisting: replaced));
+                    ReplacedExisting: replaced, PreservedChildren: carriedChildren.Count));
             }
             catch (Exception ex)
             {

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -2009,9 +2009,9 @@ public static class WritePatchBuilder
     /// this PR's self-origin path makes ordinary (a record originating in a patch that is not enabled yet). It used to
     /// be the sentinel "(none)", which the renders dropped straight into "out-ranks the current winner (none)" — a
     /// ranking asserted against a winner that does not exist (PR #313 review 3 [low]).</para>
-    /// <summary><paramref name="PreservedChildren"/> — how many records nested under <paramref name="Target"/> the
-    /// replace carried across (#324). Only ever non-zero with <paramref name="ReplacedExisting"/>, and it is what
-    /// stops the render saying "the old body is gone" over a cell whose forty placed refs are still there.</summary>
+    /// <param name="PreservedChildren">How many records nested under <paramref name="Target"/> the replace carried
+    /// across (#324). Only ever non-zero with <paramref name="ReplacedExisting"/>, and it is what stops the render
+    /// saying "the old body is gone" over a cell whose forty placed refs are still there.</param>
     public sealed record ForwardedRecord(
         FormKey Target, string RecordType, string? EditorId, string FromPlugin, string? PriorWinner, bool WasAlreadyWinner,
         bool ReplacedExisting = false, int PreservedChildren = 0);

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text.Json;
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
@@ -94,8 +95,11 @@ public static class WriteSurfaceGuardProbe
             CopySourcePathArm(fx, root);
             NestedParentHostArm(fx);
             // #324's arm also writes into the replacer IN PLACE (its second half is that lane), so it sits with the
-            // in-place arms below rather than among the read-the-fixture ones. It changes the replacer's TOPIC only —
-            // no later arm reads that record — while the two below change its WEAPON, which earlier arms do read.
+            // in-place arms below rather than among the read-the-fixture ones. It rewrites the replacer TWICE and
+            // changes two of its records: the TOPIC (W2Topic → "Master Topic") and the CELL (W2Cell → "Master Cell",
+            // keeping W2WinnerRef). No later arm reads either — but both are three-way fixtures a future arm would
+            // reach for, so an arm added after this one must read them as the MASTER's version, not the winner's.
+            // The two below change its WEAPON, which earlier arms do read.
             ForwardChildGroupArm(fx);
             // OffOrderForwardArm and ReviewFoldArm go LAST: they forward into the replacer IN PLACE, which rewrites a
             // fixture file every earlier arm reads as a known winner. Ordering them after keeps every other arm
@@ -143,6 +147,7 @@ public static class WriteSurfaceGuardProbe
         public required FormKey TopicKey { get; init; }
         public required string CellFid { get; init; }
         public required FormKey CellKey { get; init; }
+        public required string WinnerLineFid { get; init; }
         /// <summary>One filename provided by TWO disabled mod folders — the ambiguity refusal's fixture.</summary>
         public required string AmbName { get; init; }
         /// <summary>A DISABLED plugin whose forwarded body links into ANOTHER disabled plugin — the missing-master
@@ -222,7 +227,8 @@ public static class WriteSurfaceGuardProbe
             var topicOverride = (IDialogTopic)WriteEngine.GenericGetOrAddAsOverride(r, topic);
             topicOverride.Name = "Winner Topic";
             topicOverride.Quest.SetTo(winnerQuest.FormKey);
-            topicOverride.Responses.Add(new DialogResponses(r.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "W2WinnerLine" });
+            var winnerLine = new DialogResponses(r.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "W2WinnerLine" };
+            topicOverride.Responses.Add(winnerLine);
             var cellOverride = (ICell)WriteEngine.GenericGetOrAddAsOverride(r, cell, mCache);
             cellOverride.Name = "Winner Cell";
             cellOverride.Persistent.Add(new PlacedObject(r.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "W2WinnerRef" });
@@ -307,6 +313,7 @@ public static class WriteSurfaceGuardProbe
                 TopicKey = topic.FormKey,
                 CellFid = $"{cell.FormKey.ID:X6}:{mKey.FileName}",
                 CellKey = cell.FormKey,
+                WinnerLineFid = $"{winnerLine.FormKey.ID:X6}:{rKey.FileName}",
                 AmbName = aKey.FileName.String,
                 ChainName = cKey.FileName.String,
             };
@@ -1106,6 +1113,16 @@ public static class WriteSurfaceGuardProbe
         Check("…and the child SURVIVES the replace (#324: the drop no longer takes the child group)",
             after.Contains("W324Line"),
             $"{inlined}  [children=[{string.Join(", ", after)}] · whole file=[{string.Join(", ", EditorIdsIn(path))}]]");
+
+        // THE SENTENCE THE CALLER ACTS ON, which is a separate surface from the engine (the standing lesson of #323 →
+        // #324: a destructive remedy shipped through fully green guards). This render said "the old body is gone"
+        // flat. It is now false in the one case that matters: the caller reverts a cell in place, keeps their forty
+        // placed refs, and is told the old body went — so they ship what they think they deleted, or re-create a
+        // dialogue line they never lost. Measured here BEFORE it was reworded, per §11.
+        Check("…and the RESPONSE says so: the replace reports the fields gone and the nested records KEPT, with a count",
+            inlined.Contains("the old FIELDS are gone", StringComparison.Ordinal)
+            && inlined.Contains("1 record(s) nested under it were KEPT", StringComparison.Ordinal)
+            && !inlined.Contains("the old body is gone", StringComparison.Ordinal), inlined);
         Check("…and the forward still DID its job: the source's fields are inlined in the host",
             TopicNameIn(path, fx.TopicKey) == "Winner Topic",
             $"{inlined}  [topic name={TopicNameIn(path, fx.TopicKey) ?? "unreadable"}]");
@@ -1184,6 +1201,50 @@ public static class WriteSurfaceGuardProbe
             CellNameIn(replPath, fx.CellKey) == "Master Cell",
             $"{cellInPlace}  [cell name={CellNameIn(replPath, fx.CellKey) ?? "unreadable"}]");
 
+        // --- A CHILD AND ITS PARENT IN ONE CALL, on the fresh-patch lane where NOTHING is replaced. Spec 1 (the INFO)
+        //     materializes the topic in the patch to host itself; spec 2 (the topic) then copies onto a record the
+        //     CALL just created, carrying children the call just put there. A guard that infers "was this replaced?"
+        //     from the record's shape sees that as a copy arriving with children and refuses the whole write, telling
+        //     the caller to report a Mutagen bug — measured in round 2, introduced by round 1's own fold. The gate is
+        //     the capture FACT now, and this arm is what holds it there: nothing was dropped, so nothing is checked.
+        var pair = ForwardTools.Forward(fx.Svc, formids: new[] { fx.WinnerLineFid, fx.TopicFid },
+            source: fx.ReplacerName, patch: "W324Pair");
+        var pairPath = ArtifactPathFrom(fx, pair);
+        Check("a child and its parent forward in ONE call to a fresh patch — the call is not refused",
+            pairPath is not null && !pair.StartsWith("error:", StringComparison.Ordinal), pair);
+        Check("…and the child lands under its parent in the patch",
+            pairPath is not null && ChildLinesIn(pairPath, fx.TopicKey).Contains("W2WinnerLine"),
+            pairPath is null ? pair : $"children=[{string.Join(", ", ChildLinesIn(pairPath, fx.TopicKey))}]");
+        // NOT asserted, and measured rather than assumed: the parent's own FIELDS do not land here. The patch holds
+        // "Master Topic" — the definer's version that hosting the child materialized — while the call reports the
+        // topic forwarded from the replacer, whose version reads "Winner Topic". That is F1's silent-skip surviving
+        // on the lane that never populates alreadyCarried, so no replace happens and GetOrAdd's get-semantics keep
+        // the record already there. Pre-existing, in a path this branch does not touch (#333). Asserting it here
+        // would either fail a green guard or quietly widen this branch into another lane's fix.
+
+        // --- A REPLACE OF A RECORD THAT OWNS NOTHING still reports honestly. The weapon has no child group, so the
+        //     render must say the body is gone AND that there was nothing nested — "kept" and "nothing to keep" are
+        //     different facts and a caller reverting a record needs to know which one they got.
+        ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: fx.MasterName, into: Path.GetFileName(path));
+        var flat = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: fx.ReplacerName,
+            into: Path.GetFileName(path));
+        Check("…and a replace of a record with NO children says so, rather than counting a preservation that was not one",
+            flat.Contains("the old body is gone", StringComparison.Ordinal)
+            && flat.Contains("carried no nested records", StringComparison.Ordinal)
+            && !flat.Contains("were KEPT", StringComparison.Ordinal), flat);
+
+        // --- THE GATE ITSELF, BOTH DIRECTIONS. RestoreChildGroup must act if and only if a capture happened. Driven
+        //     directly, because the point is the gate's INPUT, not a lane's behaviour: the same record, the same
+        //     arriving children, one carry that came from CaptureChildGroup and one that did not.
+        var gateSubject = new DialogTopic(FormKey.Factory("123460:HcW2Master.esm"), SkyrimRelease.SkyrimSE);
+        gateSubject.Responses.Add(new DialogResponses(FormKey.Factory("123461:HcW2Master.esm"), SkyrimRelease.SkyrimSE)
+            { EditorID = "W324Gate" });
+        Check("the gate is the capture FACT: an uncaptured carry does not engage the guard at all",
+            WriteEngine.RestoreChildGroup(gateSubject, default, "…") is null, "(refused)");
+        Check("…and a captured one does, on the identical record and children",
+            WriteEngine.RestoreChildGroup(gateSubject, WriteEngine.CaptureChildGroup(gateSubject) with { Held = Array.Empty<(PropertyInfo, object?)>(), Count = 9 }, "…")
+                is not null, "(accepted)");
+
         // --- THE REFLECTED CHILD SET, PINNED. RestoreChildGroup re-attaches by walking properties that can REACH an
         //     owned record; its by-construction count check catches a path the walk cannot see, but only at call time,
         //     as a refusal in the caller's face. Pinning the set here turns a Mutagen bump that adds a container into
@@ -1215,7 +1276,12 @@ public static class WriteSurfaceGuardProbe
         var carrier = new DialogTopic(FormKey.Factory("123456:HcW2Master.esm"), SkyrimRelease.SkyrimSE);
         carrier.Responses.Add(new DialogResponses(FormKey.Factory("123457:HcW2Master.esm"), SkyrimRelease.SkyrimSE)
             { EditorID = "W324Arrived" });
-        var injection = WriteEngine.RestoreChildGroup(carrier, default, "Nothing was serialized; UNTOUCHED.");
+        // The carry is CAPTURED but empty — a destination that held nothing of its own, which is the case where an
+        // arriving set is an import rather than a clash. `default` would prove nothing here: it is uncaptured, and
+        // the gate correctly declines to engage at all.
+        var emptyCaptured = WriteEngine.CaptureChildGroup(
+            new DialogTopic(FormKey.Factory("123459:HcW2Master.esm"), SkyrimRelease.SkyrimSE));
+        var injection = WriteEngine.RestoreChildGroup(carrier, emptyCaptured, "Nothing was serialized; UNTOUCHED.");
         Check("refusal 1: a copy arriving with children of its own is refused as an IMPORT when nothing was held",
             injection is not null && injection.Contains("arrived carrying 1 child record(s)", StringComparison.Ordinal)
             && injection.Contains("W324Arrived", StringComparison.Ordinal)

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -1104,6 +1104,19 @@ public static class WriteSurfaceGuardProbe
         Check("#324 fixture: a child creates into a patch, hosted on the parent's definer", path is not null, made);
         if (path is null) return;
 
+        // THE DRY-RUN SENTENCE FIRST, because it is the one a caller reads while DECIDING whether to proceed, and it
+        // is a different string from the one they read afterwards. Same rule as the live sentences: a message claim
+        // gets its own arm. dry_run runs the whole pipeline and stops before disk, so this leaves the patch alone.
+        var dryReplace = ForwardTools.Forward(fx.Svc, formids: new[] { fx.TopicFid }, source: fx.ReplacerName,
+            into: Path.GetFileName(path), dry_run: true);
+        Check("dry_run over a replace: the PREVIEW says the fields would go and the nested records would be KEPT",
+            dryReplace.Contains("the old FIELDS would be gone", StringComparison.Ordinal)
+            && dryReplace.Contains("1 record(s) nested under it would be KEPT", StringComparison.Ordinal)
+            && !dryReplace.Contains("the old body would be gone", StringComparison.Ordinal), dryReplace);
+        Check("…and it really was a preview: the child is still the only thing under the topic on disk",
+            ChildLinesIn(path, fx.TopicKey) is { Count: 1 } d && d.Contains("W324Line"),
+            string.Join(", ", ChildLinesIn(path, fx.TopicKey)));
+
         var inlined = ForwardTools.Forward(fx.Svc, formids: new[] { fx.TopicFid }, source: fx.ReplacerName,
             into: Path.GetFileName(path));
         Check("forward into= a patch that already carries the record is accepted",
@@ -1134,6 +1147,29 @@ public static class WriteSurfaceGuardProbe
         Check("…and the group holds exactly the destination's child — the SOURCE's own line did not come with it",
             after.Count == 1 && !after.Contains("W2WinnerLine") && !after.Contains("(unreadable)"),
             string.Join(", ", after));
+
+        // --- A CHILD AND ITS PARENT IN ONE CALL, on the fresh-patch lane where NOTHING is replaced. Spec 1 (the INFO)
+        //     materializes the topic in the patch to host itself; spec 2 (the topic) then copies onto a record the
+        //     CALL just created, carrying children the call just put there. A guard that infers "was this replaced?"
+        //     from the record's shape sees that as a copy arriving with children and refuses the whole write, telling
+        //     the caller to report a Mutagen bug — measured in round 2, introduced by round 1's own fold. The gate is
+        //     the capture FACT now, and this arm is what holds it there: nothing was dropped, so nothing is checked.
+        var pair = ForwardTools.Forward(fx.Svc, formids: new[] { fx.WinnerLineFid, fx.TopicFid },
+            source: fx.ReplacerName, patch: "W324Pair");
+        var pairPath = ArtifactPathFrom(fx, pair);
+        Check("a child and its parent forward in ONE call to a fresh patch — the call is not refused",
+            pairPath is not null && !pair.StartsWith("error:", StringComparison.Ordinal), pair);
+        Check("…and the child lands under its parent in the patch",
+            pairPath is not null && ChildLinesIn(pairPath, fx.TopicKey).Contains("W2WinnerLine"),
+            pairPath is null ? pair : $"children=[{string.Join(", ", ChildLinesIn(pairPath, fx.TopicKey))}]");
+        // …and the parent's own fields land too. This block sits ABOVE the in-place half deliberately: that half
+        // rewrites the replacer's topic to "Master Topic", and with it running first BOTH sides of this comparison
+        // read "Master Topic", so the assertion cannot tell a landed copy from a skipped one. Measured in that state
+        // it looked like a silent skip and was briefly filed as #333; the fixture was the bug, not the lane. Ordered
+        // this way the replacer still reads "Winner Topic" and the discriminator is real.
+        Check("…and the parent's own fields land too — the second spec is not skipped over a record the call created",
+            pairPath is not null && TopicNameIn(pairPath, fx.TopicKey) == "Winner Topic",
+            pairPath is null ? pair : $"name={TopicNameIn(pairPath, fx.TopicKey) ?? "unreadable"}");
 
         // --- THE WORSE HALF (in_place=): the destination is the caller's OWN plugin. The replacer owns the topic and
         //     a line under it; forwarding the MASTER's version in place must land the master's fields and leave the
@@ -1201,31 +1237,16 @@ public static class WriteSurfaceGuardProbe
             CellNameIn(replPath, fx.CellKey) == "Master Cell",
             $"{cellInPlace}  [cell name={CellNameIn(replPath, fx.CellKey) ?? "unreadable"}]");
 
-        // --- A CHILD AND ITS PARENT IN ONE CALL, on the fresh-patch lane where NOTHING is replaced. Spec 1 (the INFO)
-        //     materializes the topic in the patch to host itself; spec 2 (the topic) then copies onto a record the
-        //     CALL just created, carrying children the call just put there. A guard that infers "was this replaced?"
-        //     from the record's shape sees that as a copy arriving with children and refuses the whole write, telling
-        //     the caller to report a Mutagen bug — measured in round 2, introduced by round 1's own fold. The gate is
-        //     the capture FACT now, and this arm is what holds it there: nothing was dropped, so nothing is checked.
-        var pair = ForwardTools.Forward(fx.Svc, formids: new[] { fx.WinnerLineFid, fx.TopicFid },
-            source: fx.ReplacerName, patch: "W324Pair");
-        var pairPath = ArtifactPathFrom(fx, pair);
-        Check("a child and its parent forward in ONE call to a fresh patch — the call is not refused",
-            pairPath is not null && !pair.StartsWith("error:", StringComparison.Ordinal), pair);
-        Check("…and the child lands under its parent in the patch",
-            pairPath is not null && ChildLinesIn(pairPath, fx.TopicKey).Contains("W2WinnerLine"),
-            pairPath is null ? pair : $"children=[{string.Join(", ", ChildLinesIn(pairPath, fx.TopicKey))}]");
-        // NOT asserted, and measured rather than assumed: the parent's own FIELDS do not land here. The patch holds
-        // "Master Topic" — the definer's version that hosting the child materialized — while the call reports the
-        // topic forwarded from the replacer, whose version reads "Winner Topic". That is F1's silent-skip surviving
-        // on the lane that never populates alreadyCarried, so no replace happens and GetOrAdd's get-semantics keep
-        // the record already there. Pre-existing, in a path this branch does not touch (#333). Asserting it here
-        // would either fail a green guard or quietly widen this branch into another lane's fix.
-
         // --- A REPLACE OF A RECORD THAT OWNS NOTHING still reports honestly. The weapon has no child group, so the
         //     render must say the body is gone AND that there was nothing nested — "kept" and "nothing to keep" are
         //     different facts and a caller reverting a record needs to know which one they got.
         ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: fx.MasterName, into: Path.GetFileName(path));
+        var dryFlat = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: fx.ReplacerName,
+            into: Path.GetFileName(path), dry_run: true);
+        Check("…and its dry-run twin says the same: the body would go, and there is nothing nested to keep",
+            dryFlat.Contains("the old body would be gone", StringComparison.Ordinal)
+            && dryFlat.Contains("carries no nested records", StringComparison.Ordinal)
+            && !dryFlat.Contains("would be KEPT", StringComparison.Ordinal), dryFlat);
         var flat = ForwardTools.Forward(fx.Svc, formids: new[] { fx.SubjectFid }, source: fx.ReplacerName,
             into: Path.GetFileName(path));
         Check("…and a replace of a record with NO children says so, rather than counting a preservation that was not one",
@@ -1244,6 +1265,30 @@ public static class WriteSurfaceGuardProbe
         Check("…and a captured one does, on the identical record and children",
             WriteEngine.RestoreChildGroup(gateSubject, WriteEngine.CaptureChildGroup(gateSubject) with { Held = Array.Empty<(PropertyInfo, object?)>(), Count = 9 }, "…")
                 is not null, "(accepted)");
+
+        // --- WORLDSPACE, the reason the walk recurses at all: SubCells reaches its cells through TWO non-record
+        //     container types, so it is the only pinned type whose re-attach crosses more than one level. Exercised
+        //     directly rather than through a lane — a worldspace forward needs an exterior block/subblock fixture,
+        //     and what is unproven without this is the RE-ATTACH, not the lane. Stated plainly so the gap is not
+        //     mistaken for coverage: no end-to-end forward of a WRLD is measured here (its failure mode is bounded —
+        //     a count mismatch refuses, it does not lose records).
+        var wrld = new Worldspace(FormKey.Factory("123470:HcW2Master.esm"), SkyrimRelease.SkyrimSE);
+        wrld.TopCell = new Cell(FormKey.Factory("123471:HcW2Master.esm"), SkyrimRelease.SkyrimSE) { EditorID = "W324Top" };
+        var wSub = new WorldspaceSubBlock { BlockNumberX = 0, BlockNumberY = 0, GroupType = GroupTypeEnum.ExteriorCellSubBlock };
+        wSub.Items.Add(new Cell(FormKey.Factory("123472:HcW2Master.esm"), SkyrimRelease.SkyrimSE) { EditorID = "W324Ext" });
+        var wBlock = new WorldspaceBlock { BlockNumberX = 0, BlockNumberY = 0, GroupType = GroupTypeEnum.ExteriorCellBlock };
+        wBlock.Items.Add(wSub);
+        wrld.SubCells.Add(wBlock);
+
+        var wCarry = WriteEngine.CaptureChildGroup(wrld);
+        var wFresh = new Worldspace(wrld.FormKey, SkyrimRelease.SkyrimSE);
+        var wRefusal = WriteEngine.RestoreChildGroup(wFresh, wCarry, "…");
+        Check("Worldspace: the capture sees BOTH the top cell and the exterior cell two containers down",
+            wCarry.Count == 2, $"count={wCarry.Count} names=[{string.Join(", ", wCarry.Names)}]");
+        Check("…and the re-attach restores both onto a fresh copy, with the count balancing",
+            wRefusal is null && wFresh.TopCell?.EditorID == "W324Top"
+            && wFresh.SubCells.SelectMany(b => b.Items).SelectMany(sb => sb.Items).Any(c => c.EditorID == "W324Ext"),
+            wRefusal ?? $"top={wFresh.TopCell?.EditorID ?? "(none)"} subcells={wFresh.SubCells.Count}");
 
         // --- THE REFLECTED CHILD SET, PINNED. RestoreChildGroup re-attaches by walking properties that can REACH an
         //     owned record; its by-construction count check catches a path the walk cannot see, but only at call time,

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -14,7 +14,7 @@ namespace HousecarlGenerator;
 /// <c>housecarl_write_seq</c> (tool-surface-2.0 W3 PR 2; SPEC §2.2 ACT, §5.1/§5.2, §6.1). Sibling of
 /// <c>apply-guard</c>, same posture: the REAL end-to-end tool path — a synthetic MO2 instance in temp +
 /// <see cref="LoadOrderService"/> + the tool methods themselves — so the wire readers, the LANE grammar, the
-/// alias-visible vocabulary and the engines are exercised exactly as a caller hits them. TEN arms, listed BY SUBJECT
+/// alias-visible vocabulary and the engines are exercised exactly as a caller hits them. ELEVEN arms, listed BY SUBJECT
 /// — neither declaration nor run order, both of which live in RunGuard, where the off-order/in-place pair is
 /// deliberately last because it rewrites a fixture file the others read as a known winner:
 /// <list type="number">
@@ -41,6 +41,10 @@ namespace HousecarlGenerator;
 /// <item><b>nested parent hosting</b> (#300) — a nested create under an EXISTING load-order parent hosts the child
 /// in the parent's DEFINING plugin's version: the winner does not become a master, the hosted record does not carry
 /// a frozen copy of the winner's fields, and which plugin hosted it is reported.</item>
+/// <item><b>child-group preservation</b> (#324) — a <c>forward</c> onto a record the destination ALREADY carries
+/// replaces it by DROP-then-copy, and the drop used to take the record's child group with it (INFOs under a DIAL,
+/// placed refs under a CELL) while reporting success. Both lanes, plus the reflected child-property set pinned so a
+/// Mutagen bump that adds a container fails here rather than at a caller's write.</item>
 /// <item><b>CopyFrom source paths</b> (#321) — the same ACTIVE-copy-by-path rule on the <c>CopyFrom</c> lane: a
 /// <c>from_source=</c> path to the file the order serves is refused/resolved as IN-ORDER and named by its plugin
 /// name, the copy still lands from that plugin's own version, and a path to a same-NAMED different file keeps the
@@ -89,6 +93,10 @@ public static class WriteSurfaceGuardProbe
             CopyFromViewArm(root);
             CopySourcePathArm(fx, root);
             NestedParentHostArm(fx);
+            // #324's arm also writes into the replacer IN PLACE (its second half is that lane), so it sits with the
+            // in-place arms below rather than among the read-the-fixture ones. It changes the replacer's TOPIC only —
+            // no later arm reads that record — while the two below change its WEAPON, which earlier arms do read.
+            ForwardChildGroupArm(fx);
             // OffOrderForwardArm and ReviewFoldArm go LAST: they forward into the replacer IN PLACE, which rewrites a
             // fixture file every earlier arm reads as a known winner. Ordering them after keeps every other arm
             // reading the fixture it was written against.
@@ -1045,6 +1053,97 @@ public static class WriteSurfaceGuardProbe
             inlinedName == "Winner Topic" && inlinedChildren.Contains("W2InlinedLine"),
             $"{thenChild}  [topic name={inlinedName ?? "unreadable"} · children=[{string.Join(", ", inlinedChildren)}]]");
     }
+
+    /// <summary>#324 — a <c>forward</c> onto a record the destination ALREADY carries must not destroy that record's
+    /// child group. Both lanes, because the defect was on both and the <c>in_place=</c> half deletes records out of the
+    /// caller's own plugin, on the lane whose banner reads "no houseCARL backup or undo".
+    /// <para/>
+    /// The replace is a DROP-then-copy (the F1 semantic — a collision must never silently skip the copy,
+    /// HCBR-2026-07-08-01), the drop takes the child group with it, and the copy carries none back in, so before the
+    /// fix the children were gone and the call reported success. The probe body below is the one measured on PR #323
+    /// and quoted in #324, re-pointed from "left RED to prove the defect" to "asserts the defect is fixed".
+    /// <para/>
+    /// Every arm here asserts BOTH halves — the children survive AND the source's fields actually landed — because
+    /// either alone passes on a shape the tool must not ship: a forward that no-ops preserves children perfectly.</summary>
+    static void ForwardChildGroupArm(Fixture fx)
+    {
+        Console.WriteLine("── #324: forward onto a carried record PRESERVES its child group (both lanes) ──");
+
+        // --- THE MEASURED CASE, VERBATIM (into=). Create a child into a patch that hosts the topic, then forward the
+        //     winner's version into that same patch. Before the fix this left the patch holding one record — the topic
+        //     — with the child destroyed and "extended …" reported.
+        var made = CreateTools.Create(fx.Svc, patch: "W324",
+            records: Json($$"""[{"record_type":"DialogResponses","editorid":"W324Line","parent":"{{fx.TopicFid}}"}]"""));
+        var path = ArtifactPathFrom(fx, made);
+        Check("#324 fixture: a child creates into a patch, hosted on the parent's definer", path is not null, made);
+        if (path is null) return;
+
+        var inlined = ForwardTools.Forward(fx.Svc, formids: new[] { fx.TopicFid }, source: fx.ReplacerName,
+            into: Path.GetFileName(path));
+        Check("forward into= a patch that already carries the record is accepted",
+            inlined.StartsWith("extended ", StringComparison.Ordinal), inlined);
+
+        var after = ChildLinesIn(path, fx.TopicKey);
+        Check("…and the child SURVIVES the replace (#324: the drop no longer takes the child group)",
+            after.Contains("W324Line"),
+            $"{inlined}  [children=[{string.Join(", ", after)}] · whole file=[{string.Join(", ", EditorIdsIn(path))}]]");
+        Check("…and the forward still DID its job: the source's fields are inlined in the host",
+            TopicNameIn(path, fx.TopicKey) == "Winner Topic",
+            $"{inlined}  [topic name={TopicNameIn(path, fx.TopicKey) ?? "unreadable"}]");
+
+        // …and the group holds the destination's child and ONLY that. The re-attach is lossless only because the copy
+        // arrives carrying nothing — Mutagen's behaviour, not ours, which is why RestoreChildGroup refuses rather than
+        // discards if it ever changes. Both clauses together, since the absence alone would pass vacuously on the
+        // pre-fix code, where the whole group is empty.
+        Check("…and the group holds exactly the destination's child — the SOURCE's own line did not come with it",
+            after.Count == 1 && !after.Contains("W2WinnerLine"), string.Join(", ", after));
+
+        // --- THE WORSE HALF (in_place=): the destination is the caller's OWN plugin. The replacer owns the topic and
+        //     a line under it; forwarding the MASTER's version in place must land the master's fields and leave the
+        //     replacer's own line standing. Consent for this plugin was recorded by the LANE arm; acknowledge=true is
+        //     passed anyway so this arm does not silently depend on another arm's side effect.
+        var replPath = Path.Combine(fx.ModsDir, "W2Repl", fx.ReplacerName);
+        var before = ChildLinesIn(replPath, fx.TopicKey);
+        Check("#324 in-place fixture: the target plugin carries the record AND a child of its own",
+            before.Contains("W2WinnerLine"), string.Join(", ", before));
+
+        var inPlace = ForwardTools.Forward(fx.Svc, formids: new[] { fx.TopicFid }, source: fx.MasterName,
+            in_place: fx.ReplacerName, acknowledge: true);
+        Check("forward in_place= onto a record the file already carries is accepted",
+            !inPlace.StartsWith("error:"), inPlace);
+
+        var afterInPlace = ChildLinesIn(replPath, fx.TopicKey);
+        Check("…and the caller's OWN child survives it — the no-backup lane does not lose records",
+            afterInPlace.Contains("W2WinnerLine"),
+            $"{inPlace}  [children=[{string.Join(", ", afterInPlace)}]]");
+        Check("…and the forward still DID its job: the master's fields replaced the winner's",
+            TopicNameIn(replPath, fx.TopicKey) == "Master Topic",
+            $"{inPlace}  [topic name={TopicNameIn(replPath, fx.TopicKey) ?? "unreadable"}]");
+
+        // --- THE REFLECTED CHILD SET, PINNED. RestoreChildGroup re-attaches by walking properties that can REACH an
+        //     owned record; its by-construction count check catches a path the walk cannot see, but only at call time,
+        //     as a refusal in the caller's face. Pinning the set here turns a Mutagen bump that adds a container into
+        //     a failing CI arm instead. Worldspace is the reason the walk RECURSES: SubCells reaches its cells through
+        //     two non-record types, so a one-level test would silently skip every exterior cell in the game.
+        Check("the child-bearing property set is exactly what Mutagen models: Cell(4) · DialogTopic(1) · Worldspace(2)",
+            Names(typeof(Cell)) == "Landscape,NavigationMeshes,Persistent,Temporary"
+            && Names(typeof(DialogTopic)) == "Responses"
+            && Names(typeof(Worldspace)) == "SubCells,TopCell",
+            $"Cell=[{Names(typeof(Cell))}] DialogTopic=[{Names(typeof(DialogTopic))}] Worldspace=[{Names(typeof(Worldspace))}]");
+
+        // …and the negative, which is what keeps the walk from being a performance and correctness hazard: a FormLink
+        // is a reference, not a child, so the ordinary record types own nothing and the whole mechanism is inert for
+        // them. Quest is the sharp case — it links topics and owns aliases, and reaching either would make every
+        // quest forward pay for a child walk that has nothing to preserve.
+        Check("…and nothing else owns children: a linked record is not a child (Weapon · Npc · Quest all empty)",
+            Names(typeof(Weapon)) == "" && Names(typeof(Npc)) == "" && Names(typeof(Quest)) == "",
+            $"Weapon=[{Names(typeof(Weapon))}] Npc=[{Names(typeof(Npc))}] Quest=[{Names(typeof(Quest))}]");
+    }
+
+    /// <summary>The child-bearing property names WriteEngine's reflected walk finds for a type (internal via
+    /// InternalsVisibleTo), sorted so the assertion does not depend on reflection's property order.</summary>
+    static string Names(Type t) =>
+        string.Join(",", WriteEngine.ChildBearingProperties(t).Select(p => p.Name).OrderBy(n => n, StringComparer.Ordinal));
 
     /// <summary>Every child line the written plugin's copy of the topic carries — #300's "whose CHILDREN did the host
     /// copy" probe (a full-record override may bring the parent's child list with it, which widens the trade).</summary>

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -141,6 +141,8 @@ public static class WriteSurfaceGuardProbe
         /// <summary>#300: a nestable parent DEFINED by the master and WON by the replacer, at different content.</summary>
         public required string TopicFid { get; init; }
         public required FormKey TopicKey { get; init; }
+        public required string CellFid { get; init; }
+        public required FormKey CellKey { get; init; }
         /// <summary>One filename provided by TWO disabled mod folders — the ambiguity refusal's fixture.</summary>
         public required string AmbName { get; init; }
         /// <summary>A DISABLED plugin whose forwarded body links into ANOTHER disabled plugin — the missing-master
@@ -189,7 +191,22 @@ public static class WriteSurfaceGuardProbe
             // …carrying a CHILD of its own, so the arm can answer what the host override does to the parent's child
             // list — not just its fields. The winner adds a second child below.
             topic.Responses.Add(new DialogResponses(m.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "W2MasterLine" });
+
+            // #324's CELL case, built by hand — which is exactly why the comment above chose a topic for #300. A cell
+            // is NOT in a flat group, so a forward onto one resolves through a ModContext and rebuilds the
+            // block/subblock chain: structurally different code from the topic's path, and the case the changelog
+            // names first (a placed reference under a forwarded cell). Same three-way shape as the topic: the master
+            // defines it with a ref of its own, the replacer wins it with a different name and a second ref.
+            var cell = new Cell(m.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "W2Cell", Name = "Master Cell" };
+            cell.Persistent.Add(new PlacedObject(m.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "W2MasterRef" });
+            var cSub = new CellSubBlock { BlockNumber = 0, GroupType = GroupTypeEnum.InteriorCellSubBlock };
+            cSub.Cells.Add(cell);
+            var cBlock = new CellBlock { BlockNumber = 0, GroupType = GroupTypeEnum.InteriorCellBlock };
+            cBlock.SubBlocks.Add(cSub);
+            m.Cells.Records.Add(cBlock);
+
             m.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            var mCache = m.ToImmutableLinkCache();   // the nested cell override below reconstructs its parent chain from it
 
             var r = new SkyrimMod(rKey, SkyrimRelease.SkyrimSE);
             var rw = (IWeapon)WriteEngine.GenericGetOrAddAsOverride(r, subject);
@@ -206,6 +223,9 @@ public static class WriteSurfaceGuardProbe
             topicOverride.Name = "Winner Topic";
             topicOverride.Quest.SetTo(winnerQuest.FormKey);
             topicOverride.Responses.Add(new DialogResponses(r.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "W2WinnerLine" });
+            var cellOverride = (ICell)WriteEngine.GenericGetOrAddAsOverride(r, cell, mCache);
+            cellOverride.Name = "Winner Cell";
+            cellOverride.Persistent.Add(new PlacedObject(r.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "W2WinnerRef" });
             r.BeginWrite.ToPath(replPath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
 
             // --- W3 PR 2b: the OFF-ORDER source. A DISABLED mod folder (modlist '-W2Off'), absent from loadorder.txt
@@ -285,6 +305,8 @@ public static class WriteSurfaceGuardProbe
                 MasterOnlyFid = $"{masterOnly.FormKey.ID:X6}:{mKey.FileName}",
                 TopicFid = $"{topic.FormKey.ID:X6}:{mKey.FileName}",
                 TopicKey = topic.FormKey,
+                CellFid = $"{cell.FormKey.ID:X6}:{mKey.FileName}",
+                CellKey = cell.FormKey,
                 AmbName = aKey.FileName.String,
                 ChainName = cKey.FileName.String,
             };
@@ -1008,32 +1030,29 @@ public static class WriteSurfaceGuardProbe
             && made.Contains("currently WINS this record", StringComparison.Ordinal)
             && made.Contains("out-ranks", StringComparison.Ordinal)
             && made.Contains("inlined", StringComparison.Ordinal), made);
-        // …and the ORDER, which is the load-bearing half of that lever (#324). The first wording said only "forward
-        // the winner's version in explicitly", which is the measured-DESTRUCTIVE operation; a future edit that
-        // trims back to it would ship data-loss advice again and every other assertion here would stay green. The
-        // safe order is proven below, but the SENTENCE is what a caller acts on, so the sentence gets its own pin.
-        Check("…and the inlining lever names the SAFE order and marks the other one destructive",
-            made.Contains("forward its version into a patch FIRST", StringComparison.Ordinal)
-            && made.Contains("deletes the child", StringComparison.Ordinal)
-            && made.Contains("#324", StringComparison.Ordinal), made);
+        // …and the ORDER, which is the load-bearing half of that lever. This pin has now been wrong in both
+        // directions and that is the lesson it carries: the first wording ("forward the winner's version in
+        // explicitly") was measured DESTRUCTIVE while #324 was open, so the sentence was changed to name one safe
+        // order and warn off the other — and this arm pinned the warning, including the issue number. #324 is fixed
+        // on this branch, which made the pinned sentence FALSE and this arm the thing holding it in place: correcting
+        // the message failed CI. So the pin is on what the caller must be told (which parent gets inlined, and that
+        // the children survive either way), never on a defect being open. The behaviour is proven in
+        // ForwardChildGroupArm; this is the SENTENCE arm, because a sentence is what the caller acts on.
+        Check("…and the inlining lever names the order-independent remedy, with no stale open-bug warning",
+            made.Contains("forward", StringComparison.Ordinal)
+            && made.Contains("Either order works", StringComparison.Ordinal)
+            && !made.Contains("deletes the child", StringComparison.Ordinal)
+            && !made.Contains("#324", StringComparison.Ordinal), made);
 
         // THE REMEDY THE MESSAGE PRINTS, MEASURED RATHER THAN REASONED — because it is user-facing text telling a
-        // caller to run a write, and the FIRST wording of it was measured FALSE (PR #323 review [medium]).
+        // caller to run a write, and its first wording was measured FALSE (PR #323 review [medium]).
         //
-        // What was measured false: create the child, THEN forward the winner into the SAME patch. That DESTROYS the
-        // child. `forward`'s extend path drops the whole record before re-copying it (drop-then-copy, so a collision
-        // can't silently skip the copy — HCBR-2026-07-08-01 F1) and the child group goes with the drop, while
-        // `GenericGetOrAddAsOverride` carries none back in (the arm above). The probe left the patch holding one
-        // record, the topic, with the forward reporting success. That is a `forward` defect on BOTH its into= and
-        // in_place= lanes — the in_place half deletes children out of the caller's own plugin, on the lane with no
-        // backup — and it is neither #300's nor this branch's: those lines are untouched here. Filed as #324, which
-        // carries that probe body verbatim as its RED. Deliberately NOT asserted here: #323 must not carry another
-        // lane's red, and re-pointing this arm at the destruction would assert data loss is correct.
-        //
-        // What IS asserted is the ordering the contested message now prints: forward the winner FIRST, then create
-        // the child into that patch. The create then resolves its parent from the record the patch ALREADY carries,
-        // so there is no drop for the child to survive. Both halves asserted together — the winner's FIELDS inlined
-        // and the child present — because either alone would pass on a shape the message must not recommend.
+        // This arm measures the forward-first order: forward the winner into a patch, then create the child into that
+        // patch, so the create resolves its parent from the record the patch already carries. Both halves asserted
+        // together — the winner's FIELDS inlined and the child present — because either alone would pass on a shape
+        // the message must not recommend. The OTHER order (create first, then forward onto the parent the patch now
+        // holds) was the measured-destructive one that became #324; it is fixed on this branch and measured in
+        // ForwardChildGroupArm, which is why the message no longer warns anyone off it.
         var pre = ForwardTools.Forward(fx.Svc, formids: new[] { fx.TopicFid }, source: fx.ReplacerName, patch: "W2Inline");
         var prePath = ArtifactPathFrom(fx, pre);
         Check("the SAFE ordering, step 1: the winner's version of the parent forwards into a patch of its own",
@@ -1096,7 +1115,8 @@ public static class WriteSurfaceGuardProbe
         // discards if it ever changes. Both clauses together, since the absence alone would pass vacuously on the
         // pre-fix code, where the whole group is empty.
         Check("…and the group holds exactly the destination's child — the SOURCE's own line did not come with it",
-            after.Count == 1 && !after.Contains("W2WinnerLine"), string.Join(", ", after));
+            after.Count == 1 && !after.Contains("W2WinnerLine") && !after.Contains("(unreadable)"),
+            string.Join(", ", after));
 
         // --- THE WORSE HALF (in_place=): the destination is the caller's OWN plugin. The replacer owns the topic and
         //     a line under it; forwarding the MASTER's version in place must land the master's fields and leave the
@@ -1116,9 +1136,53 @@ public static class WriteSurfaceGuardProbe
         Check("…and the caller's OWN child survives it — the no-backup lane does not lose records",
             afterInPlace.Contains("W2WinnerLine"),
             $"{inPlace}  [children=[{string.Join(", ", afterInPlace)}]]");
+        // …and the same not-the-source's-children clause the into= half asserts (round-1 review [low]): presence
+        // alone would stay green if the copy started dragging the MASTER's line in, leaving the replacer holding two
+        // INFOs under one topic — a duplicated line, not a lost one, and just as wrong.
+        Check("…and ONLY the caller's own child: the master's line did not ride in on the copy",
+            afterInPlace.Count == 1 && !afterInPlace.Contains("W2MasterLine"), string.Join(", ", afterInPlace));
         Check("…and the forward still DID its job: the master's fields replaced the winner's",
             TopicNameIn(replPath, fx.TopicKey) == "Master Topic",
             $"{inPlace}  [topic name={TopicNameIn(replPath, fx.TopicKey) ?? "unreadable"}]");
+
+        // --- THE CELL, which is a DIFFERENT copy path and the case the changelog names first. A topic lives in a flat
+        //     group; a cell does not, so the override resolves through a ModContext that rebuilds the block/subblock
+        //     chain. Every assertion above would stay green with the nested path broken (round-1 review [medium]),
+        //     and "placed references under a forwarded cell" is the loss a user is most likely to hit in the wild.
+        var madeRef = CreateTools.Create(fx.Svc, patch: "W324Cell",
+            records: Json($$"""[{"record_type":"PlacedObject","editorid":"W324Ref","parent":"{{fx.CellFid}}","collection":"Persistent"}]"""));
+        var cellPath = ArtifactPathFrom(fx, madeRef);
+        Check("#324 cell fixture: a placed ref creates into a patch, hosted on the cell's definer", cellPath is not null, madeRef);
+        if (cellPath is null) return;
+
+        var cellFwd = ForwardTools.Forward(fx.Svc, formids: new[] { fx.CellFid }, source: fx.ReplacerName,
+            into: Path.GetFileName(cellPath));
+        Check("forward into= a patch that already carries the CELL is accepted",
+            cellFwd.StartsWith("extended ", StringComparison.Ordinal), cellFwd);
+
+        var refsAfter = CellRefsIn(cellPath, fx.CellKey);
+        Check("…and the placed ref SURVIVES the replace on the nested-group path too",
+            refsAfter.Contains("W324Ref"),
+            $"{cellFwd}  [refs=[{string.Join(", ", refsAfter)}] · whole file=[{string.Join(", ", EditorIdsIn(cellPath))}]]");
+        Check("…and the forward still DID its job: the source's cell fields are inlined in the host",
+            CellNameIn(cellPath, fx.CellKey) == "Winner Cell",
+            $"{cellFwd}  [cell name={CellNameIn(cellPath, fx.CellKey) ?? "unreadable"}]");
+        Check("…and the group holds exactly the destination's ref — the SOURCE's own refs did not come with it",
+            refsAfter.Count == 1 && !refsAfter.Contains("W2WinnerRef") && !refsAfter.Contains("(unreadable)"),
+            string.Join(", ", refsAfter));
+
+        // …and the cell on the in-place lane, where the placed refs being deleted are the caller's own.
+        var cellInPlace = ForwardTools.Forward(fx.Svc, formids: new[] { fx.CellFid }, source: fx.MasterName,
+            in_place: fx.ReplacerName, acknowledge: true);
+        Check("forward in_place= onto a CELL the file already carries is accepted",
+            !cellInPlace.StartsWith("error:", StringComparison.Ordinal), cellInPlace);
+        var replRefs = CellRefsIn(replPath, fx.CellKey);
+        Check("…and the caller's OWN placed ref survives it, and only it",
+            replRefs.Count == 1 && replRefs.Contains("W2WinnerRef"),
+            $"{cellInPlace}  [refs=[{string.Join(", ", replRefs)}]]");
+        Check("…and the master's cell fields replaced the winner's",
+            CellNameIn(replPath, fx.CellKey) == "Master Cell",
+            $"{cellInPlace}  [cell name={CellNameIn(replPath, fx.CellKey) ?? "unreadable"}]");
 
         // --- THE REFLECTED CHILD SET, PINNED. RestoreChildGroup re-attaches by walking properties that can REACH an
         //     owned record; its by-construction count check catches a path the walk cannot see, but only at call time,
@@ -1131,13 +1195,108 @@ public static class WriteSurfaceGuardProbe
             && Names(typeof(Worldspace)) == "SubCells,TopCell",
             $"Cell=[{Names(typeof(Cell))}] DialogTopic=[{Names(typeof(DialogTopic))}] Worldspace=[{Names(typeof(Worldspace))}]");
 
-        // …and the negative, which is what keeps the walk from being a performance and correctness hazard: a FormLink
-        // is a reference, not a child, so the ordinary record types own nothing and the whole mechanism is inert for
-        // them. Quest is the sharp case — it links topics and owns aliases, and reaching either would make every
-        // quest forward pay for a child walk that has nothing to preserve.
-        Check("…and nothing else owns children: a linked record is not a child (Weapon · Npc · Quest all empty)",
-            Names(typeof(Weapon)) == "" && Names(typeof(Npc)) == "" && Names(typeof(Quest)) == "",
-            $"Weapon=[{Names(typeof(Weapon))}] Npc=[{Names(typeof(Npc))}] Quest=[{Names(typeof(Quest))}]");
+        // …and the negative over EVERY concrete record type Mutagen models, not a sample of three (round-1 review
+        // [low]: naming Weapon/Npc/Quest left the other 127 free to grow a container silently, and the first caller
+        // to forward one would eat the count-check refusal with CI green). This is the coverage cornerstone's own
+        // posture applied to the walk — the set is closed by construction, so the pin is too. Quest is still the
+        // sharp case the negative exists for: it LINKS topics and owns aliases, and reaching either would make every
+        // quest forward pay for a walk with nothing to preserve. Cost of the whole sweep: tens of milliseconds once.
+        var owners = ConcreteRecordTypes()
+            .Where(t => WriteEngine.ChildBearingProperties(t).Count > 0)
+            .Select(t => t.Name).OrderBy(n => n, StringComparer.Ordinal).ToList();
+        Check("…and NOTHING else does, across every concrete record type Mutagen models (a link is not a child)",
+            string.Join(",", owners) == "Cell,DialogTopic,Worldspace",
+            $"{ConcreteRecordTypes().Count} concrete record types · owners=[{string.Join(", ", owners)}]");
+
+        // --- THE REFUSALS, RENDERED. All three arms of RestoreChildGroup are user-facing sentences that no arm had
+        //     ever produced (round-1 review [low]) — and this file's own standing lesson is that a message shipped
+        //     through green guards is an unmeasured claim. Driven directly, because the states they report are ones
+        //     Mutagen cannot currently produce: a copy arriving with children, and a count that does not balance.
+        var carrier = new DialogTopic(FormKey.Factory("123456:HcW2Master.esm"), SkyrimRelease.SkyrimSE);
+        carrier.Responses.Add(new DialogResponses(FormKey.Factory("123457:HcW2Master.esm"), SkyrimRelease.SkyrimSE)
+            { EditorID = "W324Arrived" });
+        var injection = WriteEngine.RestoreChildGroup(carrier, default, "Nothing was serialized; UNTOUCHED.");
+        Check("refusal 1: a copy arriving with children of its own is refused as an IMPORT when nothing was held",
+            injection is not null && injection.Contains("arrived carrying 1 child record(s)", StringComparison.Ordinal)
+            && injection.Contains("W324Arrived", StringComparison.Ordinal)
+            && injection.Contains("refuses rather than silently import", StringComparison.Ordinal)
+            && injection.Contains("Nothing was serialized", StringComparison.Ordinal), injection ?? "(accepted)");
+
+        var held = WriteEngine.CaptureChildGroup(carrier);
+        var clash = WriteEngine.RestoreChildGroup(carrier, held, "Nothing was serialized; UNTOUCHED.");
+        Check("refusal 2: …and as a two-sets clash when the destination held some too, naming both counts",
+            clash is not null && clash.Contains("while the destination held 1", StringComparison.Ordinal)
+            && clash.Contains("discard one of the two sets", StringComparison.Ordinal), clash ?? "(accepted)");
+
+        // The count check, off a carry whose count does not match what is on the record — the shape a containment
+        // path the reflected walk cannot see would produce. The lane clause must land BEFORE "please report".
+        var empty = new DialogTopic(FormKey.Factory("123458:HcW2Master.esm"), SkyrimRelease.SkyrimSE);
+        var miscount = WriteEngine.RestoreChildGroup(empty,
+            held with { Count = 3, Names = new[] { "W324Ghost" } }, "Nothing was serialized; UNTOUCHED.");
+        Check("refusal 3: a child count that does not survive the replace refuses, naming what it cannot account for",
+            miscount is not null && miscount.Contains("it carries 3 child record(s)", StringComparison.Ordinal)
+            && miscount.Contains("W324Ghost", StringComparison.Ordinal)
+            && miscount.Contains("cannot account for", StringComparison.Ordinal)
+            && miscount.IndexOf("Nothing was serialized", StringComparison.Ordinal)
+               < miscount.IndexOf("Please report", StringComparison.Ordinal), miscount ?? "(accepted)");
+
+        // …and the doubling those three used to ship: the lane appended its own untouched-clause to a message that
+        // already carried one. Substituted now, so it appears once (round-1 review [low]).
+        Check("…and each refusal states what was left alone exactly ONCE",
+            CountOf(injection!, "Nothing was serialized") == 1 && CountOf(clash!, "Nothing was serialized") == 1
+            && CountOf(miscount!, "Nothing was serialized") == 1,
+            $"[{CountOf(injection!, "Nothing was serialized")}·{CountOf(clash!, "Nothing was serialized")}·{CountOf(miscount!, "Nothing was serialized")}]");
+    }
+
+    /// <summary>The placed references the written plugin's copy of the cell carries — <see cref="ChildLinesIn"/>'s
+    /// twin for the nested-group path, walking the block/subblock chain a cell lives in.</summary>
+    static List<string> CellRefsIn(string espPath, FormKey fk)
+    {
+        var found = new List<string>();
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(espPath, SkyrimRelease.SkyrimSE);
+            var cell = CellsIn(ov).FirstOrDefault(c => c.FormKey == fk);
+            foreach (var p in (cell?.Persistent ?? Enumerable.Empty<IPlacedGetter>())
+                         .Concat(cell?.Temporary ?? Enumerable.Empty<IPlacedGetter>()))
+                found.Add(p.EditorID ?? p.FormKey.ToString());
+        }
+        catch { found.Add("(unreadable)"); }
+        finally { (ov as IDisposable)?.Dispose(); }
+        return found;
+    }
+
+    static string? CellNameIn(string espPath, FormKey fk)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(espPath, SkyrimRelease.SkyrimSE);
+            return CellsIn(ov).FirstOrDefault(c => c.FormKey == fk)?.Name?.String;
+        }
+        catch { return null; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    static IEnumerable<ICellGetter> CellsIn(ISkyrimModGetter ov) =>
+        (ov.Cells.Records ?? Enumerable.Empty<ICellBlockGetter>())
+            .SelectMany(b => b.SubBlocks ?? Enumerable.Empty<ICellSubBlockGetter>())
+            .SelectMany(s => s.Cells ?? Enumerable.Empty<ICellGetter>());
+
+    /// <summary>Every concrete major-record type Mutagen models for Skyrim — the NestedProbe enumeration, reused so
+    /// the child-property pin is a by-construction sweep rather than a list of names someone remembered.</summary>
+    static List<Type> ConcreteRecordTypes() => typeof(Weapon).Assembly.GetTypes()
+        .Where(t => t.IsClass && !t.IsAbstract && !t.Name.EndsWith("BinaryOverlay", StringComparison.Ordinal)
+                    && typeof(IMajorRecord).IsAssignableFrom(t))
+        .ToList();
+
+    static int CountOf(string haystack, string needle)
+    {
+        int n = 0;
+        for (int i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal)) n++;
+        return n;
     }
 
     /// <summary>The child-bearing property names WriteEngine's reflected walk finds for a type (internal via

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1943,7 +1943,8 @@ static class JsonWire
     // ---- housecarl_forward (W3 PR 2) ----------------------------------------------------------------
     /// <summary>The machine-readable twin of <see cref="WriteTools.RenderForward"/> — the SAME data (decision D2),
     /// on <see cref="RenderPatchOutcome"/>'s contract. The two per-record facts the text render puts in brackets are
-    /// flags here: <c>replaced_existing</c> (an override this artifact already carried is GONE) and
+    /// flags here: <c>replaced_existing</c> (an override this artifact already carried had its FIELDS replaced, with
+    /// <c>preserved_children</c> naming how many nested records rode across the replace — #324) and
     /// <c>was_already_winner</c> (the forward re-asserts content that already wins — a no-op in effect, reported
     /// rather than silent).</summary>
     public static string RenderForwardOutcome(WritePatchBuilder.ForwardOutcome o, int maxChars, bool readback, string lane)
@@ -2003,6 +2004,9 @@ static class JsonWire
                 WriteNullable(w, "editorid", f.EditorId);
                 w.WriteString("source", f.FromPlugin);
                 w.WriteBoolean("replaced_existing", f.ReplacedExisting);
+                // #324 — how many records nested under the replaced one were carried across. The text render states
+                // it in words; a consumer branching on replaced_existing alone would still read the replace as total.
+                w.WriteNumber("preserved_children", f.PreservedChildren);
                 w.WriteBoolean("was_already_winner", f.WasAlreadyWinner);
                 WriteNullable(w, "prior_winner", f.PriorWinner);
                 w.WriteEndObject();

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -372,8 +372,9 @@ public static class WriteTools
          "excluded (unparseable), is the artifact being written itself, names a target twice, simply doesn't DEFINE/override a given " +
          "record (nothing there to forward), or names a record whose ORIGIN plugin isn't active. By default writes a fresh patch named patch_name; into= EXTENDS an existing " +
          "houseCARL patch (accumulate across calls/sessions). If the extended patch ALREADY carries a forwarded FormKey, its " +
-         "existing override is REPLACED by from_plugin's body (xEdit's copy-as-override overwrite — flagged per record in the " +
-         "response). target= + in_place=true is the opt-in THIRD route: forward INTO an existing plugin's OWN file (incl. one " +
+         "existing override's FIELDS are REPLACED by from_plugin's body (xEdit's copy-as-override overwrite — flagged per record in the " +
+         "response); records NESTED under it (a topic's lines, a cell's placed refs) are KEPT and counted in that flag. " +
+         "target= + in_place=true is the opt-in THIRD route: forward INTO an existing plugin's OWN file (incl. one " +
          "houseCARL didn't author) — same replace-on-collision semantics, same one-time acknowledge= consent as the sibling " +
          "write tools, master header grown from the copied bodies. THE STALE-WINNER BYPASS RECIPE (pinned): forward from " +
          "the source you want, then bulk_apply into= the same patch — the ops edit the patch's FORWARDED copy, never " +
@@ -862,10 +863,20 @@ public static class WriteTools
             var f = o.Forwarded[fi];
             sb.Append("  ").Append(f.RecordType).Append(' ').Append(f.Target).Append("  ").Append(f.EditorId ?? "<no editorid>")
               .Append(o.DryRun ? "  — would be copied from " : "  — copied from ").Append(f.FromPlugin);
+            // #324 — the sentence a caller acts on has to match what the replace now does. It used to say "the old
+            // body is gone" flat, which was true when the drop took the child group with it. It no longer does: the
+            // FIELDS are replaced and everything nested under the record is carried across. Left unchanged, the line
+            // reads as a clean revert over a cell whose forty placed refs are still in the file — the caller either
+            // ships what they think they removed, or re-creates a dialogue line they never lost. The count is stated
+            // rather than implied, because "nested records were kept" cannot tell nothing-was-there from twelve-kept.
             if (f.ReplacedExisting)
-                sb.Append(o.DryRun
-                    ? "  [would REPLACE the patch's own existing override of this record — the old body would be gone (xEdit's copy-as-override-into overwrite)]"
-                    : "  [REPLACED the patch's own existing override of this record — the old body is gone (xEdit's copy-as-override-into overwrite)]");
+                sb.Append(f.PreservedChildren > 0
+                    ? (o.DryRun
+                        ? $"  [would REPLACE the patch's own existing override of this record — the old FIELDS would be gone (xEdit's copy-as-override-into overwrite), but the {f.PreservedChildren} record(s) nested under it would be KEPT]"
+                        : $"  [REPLACED the patch's own existing override of this record — the old FIELDS are gone (xEdit's copy-as-override-into overwrite); the {f.PreservedChildren} record(s) nested under it were KEPT]")
+                    : (o.DryRun
+                        ? "  [would REPLACE the patch's own existing override of this record — the old body would be gone (xEdit's copy-as-override-into overwrite); it carries no nested records]"
+                        : "  [REPLACED the patch's own existing override of this record — the old body is gone (xEdit's copy-as-override-into overwrite); it carried no nested records]"));
             if (f.WasAlreadyWinner)
                 sb.Append("  [NOTE: this source IS already the load-order winner — the override just re-asserts the content that already wins (a no-op in effect)]");
             else if (f.PriorWinner is null)

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -373,7 +373,8 @@ public static class WriteTools
          "record (nothing there to forward), or names a record whose ORIGIN plugin isn't active. By default writes a fresh patch named patch_name; into= EXTENDS an existing " +
          "houseCARL patch (accumulate across calls/sessions). If the extended patch ALREADY carries a forwarded FormKey, its " +
          "existing override's FIELDS are REPLACED by from_plugin's body (xEdit's copy-as-override overwrite — flagged per record in the " +
-         "response); records NESTED under it (a topic's lines, a cell's placed refs) are KEPT and counted in that flag. " +
+         "response); records NESTED under it (a topic's lines, a cell's placed refs) are KEPT, counted per record in " +
+         "preserved_children. " +
          "target= + in_place=true is the opt-in THIRD route: forward INTO an existing plugin's OWN file (incl. one " +
          "houseCARL didn't author) — same replace-on-collision semantics, same one-time acknowledge= consent as the sibling " +
          "write tools, master header grown from the copied bodies. THE STALE-WINNER BYPASS RECIPE (pinned): forward from " +


### PR DESCRIPTION
Fixes #324.

`forward` onto a record the destination **already carries** replaced it by dropping the whole record and copying the source body in. The drop took the record's child group with it and the copy carried none back, so every record nested under the replaced one was destroyed while the call reported success — a topic's INFOs, a cell's placed references. The `in_place=` half did that to the caller's own plugin, on the lane whose banner says there is no backup.

Both lanes now lift the children off before the `Remove` and re-attach them after the copy. Nothing about the forward semantic changes: a forwarded parent asserts the source's *fields*, and the source's own children stay in the source's plugin.

## What is refused rather than guessed

Two states fail closed with nothing serialized: a copy that arrives carrying children of its own (Mutagen's semantics changing under us — re-attaching would silently discard one of the two sets, or import the source's into a destination that deliberately holds none), and a child count that does not survive the replace. The second check runs off Mutagen's own containment walk rather than the reflected property set that did the re-attach, so a containment path the walk cannot see fails loud instead of losing records.

The reflected walk recurses, and that is load-bearing: `Worldspace.SubCells` reaches its cells through two non-record container types, so a one-level test would silently skip every exterior cell in the game. `IFormLink`s are cut — a link references a record, it does not own one.

## The gate

`RestoreChildGroup` acts if and only if a capture happened — the fact that a drop-then-copy is underway, written by `CaptureChildGroup` and nowhere else. That is worth stating because the branch inferred it twice and was wrong twice (see the rounds below). Inferring it from the carry being empty made the arrival tripwire unreachable in the case where an arriving set is an *injection*; inferring it from the record's type made it fire on records the call itself had just created, refusing whole writes and blaming Mutagen. The lane knows the answer; it is now passed rather than re-derived.

## Proof

`write-surface-guard` 133 → **163**. A new `#324` arm covering both lanes on both copy paths — `DialogTopic` (flat group) and `Cell` (nested; resolves through a `ModContext` that rebuilds the block/subblock chain) — asserting the children survive **and** that the source's fields actually landed, since a forward that no-op'd would preserve children perfectly. Plus the child-bearing property set pinned across every concrete record type Mutagen models, the three refusal sentences rendered, and the response wording.

RED-checked three ways rather than assumed:
- neutering the capture fails the child-survival arms on **both** paths — so the nested cell path was destroying placed references too, which the changelog had asserted and nothing had measured;
- restoring the round-1 gate fails exactly the three arms that pin the same-call regression;
- restoring the old response sentence fails the sentence arm.

`ci-all` 117/117 · `apply-guard` 78/78.

## Pre-PR review rounds

Two rounds, three fresh independent reviewers each, prompts seeded with the branch's settled-decisions list and nothing else.

**Round 1 — 1 high, 2 medium, 6 low, 2 nits.** All three reviewers independently led with the same high: the `create` render still told callers that the order this branch had just made safe destroys their data, citing #324 as an open bug — and a guard arm pinned that wording, issue number included, so correcting the message failed CI. The CHANGELOG said both that #324 was fixed and, four paragraphs later, that it was not. Also folded: cell coverage (the arm only exercised the flat-group path), the unreachable arrival tripwire, the three refusal messages no arm had ever rendered (which surfaced a doubled "nothing was serialized"), a property pin covering 6 types of 133, a capture throw reported as "the override-copy threw", and a missing not-the-source's-children clause on the in-place half.

*Refused:* raising or restructuring the recursion depth bound — two reviewers independently ran a more generous walk (depth 12, per-branch visited set) over all 133 types and got the same answer set, and deeper nesting fails closed with the all-types pin going red first. Also refused as a live defect: the count-mismatch message reading oddly when more children survive than were held — that branch is unreachable, since an arriving set is refused earlier and the re-attach cannot add.

**Round 2 — 2 highs, both regressions round 1's own fold introduced, both on the gate.** Forwarding a child and its parent in one call now refused the whole write and told the caller to report a Mutagen bug; and the type gate short-circuited the count check for any type whose containers the walk cannot see — the silent-loss shape the function exists to prevent. Two reviewers also flagged, independently, that the forward response still said "the old body is gone" on exactly the operation this branch changed: revert a cell in place, keep your forty placed refs, and be told the old body went.

**The rounds stopped at two.** Per CLAUDE.md §11 the same failure class recurring in consecutive rounds is a design signal, not a fix queue — so the seam went to Aaron rather than into a third fold. His call was to thread the capture fact, with conditions: single writer, the response sentence measured before rewording and given its own arm, the two self-introduced cleanups riding along, and no new rounds after the directed fold.

## Review fold

Aaron's review is folded (commit `9ba7b3a`): the dry-run halves of the new render sentence now have arms of their own — they are the sentences a caller reads while deciding whether to proceed, and the branch had pinned only their live twins; the tool description names `preserved_children` instead of pointing a count at a bool; `ReachesOwnedRecord`'s visited set is a path set, so a type first reached at the depth bound is no longer memoized as unreachable for shallower branches; the new field is documented with `<param>`; and `Worldspace` — the reason the walk recurses — is exercised directly across both container levels rather than pinned by reflection alone, with the remaining gap (no end-to-end WRLD forward) stated in the arm so it is not mistaken for coverage.

His second finding was worse than filed, and retracts one of mine. The pair block's comment described a fixture state the arm no longer produced: the in-place half runs earlier in the same arm and rewrites the replacer's topic to `Master Topic`, so both sides of the comparison read `Master Topic`. **That is where #333 came from** — I read a failing assertion as a silent skip when what had actually changed was the source. Re-measured with the block moved above the in-place half, the parent's fields do land; the second spec is not skipped. #333 is closed as not-a-defect, and the ordering is now asserted with a comment recording why the block sits where it does.

`write-surface-guard` 163 → **169**. The two dry-run arms are RED-checked: restoring the old preview sentence fails both.

## Not fixed here

- A forwarded parent's child-group **header stamps** are not carried across from the destination — the `Timestamp` / `Unknown` class of field on a DIAL, and the `Timestamp` / `PersistentTimestamp` / `TemporaryTimestamp` / `UnknownGroupData` equivalents on a CELL. Dropped per §2 fix-or-drop: CK bookkeeping, invisible to the engine, visible only in xEdit, and the fix would be type-specific special-casing against the by-construction posture. Scope stated as the class of field rather than a mechanism, deliberately: round 2 reported the DIAL half as carrying the source's values and the CELL half as zeroed, and this branch's fixture cannot discriminate — its stamps are zero on both sides, which is exactly the kind of reading that produced #333.
- **#335** — filed from Aaron's aside: `mutagen-reference` classifies `Cell.Landscape` as a formlink, while this branch's all-types pin has it as an owned child record. A generator-classifier question, not this PR's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
