### PR TITLE
place_asset: a Data-relative source, and a sigiled pole that says whose copy

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,12 +13,13 @@ take.** `source=` accepts a Data-relative path — the same kind of path `housec
 resolves it through the virtual file system, so the source no longer has to be a full path typed out from your
 drive. Because the source and the destination are separate inputs, a source that differs from the destination is a
 **rename**: one file's bytes land under another file's name, which is what carrying a baked FaceGen head onto a
-different NPC's FormID path actually is. The new `source_provider=` says *whose* copy to read — a mod folder or BSA
-filename as `asset_status` spells it, or `winner` for whichever copy currently wins. Naming a mod means that mod:
-if it doesn't supply the path, the call is refused rather than quietly served from somewhere else. Naming nothing
-keeps the old behaviour — the sole provider, refused when several contend — except that the refusal now lists the
-providers by NAME rather than by on-disk path, each name quoted, and the quoted part is exactly what you pass back
-to `source_provider=`.
+different NPC's FormID path actually is. The new `source_provider=` says *whose* copy to read: `*winner` for
+whichever copy currently wins, or a mod folder / BSA filename on its own. The `*` is part of the token, and it is
+there so the two never collide — `*` is illegal in a Windows folder name, so a bare name always means a provider of
+that name and a mod actually called `winner` stays reachable. Naming a mod means that mod: if it doesn't supply the
+path, the call is refused rather than quietly served from somewhere else. Naming nothing keeps the old behaviour —
+the sole provider, refused when several contend — except that the refusal now lists the providers by NAME rather
+than by on-disk path, each in double quotes, and what's inside the quotes is exactly what you pass back.
 
 **Fixed: the text and JSON responses to a write can no longer say different things.** Every write tool renders its
 result twice — once as text, once as `format="json"` — and the two renders were maintained separately, so a warning

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,17 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**Added: `housecarl_place_asset` can now place a copy from one path under a different name, and say whose copy to
+take.** `source=` accepts a Data-relative path — the same kind of path `housecarl_asset_status` reports on — and
+resolves it through the virtual file system, so the source no longer has to be a full path typed out from your
+drive. Because the source and the destination are separate inputs, a source that differs from the destination is a
+**rename**: one file's bytes land under another file's name, which is what carrying a baked FaceGen head onto a
+different NPC's FormID path actually is. The new `source_provider=` says *whose* copy to read — a mod folder or BSA
+filename as `asset_status` spells it, or `winner` for whichever copy currently wins. Naming a mod means that mod:
+if it doesn't supply the path, the call is refused rather than quietly served from somewhere else. Naming nothing
+keeps the old behaviour — the sole provider, refused when several contend — except that the refusal now lists the
+providers by NAME instead of by on-disk path, which is what you pass back to `source_provider=`.
+
 **Fixed: the text and JSON responses to a write can no longer say different things.** Every write tool renders its
 result twice — once as text, once as `format="json"` — and the two renders were maintained separately, so a warning
 or a piece of advice could be corrected on one and left stale on the other. Nine sentences had already drifted that

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -17,7 +17,8 @@ different NPC's FormID path actually is. The new `source_provider=` says *whose*
 filename as `asset_status` spells it, or `winner` for whichever copy currently wins. Naming a mod means that mod:
 if it doesn't supply the path, the call is refused rather than quietly served from somewhere else. Naming nothing
 keeps the old behaviour — the sole provider, refused when several contend — except that the refusal now lists the
-providers by NAME instead of by on-disk path, which is what you pass back to `source_provider=`.
+providers by NAME rather than by on-disk path, each name quoted, and the quoted part is exactly what you pass back
+to `source_provider=`.
 
 **Fixed: the text and JSON responses to a write can no longer say different things.** Every write tool renders its
 result twice — once as text, once as `format="json"` — and the two renders were maintained separately, so a warning

--- a/src/housecarl-core/AssetSourceSelection.cs
+++ b/src/housecarl-core/AssetSourceSelection.cs
@@ -28,12 +28,17 @@ public enum AssetSourcePole
     Named,
 }
 
-/// <summary>A caller's source-pole choice. <see cref="Spelling"/> is the caller's own token when the choice came
-/// from wire input (used only to detect the winner-token collision below); null for an in-process choice.</summary>
+/// <summary>A caller's source-pole choice. <see cref="Spelling"/> carries the provider name for the
+/// <see cref="AssetSourcePole.Named"/> pole; null for an in-process choice and for the winner pole.</summary>
 public sealed record AssetSourceChoice(AssetSourcePole Pole, string? Spelling)
 {
-    /// <summary>The reserved wire token selecting the VFS-winner pole.</summary>
-    public const string WinnerToken = "winner";
+    /// <summary>The reserved wire token selecting the VFS-winner pole. SIGILED — '*' is illegal in a Windows file or
+    /// folder name, so the pole space and the provider-name space are disjoint BY CONSTRUCTION and a bare "winner"
+    /// always means a provider called winner. The first spelling was the bare word, which a real mod folder can also
+    /// carry; that overlap was resolved at matching time and unknown to every site that LISTS names, and it generated
+    /// a collision verdict, a suppression flag, a conditional sentence, a bespoke refusal and two unguarded holes
+    /// before it was respelled (Aaron-go 2026-08-12). Same idiom as '@file' in ops=. See SPEC §5's amendment.</summary>
+    public const string WinnerToken = "*winner";
 
     /// <summary>The sole-provider pole (no selector given).</summary>
     public static readonly AssetSourceChoice SoleProvider = new(AssetSourcePole.SoleProvider, null);
@@ -44,15 +49,15 @@ public sealed record AssetSourceChoice(AssetSourcePole Pole, string? Spelling)
     /// <summary>A named provider, chosen in-process.</summary>
     public static AssetSourceChoice Named(string providerName) => new(AssetSourcePole.Named, providerName);
 
-    /// <summary>Parse a caller's selector: blank ⇒ sole-provider, the reserved <see cref="WinnerToken"/> ⇒ winner,
-    /// anything else ⇒ that provider name. The spelling is KEPT so <see cref="AssetSourceSelection.Select"/> can
-    /// refuse rather than guess when a real provider is itself named "winner".</summary>
+    /// <summary>Parse a caller's selector. Exactly two arms: the reserved <see cref="WinnerToken"/> ⇒ the winner
+    /// pole; anything else ⇒ that provider name, matched exactly. Blank ⇒ sole-provider (no selector given). No
+    /// ambiguity is possible, so nothing here can refuse — the sigil is what makes the parse total.</summary>
     public static AssetSourceChoice Parse(string? selector)
     {
         var s = selector?.Trim();
         if (string.IsNullOrEmpty(s)) return SoleProvider;
         return s.Equals(WinnerToken, StringComparison.OrdinalIgnoreCase)
-            ? new AssetSourceChoice(AssetSourcePole.Winner, s)
+            ? Winner
             : new AssetSourceChoice(AssetSourcePole.Named, s);
     }
 }
@@ -68,32 +73,31 @@ public enum AssetSourceVerdict
     Ambiguous,
     /// <summary>Named pole, and that provider does not supply this path (others may).</summary>
     NamedAbsent,
-    /// <summary>The caller typed the reserved winner token AND a real provider is named "winner" — refuse, don't guess.</summary>
-    WinnerTokenCollision,
 }
 
 /// <summary>The outcome of a pick. <see cref="Source"/> is non-null iff <see cref="Verdict"/> is
 /// <see cref="AssetSourceVerdict.Selected"/>. <see cref="ProviderNames"/> is every contending provider as
 /// <see cref="AssetSourceSelection.Describe"/> spells it — NAMES, never on-disk paths — so a caller's refusal can
-/// list the real choices without teaching path round-tripping. <see cref="TokenNameTaken"/> reports whether one of
-/// those providers is itself called <see cref="AssetSourceChoice.WinnerToken"/>, which is the one condition under
-/// which a refusal must NOT offer that token as a remedy.</summary>
+/// list the real choices without teaching path round-tripping.</summary>
 public sealed record AssetSourcePick(
     AssetSourceVerdict Verdict,
     PlacementSource? Source,
-    IReadOnlyList<string> ProviderNames,
-    bool TokenNameTaken);
+    IReadOnlyList<string> ProviderNames);
 
 public static class AssetSourceSelection
 {
-    /// <summary>How one provider is NAMED to a caller. The name is QUOTED and the kind sits outside the quotes,
-    /// because this string is not decoration — a refusal that lists providers is handing the caller the value to
-    /// pass back as the selector, and <see cref="Select"/> matches the bare <see cref="PlacementSource.ProviderName"/>.
-    /// The first spelling of this ran the two together as <c>ModA (loose)</c>, so copying the message verbatim
-    /// produced a name no pole could match and a second refusal calling the caller's copy a typo. The quotes are
-    /// the boundary that makes the token unambiguous; a round-trip arm in place-asset-guard feeds these strings
-    /// back through the real tool and is what keeps the claim true.</summary>
-    public static string Describe(PlacementSource s) => $"'{s.ProviderName}' ({(s.Kind == AssetKind.Bsa ? "BSA" : "loose")})";
+    /// <summary>The ONE formatter for a provider name in any list a caller reads a selector out of. Every listing
+    /// site goes through here for the same reason the sentences have one source: two spellings of "how a name is
+    /// shown" is two chances for the shown form to stop being the accepted form.
+    /// <para>DOUBLE quotes, with the kind outside them. The boundary has to be a character a provider name cannot
+    /// contain, or it is not a boundary: single quotes failed that test — <c>JK's Skyrim</c> is a real and widely
+    /// installed mod, and it dissolved the delimiter mid-name. Windows forbids '"' in a file or folder name, so
+    /// double quotes cannot occur inside one. Same construction as the '*' sigil on the pole token.</para>
+    /// <para>The first spelling ran name and kind together as <c>ModA (loose)</c>, so copying a message verbatim
+    /// produced a name no pole matched and a second refusal calling the caller's copy a typo. A round-trip arm in
+    /// place-asset-guard feeds these strings back through the real tool — over hostile names, not friendly ones —
+    /// and is what keeps the claim true.</para></summary>
+    public static string Describe(PlacementSource s) => $"\"{s.ProviderName}\" ({(s.Kind == AssetKind.Bsa ? "BSA" : "loose")})";
 
     /// <summary>Pick the provider to read from, under <paramref name="choice"/>'s pole. Pure: no I/O, no bytes, no
     /// message. Every refusal verdict carries the provider names so the caller can render its own.</summary>
@@ -102,40 +106,30 @@ public static class AssetSourceSelection
         var names = new List<string>(res.Sources.Count);
         foreach (var s in res.Sources) names.Add(Describe(s));
 
-        // Computed for EVERY verdict, not just the winner pole's: the ambiguity refusal offers "or source_provider=
-        // winner" as a remedy, and on a load order carrying a mod of that name the remedy is one the next call
-        // refuses. The fact belongs to the resolution, so it is reported once here rather than re-derived per caller.
-        bool tokenTaken = false;
-        foreach (var s in res.Sources)
-            if (string.Equals(s.ProviderName, AssetSourceChoice.WinnerToken, StringComparison.OrdinalIgnoreCase))
-                { tokenTaken = true; break; }
-
         if (res.Sources.Count == 0)
-            return new AssetSourcePick(AssetSourceVerdict.NoProvider, null, names, tokenTaken);
+            return new AssetSourcePick(AssetSourceVerdict.NoProvider, null, names);
 
         switch (choice.Pole)
         {
             case AssetSourcePole.Winner:
-                // The token collision: only reachable when the pole came off the wire as the literal "winner" AND a
-                // provider really carries that name. Refusing is the Q3 call — either reading would be a silent guess
-                // at which of the two the caller meant.
-                if (choice.Spelling is not null && tokenTaken)
-                    return new AssetSourcePick(AssetSourceVerdict.WinnerTokenCollision, null, names, tokenTaken);
-                return new AssetSourcePick(AssetSourceVerdict.Selected, res.Sources[0], names, tokenTaken);
+                // No collision test, and none possible: the pole token carries a '*', which no provider name can.
+                // A whole verdict, a suppression flag and a bespoke refusal used to live here to manage the overlap
+                // a bare "winner" created; the sigil deletes the overlap instead of guarding it.
+                return new AssetSourcePick(AssetSourceVerdict.Selected, res.Sources[0], names);
 
             case AssetSourcePole.Named:
                 foreach (var s in res.Sources)
                     if (string.Equals(s.ProviderName, choice.Spelling ?? "", StringComparison.OrdinalIgnoreCase))
-                        return new AssetSourcePick(AssetSourceVerdict.Selected, s, names, tokenTaken);
-                return new AssetSourcePick(AssetSourceVerdict.NamedAbsent, null, names, tokenTaken);
+                        return new AssetSourcePick(AssetSourceVerdict.Selected, s, names);
+                return new AssetSourcePick(AssetSourceVerdict.NamedAbsent, null, names);
 
             default:
                 // Sole-provider: contention is the caller's call, not ours. Counted off Sources rather than read off
                 // PlacementResolution.Ambiguous so the pick depends on one fact (how many providers there are) —
                 // the flag means the same thing today, and this way it cannot drift into meaning something else.
                 return res.Sources.Count == 1
-                    ? new AssetSourcePick(AssetSourceVerdict.Selected, res.Sources[0], names, tokenTaken)
-                    : new AssetSourcePick(AssetSourceVerdict.Ambiguous, null, names, tokenTaken);
+                    ? new AssetSourcePick(AssetSourceVerdict.Selected, res.Sources[0], names)
+                    : new AssetSourcePick(AssetSourceVerdict.Ambiguous, null, names);
         }
     }
 }

--- a/src/housecarl-core/AssetSourceSelection.cs
+++ b/src/housecarl-core/AssetSourceSelection.cs
@@ -1,0 +1,127 @@
+namespace HousecarlCore;
+
+// ======================================================================
+//  AssetSourceSelection — the ONE policy for "which provider do I read an asset from".
+//
+//  S2's SOURCE grammar has three poles (SPEC §1): the VFS winner, a NAMED mod, and the
+//  sole provider. Every caller that reads bytes out of the asset layer picks one of them,
+//  and before this type each caller spelled the pick itself — NpcAppearanceAssets took
+//  Sources[0] inline, place_asset took Sources[0] behind its own ambiguity test. Two
+//  spellings of "how to read a contended source" is the drift class one layer up from the
+//  sentence twins, so the pick lives here and the callers pass a pole.
+//
+//  This type decides WHICH provider, and nothing else: it reads no bytes, renders no
+//  sentence, and knows no tool. The verdict enum is the whole vocabulary a caller needs to
+//  render its own refusal — every non-Selected verdict carries the provider NAMES (never
+//  their on-disk paths; naming a machine path in a refusal is how the caller learns to
+//  round-trip absolute paths that go stale between resolve and read).
+// ======================================================================
+
+/// <summary>Which pole of S2's SOURCE grammar a read is made under.</summary>
+public enum AssetSourcePole
+{
+    /// <summary>Use the only provider; more than one is a refusal (the caller chooses).</summary>
+    SoleProvider,
+    /// <summary>Use whichever copy currently wins the VFS — "what the game shows right now".</summary>
+    Winner,
+    /// <summary>Use a NAMED provider's copy, whatever else contends. Absent from that provider is a refusal.</summary>
+    Named,
+}
+
+/// <summary>A caller's source-pole choice. <see cref="Spelling"/> is the caller's own token when the choice came
+/// from wire input (used only to detect the winner-token collision below); null for an in-process choice.</summary>
+public sealed record AssetSourceChoice(AssetSourcePole Pole, string? Spelling)
+{
+    /// <summary>The reserved wire token selecting the VFS-winner pole.</summary>
+    public const string WinnerToken = "winner";
+
+    /// <summary>The sole-provider pole (no selector given).</summary>
+    public static readonly AssetSourceChoice SoleProvider = new(AssetSourcePole.SoleProvider, null);
+
+    /// <summary>The winner pole, chosen in-process (no wire spelling ⇒ no collision test).</summary>
+    public static readonly AssetSourceChoice Winner = new(AssetSourcePole.Winner, null);
+
+    /// <summary>A named provider, chosen in-process.</summary>
+    public static AssetSourceChoice Named(string providerName) => new(AssetSourcePole.Named, providerName);
+
+    /// <summary>Parse a caller's selector: blank ⇒ sole-provider, the reserved <see cref="WinnerToken"/> ⇒ winner,
+    /// anything else ⇒ that provider name. The spelling is KEPT so <see cref="AssetSourceSelection.Select"/> can
+    /// refuse rather than guess when a real provider is itself named "winner".</summary>
+    public static AssetSourceChoice Parse(string? selector)
+    {
+        var s = selector?.Trim();
+        if (string.IsNullOrEmpty(s)) return SoleProvider;
+        return s.Equals(WinnerToken, StringComparison.OrdinalIgnoreCase)
+            ? new AssetSourceChoice(AssetSourcePole.Winner, s)
+            : new AssetSourceChoice(AssetSourcePole.Named, s);
+    }
+}
+
+/// <summary>Why a pick did or didn't land on a provider.</summary>
+public enum AssetSourceVerdict
+{
+    /// <summary>A provider was picked — <see cref="AssetSourcePick.Source"/> is non-null.</summary>
+    Selected,
+    /// <summary>Nothing active provides the path at all.</summary>
+    NoProvider,
+    /// <summary>Sole-provider pole, but more than one provider contends — the caller must choose.</summary>
+    Ambiguous,
+    /// <summary>Named pole, and that provider does not supply this path (others may).</summary>
+    NamedAbsent,
+    /// <summary>The caller typed the reserved winner token AND a real provider is named "winner" — refuse, don't guess.</summary>
+    WinnerTokenCollision,
+}
+
+/// <summary>The outcome of a pick. <see cref="Source"/> is non-null iff <see cref="Verdict"/> is
+/// <see cref="AssetSourceVerdict.Selected"/>. <see cref="ProviderNames"/> is every contending provider as
+/// <c>asset_status</c> renders it ("ModX (loose)" / "Y.bsa (BSA)") — NAMES, never on-disk paths — so a caller's
+/// refusal can list the real choices without teaching path round-tripping.</summary>
+public sealed record AssetSourcePick(
+    AssetSourceVerdict Verdict,
+    PlacementSource? Source,
+    IReadOnlyList<string> ProviderNames);
+
+public static class AssetSourceSelection
+{
+    /// <summary>How one provider is NAMED to a caller — the same spelling <c>asset_status</c> renders, because a
+    /// refusal that lists providers is telling the caller what to pass back as the selector.</summary>
+    public static string Describe(PlacementSource s) => $"{s.ProviderName} ({(s.Kind == AssetKind.Bsa ? "BSA" : "loose")})";
+
+    /// <summary>Pick the provider to read from, under <paramref name="choice"/>'s pole. Pure: no I/O, no bytes, no
+    /// message. Every refusal verdict carries the provider names so the caller can render its own.</summary>
+    public static AssetSourcePick Select(PlacementResolution res, AssetSourceChoice choice)
+    {
+        var names = new List<string>(res.Sources.Count);
+        foreach (var s in res.Sources) names.Add(Describe(s));
+
+        if (res.Sources.Count == 0)
+            return new AssetSourcePick(AssetSourceVerdict.NoProvider, null, names);
+
+        switch (choice.Pole)
+        {
+            case AssetSourcePole.Winner:
+                // The token collision: only reachable when the pole came off the wire as the literal "winner" AND a
+                // provider really carries that name. Refusing is the Q3 call — either reading would be a silent guess
+                // at which of the two the caller meant.
+                if (choice.Spelling is not null)
+                    foreach (var s in res.Sources)
+                        if (string.Equals(s.ProviderName, choice.Spelling, StringComparison.OrdinalIgnoreCase))
+                            return new AssetSourcePick(AssetSourceVerdict.WinnerTokenCollision, null, names);
+                return new AssetSourcePick(AssetSourceVerdict.Selected, res.Sources[0], names);
+
+            case AssetSourcePole.Named:
+                foreach (var s in res.Sources)
+                    if (string.Equals(s.ProviderName, choice.Spelling ?? "", StringComparison.OrdinalIgnoreCase))
+                        return new AssetSourcePick(AssetSourceVerdict.Selected, s, names);
+                return new AssetSourcePick(AssetSourceVerdict.NamedAbsent, null, names);
+
+            default:
+                // Sole-provider: contention is the caller's call, not ours. Counted off Sources rather than read off
+                // PlacementResolution.Ambiguous so the pick depends on one fact (how many providers there are) —
+                // the flag means the same thing today, and this way it cannot drift into meaning something else.
+                return res.Sources.Count == 1
+                    ? new AssetSourcePick(AssetSourceVerdict.Selected, res.Sources[0], names)
+                    : new AssetSourcePick(AssetSourceVerdict.Ambiguous, null, names);
+        }
+    }
+}

--- a/src/housecarl-core/AssetSourceSelection.cs
+++ b/src/housecarl-core/AssetSourceSelection.cs
@@ -74,18 +74,26 @@ public enum AssetSourceVerdict
 
 /// <summary>The outcome of a pick. <see cref="Source"/> is non-null iff <see cref="Verdict"/> is
 /// <see cref="AssetSourceVerdict.Selected"/>. <see cref="ProviderNames"/> is every contending provider as
-/// <c>asset_status</c> renders it ("ModX (loose)" / "Y.bsa (BSA)") — NAMES, never on-disk paths — so a caller's
-/// refusal can list the real choices without teaching path round-tripping.</summary>
+/// <see cref="AssetSourceSelection.Describe"/> spells it — NAMES, never on-disk paths — so a caller's refusal can
+/// list the real choices without teaching path round-tripping. <see cref="TokenNameTaken"/> reports whether one of
+/// those providers is itself called <see cref="AssetSourceChoice.WinnerToken"/>, which is the one condition under
+/// which a refusal must NOT offer that token as a remedy.</summary>
 public sealed record AssetSourcePick(
     AssetSourceVerdict Verdict,
     PlacementSource? Source,
-    IReadOnlyList<string> ProviderNames);
+    IReadOnlyList<string> ProviderNames,
+    bool TokenNameTaken);
 
 public static class AssetSourceSelection
 {
-    /// <summary>How one provider is NAMED to a caller — the same spelling <c>asset_status</c> renders, because a
-    /// refusal that lists providers is telling the caller what to pass back as the selector.</summary>
-    public static string Describe(PlacementSource s) => $"{s.ProviderName} ({(s.Kind == AssetKind.Bsa ? "BSA" : "loose")})";
+    /// <summary>How one provider is NAMED to a caller. The name is QUOTED and the kind sits outside the quotes,
+    /// because this string is not decoration — a refusal that lists providers is handing the caller the value to
+    /// pass back as the selector, and <see cref="Select"/> matches the bare <see cref="PlacementSource.ProviderName"/>.
+    /// The first spelling of this ran the two together as <c>ModA (loose)</c>, so copying the message verbatim
+    /// produced a name no pole could match and a second refusal calling the caller's copy a typo. The quotes are
+    /// the boundary that makes the token unambiguous; a round-trip arm in place-asset-guard feeds these strings
+    /// back through the real tool and is what keeps the claim true.</summary>
+    public static string Describe(PlacementSource s) => $"'{s.ProviderName}' ({(s.Kind == AssetKind.Bsa ? "BSA" : "loose")})";
 
     /// <summary>Pick the provider to read from, under <paramref name="choice"/>'s pole. Pure: no I/O, no bytes, no
     /// message. Every refusal verdict carries the provider names so the caller can render its own.</summary>
@@ -94,8 +102,16 @@ public static class AssetSourceSelection
         var names = new List<string>(res.Sources.Count);
         foreach (var s in res.Sources) names.Add(Describe(s));
 
+        // Computed for EVERY verdict, not just the winner pole's: the ambiguity refusal offers "or source_provider=
+        // winner" as a remedy, and on a load order carrying a mod of that name the remedy is one the next call
+        // refuses. The fact belongs to the resolution, so it is reported once here rather than re-derived per caller.
+        bool tokenTaken = false;
+        foreach (var s in res.Sources)
+            if (string.Equals(s.ProviderName, AssetSourceChoice.WinnerToken, StringComparison.OrdinalIgnoreCase))
+                { tokenTaken = true; break; }
+
         if (res.Sources.Count == 0)
-            return new AssetSourcePick(AssetSourceVerdict.NoProvider, null, names);
+            return new AssetSourcePick(AssetSourceVerdict.NoProvider, null, names, tokenTaken);
 
         switch (choice.Pole)
         {
@@ -103,25 +119,23 @@ public static class AssetSourceSelection
                 // The token collision: only reachable when the pole came off the wire as the literal "winner" AND a
                 // provider really carries that name. Refusing is the Q3 call — either reading would be a silent guess
                 // at which of the two the caller meant.
-                if (choice.Spelling is not null)
-                    foreach (var s in res.Sources)
-                        if (string.Equals(s.ProviderName, choice.Spelling, StringComparison.OrdinalIgnoreCase))
-                            return new AssetSourcePick(AssetSourceVerdict.WinnerTokenCollision, null, names);
-                return new AssetSourcePick(AssetSourceVerdict.Selected, res.Sources[0], names);
+                if (choice.Spelling is not null && tokenTaken)
+                    return new AssetSourcePick(AssetSourceVerdict.WinnerTokenCollision, null, names, tokenTaken);
+                return new AssetSourcePick(AssetSourceVerdict.Selected, res.Sources[0], names, tokenTaken);
 
             case AssetSourcePole.Named:
                 foreach (var s in res.Sources)
                     if (string.Equals(s.ProviderName, choice.Spelling ?? "", StringComparison.OrdinalIgnoreCase))
-                        return new AssetSourcePick(AssetSourceVerdict.Selected, s, names);
-                return new AssetSourcePick(AssetSourceVerdict.NamedAbsent, null, names);
+                        return new AssetSourcePick(AssetSourceVerdict.Selected, s, names, tokenTaken);
+                return new AssetSourcePick(AssetSourceVerdict.NamedAbsent, null, names, tokenTaken);
 
             default:
                 // Sole-provider: contention is the caller's call, not ours. Counted off Sources rather than read off
                 // PlacementResolution.Ambiguous so the pick depends on one fact (how many providers there are) —
                 // the flag means the same thing today, and this way it cannot drift into meaning something else.
                 return res.Sources.Count == 1
-                    ? new AssetSourcePick(AssetSourceVerdict.Selected, res.Sources[0], names)
-                    : new AssetSourcePick(AssetSourceVerdict.Ambiguous, null, names);
+                    ? new AssetSourcePick(AssetSourceVerdict.Selected, res.Sources[0], names, tokenTaken)
+                    : new AssetSourcePick(AssetSourceVerdict.Ambiguous, null, names, tokenTaken);
         }
     }
 }

--- a/src/housecarl-core/NpcAppearanceAssets.cs
+++ b/src/housecarl-core/NpcAppearanceAssets.cs
@@ -191,9 +191,16 @@ public static class NpcAppearanceAssets
     {
         string? readError = null;
         var res = view.ResolveForPlacement(relPath);
-        if (res.Sources.Count > 0)
+        // The pick goes through the shared S2 source policy (AssetSourceSelection) — the same code path place_asset
+        // uses — under the WINNER pole. That pole is this lane's ORIGINAL behavior, kept verbatim, and it is a known
+        // DIVERGENCE from the successor flow: on the facegen rename (alwaysCarry) the caller has named a donor mod,
+        // so the successor reads that NAMED provider while this reads whatever currently wins. Where a replacer
+        // out-sorts the donor the two carry different bytes, and the winner's are the ones that can disagree with the
+        // donor's head-part and tint records. Deliberately NOT changed here: this tool is being subsumed, and the
+        // difference is the thing its replacement is measured against.
+        var pick = AssetSourceSelection.Select(res, AssetSourceChoice.Winner);
+        if (pick.Source is { } winner)
         {
-            var winner = res.Sources[0];
             if (!alwaysCarry)
             {
                 bool donorProvides =

--- a/src/housecarl-generator/NpcCopyProbe.cs
+++ b/src/housecarl-generator/NpcCopyProbe.cs
@@ -518,6 +518,58 @@ public static class NpcCopyProbe
                 Check(!Directory.Exists(Path.Combine(mods, "houseCARL - houseCARL_NpcCopy")),
                     "refusal: no orphan patch folder is left behind (hunt F4)");
             }
+
+            // ================= 4. the asset carry reads the VFS WINNER on a CONTENDED path =================
+            // CarryAll picks its source through the shared S2 source policy under the WINNER pole. Nothing pinned
+            // that pole: swapping it for the sole-provider pole left this guard green, because every other fixture
+            // here has exactly one provider per path — and under sole-provider a contended path yields no source at
+            // all, so the carry silently falls through to the donor-disk lane and reports the facegen MISSING. That
+            // is a silent degradation on precisely the load orders where a replacer contends, which is also the
+            // shape the successor flow deliberately diverges from (it reads the NAMED donor, not the winner).
+            {
+                var carryRoot = Path.Combine(root, "carry-pole");
+                var cMods = Path.Combine(carryRoot, "mods");
+                var cData = Path.Combine(carryRoot, "data");
+                var cOver = Path.Combine(carryRoot, "overwrite");
+                foreach (var d in new[] { cMods, cData, cOver }) Directory.CreateDirectory(d);
+
+                var carryDonorKey = new ModKey("CarryDonor", ModType.Plugin);
+                var donorNpc = new FormKey(carryDonorKey, 0xD40);
+                var newNpc = new FormKey(new ModKey("CarryPatch", ModType.Plugin), 0x800);
+                var meshRel = FaceGenPath.For(donorNpc, FaceGenSlot.Mesh);
+
+                // TWO providers of the donor's facegen mesh: the donor's own mod, and a replacer above it.
+                var carryDonorDir = Path.Combine(cMods, "CarryDonorMod");
+                var replacer = Path.Combine(cMods, "CarryReplacer");
+                var donorBytes = System.Text.Encoding.ASCII.GetBytes("donor-face\0");
+                var winBytes = System.Text.Encoding.ASCII.GetBytes("replacer-face\0");
+                foreach (var (dir, bytes) in new[] { (carryDonorDir, donorBytes), (replacer, winBytes) })
+                {
+                    var p = Path.Combine(dir, meshRel);
+                    Directory.CreateDirectory(Path.GetDirectoryName(p)!);
+                    File.WriteAllBytes(p, bytes);
+                }
+
+                // Mod NAMES, highest priority FIRST (AssetResolver.Build's contract) — so the replacer wins.
+                var enabled = new[] { "CarryReplacer", "CarryDonorMod" };
+                using var res = AssetResolver.Build(cOver, cMods, cData, enabled, Array.Empty<ActiveArchive>());
+                var view = res.Capture();
+                var resolved = view.Resolve(meshRel);
+                Check(resolved.Providers.Count == 2 && resolved.Winner?.Source == "CarryReplacer",
+                    $"carry fixture is genuinely contended and the replacer wins — {resolved.Providers.Count} providers, winner={resolved.Winner?.Source}");
+
+                var outDir = Path.Combine(carryRoot, "out");
+                Directory.CreateDirectory(outDir);
+                var outcome = NpcAppearanceAssets.CarryAll(
+                    donorNpc, newNpc, Array.Empty<string>(), view,
+                    Array.Empty<NpcAppearanceAssets.DonorDisk>(), new[] { "CarryDonorMod" }, outDir);
+
+                var carriedPath = Path.Combine(outDir, FaceGenPath.For(newNpc, FaceGenSlot.Mesh));
+                Check(outcome.FaceGenMeshCarried && File.Exists(carriedPath),
+                    $"the facegen mesh is carried to the NEW FormID path even though the donor is not the winner — carried={outcome.FaceGenMeshCarried}, missing={outcome.Missing.Count}");
+                Check(File.Exists(carriedPath) && File.ReadAllBytes(carriedPath).SequenceEqual(winBytes),
+                    "…and the bytes are the WINNER's, not the donor mod's — the pole this lane deliberately keeps  [RED arm]");
+            }
         }
         finally
         {

--- a/src/housecarl-generator/PlaceAssetProbe.cs
+++ b/src/housecarl-generator/PlaceAssetProbe.cs
@@ -31,6 +31,13 @@ namespace HousecarlGenerator;
 ///   G  non-destructive / provenance / Q3 — an all-failed FRESH batch leaves NO orphan folder; a partial batch KEEPS the
 ///      folder (the good file present); a drive-rooted / '..' destination is a per-asset named error; the tool layer
 ///      refuses malformed specs (no kind, both/neither of formid+asset_path, bad formid/kind, both-expansion + loose source).
+///   I  the VFS source lane — source= a DATA-RELATIVE path resolved through the asset layer, with source_provider=
+///      choosing the pole. A NAMED provider is read even when another copy wins (I1, the arm no other source policy
+///      passes); 'winner' reads the current winner (I2); a named provider that doesn't supply the path is refused with
+///      nothing substituted (I3); source ≠ destination is a RENAME (I4 — the mechanism an appearance copy is built
+///      from); an absent source and a pole against an on-disk source are named refusals (I5, I6).
+///   J  the reserved token vs a mod literally named 'winner' — refused both ways rather than guessed, with a
+///      places-fine control proving the refusal is the collision and not a broken fixture.
 ///
 /// Self-contained: synthetic folders/instances in temp + the committed fixtures/asset-resolver/FixtureA.bsa, NO BSArch.
 /// Run: dotnet run --project src/housecarl-generator place-asset-guard
@@ -246,7 +253,12 @@ internal static class PlaceAssetProbe
                     var store = new UserConfigStore(Path.Combine(root, "user-f2.json"));
                     using var svc = LoadOrderService.WithInstance(inst, 0, store);
                     var r = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, null) }, null, null).Results[0];
-                    Check(!r.Placed && r.Error!.Contains("ambiguous"), $"TWO providers + no source= is REFUSED (no guess) — {r.Error}");
+                    Check(!r.Placed && r.Error!.Contains(WriteSentences.PlaceSourceWillNotGuess, StringComparison.Ordinal),
+                          $"TWO providers + no source= is REFUSED (no guess) — {r.Error}");
+                    Check(r.Error!.Contains("ModA", StringComparison.Ordinal) && r.Error.Contains("ModB", StringComparison.Ordinal),
+                          "the refusal NAMES both providers — what source_provider= takes back");
+                    Check(!r.Error!.Contains(mods, StringComparison.OrdinalIgnoreCase),
+                          "the refusal leaks NO on-disk path — a provider name cannot go stale between the resolve and the read  [RED arm]");
                 }
                 // absent → refuse
                 {
@@ -367,6 +379,125 @@ internal static class PlaceAssetProbe
                               "the service place preserves the dest creation time — routes through AtomicFile (File.Replace), not File.Move  [RED arm]");
                 }
                 else Check(false, "provenance/routing skipped — first place produced no folder");
+            }
+
+            // ================= I: the VFS source lane — a Data-relative source + the three SOURCE poles =================
+            Console.WriteLine();
+            Console.WriteLine("--- I: source= a Data-relative path; source_provider= names WHOSE copy (named / winner / sole) ---");
+            {
+                var inst = Path.Combine(root, "svc-i");
+                var (mods, _, prof) = MakeInstance(inst);
+                var aBytes = new byte[] { 0xA1, 0xA1, 0xA1 };
+                var bBytes = new byte[] { 0xB2, 0xB2 };
+                foreach (var (m, b) in new[] { ("ModA", aBytes), ("ModB", bBytes) })
+                {
+                    var d = Path.Combine(mods, m);
+                    Directory.CreateDirectory(d);
+                    WriteLoose(d, FacegenRel, b);
+                }
+                File.WriteAllText(Path.Combine(mods, "ModA", "Dummy.esp"), "x");
+                WriteProfile(prof, new[] { "Dummy.esp" }, new[] { "*Dummy.esp" }, new[] { "+ModA", "+ModB" });
+                WriteSkyrimIni(prof, "");
+                var store = new UserConfigStore(Path.Combine(root, "user-i.json"));
+                using var svc = LoadOrderService.WithInstance(inst, 0, store);
+
+                // Which of the two currently WINS is read from the resolver, never assumed: the arm's claim is that a
+                // named provider is honoured whether or not it is the winner, and hard-coding the winner would make
+                // the arm pass for the wrong reason the day MO2 priority is read differently.
+                var winnerName = svc.AssetStatus(new[] { FacegenRel }).Results[0].Hit?.Winner?.Source;
+                Check(winnerName is "ModA" or "ModB", $"the fixture is genuinely contended and one copy wins — winner={winnerName ?? "(none)"}");
+                var loserName = winnerName == "ModA" ? "ModB" : "ModA";
+                var winnerBytes = winnerName == "ModA" ? aBytes : bBytes;
+                var loserBytes = winnerName == "ModA" ? bBytes : aBytes;
+
+                // I1 — the DISCRIMINATING arm: a named provider that is NOT the winner is read anyway. Every other
+                // source policy (winner-read, sole-provider) fails this one, which is why the fixture is contended.
+                {
+                    var o = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, FacegenRel, loserName) }, null, null);
+                    var r = o.Results[0];
+                    var placed = o.ModFolder is null ? null : Path.Combine(o.ModFolder, FacegenRel);
+                    Check(r.Placed && placed is not null && File.ReadAllBytes(placed).SequenceEqual(loserBytes),
+                          $"source_provider='{loserName}' places THAT provider's bytes though '{winnerName}' wins the VFS  [RED arm] — {(r.Placed ? "ok" : r.Error)}");
+                    Check(placed is not null && !File.ReadAllBytes(placed).SequenceEqual(winnerBytes),
+                          "…and specifically NOT the winner's bytes (the two copies differ, so the assertion can fail)");
+                }
+
+                // I2 — the winner pole stays reachable: "what the game shows right now".
+                {
+                    var o = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, FacegenRel, AssetSourceChoice.WinnerToken) }, null, null);
+                    var r = o.Results[0];
+                    var placed = o.ModFolder is null ? null : Path.Combine(o.ModFolder, FacegenRel);
+                    Check(r.Placed && placed is not null && File.ReadAllBytes(placed).SequenceEqual(winnerBytes),
+                          $"source_provider=winner places the CURRENT winner's bytes ('{winnerName}') — {(r.Placed ? "ok" : r.Error)}");
+                }
+
+                // I3 — a named provider that doesn't supply the path is refused, NOT quietly served by another.
+                {
+                    var r = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, FacegenRel, "NoSuchMod") }, null, null).Results[0];
+                    Check(!r.Placed && r.Error!.Contains(WriteSentences.PlaceSourceNoSubstitute, StringComparison.Ordinal),
+                          $"a named provider that does not supply the path is REFUSED with nothing substituted  [RED arm] — {r.Error}");
+                    Check(r.Error!.Contains("ModA", StringComparison.Ordinal) && r.Error.Contains("ModB", StringComparison.Ordinal),
+                          "…and the providers that DO supply it are named (the typo's remedy)");
+                }
+
+                // I4 — THE RENAME. Source path ≠ destination path: one NPC's baked facegen lands under another's
+                // FormID-derived name. This is the mechanism an appearance copy is built from.
+                {
+                    var destRel = FaceGenPath.For(FormKey.Factory("000FFF:Dummy.esp"), FaceGenSlot.Mesh);
+                    Check(destRel != FacegenRel, "the rename fixture's destination really is a different path from its source");
+                    var o = svc.PlaceAssets(new[] { new PlaceRequest(destRel, FacegenRel, loserName) }, null, null);
+                    var r = o.Results[0];
+                    var placed = o.ModFolder is null ? null : Path.Combine(o.ModFolder, destRel);
+                    Check(r.Placed && placed is not null && File.Exists(placed) && File.ReadAllBytes(placed).SequenceEqual(loserBytes),
+                          $"the source file's bytes land under the DESTINATION's name — a rename  [RED arm] — {(r.Placed ? "ok" : r.Error)}");
+                    Check(r.SourceDesc is not null && r.SourceDesc.Contains(FacegenRel, StringComparison.OrdinalIgnoreCase),
+                          $"the render states which FILE the bytes came from — a rename that reported only the provider would hide it — {r.SourceDesc}");
+                    Check(o.ModFolder is null || !File.Exists(Path.Combine(o.ModFolder, FacegenRel)),
+                          "the SOURCE path is not also written — a rename places one file, not two");
+                }
+
+                // I5 — a Data-relative source nothing provides is its own refusal, about the SOURCE (not the
+                // destination): the destination of a rename is new by definition, so the two cannot share a message.
+                {
+                    var r = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, @"meshes\nope\absent.nif", null) }, null, null).Results[0];
+                    Check(!r.Placed && r.Error!.Contains("provides the source", StringComparison.Ordinal)
+                          && r.Error.Contains(@"meshes\nope\absent.nif", StringComparison.OrdinalIgnoreCase),
+                          $"an absent Data-relative SOURCE is refused naming that path — {r.Error}");
+                }
+
+                // I6 — a pole against an on-disk source cannot apply, and is SAID rather than dropped (Q3).
+                {
+                    var onDisk = Path.Combine(root, "i7-source.nif");
+                    File.WriteAllBytes(onDisk, new byte[] { 7, 7 });
+                    var r = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, onDisk, "ModA") }, null, null).Results[0];
+                    Check(!r.Placed && r.Error!.Contains(WriteSentences.PlaceSourceProviderNeedsRelPath, StringComparison.Ordinal),
+                          $"source_provider= with an ON-DISK source is refused, never silently ignored  [RED arm] — {r.Error}");
+                }
+            }
+
+            // ================= J: the reserved token vs a mod that carries its name =================
+            Console.WriteLine();
+            Console.WriteLine("--- J: a provider literally named 'winner' collides with the reserved token → refuse, don't guess ---");
+            {
+                var inst = Path.Combine(root, "svc-j");
+                var (mods, _, prof) = MakeInstance(inst);
+                var w = Path.Combine(mods, AssetSourceChoice.WinnerToken);
+                Directory.CreateDirectory(w);
+                WriteLoose(w, FacegenRel, new byte[] { 9 });
+                File.WriteAllText(Path.Combine(w, "Dummy.esp"), "x");
+                WriteProfile(prof, new[] { "Dummy.esp" }, new[] { "*Dummy.esp" }, new[] { "+" + AssetSourceChoice.WinnerToken });
+                WriteSkyrimIni(prof, "");
+                var store = new UserConfigStore(Path.Combine(root, "user-j.json"));
+                using var svc = LoadOrderService.WithInstance(inst, 0, store);
+
+                var r = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, FacegenRel, AssetSourceChoice.WinnerToken) }, null, null).Results[0];
+                Check(!r.Placed && r.Error!.Contains(WriteSentences.PlaceSourceWinnerCollision, StringComparison.Ordinal),
+                      $"source_provider=winner with a mod named 'winner' present is REFUSED both ways  [RED arm] — {r.Error}");
+                // …and the collision is the ONLY thing that refuses here: the same instance places fine when the
+                // caller names no pole at all (one provider ⇒ sole). Without this, an arm asserting a refusal would
+                // pass on an instance that simply cannot place.
+                var ok = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, null, null) }, null, null).Results[0];
+                Check(ok.Placed, $"the same fixture places with NO pole named (so the refusal above is the collision, not a broken instance) — {(ok.Placed ? "ok" : ok.Error)}");
             }
         }
         finally { try { Directory.Delete(root, recursive: true); } catch { /* temp scratch */ } }

--- a/src/housecarl-generator/PlaceAssetProbe.cs
+++ b/src/housecarl-generator/PlaceAssetProbe.cs
@@ -422,6 +422,49 @@ internal static class PlaceAssetProbe
                           "…and specifically NOT the winner's bytes (the two copies differ, so the assertion can fail)");
                 }
 
+                // I1b — the SAME claim through the WIRE. Everything else in arm I builds PlaceRequest by hand, which
+                // pins the service policy and says nothing about whether the tool layer threads source_provider=
+                // into it at all: with the mapping deleted, every hand-built arm here still passes while the
+                // parameter silently does nothing on a real call. Both entrypoints, because they map specs
+                // separately.  [RED arm]
+                {
+                    // The folder name is read OUT of the render rather than assembled from the naming convention —
+                    // an arm that hard-codes the convention fails for a reason that has nothing to do with the claim.
+                    var text = PlaceAssetTools.PlaceAsset(svc, asset_path: FacegenRel, source: FacegenRel,
+                                                          source_provider: loserName, patch_name: "WireScalar");
+                    var placedFile = PlacedFileFrom(text, mods, FacegenRel);
+                    Check(placedFile is not null && File.ReadAllBytes(placedFile).SequenceEqual(loserBytes),
+                          $"housecarl_place_asset carries source_provider= through to the read (the loser's bytes, not the winner's) — {Trim1(text)}");
+
+                    var bulkText = PlaceAssetTools.BulkPlaceAsset(svc, new[]
+                    {
+                        new PlaceAssetSpec { AssetPath = FacegenRel, Source = FacegenRel, SourceProvider = loserName },
+                    }, patch_name: "WireBulk");
+                    var bulkFile = PlacedFileFrom(bulkText, mods, FacegenRel);
+                    Check(bulkFile is not null && File.ReadAllBytes(bulkFile).SequenceEqual(loserBytes),
+                          $"housecarl_bulk_place_asset carries per-asset source_provider through too — {Trim1(bulkText)}");
+                }
+
+                // I1c — THE ROUND TRIP. The refusal tells the caller to pass one of the names it lists; this takes
+                // those names OUT of the rendered refusal and feeds each one back, asserting it places. The first
+                // spelling of that list ran the name and its kind together ("ModA (loose)"), which no pole matches —
+                // so the message's own remedy refused, and an arm asserting Contains("ModA") passed anyway. A
+                // substring check cannot see this class; only the round trip can.  [RED arm]
+                {
+                    var refusal = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, FacegenRel, null) }, null, null).Results[0].Error!;
+                    var tokens = System.Text.RegularExpressions.Regex.Matches(refusal, @"'([^']+)'")
+                        .Select(m => m.Groups[1].Value)
+                        .Where(t => !t.Contains('\\'))          // drop the asset path the sentence also quotes
+                        .Distinct().ToList();
+                    Check(tokens.Count == 2, $"the refusal offers exactly the two provider names as quoted tokens — [{string.Join(", ", tokens)}]");
+                    foreach (var token in tokens)
+                    {
+                        var o = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, FacegenRel, token) }, null, null);
+                        var rr = o.Results[0];
+                        Check(rr.Placed, $"a token copied verbatim out of the refusal is accepted by source_provider= ('{token}') — {(rr.Placed ? "placed" : rr.Error)}");
+                    }
+                }
+
                 // I2 — the winner pole stays reachable: "what the game shows right now".
                 {
                     var o = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, FacegenRel, AssetSourceChoice.WinnerToken) }, null, null);
@@ -450,8 +493,12 @@ internal static class PlaceAssetProbe
                     var placed = o.ModFolder is null ? null : Path.Combine(o.ModFolder, destRel);
                     Check(r.Placed && placed is not null && File.Exists(placed) && File.ReadAllBytes(placed).SequenceEqual(loserBytes),
                           $"the source file's bytes land under the DESTINATION's name — a rename  [RED arm] — {(r.Placed ? "ok" : r.Error)}");
-                    Check(r.SourceDesc is not null && r.SourceDesc.Contains(FacegenRel, StringComparison.OrdinalIgnoreCase),
-                          $"the render states which FILE the bytes came from — a rename that reported only the provider would hide it — {r.SourceDesc}");
+                    // STARTS with, not Contains: the loose description already ends in the provider's ABSOLUTE path,
+                    // which has the Data-relative path as a substring — so Contains was satisfied by construction and
+                    // stayed green with the rename prefix deleted. The prefix is the claim; its position is what
+                    // distinguishes it from the path that was always there.  [RED arm]
+                    Check(r.SourceDesc is not null && r.SourceDesc.StartsWith(FacegenRel, StringComparison.OrdinalIgnoreCase),
+                          $"the render LEADS with the source file — a rename that reported only the provider would hide it — {r.SourceDesc}");
                     Check(o.ModFolder is null || !File.Exists(Path.Combine(o.ModFolder, FacegenRel)),
                           "the SOURCE path is not also written — a rename places one file, not two");
                 }
@@ -467,12 +514,90 @@ internal static class PlaceAssetProbe
 
                 // I6 — a pole against an on-disk source cannot apply, and is SAID rather than dropped (Q3).
                 {
-                    var onDisk = Path.Combine(root, "i7-source.nif");
+                    var onDisk = Path.Combine(root, "i6-source.nif");
                     File.WriteAllBytes(onDisk, new byte[] { 7, 7 });
                     var r = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, onDisk, "ModA") }, null, null).Results[0];
                     Check(!r.Placed && r.Error!.Contains(WriteSentences.PlaceSourceProviderNeedsRelPath, StringComparison.Ordinal),
                           $"source_provider= with an ON-DISK source is refused, never silently ignored  [RED arm] — {r.Error}");
                 }
+
+                // I7 — the spellings that are NOT one exact file on disk. A leading separator is Path.IsPathRooted
+                // on Windows but AssetResolver trims it, so '\meshes\…' is a legal Data-relative path as a
+                // DESTINATION; classifying it as on-disk made one string mean two things in a single call and sent
+                // it to the process CWD. Quoted is the other: it must resolve as the path inside the quotes.  [RED arm]
+                {
+                    foreach (var spelling in new[] { @"\" + FacegenRel, "/" + FacegenRel.Replace('\\', '/'), "\"" + FacegenRel + "\"" })
+                    {
+                        var o = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, spelling, loserName) }, null, null);
+                        var rr = o.Results[0];
+                        var placed = o.ModFolder is null ? null : Path.Combine(o.ModFolder, FacegenRel);
+                        Check(rr.Placed && placed is not null && File.ReadAllBytes(placed).SequenceEqual(loserBytes),
+                              $"source= '{spelling}' resolves through the VFS under the named pole — {(rr.Placed ? "placed" : rr.Error)}");
+                    }
+                }
+
+                // I8 — the pole with NO source= at all: the tool description offers this shape (read the destination
+                // path from a named provider), and nothing exercised it.
+                {
+                    var o = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, null, loserName) }, null, null);
+                    var r = o.Results[0];
+                    var placed = o.ModFolder is null ? null : Path.Combine(o.ModFolder, FacegenRel);
+                    Check(r.Placed && placed is not null && File.ReadAllBytes(placed).SequenceEqual(loserBytes),
+                          $"source_provider= with NO source= reads the destination path from the named provider — {(r.Placed ? "placed" : r.Error)}");
+                    Check(r.SourceDesc is not null && !r.SourceDesc.StartsWith(FacegenRel, StringComparison.OrdinalIgnoreCase),
+                          "…and it is NOT reported as a rename — source and destination are the same path");
+                }
+
+                // I9 — the pole token is matched case-insensitively, like the provider names beside it.
+                {
+                    var o = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, FacegenRel, "WINNER") }, null, null);
+                    var r = o.Results[0];
+                    var placed = o.ModFolder is null ? null : Path.Combine(o.ModFolder, FacegenRel);
+                    Check(r.Placed && placed is not null && File.ReadAllBytes(placed).SequenceEqual(winnerBytes),
+                          $"the winner token is case-insensitive ('WINNER') — {(r.Placed ? "placed" : r.Error)}");
+                    var up = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, FacegenRel, loserName.ToUpperInvariant()) }, null, null).Results[0];
+                    Check(up.Placed, $"…and so is a provider name ('{loserName.ToUpperInvariant()}') — {(up.Placed ? "placed" : up.Error)}");
+                }
+            }
+
+            // ================= K: a BSA provider named as the source pole =================
+            // Every other instance in this probe writes an EMPTY sResourceArchiveList, so no fixture has ever had a
+            // BSA in the VFS — the named-pole lane was proven for loose providers only, while the tool advertises a
+            // BSA filename as a legal source_provider=. This one registers the committed fixture archive as a base
+            // archive so the BSA branch of Describe and of the resolved read are both reached.
+            Console.WriteLine();
+            Console.WriteLine("--- K: source_provider= a BSA filename — the archive branch of the pole ---");
+            {
+                var inst = Path.Combine(root, "svc-k");
+                var (mods, data, prof) = MakeInstance(inst);
+                File.Copy(fixA, Path.Combine(data, "FixtureA.bsa"));          // a base archive, listed in Skyrim.ini
+                var loose = Path.Combine(mods, "LooseFace");
+                Directory.CreateDirectory(loose);
+                var looseBytes = new byte[] { 0x4C, 0x4C };
+                WriteLoose(loose, FacegenRel, looseBytes);
+                File.WriteAllText(Path.Combine(loose, "Dummy.esp"), "x");
+                WriteProfile(prof, new[] { "Dummy.esp" }, new[] { "*Dummy.esp" }, new[] { "+LooseFace" });
+                WriteSkyrimIni(prof, "FixtureA.bsa");
+                var store = new UserConfigStore(Path.Combine(root, "user-k.json"));
+                using var svc = LoadOrderService.WithInstance(inst, 0, store);
+
+                var hit = svc.AssetStatus(new[] { FacegenRel }).Results[0].Hit;
+                Check(hit is not null && hit.Providers.Any(p => p.Kind == AssetKind.Bsa),
+                      $"the fixture really does have a BSA provider in the VFS — providers: {string.Join(", ", hit?.Providers.Select(p => p.Source + " (" + p.Kind + ")") ?? Array.Empty<string>())}");
+                Check(hit?.Winner?.Kind == AssetKind.Loose, "…and the LOOSE copy wins, so naming the BSA is naming the loser  [RED arm]");
+
+                var bsaBytes = AssetResolver.TryReadArchiveEntry(fixA, FacegenRel)!;
+                var o = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, FacegenRel, "FixtureA.bsa") }, null, null);
+                var r = o.Results[0];
+                var placed = o.ModFolder is null ? null : Path.Combine(o.ModFolder, FacegenRel);
+                Check(r.Placed && placed is not null && File.ReadAllBytes(placed).SequenceEqual(bsaBytes),
+                      $"source_provider= a BSA filename extracts THAT archive's entry, not the winning loose copy  [RED arm] — {(r.Placed ? "placed" : r.Error)}");
+
+                // …and the refusal's quoted token round-trips for a BSA provider too (its name carries a '.bsa'
+                // extension, which is the shape most likely to be mangled by a list format).
+                var refusal = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, FacegenRel, "NopeMod") }, null, null).Results[0].Error!;
+                Check(refusal.Contains("'FixtureA.bsa' (BSA)", StringComparison.Ordinal),
+                      $"the BSA provider is listed as a quoted name with its kind outside the quotes — {refusal}");
             }
 
             // ================= J: the reserved token vs a mod that carries its name =================
@@ -540,6 +665,28 @@ internal static class PlaceAssetProbe
         File.WriteAllText(Path.Combine(inst, "ModOrganizer.ini"),
             "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(" + profile + ")\r\ngamePath=@ByteArray("
             + gameDir.Replace(@"\", @"\\") + ")\r\n");
+
+    /// <summary>First line of a tool render — enough to identify an outcome in a check label without pasting a block.</summary>
+    static string Trim1(string s) => s.Split('\n')[0].Trim();
+
+    /// <summary>The on-disk path of a file placed by a TOOL-level call, taken from the render's own "mod folder:"
+    /// line. Reading it back rather than rebuilding it from the patch-name convention keeps a wire arm failing only
+    /// for its own claim — the folder is auto-suffixed and prefixed, and an arm that assumed the spelling would go
+    /// red on a rename of the convention while the parameter it tests still worked. Null = no folder was reported.</summary>
+    static string? PlacedFileFrom(string render, string modsDir, string rel)
+    {
+        foreach (var line in render.Split('\n'))
+        {
+            var t = line.Trim();
+            if (!t.StartsWith("mod folder:", StringComparison.Ordinal)) continue;
+            var name = t["mod folder:".Length..].Trim();
+            var cut = name.IndexOf("  —", StringComparison.Ordinal);       // the in-place / enable-and-sort suffixes
+            if (cut >= 0) name = name[..cut].Trim();
+            var p = Path.Combine(modsDir, name, rel);
+            return File.Exists(p) ? p : null;
+        }
+        return null;
+    }
 
     static void WriteLoose(string baseDir, string rel, byte[] bytes)
     {

--- a/src/housecarl-generator/PlaceAssetProbe.cs
+++ b/src/housecarl-generator/PlaceAssetProbe.cs
@@ -32,12 +32,16 @@ namespace HousecarlGenerator;
 ///      folder (the good file present); a drive-rooted / '..' destination is a per-asset named error; the tool layer
 ///      refuses malformed specs (no kind, both/neither of formid+asset_path, bad formid/kind, both-expansion + loose source).
 ///   I  the VFS source lane — source= a DATA-RELATIVE path resolved through the asset layer, with source_provider=
-///      choosing the pole. A NAMED provider is read even when another copy wins (I1, the arm no other source policy
-///      passes); 'winner' reads the current winner (I2); a named provider that doesn't supply the path is refused with
-///      nothing substituted (I3); source ≠ destination is a RENAME (I4 — the mechanism an appearance copy is built
-///      from); an absent source and a pole against an on-disk source are named refusals (I5, I6).
-///   J  the reserved token vs a mod literally named 'winner' — refused both ways rather than guessed, with a
-///      places-fine control proving the refusal is the collision and not a broken fixture.
+///      choosing the pole. Fixtures are named HOSTILELY ("JK's Skyrim", "winner") because friendly names cannot
+///      exercise what the provider list promises. A NAMED provider is read even when another copy wins (I1, the arm
+///      no other source policy passes); '*winner' reads the current winner (I2); a named provider that doesn't supply
+///      the path is refused with nothing substituted (I3); source ≠ destination is a RENAME (I4 — the mechanism an
+///      appearance copy is built from); an absent source and a pole against an on-disk source are named refusals
+///      (I5, I6); odd path spellings resolve through the VFS (I7); the pole with no source= (I8); case-insensitivity
+///      (I9); and the static pole-spelling correction on a miss (I10). I1c round-trips the refusal's own tokens back
+///      through the tool — the arm a substring check cannot replace.
+///   K  a BSA provider named as the pole, and a Data-relative source that merely ENDS in '.bsa'.
+///   L  the wire field names — PlaceAssetSpec deserialized from the JSON an MCP client actually sends.
 ///
 /// Self-contained: synthetic folders/instances in temp + the committed fixtures/asset-resolver/FixtureA.bsa, NO BSArch.
 /// Run: dotnet run --project src/housecarl-generator place-asset-guard
@@ -325,6 +329,14 @@ internal static class PlaceAssetProbe
                 // a QUOTED .bsa source (the natural form for a spaced filename) must NOT be wrongly refused at the spec
                 // level — quotes are trimmed for the test, as ReadExplicitSource does (review fix). It then attempts to
                 // place mesh+tint (per-asset outcomes), never the "must be a bare '.bsa' path" spec refusal.
+                // A RELATIVE '.bsa' is a Data-relative asset path now, not an archive to open — so it names ONE file
+                // and cannot serve two slots. Accepting it here would hand the mesh and the tint the same bytes.
+                Check(PlaceAssetTools.BulkPlaceAsset(svc, new[] { new PlaceAssetSpec { Formid = "01A51A:Dawnguard.esm", Source = @"meshes\some\thing.bsa" } })
+                        .Contains("must be a FULL '.bsa' path", StringComparison.Ordinal),
+                      "bulk tool: a both-expansion with a RELATIVE '.bsa' source is refused (one VFS path cannot serve two slots)  [RED arm]");
+                Check(PlaceAssetTools.BulkPlaceAsset(svc, new[] { new PlaceAssetSpec { Formid = "01A51A:Dawnguard.esm", Source = @"C:\nope\x.nif", SourceProvider = "GMod" } })
+                        .Contains(WriteSentences.PlaceBothSlotsPoleConstraint, StringComparison.Ordinal),
+                      "bulk tool: the both-expansion refusal states when source_provider= actually applies there  [RED arm]");
                 Check(!PlaceAssetTools.BulkPlaceAsset(svc, new[] { new PlaceAssetSpec { Formid = "01A51A:Dawnguard.esm", Source = "\"" + fixA + "\"" } })
                         .Contains("must be a bare"),
                       "bulk tool: a QUOTED .bsa source in a both-expansion is ACCEPTED (not refused for the trailing quote)");
@@ -387,16 +399,23 @@ internal static class PlaceAssetProbe
             {
                 var inst = Path.Combine(root, "svc-i");
                 var (mods, _, prof) = MakeInstance(inst);
+                // HOSTILE names on purpose. The first fixture used ModA/ModB, which cannot exercise the one thing the
+                // provider list promises — that a name lifted out of a refusal is a name the selector accepts. An
+                // apostrophe is the common real case ("JK's Skyrim" is one of the most-installed Skyrim mods) and it
+                // dissolved the single-quote delimiter mid-name; the mod called "winner" is the one that used to
+                // collide with the pole token. Both are now ordinary names, and the arms below prove it.
+                const string ModA = "JK's Skyrim";
+                const string ModB = "winner";
                 var aBytes = new byte[] { 0xA1, 0xA1, 0xA1 };
                 var bBytes = new byte[] { 0xB2, 0xB2 };
-                foreach (var (m, b) in new[] { ("ModA", aBytes), ("ModB", bBytes) })
+                foreach (var (m, b) in new[] { (ModA, aBytes), (ModB, bBytes) })
                 {
                     var d = Path.Combine(mods, m);
                     Directory.CreateDirectory(d);
                     WriteLoose(d, FacegenRel, b);
                 }
-                File.WriteAllText(Path.Combine(mods, "ModA", "Dummy.esp"), "x");
-                WriteProfile(prof, new[] { "Dummy.esp" }, new[] { "*Dummy.esp" }, new[] { "+ModA", "+ModB" });
+                File.WriteAllText(Path.Combine(mods, ModA, "Dummy.esp"), "x");
+                WriteProfile(prof, new[] { "Dummy.esp" }, new[] { "*Dummy.esp" }, new[] { "+" + ModA, "+" + ModB });
                 WriteSkyrimIni(prof, "");
                 var store = new UserConfigStore(Path.Combine(root, "user-i.json"));
                 using var svc = LoadOrderService.WithInstance(inst, 0, store);
@@ -405,10 +424,22 @@ internal static class PlaceAssetProbe
                 // named provider is honoured whether or not it is the winner, and hard-coding the winner would make
                 // the arm pass for the wrong reason the day MO2 priority is read differently.
                 var winnerName = svc.AssetStatus(new[] { FacegenRel }).Results[0].Hit?.Winner?.Source;
-                Check(winnerName is "ModA" or "ModB", $"the fixture is genuinely contended and one copy wins — winner={winnerName ?? "(none)"}");
-                var loserName = winnerName == "ModA" ? "ModB" : "ModA";
-                var winnerBytes = winnerName == "ModA" ? aBytes : bBytes;
-                var loserBytes = winnerName == "ModA" ? bBytes : aBytes;
+                Check(winnerName == ModA || winnerName == ModB, $"the fixture is genuinely contended and one copy wins — winner={winnerName ?? "(none)"}");
+                var loserName = winnerName == ModA ? ModB : ModA;
+                var winnerBytes = winnerName == ModA ? aBytes : bBytes;
+                var loserBytes = winnerName == ModA ? bBytes : aBytes;
+
+                // The fixture's whole point: a mod called "winner" is an ORDINARY provider now. Under the bare-token
+                // spelling this name was unreachable — the selector shadowed it — and the ambiguity refusal listed it
+                // as a token its own remedy rejected. Naming it must place its bytes, and must not mean the pole.
+                {
+                    var o = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, FacegenRel, "winner") }, null, null);
+                    var r = o.Results[0];
+                    var placed = o.ModFolder is null ? null : Path.Combine(o.ModFolder, FacegenRel);
+                    var winnerModBytes = ModB == "winner" ? bBytes : aBytes;
+                    Check(r.Placed && placed is not null && File.ReadAllBytes(placed).SequenceEqual(winnerModBytes),
+                          $"a provider literally named 'winner' is reachable by its own name — the sigil un-reserved it  [RED arm] — {(r.Placed ? "ok" : r.Error)}");
+                }
 
                 // I1 — the DISCRIMINATING arm: a named provider that is NOT the winner is read anyway. Every other
                 // source policy (winner-read, sole-provider) fails this one, which is why the fixture is contended.
@@ -452,11 +483,13 @@ internal static class PlaceAssetProbe
                 // substring check cannot see this class; only the round trip can.  [RED arm]
                 {
                     var refusal = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, FacegenRel, null) }, null, null).Results[0].Error!;
-                    var tokens = System.Text.RegularExpressions.Regex.Matches(refusal, @"'([^']+)'")
+                    // DOUBLE quotes: the delimiter has to be a character a provider name cannot contain, and one of
+                    // these fixtures is named "JK's Skyrim" — a single-quote extractor returns [JK] and a fragment.
+                    var tokens = System.Text.RegularExpressions.Regex.Matches(refusal, "\"([^\"]+)\"")
                         .Select(m => m.Groups[1].Value)
-                        .Where(t => !t.Contains('\\'))          // drop the asset path the sentence also quotes
                         .Distinct().ToList();
-                    Check(tokens.Count == 2, $"the refusal offers exactly the two provider names as quoted tokens — [{string.Join(", ", tokens)}]");
+                    Check(tokens.Count == 2 && tokens.Contains(ModA) && tokens.Contains(ModB),
+                          $"the refusal offers exactly the two provider names as delimited tokens, apostrophe and all — [{string.Join(" | ", tokens)}]");
                     foreach (var token in tokens)
                     {
                         var o = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, FacegenRel, token) }, null, null);
@@ -471,7 +504,7 @@ internal static class PlaceAssetProbe
                     var r = o.Results[0];
                     var placed = o.ModFolder is null ? null : Path.Combine(o.ModFolder, FacegenRel);
                     Check(r.Placed && placed is not null && File.ReadAllBytes(placed).SequenceEqual(winnerBytes),
-                          $"source_provider=winner places the CURRENT winner's bytes ('{winnerName}') — {(r.Placed ? "ok" : r.Error)}");
+                          $"source_provider={AssetSourceChoice.WinnerToken} places the CURRENT winner's bytes ('{winnerName}') — {(r.Placed ? "ok" : r.Error)}");
                 }
 
                 // I3 — a named provider that doesn't supply the path is refused, NOT quietly served by another.
@@ -479,7 +512,7 @@ internal static class PlaceAssetProbe
                     var r = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, FacegenRel, "NoSuchMod") }, null, null).Results[0];
                     Check(!r.Placed && r.Error!.Contains(WriteSentences.PlaceSourceNoSubstitute, StringComparison.Ordinal),
                           $"a named provider that does not supply the path is REFUSED with nothing substituted  [RED arm] — {r.Error}");
-                    Check(r.Error!.Contains("ModA", StringComparison.Ordinal) && r.Error.Contains("ModB", StringComparison.Ordinal),
+                    Check(r.Error!.Contains(ModA, StringComparison.Ordinal) && r.Error.Contains(ModB, StringComparison.Ordinal),
                           "…and the providers that DO supply it are named (the typo's remedy)");
                 }
 
@@ -516,7 +549,7 @@ internal static class PlaceAssetProbe
                 {
                     var onDisk = Path.Combine(root, "i6-source.nif");
                     File.WriteAllBytes(onDisk, new byte[] { 7, 7 });
-                    var r = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, onDisk, "ModA") }, null, null).Results[0];
+                    var r = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, onDisk, ModA) }, null, null).Results[0];
                     Check(!r.Placed && r.Error!.Contains(WriteSentences.PlaceSourceProviderNeedsRelPath, StringComparison.Ordinal),
                           $"source_provider= with an ON-DISK source is refused, never silently ignored  [RED arm] — {r.Error}");
                 }
@@ -550,13 +583,22 @@ internal static class PlaceAssetProbe
 
                 // I9 — the pole token is matched case-insensitively, like the provider names beside it.
                 {
-                    var o = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, FacegenRel, "WINNER") }, null, null);
+                    var o = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, FacegenRel, "*WINNER") }, null, null);
                     var r = o.Results[0];
                     var placed = o.ModFolder is null ? null : Path.Combine(o.ModFolder, FacegenRel);
                     Check(r.Placed && placed is not null && File.ReadAllBytes(placed).SequenceEqual(winnerBytes),
-                          $"the winner token is case-insensitive ('WINNER') — {(r.Placed ? "placed" : r.Error)}");
+                          $"the winner token is case-insensitive ('*WINNER') — {(r.Placed ? "placed" : r.Error)}");
                     var up = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, FacegenRel, loserName.ToUpperInvariant()) }, null, null).Results[0];
                     Check(up.Placed, $"…and so is a provider name ('{loserName.ToUpperInvariant()}') — {(up.Placed ? "placed" : up.Error)}");
+                }
+
+                // I10 — the naming correction that rides on a named-provider miss. STATIC: it says how the pole is
+                // spelled whatever the load order contains, which is the property the conditional winner-remedy did
+                // not have. Same shape as the in_place=true correction.
+                {
+                    var r = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, FacegenRel, "NoSuchModAtAll") }, null, null).Results[0];
+                    Check(!r.Placed && r.Error!.Contains(WriteSentences.PlaceSourcePoleSpelling, StringComparison.Ordinal),
+                          $"a named-provider miss states how the winner pole is spelled  [RED arm] — {r.Error}");
                 }
             }
 
@@ -596,33 +638,37 @@ internal static class PlaceAssetProbe
                 // …and the refusal's quoted token round-trips for a BSA provider too (its name carries a '.bsa'
                 // extension, which is the shape most likely to be mangled by a list format).
                 var refusal = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, FacegenRel, "NopeMod") }, null, null).Results[0].Error!;
-                Check(refusal.Contains("'FixtureA.bsa' (BSA)", StringComparison.Ordinal),
-                      $"the BSA provider is listed as a quoted name with its kind outside the quotes — {refusal}");
+                Check(refusal.Contains("\"FixtureA.bsa\" (BSA)", StringComparison.Ordinal),
+                      $"the BSA provider is listed as a delimited name with its kind outside the delimiters — {refusal}");
+
+                // A Data-relative source that ENDS in '.bsa' is an asset path, not an archive to open. Testing the
+                // extension before the qualified-path test sent exactly this to the process working directory.
+                var relBsa = @"meshes\hcprobe\thing.bsa";
+                WriteLoose(loose, relBsa, new byte[] { 0x7A, 0x7A });
+                File.SetLastWriteTimeUtc(Path.Combine(prof, "modlist.txt"), DateTime.UtcNow.AddHours(1));
+                var bo = svc.PlaceAssets(new[] { new PlaceRequest(@"meshes\hcprobe\copy.nif", relBsa, "LooseFace") }, null, null);
+                var br = bo.Results[0];
+                var bplaced = bo.ModFolder is null ? null : Path.Combine(bo.ModFolder, @"meshes\hcprobe\copy.nif");
+                Check(br.Placed && bplaced is not null && File.ReadAllBytes(bplaced).SequenceEqual(new byte[] { 0x7A, 0x7A }),
+                      $"a Data-relative source ending '.bsa' resolves through the VFS, not against the process CWD  [RED arm] — {(br.Placed ? "placed" : br.Error)}");
             }
 
-            // ================= J: the reserved token vs a mod that carries its name =================
+            // ================= L: the wire field names =================
+            // Every other arm builds PlaceAssetSpec with the C# initializer, so the [JsonPropertyName] a real MCP
+            // caller actually sends is unexercised — a misspelled wire name would drop the parameter for every real
+            // call with the suite green. This deserializes the JSON an MCP client sends and asserts the field lands.
             Console.WriteLine();
-            Console.WriteLine("--- J: a provider literally named 'winner' collides with the reserved token → refuse, don't guess ---");
+            Console.WriteLine("--- L: source_provider survives the JSON wire, under the name a client sends ---");
             {
-                var inst = Path.Combine(root, "svc-j");
-                var (mods, _, prof) = MakeInstance(inst);
-                var w = Path.Combine(mods, AssetSourceChoice.WinnerToken);
-                Directory.CreateDirectory(w);
-                WriteLoose(w, FacegenRel, new byte[] { 9 });
-                File.WriteAllText(Path.Combine(w, "Dummy.esp"), "x");
-                WriteProfile(prof, new[] { "Dummy.esp" }, new[] { "*Dummy.esp" }, new[] { "+" + AssetSourceChoice.WinnerToken });
-                WriteSkyrimIni(prof, "");
-                var store = new UserConfigStore(Path.Combine(root, "user-j.json"));
-                using var svc = LoadOrderService.WithInstance(inst, 0, store);
-
-                var r = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, FacegenRel, AssetSourceChoice.WinnerToken) }, null, null).Results[0];
-                Check(!r.Placed && r.Error!.Contains(WriteSentences.PlaceSourceWinnerCollision, StringComparison.Ordinal),
-                      $"source_provider=winner with a mod named 'winner' present is REFUSED both ways  [RED arm] — {r.Error}");
-                // …and the collision is the ONLY thing that refuses here: the same instance places fine when the
-                // caller names no pole at all (one provider ⇒ sole). Without this, an arm asserting a refusal would
-                // pass on an instance that simply cannot place.
-                var ok = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, null, null) }, null, null).Results[0];
-                Check(ok.Placed, $"the same fixture places with NO pole named (so the refusal above is the collision, not a broken instance) — {(ok.Placed ? "ok" : ok.Error)}");
+                const string json = """
+                [ { "asset_path": "meshes\\x.nif", "source": "meshes\\y.nif", "source_provider": "SomeMod" } ]
+                """;
+                var specs = System.Text.Json.JsonSerializer.Deserialize<PlaceAssetSpec[]>(json);
+                Check(specs is { Length: 1 }, "the wire array deserializes");
+                Check(specs?[0].SourceProvider == "SomeMod",
+                      $"source_provider arrives under its wire name  [RED arm] — {specs?[0].SourceProvider ?? "(dropped)"}");
+                Check(specs?[0].Source == @"meshes\y.nif" && specs?[0].AssetPath == @"meshes\x.nif",
+                      "…and so do the sibling fields this spec pairs it with");
             }
         }
         finally { try { Directory.Delete(root, recursive: true); } catch { /* temp scratch */ } }

--- a/src/housecarl-generator/PlaceAssetProbe.cs
+++ b/src/housecarl-generator/PlaceAssetProbe.cs
@@ -328,7 +328,7 @@ internal static class PlaceAssetProbe
                       "bulk tool: a both-expansion (formid, no kind) with a non-.bsa source is refused");
                 // a QUOTED .bsa source (the natural form for a spaced filename) must NOT be wrongly refused at the spec
                 // level — quotes are trimmed for the test, as ReadExplicitSource does (review fix). It then attempts to
-                // place mesh+tint (per-asset outcomes), never the "must be a bare '.bsa' path" spec refusal.
+                // place mesh+tint (per-asset outcomes), never the "must be a FULL '.bsa' path" spec refusal.
                 // A RELATIVE '.bsa' is a Data-relative asset path now, not an archive to open — so it names ONE file
                 // and cannot serve two slots. Accepting it here would hand the mesh and the tint the same bytes.
                 Check(PlaceAssetTools.BulkPlaceAsset(svc, new[] { new PlaceAssetSpec { Formid = "01A51A:Dawnguard.esm", Source = @"meshes\some\thing.bsa" } })
@@ -579,6 +579,19 @@ internal static class PlaceAssetProbe
                           $"source_provider= with NO source= reads the destination path from the named provider — {(r.Placed ? "placed" : r.Error)}");
                     Check(r.SourceDesc is not null && !r.SourceDesc.StartsWith(FacegenRel, StringComparison.OrdinalIgnoreCase),
                           "…and it is NOT reported as a rename — source and destination are the same path");
+
+                    // The same claim when the caller SPELLS the source, which is the natural way to say "place this
+                    // path, from that mod". Keyed on the paths differing, not on a source being named — and compared
+                    // on the VFS's own key, so a case or separator variant of the destination is still the same file.
+                    // A raw string compare reports a rename between one file and itself.  [RED arm]
+                    foreach (var spelling in new[] { FacegenRel, FacegenRel.ToUpperInvariant(), FacegenRel.Replace('\\', '/') })
+                    {
+                        var same = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, spelling, loserName) }, null, null).Results[0];
+                        Check(same.Placed && same.SourceDesc is not null
+                              && !same.SourceDesc.StartsWith(spelling, StringComparison.OrdinalIgnoreCase)
+                              && !same.SourceDesc.StartsWith(FacegenRel, StringComparison.OrdinalIgnoreCase),
+                              $"source= '{spelling}' equals the destination, so no rename prefix — {(same.Placed ? same.SourceDesc : same.Error)}");
+                    }
                 }
 
                 // I9 — the pole token is matched case-insensitively, like the provider names beside it.

--- a/src/housecarl-generator/ReadPluginFileProbe.cs
+++ b/src/housecarl-generator/ReadPluginFileProbe.cs
@@ -224,6 +224,23 @@ internal static class ReadPluginFileProbe
             var disamb = svc.ReadPluginFile("Dup.esp", null, "Weapon", "DupModB", null, 1, null, 500);
             Check(disamb.Mode == "enumerate" && disamb.Rows.Count == 1 && disamb.Rows[0].EditorId == "DupDisabledW",
                   $"mod=DupModB reads THAT copy — editorid={(disamb.Rows.Count > 0 ? disamb.Rows[0].EditorId : "?")}");
+
+            // 7c — the ground under SPEC §5.5's exemption: S1 poles stay BARE (`source=winner`, not `*winner`)
+            //      because a plugin name is extension-mandatory and so can never equal a bare pole word. That is a
+            //      property of this name space, and it holds only while an extensionless spelling fails to name a
+            //      plugin. If the surface ever fuzzy-matches "Donor" to "Donor.esp", the exemption lapses and the
+            //      S1 poles need the sigil — so the amendment's ground is pinned here rather than asserted in a doc.
+            Console.WriteLine("\n--- 7c: an extensionless plugin spelling refuses by name (SPEC §5.5's exemption ground) ---");
+            var bare = svc.ReadPluginFile("Donor", null, "Weapon", null, null, 1, null, 500);
+            Check(bare.Mode == "error", $"'Donor' (no extension) does NOT resolve to Donor.esp — mode={bare.Mode}");
+            Check(bare.Rows.Count == 0, $"…and returns no rows — a near-miss never reads a real plugin's records ({bare.Rows.Count} rows)");
+            Check(bare.Error is not null && bare.Error.Contains("Donor", StringComparison.OrdinalIgnoreCase),
+                  $"…and the refusal names what it could not find — {bare.Error ?? "(no error!)"}");
+            // The control: the SAME name WITH its extension does resolve, so the refusal above is the missing
+            // extension and not a broken fixture.
+            var withExt = svc.ReadPluginFile("Donor.esp", null, "Weapon", null, null, 1, null, 500);
+            Check(withExt.Mode == "enumerate" && withExt.Rows.Count > 0,
+                  $"…while 'Donor.esp' reads normally — the refusal is the extension, not the fixture (mode={withExt.Mode}, rows={withExt.Rows.Count})");
         }
         finally { try { Directory.Delete(root, recursive: true); } catch { /* temp scratch */ } }
 

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -2222,9 +2222,11 @@ public static class WriteSurfaceGuardProbe
     }
 
     /// <summary>Drive the REAL place service to each of its source-selection refusals and return the rendered
-    /// outcomes. Its own throwaway MO2 instance rather than the shared fixture: the refusals need an asset path THREE
-    /// mods contend for — one of them named "winner" — and growing the shared fixture to carry that would move a tree
-    /// eleven other arms assert against (#333's lesson) for the sake of four sentences.</summary>
+    /// outcomes. The fixture is TWO mods contending for one asset path, plus one on-disk source and one both-slots
+    /// spec — enough to reach every sentence below. (It briefly carried a third mod named "winner", for a collision
+    /// refusal that no longer exists: the pole token is sigiled, so no provider name can collide with it.) Its own
+    /// throwaway MO2 instance rather than the shared fixture, because growing that tree would move something eleven
+    /// other arms assert against — #333's lesson — for the sake of a few sentences.</summary>
     static List<string> PlaceSourceRefusalRenders(string root)
     {
         const string rel = @"meshes\hcw2\twin.nif";

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -99,7 +99,7 @@ public static class WriteSurfaceGuardProbe
             // records from W2TwinFwd.esp. Those patches are never ticked into plugins.txt, so they stay out of the
             // active order and cannot move a later arm's winner; an arm added after this one should still know the
             // folders exist.
-            TwinParityArm(fx);
+            TwinParityArm(fx, root);
             // #324's arm also writes into the replacer IN PLACE (its second half is that lane), so it sits with the
             // in-place arms below rather than among the read-the-fixture ones. It rewrites the replacer TWICE and
             // changes two of its records: the TOPIC (W2Topic → "Master Topic") and the CELL (W2Cell → "Master Cell",
@@ -2047,7 +2047,7 @@ public static class WriteSurfaceGuardProbe
     /// on each transport actually reading it. Two further parity assertions ride per outcome: the BUDGET (a cap
     /// that truncates one transport truncates the other) and the COUNTS (the total each lane states is the same
     /// number).</para></summary>
-    static void TwinParityArm(Fixture fx)
+    static void TwinParityArm(Fixture fx, string root)
     {
         Console.WriteLine("── ARM 12: D2 TWIN PARITY — one outcome, both transports, one source per sentence ──");
 
@@ -2199,6 +2199,13 @@ public static class WriteSurfaceGuardProbe
             cap => JsonWire.RenderSeqOutcome(seqStates[2], cap),
             "quest_count", $"{quests.Count} start-game-enabled quests");
 
+        // ---- place_asset's source refusals ------------------------------------------------------------
+        // place_asset renders on ONE transport, so these sentences' claim is "reaches a render", not "reaches
+        // both" — and they are observed off outcomes the REAL service produced. A probe that built the
+        // PlaceResult itself would be handing this arm the very sentence it claims to have found, which is the
+        // circular shape the whole reach check exists to catch.
+        foreach (var render in PlaceSourceRefusalRenders(root)) Observe(render, "{}");
+
         // ---- the coverage assertion — what stops this arm being theatre ------------------------------
         var missingText = twins.Select(t => t.Name).Where(n => !seenText.Contains(n)).ToList();
         var missingJson = twins.Select(t => t.Name).Where(n => !seenJson.Contains(n)).ToList();
@@ -2212,6 +2219,47 @@ public static class WriteSurfaceGuardProbe
         var missingOuter = outer.Select(t => t.Name).Where(n => !seenOuter.Contains(n)).ToList();
         Check("every [MustState] sentence on WriteSentences itself reaches a render (the wiring half a content pin cannot provide)",
             missingOuter.Count == 0, missingOuter.Count == 0 ? null : "unobserved: " + string.Join(", ", missingOuter));
+    }
+
+    /// <summary>Drive the REAL place service to each of its source-selection refusals and return the rendered
+    /// outcomes. Its own throwaway MO2 instance rather than the shared fixture: the refusals need an asset path THREE
+    /// mods contend for — one of them named "winner" — and growing the shared fixture to carry that would move a tree
+    /// eleven other arms assert against (#333's lesson) for the sake of four sentences.</summary>
+    static List<string> PlaceSourceRefusalRenders(string root)
+    {
+        const string rel = @"meshes\hcw2\twin.nif";
+        var inst = Path.Combine(root, "place-sentences");
+        var mods = Path.Combine(inst, "mods");
+        var prof = Path.Combine(inst, "profiles", "Default");
+        foreach (var d in new[] { mods, prof, Path.Combine(inst, "game", "Data") }) Directory.CreateDirectory(d);
+        File.WriteAllText(Path.Combine(inst, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(inst, "game").Replace(@"\", @"\\") + ")\r\n");
+
+        // Three providers, one of them carrying the reserved token's name — enough for every refusal below.
+        var providers = new[] { "W2AssetA", "W2AssetB", AssetSourceChoice.WinnerToken };
+        foreach (var m in providers)
+        {
+            var dir = Path.Combine(mods, m, "meshes", "hcw2");
+            Directory.CreateDirectory(dir);
+            File.WriteAllBytes(Path.Combine(dir, "twin.nif"), new byte[] { 1, 2, 3 });
+        }
+        File.WriteAllText(Path.Combine(mods, providers[0], "Dummy.esp"), "x");
+        File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\nDummy.esp\r\n");
+        File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*Dummy.esp\r\n");
+        File.WriteAllText(Path.Combine(prof, "modlist.txt"),
+            "# header\r\n" + string.Join("\r\n", providers.Select(p => "+" + p)) + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "Skyrim.ini"), "[Archive]\r\nsResourceArchiveList=\r\n");
+
+        using var svc = LoadOrderService.WithInstance(inst, 0, new UserConfigStore(Path.Combine(root, "place-sentences.user.json")));
+        string Render(PlaceRequest req) => PlaceWire.Render(svc.PlaceAssets(new[] { req }, null, null));
+        return new List<string>
+        {
+            Render(new PlaceRequest(rel, null, null)),                                          // contended, no pole
+            Render(new PlaceRequest(rel, rel, "W2NoSuchMod")),                                  // named, absent
+            Render(new PlaceRequest(rel, rel, AssetSourceChoice.WinnerToken)),                  // token vs the mod
+            Render(new PlaceRequest(rel, Path.Combine(root, "w2-ondisk.nif"), providers[0])),   // pole vs on-disk source
+        };
     }
 
     /// <summary>The budget half of the twin harness: one outcome, one cap, both transports. Asserts (a) a cap tight

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -2236,8 +2236,8 @@ public static class WriteSurfaceGuardProbe
             "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
             + Path.Combine(inst, "game").Replace(@"\", @"\\") + ")\r\n");
 
-        // Three providers, one of them carrying the reserved token's name — enough for every refusal below.
-        var providers = new[] { "W2AssetA", "W2AssetB", AssetSourceChoice.WinnerToken };
+        // Two contending providers — enough for every refusal below now that no name can collide with the pole.
+        var providers = new[] { "W2AssetA", "W2AssetB" };
         foreach (var m in providers)
         {
             var dir = Path.Combine(mods, m, "meshes", "hcw2");
@@ -2253,13 +2253,21 @@ public static class WriteSurfaceGuardProbe
 
         using var svc = LoadOrderService.WithInstance(inst, 0, new UserConfigStore(Path.Combine(root, "place-sentences.user.json")));
         string Render(PlaceRequest req) => PlaceWire.Render(svc.PlaceAssets(new[] { req }, null, null));
+        // The both-slots constraint is refused at the TOOL layer, before any outcome exists, so it is observed
+        // through the tool rather than through PlaceWire — the sentence still has to reach a caller either way.
+        var bothSlots = PlaceAssetTools.BulkPlaceAsset(svc, new[]
+        {
+            new PlaceAssetSpec { Formid = "000800:Dummy.esp", Source = Path.Combine(root, "w2-ondisk.nif") },
+        });
         return new List<string>
         {
+            bothSlots,
+        }.Concat(new List<string>
+        {
             Render(new PlaceRequest(rel, null, null)),                                          // contended, no pole
-            Render(new PlaceRequest(rel, rel, "W2NoSuchMod")),                                  // named, absent
-            Render(new PlaceRequest(rel, rel, AssetSourceChoice.WinnerToken)),                  // token vs the mod
+            Render(new PlaceRequest(rel, rel, "W2NoSuchMod")),                                  // named, absent (+ the pole-spelling tail)
             Render(new PlaceRequest(rel, Path.Combine(root, "w2-ondisk.nif"), providers[0])),   // pole vs on-disk source
-        };
+        }).ToList();
     }
 
     /// <summary>The budget half of the twin harness: one outcome, one cap, both transports. Asserts (a) a cap tight

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1553,18 +1553,49 @@ public sealed class LoadOrderService : IDisposable
         var res = view.ResolveForPlacement(rel);                         // rel already validated — won't throw
         var winner = res.Sources.Count > 0 ? DescribeSource(res.Sources[0]) : null;
 
-        // ---- source bytes: explicit source= wins; else auto-resolve the sole provider ----
+        // ---- source bytes: an ON-DISK source= is read as named; anything else resolves through the VFS ----
+        // Three source shapes reach here: an on-disk file the caller named exactly (a rooted path, a '.bsa', a
+        // '<bsa>|<entry>'), a DATA-RELATIVE path resolved through the VFS under a pole, and no source at all — which
+        // is the same VFS lane pointed at the destination path. The last two share one code path because they are
+        // one question ("which provider supplies this Data-relative path") asked about different paths.
         byte[] bytes; string sourceDesc;
         var explicitSrc = req.Source?.Trim();
-        if (!string.IsNullOrEmpty(explicitSrc))
+        var providerSel = req.SourceProvider?.Trim();
+        if (!string.IsNullOrEmpty(explicitSrc) && !IsVfsSource(explicitSrc!))
         {
+            // An on-disk source already IS one exact copy, so a pole cannot apply to it — said, never dropped (Q3).
+            if (!string.IsNullOrEmpty(providerSel))
+                return PlaceResult.Fail(rel, WriteSentences.PlaceSourceProviderNeedsRelPath, winner);
             var (b, desc, err) = ReadExplicitSource(explicitSrc!, rel);
             if (err is not null) return PlaceResult.Fail(rel, err, winner);
             bytes = b!; sourceDesc = desc!;
         }
         else
         {
-            if (res.Sources.Count == 0)
+            // The SOURCE path: the Data-relative one the caller named, else the destination (the original lane).
+            bool sourceNamed = !string.IsNullOrEmpty(explicitSrc);
+            string srcRel = rel;
+            if (sourceNamed)
+            {
+                try { srcRel = AssetResolver.ValidateRelPath(explicitSrc!); }
+                catch (ArgumentException ex) { return PlaceResult.Fail(rel, $"source '{explicitSrc}': {ex.Message}", winner); }
+            }
+            var srcRes = sourceNamed ? view.ResolveForPlacement(srcRel) : res;
+            var pick = AssetSourceSelection.Select(srcRes, AssetSourceChoice.Parse(providerSel));
+
+            if (pick.Verdict == AssetSourceVerdict.WinnerTokenCollision)
+                return PlaceResult.Fail(rel, WriteSentences.PlaceSourceWinnerCollision, winner);
+            if (pick.Verdict == AssetSourceVerdict.NamedAbsent)
+                return PlaceResult.Fail(rel, WriteSentences.PlaceSourceNamedAbsent(providerSel!, srcRel, pick.ProviderNames), winner);
+            if (pick.Verdict == AssetSourceVerdict.Ambiguous)
+                return PlaceResult.Fail(rel, WriteSentences.PlaceSourceAmbiguous(srcRel, pick.ProviderNames), winner);
+            if (pick.Verdict == AssetSourceVerdict.NoProvider && sourceNamed)
+                return PlaceResult.Fail(rel,
+                    $"nothing in the active load order provides the source '{srcRel}'."
+                    + (AssetPathHint.AssetRootHint(view, srcRel) is { } srcHint ? " " + srcHint : "")
+                    + (srcRes.ReadIncomplete ? " NOTE: a BSA failed to read this build, so it may merely be unscanned (see the warnings)." : ""),
+                    winner);
+            if (pick.Verdict == AssetSourceVerdict.NoProvider)
             {
                 // #283 — the auto-resolve dead end is the same input mistake #273 fixed in the three sibling lanes: a
                 // path taken off a record is stored relative to its ROOT folder, so passing it verbatim is the normal
@@ -1574,28 +1605,27 @@ public sealed class LoadOrderService : IDisposable
                 // there, so an absent destination is not a mistake to correct.
                 var hint = AssetPathHint.AssetRootHint(view, rel);
                 // ORDER IS LOAD-BEARING — the hint sits directly after the sentence about the PATH, before the
-                // "Pass source=" fallback (review of this PR). It names a destination, not a source; trailing the
-                // one imperative in the message — an imperative that names source= AND lists "a loose file path"
-                // as a legal form — invited the caller to retry as source=`meshes\...`, which routes through
-                // ReadExplicitSource -> Path.GetFullPath against the process CWD -> "source file not found" for the
-                // very copy this hint just verified as provided. Adjacency to the ABSENT clause is also the shape
-                // the three sibling lanes already have (NifInspect / NifSet append MeshHint to a purely descriptive
-                // sentence; asset_status renders it on its own line), so all four read the same way.
+                // "Pass source=" fallback (review of this PR). It names a destination, not a source, and it must not
+                // trail an imperative about sources or it reads as one. The old wording ALSO had to steer callers
+                // away from retrying with a Data-relative source=, which then routed to Path.GetFullPath against the
+                // process CWD; that is no longer true — a Data-relative source= is now the VFS lane, and it is the
+                // first form the imperative offers. Adjacency to the ABSENT clause is the shape the three sibling
+                // lanes already have (NifInspect / NifSet append MeshHint to a purely descriptive sentence;
+                // asset_status renders it on its own line), so all four read the same way.
                 return PlaceResult.Fail(rel,
                     $"nothing in the active load order provides '{rel}', so there is no copy to auto-place."
                     + (hint is null ? "" : " " + hint)
-                    + " Pass source= the correct copy (a loose file path, or '<archive.bsa>|<entry>', or a '.bsa' path)."
+                    + " Pass source= the copy to place — a Data-relative path (resolved through the VFS, with"
+                    + " source_provider= to name which mod's copy), a full loose path, '<archive.bsa>|<entry>', or a '.bsa' path."
                     + (res.ReadIncomplete ? " NOTE: a BSA failed to read this build, so a source may merely be unscanned (see the warnings)." : ""),
                     winner);
             }
-            if (res.Ambiguous)
-                return PlaceResult.Fail(rel,
-                    $"{res.Sources.Count} sources provide '{rel}' — ambiguous, so place_asset will not guess which copy is correct (the skill decides). "
-                    + $"Pass source= one of: {string.Join("; ", res.Sources.Select(SourceHint))}.",
-                    winner);
-            var (b, desc, err) = ReadResolvedSource(res.Sources[0]);
+            var (b, desc, err) = ReadResolvedSource(pick.Source!);
             if (err is not null) return PlaceResult.Fail(rel, err, winner);
-            bytes = b!; sourceDesc = desc!;
+            bytes = b!;
+            // A source read from a DIFFERENT path than the destination is a rename, and the render has to say so —
+            // "placed from ModX" alone would hide that the bytes are another file's.
+            sourceDesc = sourceNamed ? $"{srcRel} — {desc}" : desc!;
         }
 
         // ---- crash-atomic place under the owned folder (originals untouched; same-volume staging done in core) ----
@@ -1618,10 +1648,12 @@ public sealed class LoadOrderService : IDisposable
         return new PlaceResult(rel, true, bytes.Length, sourceDesc, winner, null);
     }
 
-    /// <summary>Read an EXPLICIT source= the caller named. Forms: "&lt;archive.bsa&gt;|&lt;entry&gt;" (a specific BSA
-    /// entry, split on the FIRST '|'); a path ending ".bsa" (the entry is the destination rel-path — the FaceGen case,
-    /// where the entry inside the BSA IS the Data-relative path); any other path (a loose file on disk). Returns the bytes
-    /// + a human description, or a NAMED error (Q3) for a missing file / missing entry / unreadable archive.</summary>
+    /// <summary>Read an ON-DISK source= the caller named exactly. Forms: "&lt;archive.bsa&gt;|&lt;entry&gt;" (a specific
+    /// BSA entry, split on the FIRST '|'); a path ending ".bsa" (the entry is the destination rel-path — the FaceGen
+    /// case, where the entry inside the BSA IS the Data-relative path); a ROOTED path (a loose file on disk). A
+    /// Data-relative source never reaches here — <see cref="IsVfsSource"/> routes it to the VFS lane, which is the one
+    /// that can say which provider's copy. Returns the bytes + a human description, or a NAMED error (Q3) for a
+    /// missing file / missing entry / unreadable archive.</summary>
     static (byte[]? bytes, string? desc, string? error) ReadExplicitSource(string source, string destRel)
     {
         source = source.Trim();
@@ -1678,12 +1710,18 @@ public sealed class LoadOrderService : IDisposable
     /// <summary>A human label for the current winner (the sort target). "ModX (loose)" / "Y.bsa (BSA)".</summary>
     static string DescribeSource(PlacementSource s) => $"{s.ProviderName} ({(s.Kind == AssetKind.Bsa ? "BSA" : "loose")})";
 
-    /// <summary>A copy-pasteable source= hint for an ambiguous-provider refusal: a BSA provider needs its archive PATH (the
-    /// display name is just the filename), so name it as a BSA the caller must give the full path of; a loose provider's
-    /// on-disk path is exact.</summary>
-    static string SourceHint(PlacementSource s) => s.Kind == AssetKind.Bsa
-        ? $"the BSA '{s.ProviderName}' (give its full path, or '<path>|{s.EntryPath}')"
-        : $"'{s.LooseFilePath}'";
+    /// <summary>Does this source= name a copy through the VFS (a Data-relative path) rather than one exact file on
+    /// disk? The three on-disk forms are checked FIRST and in the same order <see cref="ReadExplicitSource"/> routes
+    /// them, quotes trimmed the same way — the two must agree on every input, or a source would be classified as one
+    /// shape here and read as the other there.</summary>
+    static bool IsVfsSource(string source)
+    {
+        var s = source.Trim();
+        if (s.IndexOf('|') >= 0) return false;                           // '<archive.bsa>|<entry>'
+        s = s.Trim('"');
+        if (s.EndsWith(".bsa", StringComparison.OrdinalIgnoreCase)) return false;
+        return !Path.IsPathRooted(s);                                    // rooted ⇒ a loose file on disk; else Data-relative
+    }
 
     /// <summary>Whole-order stats (forces the lazy build). For the server's stand-up / health check.</summary>
     public (int plugins, int records, int conflicts, int maxDepth, IReadOnlyList<string> loadFailures, string epoch) Stats()
@@ -8445,9 +8483,12 @@ public sealed record NifSetResult(
 
 /// <summary>One asset to PLACE (housecarl_place_asset / bulk). <see cref="AssetPath"/> is the resolved Data-relative
 /// DESTINATION (the tool computes it from a FormID+slot for FaceGen, or takes a raw path). <see cref="Source"/> is the
-/// correct copy to place — a loose file path, "&lt;archive.bsa&gt;|&lt;entry&gt;", or a ".bsa" path (entry := AssetPath);
-/// null/blank ⇒ auto-resolve (use the sole VFS provider; &gt;1 ambiguous and 0 absent are per-asset refusals, Q3).</summary>
-public sealed record PlaceRequest(string AssetPath, string? Source);
+/// copy to place — a Data-relative path resolved through the VFS, a full loose file path,
+/// "&lt;archive.bsa&gt;|&lt;entry&gt;", or a ".bsa" path (entry := AssetPath); null/blank ⇒ the VFS lane pointed at the
+/// destination path. <see cref="SourceProvider"/> picks the pole for a VFS source (a provider name, or "winner");
+/// null/blank ⇒ the sole provider, with contention refused per-asset (Q3). Source ≠ AssetPath is a RENAME — the
+/// mechanism behind carrying one NPC's baked facegen onto another's FormID path.</summary>
+public sealed record PlaceRequest(string AssetPath, string? Source, string? SourceProvider = null);
 
 /// <summary>One placed asset's outcome. <see cref="Placed"/> false ⇒ <see cref="Error"/> names why (recoverable, per-asset
 /// Q3). <see cref="CurrentWinner"/> is the source that currently wins the VFS for this path (the sort target — the placed

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1554,8 +1554,9 @@ public sealed class LoadOrderService : IDisposable
         var winner = res.Sources.Count > 0 ? DescribeSource(res.Sources[0]) : null;
 
         // ---- source bytes: an ON-DISK source= is read as named; anything else resolves through the VFS ----
-        // Three source shapes reach here: an on-disk file the caller named exactly (a rooted path, a '.bsa', a
-        // '<bsa>|<entry>'), a DATA-RELATIVE path resolved through the VFS under a pole, and no source at all — which
+        // Three source shapes reach here: an on-disk file the caller named exactly (a FULLY-QUALIFIED path, which a
+        // '.bsa' must also be to count as an archive, or a '<bsa>|<entry>' pair), a DATA-RELATIVE path resolved
+        // through the VFS under a pole, and no source at all — which
         // is the same VFS lane pointed at the destination path. The last two share one code path because they are
         // one question ("which provider supplies this Data-relative path") asked about different paths.
         byte[] bytes; string sourceDesc;
@@ -1626,8 +1627,10 @@ public sealed class LoadOrderService : IDisposable
             if (err is not null) return PlaceResult.Fail(rel, err, winner);
             bytes = b!;
             // A source read from a DIFFERENT path than the destination is a rename, and the render has to say so —
-            // "placed from ModX" alone would hide that the bytes are another file's.
-            sourceDesc = sourceNamed ? $"{srcRel} — {desc}" : desc!;
+            // "placed from ModX" alone would hide that the bytes are another file's. Keyed on whether the two PATHS
+            // differ, not on whether a source was NAMED: "place meshes\x.nif from ModB" is the natural spelling of a
+            // plain provider-scoped placement, and calling it a rename says a file moved when none did.
+            sourceDesc = sourceNamed && !SameAssetPath(srcRel, rel) ? $"{srcRel} — {desc}" : desc!;
         }
 
         // ---- crash-atomic place under the owned folder (originals untouched; same-volume staging done in core) ----
@@ -1712,6 +1715,13 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>A human label for the current winner (the sort target). "ModX (loose)" / "Y.bsa (BSA)".</summary>
     static string DescribeSource(PlacementSource s) => $"{s.ProviderName} ({(s.Kind == AssetKind.Bsa ? "BSA" : "loose")})";
+
+    /// <summary>Do two Data-relative paths name the SAME asset, by the key the VFS itself resolves on? Both inputs
+    /// have already been through <see cref="AssetResolver.ValidateRelPath"/>, which folds separators and any leading
+    /// separator; the remaining axis is CASE, and the asset layer's own lookups are ordinal-case-insensitive. So a
+    /// raw string compare would call <c>Meshes/X.NIF</c> and <c>meshes\x.nif</c> two different files and report a
+    /// rename between one file and itself.</summary>
+    static bool SameAssetPath(string a, string b) => string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>The ONE normalization of a caller's source= — trim, then strip surrounding quotes — applied before
     /// the routing decision and before every consumer, so no two of them can disagree about what the string is.
@@ -8504,11 +8514,13 @@ public sealed record NifSetResult(
 
 /// <summary>One asset to PLACE (housecarl_place_asset / bulk). <see cref="AssetPath"/> is the resolved Data-relative
 /// DESTINATION (the tool computes it from a FormID+slot for FaceGen, or takes a raw path). <see cref="Source"/> is the
-/// copy to place — a Data-relative path resolved through the VFS, a full loose file path,
-/// "&lt;archive.bsa&gt;|&lt;entry&gt;", or a ".bsa" path (entry := AssetPath); null/blank ⇒ the VFS lane pointed at the
-/// destination path. <see cref="SourceProvider"/> picks the pole for a VFS source (a provider name, or "winner");
-/// null/blank ⇒ the sole provider, with contention refused per-asset (Q3). Source ≠ AssetPath is a RENAME — the
-/// mechanism behind carrying one NPC's baked facegen onto another's FormID path.</summary>
+/// copy to place — a Data-relative path resolved through the VFS, a fully-qualified loose file path,
+/// "&lt;archive.bsa&gt;|&lt;entry&gt;", or a fully-qualified ".bsa" path (entry := AssetPath); null/blank ⇒ the VFS lane
+/// pointed at the destination path. <see cref="SourceProvider"/> picks the pole for a VFS source: a provider NAME on
+/// its own, or the sigiled winner token (<see cref="AssetSourceChoice.WinnerToken"/> — a bare name always means a
+/// provider of that name, so the two spaces cannot collide); null/blank ⇒ the sole provider, with contention refused
+/// per-asset (Q3). A Source naming a DIFFERENT path from AssetPath is a RENAME — the mechanism behind carrying one
+/// NPC's baked facegen onto another's FormID path; the same path is not, and renders without the rename prefix.</summary>
 public sealed record PlaceRequest(string AssetPath, string? Source, string? SourceProvider = null);
 
 /// <summary>One placed asset's outcome. <see cref="Placed"/> false ⇒ <see cref="Error"/> names why (recoverable, per-asset

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1587,12 +1587,10 @@ public sealed class LoadOrderService : IDisposable
             var srcRes = sourceNamed ? view.ResolveForPlacement(srcRel) : res;
             var pick = AssetSourceSelection.Select(srcRes, AssetSourceChoice.Parse(providerSel));
 
-            if (pick.Verdict == AssetSourceVerdict.WinnerTokenCollision)
-                return PlaceResult.Fail(rel, WriteSentences.PlaceSourceWinnerCollision, winner);
             if (pick.Verdict == AssetSourceVerdict.NamedAbsent)
                 return PlaceResult.Fail(rel, WriteSentences.PlaceSourceNamedAbsent(providerSel!, srcRel, pick.ProviderNames), winner);
             if (pick.Verdict == AssetSourceVerdict.Ambiguous)
-                return PlaceResult.Fail(rel, WriteSentences.PlaceSourceAmbiguous(srcRel, pick.ProviderNames, !pick.TokenNameTaken), winner);
+                return PlaceResult.Fail(rel, WriteSentences.PlaceSourceAmbiguous(srcRel, pick.ProviderNames), winner);
             if (pick.Verdict == AssetSourceVerdict.NoProvider && sourceNamed)
                 return PlaceResult.Fail(rel,
                     $"nothing in the active load order provides the source '{srcRel}'."
@@ -1733,12 +1731,17 @@ public sealed class LoadOrderService : IDisposable
     /// '/', but <c>AssetResolver.Normalize</c> trims exactly those, so <c>\meshes\…</c> is a legal Data-relative
     /// path as a DESTINATION. Reading it as on-disk made one spelling mean two different things in a single call —
     /// and sent it to Path.GetFullPath against the process CWD, the round-trip this lane exists to end. A path is
-    /// on-disk when it names a volume (<c>C:\…</c>) or a UNC share, and not before.</para></summary>
+    /// on-disk when it names a volume (<c>C:\…</c>) or a UNC share, and not before.</para>
+    /// <para>ORDER: the qualified test runs BEFORE the extension test, because an extension is a property of a
+    /// filename and says nothing about where the file is. A mod can legitimately ship <c>meshes\thing.bsa</c> as a
+    /// Data-relative asset, and testing '.bsa' first sent exactly that to the process CWD — the same round-trip one
+    /// clause up, reintroduced by the clause order beneath it. A '.bsa' only means "an archive to open" once we know
+    /// the caller named a file on disk.</para></summary>
     static bool IsVfsSource(string source)
     {
-        if (source.IndexOf('|') >= 0) return false;                      // '<archive.bsa>|<entry>'
-        if (source.EndsWith(".bsa", StringComparison.OrdinalIgnoreCase)) return false;
-        return !Path.IsPathFullyQualified(source);
+        if (source.IndexOf('|') >= 0) return false;                      // '<archive.bsa>|<entry>' — an entry, not a path
+        if (!Path.IsPathFullyQualified(source)) return true;             // Data-relative ⇒ the VFS answers, whatever it ends in
+        return false;                                                    // a volume or UNC path ⇒ one exact file (or archive) on disk
     }
 
     /// <summary>Whole-order stats (forces the lazy build). For the server's stand-up / health check.</summary>

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1559,7 +1559,11 @@ public sealed class LoadOrderService : IDisposable
         // is the same VFS lane pointed at the destination path. The last two share one code path because they are
         // one question ("which provider supplies this Data-relative path") asked about different paths.
         byte[] bytes; string sourceDesc;
-        var explicitSrc = req.Source?.Trim();
+        // ONE normalization point for source=, ahead of BOTH the classification and every consumer. IsVfsSource used
+        // to trim quotes to decide and the VFS lane then resolved the un-trimmed string, so a quoted Data-relative
+        // source classified one way and was read another — refused as "nothing provides '"meshes\…"'" for a path two
+        // mods supplied. Whatever trimming the routing decision depends on has to have happened before this line.
+        var explicitSrc = NormalizeSourceArg(req.Source);
         var providerSel = req.SourceProvider?.Trim();
         if (!string.IsNullOrEmpty(explicitSrc) && !IsVfsSource(explicitSrc!))
         {
@@ -1588,7 +1592,7 @@ public sealed class LoadOrderService : IDisposable
             if (pick.Verdict == AssetSourceVerdict.NamedAbsent)
                 return PlaceResult.Fail(rel, WriteSentences.PlaceSourceNamedAbsent(providerSel!, srcRel, pick.ProviderNames), winner);
             if (pick.Verdict == AssetSourceVerdict.Ambiguous)
-                return PlaceResult.Fail(rel, WriteSentences.PlaceSourceAmbiguous(srcRel, pick.ProviderNames), winner);
+                return PlaceResult.Fail(rel, WriteSentences.PlaceSourceAmbiguous(srcRel, pick.ProviderNames, !pick.TokenNameTaken), winner);
             if (pick.Verdict == AssetSourceVerdict.NoProvider && sourceNamed)
                 return PlaceResult.Fail(rel,
                     $"nothing in the active load order provides the source '{srcRel}'."
@@ -1650,20 +1654,21 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>Read an ON-DISK source= the caller named exactly. Forms: "&lt;archive.bsa&gt;|&lt;entry&gt;" (a specific
     /// BSA entry, split on the FIRST '|'); a path ending ".bsa" (the entry is the destination rel-path — the FaceGen
-    /// case, where the entry inside the BSA IS the Data-relative path); a ROOTED path (a loose file on disk). A
-    /// Data-relative source never reaches here — <see cref="IsVfsSource"/> routes it to the VFS lane, which is the one
+    /// case, where the entry inside the BSA IS the Data-relative path); a FULLY-QUALIFIED path (a loose file on disk).
+    /// A Data-relative source never reaches here — <see cref="IsVfsSource"/> routes it to the VFS lane, which is the one
     /// that can say which provider's copy. Returns the bytes + a human description, or a NAMED error (Q3) for a
     /// missing file / missing entry / unreadable archive.</summary>
     static (byte[]? bytes, string? desc, string? error) ReadExplicitSource(string source, string destRel)
     {
-        source = source.Trim();
+        // The whole-string trim + unquote happened in NormalizeSourceArg, ahead of the routing decision. The per-PART
+        // trims below are a different job and stay: each side of a '<archive>|<entry>' pair can carry its own quotes
+        // ("C:\X - Textures.bsa"|"meshes\y.nif"), which no whole-string normalization can reach. Re-trimming the whole
+        // string here would be harmless but would put a second spelling of "what the source is" in the file, and one
+        // spelling is the point (a quoted ".bsa" that kept its quotes would route as a loose file and place the WHOLE
+        // archive as the asset — a silent-wrong placement that passes the size check).
         int bar = source.IndexOf('|');
         if (bar >= 0)
             return ReadBsaEntry(source[..bar].Trim().Trim('"'), source[(bar + 1)..].Trim().Trim('"'));
-        // Strip surrounding quotes BEFORE the .bsa-vs-loose routing decision (NOT inside each branch): a quoted ".bsa"
-        // path ends in '"' not ".bsa", so routing on the raw string would read the WHOLE archive as a loose file and
-        // place it as the asset — a silent-wrong placement that passes the size check (Q3). The ONE trim point.
-        source = source.Trim('"');
         if (source.EndsWith(".bsa", StringComparison.OrdinalIgnoreCase))
             return ReadBsaEntry(source, destRel);                        // .bsa with no explicit entry → entry := the destination path
         string path;
@@ -1710,17 +1715,30 @@ public sealed class LoadOrderService : IDisposable
     /// <summary>A human label for the current winner (the sort target). "ModX (loose)" / "Y.bsa (BSA)".</summary>
     static string DescribeSource(PlacementSource s) => $"{s.ProviderName} ({(s.Kind == AssetKind.Bsa ? "BSA" : "loose")})";
 
+    /// <summary>The ONE normalization of a caller's source= — trim, then strip surrounding quotes — applied before
+    /// the routing decision and before every consumer, so no two of them can disagree about what the string is.
+    /// Blank becomes null (the "no source" lane) rather than an empty path nobody can resolve.</summary>
+    static string? NormalizeSourceArg(string? source)
+    {
+        var s = source?.Trim();
+        if (string.IsNullOrEmpty(s)) return null;
+        s = s.Trim('"').Trim();
+        return string.IsNullOrEmpty(s) ? null : s;
+    }
+
     /// <summary>Does this source= name a copy through the VFS (a Data-relative path) rather than one exact file on
-    /// disk? The three on-disk forms are checked FIRST and in the same order <see cref="ReadExplicitSource"/> routes
-    /// them, quotes trimmed the same way — the two must agree on every input, or a source would be classified as one
-    /// shape here and read as the other there.</summary>
+    /// disk? Expects an already-<see cref="NormalizeSourceArg"/>d string. The on-disk forms are tested in the same
+    /// order <see cref="ReadExplicitSource"/> routes them.
+    /// <para>FULLY-QUALIFIED, not merely rooted: on Windows <c>Path.IsPathRooted</c> is true for a leading '\' or
+    /// '/', but <c>AssetResolver.Normalize</c> trims exactly those, so <c>\meshes\…</c> is a legal Data-relative
+    /// path as a DESTINATION. Reading it as on-disk made one spelling mean two different things in a single call —
+    /// and sent it to Path.GetFullPath against the process CWD, the round-trip this lane exists to end. A path is
+    /// on-disk when it names a volume (<c>C:\…</c>) or a UNC share, and not before.</para></summary>
     static bool IsVfsSource(string source)
     {
-        var s = source.Trim();
-        if (s.IndexOf('|') >= 0) return false;                           // '<archive.bsa>|<entry>'
-        s = s.Trim('"');
-        if (s.EndsWith(".bsa", StringComparison.OrdinalIgnoreCase)) return false;
-        return !Path.IsPathRooted(s);                                    // rooted ⇒ a loose file on disk; else Data-relative
+        if (source.IndexOf('|') >= 0) return false;                      // '<archive.bsa>|<entry>'
+        if (source.EndsWith(".bsa", StringComparison.OrdinalIgnoreCase)) return false;
+        return !Path.IsPathFullyQualified(source);
     }
 
     /// <summary>Whole-order stats (forces the lazy build). For the server's stand-up / health check.</summary>

--- a/src/housecarl-mcp/PlaceAssetTools.cs
+++ b/src/housecarl-mcp/PlaceAssetTools.cs
@@ -49,7 +49,7 @@ public static class PlaceAssetTools
             string? asset_path = null,
         [Description("Optional. The copy to place: a DATA-RELATIVE path (resolved through the VFS — use source_provider= to say whose copy, and note that a source path DIFFERENT from the destination is a rename); or a full loose file path; or '<archive.bsa path>|<entry inside>'; or just a '.bsa' path (the entry is taken to be the destination path). If omitted, the destination path is resolved through the VFS instead.")]
             string? source = null,
-        [Description("Optional (with a Data-relative source=, or with no source=). Whose copy to read: the provider's NAME ALONE — a mod folder name, 'overwrite', 'Data', or a BSA filename like 'X - Textures.bsa' — or 'winner' for whichever copy currently wins the VFS. housecarl_asset_status shows the same names with a kind annotation after them ('SomeMod (loose)'); pass only the name, not the annotation. Omitted = the sole provider, refused if more than one contends. A named provider that doesn't supply the path is refused, never silently replaced by another.")]
+        [Description("Optional (with a Data-relative source=, or with no source=). Whose copy to read. Two forms: '*winner' (the sigil is part of the token) for whichever copy currently wins the VFS; or the provider's NAME ALONE — a mod folder name, 'overwrite', 'Data', or a BSA filename like 'X - Textures.bsa' — matched exactly. A bare name ALWAYS means a provider of that name, so a mod called 'winner' is reachable and nothing is reserved out of the name space. housecarl_asset_status shows the same names with a kind annotation after them ('SomeMod (loose)'); pass only the name. Omitted = the sole provider, refused if more than one contends. A named provider that doesn't supply the path is refused, never silently replaced by another.")]
             string? source_provider = null,
         [Description("Optional. Base name for the NEW houseCARL mod folder the file lands in (default 'houseCARL_Assets'); auto-suffixed if taken.")]
             string? patch_name = null,
@@ -140,14 +140,19 @@ public static class PlaceAssetTools
             error = $"{where}kind is required with formid (mesh or tint — housecarl_place_asset places ONE file). To place both at once, use housecarl_bulk_place_asset.";
             return null;
         }
-        // Trim quotes for the both-expansion test the same way ReadExplicitSource trims before it routes — else a quoted
+        // Trim quotes for the both-expansion test the same way the service normalizes before it routes — else a quoted
         // spaced BSA name (the natural form, "C:\...\X - Textures.bsa") ends in '"' not '.bsa' and would be wrongly
-        // refused here on the marquee mesh+tint path. (The actual read also trims-before-routing, so the two agree.)
+        // refused here on the marquee mesh+tint path. (The service unquotes before routing too, so the two agree.)
+        // FULLY-QUALIFIED, matching that routing: a RELATIVE '.bsa' is a Data-relative asset path resolved through the
+        // VFS, and one such path cannot serve two slots — accepting it here would hand both slots the same file.
         var srcProbe = src?.Trim('"');
-        bool srcOkForBoth = srcProbe is null || (srcProbe.EndsWith(".bsa", StringComparison.OrdinalIgnoreCase) && srcProbe.IndexOf('|') < 0);
+        bool srcOkForBoth = srcProbe is null
+            || (srcProbe.EndsWith(".bsa", StringComparison.OrdinalIgnoreCase)
+                && srcProbe.IndexOf('|') < 0
+                && Path.IsPathFullyQualified(srcProbe));
         if (!srcOkForBoth)
         {
-            error = $"{where}with formid and no kind (placing BOTH mesh and tint), an explicit source= must be a bare '.bsa' path — each slot's entry is then derived. Any single path names ONE file and cannot serve both slots, so for a loose file, a BSA entry, or a Data-relative path set kind= mesh or tint (source_provider= is fine here — it names whose copy, not which file).";
+            error = $"{where}with formid and no kind (placing BOTH mesh and tint), an explicit source= must be a FULL '.bsa' path — each slot's entry is then derived. Any single file path names ONE file and cannot serve both slots, so for a loose file, a BSA entry, or a Data-relative path set kind= mesh or tint. {WriteSentences.PlaceBothSlotsPoleConstraint}.";
             return null;
         }
         var reqs = new List<PlaceRequest>(2);
@@ -247,6 +252,6 @@ public sealed record PlaceAssetSpec
     [JsonPropertyName("source"), Description("The copy to place: a Data-relative path (resolved through the VFS; different from the destination = a rename), a full loose file path, '<archive.bsa>|<entry>', or a '.bsa' path. Omit to resolve the destination path through the VFS. With formid and no kind, an explicit source must be a bare '.bsa' path.")]
     public string? Source { get; init; }
 
-    [JsonPropertyName("source_provider"), Description("Whose copy to read for a VFS-resolved source: the provider's NAME ALONE (a mod folder, 'overwrite', 'Data', or a BSA filename) — not asset_status's ' (loose)' / ' (BSA)' annotation — or 'winner' for the current VFS winner. Omit for the sole provider (contention is refused). Not valid with an on-disk source.")]
+    [JsonPropertyName("source_provider"), Description("Whose copy to read for a VFS-resolved source: '*winner' for the current VFS winner, or the provider's NAME ALONE (a mod folder, 'overwrite', 'Data', or a BSA filename) — not asset_status's ' (loose)' / ' (BSA)' annotation. A bare name always means a provider of that name. Omit for the sole provider (contention is refused). Not valid with an on-disk source.")]
     public string? SourceProvider { get; init; }
 }

--- a/src/housecarl-mcp/PlaceAssetTools.cs
+++ b/src/housecarl-mcp/PlaceAssetTools.cs
@@ -29,7 +29,8 @@ public static class PlaceAssetTools
          "Data-relative path); OR, for an NPC's generated FaceGen file, as formid (the NPC's FormID 'XXXXXX:Plugin.esp') " +
          "+ kind ('mesh' = the head .nif, 'tint' = the face .dds), which houseCARL computes the path for. Give the SOURCE " +
          "(the copy to place) as source= a DATA-RELATIVE path resolved through the VFS — with source_provider= naming " +
-         "whose copy (a mod folder / BSA filename as housecarl_asset_status renders it, or 'winner') — or as a full loose " +
+         "whose copy (a mod folder or BSA filename on its own, or " + AssetSourceChoice.WinnerToken + " for the current " +
+         "VFS winner) — or as a full loose " +
          "file path, or '<archive.bsa path>|<entry inside>', or just a '.bsa' path (the entry is taken to be the " +
          "destination — a quick way to pull ONE file out of a BSA as a loose override). A source path DIFFERENT from the " +
          "destination is a RENAME: the bytes of one file land under another file's name, which is how a baked FaceGen " +
@@ -49,7 +50,14 @@ public static class PlaceAssetTools
             string? asset_path = null,
         [Description("Optional. The copy to place: a DATA-RELATIVE path (resolved through the VFS — use source_provider= to say whose copy, and note that a source path DIFFERENT from the destination is a rename); or a full loose file path; or '<archive.bsa path>|<entry inside>'; or just a '.bsa' path (the entry is taken to be the destination path). If omitted, the destination path is resolved through the VFS instead.")]
             string? source = null,
-        [Description("Optional (with a Data-relative source=, or with no source=). Whose copy to read. Two forms: '*winner' (the sigil is part of the token) for whichever copy currently wins the VFS; or the provider's NAME ALONE — a mod folder name, 'overwrite', 'Data', or a BSA filename like 'X - Textures.bsa' — matched exactly. A bare name ALWAYS means a provider of that name, so a mod called 'winner' is reachable and nothing is reserved out of the name space. housecarl_asset_status shows the same names with a kind annotation after them ('SomeMod (loose)'); pass only the name. Omitted = the sole provider, refused if more than one contends. A named provider that doesn't supply the path is refused, never silently replaced by another.")]
+        [Description("Optional (with a Data-relative source=, or with no source=). Whose copy to read. Two forms: "
+                     + AssetSourceChoice.WinnerToken + " (the sigil is part of the token) for whichever copy currently wins the VFS; "
+                     + "or the provider's NAME ALONE — a mod folder name, 'overwrite', 'Data', or a BSA filename like "
+                     + "'X - Textures.bsa' — matched exactly. A bare name ALWAYS means a provider of that name, so a mod whose "
+                     + "folder happens to carry the pole's word is still reachable and nothing is reserved out of the name space. "
+                     + "housecarl_asset_status shows these names with a kind annotation after them ('SomeMod (loose)'); pass the "
+                     + "name only, without the annotation. Omitted = the sole provider, refused if more than one contends. A named "
+                     + "provider that doesn't supply the path is refused, never silently replaced by another.")]
             string? source_provider = null,
         [Description("Optional. Base name for the NEW houseCARL mod folder the file lands in (default 'houseCARL_Assets'); auto-suffixed if taken.")]
             string? patch_name = null,
@@ -72,8 +80,9 @@ public static class PlaceAssetTools
          "loose file path, '<archive.bsa>|<entry>', or a '.bsa' path); omit it to resolve the destination path instead " +
          "(an ambiguous or absent source becomes a per-asset error — the rest still place). A per-asset source that " +
          "differs from its destination is a RENAME. When you give " +
-         "a FormID with no kind (placing both files), an explicit source must be a '.bsa' path (each slot's entry is " +
-         "derived) — for a single loose/entry source set kind=. All files land in ONE reviewable mod folder. A malformed " +
+         "a FormID with no kind (placing both files), an explicit source must be a FULLY-QUALIFIED '.bsa' path (each slot's " +
+         "entry is derived; a RELATIVE '.bsa' is a Data-relative asset path, and one path cannot serve two slots) — for a " +
+         "single loose/entry/Data-relative source set kind=. All files land in ONE reviewable mod folder. A malformed " +
          "spec (bad FormID, bad kind, neither/both of formid+asset_path) refuses the WHOLE call with per-spec reasons and " +
          "places nothing. As with the single tool, the placed copies do NOT win until you enable + sort the mod in MO2 " +
          "(reported back).")]
@@ -109,7 +118,7 @@ public static class PlaceAssetTools
     /// <summary>Map one wire spec to its placement request(s): asset_path → one request; formid+kind → one request (the
     /// computed FaceGen path); formid with NO kind → BOTH mesh+tint (only when <paramref name="allowExpand"/> — the bulk
     /// tool). Exactly one of formid/asset_path is required. A both-expansion forbids a single loose/entry source (it can't
-    /// serve two different files) — only a bare '.bsa' source (entry derived per slot) or auto-resolve. Q3: every bad
+    /// serve two different files) — only a FULLY-QUALIFIED '.bsa' source (entry derived per slot) or auto-resolve. Q3: every bad
     /// input is a NAMED error (returned via <paramref name="error"/>), never a silent skip.</summary>
     static List<PlaceRequest>? MapSpec(string? formid, string? kind, string? assetPath, string? source, string? sourceProvider, bool allowExpand, string where, out string? error)
     {
@@ -249,9 +258,12 @@ public sealed record PlaceAssetSpec
     [JsonPropertyName("asset_path"), Description("A Data-relative destination path (e.g. 'meshes/actors/...'), instead of formid. Provide this OR formid.")]
     public string? AssetPath { get; init; }
 
-    [JsonPropertyName("source"), Description("The copy to place: a Data-relative path (resolved through the VFS; different from the destination = a rename), a full loose file path, '<archive.bsa>|<entry>', or a '.bsa' path. Omit to resolve the destination path through the VFS. With formid and no kind, an explicit source must be a bare '.bsa' path.")]
+    [JsonPropertyName("source"), Description("The copy to place: a Data-relative path (resolved through the VFS; different from the destination = a rename), a full loose file path, '<archive.bsa>|<entry>', or a '.bsa' path. Omit to resolve the destination path through the VFS. With formid and no kind, an explicit source must be a FULLY-QUALIFIED '.bsa' path (a relative one is a Data-relative asset path, and one path cannot serve both slots).")]
     public string? Source { get; init; }
 
-    [JsonPropertyName("source_provider"), Description("Whose copy to read for a VFS-resolved source: '*winner' for the current VFS winner, or the provider's NAME ALONE (a mod folder, 'overwrite', 'Data', or a BSA filename) — not asset_status's ' (loose)' / ' (BSA)' annotation. A bare name always means a provider of that name. Omit for the sole provider (contention is refused). Not valid with an on-disk source.")]
+    [JsonPropertyName("source_provider"), Description("Whose copy to read for a VFS-resolved source: "
+        + AssetSourceChoice.WinnerToken + " for the current VFS winner, or the provider's NAME ALONE (a mod folder, 'overwrite', "
+        + "'Data', or a BSA filename) — not asset_status's ' (loose)' / ' (BSA)' annotation. A bare name always means a provider "
+        + "of that name. Omit for the sole provider (contention is refused). Not valid with an on-disk source.")]
     public string? SourceProvider { get; init; }
 }

--- a/src/housecarl-mcp/PlaceAssetTools.cs
+++ b/src/housecarl-mcp/PlaceAssetTools.cs
@@ -28,10 +28,14 @@ public static class PlaceAssetTools
          "housecarl_asset_status (which reports which copy currently wins). Give the DESTINATION as asset_path (a " +
          "Data-relative path); OR, for an NPC's generated FaceGen file, as formid (the NPC's FormID 'XXXXXX:Plugin.esp') " +
          "+ kind ('mesh' = the head .nif, 'tint' = the face .dds), which houseCARL computes the path for. Give the SOURCE " +
-         "(the copy to place) as source= a loose file path, or '<archive.bsa path>|<entry inside>', or just a '.bsa' path " +
-         "(the entry is taken to be the destination — a quick way to pull ONE file out of a BSA as a loose override). If " +
-         "source is OMITTED, houseCARL auto-resolves: it uses the SOLE provider in your load order, and REFUSES (telling " +
-         "you the candidates) if more than one provides it — it will not guess which is correct. The write is crash-atomic; " +
+         "(the copy to place) as source= a DATA-RELATIVE path resolved through the VFS — with source_provider= naming " +
+         "whose copy (a mod folder / BSA filename as housecarl_asset_status renders it, or 'winner') — or as a full loose " +
+         "file path, or '<archive.bsa path>|<entry inside>', or just a '.bsa' path (the entry is taken to be the " +
+         "destination — a quick way to pull ONE file out of a BSA as a loose override). A source path DIFFERENT from the " +
+         "destination is a RENAME: the bytes of one file land under another file's name, which is how a baked FaceGen " +
+         "head is carried onto a different NPC's FormID path. If source is OMITTED, houseCARL resolves the DESTINATION " +
+         "path instead: the sole provider, or the one source_provider= names, REFUSING (and listing the providers) when " +
+         "several contend and none was named — it will not guess which is correct. The write is crash-atomic; " +
          "originals are never touched. IMPORTANT (and reported back): the placed copy does NOT win on write — you must " +
          "ENABLE the new mod in MO2 and SORT it above the current winner. This tool places ONE file; to place several (or " +
          "an NPC's mesh AND tint together) use housecarl_bulk_place_asset.")]
@@ -43,15 +47,17 @@ public static class PlaceAssetTools
             string? kind = null,
         [Description("Optional. The Data-relative destination path to place to (any file — e.g. 'textures/armor/iron/cuirass_1.dds', 'meshes/...', a script, a sound), instead of formid+kind. Provide this OR formid. A drive-rooted or '..'-escaping path is rejected.")]
             string? asset_path = null,
-        [Description("Optional. The correct copy to place: a loose file path; or '<archive.bsa path>|<entry inside>'; or just a '.bsa' path (the entry is taken to be the destination path). If omitted, houseCARL uses the SOLE provider in your load order and refuses if more than one provides it (you choose).")]
+        [Description("Optional. The copy to place: a DATA-RELATIVE path (resolved through the VFS — use source_provider= to say whose copy, and note that a source path DIFFERENT from the destination is a rename); or a full loose file path; or '<archive.bsa path>|<entry inside>'; or just a '.bsa' path (the entry is taken to be the destination path). If omitted, the destination path is resolved through the VFS instead.")]
             string? source = null,
+        [Description("Optional (with a Data-relative source=, or with no source=). Whose copy to read: a mod folder / overwrite / 'Data' / a BSA filename, spelled as housecarl_asset_status renders it — or 'winner' for whichever copy currently wins the VFS. Omitted = the sole provider, refused if more than one contends. A named provider that doesn't supply the path is refused, never silently replaced by another.")]
+            string? source_provider = null,
         [Description("Optional. Base name for the NEW houseCARL mod folder the file lands in (default 'houseCARL_Assets'); auto-suffixed if taken.")]
             string? patch_name = null,
         [Description("Optional. Filename of an existing houseCARL patch mod to place into instead of a fresh folder (accumulate across calls). Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
             string? into = null) => Guard.Tool("housecarl_place_asset", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        var reqs = MapSpec(formid, kind, asset_path, source, allowExpand: false, where: "", out var err);
+        var reqs = MapSpec(formid, kind, asset_path, source, source_provider, allowExpand: false, where: "", out var err);
         if (err is not null) return "error: " + err;
         return PlaceWire.Render(svc.PlaceAssets(reqs!, patch_name, into));
     });
@@ -62,8 +68,10 @@ public static class PlaceAssetTools
          "several overrides at once; or, for an NPC, its FaceGen mesh AND tint together). assets is an array of " +
          "{ formid?, kind?, asset_path?, source? }: give EITHER asset_path (any Data-relative path) OR formid (an NPC " +
          "FormID — omit kind to place BOTH the FaceGen mesh and the tint; or set kind='mesh'/'tint' for just one). source " +
-         "is the copy to place (a loose file path, '<archive.bsa>|<entry>', or a '.bsa' path); omit it to auto-resolve the " +
-         "sole VFS provider (an ambiguous or absent source becomes a per-asset error — the rest still place). When you give " +
+         "is the copy to place (a Data-relative path resolved through the VFS — source_provider names whose copy — a full " +
+         "loose file path, '<archive.bsa>|<entry>', or a '.bsa' path); omit it to resolve the destination path instead " +
+         "(an ambiguous or absent source becomes a per-asset error — the rest still place). A per-asset source that " +
+         "differs from its destination is a RENAME. When you give " +
          "a FormID with no kind (placing both files), an explicit source must be a '.bsa' path (each slot's entry is " +
          "derived) — for a single loose/entry source set kind=. All files land in ONE reviewable mod folder. A malformed " +
          "spec (bad FormID, bad kind, neither/both of formid+asset_path) refuses the WHOLE call with per-spec reasons and " +
@@ -89,7 +97,7 @@ public static class PlaceAssetTools
         for (int i = 0; i < assets.Length; i++)
         {
             var a = assets[i];
-            var reqs = MapSpec(a.Formid, a.Kind, a.AssetPath, a.Source, allowExpand: true, where: $"assets[{i}]: ", out var err);
+            var reqs = MapSpec(a.Formid, a.Kind, a.AssetPath, a.Source, a.SourceProvider, allowExpand: true, where: $"assets[{i}]: ", out var err);
             if (err is not null) problems.Add(err); else all.AddRange(reqs!);
         }
         if (problems.Count > 0)
@@ -103,7 +111,7 @@ public static class PlaceAssetTools
     /// tool). Exactly one of formid/asset_path is required. A both-expansion forbids a single loose/entry source (it can't
     /// serve two different files) — only a bare '.bsa' source (entry derived per slot) or auto-resolve. Q3: every bad
     /// input is a NAMED error (returned via <paramref name="error"/>), never a silent skip.</summary>
-    static List<PlaceRequest>? MapSpec(string? formid, string? kind, string? assetPath, string? source, bool allowExpand, string where, out string? error)
+    static List<PlaceRequest>? MapSpec(string? formid, string? kind, string? assetPath, string? source, string? sourceProvider, bool allowExpand, string where, out string? error)
     {
         error = null;
         bool hasFormid = !string.IsNullOrWhiteSpace(formid);
@@ -111,9 +119,10 @@ public static class PlaceAssetTools
         if (hasFormid == hasPath) { error = $"{where}provide exactly one of formid or asset_path."; return null; }
 
         var src = NullIfBlank(source);
+        var prov = NullIfBlank(sourceProvider);
 
         if (hasPath)
-            return new List<PlaceRequest> { new(assetPath!.Trim(), src) };
+            return new List<PlaceRequest> { new(assetPath!.Trim(), src, prov) };
 
         FormKey fk;
         try { fk = FormKey.Factory(formid!.Trim()); }
@@ -123,7 +132,7 @@ public static class PlaceAssetTools
         if (slotErr is not null) { error = $"{where}{slotErr}"; return null; }
 
         if (slot is { } s)                                            // explicit mesh|tint → one file
-            return new List<PlaceRequest> { new(FaceGenPath.For(fk, s), src) };
+            return new List<PlaceRequest> { new(FaceGenPath.For(fk, s), src, prov) };
 
         // kind omitted → both mesh + tint (bulk only)
         if (!allowExpand)
@@ -138,11 +147,11 @@ public static class PlaceAssetTools
         bool srcOkForBoth = srcProbe is null || (srcProbe.EndsWith(".bsa", StringComparison.OrdinalIgnoreCase) && srcProbe.IndexOf('|') < 0);
         if (!srcOkForBoth)
         {
-            error = $"{where}with formid and no kind (placing BOTH mesh and tint), an explicit source= must be a bare '.bsa' path — each slot's entry is then derived. For a single loose file or BSA entry, set kind= mesh or tint.";
+            error = $"{where}with formid and no kind (placing BOTH mesh and tint), an explicit source= must be a bare '.bsa' path — each slot's entry is then derived. Any single path names ONE file and cannot serve both slots, so for a loose file, a BSA entry, or a Data-relative path set kind= mesh or tint (source_provider= is fine here — it names whose copy, not which file).";
             return null;
         }
         var reqs = new List<PlaceRequest>(2);
-        foreach (var (_, rel) in FaceGenPath.Both(fk)) reqs.Add(new PlaceRequest(rel, src));
+        foreach (var (_, rel) in FaceGenPath.Both(fk)) reqs.Add(new PlaceRequest(rel, src, prov));
         return reqs;
     }
 
@@ -234,6 +243,9 @@ public sealed record PlaceAssetSpec
     [JsonPropertyName("asset_path"), Description("A Data-relative destination path (e.g. 'meshes/actors/...'), instead of formid. Provide this OR formid.")]
     public string? AssetPath { get; init; }
 
-    [JsonPropertyName("source"), Description("The correct copy to place: a loose file path, '<archive.bsa>|<entry>', or a '.bsa' path. Omit to auto-resolve the sole VFS provider. With formid and no kind, an explicit source must be a bare '.bsa' path.")]
+    [JsonPropertyName("source"), Description("The copy to place: a Data-relative path (resolved through the VFS; different from the destination = a rename), a full loose file path, '<archive.bsa>|<entry>', or a '.bsa' path. Omit to resolve the destination path through the VFS. With formid and no kind, an explicit source must be a bare '.bsa' path.")]
     public string? Source { get; init; }
+
+    [JsonPropertyName("source_provider"), Description("Whose copy to read for a VFS-resolved source: a mod folder / overwrite / 'Data' / a BSA filename as asset_status renders it, or 'winner' for the current VFS winner. Omit for the sole provider (contention is refused). Not valid with an on-disk source.")]
+    public string? SourceProvider { get; init; }
 }

--- a/src/housecarl-mcp/PlaceAssetTools.cs
+++ b/src/housecarl-mcp/PlaceAssetTools.cs
@@ -49,7 +49,7 @@ public static class PlaceAssetTools
             string? asset_path = null,
         [Description("Optional. The copy to place: a DATA-RELATIVE path (resolved through the VFS — use source_provider= to say whose copy, and note that a source path DIFFERENT from the destination is a rename); or a full loose file path; or '<archive.bsa path>|<entry inside>'; or just a '.bsa' path (the entry is taken to be the destination path). If omitted, the destination path is resolved through the VFS instead.")]
             string? source = null,
-        [Description("Optional (with a Data-relative source=, or with no source=). Whose copy to read: a mod folder / overwrite / 'Data' / a BSA filename, spelled as housecarl_asset_status renders it — or 'winner' for whichever copy currently wins the VFS. Omitted = the sole provider, refused if more than one contends. A named provider that doesn't supply the path is refused, never silently replaced by another.")]
+        [Description("Optional (with a Data-relative source=, or with no source=). Whose copy to read: the provider's NAME ALONE — a mod folder name, 'overwrite', 'Data', or a BSA filename like 'X - Textures.bsa' — or 'winner' for whichever copy currently wins the VFS. housecarl_asset_status shows the same names with a kind annotation after them ('SomeMod (loose)'); pass only the name, not the annotation. Omitted = the sole provider, refused if more than one contends. A named provider that doesn't supply the path is refused, never silently replaced by another.")]
             string? source_provider = null,
         [Description("Optional. Base name for the NEW houseCARL mod folder the file lands in (default 'houseCARL_Assets'); auto-suffixed if taken.")]
             string? patch_name = null,
@@ -66,7 +66,7 @@ public static class PlaceAssetTools
      Description(
          "Place MANY asset files in ONE houseCARL-owned MO2 mod folder — the batch form of housecarl_place_asset (place " +
          "several overrides at once; or, for an NPC, its FaceGen mesh AND tint together). assets is an array of " +
-         "{ formid?, kind?, asset_path?, source? }: give EITHER asset_path (any Data-relative path) OR formid (an NPC " +
+         "{ formid?, kind?, asset_path?, source?, source_provider? }: give EITHER asset_path (any Data-relative path) OR formid (an NPC " +
          "FormID — omit kind to place BOTH the FaceGen mesh and the tint; or set kind='mesh'/'tint' for just one). source " +
          "is the copy to place (a Data-relative path resolved through the VFS — source_provider names whose copy — a full " +
          "loose file path, '<archive.bsa>|<entry>', or a '.bsa' path); omit it to resolve the destination path instead " +
@@ -231,7 +231,8 @@ static class PlaceWire
 }
 
 /// <summary>One asset to place off the wire (housecarl_bulk_place_asset). Mirrors the scalar args of
-/// housecarl_place_asset: a FormID (+ optional slot) or a raw destination path, and the optional source.</summary>
+/// housecarl_place_asset: a FormID (+ optional slot) or a raw destination path, the optional source, and the
+/// optional source-provider pole that says whose copy of a VFS-resolved source to read.</summary>
 public sealed record PlaceAssetSpec
 {
     [JsonPropertyName("formid"), Description("The NPC's FormID 'XXXXXX:Plugin.esp' — houseCARL computes the FaceGen path. Omit kind to place BOTH the mesh and the tint. Provide this OR asset_path.")]
@@ -246,6 +247,6 @@ public sealed record PlaceAssetSpec
     [JsonPropertyName("source"), Description("The copy to place: a Data-relative path (resolved through the VFS; different from the destination = a rename), a full loose file path, '<archive.bsa>|<entry>', or a '.bsa' path. Omit to resolve the destination path through the VFS. With formid and no kind, an explicit source must be a bare '.bsa' path.")]
     public string? Source { get; init; }
 
-    [JsonPropertyName("source_provider"), Description("Whose copy to read for a VFS-resolved source: a mod folder / overwrite / 'Data' / a BSA filename as asset_status renders it, or 'winner' for the current VFS winner. Omit for the sole provider (contention is refused). Not valid with an on-disk source.")]
+    [JsonPropertyName("source_provider"), Description("Whose copy to read for a VFS-resolved source: the provider's NAME ALONE (a mod folder, 'overwrite', 'Data', or a BSA filename) — not asset_status's ' (loose)' / ' (BSA)' annotation — or 'winner' for the current VFS winner. Omit for the sole provider (contention is refused). Not valid with an on-disk source.")]
     public string? SourceProvider { get; init; }
 }

--- a/src/housecarl-mcp/WriteSentences.cs
+++ b/src/housecarl-mcp/WriteSentences.cs
@@ -242,14 +242,17 @@ internal static class WriteSentences
     [MustState("will not guess which copy is correct")]
     internal const string PlaceSourceWillNotGuess = "houseCARL will not guess which copy is correct";
 
-    /// <summary>Contended source, no pole named. Lists the providers by NAME — the spelling <c>asset_status</c>
-    /// renders and the spelling <c>source_provider=</c> takes back, so the refusal hands the caller its own next
-    /// call. Deliberately NOT the on-disk paths: a path round-tripped through the caller can go stale between the
-    /// resolve and the read, and the whole point of naming a provider is that it cannot.</summary>
-    internal static string PlaceSourceAmbiguous(string rel, IReadOnlyList<string> providerNames) =>
+    /// <summary>Contended source, no pole named. Lists the providers by NAME, each QUOTED — the quoted half is
+    /// literally what <c>source_provider=</c> takes back, so the refusal hands the caller its own next call.
+    /// Deliberately NOT the on-disk paths: a path round-tripped through the caller can go stale between the resolve
+    /// and the read, and the whole point of naming a provider is that it cannot.
+    /// <para><paramref name="winnerTokenFree"/> false ⇒ a provider is itself called "winner", so the token remedy is
+    /// withheld rather than offered — advising an input the very next call refuses is the defect this parameter
+    /// exists to stop, and it was shipping.</para></summary>
+    internal static string PlaceSourceAmbiguous(string rel, IReadOnlyList<string> providerNames, bool winnerTokenFree) =>
         $"{providerNames.Count} providers supply '{rel}' — {PlaceSourceWillNotGuess}. "
-      + $"Name one with source_provider=: {string.Join("; ", providerNames)} "
-      + "(or source_provider=winner for whichever copy currently wins the VFS).";
+      + $"Pass source_provider= one of these names, quotes excluded: {string.Join("; ", providerNames)}"
+      + (winnerTokenFree ? ", or source_provider=winner for whichever copy currently wins the VFS." : ".");
 
     /// <summary>Why a named-provider miss is a refusal and not a fallback. The hazard is silent substitution: a
     /// mistyped mod name that quietly read some OTHER mod's copy would place bytes the caller never chose, and the
@@ -258,16 +261,25 @@ internal static class WriteSentences
     internal const string PlaceSourceNoSubstitute =
         "nothing was substituted for it — the providers below still supply it, and one of them is what you meant if the name is a typo";
 
-    /// <summary>The named provider does not supply this path (others may).</summary>
+    /// <summary>The named provider does not supply this path (others may). The list is the same quoted-name spelling
+    /// the ambiguity refusal uses, and for the same reason — this is the caller's next call, not a display.</summary>
     internal static string PlaceSourceNamedAbsent(string provider, string rel, IReadOnlyList<string> providerNames) =>
-        $"'{provider}' does not supply '{rel}', so {PlaceSourceNoSubstitute}: {string.Join("; ", providerNames)}.";
+        $"'{provider}' does not supply '{rel}', so {PlaceSourceNoSubstitute} — pass one of these names instead, "
+      + $"quotes excluded: {string.Join("; ", providerNames)}.";
 
     /// <summary>The one case where the reserved token and a real mod folder collide. Reading either would be a
-    /// guess, so both are refused and the caller is sent to the form that cannot be ambiguous.</summary>
-    [MustState("is itself named", "which of the two you meant")]
+    /// guess, so both are refused and the caller is sent to a form that cannot be ambiguous — the IN-TOOL route
+    /// first (asset_status names the winner; that name is a selector), with the on-disk form kept as the fallback
+    /// for a caller who has the file in front of them.
+    /// <para>The pinned phrase is the one that cannot survive the sentence being negated: a sentence saying the
+    /// token IS unambiguous still contains "is itself named", which is a topic, not a claim.</para></summary>
+    [MustState("cannot say which of the two you meant")]
     internal const string PlaceSourceWinnerCollision =
         "a provider in your load order is itself named 'winner', so source_provider=winner cannot say which of the two you meant. "
-      + "Pass that copy directly with source= (a full loose path, or '<archive.bsa>|<entry>').";
+      + "To take whichever copy currently wins, read the winning provider's name from housecarl_asset_status and pass THAT "
+      + "as source_provider= — which resolves it whenever the winner is some other mod. To take the mod called 'winner' "
+      + "itself, name its file directly with source= (a full loose path, or '<archive.bsa>|<entry>'): the token shadows "
+      + "that mod's name, so no selector can address it.";
 
     /// <summary>A pole named against a source that is already one exact file. Q3 — an input that cannot apply is
     /// said, never dropped: silently ignoring it would let a caller believe a provider was honoured.</summary>

--- a/src/housecarl-mcp/WriteSentences.cs
+++ b/src/housecarl-mcp/WriteSentences.cs
@@ -235,6 +235,47 @@ internal static class WriteSentences
     internal const string CellRowsCutLoss =
         "each dropped row is Creation-Kit work this response was supposed to name";
 
+    // ---- place_asset: naming which copy to read (S2's SOURCE poles) ----------------------------------
+    /// <summary>The refusal's load-bearing half: houseCARL picked NOTHING. Which copy of a contended file is the
+    /// right one is a judgement about the modlist, and the tool has never made it (the placer's own charter) — the
+    /// sentence exists so a caller reads "choose" rather than "retry".</summary>
+    [MustState("will not guess which copy is correct")]
+    internal const string PlaceSourceWillNotGuess = "houseCARL will not guess which copy is correct";
+
+    /// <summary>Contended source, no pole named. Lists the providers by NAME — the spelling <c>asset_status</c>
+    /// renders and the spelling <c>source_provider=</c> takes back, so the refusal hands the caller its own next
+    /// call. Deliberately NOT the on-disk paths: a path round-tripped through the caller can go stale between the
+    /// resolve and the read, and the whole point of naming a provider is that it cannot.</summary>
+    internal static string PlaceSourceAmbiguous(string rel, IReadOnlyList<string> providerNames) =>
+        $"{providerNames.Count} providers supply '{rel}' — {PlaceSourceWillNotGuess}. "
+      + $"Name one with source_provider=: {string.Join("; ", providerNames)} "
+      + "(or source_provider=winner for whichever copy currently wins the VFS).";
+
+    /// <summary>Why a named-provider miss is a refusal and not a fallback. The hazard is silent substitution: a
+    /// mistyped mod name that quietly read some OTHER mod's copy would place bytes the caller never chose, and the
+    /// file would look placed. Naming a provider means that provider or nothing.</summary>
+    [MustState("nothing was substituted", "still supply it")]
+    internal const string PlaceSourceNoSubstitute =
+        "nothing was substituted for it — the providers below still supply it, and one of them is what you meant if the name is a typo";
+
+    /// <summary>The named provider does not supply this path (others may).</summary>
+    internal static string PlaceSourceNamedAbsent(string provider, string rel, IReadOnlyList<string> providerNames) =>
+        $"'{provider}' does not supply '{rel}', so {PlaceSourceNoSubstitute}: {string.Join("; ", providerNames)}.";
+
+    /// <summary>The one case where the reserved token and a real mod folder collide. Reading either would be a
+    /// guess, so both are refused and the caller is sent to the form that cannot be ambiguous.</summary>
+    [MustState("is itself named", "which of the two you meant")]
+    internal const string PlaceSourceWinnerCollision =
+        "a provider in your load order is itself named 'winner', so source_provider=winner cannot say which of the two you meant. "
+      + "Pass that copy directly with source= (a full loose path, or '<archive.bsa>|<entry>').";
+
+    /// <summary>A pole named against a source that is already one exact file. Q3 — an input that cannot apply is
+    /// said, never dropped: silently ignoring it would let a caller believe a provider was honoured.</summary>
+    [MustState("only applies to a Data-relative source", "already names one exact copy")]
+    internal const string PlaceSourceProviderNeedsRelPath =
+        "source_provider= only applies to a Data-relative source resolved through the VFS. The source you passed is an "
+      + "on-disk path, which already names one exact copy — drop source_provider=, or pass source= the Data-relative path.";
+
     /// <summary>Sentences the SAME outcome must carry on BOTH transports. Reflected over by the write-surface
     /// guard's twin arm — see this class's summary. Members are whole invariant strings on purpose: a sentence
     /// interpolating a cap or a filename cannot be compared verbatim across lanes, so parameterised twins stay on

--- a/src/housecarl-mcp/WriteSentences.cs
+++ b/src/housecarl-mcp/WriteSentences.cs
@@ -246,13 +246,13 @@ internal static class WriteSentences
     /// literally what <c>source_provider=</c> takes back, so the refusal hands the caller its own next call.
     /// Deliberately NOT the on-disk paths: a path round-tripped through the caller can go stale between the resolve
     /// and the read, and the whole point of naming a provider is that it cannot.
-    /// <para><paramref name="winnerTokenFree"/> false ⇒ a provider is itself called "winner", so the token remedy is
-    /// withheld rather than offered — advising an input the very next call refuses is the defect this parameter
-    /// exists to stop, and it was shipping.</para></summary>
-    internal static string PlaceSourceAmbiguous(string rel, IReadOnlyList<string> providerNames, bool winnerTokenFree) =>
+    /// <para>The remedy is UNCONDITIONAL. It used to be withheld when a provider was itself called "winner", because
+    /// the bare token could not tell the two apart; the pole is sigiled now, so no listed name can ever collide with
+    /// it and there is no load-order state this sentence has to know about.</para></summary>
+    internal static string PlaceSourceAmbiguous(string rel, IReadOnlyList<string> providerNames) =>
         $"{providerNames.Count} providers supply '{rel}' — {PlaceSourceWillNotGuess}. "
       + $"Pass source_provider= one of these names, quotes excluded: {string.Join("; ", providerNames)}"
-      + (winnerTokenFree ? ", or source_provider=winner for whichever copy currently wins the VFS." : ".");
+      + $", or source_provider={AssetSourceChoice.WinnerToken} for whichever copy currently wins the VFS.";
 
     /// <summary>Why a named-provider miss is a refusal and not a fallback. The hazard is silent substitution: a
     /// mistyped mod name that quietly read some OTHER mod's copy would place bytes the caller never chose, and the
@@ -261,25 +261,28 @@ internal static class WriteSentences
     internal const string PlaceSourceNoSubstitute =
         "nothing was substituted for it — the providers below still supply it, and one of them is what you meant if the name is a typo";
 
+    /// <summary>The naming correction that rides on every named-provider miss — the same shape as the in_place=true
+    /// correction: a caller who reached this error by typing the pole as a bare word gets told the spelling, and a
+    /// caller who genuinely mistyped a mod name loses one clause. STATIC, never conditional on what the load order
+    /// happens to contain: a sentence that knows which mods are installed is a sentence with a state to get wrong,
+    /// and that is exactly what the conditional winner-remedy was.</summary>
+    [MustState("winner pole is spelled")]
+    internal const string PlaceSourcePoleSpelling =
+        "(the winner pole is spelled " + AssetSourceChoice.WinnerToken + " — a bare name always means a provider of that name)";
+
     /// <summary>The named provider does not supply this path (others may). The list is the same quoted-name spelling
     /// the ambiguity refusal uses, and for the same reason — this is the caller's next call, not a display.</summary>
     internal static string PlaceSourceNamedAbsent(string provider, string rel, IReadOnlyList<string> providerNames) =>
         $"'{provider}' does not supply '{rel}', so {PlaceSourceNoSubstitute} — pass one of these names instead, "
-      + $"quotes excluded: {string.Join("; ", providerNames)}.";
+      + $"quotes excluded: {string.Join("; ", providerNames)}. {PlaceSourcePoleSpelling}";
 
-    /// <summary>The one case where the reserved token and a real mod folder collide. Reading either would be a
-    /// guess, so both are refused and the caller is sent to a form that cannot be ambiguous — the IN-TOOL route
-    /// first (asset_status names the winner; that name is a selector), with the on-disk form kept as the fallback
-    /// for a caller who has the file in front of them.
-    /// <para>The pinned phrase is the one that cannot survive the sentence being negated: a sentence saying the
-    /// token IS unambiguous still contains "is itself named", which is a topic, not a claim.</para></summary>
-    [MustState("cannot say which of the two you meant")]
-    internal const string PlaceSourceWinnerCollision =
-        "a provider in your load order is itself named 'winner', so source_provider=winner cannot say which of the two you meant. "
-      + "To take whichever copy currently wins, read the winning provider's name from housecarl_asset_status and pass THAT "
-      + "as source_provider= — which resolves it whenever the winner is some other mod. To take the mod called 'winner' "
-      + "itself, name its file directly with source= (a full loose path, or '<archive.bsa>|<entry>'): the token shadows "
-      + "that mod's name, so no selector can address it.";
+    /// <summary>The both-slots expansion's own constraint on the pole. A FormID with no kind derives TWO destination
+    /// paths, so an explicit source= (one file) cannot serve them — but the pole can, because it names whose copy
+    /// rather than which file. The refusal used to assert the pole was "fine here" without that qualifier, which was
+    /// false for every call that also passed a source.</summary>
+    [MustState("only when source= is omitted")]
+    internal const string PlaceBothSlotsPoleConstraint =
+        "source_provider= works here only when source= is omitted — it names WHOSE copy, not which file, and two slots are two files";
 
     /// <summary>A pole named against a source that is already one exact file. Q3 — an input that cannot apply is
     /// said, never dropped: silently ignoring it would let a caller believe a provider was honoured.</summary>


### PR DESCRIPTION
`place_asset` could only read a source it was handed as an exact on-disk path, and no read tool emits one — `asset_status` reports provider *names*. So nothing could express "the copy of this Data-relative path that mod X supplies", which is the shape an NPC appearance copy is built from.

This is the source primitive split out of PR 3b, not the `copy` verb. `copy` has not started.

No linked issue — this lane charters from plan docs (same as #337).

## The settle question that produced this branch

PR 3b's charter said to settle first whether the FormID-keyed facegen rename is already expressible, because that decides whether `copy` has to carry it. Measured against the source rather than argued:

- **The destination side already renames.** `place_asset` takes source and destination independently; the destination can be `formid`+`kind`, computed by `FaceGenPath.For`. Pass the *new* FormKey and you get the new facegen name. Nothing to build.
- **The source side could not name what to read.** `source=` was `<abs .bsa>|<entry>`, a bare `.bsa`, or `Path.GetFullPath` against the process working directory. The concrete `PlacementSource` exists in core but is reachable only by `place_asset`'s own auto-resolve — which resolves the *destination*, and a rename's destination is new, so nothing provides it.

So the answer was neither of the two the charter anticipated: **the gap is real, and it belongs on the asset surface, not in `copy`.** `copy` carries nothing.

## What changed

**`source=` accepts a Data-relative path**, resolved through the VFS. **`source_provider=` picks the pole** — the three S2 SOURCE poles from SPEC §1: the VFS winner, a named provider, or (omitted) the sole provider with contention refused. Source path ≠ destination path is therefore a **rename**.

**One shared policy in core** (`AssetSourceSelection`) makes the pick. `NpcAppearanceAssets.ResolveForCarry` now goes through it too, so "how to read a contended source" has one spelling rather than two.

**Aaron's semantics, as built:** a named provider is honoured *whatever else contends* — the caller always names the donor mod, so this is a named-provider read, not a winner read and not an ambiguity refusal.

### Known, intentional divergence

`copy_npc_appearance`'s facegen arm keeps its **winner-read** (`alwaysCarry`). Where a replacer out-sorts the donor, the old tool carries the winner's bytes — facegen that may not match the donor's head-part and tint records. The successor flow reads the **named donor**. Left divergent on purpose: that tool is being subsumed, and the difference is what PR 3b's differential acceptance measures. Commented where it lives, and now pinned by an arm.

## The grammar decision

`source_provider=` originally spelled the winner pole as the bare word `winner` — which is also a legal MO2 folder name. The overlap was handled where names are *matched* and unknown everywhere names are *listed*. That produced, in sequence: a collision verdict, a `TokenNameTaken` flag, a conditional sentence, a bespoke refusal, and two holes no guard covered — including an ambiguity refusal that listed `winner` as a token its own remedy then rejected.

Escalated under §11; **Aaron's ruling: sigil it.** The pole is `*winner`. `*` is illegal in a Windows file or folder name, so the pole space and the provider-name space are disjoint by construction, a bare name always means a provider of that name, and a mod actually called `winner` is reachable. Same idiom as `@file` in `ops=`. The collision machinery is **deleted, not stranded**; both listing holes close by construction.

Recorded as **SPEC §5.5**, a §4-gated post-freeze amendment entry (Aaron-go, dated) rather than a rewrite of frozen text: pole tokens are sigiled where the co-resident name space can legally contain the bare token. S1's `source` / `where_source` / `fields_source` stay bare — plugin names are extension-mandatory — and that exemption's ground is **pinned**, not asserted: `read-plugin-file-guard` proves an extensionless spelling refuses by name and never fuzzy-matches.

## Review rounds (§11)

**Two rounds, five agents, each in its own worktree, prompts seeded with the settled-decisions list only.** Stopped at two on the convergence rule, escalated, folded on the ruling; no rounds after the directed fold.

**Round 1 — 3 agents.** 3 HIGH, 3 MEDIUM, 2 LOW folded.
- The provider list rendered `ModA (loose)` while the pole matched bare `ModA`, so the refusal's own remedy refused and the next refusal called the caller's verbatim copy a typo. Found independently by all three.
- `source_provider` was **never exercised through either tool entrypoint** — deleting the mapping left the suite green.
- The rename-provenance arm **passed with the thing it tested removed** (the relative path is a substring of the provider's absolute path, so `Contains` held by construction).
- `IsPathRooted` made `\meshes\…` a Data-relative destination and an on-disk source in the same call.
- Quoted sources classified with quotes stripped, consumed with them intact.

**Round 2 — 2 agents.** Nothing folded; escalated instead.
- The round-1 fix (`winnerTokenFree`) shipped **with no arm in either direction** — hard-coded `true` or `false`, all guards stayed green.
- The round-1 round-trip arm **could not see an apostrophe**: single quotes are not a boundary, and `JK's Skyrim` dissolves them mid-name.
- The `.bsa` extension test pre-empted the volume test, so a genuine Data-relative `meshes\thing.bsa` still resolved against the process working directory.
- The both-slots refusal promised `source_provider=` was "fine here" for combinations the service refuses.

