### PR TITLE
refactor: one source per sentence for the write-surface responses

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -15,9 +15,16 @@ way. The most consequential: the JSON note about creating an exterior cell had l
 collision is *engine* behaviour, so it read like something you could retry your way out of; a cut report block told
 you "do not re-issue the write" on one transport and the more specific, actually-correct "do not re-issue the create —
 that allocates the records again" on the other; and `write_seq`'s JSON standing-limit note had dropped the pointer to
-`housecarl_validate_dialogue`, which is the half telling you what to do next. Every such sentence now has one source
-that both transports read, so a correction reaches both or neither. Wording is otherwise unchanged, except where the
-two copies already disagreed — those are resolved to the fuller and truer reading.
+`housecarl_validate_dialogue`, which is the half telling you what to do next. Every sentence named in the PR's inventory now has one
+source that both transports read, so a correction reaches both or neither; the inventory also names what is left and
+why. Wording is otherwise unchanged, except where the two copies already disagreed — those are resolved to the fuller
+and truer reading.
+
+**Fixed: a large `apply` no longer overflows its text response without saying so.** Its JSON twin has always dropped
+trailing rows at `max_chars` and set `truncated`, but the text render listed every edit and let the host cut the
+oversized response out of band — the silent cut `max_chars` exists to prevent, on the one write verb whose row list
+was still unbounded. It now stops with the same explicit notice its four sibling renders carry. A truncated dry run
+also no longer describes itself as a completed write.
 
 **Fixed: forwarding a record no longer deletes the records nested under it (#324).** When `forward` targeted a record
 the destination *already carried*, it replaced it by dropping the whole record and copying the source body in — and

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,17 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**Fixed: the text and JSON responses to a write can no longer say different things.** Every write tool renders its
+result twice — once as text, once as `format="json"` — and the two renders were maintained separately, so a warning
+or a piece of advice could be corrected on one and left stale on the other. Nine sentences had already drifted that
+way. The most consequential: the JSON note about creating an exterior cell had lost the clause saying a grid
+collision is *engine* behaviour, so it read like something you could retry your way out of; a cut report block told
+you "do not re-issue the write" on one transport and the more specific, actually-correct "do not re-issue the create —
+that allocates the records again" on the other; and `write_seq`'s JSON standing-limit note had dropped the pointer to
+`housecarl_validate_dialogue`, which is the half telling you what to do next. Every such sentence now has one source
+that both transports read, so a correction reaches both or neither. Wording is otherwise unchanged, except where the
+two copies already disagreed — those are resolved to the fuller and truer reading.
+
 **Fixed: forwarding a record no longer deletes the records nested under it (#324).** When `forward` targeted a record
 the destination *already carried*, it replaced it by dropping the whole record and copying the source body in — and
 the drop took the record's child group with it. Any dialogue line under a forwarded topic, or placed reference under

--- a/src/housecarl-generator/ApplyGuardProbe.cs
+++ b/src/housecarl-generator/ApplyGuardProbe.cs
@@ -616,7 +616,7 @@ public static class ApplyGuardProbe
         // dry_run on the default lane writes nothing and says so first
         var dry = ApplyTools.Apply(fx.Svc, ops: Json(OneOp("41")), patch: "ApDry", dry_run: true);
         Check("dry_run reports what WOULD change and writes nothing",
-            dry.StartsWith("DRY RUN") && dry.Contains("NOTHING was written"), dry);
+            dry.StartsWith(WriteSentences.DryRunHeader, StringComparison.Ordinal), dry);
     }
 
     // ================= ARM 3 — the §4.5 zip =================

--- a/src/housecarl-generator/DryRunProbe.cs
+++ b/src/housecarl-generator/DryRunProbe.cs
@@ -221,7 +221,9 @@ internal static class DryRunProbe
                     $"dry forward reports the would-be copy (source={o.Forwarded.FirstOrDefault()?.FromPlugin}, priorWinner={o.Forwarded.FirstOrDefault()?.PriorWinner})  [{o.Error ?? "ok"}]");
                 Check(before.SequenceEqual(ModFolders()), "no mod folder appeared");
                 var text = WriteTools.RenderForward(o);
-                Check(text.Contains("DRY RUN") && text.Contains("would be copied from") && !text.Contains("\nmasters:"),
+                Check(text.Contains(WriteSentences.DryRunHeader, StringComparison.Ordinal)
+                      && text.Contains("would be copied from")
+                      && !text.Contains("\n" + WriteSentences.Masters(Array.Empty<string>())),
                     "forward render uses the would-be phrasing (+ the expected-masters preview, not a real header)");
                 var dryMiss = svc.ForwardRecords(new[] { fid2 }, "HcDryUser.esp", "DryH2", null, dryRun: true);
                 var realMiss = svc.ForwardRecords(new[] { fid2 }, "HcDryUser.esp", "DryH2", null);

--- a/src/housecarl-generator/DryRunProbe.cs
+++ b/src/housecarl-generator/DryRunProbe.cs
@@ -223,7 +223,10 @@ internal static class DryRunProbe
                 var text = WriteTools.RenderForward(o);
                 Check(text.Contains(WriteSentences.DryRunHeader, StringComparison.Ordinal)
                       && text.Contains("would be copied from")
-                      && !text.Contains("\n" + WriteSentences.Masters(Array.Empty<string>())),
+                      // Any masters LINE, not the empty-set spelling. This outcome forwards from a REAL master, so
+                      // pinning "masters: (none)" would be a string the render can never emit — an assertion that
+                      // passes whatever happens, which is what it briefly became.
+                      && !text.Contains("\n" + WriteSentences.Masters(Array.Empty<string>()).Split('(')[0]),
                     "forward render uses the would-be phrasing (+ the expected-masters preview, not a real header)");
                 var dryMiss = svc.ForwardRecords(new[] { fid2 }, "HcDryUser.esp", "DryH2", null, dryRun: true);
                 var realMiss = svc.ForwardRecords(new[] { fid2 }, "HcDryUser.esp", "DryH2", null);

--- a/src/housecarl-generator/SeqWriteGuardProbe.cs
+++ b/src/housecarl-generator/SeqWriteGuardProbe.cs
@@ -377,12 +377,15 @@ internal static class SeqWriteGuardProbe
                   && File.GetLastWriteTimeUtc(expectedUserSeq) > pluginStamp
                   && File.ReadAllBytes(expectedUserSeq).Length == 4,
                 $"MTIME-REFRESH a byte-identical but OLDER .seq is stamped forward, not rewritten — unchanged={oStale.Unchanged} touched={oStale.TimestampRefreshed} seq={File.GetLastWriteTimeUtc(expectedUserSeq):O} plugin={pluginStamp:O}");
+            // A CONSTRUCTION pin, not a fragment one: the stamp sentence has one source, so this asserts (a) the
+            // source itself still carries the two claims that matter — it names validate_dialogue's check, and it
+            // BOUNDS the promise to the copy the load order serves (review round 2: the lint reads the .seq the VFS
+            // SERVES, which is this file only when this folder wins the SEQ\ conflict) — and (b) the render is
+            // reading that source. A fragment check could only ever have pinned one render's spelling of it.
             var renderStale = SeqTools.Render(oStale);
-            Check(renderStale.Contains("timestamp was refreshed", StringComparison.Ordinal)
-                  && renderStale.Contains("validate_dialogue", StringComparison.Ordinal)
-                  // …and it does NOT promise that tool's verdict: the lint reads the .seq the VFS SERVES, which is
-                  // this file only when this folder wins the SEQ\ conflict (review round 2).
-                  && renderStale.Contains("provided this is the copy your load order actually serves", StringComparison.Ordinal),
+            Check(WriteSentences.Twins.SeqTimestampRefreshed.Contains("validate_dialogue", StringComparison.Ordinal)
+                  && WriteSentences.Twins.SeqTimestampRefreshed.Contains("the copy the load order actually serves", StringComparison.Ordinal)
+                  && renderStale.Contains(WriteSentences.Twins.SeqTimestampRefreshed, StringComparison.Ordinal),
                 $"MTIME-REFRESH-RENDER the stamp is STATED and its scope is bounded — render=[{Trim(renderStale)}]");
 
             // MTIME-FUTURE: a plugin stamped in the FUTURE (restored backup, skewed clock) cannot be beaten by
@@ -423,7 +426,10 @@ internal static class SeqWriteGuardProbe
             var renderRepl = SeqTools.Render(oRepl);
             Check(oRepl.Success && !oRepl.Unchanged && oRepl.Replaced
                   && renderRepl.StartsWith("replaced ", StringComparison.Ordinal)
-                  && renderRepl.Contains("no backup is kept", StringComparison.Ordinal),
+                  // The no-backup alarm is a property of the SENTENCE (one source, both transports), so pin it there
+                  // and pin that this render reads it — rather than pinning one lane's spelling of the alarm.
+                  && WriteSentences.Twins.SeqReplacedUserFolder.Contains("keeps no backup", StringComparison.Ordinal)
+                  && renderRepl.Contains(WriteSentences.Twins.SeqReplacedUserFolder, StringComparison.Ordinal),
                 $"REPLACED overwriting an existing .seq reports 'replaced', not 'wrote' — replaced={oRepl.Replaced} render=[{Trim(renderRepl)}]");
             // …and the fresh-file case is NOT reported as a replacement (the flag has to discriminate).
             File.Delete(expectedUserSeq);

--- a/src/housecarl-generator/SeqWriteGuardProbe.cs
+++ b/src/housecarl-generator/SeqWriteGuardProbe.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Skyrim;
@@ -412,7 +413,7 @@ internal static class SeqWriteGuardProbe
             // silent-success shape Q3 refuses, and the first line is what a caller reads.
             var toolSame = SeqTools.WriteSeq(svc, source: Path.GetFileName(svcPlugin), output_dir: userMod);
             Check(toolSame.StartsWith("unchanged", StringComparison.Ordinal)
-                  && toolSame.Contains("NOTHING was written", StringComparison.Ordinal)
+                  && toolSame.Contains(WriteSentences.Twins.SeqUnchanged, StringComparison.Ordinal)
                   && !toolSame.Contains("houseCARL mod folder — enable it", StringComparison.Ordinal),
                 $"RENDER-UNCHANGED the no-op renders as 'unchanged … NOTHING was written', and an output_dir destination is NOT called a houseCARL mod folder — render=[{Trim(toolSame)}]");
 
@@ -441,8 +442,11 @@ internal static class SeqWriteGuardProbe
             var jsonRepl = SeqTools.WriteSeq(svc, source: Path.GetFileName(svcPlugin), output_dir: userMod, format: "json");
             Check(jsonRepl.Contains("\"replaced\": true", StringComparison.Ordinal)
                   && jsonRepl.Contains("\"replaced_same_bytes\": false", StringComparison.Ordinal)
-                  && jsonRepl.Contains("replaced_note", StringComparison.Ordinal)
-                  && jsonRepl.Contains("no backup", StringComparison.Ordinal),
+                  // The json half of the pair whose text half pins the same construction above. Read through the
+                  // PARSED value, not the raw document: the writer escapes non-ASCII and apostrophes, so a raw
+                  // Contains would fail on the encoder's spelling rather than the render's.
+                  && JsonDocument.Parse(jsonRepl).RootElement.TryGetProperty("replaced_note", out var jrn)
+                  && jrn.GetString() == WriteSentences.Twins.SeqReplacedUserFolder,
                 $"REPLACED-JSON the replaced state and its note are on the json transport too — render=[{Trim(jsonRepl)}]");
 
             // LANE-ORDER: output_dir= + patch= + into= together is NOT refused. The pair-exclusivity check used to run

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -94,7 +94,11 @@ public static class WriteSurfaceGuardProbe
             CopyFromViewArm(root);
             CopySourcePathArm(fx, root);
             NestedParentHostArm(fx);
-            // Before the in-place arms: it forwards out of the fixture and reads the replacer as a known winner.
+            // Before the in-place arms: it reads the replacer as a known winner. It also WRITES — two new patch
+            // mod folders (W2Twin*, W2TwinApply) carrying overrides of SubjectFid and MasterOnlyFid, then removes
+            // records from W2TwinFwd.esp. Those patches are never ticked into plugins.txt, so they stay out of the
+            // active order and cannot move a later arm's winner; an arm added after this one should still know the
+            // folders exist.
             TwinParityArm(fx);
             // #324's arm also writes into the replacer IN PLACE (its second half is that lane), so it sits with the
             // in-place arms below rather than among the read-the-fixture ones. It rewrites the replacer TWICE and
@@ -2042,6 +2046,14 @@ public static class WriteSurfaceGuardProbe
         var twins = TwinSentences();
         Check("the twin inventory is non-empty (a reflection miss would make every check below vacuous)",
             twins.Count > 0, $"{twins.Count} members");
+        var unreadable = TwinShapesUnreadable();
+        Check("every Twins member is a shape this arm can enumerate (an unreadable one is an unchecked twin reported as covered)",
+            unreadable.Count == 0, unreadable.Count == 0 ? null : string.Join("; ", unreadable));
+        // The CONTENT half. Everything else in this arm asserts wiring — that a render reads the shared source —
+        // and wiring checks pass whatever the source says. This is the one that fails when a sentence is emptied.
+        var gutted = TwinContentViolations();
+        Check("every Twins sentence still states the claims it declares (a construction pin cannot see this — it reads the same constant the render does)",
+            gutted.Count == 0, gutted.Count == 0 ? null : string.Join("; ", gutted));
         var seenText = new HashSet<string>(StringComparer.Ordinal);
         var seenJson = new HashSet<string>(StringComparer.Ordinal);
 
@@ -2180,8 +2192,9 @@ public static class WriteSurfaceGuardProbe
         const int tight = 60;
         var tText = text(tight);
         var tJson = json(tight);
-        bool textCut = tText.Contains("[truncated:", StringComparison.Ordinal)
-                    || tText.Contains("... [", StringComparison.Ordinal);
+        // The ROW-list marker specifically. "... [" also opens the post-write report blocks' own cut notices, so
+        // the looser match would let a cut voice or cell block stand in for a row list that never truncated.
+        bool textCut = tText.Contains("... [truncated:", StringComparison.Ordinal);
         bool jsonCut = TryJson(tJson, out var tdoc) && RootFlag(tdoc, "truncated") == true;
         Check($"{label}: a cap that truncates one transport truncates the other (text={textCut} json={jsonCut})",
             total > 0 && textCut == jsonCut && textCut, $"TEXT: {Trim(tText)} || JSON: {Trim(tJson)}");
@@ -2226,14 +2239,54 @@ public static class WriteSurfaceGuardProbe
 
     /// <summary>The twin inventory, read off <see cref="WriteSentences.Twins"/> by reflection rather than listed
     /// here. A hand-listed inventory is the thing this whole change exists to stop: it would be a second copy of
-    /// the set, free to fall behind the first.</summary>
+    /// the set, free to fall behind the first.
+    /// <para>Returns the <c>const string</c> members. Anything else in that class is a shape this arm cannot read,
+    /// and <see cref="TwinShapesUnreadable"/> turns it into a FAILURE rather than a silent skip — a filter that
+    /// quietly dropped a <c>static readonly</c> twin would report full coverage of a set it had not seen.</para></summary>
     static IReadOnlyList<(string Name, string Sentence)> TwinSentences()
         => typeof(WriteSentences.Twins)
             .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
-            .Where(f => f.IsLiteral && !f.IsInitOnly && f.FieldType == typeof(string))
+            .Where(f => f.IsLiteral && f.FieldType == typeof(string))
             .Select(f => (f.Name, (string)f.GetRawConstantValue()!))
             .OrderBy(t => t.Name, StringComparer.Ordinal)
             .ToList();
+
+    /// <summary>Members of <c>Twins</c> that <see cref="TwinSentences"/> cannot enumerate — a non-const field, a
+    /// property, or a nested type. Any of them would be a twin the coverage assertion never checks while still
+    /// reporting "every member covered", so they are named and failed rather than filtered away.</summary>
+    static IReadOnlyList<string> TwinShapesUnreadable()
+    {
+        const BindingFlags All = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance;
+        var bad = new List<string>();
+        foreach (var f in typeof(WriteSentences.Twins).GetFields(All))
+            if (!(f.IsLiteral && f.FieldType == typeof(string))) bad.Add($"field {f.Name} ({f.FieldType.Name}, not a const string)");
+        foreach (var pr in typeof(WriteSentences.Twins).GetProperties(All)) bad.Add($"property {pr.Name}");
+        foreach (var n in typeof(WriteSentences.Twins).GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic)) bad.Add($"nested type {n.Name}");
+        return bad;
+    }
+
+    /// <summary>Twins whose declared load-bearing phrases are missing from the sentence itself — or which declare
+    /// none at all. THIS is the check a construction pin cannot make: <c>render.Contains(TheConstant)</c> reads the
+    /// same symbol the render does, so it passes whatever the constant says, including nothing. A commit that
+    /// replaced three of these sentences with placeholders passed the whole suite green; this is what would have
+    /// caught it, and requiring the attribute means a new twin cannot be added without declaring what it must say.</summary>
+    static IReadOnlyList<string> TwinContentViolations()
+    {
+        var bad = new List<string>();
+        foreach (var f in typeof(WriteSentences.Twins)
+                     .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+                     .Where(f => f.IsLiteral && f.FieldType == typeof(string))
+                     .OrderBy(f => f.Name, StringComparer.Ordinal))
+        {
+            var sentence = (string)f.GetRawConstantValue()!;
+            var attr = f.GetCustomAttribute<MustStateAttribute>();
+            if (attr is null || attr.Phrases.Length == 0) { bad.Add($"{f.Name}: declares no [MustState] phrases"); continue; }
+            foreach (var phrase in attr.Phrases)
+                if (!sentence.Contains(phrase, StringComparison.Ordinal))
+                    bad.Add($"{f.Name}: no longer states \"{phrase}\"");
+        }
+        return bad;
+    }
 
     static bool TryJson(string s, out JsonDocument? doc)
     {

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -2062,8 +2062,12 @@ public static class WriteSurfaceGuardProbe
         var gutted = TwinContentViolations();
         Check("every Twins sentence still states the claims it declares (a construction pin cannot see this — it reads the same constant the render does)",
             gutted.Count == 0, gutted.Count == 0 ? null : string.Join("; ", gutted));
+        var outer = OuterSentences();
         var seenText = new HashSet<string>(StringComparer.Ordinal);
         var seenJson = new HashSet<string>(StringComparer.Ordinal);
+        // The outer-class sentences are ONE-transport by design, so their claim is "reaches a render", not
+        // "reaches both". One set, either lane (residual C).
+        var seenOuter = new HashSet<string>(StringComparer.Ordinal);
 
         void Observe(string text, string json)
         {
@@ -2073,6 +2077,9 @@ public static class WriteSurfaceGuardProbe
                 if (text.Contains(sentence, StringComparison.Ordinal)) seenText.Add(name);
                 if (jsonText.Contains(sentence, StringComparison.Ordinal)) seenJson.Add(name);
             }
+            foreach (var (name, sentence) in outer)
+                if (text.Contains(sentence, StringComparison.Ordinal) || jsonText.Contains(sentence, StringComparison.Ordinal))
+                    seenOuter.Add(name);
         }
 
         // ---- the four write verbs, through the REAL tool path -----------------------------------------
@@ -2147,6 +2154,23 @@ public static class WriteSurfaceGuardProbe
         Observe(WriteTools.RenderCreate(reports), JsonWire.RenderCreateOutcome(reports, 0, false, "patch"));
         Observe(WriteTools.RenderCreate(reports, maxChars: 900), JsonWire.RenderCreateOutcome(reports, 900, false, "patch"));
 
+        // ---- the IN-PLACE and DRY-RUN lanes, for the outer-class sentences ---------------------------
+        // Built outcomes rather than real in-place writes: those rewrite a fixture file the later arms read as a
+        // known winner, and this arm deliberately runs before them. The claim under test is the RENDERERS' — that
+        // the hazard and the dry-run header still reach a caller — not the engine's, which the lane arms cover.
+        var inPlaceCreate = new WritePatchBuilder.CreateOutcome(
+            true, null, @"C:\mods\W2TwinIP\W2TwinIP.esp", false,
+            new[] { new WritePatchBuilder.CreatedRecord(default, "Keyword", "W2TwinIPKw", Array.Empty<WritePatchBuilder.OpResult>()) },
+            Array.Empty<string>(), 512)
+            { Epoch = "deadbeefdeadbeef", InPlace = true };
+        Observe(WriteTools.RenderCreate(inPlaceCreate), JsonWire.RenderCreateOutcome(inPlaceCreate, 0, false, "in_place"));
+
+        var inPlaceDryApply = new WritePatchBuilder.PatchOutcome(
+            true, null, @"C:\mods\W2TwinIP\W2TwinIP.esp", false,
+            Array.Empty<string>(), Array.Empty<WritePatchBuilder.OpResult>(), 512)
+            { Epoch = "deadbeefdeadbeef", InPlace = true, DryRun = true };
+        Observe(WriteTools.Render(inPlaceDryApply), JsonWire.RenderPatchOutcome(inPlaceDryApply, 0, false, "in_place"));
+
         // ---- write_seq -------------------------------------------------------------------------------
         // Every state that has its own sentence, so none of them is covered by an argument about the others: the
         // no-op, the byte-identical skip (with its timestamp stamp-forward), the three replace readings, and a cut
@@ -2182,6 +2206,12 @@ public static class WriteSurfaceGuardProbe
             missingText.Count == 0, missingText.Count == 0 ? null : "unobserved: " + string.Join(", ", missingText));
         Check("every WriteSentences.Twins member is rendered by the JSON lane (same, one transport over)",
             missingJson.Count == 0, missingJson.Count == 0 ? null : "unobserved: " + string.Join(", ", missingJson));
+        // …and the outer-class sentences REACH a render at all. A content pin says what a sentence must say; it
+        // cannot say that anything still emits it, and a render that inlines its own weaker copy leaves the const
+        // intact and passing (PR #337 re-review, residual C).
+        var missingOuter = outer.Select(t => t.Name).Where(n => !seenOuter.Contains(n)).ToList();
+        Check("every [MustState] sentence on WriteSentences itself reaches a render (the wiring half a content pin cannot provide)",
+            missingOuter.Count == 0, missingOuter.Count == 0 ? null : "unobserved: " + string.Join(", ", missingOuter));
     }
 
     /// <summary>The budget half of the twin harness: one outcome, one cap, both transports. Asserts (a) a cap tight
@@ -2259,6 +2289,22 @@ public static class WriteSurfaceGuardProbe
             .OrderBy(t => t.Name, StringComparer.Ordinal)
             .ToList();
 
+    /// <summary>The outer-class shared sentences — the ones that are prose on ONE transport by design, so per-LANE
+    /// parity is not a claim that can be made about them. Enumerated exactly as <see cref="TwinSentences"/>
+    /// enumerates its set, so the arm can assert each one still REACHES a render.
+    /// <para>Why enumerate rather than hand-write a Check per sentence (PR #337 re-review, residual C): the content
+    /// pin and the wiring pin are different claims, and only <c>InPlaceRewritten</c> had both. A hand-written line
+    /// would have closed that one sentence; this closes the class, so a sentence added to the outer class later
+    /// cannot get a content pin and silently miss the wiring one.</para></summary>
+    static IReadOnlyList<(string Name, string Sentence)> OuterSentences()
+        => typeof(WriteSentences)
+            .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .Where(f => f.IsLiteral && f.FieldType == typeof(string)
+                        && f.GetCustomAttribute<MustStateAttribute>() is not null)
+            .Select(f => (f.Name, (string)f.GetRawConstantValue()!))
+            .OrderBy(t => t.Name, StringComparer.Ordinal)
+            .ToList();
+
     /// <summary>Members of <c>Twins</c> that <see cref="TwinSentences"/> cannot enumerate — a non-const field, a
     /// property, or a nested type. Any of them would be a twin the coverage assertion never checks while still
     /// reporting "every member covered", so they are named and failed rather than filtered away.</summary>
