### PR TITLE
docs(claude.md): the advisor lane — dev/advisor/, fresh judgment sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ A session picking up work reads:
 
 **Sub-project sessions.** Some work runs as a self-contained sub-project under `dev/projects/<name>/` (its own tracking, walled off from the main gap/bug/release lane — see `dev/projects/README.md`). If a session is for one, the user will name it ("the follower skill", "the `<name>` project"); then read `dev/projects/<name>/STATUS.md` **instead of** the latest `dev/session-handoffs/` handoff (item 2), and stay in that lane. Absent that, boot normally — the default is unchanged.
 
+**Advisor sessions.** `dev/advisor/` is a project-wide judgment lane (created 2026-08-12): fresh Fable-class sessions that render recommendations on escalations, review the reviews, and translate for Aaron — advisory only, Aaron decides, and the session never builds or holds a worktree. If a session is named as one ("advisor session", "the judgment seat"), boot per `dev/advisor/README.md` instead of items 2–3. Build sessions interact with the lane only through Aaron — an escalation goes to him, and he may bring back its ruling.
+
 The cornerstones (§3) and revalidation protocol (§4) are restated in this file, so you operate correctly from CLAUDE.md alone — the corpus is the authority you re-read when the protocol sends you there, not a tax every session pays.
 
 ---


### PR DESCRIPTION
## What

One paragraph added to §2, pointing at the new `dev/advisor/` lane (the lane itself is in the gitignored `dev/` tree, created directly): fresh Fable-class sessions that render recommendations on escalations, review the reviews, and translate decisions into plain English for Aaron. Advisory only — Aaron decides; the session never builds or holds a worktree. Sessions are fresh per engagement rather than standing, so the judge never ends up grading its own prior rulings; continuity lives in the lane's `DECISIONS.md` (seeded with this era's calls: the §11 reforms, the #334 A/B seam, the #337 MustState verdict and class-shaped folds) and its handoffs.

Aaron-directed 2026-08-12, from the observation that the last two PRs' gate decisions needed a code-reading judgment seat.

## Review rounds

None — docs-only PR, per §11's scope rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)