**Refused, with reasons** — the refusal rate is the triage signal, so both are named:
1. Arming the `AssetRootHint` / `ReadIncomplete` clauses on the source-absent message. They duplicate an already-armed pattern one lane over, it's a low, and lows here are fix-or-drop rather than a count to grow.
2. Half of the collision-remedy finding: took the in-tool route it was right that I omitted, kept the on-disk fallback rather than accepting the premise that it's useless — a caller with MO2 open can act on it. (Moot now; the sentence is deleted.)

Two defects I caught on myself mid-fold rather than folding blind: a collision remedy that told the caller to pass `source_provider=` the mod's own name — which *is* the collision — and a helper that guessed the patch folder from the naming convention, so the wire arms failed for a reason unrelated to their claim.

## Guards

`ci-all` **117/117** · `write-surface-guard` **191/191** · `place-asset-guard` arms I, K, L · `copy-npc-appearance-guard` arm 4 · `read-plugin-file-guard` arm 7c.

Probe fixtures are named **hostilely on purpose** — `JK's Skyrim` and `winner` — because friendly names cannot exercise what the provider list promises.

**RED-verified, each sabotage confirmed applied before its result was trusted, each restored:** un-sigiling the pole token · single quotes in the name list · extension tested before the qualified path · the pole-spelling tail removed · the both-slots relative-`.bsa` test removed · the rename prefix dropped · `source_provider` dropped at the wire · `IsPathRooted` restored · the carry pole swapped to sole-provider.

The `read-plugin-file-guard` arm carries a same-name-with-extension control, which caught the arm passing for the wrong reason once — everything errored because the corpus hadn't been generated.

## Outside this branch

`nif_inspect` / `nif_set`'s `mod=` has the same print/accept mismatch on `main` — it matches a bare provider name while its not-found message lists the annotated form. Not touched here. `[JsonPropertyName]` pinning for the *sibling* fields (`source`, `asset_path`) is the same pre-existing class; the branch's own new field is pinned in arm L. Both are Issues-lane items awaiting your go — say the word and I'll file them.