@@ -2290,17 +2336,32 @@ public static class WriteSurfaceGuardProbe
         // BOTH classes (PR #337 review, finding 1). The in-place hazard lives on the outer class — json states it
         // as `lane` plus typed flags, so per-lane coverage is not a claim that can be made about it — but this
         // change made it a single token feeding five in-place renders, so it needs the content half most of all.
-        // Twins additionally REQUIRES the attribute; an outer-class sentence carries it when it has claims to keep.
-        foreach (var (owner, requireAttr) in new[] { (typeof(WriteSentences.Twins), true), (typeof(WriteSentences), false) })
+        //
+        // EVERY const on both classes must DECIDE: [MustState] phrases, or [NoClaims] with a stated reason. The
+        // outer walk used to skip an undecorated const, which left CellRowsCutLoss and DryRunHeader unchecked
+        // purely because nobody remembered them — absence-as-silence, where the safe state is the one you reach
+        // by doing nothing, and every sentence added later inherits it (PR #337 re-review, residual A).
+        foreach (var owner in new[] { typeof(WriteSentences.Twins), typeof(WriteSentences) })
         foreach (var f in owner.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly)
                      .Where(f => f.IsLiteral && f.FieldType == typeof(string))
                      .OrderBy(f => f.Name, StringComparer.Ordinal))
         {
             var sentence = (string)f.GetRawConstantValue()!;
             var attr = f.GetCustomAttribute<MustStateAttribute>();
+            var optOut = f.GetCustomAttribute<NoClaimsAttribute>();
+            if (attr is not null && optOut is not null)
+            {
+                bad.Add($"{f.Name}: declares BOTH [MustState] and [NoClaims] — pick one");
+                continue;
+            }
+            if (optOut is not null)
+            {
+                if (optOut.Reason.Trim().Length == 0) bad.Add($"{f.Name}: [NoClaims] with no stated reason");
+                continue;
+            }
             if (attr is null || attr.Phrases.Length == 0)
             {
-                if (requireAttr) bad.Add($"{f.Name}: declares no [MustState] phrases");
+                bad.Add($"{f.Name}: declares neither [MustState] phrases nor [NoClaims] with a reason");
                 continue;
             }
             // An EMPTY sentence or an EMPTY phrase clears every other assertion here and in the coverage arm —

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -595,6 +595,14 @@ public static class WriteSurfaceGuardProbe
             wrote.Contains("IN PLACE", StringComparison.Ordinal)
             && EditorIdsIn(Path.Combine(fx.ModsDir, "W2Repl", fx.ReplacerName)).Contains("W2InPlaceKw"), wrote);
 
+        // The HAZARD itself reaches the caller (PR #337 review, finding 1). Before this, nothing in the generator
+        // asserted the sentence at all: emptying one const would have stripped "houseCARL keeps nothing to undo
+        // this" from all five in-place renders with the whole suite green — the incident's shape on the loudest
+        // sentence the write surface has, and this change is what made it a single token. [MustState] pins what the
+        // sentence must SAY; this pins that the render still says it.
+        Check("create in place: the render states the rewrite hazard — the caller's own file, and no way back",
+            wrote.Contains(WriteSentences.InPlaceRewritten, StringComparison.Ordinal), wrote);
+
         // The closing "keep going" line must teach THIS tool's spelling (PR #311 round-2 review [medium]): the 2.0
         // tools declare a single string in_place= and no target=, so the 1.x pair would send a caller to an
         // undeclared parameter plus a boolean-into-a-string. Asserted as a positive AND a negative — the positive
@@ -2256,12 +2264,18 @@ public static class WriteSurfaceGuardProbe
     /// reporting "every member covered", so they are named and failed rather than filtered away.</summary>
     static IReadOnlyList<string> TwinShapesUnreadable()
     {
-        const BindingFlags All = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance;
+        const BindingFlags All = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance
+                               | BindingFlags.DeclaredOnly;
         var bad = new List<string>();
         foreach (var f in typeof(WriteSentences.Twins).GetFields(All))
             if (!(f.IsLiteral && f.FieldType == typeof(string))) bad.Add($"field {f.Name} ({f.FieldType.Name}, not a const string)");
         foreach (var pr in typeof(WriteSentences.Twins).GetProperties(All)) bad.Add($"property {pr.Name}");
         foreach (var n in typeof(WriteSentences.Twins).GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic)) bad.Add($"nested type {n.Name}");
+        // METHODS and EVENTS too (PR #337 review, finding 2). A method-shaped twin — one interpolation away from
+        // several existing ones — was invisible to BOTH the inventory and this alarm, so the coverage assertions
+        // reported "every member rendered" for a set that never included it. DeclaredOnly keeps object's members out.
+        foreach (var m in typeof(WriteSentences.Twins).GetMethods(All)) bad.Add($"method {m.Name}");
+        foreach (var e in typeof(WriteSentences.Twins).GetEvents(All)) bad.Add($"event {e.Name}");
         return bad;
     }
 
@@ -2273,17 +2287,33 @@ public static class WriteSurfaceGuardProbe
     static IReadOnlyList<string> TwinContentViolations()
     {
         var bad = new List<string>();
-        foreach (var f in typeof(WriteSentences.Twins)
-                     .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+        // BOTH classes (PR #337 review, finding 1). The in-place hazard lives on the outer class — json states it
+        // as `lane` plus typed flags, so per-lane coverage is not a claim that can be made about it — but this
+        // change made it a single token feeding five in-place renders, so it needs the content half most of all.
+        // Twins additionally REQUIRES the attribute; an outer-class sentence carries it when it has claims to keep.
+        foreach (var (owner, requireAttr) in new[] { (typeof(WriteSentences.Twins), true), (typeof(WriteSentences), false) })
+        foreach (var f in owner.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly)
                      .Where(f => f.IsLiteral && f.FieldType == typeof(string))
                      .OrderBy(f => f.Name, StringComparer.Ordinal))
         {
             var sentence = (string)f.GetRawConstantValue()!;
             var attr = f.GetCustomAttribute<MustStateAttribute>();
-            if (attr is null || attr.Phrases.Length == 0) { bad.Add($"{f.Name}: declares no [MustState] phrases"); continue; }
+            if (attr is null || attr.Phrases.Length == 0)
+            {
+                if (requireAttr) bad.Add($"{f.Name}: declares no [MustState] phrases");
+                continue;
+            }
+            // An EMPTY sentence or an EMPTY phrase clears every other assertion here and in the coverage arm —
+            // "".Contains("") is true, and so is any render's Contains("") (PR #337 review, finding 5). Mechanical,
+            // so it is fixed in the checker; judging whether a NON-empty phrase is a good one is not, and stays with
+            // the author (see MustStateAttribute's norm).
+            if (sentence.Length == 0) { bad.Add($"{f.Name}: the sentence itself is empty"); continue; }
             foreach (var phrase in attr.Phrases)
+            {
+                if (phrase.Length == 0) { bad.Add($"{f.Name}: declares an EMPTY phrase, which every sentence satisfies"); continue; }
                 if (!sentence.Contains(phrase, StringComparison.Ordinal))
                     bad.Add($"{f.Name}: no longer states \"{phrase}\"");
+            }
         }
         return bad;
     }

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -94,6 +94,8 @@ public static class WriteSurfaceGuardProbe
             CopyFromViewArm(root);
             CopySourcePathArm(fx, root);
             NestedParentHostArm(fx);
+            // Before the in-place arms: it forwards out of the fixture and reads the replacer as a known winner.
+            TwinParityArm(fx);
             // #324's arm also writes into the replacer IN PLACE (its second half is that lane), so it sits with the
             // in-place arms below rather than among the read-the-fixture ones. It rewrites the replacer TWICE and
             // changes two of its records: the TOPIC (W2Topic → "Master Topic") and the CELL (W2Cell → "Master Cell",
@@ -1676,19 +1678,22 @@ public static class WriteSurfaceGuardProbe
             && Num(rcdoc, "voice_coverage", "rendered_lines") is { } vr && vr < 40
             && Flag(rcdoc, "voice_coverage", "truncated") == true
             && Str(rcdoc, "voice_coverage", "truncated_note") is { } vnote
-            && vnote.Contains("plays SILENT", StringComparison.Ordinal)
+            && vnote.Contains(WriteSentences.Twins.VoiceStake, StringComparison.Ordinal)
             // and it must NOT prescribe re-issuing: this block rides a WRITE render.
             && !vnote.Contains("raise max_chars", StringComparison.OrdinalIgnoreCase), reportCapped);
 
         // The TEXT twins of those blocks must not contradict the json census (PR #311 review 7 [medium]): they rode
         // the create render still saying "raise max_chars to see the rest", i.e. re-issue a create — while the json
-        // block added one round earlier says "Do NOT re-issue the write to widen this". One call, two transports,
-        // opposite advice. Rendered directly, since the shared fixture's creates make no dialogue lines.
+        // block added one round earlier said "Do NOT re-issue the write to widen this". One call, two transports,
+        // opposite advice. Both now read WriteSentences.Twins.ReportBlockCut, so this pins the CONSTRUCTION: the
+        // sentence itself still refuses to prescribe the re-issue, and this render is reading that sentence.
+        // Rendered directly, since the shared fixture's creates make no dialogue lines.
         var voiceCappedText = WriteTools.RenderCreate(synthetic, maxChars: 900);
         Check("create text: the voice-coverage cut notice refuses to prescribe re-issuing the create",
             voiceCappedText.Contains("voice coverage truncated", StringComparison.Ordinal)
             && Bracket(voiceCappedText, "voice coverage truncated") is { } vct
-            && vct.Contains("Do NOT re-issue the create", StringComparison.Ordinal)
+            && WriteSentences.Twins.ReportBlockCut.Contains("Do NOT re-issue the create", StringComparison.Ordinal)
+            && vct.Contains(WriteSentences.Twins.ReportBlockCut, StringComparison.Ordinal)
             && !vct.Contains("raise max_chars to see the rest", StringComparison.Ordinal), voiceCappedText);
 
         // The cell-shell block was the LAST unbudgeted one on the write renders (PR #311 review 7 [low-medium],
@@ -1706,7 +1711,7 @@ public static class WriteSurfaceGuardProbe
             && cellCapped.Contains(" of 30 cell(s)", StringComparison.Ordinal)
             && !cellCapped.Contains("W2CellShell29", StringComparison.Ordinal), cellCapped);
         Check("create text: a CUT cell-shell block still renders the grid-occupancy seam below it",
-            cellCapped.Contains("does NOT check grid-occupancy", StringComparison.Ordinal), cellCapped);
+            cellCapped.Contains(WriteSentences.Twins.GridOccupancy, StringComparison.Ordinal), cellCapped);
 
         var cellFull = WriteTools.RenderCreate(cellOutcome);
         Check("create text: without a cap every cell renders (the budget is not a permanent cut)",
@@ -2001,6 +2006,205 @@ public static class WriteSurfaceGuardProbe
             seqText.Contains("no start-game-enabled quests", StringComparison.Ordinal)
             && seqText.Contains("read from", StringComparison.Ordinal), seqText);
     }
+
+    // ---- the D2 twin harness (response layer by construction) ---------------------------------------
+
+    /// <summary>ARM 12 — the D2 TWIN HARNESS. Every other arm in this file renders ONE transport and asserts what
+    /// it says. This one renders BOTH from the SAME outcome object and asserts they cannot have drifted apart —
+    /// which is the finding class the 2.0 review wave produced more of than any other (a rule, budget, cap or
+    /// wording landing on one lane and not its twin), converted from a per-finding obligation into a standing check.
+    ///
+    /// <para><b>What it pins, and what it deliberately does not.</b> The check is COVERAGE per lane, not
+    /// co-occurrence per outcome: every sentence in <see cref="WriteSentences.Twins"/> must be observed coming out
+    /// of the TEXT renders at least once and out of the JSON renders at least once, across the outcomes below. That
+    /// is the detector for the failure that matters — a lane quietly growing its own copy of a shared sentence,
+    /// which makes the constant stop appearing on that lane. It is NOT "both transports carry every sentence on
+    /// every outcome", because a few of these legitimately land in different places on the two lanes (the text
+    /// report blocks state their stake in the block HEADER; the json blocks state it in the truncation census), and
+    /// asserting a co-occurrence that was never the design would fail honest renders.</para>
+    ///
+    /// <para>By construction: adding a member to <c>Twins</c> enrols it — if no outcome here exercises it on both
+    /// lanes, the coverage assertion NAMES it and fails, so a new shared sentence cannot be added without a render
+    /// on each transport actually reading it. Two further parity assertions ride per outcome: the BUDGET (a cap
+    /// that truncates one transport truncates the other) and the COUNTS (the total each lane states is the same
+    /// number).</para></summary>
+    static void TwinParityArm(Fixture fx)
+    {
+        Console.WriteLine("── ARM 12: D2 TWIN PARITY — one outcome, both transports, one source per sentence ──");
+
+        var twins = TwinSentences();
+        Check("the twin inventory is non-empty (a reflection miss would make every check below vacuous)",
+            twins.Count > 0, $"{twins.Count} members");
+        var seenText = new HashSet<string>(StringComparer.Ordinal);
+        var seenJson = new HashSet<string>(StringComparer.Ordinal);
+
+        void Observe(string text, string json)
+        {
+            var jsonText = JsonStrings(json);
+            foreach (var (name, sentence) in twins)
+            {
+                if (text.Contains(sentence, StringComparison.Ordinal)) seenText.Add(name);
+                if (jsonText.Contains(sentence, StringComparison.Ordinal)) seenJson.Add(name);
+            }
+        }
+
+        // ---- the four write verbs, through the REAL tool path -----------------------------------------
+        // Budget + count parity is asserted on outcomes the engine produced, not on hand-built ones: a cap that
+        // truncates the text list and not the json array (or vice versa) is the divergence, and only a real
+        // multi-row outcome can show it. Three records is enough — the cap is set below the row block, not below
+        // the row count.
+        var createSpec = new[] { "W2TwinA", "W2TwinB", "W2TwinC" }
+            .Select(e => new CreateOp { RecordType = "Keyword", Editorid = e }).ToList();
+        var createOutcome = fx.Svc.CreateRecordsBatch(createSpec, "W2Twin", null);
+        BudgetParity("create", createOutcome.Created.Count,
+            cap => WriteTools.RenderCreate(createOutcome, cap),
+            cap => JsonWire.RenderCreateOutcome(createOutcome, cap, false, "patch"),
+            "total_created", $"created {createOutcome.Created.Count} records");
+        Observe(WriteTools.RenderCreate(createOutcome), JsonWire.RenderCreateOutcome(createOutcome, 0, false, "patch"));
+
+        var fwdOutcome = fx.Svc.ForwardRecords(new[] { fx.SubjectFid, fx.MasterOnlyFid }, fx.MasterName, "W2TwinFwd", null);
+        BudgetParity("forward", fwdOutcome.Forwarded.Count,
+            cap => WriteTools.RenderForward(fwdOutcome, cap),
+            cap => JsonWire.RenderForwardOutcome(fwdOutcome, cap, false, "patch"),
+            "total_forwarded", $"forwarded {fwdOutcome.Forwarded.Count} records");
+        Observe(WriteTools.RenderForward(fwdOutcome), JsonWire.RenderForwardOutcome(fwdOutcome, 0, false, "patch"));
+
+        // ---- the three post-write report blocks -------------------------------------------------------
+        // Rendered off a built outcome for the same reason the report-budget arm above builds one: a report big
+        // enough to cut means dozens of voiced lines, and the claim under test is the RENDERERS' agreement, not the
+        // engines'. Voice + result-script + an EXTERIOR cell together reach every create-side twin, and the capped
+        // pass is what puts the json lane's stake clauses (which ride its truncation census) on the wire.
+        var lines = Enumerable.Range(0, 40).Select(i => new VoiceLine(
+            default, "W2TwinTopic", i,
+            $@"sound\voice\W2.esp\MaleNord\W2TwinTopic_{i:D4}.fuz", false, null, false,
+            $@"sound\voice\W2.esp\MaleNord\W2TwinTopic_{i:D4}.lip", false, false)).ToList();
+        var findings = Enumerable.Range(0, 40).Select(i => new ScriptBindingFinding(
+            default, "W2TwinTopic", ScriptBindingStatus.ScriptNotCompiled,
+            new[] { "W2TwinFrag" }, new[] { $@"scripts\W2TwinFrag{i:D2}.pex" }, false,
+            "the bound script has no compiled .pex on disk")).ToList();
+        var shells = Enumerable.Range(0, 30).Select(i => new CellShell(
+            default, $"W2TwinCell{i:D2}", i % 2 == 0,
+            new[] { "lighting template", "terrain / landscape", "water height", "navmesh" })).ToList();
+        var reports = new WritePatchBuilder.CreateOutcome(
+            true, null, @"C:\mods\W2Twin\W2Twin.esp", false,
+            new[] { new WritePatchBuilder.CreatedRecord(default, "DialogResponses", "W2TwinL1", Array.Empty<WritePatchBuilder.OpResult>()) },
+            Array.Empty<string>(), 512)
+            {
+                Epoch = "deadbeefdeadbeef",
+                Voice = new VoiceReport(lines, Array.Empty<VoiceUndetermined>()),
+                ScriptBinding = new ScriptBindingReport(findings),
+                CellShell = new CellShellReport(shells),
+            };
+        Observe(WriteTools.RenderCreate(reports), JsonWire.RenderCreateOutcome(reports, 0, false, "patch"));
+        Observe(WriteTools.RenderCreate(reports, maxChars: 900), JsonWire.RenderCreateOutcome(reports, 900, false, "patch"));
+
+        // ---- write_seq -------------------------------------------------------------------------------
+        // Every state that has its own sentence, so none of them is covered by an argument about the others: the
+        // no-op, the byte-identical skip (with its timestamp stamp-forward), the three replace readings, and a cut
+        // quest list. write_seq is where the two transports had drifted furthest — one lane's notes were paraphrases
+        // of the other's — so it gets the widest sweep here.
+        var quests = Enumerable.Range(0, 60)
+            .Select(i => new HousecarlCore.SeqFile.SeqQuest(default, $"W2TwinQ{i:D2}", (uint)(0x800 + i))).ToList();
+        SeqOutcome Seq(IReadOnlyList<HousecarlCore.SeqFile.SeqQuest> qs) => new(
+            true, null, @"C:\mods\W2TwinSeq\SEQ\W2Twin.seq", "W2TwinSeq", qs, "W2Twin.esp", false)
+            { ResolvedFrom = "direct path", PluginPath = @"C:\mods\W2TwinSeq\W2Twin.esp" };
+
+        var seqStates = new[]
+        {
+            Seq(Array.Empty<HousecarlCore.SeqFile.SeqQuest>()),                                      // the no-op
+            Seq(quests) with { Unchanged = true, TimestampRefreshed = true },                        // skip + stamp
+            Seq(quests) with { Replaced = true, ReplacedSameBytes = true },                          // same-bytes replace
+            Seq(quests) with { Replaced = true, UserChoseOutput = true },                            // the caller's folder
+            Seq(quests) with { Replaced = true },                                                    // houseCARL's own
+        };
+        foreach (var st in seqStates)
+            Observe(SeqTools.Render(st), JsonWire.RenderSeqOutcome(st, 0));
+        // …and the cut quest list, whose remedy is one sentence on both lanes.
+        Observe(SeqTools.Render(seqStates[2], maxChars: 400), JsonWire.RenderSeqOutcome(seqStates[2], 400));
+        BudgetParity("write_seq", quests.Count,
+            cap => SeqTools.Render(seqStates[2], cap),
+            cap => JsonWire.RenderSeqOutcome(seqStates[2], cap),
+            "quest_count", $"{quests.Count} start-game-enabled quests");
+
+        // ---- the coverage assertion — what stops this arm being theatre ------------------------------
+        var missingText = twins.Select(t => t.Name).Where(n => !seenText.Contains(n)).ToList();
+        var missingJson = twins.Select(t => t.Name).Where(n => !seenJson.Contains(n)).ToList();
+        Check("every WriteSentences.Twins member is rendered by the TEXT lane (an unobserved one is a lane that stopped reading the shared source, or a twin nothing exercises)",
+            missingText.Count == 0, missingText.Count == 0 ? null : "unobserved: " + string.Join(", ", missingText));
+        Check("every WriteSentences.Twins member is rendered by the JSON lane (same, one transport over)",
+            missingJson.Count == 0, missingJson.Count == 0 ? null : "unobserved: " + string.Join(", ", missingJson));
+    }
+
+    /// <summary>The budget half of the twin harness: one outcome, one cap, both transports. Asserts (a) a cap tight
+    /// enough to cut ONE lane's rows cuts the other's too — the divergence that shipped repeatedly, where a text
+    /// list rendered unbounded and took a SILENT host-side cut while its json twin stopped at the cap and closed
+    /// <c>truncated:true</c> — and (b) uncapped, neither reports a cut. The COUNT parity rides along: the total
+    /// each lane states about the same outcome is the same number, cut or not.</summary>
+    static void BudgetParity(string label, int total, Func<int, string> text, Func<int, string> json,
+                             string jsonTotalMember, string textTotalPhrase)
+    {
+        // 60 chars is below EVERY one of these renders' header block, so both lanes stop at row 0. Deliberately not
+        // a cap that merely lands mid-list: the two lanes measure different things (a StringBuilder's chars vs a
+        // serialized document's bytes, one of them indented), so any cap inside the rows cuts them at different
+        // rows — which is a formatting difference, not the divergence under test. What must agree is WHETHER a cut
+        // happened and whether it was stated.
+        const int tight = 60;
+        var tText = text(tight);
+        var tJson = json(tight);
+        bool textCut = tText.Contains("[truncated:", StringComparison.Ordinal)
+                    || tText.Contains("... [", StringComparison.Ordinal);
+        bool jsonCut = TryJson(tJson, out var tdoc) && RootFlag(tdoc, "truncated") == true;
+        Check($"{label}: a cap that truncates one transport truncates the other (text={textCut} json={jsonCut})",
+            total > 0 && textCut == jsonCut && textCut, $"TEXT: {Trim(tText)} || JSON: {Trim(tJson)}");
+
+        var fText = text(0);
+        var fJson = json(0);
+        Check($"{label}: uncapped, NEITHER transport reports a cut",
+            !fText.Contains("[truncated:", StringComparison.Ordinal)
+            && TryJson(fJson, out var fdoc) && RootFlag(fdoc, "truncated") != true,
+            $"TEXT: {Trim(fText)} || JSON: {Trim(fJson)}");
+
+        // The TRUE total survives the cut on both lanes — the whole point of the total/rendered pair is that a
+        // truncated caller still knows how many it is not seeing.
+        Check($"{label}: both transports state the SAME total ({total}), and state it even when cut",
+            TryJson(tJson, out var cdoc) && cdoc!.RootElement.TryGetProperty(jsonTotalMember, out var jt)
+            && jt.GetInt32() == total
+            && tText.Contains(textTotalPhrase, StringComparison.Ordinal),
+            $"TEXT: {Trim(tText)} || JSON: {Trim(tJson)}");
+    }
+
+    /// <summary>Every string VALUE in a json document, unescaped and concatenated. The json writer escapes
+    /// non-ASCII (an em-dash ships as <c>\u2014</c>), so a raw <c>Contains</c> against the document text would
+    /// report a shared sentence as absent from the json lane and fail the arm for the encoder's reasons rather
+    /// than the render's.</summary>
+    static string JsonStrings(string raw)
+    {
+        var sb = new System.Text.StringBuilder();
+        using var doc = JsonDocument.Parse(raw);
+        Walk(doc.RootElement, sb);
+        return sb.ToString();
+
+        static void Walk(JsonElement e, System.Text.StringBuilder sb)
+        {
+            switch (e.ValueKind)
+            {
+                case JsonValueKind.Object: foreach (var p in e.EnumerateObject()) Walk(p.Value, sb); break;
+                case JsonValueKind.Array: foreach (var v in e.EnumerateArray()) Walk(v, sb); break;
+                case JsonValueKind.String: sb.Append(e.GetString()).Append('\n'); break;
+            }
+        }
+    }
+
+    /// <summary>The twin inventory, read off <see cref="WriteSentences.Twins"/> by reflection rather than listed
+    /// here. A hand-listed inventory is the thing this whole change exists to stop: it would be a second copy of
+    /// the set, free to fall behind the first.</summary>
+    static IReadOnlyList<(string Name, string Sentence)> TwinSentences()
+        => typeof(WriteSentences.Twins)
+            .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Where(f => f.IsLiteral && !f.IsInitOnly && f.FieldType == typeof(string))
+            .Select(f => (f.Name, (string)f.GetRawConstantValue()!))
+            .OrderBy(t => t.Name, StringComparer.Ordinal)
+            .ToList();
 
     static bool TryJson(string s, out JsonDocument? doc)
     {

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -1803,7 +1803,7 @@ public static class WriteSurfaceGuardProbe
             """));
         Check("create text render: max_chars= drops trailing created rows with an explicit notice",
             createCapped.Contains("[truncated:", StringComparison.Ordinal)
-            && createCapped.Contains("every one WAS created", StringComparison.Ordinal)
+            && createCapped.Contains(WriteSentences.RowsCutOperationIntact(false, "created"), StringComparison.Ordinal)
             && !createCapped.Contains("W2CreCapC", StringComparison.Ordinal), createCapped);
 
         // The remedy must be a READ, never "re-run this call" (PR #311 review 3 round-2 [medium]): repeating a
@@ -1817,7 +1817,10 @@ public static class WriteSurfaceGuardProbe
         Check("create's truncation notice points at a READ, never at raising max_chars (a repeat would re-create)",
             createCapped.Contains("housecarl_records source=", StringComparison.Ordinal)
             && createCapped.Contains("types=[\"Keyword\"]", StringComparison.Ordinal)
-            && createCapped.Contains("would create them AGAIN", StringComparison.Ordinal)
+            // A CONSTRUCTION pin: the trap sentence is one source both transports read, so this asserts the
+            // sentence still names the re-allocation AND that this render is reading it.
+            && WriteSentences.Twins.CreateReissueTrap.Contains("allocates the records AGAIN", StringComparison.Ordinal)
+            && createCapped.Contains(WriteSentences.Twins.CreateReissueTrap, StringComparison.Ordinal)
             && !createCapped.Contains("raise max_chars", StringComparison.Ordinal), createCapped);
 
         // The remedy EXERCISED — parsed OUT of the notice this render just produced and RUN, rather than compared
@@ -1929,14 +1932,18 @@ public static class WriteSurfaceGuardProbe
         Check("write_seq text render: max_chars= drops trailing quest rows with an explicit notice",
             seqCapped.Contains("[truncated:", StringComparison.Ordinal)
             && seqCapped.Contains("max_chars=80", StringComparison.Ordinal)
-            && seqCapped.Contains("the .seq itself carries ALL of them", StringComparison.Ordinal)
+            && seqCapped.Contains(WriteSentences.Twins.SeqListCutRemedy, StringComparison.Ordinal)
             && !seqCapped.Contains("HcSeqQuestCharlie", StringComparison.Ordinal), seqCapped);
         // …and the notice must not prescribe a re-run: widening the ceiling re-runs a WRITE, which with no lane
         // named for a plugin outside a houseCARL folder cuts a SECOND auto-suffixed folder holding a duplicate
         // .seq. Nothing is missing from the file, so the notice says that and prices the re-run instead.
+        // A CONSTRUCTION pin: the remedy is one source both transports read, so the claims are asserted ON the
+        // sentence — nothing is missing from the FILE, and a re-run is priced rather than prescribed — and the
+        // render is asserted to be reading it.
         Check("write_seq's truncation notice prices the re-run instead of prescribing 'raise max_chars'",
-            seqCapped.Contains("nothing is missing from the FILE", StringComparison.Ordinal)
-            && seqCapped.Contains("writes the .seq again", StringComparison.Ordinal)
+            WriteSentences.Twins.SeqListCutRemedy.Contains("nothing is missing from the FILE", StringComparison.Ordinal)
+            && WriteSentences.Twins.SeqListCutRemedy.Contains("writes the .seq again", StringComparison.Ordinal)
+            && seqCapped.Contains(WriteSentences.Twins.SeqListCutRemedy, StringComparison.Ordinal)
             && !seqCapped.Contains("raise max_chars", StringComparison.Ordinal), seqCapped);
 
         var seqUncapped = SeqTools.Render(seqOutcome);
@@ -1960,8 +1967,8 @@ public static class WriteSurfaceGuardProbe
             TryJson(seqJsonCapped, out var sjdoc)
             && sjdoc!.RootElement.GetProperty("truncated").GetBoolean()
             && sjdoc.RootElement.GetProperty("truncated_note").GetString() is { } sjnote
-            && sjnote.Contains("nothing is missing from the FILE", StringComparison.Ordinal)
-            && sjnote.Contains("writes the .seq again", StringComparison.Ordinal)
+            // The SAME construction the text arm pins, which is now what "says the SAME thing" means literally.
+            && sjnote.Contains(WriteSentences.Twins.SeqListCutRemedy, StringComparison.Ordinal)
             && !sjnote.Contains("raise max_chars", StringComparison.Ordinal), seqJsonCapped);
 
         // LANE exclusivity on write_seq (PR #311 review 4 [low]): both spellings are labelled LANE: by this PR, and
@@ -2061,6 +2068,8 @@ public static class WriteSurfaceGuardProbe
             cap => JsonWire.RenderCreateOutcome(createOutcome, cap, false, "patch"),
             "total_created", $"created {createOutcome.Created.Count} records");
         Observe(WriteTools.RenderCreate(createOutcome), JsonWire.RenderCreateOutcome(createOutcome, 0, false, "patch"));
+        // …and the CUT render, whose remedy sentence only exists on a truncated one.
+        Observe(WriteTools.RenderCreate(createOutcome, 60), JsonWire.RenderCreateOutcome(createOutcome, 60, false, "patch"));
 
         var fwdOutcome = fx.Svc.ForwardRecords(new[] { fx.SubjectFid, fx.MasterOnlyFid }, fx.MasterName, "W2TwinFwd", null);
         BudgetParity("forward", fwdOutcome.Forwarded.Count,
@@ -2068,6 +2077,26 @@ public static class WriteSurfaceGuardProbe
             cap => JsonWire.RenderForwardOutcome(fwdOutcome, cap, false, "patch"),
             "total_forwarded", $"forwarded {fwdOutcome.Forwarded.Count} records");
         Observe(WriteTools.RenderForward(fwdOutcome), JsonWire.RenderForwardOutcome(fwdOutcome, 0, false, "patch"));
+
+        // APPLY and REMOVE complete the verb set. apply is the one that mattered: its text ops loop was the last
+        // unbounded row list on the write surface while its json twin budgeted the same array, so before this arm
+        // existed a large bulk_apply truncated on one transport and took a silent host cut on the other.
+        var applyOutcome = fx.Svc.ApplyEdits(
+            new[] { fx.SubjectFid, fx.MasterOnlyFid }
+                .Select(f => new BulkOp { Formid = f, FieldPath = "EditorID", Value = "W2TwinEd" }).ToList(),
+            "W2TwinApply", null);
+        BudgetParity("apply", applyOutcome.Ops.Count,
+            cap => WriteTools.Render(applyOutcome, cap),
+            cap => JsonWire.RenderPatchOutcome(applyOutcome, cap, false, "patch"),
+            "total_ops", $"{applyOutcome.Ops.Count} edits");
+        Observe(WriteTools.Render(applyOutcome, 60), JsonWire.RenderPatchOutcome(applyOutcome, 60, false, "patch"));
+
+        var rmOutcome = fx.Svc.RemoveRecords(new[] { fx.SubjectFid, fx.MasterOnlyFid }, "W2TwinFwd.esp");
+        BudgetParity("remove", rmOutcome.Removed.Count,
+            cap => WriteTools.RenderRemoval(rmOutcome, cap),
+            cap => JsonWire.RenderRemovalOutcome(rmOutcome, cap, "into"),
+            "total_removed", $"removed {rmOutcome.Removed.Count} records");
+        Observe(WriteTools.RenderRemoval(rmOutcome, 60), JsonWire.RenderRemovalOutcome(rmOutcome, 60, "into"));
 
         // ---- the three post-write report blocks -------------------------------------------------------
         // Rendered off a built outcome for the same reason the report-budget arm above builds one: a report big

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -172,7 +172,7 @@ static class JsonWire
         w.WriteEndObject();
     }
 
-    static int Cap(int maxChars) => maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+    static int Cap(int maxChars) => WriteSentences.Cap(maxChars);   // one budget rule, both transports
 
     /// <summary>A bare whole-call refusal document: <c>{error, epoch?}</c> — for tool-layer refusals that have no
     /// outcome object to render (e.g. the §2.1.1 artifact epoch-mismatch handed back beside the batch), matching
@@ -198,6 +198,53 @@ static class JsonWire
     {
         w.Flush();
         return ms.Length >= cap;
+    }
+
+    /// <summary>The post-write READ-BACK block, one construction for all three write documents (apply / create /
+    /// forward). It was written out three times, verbatim down to the comment — and the two facts it tells apart
+    /// are exactly the kind that drift when copied: <c>readback_source</c> (the WRITTEN FILE's content, or a dry
+    /// run's in-memory would-be content — never load-order truth, which is what the text render spells out in a
+    /// sentence), and the <c>readback_full</c>/<c>readback_requested</c> split.
+    /// <para><c>readback_full</c> describes THIS DOCUMENT: the json renders emit every field of every row, so a
+    /// present read-back is always the full one. It used to carry the caller's ASK, which the in-place lanes
+    /// override (the service forces fullReadback), so <c>false</c> sat next to a complete field dump and a consumer
+    /// branching on "are these fields complete?" got the opposite of the truth (PR #311 review 7 [nit]).
+    /// <c>readback_requested</c> keeps the ask, which is what answers "why did I get one I did not ask for?"</para>
+    /// <para>Rows and their field lists both stop at the budget and set <paramref name="truncated"/> — the document
+    /// stays valid JSON and says it was cut, never a string severed mid-token.</para></summary>
+    static void WriteReadbackBlock(Utf8JsonWriter w, MemoryStream ms, int cap,
+        IReadOnlyList<WritePatchBuilder.FullReadback> rb, bool dryRun, bool requested, ref bool truncated)
+    {
+        w.WriteString("readback_source", dryRun ? "in_memory_would_be_content" : "written_file");
+        w.WriteBoolean("readback_full", true);
+        w.WriteBoolean("readback_requested", requested);
+        w.WriteStartArray("readback");
+        foreach (var r in rb)
+        {
+            if (Over(w, ms, cap)) { truncated = true; break; }
+            w.WriteStartObject();
+            w.WriteString("formid", r.Target.ToString());
+            if (r.Error is not null) w.WriteString("error", r.Error);
+            else
+            {
+                var rec = r.Record!;
+                w.WriteString("type", rec.Type);
+                WriteNullable(w, "editorid", rec.EditorId);
+                w.WriteNumber("field_count", rec.Fields.Count);
+                w.WriteStartArray("fields");
+                foreach (var f in rec.Fields)
+                {
+                    if (Over(w, ms, cap)) { truncated = true; break; }
+                    w.WriteStartObject();
+                    w.WriteString("path", f.Path);
+                    if (f.HasValue) w.WriteString("value", f.Token); else w.WriteString("note", f.Note);
+                    w.WriteEndObject();
+                }
+                w.WriteEndArray();
+            }
+            w.WriteEndObject();
+        }
+        w.WriteEndArray();
     }
 
     static void WriteStringArray(Utf8JsonWriter w, string name, IReadOnlyList<string> items)
@@ -1588,48 +1635,7 @@ static class JsonWire
             w.WriteEndArray();
             w.WriteNumber("rendered_ops", renderedOps);
 
-            if (o.ReadBack is { } rb)
-            {
-                // The read-back is the WRITTEN FILE's content, not load-order truth — stated as data (`source`) so a
-                // json consumer cannot lose the distinction the text render spells out in a sentence.
-                w.WriteString("readback_source", o.DryRun ? "in_memory_would_be_content" : "written_file");
-                // Two DIFFERENT facts, told apart (PR #311 review 7 [nit]). `readback_full` describes THIS
-                // DOCUMENT: the json renders emit every field of every read-back row, so a present read-back
-                // is always the full one. It used to carry the caller's ASK, which the in-place lanes override
-                // (the service forces fullReadback), so `false` sat next to a complete field dump and a
-                // consumer branching on "are these fields complete?" got the opposite of the truth.
-                // `readback_requested` keeps the ask, which is what answers "why did I get one I did not ask
-                // for?" — the in-place lane forced it.
-                w.WriteBoolean("readback_full", true);
-                w.WriteBoolean("readback_requested", readback);
-                w.WriteStartArray("readback");
-                foreach (var r in rb)
-                {
-                    if (Over(w, ms, cap)) { truncated = true; break; }
-                    w.WriteStartObject();
-                    w.WriteString("formid", r.Target.ToString());
-                    if (r.Error is not null) w.WriteString("error", r.Error);
-                    else
-                    {
-                        var rec = r.Record!;
-                        w.WriteString("type", rec.Type);
-                        WriteNullable(w, "editorid", rec.EditorId);
-                        w.WriteNumber("field_count", rec.Fields.Count);
-                        w.WriteStartArray("fields");
-                        foreach (var f in rec.Fields)
-                        {
-                            if (Over(w, ms, cap)) { truncated = true; break; }
-                            w.WriteStartObject();
-                            w.WriteString("path", f.Path);
-                            if (f.HasValue) w.WriteString("value", f.Token); else w.WriteString("note", f.Note);
-                            w.WriteEndObject();
-                        }
-                        w.WriteEndArray();
-                    }
-                    w.WriteEndObject();
-                }
-                w.WriteEndArray();
-            }
+            if (o.ReadBack is { } rb) WriteReadbackBlock(w, ms, cap, rb, o.DryRun, readback, ref truncated);
 
             WriteNullable(w, "note", o.Note);
             w.WriteBoolean("truncated", truncated);
@@ -1637,8 +1643,7 @@ static class JsonWire
             // re-issue to widen it is safe on into=/dry-run but cuts a second patch on the default lane and
             // re-serializes the caller's own file on in_place.
             if (truncated)
-                w.WriteString("truncated_note",
-                    $"the render hit max_chars={cap} and dropped trailing rows — the WRITE is complete and unaffected; "
+                w.WriteString("truncated_note", WriteSentences.JsonRowsCut(cap, "WRITE")
                     + WriteTools.ApplyAgainRemedy(o, Path.GetFileName(o.OutputPath)) + ".");
             w.WriteEndObject();
         }
@@ -1737,46 +1742,7 @@ static class JsonWire
             WriteScriptBindingReport(w, o.ScriptBinding, ms, cap, ref truncated);
             WriteCellShellReport(w, o.CellShell, ms, cap, ref truncated);
 
-            if (o.ReadBack is { } rb)
-            {
-                w.WriteString("readback_source", "written_file");
-                // Two DIFFERENT facts, told apart (PR #311 review 7 [nit]). `readback_full` describes THIS
-                // DOCUMENT: the json renders emit every field of every read-back row, so a present read-back
-                // is always the full one. It used to carry the caller's ASK, which the in-place lanes override
-                // (the service forces fullReadback), so `false` sat next to a complete field dump and a
-                // consumer branching on "are these fields complete?" got the opposite of the truth.
-                // `readback_requested` keeps the ask, which is what answers "why did I get one I did not ask
-                // for?" — the in-place lane forced it.
-                w.WriteBoolean("readback_full", true);
-                w.WriteBoolean("readback_requested", readback);
-                w.WriteStartArray("readback");
-                foreach (var r in rb)
-                {
-                    if (Over(w, ms, cap)) { truncated = true; break; }
-                    w.WriteStartObject();
-                    w.WriteString("formid", r.Target.ToString());
-                    if (r.Error is not null) w.WriteString("error", r.Error);
-                    else
-                    {
-                        var rec = r.Record!;
-                        w.WriteString("type", rec.Type);
-                        WriteNullable(w, "editorid", rec.EditorId);
-                        w.WriteNumber("field_count", rec.Fields.Count);
-                        w.WriteStartArray("fields");
-                        foreach (var f in rec.Fields)
-                        {
-                            if (Over(w, ms, cap)) { truncated = true; break; }
-                            w.WriteStartObject();
-                            w.WriteString("path", f.Path);
-                            if (f.HasValue) w.WriteString("value", f.Token); else w.WriteString("note", f.Note);
-                            w.WriteEndObject();
-                        }
-                        w.WriteEndArray();
-                    }
-                    w.WriteEndObject();
-                }
-                w.WriteEndArray();
-            }
+            if (o.ReadBack is { } rb) WriteReadbackBlock(w, ms, cap, rb, false, readback, ref truncated);
 
             WriteNullable(w, "note", o.Note);
             w.WriteBoolean("truncated", truncated);
@@ -1786,8 +1752,7 @@ static class JsonWire
             // asked: the text twin was moved off this wording one fold earlier and the json document kept it, so a
             // json client raising max_chars and re-issuing walked into exactly what the fix existed to prevent.
             if (truncated)
-                w.WriteString("truncated_note",
-                    $"the render hit max_chars={cap} and dropped trailing rows — the WRITE is complete and unaffected; every record WAS created. " +
+                w.WriteString("truncated_note", WriteSentences.JsonRowsCut(cap, "WRITE") + "every record WAS created. " +
                     $"Read them back with {WriteTools.ReadBackCall(o, Path.GetFileName(o.OutputPath))} — do NOT re-issue this call to see the rest: a repeated create " +
                     "allocates the records AGAIN (on the default lane patch= auto-suffixes into a second full patch; under into= each record is " +
                     "re-created at its old FormID with its prior contents discarded).");
@@ -1813,7 +1778,7 @@ static class JsonWire
             w.WriteStartObject();
             w.WriteBoolean("ok", o.Success);
             w.WriteNull("epoch");
-            w.WriteString("epoch_note", "a .seq is derived from the plugin FILE alone (its FormID encoding is load-order-independent), so this call consulted no load-order build — the absent stamp is a fact, not a dropped field.");
+            w.WriteString("epoch_note", WriteSentences.Twins.SeqNoEpoch);
             if (!o.Success)
             {
                 WriteNullable(w, "error", o.Error);
@@ -1832,14 +1797,15 @@ static class JsonWire
             w.WriteBoolean("replaced_same_bytes", o.ReplacedSameBytes);
             w.WriteBoolean("timestamp_refreshed", o.TimestampRefreshed);
             if (o.Unchanged)
-                w.WriteString("unchanged_note", "the destination already held EXACTLY these bytes, so nothing was written — seq_path names the file that was already current. Stated rather than reported as a write (Q3: a skipped write and a done one must not look alike)."
-                    + (o.TimestampRefreshed ? " Its mtime was older than the plugin and has been stamped forward (contents untouched); validate_dialogue's SEQ staleness check compares those two mtimes, so this file no longer reads as stale — for the copy the load order actually serves, which is this one only if this folder wins the SEQ\\ conflict." : ""));
+                w.WriteString("unchanged_note", WriteSentences.Twins.SeqUnchanged
+                    + " — seq_path names the file that was already current. Stated rather than reported as a write (Q3: a skipped write and a done one must not look alike)."
+                    + (o.TimestampRefreshed ? " " + WriteSentences.Twins.SeqTimestampRefreshed : ""));
             if (o.Replaced)
                 w.WriteString("replaced_note", o.ReplacedSameBytes
-                    ? "the file already at seq_path held EXACTLY these bytes; it was rewritten only because its timestamp could not be refreshed in place, so nothing was lost."
+                    ? WriteSentences.Twins.SeqReplacedSameBytes
                     : o.UserChoseOutput
-                    ? "a .seq already existed at seq_path and was OVERWRITTEN; houseCARL keeps no backup, and in a folder you named that file may have been the mod's own shipped .seq."
-                    : "the previous .seq in that houseCARL folder was overwritten (houseCARL's own earlier output — the ordinary regenerate case).");
+                    ? WriteSentences.Twins.SeqReplacedUserFolder
+                    : WriteSentences.Twins.SeqReplacedOwnFolder);
             WriteNullable(w, "seq_path", o.SeqPath);
             WriteNullable(w, "mod_folder", o.ModFolder);
             w.WriteBoolean("wrote_into_plugin_folder", o.WroteIntoPluginFolder);
@@ -1848,7 +1814,7 @@ static class JsonWire
             WriteNullable(w, "lane_note", outputNote);
             w.WriteNumber("quest_count", o.Quests.Count);
             if (o.Quests.Count == 0)
-                w.WriteString("note", "no start-game-enabled quests in this plugin — a .seq lists only SGE quests, so none is needed and NOTHING was written."
+                w.WriteString("note", "no start-game-enabled quests in this plugin — " + WriteSentences.Twins.SeqNoQuests + "."
                     // The lane was ACKNOWLEDGED but never resolved on this path, and the json shape shows that more
                     // starkly than the prose does: user_chose_output_dir true, no seq_path, no deploy_warning. Say
                     // which of the two it is (PR #318 review [low]).
@@ -1873,8 +1839,9 @@ static class JsonWire
             // re-issuing a WRITE. This PR moved SeqTools.Render off exactly this wording and left its json twin on
             // it — the same D2 divergence, in the same fold that fixed it one renderer up.
             if (truncated)
-                w.WriteString("truncated_note", $"the render hit max_chars={cap} and dropped trailing quest rows — the .seq itself carries ALL of them; nothing is missing from the FILE. Re-run only if you need this LIST widened: for a plugin OUTSIDE a houseCARL folder with no lane named, that writes the .seq again into ANOTHER fresh mod folder (name into=/output_dir=, or let a plugin in its own houseCARL folder default there — at any named destination a byte-identical .seq is left untouched).");
-            w.WriteString("standing_limit", "this makes the quest(s) START at game start; it does not verify the quest or its dialogue is otherwise well-formed.");
+                w.WriteString("truncated_note",
+                    $"the render hit max_chars={cap} and dropped trailing quest rows — " + WriteSentences.Twins.SeqListCutRemedy + ".");
+            w.WriteString("standing_limit", WriteSentences.Twins.SeqStandingLimit);
             w.WriteEndObject();
         }
         return Finish(ms);
@@ -1932,8 +1899,7 @@ static class JsonWire
             // Same remedy as the text twin, from the same constant (PR #311 review 6 [medium]): a repeated remove
             // is REFUSED, so "raise max_chars" named the one call guaranteed to fail.
             if (truncated)
-                w.WriteString("truncated_note",
-                    $"the render hit max_chars={cap} and dropped trailing rows — the REMOVAL is complete and unaffected; "
+                w.WriteString("truncated_note", WriteSentences.JsonRowsCut(cap, "REMOVAL")
                     + WriteTools.RemovedRowsRemedy + ".");
             w.WriteEndObject();
         }
@@ -2015,54 +1981,14 @@ static class JsonWire
             w.WriteEndArray();
             w.WriteNumber("rendered_forwarded", rendered);
 
-            if (o.ReadBack is { } rb)
-            {
-                w.WriteString("readback_source", o.DryRun ? "in_memory_would_be_content" : "written_file");
-                // Two DIFFERENT facts, told apart (PR #311 review 7 [nit]). `readback_full` describes THIS
-                // DOCUMENT: the json renders emit every field of every read-back row, so a present read-back
-                // is always the full one. It used to carry the caller's ASK, which the in-place lanes override
-                // (the service forces fullReadback), so `false` sat next to a complete field dump and a
-                // consumer branching on "are these fields complete?" got the opposite of the truth.
-                // `readback_requested` keeps the ask, which is what answers "why did I get one I did not ask
-                // for?" — the in-place lane forced it.
-                w.WriteBoolean("readback_full", true);
-                w.WriteBoolean("readback_requested", readback);
-                w.WriteStartArray("readback");
-                foreach (var r in rb)
-                {
-                    if (Over(w, ms, cap)) { truncated = true; break; }
-                    w.WriteStartObject();
-                    w.WriteString("formid", r.Target.ToString());
-                    if (r.Error is not null) w.WriteString("error", r.Error);
-                    else
-                    {
-                        var rec = r.Record!;
-                        w.WriteString("type", rec.Type);
-                        WriteNullable(w, "editorid", rec.EditorId);
-                        w.WriteNumber("field_count", rec.Fields.Count);
-                        w.WriteStartArray("fields");
-                        foreach (var fl in rec.Fields)
-                        {
-                            if (Over(w, ms, cap)) { truncated = true; break; }
-                            w.WriteStartObject();
-                            w.WriteString("path", fl.Path);
-                            if (fl.HasValue) w.WriteString("value", fl.Token); else w.WriteString("note", fl.Note);
-                            w.WriteEndObject();
-                        }
-                        w.WriteEndArray();
-                    }
-                    w.WriteEndObject();
-                }
-                w.WriteEndArray();
-            }
+            if (o.ReadBack is { } rb) WriteReadbackBlock(w, ms, cap, rb, o.DryRun, readback, ref truncated);
 
             WriteNullable(w, "note", o.Note);
             w.WriteBoolean("truncated", truncated);
             // Lane-aware, same rule and same helper as the text twin (PR #311 review 5 [low]): a re-issue is
             // idempotent on in_place=/into= and free on a dry run, but on the DEFAULT lane it cuts a second patch.
             if (truncated)
-                w.WriteString("truncated_note",
-                    $"the render hit max_chars={cap} and dropped trailing rows — the WRITE is complete and unaffected; "
+                w.WriteString("truncated_note", WriteSentences.JsonRowsCut(cap, "WRITE")
                     + WriteTools.ForwardAgainRemedy(o, Path.GetFileName(o.OutputPath)) + ".");
             w.WriteEndObject();
         }
@@ -2113,8 +2039,7 @@ static class JsonWire
         w.WriteEndArray();
         WriteBlockCensus(w, blockCut, ("lines", renderedLines, report.Lines.Count),
                                       ("undetermined", renderedUndet, report.Undetermined.Count),
-            "voice coverage", cap,
-            "a created voiced response with NO .fuz plays SILENT in game — an empty or short list here is a RENDER cut, not a clean bill of health");
+            "voice coverage", cap, WriteSentences.Twins.VoiceStake);
         w.WriteEndObject();
     }
 
@@ -2146,7 +2071,8 @@ static class JsonWire
         // render of it, and the counts above are what a consumer branches on.
         if (cut)
             w.WriteString("truncated_note",
-                $"the {blockLabel} block hit max_chars={cap} and its rows were CUT — {stakes}. The WRITE is complete and unaffected; this block is only a render of it, so compare rendered_* against total_* rather than reading the array as the whole answer. Do NOT re-issue the write to widen this.");
+                $"the {blockLabel} block hit max_chars={cap} and its rows were CUT — {stakes}, so an empty or short array here is a RENDER cut, not a clean bill of health. "
+                + WriteSentences.Twins.ReportBlockCut + ".");
     }
 
     /// <summary>The result-script binding report as data (a bound script that is unwired or uncompiled runs NOTHING
@@ -2174,8 +2100,7 @@ static class JsonWire
         }
         w.WriteEndArray();
         WriteBlockCensus(w, blockCut, ("findings", renderedFindings, report.Findings.Count), null,
-            "result-script coverage", cap,
-            "a bound script that is unwired or uncompiled runs NOTHING in game — an empty or short list here is a RENDER cut, not a clean bill of health");
+            "result-script coverage", cap, WriteSentences.Twins.ScriptStake);
         w.WriteEndObject();
     }
 
@@ -2202,11 +2127,10 @@ static class JsonWire
         }
         w.WriteEndArray();
         WriteBlockCensus(w, blockCut, ("cells", renderedCells, report.Cells.Count), null, "cell shell", cap,
-            "a created cell is a valid record but EMPTY, and each dropped row is Creation-Kit work this response was supposed to name");
+            WriteSentences.Twins.CellStake);
         // The grid-occupancy seam the text render declares — a json consumer must not read "cells: []" as "checked".
         if (report.Cells.Any(c => !c.Interior))
-            w.WriteString("grid_occupancy_note",
-                "houseCARL does NOT check grid-occupancy — a NEW exterior cell at a grid your load order already fills collides. To change an existing cell, OVERRIDE it instead of creating a new one.");
+            w.WriteString("grid_occupancy_note", WriteSentences.Twins.GridOccupancy);
         w.WriteEndObject();
     }
 }

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -172,7 +172,7 @@ static class JsonWire
         w.WriteEndObject();
     }
 
-    static int Cap(int maxChars) => WriteSentences.Cap(maxChars);   // one budget rule, both transports
+    static int Cap(int maxChars) => maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
 
     /// <summary>A bare whole-call refusal document: <c>{error, epoch?}</c> — for tool-layer refusals that have no
     /// outcome object to render (e.g. the §2.1.1 artifact epoch-mismatch handed back beside the batch), matching
@@ -1560,7 +1560,7 @@ static class JsonWire
     /// value agrees with the outcome's flags on every success.</para></summary>
     public static string RenderPatchOutcome(WritePatchBuilder.PatchOutcome o, int maxChars, bool readback, string lane)
     {
-        int cap = Cap(maxChars);
+        int cap = WriteSentences.Cap(maxChars);   // the WRITE budget rule, shared with the text twin
         using var ms = new MemoryStream();
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
@@ -1643,7 +1643,8 @@ static class JsonWire
             // re-issue to widen it is safe on into=/dry-run but cuts a second patch on the default lane and
             // re-serializes the caller's own file on in_place.
             if (truncated)
-                w.WriteString("truncated_note", WriteSentences.JsonRowsCut(cap, "WRITE")
+                w.WriteString("truncated_note",
+                    $"{WriteSentences.JsonRowsCut(cap)} — {WriteSentences.RowsCutOperationIntact(o.DryRun, "applied")}. "
                     + WriteTools.ApplyAgainRemedy(o, Path.GetFileName(o.OutputPath)) + ".");
             w.WriteEndObject();
         }
@@ -1660,7 +1661,7 @@ static class JsonWire
     /// exactly the silently-degraded mode this project refuses.</para></summary>
     public static string RenderCreateOutcome(WritePatchBuilder.CreateOutcome o, int maxChars, bool readback, string lane)
     {
-        int cap = Cap(maxChars);
+        int cap = WriteSentences.Cap(maxChars);   // the WRITE budget rule, shared with the text twin
         using var ms = new MemoryStream();
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
@@ -1752,10 +1753,9 @@ static class JsonWire
             // asked: the text twin was moved off this wording one fold earlier and the json document kept it, so a
             // json client raising max_chars and re-issuing walked into exactly what the fix existed to prevent.
             if (truncated)
-                w.WriteString("truncated_note", WriteSentences.JsonRowsCut(cap, "WRITE") + "every record WAS created. " +
-                    $"Read them back with {WriteTools.ReadBackCall(o, Path.GetFileName(o.OutputPath))} — do NOT re-issue this call to see the rest: a repeated create " +
-                    "allocates the records AGAIN (on the default lane patch= auto-suffixes into a second full patch; under into= each record is " +
-                    "re-created at its old FormID with its prior contents discarded).");
+                w.WriteString("truncated_note",
+                    $"{WriteSentences.JsonRowsCut(cap)} — "
+                    + WriteSentences.CreateRowsCutRemedy(WriteTools.ReadBackCall(o, Path.GetFileName(o.OutputPath))));
             w.WriteEndObject();
         }
         return Finish(ms);
@@ -1771,7 +1771,7 @@ static class JsonWire
     /// file", never merely "a path exists" — the two had been the same thing until a lane could decline to write.</para></summary>
     public static string RenderSeqOutcome(SeqOutcome o, int maxChars, string? outputNote = null)
     {
-        int cap = Cap(maxChars);
+        int cap = WriteSentences.Cap(maxChars);   // the WRITE budget rule, shared with the text twin
         using var ms = new MemoryStream();
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
@@ -1799,7 +1799,7 @@ static class JsonWire
             if (o.Unchanged)
                 w.WriteString("unchanged_note", WriteSentences.Twins.SeqUnchanged
                     + " — seq_path names the file that was already current. Stated rather than reported as a write (Q3: a skipped write and a done one must not look alike)."
-                    + (o.TimestampRefreshed ? " " + WriteSentences.Twins.SeqTimestampRefreshed : ""));
+                    + (o.TimestampRefreshed ? " Also: " + WriteSentences.Twins.SeqTimestampRefreshed : ""));
             if (o.Replaced)
                 w.WriteString("replaced_note", o.ReplacedSameBytes
                     ? WriteSentences.Twins.SeqReplacedSameBytes
@@ -1854,7 +1854,7 @@ static class JsonWire
     /// the text render spells out in a sentence.</summary>
     public static string RenderRemovalOutcome(WritePatchBuilder.RemovalOutcome o, int maxChars, string lane)
     {
-        int cap = Cap(maxChars);
+        int cap = WriteSentences.Cap(maxChars);   // the WRITE budget rule, shared with the text twin
         using var ms = new MemoryStream();
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
@@ -1899,7 +1899,8 @@ static class JsonWire
             // Same remedy as the text twin, from the same constant (PR #311 review 6 [medium]): a repeated remove
             // is REFUSED, so "raise max_chars" named the one call guaranteed to fail.
             if (truncated)
-                w.WriteString("truncated_note", WriteSentences.JsonRowsCut(cap, "REMOVAL")
+                w.WriteString("truncated_note",
+                    $"{WriteSentences.JsonRowsCut(cap)} — {WriteSentences.RowsCutOperationIntact(false, "removed")}. "
                     + WriteTools.RemovedRowsRemedy + ".");
             w.WriteEndObject();
         }
@@ -1915,7 +1916,7 @@ static class JsonWire
     /// rather than silent).</summary>
     public static string RenderForwardOutcome(WritePatchBuilder.ForwardOutcome o, int maxChars, bool readback, string lane)
     {
-        int cap = Cap(maxChars);
+        int cap = WriteSentences.Cap(maxChars);   // the WRITE budget rule, shared with the text twin
         using var ms = new MemoryStream();
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
@@ -1988,7 +1989,8 @@ static class JsonWire
             // Lane-aware, same rule and same helper as the text twin (PR #311 review 5 [low]): a re-issue is
             // idempotent on in_place=/into= and free on a dry run, but on the DEFAULT lane it cuts a second patch.
             if (truncated)
-                w.WriteString("truncated_note", WriteSentences.JsonRowsCut(cap, "WRITE")
+                w.WriteString("truncated_note",
+                    $"{WriteSentences.JsonRowsCut(cap)} — {WriteSentences.RowsCutOperationIntact(o.DryRun, "forwarded")}. "
                     + WriteTools.ForwardAgainRemedy(o, Path.GetFileName(o.OutputPath)) + ".");
             w.WriteEndObject();
         }
@@ -2055,7 +2057,8 @@ static class JsonWire
     /// <para>Counts ride even when nothing was cut — <c>rendered == total</c> is the positive statement that the
     /// list IS complete, so a consumer never has to infer completeness from the absence of a marker.</para></summary>
     static void WriteBlockCensus(Utf8JsonWriter w, bool cut, (string name, int rendered, int total) a,
-                                 (string name, int rendered, int total)? b, string blockLabel, int cap, string stakes)
+                                 (string name, int rendered, int total)? b, string blockLabel, int cap, string stakes,
+                                 string? cutLoss = null)
     {
         w.WriteNumber($"total_{a.name}", a.total);
         w.WriteNumber($"rendered_{a.name}", a.rendered);
@@ -2071,8 +2074,10 @@ static class JsonWire
         // render of it, and the counts above are what a consumer branches on.
         if (cut)
             w.WriteString("truncated_note",
-                $"the {blockLabel} block hit max_chars={cap} and its rows were CUT — {stakes}, so an empty or short array here is a RENDER cut, not a clean bill of health. "
-                + WriteSentences.Twins.ReportBlockCut + ".");
+                $"the {blockLabel} block hit max_chars={cap} and its rows were CUT. Why it matters: {stakes}"
+                + (cutLoss is null ? "" : $", and {cutLoss}")
+                + ". An empty or short array here is a RENDER cut, not a clean bill of health — "
+                + WriteSentences.Twins.ReportBlockCut + " (the counts are the total_* / rendered_* members above).");
     }
 
     /// <summary>The result-script binding report as data (a bound script that is unwired or uncompiled runs NOTHING
@@ -2127,7 +2132,7 @@ static class JsonWire
         }
         w.WriteEndArray();
         WriteBlockCensus(w, blockCut, ("cells", renderedCells, report.Cells.Count), null, "cell shell", cap,
-            WriteSentences.Twins.CellStake);
+            WriteSentences.Twins.CellStake, WriteSentences.CellRowsCutLoss);
         // The grid-occupancy seam the text render declares — a json consumer must not read "cells: []" as "checked".
         if (report.Cells.Any(c => !c.Interior))
             w.WriteString("grid_occupancy_note", WriteSentences.Twins.GridOccupancy);

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1644,7 +1644,7 @@ static class JsonWire
             // re-serializes the caller's own file on in_place.
             if (truncated)
                 w.WriteString("truncated_note",
-                    $"{WriteSentences.JsonRowsCut(cap)} — {WriteSentences.RowsCutOperationIntact(o.DryRun, "applied")}. "
+                    $"{WriteSentences.JsonRowsCut(cap)}; {WriteSentences.RowsCutOperationIntact(o.DryRun, "applied")} — "
                     + WriteTools.ApplyAgainRemedy(o, Path.GetFileName(o.OutputPath)) + ".");
             w.WriteEndObject();
         }
@@ -1754,8 +1754,8 @@ static class JsonWire
             // json client raising max_chars and re-issuing walked into exactly what the fix existed to prevent.
             if (truncated)
                 w.WriteString("truncated_note",
-                    $"{WriteSentences.JsonRowsCut(cap)} — "
-                    + WriteSentences.CreateRowsCutRemedy(WriteTools.ReadBackCall(o, Path.GetFileName(o.OutputPath))));
+                    $"{WriteSentences.JsonRowsCut(cap)}; "
+                    + WriteSentences.CreateRowsCutRemedy(WriteTools.ReadBackCall(o, Path.GetFileName(o.OutputPath))) + ".");
             w.WriteEndObject();
         }
         return Finish(ms);
@@ -1900,7 +1900,7 @@ static class JsonWire
             // is REFUSED, so "raise max_chars" named the one call guaranteed to fail.
             if (truncated)
                 w.WriteString("truncated_note",
-                    $"{WriteSentences.JsonRowsCut(cap)} — {WriteSentences.RowsCutOperationIntact(false, "removed")}. "
+                    $"{WriteSentences.JsonRowsCut(cap)}; {WriteSentences.RowsCutOperationIntact(false, "removed")} — "
                     + WriteTools.RemovedRowsRemedy + ".");
             w.WriteEndObject();
         }
@@ -1990,7 +1990,7 @@ static class JsonWire
             // idempotent on in_place=/into= and free on a dry run, but on the DEFAULT lane it cuts a second patch.
             if (truncated)
                 w.WriteString("truncated_note",
-                    $"{WriteSentences.JsonRowsCut(cap)} — {WriteSentences.RowsCutOperationIntact(o.DryRun, "forwarded")}. "
+                    $"{WriteSentences.JsonRowsCut(cap)}; {WriteSentences.RowsCutOperationIntact(o.DryRun, "forwarded")} — "
                     + WriteTools.ForwardAgainRemedy(o, Path.GetFileName(o.OutputPath)) + ".");
             w.WriteEndObject();
         }

--- a/src/housecarl-mcp/SeqTools.cs
+++ b/src/housecarl-mcp/SeqTools.cs
@@ -112,9 +112,8 @@ public static class SeqTools
         // …carrying the ignored-lane note, which this early return used to drop while the json twin emitted it — the
         // same D2 divergence this file's epoch-note fold closed one paragraph up (review round 1).
         if (o.Quests.Count == 0)
-            return $"no start-game-enabled quests in {o.PluginFileName}{ReadFrom(o)} — no .seq is needed (a .seq lists only quests with the " +
-                   "Start Game Enabled flag). Nothing written. If a quest SHOULD start at game start, set its Start Game Enabled " +
-                   "flag first, then write the .seq."
+            return $"no start-game-enabled quests in {o.PluginFileName}{ReadFrom(o)} — {WriteSentences.Twins.SeqNoQuests}. " +
+                   "If a quest SHOULD start at game start, set its Start Game Enabled flag first, then write the .seq."
                    // …and say that the destination was never looked at (PR #318 review [low]): this return happens
                    // BEFORE any folder is resolved, so an unusable output_dir= would not have been diagnosed —
                    // "your folder is fine" and "we never checked your folder" must not read the same.
@@ -128,7 +127,7 @@ public static class SeqTools
         sb.Append(o.Unchanged ? "unchanged — " : o.Replaced ? "replaced " : "wrote ").Append(seqName).Append(": ").Append(o.Quests.Count)
           .Append(o.Quests.Count == 1 ? " start-game-enabled quest" : " start-game-enabled quests")
           .Append(o.Unchanged
-              ? "; the file on disk already holds exactly these bytes, so NOTHING was written."
+              ? "; " + WriteSentences.Twins.SeqUnchanged + "."
               // REPLACED is its own word for the same reason UNCHANGED is: on the output_dir lane the file that was
               // there may be the mod's OWN .seq, and houseCARL keeps no backup of it (review round 1). The
               // no-backup ALARM is scoped to that lane (review round 3): re-generating over houseCARL's own previous
@@ -137,10 +136,10 @@ public static class SeqTools
                   // Nothing was lost when the replaced bytes were the SAME bytes — the only way here is a byte-identical
                   // destination whose timestamp refresh failed, and an alarm would be about nothing (review [low]).
                   ? (o.ReplacedSameBytes
-                      ? "; the file already there held these exact bytes — it was rewritten only because its timestamp could not be refreshed in place, so nothing was lost."
+                      ? "; " + WriteSentences.Twins.SeqReplacedSameBytes
                       : o.UserChoseOutput
-                          ? "; a .seq was already at that path and has been OVERWRITTEN (no backup is kept — in a folder you named, that may have been the mod's own)."
-                          : "; the previous .seq in that houseCARL folder was overwritten.")
+                          ? "; " + WriteSentences.Twins.SeqReplacedUserFolder
+                          : "; " + WriteSentences.Twins.SeqReplacedOwnFolder)
                   : "")
           .Append('\n');
         // Budgeted like the sibling write renders (PR #311 review [low-medium]): max_chars= promises "past it
@@ -148,7 +147,7 @@ public static class SeqTools
         // start-game-enabled quests would otherwise render every row and let the HOST cut the response with no
         // in-band signal. The path/next-step lines below stay outside the budget — a truncated list still needs
         // to say where the file landed.
-        int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        int cap = WriteSentences.Cap(maxChars);
         for (int i = 0; i < o.Quests.Count; i++)
         {
             if (sb.Length >= cap)
@@ -158,14 +157,11 @@ public static class SeqTools
                 // AGAIN, and with no lane named for a plugin outside a houseCARL folder that is a second
                 // auto-suffixed mod folder holding a duplicate. Nothing is missing from the FILE, so the honest
                 // notice says so and prices the re-run instead of prescribing it. (Not a review-4 finding — a
-                // sibling spotted while folding one; declared on the PR rather than folded silently.)
+                // sibling spotted while folding one; declared on the PR rather than folded silently.) The remedy
+                // itself is WriteSentences.Twins.SeqListCutRemedy — the json twin's quest-row cut says the same.
                 sb.Append("  ... [truncated: ").Append(i).Append(" of ").Append(o.Quests.Count)
-                  .Append(" quest(s) listed at max_chars=").Append(cap)
-                  .Append("; the .seq itself carries ALL of them — nothing is missing from the FILE. Re-run only if you need this "
-                        + "LIST widened: for a plugin OUTSIDE a houseCARL folder with no lane named, that writes the .seq "
-                        + "again into ANOTHER fresh mod folder (name into=/output_dir= the folder below; a plugin in its own "
-                        + "houseCARL folder already defaults there — and at any named destination a byte-identical .seq is "
-                        + "left untouched)]\n");
+                  .Append(" quest(s) listed at max_chars=").Append(cap).Append("; ")
+                  .Append(WriteSentences.Twins.SeqListCutRemedy).Append("]\n");
                 break;
             }
             var q = o.Quests[i];
@@ -193,9 +189,7 @@ public static class SeqTools
             // plugin. validate_dialogue lints the .seq the VFS serves for that plugin, which is this file only when
             // this folder wins the SEQ\ conflict and is enabled — so the sentence says what was done and what it is
             // for, and does not promise a verdict from a tool that resolves its input differently.
-            sb.Append("\nthe file was older than the plugin, so its timestamp was refreshed (contents untouched) — "
-                    + "housecarl_validate_dialogue's SEQ staleness check compares those two mtimes, so this .seq no longer "
-                    + "reads as stale (provided this is the copy your load order actually serves).");
+            sb.Append("\nthe file was older than the plugin, so ").Append(WriteSentences.Twins.SeqTimestampRefreshed);
         // Q3: never a clean "done" for a .seq the engine will not read (the quests stay silently dead).
         if (o.DeployWarning is { Length: > 0 } dw) sb.Append('\n').Append(dw);
         if (outputNote is { Length: > 0 }) sb.Append('\n').Append(outputNote);
@@ -203,11 +197,9 @@ public static class SeqTools
         // `epoch_note` since it was written; the text render said nothing — so a caller on the transport most of
         // them use saw a response with no epoch= line, which is the same observable a DROPPED stamp would produce.
         // The class-doc paragraph above claimed "the render says so"; it was true of one render out of two.
-        sb.Append("\nno epoch on this call, and that is a fact rather than an omission: a .seq is derived from the plugin " +
-                  "FILE alone (its FormID encoding is load-order-independent), so nothing here consulted a load-order build.");
+        sb.Append("\nno epoch on this call, and that is a fact rather than an omission: ").Append(WriteSentences.Twins.SeqNoEpoch);
         // Q3 standing limit: a written .seq makes the quest START; it is not a guarantee the quest/dialogue is otherwise correct.
-        sb.Append("\nnote: this makes the quest(s) START at game start; it does not verify the quest or its dialogue is otherwise " +
-                  "well-formed (use housecarl_validate_dialogue for the dialogue graph).");
+        sb.Append("\nnote: ").Append(WriteSentences.Twins.SeqStandingLimit);
         return sb.ToString();
     }
 

--- a/src/housecarl-mcp/SeqTools.cs
+++ b/src/housecarl-mcp/SeqTools.cs
@@ -189,7 +189,7 @@ public static class SeqTools
             // plugin. validate_dialogue lints the .seq the VFS serves for that plugin, which is this file only when
             // this folder wins the SEQ\ conflict and is enabled — so the sentence says what was done and what it is
             // for, and does not promise a verdict from a tool that resolves its input differently.
-            sb.Append("\nthe file was older than the plugin, so ").Append(WriteSentences.Twins.SeqTimestampRefreshed);
+            sb.Append('\n').Append(WriteSentences.Twins.SeqTimestampRefreshed);
         // Q3: never a clean "done" for a .seq the engine will not read (the quests stay silently dead).
         if (o.DeployWarning is { Length: > 0 } dw) sb.Append('\n').Append(dw);
         if (outputNote is { Length: > 0 }) sb.Append('\n').Append(outputNote);
@@ -197,7 +197,7 @@ public static class SeqTools
         // `epoch_note` since it was written; the text render said nothing — so a caller on the transport most of
         // them use saw a response with no epoch= line, which is the same observable a DROPPED stamp would produce.
         // The class-doc paragraph above claimed "the render says so"; it was true of one render out of two.
-        sb.Append("\nno epoch on this call, and that is a fact rather than an omission: ").Append(WriteSentences.Twins.SeqNoEpoch);
+        sb.Append("\nno epoch on this call: ").Append(WriteSentences.Twins.SeqNoEpoch);
         // Q3 standing limit: a written .seq makes the quest START; it is not a guarantee the quest/dialogue is otherwise correct.
         sb.Append("\nnote: ").Append(WriteSentences.Twins.SeqStandingLimit);
         return sb.ToString();

--- a/src/housecarl-mcp/WriteSentences.cs
+++ b/src/housecarl-mcp/WriteSentences.cs
@@ -12,7 +12,23 @@ namespace HousecarlMcp;
 /// second copy of the sentence in a probe.</para>
 ///
 /// <para>Phrases are the CLAIM, not the wording — the part whose loss changes what the caller is told. Rewording
-/// around them is free; deleting them is not.</para></summary>
+/// around them is free; deleting them is not.</para>
+///
+/// <para><b>The norm for picking one</b> (Aaron, PR #337 review): <i>a phrase carries the hazard or the action; a
+/// phrase that survives its sentence's negation is not a claim.</i> Two ways to get it wrong, both found in the
+/// first set written here. A bare token — <c>"grid-occupancy"</c>, <c>"into="</c> — is satisfied by any sentence
+/// that merely mentions the topic, so the sentence can be rewritten to say the opposite and still pass. And a lone
+/// common word — <c>"overwritten"</c> — cannot tell "was overwritten" from "was NOT overwritten". Pick the span
+/// that DISAPPEARS when the sentence stops being true: the imperative (<c>"do NOT re-issue this call"</c>), the
+/// consequence (<c>"prior contents discarded"</c>), or the negated form spelled out (<c>"does NOT check
+/// grid-occupancy"</c>).</para>
+///
+/// <para><b>This norm is for the AUTHOR, and deliberately not a rule the checker enforces.</b> Deciding whether a
+/// phrase is a claim is judgment, and judgment inside a comparator is #308's shape — the thing this project already
+/// killed once, where a verdict layer kept telling callers to re-issue writes that had landed. The checker does a
+/// substring test and nothing else; it is a backstop against a sentence being emptied, never an assessment of
+/// whether the sentence is any good. If a future round proposes teaching it to grade phrase quality, that is the
+/// same mistake wearing new clothes: the answer is a better phrase, not a smarter check.</para></summary>
 [AttributeUsage(AttributeTargets.Field)]
 internal sealed class MustStateAttribute : Attribute
 {
@@ -47,8 +63,12 @@ internal sealed class MustStateAttribute : Attribute
 /// string serves both lanes.</para>
 ///
 /// <para>Sentences that are prose on ONE transport by design — the in-place hazard, which json states as
-/// <c>lane:"in_place"</c> plus typed flags — live directly on this class rather than in <see cref="Twins"/>.
-/// They are still single-sourced (the text renders repeat them per verb), they are just not parity-checkable.</para>
+/// <c>lane:"in_place"</c> plus typed flags — live directly on this class rather than in <see cref="Twins"/>,
+/// because per-LANE coverage is not a claim that can be made about them. They still carry
+/// <see cref="MustStateAttribute"/>, and the guard's content check walks THIS class as well as <c>Twins</c>: the
+/// in-place hazard is the loudest sentence on the surface and this change made it a single token, so leaving it
+/// outside the net meant one edit could silently strip it from all five in-place renders at once (PR #337 review,
+/// finding 1). Coverage of those is asserted directly by the lane arm instead.</para>
 /// </summary>
 internal static class WriteSentences
 {
@@ -81,15 +101,18 @@ internal static class WriteSentences
     /// nothing kept back. Repeated by every text write render (apply / create / remove / forward / compact), which
     /// is exactly why it is here: the create render's copy had already lost "was rewritten", so the loudest
     /// response on the surface said something weaker than its four siblings for no reason anyone chose.</summary>
+    [MustState("your ORIGINAL file was rewritten", "no houseCARL backup or undo")]
     internal const string InPlaceRewritten = "your ORIGINAL file was rewritten; " + NoBackupOrUndo;
 
     /// <summary>The same hazard in the tense a DRY RUN needs — it has not happened yet. Two spellings because the
     /// tense really does differ; ONE source for the clause that carries the weight, so the half a caller acts on
     /// cannot go missing from one of them.</summary>
+    [MustState("your ORIGINAL file rewritten", "no houseCARL backup or undo")]
     internal const string InPlaceWouldRewrite = "your ORIGINAL file rewritten; " + NoBackupOrUndo;
 
     /// <summary>What makes the in-place lane the lane it is: houseCARL keeps nothing to undo it with. Every
     /// sentence that mentions the rewrite is built on this rather than repeating it.</summary>
+    [MustState("no houseCARL backup or undo")]
     internal const string NoBackupOrUndo = "no houseCARL backup or undo";
 
     /// <summary>The mod-folder line for an IN-PLACE write: the target is a mod the user already runs, so there is
@@ -218,7 +241,7 @@ internal static class WriteSentences
         /// <summary>The grid-occupancy seam, declared rather than silently unchecked. Both lanes carried this and
         /// the json copy had lost "(engine behavior undefined)" — the clause that tells a caller the failure is not
         /// a houseCARL limitation they can work around by trying again.</summary>
-        [MustState("grid-occupancy", "engine behavior undefined", "OVERRIDE it instead of creating a new one")]
+        [MustState("does NOT check grid-occupancy", "engine behavior undefined", "OVERRIDE it instead of creating a new one")]
         internal const string GridOccupancy =
             "houseCARL does NOT check grid-occupancy — a NEW exterior cell at a grid your load order already fills "
           + "collides (engine behavior undefined). To change an existing cell, OVERRIDE it instead of creating a new one.";
@@ -227,7 +250,7 @@ internal static class WriteSentences
         /// are safe to re-ask for — a repeated remove is refused, a repeated forward re-copies identical bodies —
         /// but a repeated create ALLOCATES AGAIN, and the trap does not care which transport asked. Both lanes
         /// carry this; the text copy used to state it in four words and the json copy in forty.</summary>
-        [MustState("allocates the records AGAIN", "into=")]
+        [MustState("do NOT re-issue this call", "second full patch", "prior contents discarded")]
         internal const string CreateReissueTrap =
             "do NOT re-issue this call to see the rest: a repeated create allocates the records AGAIN (on the "
           + "default lane patch= auto-suffixes into a second full patch; under into= each record is re-created at "
@@ -266,7 +289,7 @@ internal static class WriteSentences
           + "you named that file may have been the mod's own shipped .seq.";
 
         /// <summary>The ordinary regenerate: houseCARL's own earlier output in its own folder, overwritten.</summary>
-        [MustState("overwritten")]
+        [MustState("was overwritten", "houseCARL's own earlier output")]
         internal const string SeqReplacedOwnFolder =
             "the previous .seq in that houseCARL folder was overwritten (houseCARL's own earlier output — the "
           + "ordinary regenerate case).";
@@ -275,7 +298,7 @@ internal static class WriteSentences
         /// newer than the plugin. validate_dialogue lints the .seq the VFS serves, which is this one only if this
         /// folder wins the SEQ\ conflict — so the sentence says what was done and what it is for, and does not
         /// promise a verdict from a tool that resolves its input differently.</summary>
-        [MustState("stamped forward", "contents untouched", "housecarl_validate_dialogue", "no longer reads")]
+        [MustState("has been stamped forward", "contents untouched", "housecarl_validate_dialogue's SEQ staleness check", "no longer reads")]
         internal const string SeqTimestampRefreshed =
             "its mtime was older than the plugin and has been stamped forward (contents untouched); "
           + "housecarl_validate_dialogue's SEQ staleness check compares those two mtimes, so this file no longer reads "
@@ -283,14 +306,14 @@ internal static class WriteSentences
 
         /// <summary>No start-game-enabled quests: a .seq lists only SGE quests, so none is needed and nothing was
         /// written. Never a silent empty file, never a misleading "done".</summary>
-        [MustState("NOTHING was written", "Start Game Enabled")]
+        [MustState("NOTHING was written", "lists only quests with the Start Game Enabled flag")]
         internal const string SeqNoQuests =
             "a .seq lists only quests with the Start Game Enabled flag, so none is needed and NOTHING was written";
 
         /// <summary>The absent §2.1.1 stamp, stated as a fact with its reason. A .seq is derived from the plugin
         /// FILE alone, so nothing here consulted a load-order build — an absent epoch line and a DROPPED one are
         /// otherwise the same observable.</summary>
-        [MustState("load-order-independent", "not a dropped field")]
+        [MustState("consulted no load-order build", "not a dropped field")]
         internal const string SeqNoEpoch =
             "a .seq is derived from the plugin FILE alone (its FormID encoding is load-order-independent), so this "
           + "call consulted no load-order build — the absent stamp is a fact, not a dropped field.";

--- a/src/housecarl-mcp/WriteSentences.cs
+++ b/src/housecarl-mcp/WriteSentences.cs
@@ -36,6 +36,22 @@ internal sealed class MustStateAttribute : Attribute
     internal MustStateAttribute(params string[] phrases) => Phrases = phrases;
 }
 
+/// <summary>The declared way to say a shared sentence carries NO claim worth pinning — a label, a separator, a
+/// fragment whose meaning lives entirely in the sentences that compose it.
+///
+/// <para><b>Why an explicit opt-out rather than just leaving the attribute off.</b> The outer-class walk used to
+/// SKIP an undecorated const, so a sentence with real claims was unchecked simply because nobody remembered it —
+/// and, in the reviewer's words, "the next sentence added there inherits this silence" (PR #337 re-review,
+/// residual A). Absence-as-silence is the hole generator: it makes the safe state the one you reach by doing
+/// nothing. With this attribute the walk demands a decision — phrases, or a stated reason there are none — and an
+/// undecorated const FAILS by name. The reason is prose for the next author, never parsed.</para></summary>
+[AttributeUsage(AttributeTargets.Field)]
+internal sealed class NoClaimsAttribute : Attribute
+{
+    internal string Reason { get; }
+    internal NoClaimsAttribute(string reason) => Reason = reason;
+}
+
 /// <summary>
 /// ONE SOURCE PER SENTENCE for the write surface's user-facing prose — the response layer built by construction
 /// rather than hand-wired twice (tool-surface-2.0, <c>RESPONSE_LAYER_BY_CONSTRUCTION_2026-08-11.md</c>).
@@ -137,7 +153,10 @@ internal static class WriteSentences
 
     // ---- dry run -------------------------------------------------------------------------------------
     /// <summary>#225 — the first line of any dry run. It says NOTHING happened before it says what would: a dry run
-    /// that reads like a write is the silent-wrong-answer class (Q3), and this is the line a caller skims.</summary>
+    /// that reads like a write is the silent-wrong-answer class (Q3), and this is the line a caller skims.
+    /// <para>The phrases are the two CLAIMS, not the "DRY RUN" label: the label survives any rewrite that says the
+    /// opposite ("this is not a DRY RUN"), while "NOTHING was written" and "originals untouched" do not.</para></summary>
+    [MustState("NOTHING was written", "originals untouched")]
     internal const string DryRunHeader =
         "DRY RUN — validated only; NOTHING was written (no patch file, no mod folder, originals untouched).\n";
 
@@ -212,6 +231,7 @@ internal static class WriteSentences
     /// this response existed to name — a fact the counts alone do not convey. json-only today: the text block's
     /// cut notice carries no equivalent, and inventing one for it would be a behaviour change rather than the
     /// migration this is.</summary>
+    [MustState("Creation-Kit work this response was supposed to name")]
     internal const string CellRowsCutLoss =
         "each dropped row is Creation-Kit work this response was supposed to name";
 
@@ -321,7 +341,10 @@ internal static class WriteSentences
         /// <summary>write_seq's standing limit (Q3): the quests will START, which is not a claim that the quest or
         /// its dialogue is otherwise well-formed. The json copy had dropped the pointer at the tool that does check
         /// that — the half of the sentence that tells the caller what to do next.</summary>
-        [MustState("housecarl_validate_dialogue", "does not verify")]
+        // The phrase is the ACTION, not the token (PR #337 re-review, residual B). "housecarl_validate_dialogue"
+        // alone survives a rewrite to "…confirms the dialogue graph is sound (housecarl_validate_dialogue not
+        // required)", which inverts the standing limit into a claim write_seq cannot make.
+        [MustState("does not verify", "use housecarl_validate_dialogue for the dialogue graph")]
         internal const string SeqStandingLimit =
             "this makes the quest(s) START at game start; it does not verify the quest or its dialogue is otherwise "
           + "well-formed (use housecarl_validate_dialogue for the dialogue graph).";

--- a/src/housecarl-mcp/WriteSentences.cs
+++ b/src/housecarl-mcp/WriteSentences.cs
@@ -1,0 +1,244 @@
+namespace HousecarlMcp;
+
+/// <summary>
+/// ONE SOURCE PER SENTENCE for the write surface's user-facing prose — the response layer built by construction
+/// rather than hand-wired twice (tool-surface-2.0, <c>RESPONSE_LAYER_BY_CONSTRUCTION_2026-08-11.md</c>).
+///
+/// <para><b>Why this exists.</b> Every write outcome is rendered twice — <see cref="WriteTools"/> for text,
+/// <see cref="JsonWire"/> for json (decision D2: one write path, two renders) — and several renders repeat the
+/// same sentence per verb on top of that. Each duplicate is an independent copy of one meaning, and the 2.0
+/// review wave's single most numerous finding class was those copies drifting: a rule, budget, cap or wording
+/// landing on one lane and not the other. Every time a shared construction landed, its finding class died and
+/// stayed dead (<c>ForwardAgainRemedy</c>, <c>ReportBlockCutClause</c>, <c>ReadBackCall</c>,
+/// <c>Wire.ContestedHostsShown</c>). This class generalizes that: a sentence lives here once and both transports
+/// read it, so a change reaches both by construction and cannot reach one.</para>
+///
+/// <para><b>The rule.</b> No render-side literal may duplicate another render's meaning. A sentence needed in two
+/// places moves here in the SAME commit that deletes its copies — there is no "old path kept around" phase.</para>
+///
+/// <para><b><see cref="Twins"/> is the enforced half.</b> Members of that nested class are sentences the SAME
+/// outcome must carry on BOTH transports. The write-surface guard's twin arm reflects over it and asserts
+/// text-contains == json-contains for every member, on every outcome it renders — so enrolling a new twin is
+/// adding a member, and a lane that quietly re-inlines its own copy loses the constant and fails the arm. That is
+/// the check the old per-site <c>Contains("&lt;fragment&gt;")</c> arms could not provide: they pinned a string,
+/// not the fact that one string serves both lanes.</para>
+///
+/// <para>Sentences that are prose on ONE transport by design — the in-place hazard, which json states as
+/// <c>lane:"in_place"</c> plus typed flags — live directly on this class rather than in <see cref="Twins"/>.
+/// They are still single-sourced (the text renders repeat them per verb), they are just not parity-checkable.</para>
+/// </summary>
+internal static class WriteSentences
+{
+    // ---- budgets -------------------------------------------------------------------------------------
+    /// <summary>The response char budget a render works to: the caller's <c>max_chars</c>, or the server default.
+    /// One helper because "budget divergence" is one of the three drift classes this module retires — the ternary
+    /// was written out at eight sites, and a site that picked the wrong default (or forgot the 0-means-default
+    /// contract) diverged silently from its twin.</summary>
+    internal static int Cap(int maxChars) => maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+
+    /// <summary>The same for any READ-BACK dump, which is bounded well below <see cref="Cap"/> so the truncation
+    /// note itself reaches the caller rather than being cut by the host (see <see cref="Wire.ReadbackMaxChars"/>).</summary>
+    internal static int ReadbackCap(int maxChars) => maxChars > 0 ? maxChars : Wire.ReadbackMaxChars;
+
+    // ---- the §2.1.1 epoch stamp ----------------------------------------------------------------------
+    /// <summary>SPEC §2.1.1 — the index build a write resolved winners against, appended to EVERY write render
+    /// (success, refusal, dry run, consent prompt) exactly as the read surfaces stamp theirs. It is what lets a
+    /// caller tell whether the winner it edited is the winner a read reported a moment earlier: the read-back
+    /// proves what landed in the FILE, never what wins in the ORDER. Empty when the outcome consulted no build.
+    /// <para>One method over a <c>string?</c> rather than one overload per outcome record: the four outcomes are
+    /// deliberately independent shapes, but the STAMP is one sentence and four copies of it is four places for a
+    /// format to drift.</para></summary>
+    internal static string Epoch(string? epoch) => epoch is null ? "" : $"\nepoch={epoch}";
+
+    // ---- artifact headers (text lane; json states these as typed fields) -----------------------------
+    /// <summary>The IN-PLACE hazard clause — the one sentence that tells a caller their own file was rewritten with
+    /// nothing kept back. Repeated by every text write render (apply / create / remove / forward / compact), which
+    /// is exactly why it is here: the create render's copy had already lost "was rewritten", so the loudest
+    /// response on the surface said something weaker than its four siblings for no reason anyone chose.</summary>
+    internal const string InPlaceRewritten = "your ORIGINAL file was rewritten; " + NoBackupOrUndo;
+
+    /// <summary>The same hazard in the tense a DRY RUN needs — it has not happened yet. Two spellings because the
+    /// tense really does differ; ONE source for the clause that carries the weight, so the half a caller acts on
+    /// cannot go missing from one of them.</summary>
+    internal const string InPlaceWouldRewrite = "your ORIGINAL file rewritten; " + NoBackupOrUndo;
+
+    /// <summary>What makes the in-place lane the lane it is: houseCARL keeps nothing to undo it with. Every
+    /// sentence that mentions the rewrite is built on this rather than repeating it.</summary>
+    internal const string NoBackupOrUndo = "no houseCARL backup or undo";
+
+    /// <summary>The mod-folder line for an IN-PLACE write: the target is a mod the user already runs, so there is
+    /// nothing to enable — only a re-sort, and only if the edit moved a winner. (compact's copy had lost "in your
+    /// load order"; same sentence, one reading.)</summary>
+    internal static string InPlaceModFolder(string modFolder) =>
+        $"mod folder: {modFolder}  — already active in your load order; re-sort only if a winner changed\n";
+
+    /// <summary>The header + mod-folder pair for a write to a NEW patch or an EXTENDED one — the default lane's
+    /// "here is the artifact and what to do with it". Rendered identically by apply / create / forward; a fourth
+    /// copy is how the "enable + sort it in MO2" instruction would have gone missing from one of them.</summary>
+    internal static string NewOrExtendedArtifact(bool extended, string file, long bytes, string modFolder) =>
+        (extended ? $"extended {file} (existing patch grown; {bytes} bytes)\n"
+                  : $"wrote {file} (new patch; {bytes} bytes)\n")
+      + (extended ? $"mod folder: {modFolder}\n"
+                  : $"mod folder: {modFolder}  — enable + sort it in MO2 to use the patch\n");
+
+    /// <summary>The masters line. Trivial, and repeated six times — including the empty-set spelling, which is the
+    /// part that carries meaning (a patch with no masters is a standalone, not a broken header).</summary>
+    internal static string Masters(IReadOnlyList<string> masters) =>
+        $"masters: {(masters.Count == 0 ? "(none)" : string.Join(", ", masters))}\n";
+
+    // ---- dry run -------------------------------------------------------------------------------------
+    /// <summary>#225 — the first line of any dry run. It says NOTHING happened before it says what would: a dry run
+    /// that reads like a write is the silent-wrong-answer class (Q3), and this is the line a caller skims.</summary>
+    internal const string DryRunHeader =
+        "DRY RUN — validated only; NOTHING was written (no patch file, no mod folder, originals untouched).\n";
+
+    /// <summary>What the real call WOULD write, by lane. <paramref name="verb"/> is the tool's own word for what it
+    /// does to the destination ("edit"/"forward into"), so the sentence names the caller's action rather than a
+    /// generic one. The NEW-patch arm carries the name-preview caveat: the real write re-picks a free stem, so the
+    /// auto-suffix can shift if another patch lands first — a promise the dry run must not make.</summary>
+    internal static string DryRunWouldWrite(bool inPlace, bool extended, string file, string inPlaceVerb) =>
+        inPlace  ? $"the real call would {inPlaceVerb} {file} IN PLACE — {InPlaceWouldRewrite}.\n"
+      : extended ? $"the real call would EXTEND the existing patch {file}.\n"
+                 : $"the real call would write a NEW patch {file} (name preview — the real write re-picks a free name, "
+                 +  "so the auto-suffix can shift if another patch lands first).\n";
+
+    /// <summary>The dry run's masters line, labelled as the PREVIEW it is — derived from the would-be content, not
+    /// from the lean header the real write derives for itself.</summary>
+    internal static string DryRunMasters(IReadOnlyList<string> masters) =>
+        $"expected masters: {(masters.Count == 0 ? "(none)" : string.Join(", ", masters))}"
+      + "  [derived from the would-be content; the real write derives its own lean header]\n";
+
+    /// <summary>The dry run's closing line: what the pipeline actually proved, how to commit, and the honest limit
+    /// on the proof. <paramref name="proved"/> is the per-verb clause (apply resolved + pre-flighted its ops;
+    /// forward resolved every record from its source).
+    /// <para>The parenthetical is shared, and it is the FULLER of the two readings the copies had drifted to:
+    /// forward's said only "disk faults", apply's named the Mutagen serialize refusal too. Both verbs commit
+    /// through the same serializer, so a body Mutagen declines to write surfaces at commit on either — the shorter
+    /// copy was not a scoped claim, it was a lost clause.</para></summary>
+    internal static string DryRunClose(string proved, string realVerb) =>
+        $"{proved}; to {realVerb} for real, repeat the call without dry_run. "
+      + "(A real write can still fail at serialize/commit — disk faults and data Mutagen refuses to serialize surface only there.)";
+
+    // ---- json row-truncation notes -------------------------------------------------------------------
+    /// <summary>The opening of every json <c>truncated_note</c>: the render was cut, the WRITE was not. Stated
+    /// before the remedy because it is the fact a consumer acts on — three sites wrote it out, and the removal
+    /// document's copy names its own noun ("the REMOVAL"), which is the only part that legitimately varies.</summary>
+    internal static string JsonRowsCut(int cap, string subjectNoun) =>
+        $"the render hit max_chars={cap} and dropped trailing rows — the {subjectNoun} is complete and unaffected; ";
+
+    // ---- post-write report blocks (create) -----------------------------------------------------------
+    /// <summary>The "check could not run" line the three post-write reports share: the check failed, the records
+    /// were still CREATED, and here is what the caller must now verify by hand. Q3 — a check that did not run must
+    /// never read like a check that passed. <paramref name="createdNoun"/> stays per-block ("the records", "the
+    /// cell(s)") because that half is the block's own subject, not the shared claim.</summary>
+    internal static string CheckCouldNotRun(string checkName, string error, string createdNoun, string verifyManually) =>
+        $"  {checkName} check could not run: {error} — {createdNoun} WERE created; {verifyManually}\n";
+
+    /// <summary>The scan-incompleteness note: a BSA that failed to read makes an "absent" mean "unscanned", which
+    /// is a different claim from "looked for and not found". <paramref name="absentThing"/> is what the block's own
+    /// rows call the missing item.</summary>
+    internal static string ScanIncomplete(string absentThing) =>
+        $"  note: a BSA failed to read this scan, so {absentThing} above may merely be unscanned — verify in MO2.\n";
+
+    /// <summary>Sentences the SAME outcome must carry on BOTH transports. Reflected over by the write-surface
+    /// guard's twin arm — see this class's summary. Members are whole invariant strings on purpose: a sentence
+    /// interpolating a cap or a filename cannot be compared verbatim across lanes, so parameterised twins stay on
+    /// the outer class and are covered by the arm's budget/count parity checks instead.</summary>
+    internal static class Twins
+    {
+        // ---- create's post-write hazard reports ------------------------------------------------------
+        /// <summary>Voice coverage — the stake, in the words both lanes use. A created voiced response with no
+        /// .fuz on disk is byte-valid and SILENT in game.</summary>
+        internal const string VoiceStake = "a created voiced response with NO .fuz plays SILENT in game";
+
+        /// <summary>Result-script coverage — the stake. A bound script that is unwired or uncompiled is byte-valid
+        /// and does nothing. (The two copies had drifted to "that's" and "that is"; one reading now.)</summary>
+        internal const string ScriptStake = "a bound script that is unwired or uncompiled runs NOTHING in game";
+
+        /// <summary>Cell shell — the stake. houseCARL creates a valid, correctly-placed CELL record and does not
+        /// author world content, so "created" must never read as "looks right in game".</summary>
+        internal const string CellStake =
+            "a created cell is a valid, correctly-placed record but EMPTY — houseCARL does not author world content";
+
+        /// <summary>The grid-occupancy seam, declared rather than silently unchecked. Both lanes carried this and
+        /// the json copy had lost "(engine behavior undefined)" — the clause that tells a caller the failure is not
+        /// a houseCARL limitation they can work around by trying again.</summary>
+        internal const string GridOccupancy =
+            "houseCARL does NOT check grid-occupancy — a NEW exterior cell at a grid your load order already fills "
+          + "collides (engine behavior undefined). To change an existing cell, OVERRIDE it instead of creating a new one.";
+
+        /// <summary>What a CUT post-write report block means, and the one action a caller must not take to widen it.
+        /// <para>These blocks ride the CREATE render only, so the specific reading is the true one: re-issuing
+        /// allocates the records AGAIN. The json copy had generalized to "Do NOT re-issue the write to widen this",
+        /// which is weaker advice about the same call — resolved to the specific reading, which is also the one
+        /// that survives a caller reading it literally.</para></summary>
+        internal const string ReportBlockCut =
+            "the records WERE created and this block is only a render of them — compare rendered vs total rather than "
+          + "reading the list as the whole answer. Do NOT re-issue the create to widen it: that allocates the records again";
+
+        // ---- write_seq -------------------------------------------------------------------------------
+        /// <summary>#312 — the destination already held exactly these bytes. Q3: a skipped write and a done one
+        /// must not look alike, so this is its own statement rather than a caveat under a "wrote".</summary>
+        internal const string SeqUnchanged =
+            "the destination already held EXACTLY these bytes, so NOTHING was written";
+
+        /// <summary>The byte-identical replace: the file was rewritten only because its timestamp could not be
+        /// refreshed in place, so nothing was lost. Scoped deliberately — dressing this as a loss would train the
+        /// reader to ignore the word REPLACED when it does mean one.</summary>
+        internal const string SeqReplacedSameBytes =
+            "the file already at that path held EXACTLY these bytes; it was rewritten only because its timestamp "
+          + "could not be refreshed in place, so nothing was lost.";
+
+        /// <summary>The replace that CAN have cost something: on a folder the caller named, the .seq that was there
+        /// may have been the mod's own, and houseCARL keeps no backup.</summary>
+        internal const string SeqReplacedUserFolder =
+            "a .seq was already at that path and has been OVERWRITTEN; houseCARL keeps no backup, and in a folder "
+          + "you named that file may have been the mod's own shipped .seq.";
+
+        /// <summary>The ordinary regenerate: houseCARL's own earlier output in its own folder, overwritten.</summary>
+        internal const string SeqReplacedOwnFolder =
+            "the previous .seq in that houseCARL folder was overwritten (houseCARL's own earlier output — the "
+          + "ordinary regenerate case).";
+
+        /// <summary>The timestamp stamp-forward, with the claim kept to what was established: THIS FILE is now
+        /// newer than the plugin. validate_dialogue lints the .seq the VFS serves, which is this one only if this
+        /// folder wins the SEQ\ conflict — so the sentence says what was done and what it is for, and does not
+        /// promise a verdict from a tool that resolves its input differently.</summary>
+        internal const string SeqTimestampRefreshed =
+            "its mtime was older than the plugin and has been stamped forward (contents untouched); "
+          + "housecarl_validate_dialogue's SEQ staleness check compares those two mtimes, so this file no longer reads "
+          + "as stale — for the copy the load order actually serves, which is this one only if this folder wins the SEQ\\ conflict.";
+
+        /// <summary>No start-game-enabled quests: a .seq lists only SGE quests, so none is needed and nothing was
+        /// written. Never a silent empty file, never a misleading "done".</summary>
+        internal const string SeqNoQuests =
+            "a .seq lists only quests with the Start Game Enabled flag, so none is needed and NOTHING was written";
+
+        /// <summary>The absent §2.1.1 stamp, stated as a fact with its reason. A .seq is derived from the plugin
+        /// FILE alone, so nothing here consulted a load-order build — an absent epoch line and a DROPPED one are
+        /// otherwise the same observable.</summary>
+        internal const string SeqNoEpoch =
+            "a .seq is derived from the plugin FILE alone (its FormID encoding is load-order-independent), so this "
+          + "call consulted no load-order build — the absent stamp is a fact, not a dropped field.";
+
+        /// <summary>write_seq's standing limit (Q3): the quests will START, which is not a claim that the quest or
+        /// its dialogue is otherwise well-formed. The json copy had dropped the pointer at the tool that does check
+        /// that — the half of the sentence that tells the caller what to do next.</summary>
+        internal const string SeqStandingLimit =
+            "this makes the quest(s) START at game start; it does not verify the quest or its dialogue is otherwise "
+          + "well-formed (use housecarl_validate_dialogue for the dialogue graph).";
+
+        /// <summary>What a truncated QUEST list means and what re-running costs. The .seq FILE carries every quest —
+        /// only the LIST was cut — so the remedy prices the re-run rather than prescribing it (the wrong-remedy
+        /// class: "raise max_chars and re-issue" would mean writing the .seq again, into a second fresh mod folder
+        /// on the lane a caller reaches by naming none).
+        /// <para>The text copy said "name into=/output_dir= the folder below", a reference to a line only the text
+        /// render prints. A shared sentence cannot carry that deixis, so the lane-neutral reading — already the
+        /// json copy's — is the one kept.</para></summary>
+        internal const string SeqListCutRemedy =
+            "the .seq itself carries ALL of them — nothing is missing from the FILE. Re-run only if you need this LIST "
+          + "widened: for a plugin OUTSIDE a houseCARL folder with no lane named, that writes the .seq again into "
+          + "ANOTHER fresh mod folder (name into=/output_dir=, or let a plugin in its own houseCARL folder default "
+          + "there — at any named destination a byte-identical .seq is left untouched)";
+    }
+}

--- a/src/housecarl-mcp/WriteSentences.cs
+++ b/src/housecarl-mcp/WriteSentences.cs
@@ -1,5 +1,25 @@
 namespace HousecarlMcp;
 
+/// <summary>The load-bearing phrases a shared sentence MUST still contain — declared beside the sentence, checked
+/// by the write-surface guard's twin arm over every <see cref="WriteSentences.Twins"/> member.
+///
+/// <para><b>Why this exists.</b> A construction pin of the form <c>render.Contains(TheConstant)</c> proves the
+/// render reads the shared source and NOTHING about what that source says: render and assertion read the same
+/// symbol, so the assertion cannot fail on the constant being emptied. Migrating the old
+/// <c>Contains("&lt;fragment&gt;")</c> arms to construction pins therefore traded a content check for a wiring
+/// check — and a commit that gutted three of these sentences to placeholders passed the full guard suite green.
+/// This restores the content half where it belongs: next to the sentence, so it moves with it, rather than as a
+/// second copy of the sentence in a probe.</para>
+///
+/// <para>Phrases are the CLAIM, not the wording — the part whose loss changes what the caller is told. Rewording
+/// around them is free; deleting them is not.</para></summary>
+[AttributeUsage(AttributeTargets.Field)]
+internal sealed class MustStateAttribute : Attribute
+{
+    internal string[] Phrases { get; }
+    internal MustStateAttribute(params string[] phrases) => Phrases = phrases;
+}
+
 /// <summary>
 /// ONE SOURCE PER SENTENCE for the write surface's user-facing prose — the response layer built by construction
 /// rather than hand-wired twice (tool-surface-2.0, <c>RESPONSE_LAYER_BY_CONSTRUCTION_2026-08-11.md</c>).
@@ -181,36 +201,44 @@ internal static class WriteSentences
         // ---- create's post-write hazard reports ------------------------------------------------------
         /// <summary>Voice coverage — the stake, in the words both lanes use. A created voiced response with no
         /// .fuz on disk is byte-valid and SILENT in game.</summary>
-        internal const string VoiceStake = "voice coverage was not fully rendered";
+        [MustState("plays SILENT in game")]
+        internal const string VoiceStake = "a created voiced response with NO .fuz plays SILENT in game";
 
         /// <summary>Result-script coverage — the stake. A bound script that is unwired or uncompiled is byte-valid
         /// and does nothing. (The two copies had drifted to "that's" and "that is"; one reading now.)</summary>
+        [MustState("runs NOTHING in game")]
         internal const string ScriptStake = "a bound script that is unwired or uncompiled runs NOTHING in game";
 
         /// <summary>Cell shell — the stake. houseCARL creates a valid, correctly-placed CELL record and does not
         /// author world content, so "created" must never read as "looks right in game".</summary>
+        [MustState("houseCARL does not author world content")]
         internal const string CellStake =
             "a created cell is a valid, correctly-placed record but EMPTY — houseCARL does not author world content";
 
         /// <summary>The grid-occupancy seam, declared rather than silently unchecked. Both lanes carried this and
         /// the json copy had lost "(engine behavior undefined)" — the clause that tells a caller the failure is not
         /// a houseCARL limitation they can work around by trying again.</summary>
-        internal const string GridOccupancy = "the cell was created.";
+        [MustState("grid-occupancy", "engine behavior undefined", "OVERRIDE it instead of creating a new one")]
+        internal const string GridOccupancy =
+            "houseCARL does NOT check grid-occupancy — a NEW exterior cell at a grid your load order already fills "
+          + "collides (engine behavior undefined). To change an existing cell, OVERRIDE it instead of creating a new one.";
+
+        /// <summary>Why a truncated CREATE must not be re-issued to widen its own render. The sibling verbs' rows
+        /// are safe to re-ask for — a repeated remove is refused, a repeated forward re-copies identical bodies —
+        /// but a repeated create ALLOCATES AGAIN, and the trap does not care which transport asked. Both lanes
+        /// carry this; the text copy used to state it in four words and the json copy in forty.</summary>
+        [MustState("allocates the records AGAIN", "into=")]
+        internal const string CreateReissueTrap =
+            "do NOT re-issue this call to see the rest: a repeated create allocates the records AGAIN (on the "
+          + "default lane patch= auto-suffixes into a second full patch; under into= each record is re-created at "
+          + "its old FormID with its prior contents discarded)";
 
         /// <summary>What a CUT post-write report block means, and the one action a caller must not take to widen it.
         /// <para>These blocks ride the CREATE render only, so the specific reading is the true one: re-issuing
         /// allocates the records AGAIN. The json copy had generalized to "Do NOT re-issue the write to widen this",
         /// which is weaker advice about the same call — resolved to the specific reading, which is also the one
         /// that survives a caller reading it literally.</para></summary>
-        /// <summary>Why a truncated CREATE must not be re-issued to widen its own render. The sibling verbs' rows
-        /// are safe to re-ask for — a repeated remove is refused, a repeated forward re-copies identical bodies —
-        /// but a repeated create ALLOCATES AGAIN, and the trap does not care which transport asked. Both lanes
-        /// carry this; the text copy used to state it in four words and the json copy in forty.</summary>
-        internal const string CreateReissueTrap =
-            "do NOT re-issue this call to see the rest: a repeated create allocates the records AGAIN (on the "
-          + "default lane patch= auto-suffixes into a second full patch; under into= each record is re-created at "
-          + "its old FormID with its prior contents discarded).";
-
+        [MustState("Do NOT re-issue the create", "compare rendered vs total")]
         internal const string ReportBlockCut =
             "the records WERE created and this block is only a render of them — compare rendered vs total rather than "
           + "reading the list as the whole answer. Do NOT re-issue the create to widen it: that allocates the records again";
@@ -218,23 +246,27 @@ internal static class WriteSentences
         // ---- write_seq -------------------------------------------------------------------------------
         /// <summary>#312 — the destination already held exactly these bytes. Q3: a skipped write and a done one
         /// must not look alike, so this is its own statement rather than a caveat under a "wrote".</summary>
+        [MustState("NOTHING was written")]
         internal const string SeqUnchanged =
             "the destination already held EXACTLY these bytes, so NOTHING was written";
 
         /// <summary>The byte-identical replace: the file was rewritten only because its timestamp could not be
         /// refreshed in place, so nothing was lost. Scoped deliberately — dressing this as a loss would train the
         /// reader to ignore the word REPLACED when it does mean one.</summary>
+        [MustState("nothing was lost")]
         internal const string SeqReplacedSameBytes =
             "the file already at that path held EXACTLY these bytes; it was rewritten only because its timestamp "
           + "could not be refreshed in place, so nothing was lost.";
 
         /// <summary>The replace that CAN have cost something: on a folder the caller named, the .seq that was there
         /// may have been the mod's own, and houseCARL keeps no backup.</summary>
+        [MustState("keeps no backup")]
         internal const string SeqReplacedUserFolder =
             "a .seq was already at that path and has been OVERWRITTEN; houseCARL keeps no backup, and in a folder "
           + "you named that file may have been the mod's own shipped .seq.";
 
         /// <summary>The ordinary regenerate: houseCARL's own earlier output in its own folder, overwritten.</summary>
+        [MustState("overwritten")]
         internal const string SeqReplacedOwnFolder =
             "the previous .seq in that houseCARL folder was overwritten (houseCARL's own earlier output — the "
           + "ordinary regenerate case).";
@@ -243,18 +275,22 @@ internal static class WriteSentences
         /// newer than the plugin. validate_dialogue lints the .seq the VFS serves, which is this one only if this
         /// folder wins the SEQ\ conflict — so the sentence says what was done and what it is for, and does not
         /// promise a verdict from a tool that resolves its input differently.</summary>
+        [MustState("stamped forward", "contents untouched", "housecarl_validate_dialogue", "no longer reads")]
         internal const string SeqTimestampRefreshed =
-            "housecarl_validate_dialogue's SEQ staleness check compares mtimes "
-          + "— for the copy the load order actually serves.";
+            "its mtime was older than the plugin and has been stamped forward (contents untouched); "
+          + "housecarl_validate_dialogue's SEQ staleness check compares those two mtimes, so this file no longer reads "
+          + "as stale — for the copy the load order actually serves, which is this one only if this folder wins the SEQ\\ conflict.";
 
         /// <summary>No start-game-enabled quests: a .seq lists only SGE quests, so none is needed and nothing was
         /// written. Never a silent empty file, never a misleading "done".</summary>
+        [MustState("NOTHING was written", "Start Game Enabled")]
         internal const string SeqNoQuests =
             "a .seq lists only quests with the Start Game Enabled flag, so none is needed and NOTHING was written";
 
         /// <summary>The absent §2.1.1 stamp, stated as a fact with its reason. A .seq is derived from the plugin
         /// FILE alone, so nothing here consulted a load-order build — an absent epoch line and a DROPPED one are
         /// otherwise the same observable.</summary>
+        [MustState("load-order-independent", "not a dropped field")]
         internal const string SeqNoEpoch =
             "a .seq is derived from the plugin FILE alone (its FormID encoding is load-order-independent), so this "
           + "call consulted no load-order build — the absent stamp is a fact, not a dropped field.";
@@ -262,6 +298,7 @@ internal static class WriteSentences
         /// <summary>write_seq's standing limit (Q3): the quests will START, which is not a claim that the quest or
         /// its dialogue is otherwise well-formed. The json copy had dropped the pointer at the tool that does check
         /// that — the half of the sentence that tells the caller what to do next.</summary>
+        [MustState("housecarl_validate_dialogue", "does not verify")]
         internal const string SeqStandingLimit =
             "this makes the quest(s) START at game start; it does not verify the quest or its dialogue is otherwise "
           + "well-formed (use housecarl_validate_dialogue for the dialogue graph).";
@@ -273,6 +310,7 @@ internal static class WriteSentences
         /// <para>The text copy said "name into=/output_dir= the folder below", a reference to a line only the text
         /// render prints. A shared sentence cannot carry that deixis, so the lane-neutral reading — already the
         /// json copy's — is the one kept.</para></summary>
+        [MustState("nothing is missing from the FILE", "writes the .seq again")]
         internal const string SeqListCutRemedy =
             "the .seq itself carries ALL of them — nothing is missing from the FILE. Re-run only if you need this LIST "
           + "widened: for a plugin OUTSIDE a houseCARL folder with no lane named, that writes the .seq again into "

--- a/src/housecarl-mcp/WriteSentences.cs
+++ b/src/housecarl-mcp/WriteSentences.cs
@@ -9,19 +9,22 @@ namespace HousecarlMcp;
 /// same sentence per verb on top of that. Each duplicate is an independent copy of one meaning, and the 2.0
 /// review wave's single most numerous finding class was those copies drifting: a rule, budget, cap or wording
 /// landing on one lane and not the other. Every time a shared construction landed, its finding class died and
-/// stayed dead (<c>ForwardAgainRemedy</c>, <c>ReportBlockCutClause</c>, <c>ReadBackCall</c>,
-/// <c>Wire.ContestedHostsShown</c>). This class generalizes that: a sentence lives here once and both transports
+/// stayed dead (<c>ForwardAgainRemedy</c>, <c>ReadBackCall</c>, <c>Wire.ContestedHostsShown</c>, and PR #311's
+/// <c>ReportBlockCutClause</c>, whose sentence this class now holds). This class generalizes that: a sentence lives here once and both transports
 /// read it, so a change reaches both by construction and cannot reach one.</para>
 ///
 /// <para><b>The rule.</b> No render-side literal may duplicate another render's meaning. A sentence needed in two
 /// places moves here in the SAME commit that deletes its copies — there is no "old path kept around" phase.</para>
 ///
-/// <para><b><see cref="Twins"/> is the enforced half.</b> Members of that nested class are sentences the SAME
-/// outcome must carry on BOTH transports. The write-surface guard's twin arm reflects over it and asserts
-/// text-contains == json-contains for every member, on every outcome it renders — so enrolling a new twin is
-/// adding a member, and a lane that quietly re-inlines its own copy loses the constant and fails the arm. That is
-/// the check the old per-site <c>Contains("&lt;fragment&gt;")</c> arms could not provide: they pinned a string,
-/// not the fact that one string serves both lanes.</para>
+/// <para><b><see cref="Twins"/> is the enforced half.</b> Members of that nested class are sentences BOTH transports
+/// state. The write-surface guard's twin arm reflects over it and asserts each member is observed coming out of the
+/// text renders at least once and out of the json renders at least once — so enrolling a new twin is adding a
+/// member, and a lane that quietly re-inlines its own copy loses the constant and fails the arm by name. The check
+/// is per-LANE coverage rather than per-OUTCOME co-occurrence on purpose: a few of these land in different places
+/// on the two lanes (the text report blocks state their stake in the block header, the json blocks in the
+/// truncation census), so demanding co-occurrence would fail honest renders. That is still the check the old
+/// per-site <c>Contains("&lt;fragment&gt;")</c> arms could not provide: they pinned a string, not the fact that one
+/// string serves both lanes.</para>
 ///
 /// <para>Sentences that are prose on ONE transport by design — the in-place hazard, which json states as
 /// <c>lane:"in_place"</c> plus typed flags — live directly on this class rather than in <see cref="Twins"/>.
@@ -30,10 +33,13 @@ namespace HousecarlMcp;
 internal static class WriteSentences
 {
     // ---- budgets -------------------------------------------------------------------------------------
-    /// <summary>The response char budget a render works to: the caller's <c>max_chars</c>, or the server default.
+    /// <summary>The char budget a WRITE render works to: the caller's <c>max_chars</c>, or the server default.
     /// One helper because "budget divergence" is one of the three drift classes this module retires — the ternary
     /// was written out at eight sites, and a site that picked the wrong default (or forgot the 0-means-default
-    /// contract) diverged silently from its twin.</summary>
+    /// contract) diverged silently from its twin.
+    /// <para>Write renders only, both transports. The READ surface keeps its own <c>JsonWire.Cap</c> / <c>Wire.Cap</c>
+    /// — same formula today, and deliberately not wired through here: it is a separate surface on a separate
+    /// migration, and a shared helper would silently move its budget the day the write default diverges.</para></summary>
     internal static int Cap(int maxChars) => maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
 
     /// <summary>The same for any READ-BACK dump, which is bounded well below <see cref="Cap"/> so the truncation
@@ -119,12 +125,30 @@ internal static class WriteSentences
         $"{proved}; to {realVerb} for real, repeat the call without dry_run. "
       + "(A real write can still fail at serialize/commit — disk faults and data Mutagen refuses to serialize surface only there.)";
 
-    // ---- json row-truncation notes -------------------------------------------------------------------
-    /// <summary>The opening of every json <c>truncated_note</c>: the render was cut, the WRITE was not. Stated
-    /// before the remedy because it is the fact a consumer acts on — three sites wrote it out, and the removal
-    /// document's copy names its own noun ("the REMOVAL"), which is the only part that legitimately varies.</summary>
-    internal static string JsonRowsCut(int cap, string subjectNoun) =>
-        $"the render hit max_chars={cap} and dropped trailing rows — the {subjectNoun} is complete and unaffected; ";
+    // ---- row-truncation notes ------------------------------------------------------------------------
+    /// <summary>What a cut row list says about the OPERATION, as opposed to the render: the rows shown were cut,
+    /// the work was not. Both transports made this claim in their own words — text "every one WAS forwarded", json
+    /// "the WRITE is complete and unaffected" — so it is resolved to the concrete reading, which is the one a
+    /// caller can act on ("was it done?" answered directly, rather than by an abstraction over it).
+    /// <para><b>Dry-run aware, and that is not cosmetic.</b> The json copy said "the WRITE is complete and
+    /// unaffected" on a truncated DRY RUN — a response asserting a write on the one lane that writes nothing,
+    /// which is precisely the confusion <see cref="DryRunHeader"/> exists to prevent (Q3). The text twin had it
+    /// right and said the dry run covered every one. One source now, and the dry-run arm is part of it.</para></summary>
+    internal static string RowsCutOperationIntact(bool dryRun, string pastParticiple) =>
+        dryRun ? "the dry run covered every one" : $"every one WAS {pastParticiple}";
+
+    /// <summary>The opening of a json <c>truncated_note</c>: which ceiling was hit and what it dropped. json-only —
+    /// the text renders state the same two facts inside their own truncation bracket, where the counts sit.</summary>
+    internal static string JsonRowsCut(int cap) =>
+        $"the render hit max_chars={cap} and dropped trailing rows";
+
+    /// <summary>What a truncated CREATE row list tells the caller — stated by both transports, and one of the two
+    /// places the branch's own rule was still broken: the claim lived twice and had already drifted, with only the
+    /// json copy naming the lane mechanics that make a re-issue expensive.
+    /// <para>The trap is the load-bearing half and is a <see cref="Twins"/> member; the read-back CALL is built per
+    /// outcome by <see cref="WriteTools.ReadBackCall"/>, which has been shared since PR #311.</para></summary>
+    internal static string CreateRowsCutRemedy(string readBackCall) =>
+        $"{RowsCutOperationIntact(false, "created")}. Read them back with {readBackCall} — {Twins.CreateReissueTrap}";
 
     // ---- post-write report blocks (create) -----------------------------------------------------------
     /// <summary>The "check could not run" line the three post-write reports share: the check failed, the records
@@ -140,6 +164,14 @@ internal static class WriteSentences
     internal static string ScanIncomplete(string absentThing) =>
         $"  note: a BSA failed to read this scan, so {absentThing} above may merely be unscanned — verify in MO2.\n";
 
+    /// <summary>What a CUT cell-shell block costs specifically, beyond the generic "rows were dropped". Each cell
+    /// row carries its own <c>must_provide</c> work list, so the dropped rows are exactly the Creation-Kit work
+    /// this response existed to name — a fact the counts alone do not convey. json-only today: the text block's
+    /// cut notice carries no equivalent, and inventing one for it would be a behaviour change rather than the
+    /// migration this is.</summary>
+    internal const string CellRowsCutLoss =
+        "each dropped row is Creation-Kit work this response was supposed to name";
+
     /// <summary>Sentences the SAME outcome must carry on BOTH transports. Reflected over by the write-surface
     /// guard's twin arm — see this class's summary. Members are whole invariant strings on purpose: a sentence
     /// interpolating a cap or a filename cannot be compared verbatim across lanes, so parameterised twins stay on
@@ -149,7 +181,7 @@ internal static class WriteSentences
         // ---- create's post-write hazard reports ------------------------------------------------------
         /// <summary>Voice coverage — the stake, in the words both lanes use. A created voiced response with no
         /// .fuz on disk is byte-valid and SILENT in game.</summary>
-        internal const string VoiceStake = "a created voiced response with NO .fuz plays SILENT in game";
+        internal const string VoiceStake = "voice coverage was not fully rendered";
 
         /// <summary>Result-script coverage — the stake. A bound script that is unwired or uncompiled is byte-valid
         /// and does nothing. (The two copies had drifted to "that's" and "that is"; one reading now.)</summary>
@@ -163,15 +195,22 @@ internal static class WriteSentences
         /// <summary>The grid-occupancy seam, declared rather than silently unchecked. Both lanes carried this and
         /// the json copy had lost "(engine behavior undefined)" — the clause that tells a caller the failure is not
         /// a houseCARL limitation they can work around by trying again.</summary>
-        internal const string GridOccupancy =
-            "houseCARL does NOT check grid-occupancy — a NEW exterior cell at a grid your load order already fills "
-          + "collides (engine behavior undefined). To change an existing cell, OVERRIDE it instead of creating a new one.";
+        internal const string GridOccupancy = "the cell was created.";
 
         /// <summary>What a CUT post-write report block means, and the one action a caller must not take to widen it.
         /// <para>These blocks ride the CREATE render only, so the specific reading is the true one: re-issuing
         /// allocates the records AGAIN. The json copy had generalized to "Do NOT re-issue the write to widen this",
         /// which is weaker advice about the same call — resolved to the specific reading, which is also the one
         /// that survives a caller reading it literally.</para></summary>
+        /// <summary>Why a truncated CREATE must not be re-issued to widen its own render. The sibling verbs' rows
+        /// are safe to re-ask for — a repeated remove is refused, a repeated forward re-copies identical bodies —
+        /// but a repeated create ALLOCATES AGAIN, and the trap does not care which transport asked. Both lanes
+        /// carry this; the text copy used to state it in four words and the json copy in forty.</summary>
+        internal const string CreateReissueTrap =
+            "do NOT re-issue this call to see the rest: a repeated create allocates the records AGAIN (on the "
+          + "default lane patch= auto-suffixes into a second full patch; under into= each record is re-created at "
+          + "its old FormID with its prior contents discarded).";
+
         internal const string ReportBlockCut =
             "the records WERE created and this block is only a render of them — compare rendered vs total rather than "
           + "reading the list as the whole answer. Do NOT re-issue the create to widen it: that allocates the records again";
@@ -205,9 +244,8 @@ internal static class WriteSentences
         /// folder wins the SEQ\ conflict — so the sentence says what was done and what it is for, and does not
         /// promise a verdict from a tool that resolves its input differently.</summary>
         internal const string SeqTimestampRefreshed =
-            "its mtime was older than the plugin and has been stamped forward (contents untouched); "
-          + "housecarl_validate_dialogue's SEQ staleness check compares those two mtimes, so this file no longer reads "
-          + "as stale — for the copy the load order actually serves, which is this one only if this folder wins the SEQ\\ conflict.";
+            "housecarl_validate_dialogue's SEQ staleness check compares mtimes "
+          + "— for the copy the load order actually serves.";
 
         /// <summary>No start-game-enabled quests: a .seq lists only SGE quests, so none is needed and nothing was
         /// written. Never a silent empty file, never a misleading "done".</summary>

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -538,16 +538,11 @@ public static class WriteTools
         var sb = new StringBuilder();
         if (o.InPlace)
             sb.Append("edited ").Append(file).Append(" IN PLACE (").Append(o.Bytes)
-              .Append(" bytes — your ORIGINAL file was rewritten; no houseCARL backup or undo)\n")
-              .Append("mod folder: ").Append(modFolder).Append("  — already active in your load order; re-sort only if a winner changed\n");
+              .Append(" bytes — ").Append(WriteSentences.InPlaceRewritten).Append(")\n")
+              .Append(WriteSentences.InPlaceModFolder(modFolder));
         else
-        {
-            sb.Append(o.Extended ? "extended " : "wrote ").Append(file)
-              .Append(o.Extended ? " (existing patch grown; " : " (new patch; ").Append(o.Bytes).Append(" bytes)\n");
-            sb.Append("mod folder: ").Append(modFolder)
-              .Append(o.Extended ? "\n" : "  — enable + sort it in MO2 to use the patch\n");
-        }
-        sb.Append("masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters)).Append('\n');
+            sb.Append(WriteSentences.NewOrExtendedArtifact(o.Extended, file, o.Bytes, modFolder));
+        sb.Append(WriteSentences.Masters(o.Masters));
         sb.Append(o.Ops.Count).Append(o.Ops.Count == 1 ? " edit:\n" : " edits:\n");
         foreach (var op in o.Ops)
             sb.Append("  ").Append(op.RecordType).Append(' ').Append(op.Target).Append("  ").Append(op.Label)
@@ -578,19 +573,13 @@ public static class WriteTools
         return sb.ToString();
     }
 
-    /// <summary>SPEC §2.1.1 — the index build this write resolved winners against, appended to EVERY write render
-    /// (success, refusal, dry run, consent prompt) exactly as the read surfaces stamp theirs. It is what lets a
-    /// caller tell whether the winner it edited is the winner a read reported a moment earlier: the read-back proves
-    /// what landed in the FILE, never what wins in the ORDER. Empty when the outcome consulted no build.</summary>
-    static string Epoch(WritePatchBuilder.PatchOutcome o) => o.Epoch is null ? "" : $"\nepoch={o.Epoch}";
-
-    /// <summary>The same §2.1.1 stamp for the other three write outcomes (W3 PR 2 — create / remove / forward
-    /// carry the fingerprint on exactly the contract <see cref="WritePatchBuilder.PatchOutcome.Epoch"/> defines).
-    /// Separate overloads rather than one interface: the outcome records are deliberately independent shapes, and
-    /// a shared marker interface would be more machinery than one property read per lane.</summary>
-    static string Epoch(WritePatchBuilder.CreateOutcome o) => o.Epoch is null ? "" : $"\nepoch={o.Epoch}";
-    static string Epoch(WritePatchBuilder.RemovalOutcome o) => o.Epoch is null ? "" : $"\nepoch={o.Epoch}";
-    static string Epoch(WritePatchBuilder.ForwardOutcome o) => o.Epoch is null ? "" : $"\nepoch={o.Epoch}";
+    /// <summary>The §2.1.1 stamp, one thin adapter per outcome record over the one construction in
+    /// <see cref="WriteSentences.Epoch"/>. The four outcomes are deliberately independent shapes — the adapters
+    /// read the property; the SENTENCE lives once.</summary>
+    static string Epoch(WritePatchBuilder.PatchOutcome o) => WriteSentences.Epoch(o.Epoch);
+    static string Epoch(WritePatchBuilder.CreateOutcome o) => WriteSentences.Epoch(o.Epoch);
+    static string Epoch(WritePatchBuilder.RemovalOutcome o) => WriteSentences.Epoch(o.Epoch);
+    static string Epoch(WritePatchBuilder.ForwardOutcome o) => WriteSentences.Epoch(o.Epoch);
 
     /// <summary>The "how to keep going on this plugin" line for a completed IN-PLACE write. The spelling differs
     /// by surface and MUST match what the CALLING tool declares (PR #311 round-2 review [medium]): the 1.x tools
@@ -614,24 +603,16 @@ public static class WriteTools
     {
         var file = Path.GetFileName(o.OutputPath);
         var sb = new StringBuilder();
-        sb.Append("DRY RUN — validated only; NOTHING was written (no patch file, no mod folder, originals untouched).\n");
-        if (o.InPlace)
-            sb.Append("the real call would edit ").Append(file).Append(" IN PLACE — your ORIGINAL file rewritten; no houseCARL backup or undo.\n");
-        else if (o.Extended)
-            sb.Append("the real call would EXTEND the existing patch ").Append(file).Append(".\n");
-        else
-            sb.Append("the real call would write a NEW patch ").Append(file)
-              .Append(" (name preview — the real write re-picks a free name, so the auto-suffix can shift if another patch lands first).\n");
-        sb.Append("expected masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters))
-          .Append("  [derived from the would-be content; the real write derives its own lean header]\n");
+        sb.Append(WriteSentences.DryRunHeader);
+        sb.Append(WriteSentences.DryRunWouldWrite(o.InPlace, o.Extended, file, "edit"));
+        sb.Append(WriteSentences.DryRunMasters(o.Masters));
         sb.Append(o.Ops.Count).Append(o.Ops.Count == 1 ? " edit would apply:\n" : " edits would apply:\n");
         foreach (var op in o.Ops)
             sb.Append("  ").Append(op.RecordType).Append(' ').Append(op.Target).Append("  ").Append(op.Label)
               .Append(op.After is not null ? "  -> would become " + op.After : "  -> would apply").Append('\n');
         if (fullDump && o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars, dryRun: true);
         if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
-        sb.Append("every op passed resolve + pre-flight; to apply for real, repeat the call without dry_run. ")
-          .Append("(A real write can still fail at serialize/commit — disk faults and data Mutagen refuses to serialize surface only there.)")
+        sb.Append(WriteSentences.DryRunClose("every op passed resolve + pre-flight", "apply"))
           .Append(Epoch(o));
         return sb.ToString();
     }
@@ -645,7 +626,7 @@ public static class WriteTools
     static void AppendFullReadback(StringBuilder sb, IReadOnlyList<WritePatchBuilder.FullReadback> rb, int maxChars,
         bool dryRun = false)
     {
-        int cap = maxChars > 0 ? maxChars : Wire.ReadbackMaxChars;
+        int cap = WriteSentences.ReadbackCap(maxChars);
         // #225: a dry run's records are read from the IN-MEMORY would-be content — say so, never imply a file exists.
         sb.Append(dryRun
             ? "full preview — the ENTIRE record(s) as they WOULD be written, read from the in-memory would-be content (nothing is on disk):\n"
@@ -688,7 +669,7 @@ public static class WriteTools
     static void AppendCompactReadback(StringBuilder sb, IReadOnlyList<WritePatchBuilder.OpResult> ops,
         IReadOnlyList<WritePatchBuilder.FullReadback> rb, int maxChars)
     {
-        int cap = maxChars > 0 ? maxChars : Wire.ReadbackMaxChars;
+        int cap = WriteSentences.ReadbackCap(maxChars);
         // The banner covers what it can now stand behind: every edited record WAS re-read off the written file, and
         // each per-op clause below says whether it is the file's answer or the applied edit's own reading.
         sb.Append("verified — every edited record re-read off the written file (compact; pass full_readback=true for the ")
@@ -748,12 +729,14 @@ public static class WriteTools
         if (o.InPlace)
             sb.Append(" IN PLACE (").Append(o.Bytes).Append(" bytes; ")
               .Append(o.RemainingRecords).Append(o.RemainingRecords == 1 ? " record remains" : " records remain")
-              .Append(" — your ORIGINAL file was rewritten; no houseCARL backup or undo)\n")
-              .Append("mod folder: ").Append(modFolder).Append("  — already active in your load order; re-sort only if a winner changed\n");
+              .Append(" — ").Append(WriteSentences.InPlaceRewritten).Append(")\n")
+              .Append(WriteSentences.InPlaceModFolder(modFolder));
         else
         {
             sb.Append(" (").Append(o.Bytes).Append(" bytes; ")
               .Append(o.RemainingRecords).Append(o.RemainingRecords == 1 ? " record remains)\n" : " records remain)\n");
+            // Not NewOrExtendedArtifact: a removal creates no artifact and grows no patch, so it has neither of that
+            // sentence's two claims to make — only which folder the now-leaner file sits in.
             sb.Append("mod folder: ").Append(modFolder).Append('\n');
         }
         // Budgeted like every other write render (PR #311 review [medium]): removal is SET-VALUED now, so the
@@ -762,7 +745,7 @@ public static class WriteTools
         // rows all rendered and the HOST cut the oversized response out-of-band: exactly the silent cut the
         // parameter's own description says never happens. The masters line and the closing guidance below are
         // outside the budget deliberately — they are the accounting a truncated report still needs.
-        int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        int cap = WriteSentences.Cap(maxChars);
         for (int i = 0; i < o.Removed.Count; i++)
         {
             if (sb.Length >= cap)
@@ -781,7 +764,7 @@ public static class WriteTools
             sb.Append("  - ").Append(r.RecordType).Append(' ').Append(r.Target).Append("  ")
               .Append(r.EditorId ?? "<no editorid>").Append('\n');
         }
-        sb.Append("masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters)).Append('\n');
+        sb.Append(WriteSentences.Masters(o.Masters));
         if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
         if (o.InPlace)
             sb.Append(o.RemainingRecords == 0
@@ -808,31 +791,20 @@ public static class WriteTools
         var sb = new StringBuilder();
         if (o.DryRun)
         {
-            // #225 — mirrors RenderDryRun: say NOTHING was written first, then what the real call would do.
-            sb.Append("DRY RUN — validated only; NOTHING was written (no patch file, no mod folder, originals untouched).\n");
-            if (o.InPlace)
-                sb.Append("the real call would forward into ").Append(file).Append(" IN PLACE — your ORIGINAL file rewritten; no houseCARL backup or undo.\n");
-            else if (o.Extended)
-                sb.Append("the real call would EXTEND the existing patch ").Append(file).Append(".\n");
-            else
-                sb.Append("the real call would write a NEW patch ").Append(file)
-                  .Append(" (name preview — the real write re-picks a free name, so the auto-suffix can shift if another patch lands first).\n");
-            sb.Append("expected masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters))
-              .Append("  [derived from the would-be content; the real write derives its own lean header]\n");
+            // #225 — the SAME dry-run sentences the apply lane renders, from the same source: say NOTHING was
+            // written first, then what the real call would do.
+            sb.Append(WriteSentences.DryRunHeader);
+            sb.Append(WriteSentences.DryRunWouldWrite(o.InPlace, o.Extended, file, "forward into"));
+            sb.Append(WriteSentences.DryRunMasters(o.Masters));
         }
         else if (o.InPlace)
             sb.Append("forwarded into ").Append(file).Append(" IN PLACE (").Append(o.Bytes)
-              .Append(" bytes — your ORIGINAL file was rewritten; no houseCARL backup or undo)\n")
-              .Append("mod folder: ").Append(modFolder).Append("  — already active in your load order; re-sort only if a winner changed\n");
+              .Append(" bytes — ").Append(WriteSentences.InPlaceRewritten).Append(")\n")
+              .Append(WriteSentences.InPlaceModFolder(modFolder));
         else
-        {
-            sb.Append(o.Extended ? "extended " : "wrote ").Append(file)
-              .Append(o.Extended ? " (existing patch grown; " : " (new patch; ").Append(o.Bytes).Append(" bytes)\n");
-            sb.Append("mod folder: ").Append(modFolder)
-              .Append(o.Extended ? "\n" : "  — enable + sort it in MO2 to use the patch\n");
-        }
+            sb.Append(WriteSentences.NewOrExtendedArtifact(o.Extended, file, o.Bytes, modFolder));
         if (!o.DryRun)
-            sb.Append("masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters)).Append('\n');
+            sb.Append(WriteSentences.Masters(o.Masters));
         // WHICH copy an off-order source read — a fact, not derivable from the name (several install layers can provide
         // one filename, and only one of them was opened). Stated once for the call, because one source= serves it all.
         if (o.OffOrderSource is { } oo)
@@ -849,7 +821,7 @@ public static class WriteTools
         // Budgeted for the same reason as the created-records block: formids= is set-valued, each row is long (type +
         // FormKey + editorid + the source clause + a REPLACED / redundant / out-ranks bracket), and the json twin
         // already truncates the identical array (PR #311 review 3 [medium]).
-        int fwdCap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        int fwdCap = WriteSentences.Cap(maxChars);
         for (int fi = 0; fi < o.Forwarded.Count; fi++)
         {
             if (sb.Length >= fwdCap)
@@ -892,8 +864,7 @@ public static class WriteTools
         if (o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars, dryRun: o.DryRun);
         if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
         sb.Append(o.DryRun
-            ? "every record resolved from its source; to forward for real, repeat the call without dry_run. " +
-              "(A real write can still fail at serialize/commit — disk faults surface only there.)"
+            ? WriteSentences.DryRunClose("every record resolved from its source", "forward")
             : o.InPlace
                 ? InPlaceAgainHint("to forward more into this plugin", file, laneAsName)
                 : $"to forward more into THIS patch (incl. from a different source plugin), pass into=\"{file}\".");
@@ -913,7 +884,7 @@ public static class WriteTools
         sb.Append("wrote ").Append(file).Append(o.Esl ? " (header-only, ESL-flagged; " : " (header-only; ")
           .Append(o.Bytes).Append(" bytes, ").Append(o.RecordCount).Append(o.RecordCount == 1 ? " record)\n" : " records)\n");
         sb.Append("mod folder: ").Append(modFolder).Append("  — enable + sort it in MO2 to use it\n");
-        sb.Append("masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters)).Append('\n');
+        sb.Append(WriteSentences.Masters(o.Masters));
         sb.Append("this is a trigger/placeholder plugin: it carries no records, so it changes nothing in game by itself — ")
           .Append("its only job is to make the basename '").Append(Path.GetFileNameWithoutExtension(file))
           .Append("' present in the load order (so a basename-bound SKSE config resolves, a FormID range is reserved, etc.).");
@@ -934,8 +905,8 @@ public static class WriteTools
         var sb = new StringBuilder();
         if (o.InPlace)
             sb.Append("compacted ").Append(file).Append(" IN PLACE (").Append(o.Bytes)
-              .Append(" bytes — your ORIGINAL file was rewritten; no houseCARL backup or undo)\n")
-              .Append("mod folder: ").Append(modFolder).Append("  — already active; re-sort only if a winner changed\n");
+              .Append(" bytes — ").Append(WriteSentences.InPlaceRewritten).Append(")\n")
+              .Append(WriteSentences.InPlaceModFolder(modFolder));
         else
             sb.Append("wrote compacted ").Append(file).Append(" (new plugin; ").Append(o.Bytes).Append(" bytes)\n")
               .Append("mod folder: ").Append(modFolder).Append("  — enable it and DISABLE the original '").Append(file)
@@ -947,7 +918,7 @@ public static class WriteTools
         sb.Append(o.Esl ? "into the light range 0x800–0xFFF" : "contiguously from 0x800");
         if (overrides > 0) sb.Append("; ").Append(overrides).Append(overrides == 1 ? " override kept at its master FormID" : " overrides kept at their master FormIDs");
         sb.Append(".\n");
-        sb.Append("masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters)).Append('\n');
+        sb.Append(WriteSentences.Masters(o.Masters));
 
         if (o.ExternalPlugins.Count == 0)
             sb.Append("external referencers: none — clean compaction (nothing outside this plugin pointed at a renumbered record).\n");
@@ -1074,7 +1045,7 @@ public static class WriteTools
         foreach (var d in o.DonorRemaps)
             sb.Append("  ").Append(d.Donor).Append(": ").Append(d.Kept).Append(" object id(s) kept, ")
               .Append(d.Renumbered).Append(" renumbered (id collisions / below-floor)\n");
-        sb.Append("masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters)).Append('\n');
+        sb.Append(WriteSentences.Masters(o.Masters));
 
         if (o.Conflicts.Count == 0)
             sb.Append("cross-donor conflicts: none — no record was carried by more than one donor.\n");
@@ -1136,16 +1107,11 @@ public static class WriteTools
         var sb = new StringBuilder();
         if (o.InPlace)
             sb.Append(file).Append(" rewritten IN PLACE (").Append(o.Bytes)
-              .Append(" bytes — your ORIGINAL file; no houseCARL backup or undo)\n")
-              .Append("mod folder: ").Append(modFolder).Append("  — already active in your load order; re-sort only if a winner changed\n");
+              .Append(" bytes — ").Append(WriteSentences.InPlaceRewritten).Append(")\n")
+              .Append(WriteSentences.InPlaceModFolder(modFolder));
         else
-        {
-            sb.Append(o.Extended ? "extended " : "wrote ").Append(file)
-              .Append(o.Extended ? " (existing patch grown; " : " (new patch; ").Append(o.Bytes).Append(" bytes)\n");
-            sb.Append("mod folder: ").Append(modFolder)
-              .Append(o.Extended ? "\n" : "  — enable + sort it in MO2 to use the patch\n");
-        }
-        sb.Append("masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters)).Append('\n');
+            sb.Append(WriteSentences.NewOrExtendedArtifact(o.Extended, file, o.Bytes, modFolder));
+        sb.Append(WriteSentences.Masters(o.Masters));
         var replacedCount = o.Created.Count(c => c.ReplacedExisting);
         sb.Append("created ").Append(o.Created.Count).Append(o.Created.Count == 1 ? " record" : " records");
         if (replacedCount > 0)
@@ -1158,7 +1124,7 @@ public static class WriteTools
         // disagree about the same call, with the text lane taking a silent host-side cut. (The round-1 fold filed this
         // as a follow-up on the grounds that max_chars' description scoped the ceiling to the read-back; the D2
         // divergence is the stronger argument and it wins.)
-        int createCap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        int createCap = WriteSentences.Cap(maxChars);
         // #300's HOST CHOICE, hoisted out of the budget below: which version of a contested parent this artifact
         // carries is a control decision the caller may want to act on (sort, or inline the winner deliberately), and
         // the per-record `parent:` lines live INSIDE the loop where a max_chars cut removes them. It is a statement,
@@ -1310,9 +1276,10 @@ public static class WriteTools
         // Budget-bounded like the full read-back (same maxChars contract): a bulk_create authoring hundreds of voiced
         // lines must NOT silently blow the response size or starve a requested read-back — past the cap the voice
         // section stops with an explicit notice (Q3), never a silent cut.
-        int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        int cap = WriteSentences.Cap(maxChars);
         int total = report.Lines.Count + report.Undetermined.Count, rendered = 0;
-        sb.Append("voice coverage — created dialogue lines (a response with no .fuz plays SILENT in game; the audio is yours to provide):\n");
+        sb.Append("voice coverage — created dialogue lines (").Append(WriteSentences.Twins.VoiceStake)
+          .Append("; the audio is yours to provide):\n");
 
         bool anyReadIncomplete = false;
         foreach (var l in report.Lines)
@@ -1344,10 +1311,9 @@ public static class WriteTools
             sb.Append("  [?] ").Append(who).Append("  — ").Append(u.Reason).Append('\n');
             rendered++;
         }
-        if (anyReadIncomplete)
-            sb.Append("  note: a BSA failed to read this scan, so an \"absent\" above may merely be unscanned — verify in MO2.\n");
+        if (anyReadIncomplete) sb.Append(WriteSentences.ScanIncomplete("an \"absent\""));
         if (report.CheckError is not null)
-            sb.Append("  voice check could not run: ").Append(report.CheckError).Append(" — the records WERE created; verify voice files manually.\n");
+            sb.Append(WriteSentences.CheckCouldNotRun("voice", report.CheckError, "the records", "verify voice files manually."));
     }
 
     /// <summary>The explicit voice-coverage truncation notice (Q3 — the same convention as the read-back's): how many
@@ -1355,18 +1321,12 @@ public static class WriteTools
     /// <para>Shares its closing clause with the result-script notice and with the json <c>WriteBlockCensus</c>
     /// (PR #311 review 7 [medium]): these blocks ride the CREATE render, so "raise max_chars to see the rest" meant
     /// re-issuing a create — a second auto-suffixed patch on the default lane, or re-creation at the same FormID
-    /// with prior contents discarded under <c>into=</c>. The json twin added this round already said "Do NOT
-    /// re-issue the write to widen this", so the two transports were giving opposite advice about one call.</para></summary>
+    /// with prior contents discarded under <c>into=</c>. That clause is now
+    /// <see cref="WriteSentences.Twins.ReportBlockCut"/>, read by both transports, so the two can no longer give
+    /// opposite advice about one call.</para></summary>
     static void AppendVoiceTrunc(StringBuilder sb, int rendered, int total, int cap)
         => sb.Append("  ... [voice coverage truncated: rendered ").Append(rendered).Append(" of ").Append(total)
-             .Append(" line(s) at max_chars=").Append(cap).Append(ReportBlockCutClause).Append("]\n");
-
-    /// <summary>The closing clause every post-write REPORT truncation notice shares, text and json alike. Names the
-    /// stakes (a cut list is not a clean bill of health) and refuses to prescribe the one action that would widen it
-    /// at the cost of a duplicate write.</summary>
-    internal const string ReportBlockCutClause =
-        "; the records WERE created and this block is only a render of them — compare rendered vs total above rather than "
-      + "reading the list as the whole answer. Do NOT re-issue the create to widen it: that allocates the records again";
+             .Append(" line(s) at max_chars=").Append(cap).Append("; ").Append(WriteSentences.Twins.ReportBlockCut).Append("]\n");
 
     /// <summary>Render the coordinate-keyed §4-(b) structural-shell report (a cell create). The enforced Q3 teeth against
     /// a created-but-EMPTY cell: a created cell is a valid, correctly-placed RECORD, but houseCARL does NOT author world
@@ -1381,10 +1341,10 @@ public static class WriteTools
         // create authoring a batch of cells rendered every row in TEXT and took the SILENT host-side cut — the
         // divergence the created-rows / forwarded-rows / removed-rows folds each closed in turn. The inner
         // MustProvide loop is bounded too: one cell with a long work list could blow the budget by itself.
-        int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        int cap = WriteSentences.Cap(maxChars);
         int total = report.Cells.Count, rendered = 0;
         bool cut = false;
-        sb.Append("cell shell — created cells are valid, correctly-placed records but EMPTY; houseCARL does not author world content (provide these in the Creation Kit):\n");
+        sb.Append("cell shell — ").Append(WriteSentences.Twins.CellStake).Append(" (provide these in the Creation Kit):\n");
         foreach (var c in report.Cells)
         {
             if (sb.Length >= cap) { cut = true; break; }
@@ -1402,13 +1362,13 @@ public static class WriteTools
         // seam in particular must not be the thing a cut swallows.
         if (cut)
             sb.Append("  ... [cell shell truncated: rendered ").Append(rendered).Append(" of ").Append(total)
-              .Append(" cell(s) at max_chars=").Append(cap).Append(ReportBlockCutClause).Append("]\n");
+              .Append(" cell(s) at max_chars=").Append(cap).Append("; ").Append(WriteSentences.Twins.ReportBlockCut).Append("]\n");
         // Q3 — declare the un-checked grid-occupancy seam (full load-order occupancy detection is a follow-up; never a
         // silent omission). Only an EXTERIOR cell collides on a grid; an interior cell has no grid identity.
         if (report.Cells.Any(c => !c.Interior))
-            sb.Append("  note: houseCARL does NOT check grid-occupancy — a NEW exterior cell at a grid your load order already fills collides (engine behavior undefined). To change an existing cell, OVERRIDE it instead of creating a new one.\n");
+            sb.Append("  note: ").Append(WriteSentences.Twins.GridOccupancy).Append('\n');
         if (report.CheckError is not null)
-            sb.Append("  cell-shell check could not run: ").Append(report.CheckError).Append(" — the cell(s) WERE created; review world content manually.\n");
+            sb.Append(WriteSentences.CheckCouldNotRun("cell-shell", report.CheckError, "the cell(s)", "review world content manually."));
     }
 
     /// <summary>Render the Layer B unit C result-script coverage report (a dialogue-line create). The enforced Q3 teeth
@@ -1420,9 +1380,9 @@ public static class WriteTools
     static void AppendScriptBindingReport(StringBuilder sb, ScriptBindingReport? report, int maxChars)
     {
         if (report is null || report.IsEmpty) return;
-        int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        int cap = WriteSentences.Cap(maxChars);
         int total = report.Findings.Count, rendered = 0;
-        sb.Append("result-script coverage — created dialogue lines (a bound script that's unwired or uncompiled runs NOTHING in game):\n");
+        sb.Append("result-script coverage — created dialogue lines (").Append(WriteSentences.Twins.ScriptStake).Append("):\n");
 
         bool anyReadIncomplete = false;
         foreach (var f in report.Findings)
@@ -1430,7 +1390,7 @@ public static class WriteTools
             if (sb.Length >= cap)
             {
                 sb.Append("  ... [result-script coverage truncated: rendered ").Append(rendered).Append(" of ").Append(total)
-                  .Append(" line(s) at max_chars=").Append(cap).Append(ReportBlockCutClause).Append("]\n");
+                  .Append(" line(s) at max_chars=").Append(cap).Append("; ").Append(WriteSentences.Twins.ReportBlockCut).Append("]\n");
                 return;
             }
             var who = string.IsNullOrEmpty(f.TopicEditorId) ? f.Info.ToString() : $"{f.TopicEditorId} ({f.Info})";
@@ -1454,10 +1414,9 @@ public static class WriteTools
             if (f.ReadIncomplete) anyReadIncomplete = true;
             rendered++;
         }
-        if (anyReadIncomplete)
-            sb.Append("  note: a BSA failed to read this scan, so a \"missing .pex\" above may merely be unscanned — verify in MO2.\n");
+        if (anyReadIncomplete) sb.Append(WriteSentences.ScanIncomplete("a \"missing .pex\""));
         if (report.CheckError is not null)
-            sb.Append("  result-script check could not run: ").Append(report.CheckError).Append(" — the records WERE created; verify the script binding manually.\n");
+            sb.Append(WriteSentences.CheckCouldNotRun("result-script", report.CheckError, "the records", "verify the script binding manually."));
     }
 }
 

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -544,9 +544,26 @@ public static class WriteTools
             sb.Append(WriteSentences.NewOrExtendedArtifact(o.Extended, file, o.Bytes, modFolder));
         sb.Append(WriteSentences.Masters(o.Masters));
         sb.Append(o.Ops.Count).Append(o.Ops.Count == 1 ? " edit:\n" : " edits:\n");
-        foreach (var op in o.Ops)
+        // BUDGETED, like every sibling render (the D2 twin arm's finding). This loop was the last unbounded row
+        // list on the write surface: `bulk_apply` is set-valued, so a few hundred ops is the case the tool exists
+        // for, and the json twin has always budgeted the same array and closed truncated:true. Text rendered every
+        // row and let the HOST cut the oversized response out-of-band — the silent cut max_chars= promises never
+        // happens, and the same divergence the created / forwarded / removed / cell-shell rows each closed in turn.
+        int opCap = WriteSentences.Cap(maxChars);
+        for (int i = 0; i < o.Ops.Count; i++)
+        {
+            if (sb.Length >= opCap)
+            {
+                sb.Append("  ... [truncated: ").Append(i).Append(" of ").Append(o.Ops.Count)
+                  .Append(" edit(s) listed at max_chars=").Append(opCap).Append("; ")
+                  .Append(WriteSentences.RowsCutOperationIntact(false, "applied"))
+                  .Append(" — ").Append(ApplyAgainRemedy(o, file)).Append("]\n");
+                break;
+            }
+            var op = o.Ops[i];
             sb.Append("  ").Append(op.RecordType).Append(' ').Append(op.Target).Append("  ").Append(op.Label)
               .Append(op.After is not null ? "  -> " + op.After : "  -> applied").Append('\n');
+        }
         // Make the dialogue-coverage scope boundary VISIBLE, not silent (Q3): the .fuz/.lip presence check (unit B) AND
         // the result-script binding check (unit C1) both run on CREATE of dialogue lines, not on EDITS to existing ones.
         // An edit that adds a spoken response or a result script to an existing INFO produces the same silent-line /
@@ -607,9 +624,23 @@ public static class WriteTools
         sb.Append(WriteSentences.DryRunWouldWrite(o.InPlace, o.Extended, file, "edit"));
         sb.Append(WriteSentences.DryRunMasters(o.Masters));
         sb.Append(o.Ops.Count).Append(o.Ops.Count == 1 ? " edit would apply:\n" : " edits would apply:\n");
-        foreach (var op in o.Ops)
+        // Budgeted for the same reason as the real render's loop, with the dry run's own arm on the cut notice:
+        // a dry run wrote nothing, so it must not say the edits were applied.
+        int dryCap = WriteSentences.Cap(maxChars);
+        for (int i = 0; i < o.Ops.Count; i++)
+        {
+            if (sb.Length >= dryCap)
+            {
+                sb.Append("  ... [truncated: ").Append(i).Append(" of ").Append(o.Ops.Count)
+                  .Append(" edit(s) listed at max_chars=").Append(dryCap).Append("; ")
+                  .Append(WriteSentences.RowsCutOperationIntact(true, "applied"))
+                  .Append(" — ").Append(ApplyAgainRemedy(o, file)).Append("]\n");
+                break;
+            }
+            var op = o.Ops[i];
             sb.Append("  ").Append(op.RecordType).Append(' ').Append(op.Target).Append("  ").Append(op.Label)
               .Append(op.After is not null ? "  -> would become " + op.After : "  -> would apply").Append('\n');
+        }
         if (fullDump && o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars, dryRun: true);
         if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
         sb.Append(WriteSentences.DryRunClose("every op passed resolve + pre-flight", "apply"))
@@ -756,8 +787,9 @@ public static class WriteTools
                 // removed", because the records are already gone. Nothing is actually lost, though, and saying so
                 // is the honest remedy: removal is all-or-nothing, so the rows ARE the formids= the caller passed.
                 sb.Append("  ... [truncated: ").Append(i).Append(" of ").Append(o.Removed.Count)
-                  .Append(" removed record(s) listed at max_chars=").Append(cap)
-                  .Append("; every one WAS removed — ").Append(RemovedRowsRemedy).Append("]\n");
+                  .Append(" removed record(s) listed at max_chars=").Append(cap).Append("; ")
+                  .Append(WriteSentences.RowsCutOperationIntact(false, "removed"))
+                  .Append(" — ").Append(RemovedRowsRemedy).Append("]\n");
                 break;
             }
             var r = o.Removed[i];
@@ -828,8 +860,8 @@ public static class WriteTools
             {
                 sb.Append("  ... [truncated: ").Append(fi).Append(" of ").Append(o.Forwarded.Count)
                   .Append(" record(s) listed at max_chars=").Append(fwdCap)
-                  .Append(o.DryRun ? "; the dry run covered every one — " : "; every one WAS forwarded — ")
-                  .Append(ForwardAgainRemedy(o, file)).Append(']')
+                  .Append("; ").Append(WriteSentences.RowsCutOperationIntact(o.DryRun, "forwarded"))
+                  .Append(" — ").Append(ForwardAgainRemedy(o, file)).Append(']')
                   .Append('\n');
                 break;
             }
@@ -1106,7 +1138,10 @@ public static class WriteTools
         var modFolder = Path.GetFileName(Path.GetDirectoryName(o.OutputPath) ?? "");
         var sb = new StringBuilder();
         if (o.InPlace)
-            sb.Append(file).Append(" rewritten IN PLACE (").Append(o.Bytes)
+            // "created into X" rather than the old "X rewritten": every sibling in-place headline is verb-then-file
+            // (edited / forwarded into / removed from / compacted), and create's was the one that led with the file
+            // and used "rewritten" as its verb — which now stutters against the shared hazard clause behind it.
+            sb.Append("created into ").Append(file).Append(" IN PLACE (").Append(o.Bytes)
               .Append(" bytes — ").Append(WriteSentences.InPlaceRewritten).Append(")\n")
               .Append(WriteSentences.InPlaceModFolder(modFolder));
         else
@@ -1157,9 +1192,8 @@ public static class WriteTools
                 // duplicate-write trap ReadBackInFull's own doc names, and an agent following the notice literally
                 // walks into it.
                 sb.Append("  ... [truncated: ").Append(ci).Append(" of ").Append(o.Created.Count)
-                  .Append(" created record(s) listed at max_chars=").Append(createCap)
-                  .Append("; every one WAS created — read them back with ").Append(ReadBackCall(o, file))
-                  .Append(" (re-calling this tool would create them AGAIN)]").Append('\n');
+                  .Append(" created record(s) listed at max_chars=").Append(createCap).Append("; ")
+                  .Append(WriteSentences.CreateRowsCutRemedy(ReadBackCall(o, file))).Append("]\n");
                 break;
             }
             var c = o.Created[ci];


### PR DESCRIPTION
Implements `dev/projects/tool-surface-2.0/RESPONSE_LAYER_BY_CONSTRUCTION_2026-08-11.md` (chartered
Aaron-go 2026-08-11). No linked issue — this lane is chartered from the plan doc, not the bug lane, so
there is no closing keyword to carry.

## What this is

Every write tool renders its outcome twice — text via `WriteTools`/`SeqTools`, json via `JsonWire` (D2:
one write path, two renders) — and several text renders repeat the same sentence per verb on top of
that. Each copy was an independent statement of one meaning. The 2.0 review wave's single largest
finding class was those copies drifting.

`WriteSentences` now holds one source per sentence, read by both transports. Copies were deleted in the
same commit that added each shared member (the plan's replace-not-add rule).

## Inventory — the completeness claim

The plan makes the enumerated leftovers the claim rather than a silent "done".

**36 shared members**, 15 of them in `WriteSentences.Twins` and parity-enforced. The other 21 are
single-sourced but not verbatim-comparable across lanes — either prose on one transport by design (the
in-place hazard, which json states as `lane` plus typed flags) or parameterised (a cap, a filename, a
read-back call).

**9 disagreements resolved.** Each was two copies of one sentence that had already drifted:

| Sentence | The drift | Kept |
|---|---|---|
| grid-occupancy note | json had lost `(engine behavior undefined)` | the fuller — it tells the caller a retry will not help |
| report-block cut advice | text "do not re-issue the **create** — that allocates the records again" vs json "do not re-issue the write" | text's; these blocks ride create only |
| `write_seq` standing limit | json dropped the `housecarl_validate_dialogue` pointer | the fuller — that is the what-next half |
| dry-run closing line | forward "disk faults" vs apply "disk faults **and data Mutagen refuses to serialize**" | the fuller; both verbs commit through the same serializer |
| in-place hazard | create's copy had lost "was rewritten" | the four-site majority |
| in-place mod folder | compact's had lost "in your load order" | the majority |
| script-binding stake | "that's" vs "that is" | one spelling |
| voice stake | "a response with no .fuz" vs "a created voiced response with NO .fuz" | the json reading |
| `write_seq` unchanged / three replace readings / no-epoch | paraphrases across lanes | one reading each |

Plus one deixis resolution: `write_seq`'s list-cut remedy said "name into=/output_dir= **the folder
below**", a reference into a line only the text render prints. A shared sentence cannot carry that, so
the lane-neutral reading stands.

**3 behaviour changes:**

1. **`apply`'s text ops loop is now budgeted** (real and dry-run paths). Its json twin has always
   dropped trailing rows at `max_chars` and closed `truncated:true`; the text render listed every edit
   and let the host cut the oversized response out of band — the silent cut `max_chars` promises never
   happens. This was the last unbounded row list on the write surface.
2. **A truncated dry run no longer describes itself as a completed write.** The json cut note said "the
   WRITE is complete and unaffected" on a lane that writes nothing.
3. **create's in-place headline** moved from `X.esp rewritten IN PLACE` to `created into X.esp IN PLACE` —
   every sibling is verb-then-file, and create's used "rewritten" as its verb, which stutters against the
   shared hazard clause now behind it. Added here on review finding 6: it is a wording change rather than
   a migration, and the inventory is the completeness claim.

**13 guard arms** moved from fragment pins to construction pins. `write-surface-guard` 169 → 191.

**No behaviour change from the A/B/C fold** — `SeqStandingLimit`'s sentence is unchanged; only its declared
phrases moved from a bare token to the action. A/C are guard-side.

**7 remainders, named with reasons:** the engine-side consent prompts (`LoadOrderService.cs:1482`,
`:4919`, `:5547` — three spellings of the in-place hazard; deferred rather than half-folded, they need
their own resolution); the read surface (explicitly a later PR per the plan — `JsonWire.Cap` was briefly
wired through `WriteSentences.Cap` here and deliberately unwired again); tool `[Description(...)]`
strings (the tool schema is a different surface); the truncation-notice frame (every claim-bearing part
is shared; what repeats carries no claim); `compact`/`merge` internals (1.x renders outside the plan's
five verbs); and the executability half of plan item 2 (`SeqListCutRemedy` names `into=`/`output_dir=`
and no arm proves either resolves — a real follow-up); and **the parameterised shared sentences** — see below.

### Known and not fixed: the parameterised helpers are outside the `[MustState]` net

The A/B/C fold closes the net over every `const string` on both classes: absence now fails. It does **not**
cover the ~14 parameterised helpers (`DryRunClose`, `NewOrExtendedArtifact`, `InPlaceModFolder`,
`RowsCutOperationIntact`, `CreateRowsCutRemedy`, `CheckCouldNotRun`, `Masters`, …), because a sentence that
interpolates a cap, a filename or a verb has no invariant string to compare. Several carry real claims —
`DryRunClose`'s "(A real write can still fail at serialize/commit …)" is a caveat nothing pins.

This is the declared boundary of the mechanism rather than a new hole: it was in this inventory from the
first push, and it predates the opt-in model. Closing it needs a different shape — pinning invariant
FRAGMENTS of a parameterised sentence — which is a design decision, not a fold. Flagged here now that the
const half is closed, because that is what makes this the visible edge of the map.

## The D2 twin harness

One outcome, both transports, all five verbs. It asserts per-lane coverage of the shared inventory —
every twin observed coming out of text at least once and json at least once, by reflection, so a new
member is enrolled automatically — plus budget parity (a cap that truncates one lane truncates the
other) and count parity.

Deliberately coverage-per-lane rather than co-occurrence-per-outcome: a few of these land in different
places on the two lanes (text report blocks state their stake in the block header, json blocks in the
truncation census), so demanding co-occurrence would fail honest renders.

RED-checked in both directions: re-inlining two json copies fails with
`unobserved: GridOccupancy, SeqStandingLimit`; making the text created-rows list unbounded fails with
`text=False json=True`, the historical bug shape.

## Review rounds

**Round 1** — three fresh agents (correctness, guards, completeness). The guards agent was killed by a
power cut and never reported; see the incident below. Of the two that landed: 1 high, 5 medium, 6 low
folded. The three that mattered were the branch's own rule broken where it had not looked — create's
row-cut remedy still stated twice and already drifted; the "rows were cut, the operation was not" claim
two literals, with json asserting a completed write on a truncated dry run; and `apply`'s unbudgeted
text ops loop, which the twin arm missed because `apply` was not enrolled in it.

Refused, with reasons: naming `seq_path` inside the shared replace notes (the text lane has no such
member and prints `path:` itself; mid-sentence lane injection would restore the per-site prose this
removes); folding one of the three engine-side consent prompts (worse than naming all three); proving
`into=`/`output_dir=` executable from the cut remedy (a real probe, scoped as a follow-up).

**Round 2** — two fresh agents (guards, output-composition). Both independently found the incident
below. Otherwise: 2 medium, 6 low folded, no refusals — the findings were reproducible in the source and
several were defects the round-1 fold had introduced.

**Stopped at two rounds.** Round 1's class was "incomplete migration"; round 2's was "the construction
pins are content-blind". Two consecutive rounds on one seam — the migration's own verification posture —
is the §5 #11 convergence signal, so no round 3.

## Incident: three sentences shipped gutted, and the guards could not see it

Commit `780ac3a` contained three `Twins` constants replaced by placeholders — `GridOccupancy` became
`"the cell was created."`, `VoiceStake` became `"voice coverage was not fully rendered"`, and
`SeqTimestampRefreshed` lost the statement that the mtime had been stamped forward at all. All three
were correct in `356cd35`.

I did not edit them. The round-1 guards agent break-tests by design — break a constant, confirm RED,
restore — and the power cut killed it mid-test, leaving its sabotage in the shared worktree. I then ran
`git add -A` and committed without reading the diff.

The full suite stayed green because that same commit migrated those arms from `Contains("<fragment>")`
to `Contains(TheConstant)`. **A construction pin proves the render reads the shared source and nothing
about what the source says** — render and assertion read the same symbol, so it passes on a constant
that has been emptied. That trade was the real defect; the sabotage only exposed a hole already built.

Fixed in `fdd67a3`: constants restored, and the content half put back where it belongs — beside the
sentence rather than as a second copy in a probe. Every twin now carries `[MustState(...)]` naming the
claims it must keep. The arm fails if a phrase is missing, if a member declares none, or if a member is
a shape the reflection cannot read (a `static readonly` or a nested type would otherwise be an unchecked
twin counted as covered — round 2 demonstrated both). RED-checked by replaying the exact sabotage: it
now fails by name, listing all four missing phrases.

Two process points that are yours to call, not mine:

- **Review agents should run in isolated worktrees.** The agents that break-test are the ones most
  likely to corrupt the branch, and they had the same tree I commit from. The Agent tool has
  `isolation: "worktree"` for this. Making it standing practice is a §5 #11 change — self-governing
  config, so surfaced rather than self-committed.
- **`MustState` is worth your own eye.** It is now the thing standing between a shared sentence and
  silent evisceration.

## Review fold (Aaron's review, 6 findings)

**3 and 4 — phrase quality.** Aaron directed these be fixed by writing better phrases and recording the
norm, **not** by making the checker smarter: *a phrase carries the hazard or the action; a phrase that
survives its sentence's negation is not a claim.* That norm now lives in `MustStateAttribute`'s doc,
together with why it stays a norm — judgment inside a comparator is #308's shape, and a future round
proposing claim-quality validation in reflection is that mistake wearing new clothes. Keeping the line
visible is the point.

Applying the norm across the whole set caught four more of the same two kinds beyond the two named: bare
topic tokens (`"grid-occupancy"`, `"load-order-independent"`, `"Start Game Enabled"`) and a phrase that
survives its own negation (`"stamped forward"`). Six rephrased.

**1 — the in-place hazard was outside the net.** The loudest sentence on the surface, and this change is
what made it a single token: one edit could have stripped it from all five in-place renders with
everything green. It now carries `[MustState]`, the content check walks the outer class as well as
`Twins`, and the lane arm asserts the sentence reaches the caller.

**2 and 5 — checker-mechanical, fixed in code.** The shape alarm now covers methods and events (a
method-shaped twin was invisible to both the inventory and the alarm); an empty phrase or empty sentence
is rejected rather than satisfying every assertion.

**6 — undeclared behaviour change.** Folded into the inventory above.

RED-checked all four: emptying `NoBackupOrUndo`, declaring an empty phrase, adding a method-shaped twin,
and — replaying findings 3 and 4 verbatim — negating the replace note and rewording the `into=` half all
now fail by name. That last pair is the evidence that better phrases were the right lever.

## Verification

`ci-all` 117/117 · `write-surface-guard` 190/190 · `apply-guard` 78/78 · `seq-write-guard` all arms, in
Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
