### PR TITLE
Owned-child cell annotation: say when a winner's child list is not the whole story (#342 stage 1)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -10,22 +10,35 @@ when it changes.
   topic's INFO lines and a worldspace's cells are declared **per plugin**, and the game assembles a parent's
   children from every plugin that declares them. So a plugin that overrides a cell for an unrelated reason —
   occlusion planes, lighting, music — carries no references and deletes none either, yet reading that winner's
-  `Persistent` / `Temporary` showed you its own empty list. Anyone auditing "what is in this cell" through the
-  winner got a plausible, confident, wrong answer: on one order, Dawnstar's exterior cell read 0 references at its
-  winner while the game loads the 201 that `Skyrim.esm` declares. `housecarl_read_record`,
-  `housecarl_batch_record_detail` and `housecarl_cross_plugin_query` now name, beside the field, **which other
-  plugins touching the record also declare content for it** — whenever any of them does, not only when the body
-  you are reading looks emptier. That matters because plugins declare children *additively*: a cell whose winner
-  lists 50 references of its own is still not the whole set if another plugin declares 30 more. It fires on every
-  field that owns child records, taken from the same list the write surface uses to preserve them (a cell's
-  `Persistent`, `Temporary`, `Landscape` and `NavigationMeshes`, a topic's `Responses`, a worldspace's cells),
-  never a hand-kept set of cell fields, and it costs nothing on a read of any other record type. A plugin that
-  merely touches the parent without declaring children is not named — including a worldspace override that carries
-  block scaffolding but no cells. Reading a specific plugin's version is annotated too, because that body is not
-  the whole set either — the plugins **above** it declare children it cannot see. The value itself is untouched:
-  the annotation sits beside it, and a write can still reuse the token verbatim. Note what this is not — houseCARL
-  does not yet have a read that answers "what is actually live in this cell" (every child at its own winner, minus
-  the deleted and disabled ones); that is separate work, and this annotation deliberately promises nothing about it.
+  `Persistent` / `Temporary` showed you its own empty list with nothing to suggest otherwise. Anyone auditing
+  "what is in this cell" through the winner got a plausible, confident, wrong answer: on one order, Dawnstar's
+  exterior cell read 0 references at its winner while the game loads the 201 that `Skyrim.esm` declares.
+
+  `housecarl_read_record`, `housecarl_batch_record_detail` and `housecarl_cross_plugin_query` now say so, in two
+  tiers. **Every read** of a field that owns child records notes how many other plugins touch that record and that
+  this read did not open them — free, because it comes from the load-order index rather than from opening
+  anything. **`conflict_tree=true`**, which already fetches every touching plugin's body, additionally **names
+  which of them declare content** for each field, at no extra cost. The split is deliberate: naming the plugins
+  requires reading their bodies, and doing that on every read took a single Dawnstar cell read from 27 ms to
+  588 ms, a worldspace read to 2.5 seconds, and a whole-order cell catalogue past ten minutes.
+
+  What is annotated comes from the same list the write surface uses to preserve children — a cell's `Persistent`,
+  `Temporary`, `Landscape` and `NavigationMeshes`, a topic's `Responses`, a worldspace's cells — never a
+  hand-kept set of cell fields, and it costs nothing on a read of any other record type. Two kinds of child field
+  get two different statements, because two different things are true of them: `Persistent`, `Temporary`,
+  `NavigationMeshes`, `Responses` and a worldspace's cells hold **many** children and are merged from every plugin
+  that declares any, while `Landscape` and `TopCell` hold **one** record that plugins override — for those, other
+  plugins carrying one does not mean a bigger total, it means load order decides which you get, and that the child
+  exists even though the body you are reading has none. A plugin that merely touches the parent without declaring
+  children is never named, including a worldspace override carrying block scaffolding but no cells. Reading a
+  specific plugin's version is annotated too, because that body is not the whole set either — the plugins **above**
+  it declare children it cannot see. The value itself is untouched: the annotation sits beside it, and a write can
+  still reuse the token verbatim. A `to_file=` artifact carries the note on its rows and the sentence explaining it
+  on the manifest line, so a catalogue you re-open next week still says what it means.
+
+  Note what this is not — houseCARL does not yet have a read that answers "what is actually live in this cell"
+  (every child at its own winner, minus the deleted and disabled ones); that is separate work, and this annotation
+  deliberately promises nothing about it.
 
 - **`housecarl_copy`** — copy a record together with the records it depends on (its link closure) into a patch under new FormIDs, so the result no longer masters the plugin you copied from. The walk starts from the link-bearing fields you name (`seed_paths=`) and is bounded by the record types you exclude (`exclude_types=`), so the tool stays generic and the domain knowledge is yours to supply. `from_source=` is an ordered list of sources tried first-hit-wins — `winner` for the load order's winning version, or a plugin filename, active or sitting in a disabled mod — and the result names which source produced each copied record. Destination is either an existing record (`target=`) or a fresh clone (`new_editorid=`), whose remaining links into the source are stripped and reported by name — including when clearing one takes a whole property with it. When nothing is being copied away from at all — the source and every named source are base-game masters — the result is reported as an appearance transplant rather than a standalone-ization, because an always-loaded master is not being removed from anything. An off-order link the finished patch still carries is refused, and the refusal names which cause: your own `Type:stop`, a field `seed_paths` never named, or a record an earlier call left in the patch you are extending.
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -6,6 +6,25 @@ when it changes.
 
 ## Unreleased
 
+- **Fixed: reading a cell's placed references could report an empty cell the game fills.** Placed references, a
+  topic's INFO lines and a worldspace's cells are declared **per plugin**, and the game assembles a parent's
+  children from every plugin that declares them. So a plugin that overrides a cell for an unrelated reason —
+  occlusion planes, lighting, music — carries no references and deletes none either, yet reading that winner's
+  `Persistent` / `Temporary` showed you its own empty list. Anyone auditing "what is in this cell" through the
+  winner got a plausible, confident, wrong answer: on one order, Dawnstar's exterior cell read 0 references at its
+  winner while the game loads the 201 that `Skyrim.esm` declares. `housecarl_read_record`,
+  `housecarl_batch_record_detail` and `housecarl_cross_plugin_query` now state the fact on the field itself —
+  how many other plugins touching the record declare content for it, the largest such declaration and which plugin
+  made it — whenever another plugin declares more than the body you are reading. It fires on every field that owns
+  child records, taken from the same list the write surface uses to preserve them (a cell's `Persistent`,
+  `Temporary`, `Landscape` and `NavigationMeshes`, a topic's `Responses`, a worldspace's cells), never a hand-kept
+  set of cell fields, and it costs nothing on a read of any other record type. Reading a specific plugin's version
+  is annotated too, because that body is not the whole set either — the plugins **above** it declare children it
+  cannot see. The value itself is untouched: the annotation is added beside it, and a write can still reuse the
+  token verbatim. Note what this is not — houseCARL does not yet have a read that answers "what is actually live in
+  this cell" (every child at its own winner, minus the deleted and disabled ones); that is separate work, and this
+  annotation deliberately promises nothing about it.
+
 - **`housecarl_copy`** — copy a record together with the records it depends on (its link closure) into a patch under new FormIDs, so the result no longer masters the plugin you copied from. The walk starts from the link-bearing fields you name (`seed_paths=`) and is bounded by the record types you exclude (`exclude_types=`), so the tool stays generic and the domain knowledge is yours to supply. `from_source=` is an ordered list of sources tried first-hit-wins — `winner` for the load order's winning version, or a plugin filename, active or sitting in a disabled mod — and the result names which source produced each copied record. Destination is either an existing record (`target=`) or a fresh clone (`new_editorid=`), whose remaining links into the source are stripped and reported by name — including when clearing one takes a whole property with it. When nothing is being copied away from at all — the source and every named source are base-game masters — the result is reported as an appearance transplant rather than a standalone-ization, because an always-loaded master is not being removed from anything. An off-order link the finished patch still carries is refused, and the refusal names which cause: your own `Type:stop`, a field `seed_paths` never named, or a record an earlier call left in the patch you are extending.
 
 - **New skill: `npc-appearance-copy`** — the domain half of `housecarl_copy` for NPC faces, carried as data and flow rather than as tool code: which four link-bearing fields seed the walk, why a Race is excluded rather than walked into, which inline fields (tints, morphs, `TextureLighting`, weight) ride `housecarl_apply`'s copy zip instead, and how the FaceGen mesh + tint are placed under the new FormID from the **named donor** rather than the VFS winner. Also states the two things the split costs: three calls means three refusal surfaces, and a donor sitting in a disabled MO2 mod is a records-only job until its files can be named.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,17 +13,19 @@ when it changes.
   `Persistent` / `Temporary` showed you its own empty list. Anyone auditing "what is in this cell" through the
   winner got a plausible, confident, wrong answer: on one order, Dawnstar's exterior cell read 0 references at its
   winner while the game loads the 201 that `Skyrim.esm` declares. `housecarl_read_record`,
-  `housecarl_batch_record_detail` and `housecarl_cross_plugin_query` now state the fact on the field itself —
-  how many other plugins touching the record declare content for it, the largest such declaration and which plugin
-  made it — whenever another plugin declares more than the body you are reading. It fires on every field that owns
-  child records, taken from the same list the write surface uses to preserve them (a cell's `Persistent`,
-  `Temporary`, `Landscape` and `NavigationMeshes`, a topic's `Responses`, a worldspace's cells), never a hand-kept
-  set of cell fields, and it costs nothing on a read of any other record type. Reading a specific plugin's version
-  is annotated too, because that body is not the whole set either — the plugins **above** it declare children it
-  cannot see. The value itself is untouched: the annotation is added beside it, and a write can still reuse the
-  token verbatim. Note what this is not — houseCARL does not yet have a read that answers "what is actually live in
-  this cell" (every child at its own winner, minus the deleted and disabled ones); that is separate work, and this
-  annotation deliberately promises nothing about it.
+  `housecarl_batch_record_detail` and `housecarl_cross_plugin_query` now name, beside the field, **which other
+  plugins touching the record also declare content for it** — whenever any of them does, not only when the body
+  you are reading looks emptier. That matters because plugins declare children *additively*: a cell whose winner
+  lists 50 references of its own is still not the whole set if another plugin declares 30 more. It fires on every
+  field that owns child records, taken from the same list the write surface uses to preserve them (a cell's
+  `Persistent`, `Temporary`, `Landscape` and `NavigationMeshes`, a topic's `Responses`, a worldspace's cells),
+  never a hand-kept set of cell fields, and it costs nothing on a read of any other record type. A plugin that
+  merely touches the parent without declaring children is not named — including a worldspace override that carries
+  block scaffolding but no cells. Reading a specific plugin's version is annotated too, because that body is not
+  the whole set either — the plugins **above** it declare children it cannot see. The value itself is untouched:
+  the annotation sits beside it, and a write can still reuse the token verbatim. Note what this is not — houseCARL
+  does not yet have a read that answers "what is actually live in this cell" (every child at its own winner, minus
+  the deleted and disabled ones); that is separate work, and this annotation deliberately promises nothing about it.
 
 - **`housecarl_copy`** — copy a record together with the records it depends on (its link closure) into a patch under new FormIDs, so the result no longer masters the plugin you copied from. The walk starts from the link-bearing fields you name (`seed_paths=`) and is bounded by the record types you exclude (`exclude_types=`), so the tool stays generic and the domain knowledge is yours to supply. `from_source=` is an ordered list of sources tried first-hit-wins — `winner` for the load order's winning version, or a plugin filename, active or sitting in a disabled mod — and the result names which source produced each copied record. Destination is either an existing record (`target=`) or a fresh clone (`new_editorid=`), whose remaining links into the source are stripped and reported by name — including when clearing one takes a whole property with it. When nothing is being copied away from at all — the source and every named source are base-game masters — the result is reported as an appearance transplant rather than a standalone-ization, because an always-loaded master is not being removed from anything. An off-order link the finished patch still carries is refused, and the refusal names which cause: your own `Type:stop`, a field `seed_paths` never named, or a record an earlier call left in the patch you are extending.
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -15,9 +15,10 @@ when it changes.
   exterior cell read 0 references at its winner while the game loads the 201 that `Skyrim.esm` declares.
 
   `housecarl_read_record`, `housecarl_batch_record_detail` and `housecarl_cross_plugin_query` now say so, in two
-  tiers. **Every read** of a field that owns child records notes how many other plugins touch that record and that
-  this read did not open them — free, because it comes from the load-order index rather than from opening
-  anything. **`conflict_tree=true`**, which already fetches every touching plugin's body, additionally **names
+  tiers. **A load-order read** of a field that owns child records notes how many other plugins touch that record
+  and that this read did not open them — free, because it comes from the load-order index rather than from opening
+  anything. (Two lanes deliberately stay silent, because a load-order statement would be wrong there: a read
+  scoped to a file outside the load order, and the SkyPatcher overlay pole.) **`conflict_tree=true`**, which already fetches every touching plugin's body, additionally **names
   which of them declare content** for each field, at no extra cost. The split is deliberate: naming the plugins
   requires reading their bodies, and doing that on every read took a single Dawnstar cell read from 27 ms to
   588 ms, a worldspace read to 2.5 seconds, and a whole-order cell catalogue past ten minutes.

--- a/src/housecarl-core/OwnedChildContent.cs
+++ b/src/housecarl-core/OwnedChildContent.cs
@@ -1,0 +1,76 @@
+using System.Collections.Concurrent;
+using Mutagen.Bethesda.Plugins.Records;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// The READ side's view of the fields that own child records — the same question
+/// <see cref="WriteEngine.ChildBearingProperties"/> answers for the write surface, asked of a body the read
+/// engine just fetched.
+///
+/// <para><b>Why the read side asks it at all (#342).</b> An owned child record is declared PER PLUGIN and the
+/// game assembles a parent's children from every plugin that declares them — a cell override that touches the
+/// record for an unrelated reason (occlusion data, lighting, music) carries no placed references and deletes
+/// none either. Reading such a winner's <c>Temporary</c> therefore reports an empty list for a cell the game
+/// fills with hundreds of references. Measured: <c>008EB5:Skyrim.esm</c> (Dawnstar exterior) reads
+/// Persistent 0 / Temporary 0 at its winner while <c>Skyrim.esm</c>'s own body carries 201 Temporary.</para>
+///
+/// <para><b>The field set is not a hand list.</b> It is <see cref="WriteEngine.ChildBearingProperties"/> — the
+/// reflected, recursive walk the write surface's child-preservation runs on, pinned by write-surface-guard over
+/// EVERY concrete record type Mutagen models and cross-checked against the corpus by corpus-hygiene-guard's
+/// INV6. So the read side inherits the same coverage by construction: against Mutagen 0.53.1 that is Cell
+/// (Landscape, NavigationMeshes, Persistent, Temporary), DialogTopic (Responses) and Worldspace (TopCell,
+/// SubCells), and a Mutagen bump that grows one is annotated without an edit here.</para>
+///
+/// <para>The read engine hands this a getter — an overlay body, not the settable class the write walk reflects
+/// over — so <see cref="FieldNames"/> maps getter → concrete through the engine's own
+/// <see cref="WriteEngine.PrimaryGetter"/> / <see cref="WriteEngine.ConcreteOf"/> pair rather than a second
+/// name mapping of its own.</para>
+/// </summary>
+public static class OwnedChildContent
+{
+    /// <summary>The names of <paramref name="body"/>'s fields that own child records, memoized per runtime type
+    /// (the <see cref="WriteEngine.ChildBearingProperties"/> precedent — reflection metadata, constant for the
+    /// process lifetime, and this is asked on every record read). EMPTY for every record type but the three that
+    /// own children, which is what makes the caller's walk free on the reads that don't touch this shape.</summary>
+    public static IReadOnlyList<string> FieldNames(IMajorRecordGetter body) =>
+        _byType.GetOrAdd(body.GetType(), static t =>
+        {
+            // A binary-overlay getter's properties are all read-only, and ChildBearingProperties requires a
+            // SETTABLE property (it exists to lift children off a record and put them back). Asking it about the
+            // overlay type directly would answer "nothing owns children" for every record in the load order — so
+            // the getter is mapped to the concrete settable class first, through the engine's own mapper.
+            var getter = WriteEngine.PrimaryGetter(t);
+            var concrete = getter is null ? null : WriteEngine.ConcreteOf(getter);
+            return concrete is null
+                ? Array.Empty<string>()
+                : WriteEngine.ChildBearingProperties(concrete).Select(p => p.Name).ToArray();
+        });
+
+    static readonly ConcurrentDictionary<Type, IReadOnlyList<string>> _byType = new();
+
+    /// <summary>How much child content <paramref name="body"/>'s own <paramref name="field"/> DECLARES: the
+    /// element count for a list (0 = declared nothing), 1/0 for a singular owned child (Cell.Landscape,
+    /// Worldspace.TopCell — present or absent, the singular analogue of a list's count).
+    ///
+    /// <para>NULL means the field could not be READ on this body — never 0. "I could not look" is not evidence of
+    /// "there is nothing there" (the #308 rule the read engine's own
+    /// <see cref="ReadEngine.LeafRead.Unreadable"/> exists for), and a caller comparing counts must not treat an
+    /// unreadable body as one that declares nothing.</para></summary>
+    public static int? DeclaredCount(IMajorRecordGetter body, string field)
+    {
+        try
+        {
+            var p = WriteEngine.ResolveProperty(body.GetType(), field);
+            if (p is null) return null;
+            return p.GetValue(body) switch
+            {
+                null => 0,                                                        // absent optional — declares nothing
+                IMajorRecordGetter => 1,                                          // a singular owned child, present
+                System.Collections.IEnumerable e => e.Cast<object?>().Count(),    // a list/dict of them
+                _ => null,                                                        // some other shape — don't guess (Q3)
+            };
+        }
+        catch { return null; }
+    }
+}

--- a/src/housecarl-core/OwnedChildContent.cs
+++ b/src/housecarl-core/OwnedChildContent.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records;
 
 namespace HousecarlCore;
@@ -54,28 +55,62 @@ public static class OwnedChildContent
 
     static readonly ConcurrentDictionary<Type, IReadOnlyList<string>> _byType = new();
 
-    /// <summary>How much child content <paramref name="body"/>'s own <paramref name="field"/> DECLARES: the
-    /// element count for a list (0 = declared nothing), 1/0 for a singular owned child (Cell.Landscape,
-    /// Worldspace.TopCell — present or absent, the singular analogue of a list's count).
+    /// <summary>Does <paramref name="body"/>'s own <paramref name="field"/> DECLARE at least one child record?
     ///
-    /// <para>NULL means the field could not be READ on this body — never 0. "I could not look" is not evidence of
-    /// "there is nothing there" (the #308 rule the read engine's own
-    /// <see cref="ReadEngine.LeafRead.Unreadable"/> exists for), and a caller comparing counts must not treat an
-    /// unreadable body as one that declares nothing.</para></summary>
-    public static int? DeclaredCount(IMajorRecordGetter body, string field)
+    /// <para><b>Reaching a record, not holding an element.</b> The two are not the same question, and answering
+    /// the easy one imports the bug this whole feature exists to kill. <c>Worldspace.SubCells</c> holds
+    /// <c>WorldspaceBlock</c>s, whose cells sit two container levels down — so "has a first element" is true of a
+    /// worldspace declaring nothing but empty block scaffolding. Measured on Mutagen 0.53.1: a worldspace written
+    /// with 2 blocks / 2 sub-blocks / ZERO cells exposes 2 top-level elements and enumerates 0 child records,
+    /// while one with 1 block / 1 sub-block / 3 cells exposes 1 element and enumerates 3. An element-level answer
+    /// would call the empty scaffold a declarer and rank it above the real one.</para>
+    ///
+    /// <para>So the walk descends to the first actual record and stops there: a singular owned child is its own
+    /// answer; a container defers to <see cref="IMajorRecordGetterEnumerable"/> — Mutagen's OWN containment
+    /// enumeration, the same independent yardstick <c>WriteEngine.RestoreChildGroup</c> checks itself against —
+    /// which is lazy, so the common case parses one child and returns. FormLinks are cut exactly as the
+    /// type-level walk cuts them: a link REFERENCES a record, it does not own one.</para>
+    ///
+    /// <para>NULL means the field could not be READ — never false. "I could not look" is not evidence of "there
+    /// is nothing there" (the #308 rule the read engine's own <see cref="ReadEngine.LeafRead.Unreadable"/> exists
+    /// for), and a caller must not report an unreadable body as one that declares nothing.</para></summary>
+    public static bool? DeclaresChild(IMajorRecordGetter body, string field)
     {
         try
         {
             var p = WriteEngine.ResolveProperty(body.GetType(), field);
-            if (p is null) return null;
-            return p.GetValue(body) switch
-            {
-                null => 0,                                                        // absent optional — declares nothing
-                IMajorRecordGetter => 1,                                          // a singular owned child, present
-                System.Collections.IEnumerable e => e.Cast<object?>().Count(),    // a list/dict of them
-                _ => null,                                                        // some other shape — don't guess (Q3)
-            };
+            return p is null ? null : ReachesRecord(p.GetValue(body), 0);
         }
         catch { return null; }
+    }
+
+    /// <summary>The deepest container nesting the value walk will follow before answering "I could not look".
+    /// The type-level walk (<c>WriteEngine.ReachesOwnedRecord</c>) uses the same constant against TYPES, where
+    /// the deepest real path is 5; against VALUES the walk is shallower still, because a container hands off to
+    /// Mutagen's containment enumeration rather than being stepped through property by property. So this is a
+    /// tripwire for a Mutagen shape nobody has seen, not a limit the current model approaches — and it answers
+    /// NULL rather than false, because a bound hit is exactly "I could not look".</summary>
+    const int MaxDepth = 6;
+
+    static bool? ReachesRecord(object? val, int depth)
+    {
+        if (val is null) return false;                       // absent optional / empty — declares nothing
+        if (depth > MaxDepth) return null;                   // nested deeper than any known shape — unknown, not "no"
+        if (val is IFormLinkGetter) return false;            // a reference, not a child (the type walk's own cut)
+        if (val is IMajorRecordGetter) return true;          // a singular owned child, present
+        if (val is string) return false;
+        // Mutagen's own containment walk, and it is LAZY: Any() stops at the first child record rather than
+        // counting them, which is what keeps a worldspace from being enumerated to answer a yes/no question.
+        if (val is IMajorRecordGetterEnumerable en) return en.EnumerateMajorRecords().Any();
+        if (val is System.Collections.IEnumerable seq)
+        {
+            foreach (var item in seq)
+            {
+                var r = ReachesRecord(item, depth + 1);
+                if (r is not false) return r;                // true, or an unknown that must not be reported as "no"
+            }
+            return false;
+        }
+        return false;
     }
 }

--- a/src/housecarl-core/OwnedChildContent.cs
+++ b/src/housecarl-core/OwnedChildContent.cs
@@ -4,16 +4,34 @@ using Mutagen.Bethesda.Plugins.Records;
 
 namespace HousecarlCore;
 
+/// <summary>How a field holds its owned child records — the distinction that decides what is TRUE of it.
+///
+/// <para>A <see cref="Collection"/> field (a cell's Persistent/Temporary/NavigationMeshes, a topic's Responses, a
+/// worldspace's SubCells) holds MANY children, each with its own FormKey, and the game assembles them from every
+/// plugin that declares any — so one plugin's list is not the total. A <see cref="Singular"/> field
+/// (Cell.Landscape, Worldspace.TopCell) holds ONE child record: several plugins declaring it are OVERRIDING one
+/// record, resolved by load order, not contributing to a merge. Saying "not the merged total" about a singular
+/// child is simply false, which is why this distinction is structural rather than a wording choice.</para></summary>
+public enum OwnedChildShape
+{
+    /// <summary>The field is not one that owns child records, or its shape could not be determined.</summary>
+    None,
+    /// <summary>ONE owned child record — declarers override each other (Cell.Landscape, Worldspace.TopCell).</summary>
+    Singular,
+    /// <summary>MANY owned child records — declarers contribute additively (Persistent, Temporary, Responses, …).</summary>
+    Collection,
+}
+
 /// <summary>
 /// The READ side's view of the fields that own child records — the same question
 /// <see cref="WriteEngine.ChildBearingProperties"/> answers for the write surface, asked of a body the read
 /// engine just fetched.
 ///
-/// <para><b>Why the read side asks it at all (#342).</b> An owned child record is declared PER PLUGIN and the
-/// game assembles a parent's children from every plugin that declares them — a cell override that touches the
-/// record for an unrelated reason (occlusion data, lighting, music) carries no placed references and deletes
-/// none either. Reading such a winner's <c>Temporary</c> therefore reports an empty list for a cell the game
-/// fills with hundreds of references. Measured: <c>008EB5:Skyrim.esm</c> (Dawnstar exterior) reads
+/// <para><b>Why the read side asks it at all (#342).</b> An owned child record is declared PER PLUGIN, and for a
+/// COLLECTION field the game assembles a parent's children from every plugin that declares them — a cell override
+/// that touches the record for an unrelated reason (occlusion data, lighting, music) carries no placed references
+/// and deletes none either. Reading such a winner's <c>Temporary</c> therefore reports an empty list for a cell
+/// the game fills with hundreds of references. Measured: <c>008EB5:Skyrim.esm</c> (Dawnstar exterior) reads
 /// Persistent 0 / Temporary 0 at its winner while <c>Skyrim.esm</c>'s own body carries 201 Temporary.</para>
 ///
 /// <para><b>The field set is not a hand list.</b> It is <see cref="WriteEngine.ChildBearingProperties"/> — the
@@ -24,19 +42,20 @@ namespace HousecarlCore;
 /// SubCells), and a Mutagen bump that grows one is annotated without an edit here.</para>
 ///
 /// <para>The read engine hands this a getter — an overlay body, not the settable class the write walk reflects
-/// over — so <see cref="FieldNames"/> maps getter → concrete through the engine's own
-/// <see cref="WriteEngine.PrimaryGetter"/> / <see cref="WriteEngine.ConcreteOf"/> pair rather than a second
-/// name mapping of its own. That hop is load-bearing and its cost is measured, not assumed: asking the overlay
-/// type directly answers correctly for the LIST children and silently drops the SINGULAR ones (see the comment
-/// on the walk), which the guard's Landscape arm holds.</para>
+/// over — so the field set maps getter → concrete through the engine's own <see cref="WriteEngine.PrimaryGetter"/>
+/// / <see cref="WriteEngine.ConcreteOf"/> pair rather than a second name mapping of its own. That hop is
+/// load-bearing and its cost is measured, not assumed: asking the overlay type directly answers correctly for the
+/// LIST children and silently drops the SINGULAR ones, which the guard holds in both a Landscape arm and a
+/// type-level arm over every concrete child-bearing type.</para>
 /// </summary>
 public static class OwnedChildContent
 {
-    /// <summary>The names of <paramref name="body"/>'s fields that own child records, memoized per runtime type
-    /// (the <see cref="WriteEngine.ChildBearingProperties"/> precedent — reflection metadata, constant for the
-    /// process lifetime, and this is asked on every record read). EMPTY for every record type but the three that
-    /// own children, which is what makes the caller's walk free on the reads that don't touch this shape.</summary>
-    public static IReadOnlyList<string> FieldNames(IMajorRecordGetter body) =>
+    /// <summary>The child-bearing fields of <paramref name="body"/>'s type, each with its
+    /// <see cref="OwnedChildShape"/> — memoized per runtime type (the
+    /// <see cref="WriteEngine.ChildBearingProperties"/> precedent: reflection metadata, constant for the process
+    /// lifetime, asked on every record read). EMPTY for every record type but the three that own children, which
+    /// is what makes a caller's walk free on the reads that don't touch this shape.</summary>
+    public static IReadOnlyDictionary<string, OwnedChildShape> Fields(IMajorRecordGetter body) =>
         _byType.GetOrAdd(body.GetType(), static t =>
         {
             // ChildBearingProperties requires a SETTABLE property (it exists to lift children off a record and put
@@ -44,16 +63,26 @@ public static class OwnedChildContent
             // CellBinaryOverlay answers [NavigationMeshes, Persistent, Temporary] but NOT Landscape — the overlay
             // exposes the LIST children settably and the SINGULAR one read-only. So asking the runtime type
             // directly loses exactly the singular owned children (Cell.Landscape, Worldspace.TopCell — #335's
-            // shape) while looking correct on the common ones, which is the worst way for it to be wrong. The
-            // getter is mapped to the concrete settable class first, through the engine's own mapper.
+            // shape) while looking correct on the common ones, which is the worst way for it to be wrong.
             var getter = WriteEngine.PrimaryGetter(t);
             var concrete = getter is null ? null : WriteEngine.ConcreteOf(getter);
-            return concrete is null
-                ? Array.Empty<string>()
-                : WriteEngine.ChildBearingProperties(concrete).Select(p => p.Name).ToArray();
+            var map = new Dictionary<string, OwnedChildShape>(StringComparer.Ordinal);
+            if (concrete is null) return map;
+            foreach (var p in WriteEngine.ChildBearingProperties(concrete))
+                // The shape is a fact about the PROPERTY, not about any one body's value — so it is answered here,
+                // off the type, and is available to a caller that has read no bodies at all.
+                map[p.Name] = typeof(IMajorRecordGetter).IsAssignableFrom(p.PropertyType)
+                    ? OwnedChildShape.Singular
+                    : OwnedChildShape.Collection;
+            return map;
         });
 
-    static readonly ConcurrentDictionary<Type, IReadOnlyList<string>> _byType = new();
+    static readonly ConcurrentDictionary<Type, IReadOnlyDictionary<string, OwnedChildShape>> _byType = new();
+
+    /// <summary>The shape of one field on <paramref name="body"/>'s type, or <see cref="OwnedChildShape.None"/>
+    /// when the field owns no children.</summary>
+    public static OwnedChildShape ShapeOf(IMajorRecordGetter body, string field) =>
+        Fields(body).TryGetValue(field, out var s) ? s : OwnedChildShape.None;
 
     /// <summary>Does <paramref name="body"/>'s own <paramref name="field"/> DECLARE at least one child record?
     ///
@@ -73,7 +102,12 @@ public static class OwnedChildContent
     ///
     /// <para>NULL means the field could not be READ — never false. "I could not look" is not evidence of "there
     /// is nothing there" (the #308 rule the read engine's own <see cref="ReadEngine.LeafRead.Unreadable"/> exists
-    /// for), and a caller must not report an unreadable body as one that declares nothing.</para></summary>
+    /// for), and a caller must not report an unreadable body as one that declares nothing.</para>
+    ///
+    /// <para><b>This reads a BODY, and reading a body is not free</b> — the resolver fetches one by enumerating a
+    /// whole overlay, so a caller asking this of every plugin touching a record pays per plugin. Only the lane
+    /// that has already fetched those bodies (the conflict tree) asks it; the default read answers the cheaper
+    /// question the index alone can settle.</para></summary>
     public static bool? DeclaresChild(IMajorRecordGetter body, string field)
     {
         try

--- a/src/housecarl-core/OwnedChildContent.cs
+++ b/src/housecarl-core/OwnedChildContent.cs
@@ -25,7 +25,9 @@ namespace HousecarlCore;
 /// <para>The read engine hands this a getter — an overlay body, not the settable class the write walk reflects
 /// over — so <see cref="FieldNames"/> maps getter → concrete through the engine's own
 /// <see cref="WriteEngine.PrimaryGetter"/> / <see cref="WriteEngine.ConcreteOf"/> pair rather than a second
-/// name mapping of its own.</para>
+/// name mapping of its own. That hop is load-bearing and its cost is measured, not assumed: asking the overlay
+/// type directly answers correctly for the LIST children and silently drops the SINGULAR ones (see the comment
+/// on the walk), which the guard's Landscape arm holds.</para>
 /// </summary>
 public static class OwnedChildContent
 {
@@ -36,10 +38,13 @@ public static class OwnedChildContent
     public static IReadOnlyList<string> FieldNames(IMajorRecordGetter body) =>
         _byType.GetOrAdd(body.GetType(), static t =>
         {
-            // A binary-overlay getter's properties are all read-only, and ChildBearingProperties requires a
-            // SETTABLE property (it exists to lift children off a record and put them back). Asking it about the
-            // overlay type directly would answer "nothing owns children" for every record in the load order — so
-            // the getter is mapped to the concrete settable class first, through the engine's own mapper.
+            // ChildBearingProperties requires a SETTABLE property (it exists to lift children off a record and put
+            // them back), and an overlay body is not the type it was written against. Measured on Mutagen 0.53.1:
+            // CellBinaryOverlay answers [NavigationMeshes, Persistent, Temporary] but NOT Landscape — the overlay
+            // exposes the LIST children settably and the SINGULAR one read-only. So asking the runtime type
+            // directly loses exactly the singular owned children (Cell.Landscape, Worldspace.TopCell — #335's
+            // shape) while looking correct on the common ones, which is the worst way for it to be wrong. The
+            // getter is mapped to the concrete settable class first, through the engine's own mapper.
             var getter = WriteEngine.PrimaryGetter(t);
             var concrete = getter is null ? null : WriteEngine.ConcreteOf(getter);
             return concrete is null

--- a/src/housecarl-core/ResultArtifact.cs
+++ b/src/housecarl-core/ResultArtifact.cs
@@ -248,6 +248,14 @@ public static class ResultArtifact
                 typeCounts = new(StringComparer.Ordinal);
                 foreach (var p in tc.EnumerateObject()) typeCounts[p.Name] = p.Value.GetInt32();
             }
+            // Parsed back for the same reason it is written: a note explains what the ROWS mean. A parse that
+            // dropped it would let a round-trip quietly strip the sentence the rows depend on.
+            List<string>? notes = null;
+            if (r.TryGetProperty("notes", out var nt) && nt.ValueKind == JsonValueKind.Array)
+            {
+                notes = new List<string>();
+                foreach (var n in nt.EnumerateArray()) if (n.ValueKind == JsonValueKind.String) notes.Add(n.GetString()!);
+            }
             return (new Manifest(
                         r.TryGetProperty("tool", out var t) ? t.GetString() ?? "?" : "?",
                         query,
@@ -258,7 +266,8 @@ public static class ResultArtifact
                         r.TryGetProperty("total", out var tot) ? tot.GetInt32() : 0,
                         typeCounts,
                         r.TryGetProperty("epoch", out var e) ? e.GetString() ?? "?" : "?",
-                        r.TryGetProperty("created", out var cr) ? cr.GetString() ?? "?" : "?"),
+                        r.TryGetProperty("created", out var cr) ? cr.GetString() ?? "?" : "?",
+                        notes),
                     null);
         }
         catch (Exception ex) when (ex is JsonException or FormatException or InvalidOperationException)

--- a/src/housecarl-core/ResultArtifact.cs
+++ b/src/housecarl-core/ResultArtifact.cs
@@ -60,13 +60,20 @@ public static class ResultArtifact
         /// IO failure (the caller renders it; Q3). <paramref name="total"/> is the TRUE result total; it equals
         /// <see cref="RowCount"/> unless the producing lane deliberately windowed (an auto-spill of an explicit
         /// limit= window writes the window and says so via total &gt; row_count).</summary>
+        /// <param name="notes">Response-level statements the ROWS depend on for their meaning — a note a row's own
+        /// annotation would otherwise leave unexplained. An artifact is re-entered later with no conversation
+        /// attached, so a label that ships without its meaning ships as noise (#342: rows carrying "also declared
+        /// by X" need the sentence that says what a child record is). Stated once here rather than per row, which
+        /// on a 100k-row artifact would be megabytes of one repeated sentence.</param>
         public (Manifest? Manifest, string? Error) Save(
             string path, string tool, IReadOnlyList<KeyValuePair<string, string>> query, string? identity,
-            IReadOnlyList<string> rowSchema, string sort, int total, string epoch)
+            IReadOnlyList<string> rowSchema, string sort, int total, string epoch,
+            IReadOnlyList<string>? notes = null)
         {
             var manifest = new Manifest(tool, query, identity, rowSchema, sort, _rowCount, total,
                                         _typeCounts.Count > 0 ? _typeCounts : null, epoch,
-                                        DateTime.UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'"));
+                                        DateTime.UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'"),
+                                        notes is { Count: > 0 } ? notes : null);
             string? tmp = null;
             try
             {
@@ -113,7 +120,8 @@ public static class ResultArtifact
         int Total,
         IReadOnlyDictionary<string, int>? TypeCounts,
         string Epoch,
-        string Created)
+        string Created,
+        IReadOnlyList<string>? Notes = null)
     {
         internal void WriteTo(Utf8JsonWriter w)
         {
@@ -139,6 +147,12 @@ public static class ResultArtifact
             }
             w.WriteString("epoch", Epoch);
             w.WriteString("created", Created);
+            if (Notes is { Count: > 0 })   // response-level statements the rows' own annotations rely on (#342)
+            {
+                w.WriteStartArray("notes");
+                foreach (var n in Notes) w.WriteStringValue(n);
+                w.WriteEndArray();
+            }
             w.WriteEndObject();
         }
     }

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -55,6 +55,12 @@ public static class CiAll
         // decimal, losing the known bits) now hangs a DISPLAY-ONLY "<names> (+unknown bits 0x…)" decode — the token
         // (bare decimal, Enum.Parse-round-trippable) is untouched; biped-slot flags keep their own slot decode.
         ("flag-bits-display-guard", FlagBitsDisplayProbe.RunGuard),
+        // owned-child content annotation (#342 stage 1): a parent's child records are declared PER PLUGIN and the
+        // game assembles them from every plugin that declares them, so a winner that touched the parent for an
+        // unrelated reason reports an empty cell the game fills. A read of an owning field (the write surface's
+        // pinned child-bearing set, not a cell hand-list) now states the fact when another toucher declares more.
+        // Display-only, per-field, and free on every read whose type owns no children.
+        ("owned-child-content-guard", OwnedChildContentProbe.RunGuard),
         ("floi-read-guard", FloiReadProbe.RunGuard),
         ("floi-fields-guard", FloiFieldsProbe.RunGuard),
         ("forward-from-plugin-guard", ForwardFromPluginProbe.RunGuard),

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -55,11 +55,13 @@ public static class CiAll
         // decimal, losing the known bits) now hangs a DISPLAY-ONLY "<names> (+unknown bits 0x…)" decode — the token
         // (bare decimal, Enum.Parse-round-trippable) is untouched; biped-slot flags keep their own slot decode.
         ("flag-bits-display-guard", FlagBitsDisplayProbe.RunGuard),
-        // owned-child content annotation (#342 stage 1): a parent's child records are declared PER PLUGIN and the
-        // game assembles them from every plugin that declares them, so a winner that touched the parent for an
-        // unrelated reason reports an empty cell the game fills. A read of an owning field (the write surface's
-        // pinned child-bearing set, not a cell hand-list) now states the fact when another toucher declares more.
-        // Display-only, per-field, and free on every read whose type owns no children.
+        // owned-child content annotation (#342 stage 1): a parent's child records are declared PER PLUGIN, so a
+        // winner that touched the parent for an unrelated reason reports an empty cell the game fills. A read of an
+        // owning field (the write surface's pinned child-bearing set, not a cell hand-list) now says so, in two
+        // tiers — the default read states from the INDEX that other plugins touch the record and were not opened;
+        // conflict_tree, which has already fetched every body, names which ones declare. Two sentence arms, because
+        // a COLLECTION child is assembled additively and a SINGULAR one is overridden. Display-only, and free on
+        // every read whose type owns no children.
         ("owned-child-content-guard", OwnedChildContentProbe.RunGuard),
         ("floi-read-guard", FloiReadProbe.RunGuard),
         ("floi-fields-guard", FloiFieldsProbe.RunGuard),

--- a/src/housecarl-generator/OwnedChildContentProbe.cs
+++ b/src/housecarl-generator/OwnedChildContentProbe.cs
@@ -30,7 +30,7 @@ namespace HousecarlGenerator;
 ///                  and a Landscape. Each is annotated, naming the declarer. The pre-fix hazard is asserted first
 ///                  — a fixture that stopped exhibiting it would make every arm below vacuous.
 ///   SINGULAR     — Cell.Landscape is a SINGULAR owned child, not a list.
-///   NOT-A-CELL   — DialogTopic.Responses, because the field set is <see cref="OwnedChildContent.FieldNames"/>
+///   NOT-A-CELL   — DialogTopic.Responses, because the field set is <see cref="OwnedChildContent.Fields"/>
 ///                  over the write surface's pinned authority, never a hand list of cell fields.
 ///   SOLE / SELF  — one declarer: no annotation, and the read body is never named among the "others".
 ///   UNREQUESTED  — fields=[EditorID]: no annotation (the walk is gated on the read's own field lines).
@@ -383,6 +383,38 @@ public static class OwnedChildContentProbe
                 $"note={fileText.Contains(ReadSentences.NotRead, StringComparison.Ordinal)} clause-in-manifest={fileDecoded.Contains(ReadSentences.NotReadClause, StringComparison.Ordinal)}");
             Check("ARTIFACT: the manifest-only response does NOT state a clause over rows it did not render",
                 !inline.Contains(ReadSentences.NotReadClause, StringComparison.Ordinal), Trim(inline));
+
+            // ---- THE PRECISE TIER INHERITS THE TREE RENDER'S SKIPS ----
+            // A tree fetch is one whole-overlay enumeration per touching plugin. The annotation must never buy
+            // those bodies where the diff itself would not: on a record nothing else touches (nothing to diff), or
+            // on a response already over budget (the diff is skipped and the bodies thrown away).
+            var soleCt = ReadCt(cellC);
+            Check("SKIP: conflict_tree on a SOLE-toucher record does not fetch a tree — nothing to diff, nothing to name",
+                !soleCt.Contains("diff (field deltas", StringComparison.Ordinal)
+                && FieldLine(soleCt, "Temporary") is { } sk1
+                && !sk1.Contains(ReadSentences.DeclaredBy, StringComparison.Ordinal)
+                && !sk1.Contains(ReadSentences.NotRead, StringComparison.Ordinal), FieldLine(soleCt, "Temporary"));
+            // The over-budget half of that skip is NOT pinned, and the code says why: the prefetch runs before the
+            // record's own fields are rendered, so it cannot foresee a cap hit during them. What IS pinned is that
+            // a bulk lane whose buffer is already full renders no further rows at all, so those rows pay nothing.
+            var capped = ReadTools.BatchRecordDetail(svc, new[] { cellA.ToString(), cellB.ToString() },
+                                                     conflict_tree: true, max_chars: 400);
+            Check("SKIP: a bulk response past its budget stops rendering rows, so the rows past it buy no bodies",
+                capped.Contains("truncated: rendered", StringComparison.Ordinal), Trim(capped));
+
+            // ---- JSON gates the clause on rows RENDERED, exactly as the text lane does ----
+            var jsonTrunc = ReadTools.BatchRecordDetail(svc, new[] { weapon.ToString(), cellA.ToString() },
+                                                        format: "json", max_chars: 400);
+            using (var doc = JsonDocument.Parse(jsonTrunc))
+                Check("JSON: a batch truncated before its only annotated row states NO clause",
+                    doc.RootElement.GetProperty("truncated").GetBoolean()
+                    && !doc.RootElement.TryGetProperty("owned_child_note", out _),
+                    $"rendered={doc.RootElement.GetProperty("rendered").GetInt32()} clause={doc.RootElement.TryGetProperty("owned_child_note", out _)}");
+            var jsonSpill = ReadTools.BatchRecordDetail(svc, new[] { cellA.ToString() }, format: "json",
+                                                        to_file: Path.Combine(root, "spill.jsonl"));
+            using (var doc = JsonDocument.Parse(jsonSpill))
+                Check("JSON: a manifest-only response states NO clause over rows it did not render",
+                    !doc.RootElement.TryGetProperty("owned_child_note", out _), Trim(jsonSpill));
 
             // ---- UNREADABLE: a toucher whose body cannot be read is NAMED, not dropped ----
             CheckUnreadable(root, mods, baseDir, baseKey, topKey, cellA);

--- a/src/housecarl-generator/OwnedChildContentProbe.cs
+++ b/src/housecarl-generator/OwnedChildContentProbe.cs
@@ -189,11 +189,14 @@ public static class OwnedChildContentProbe
             using var svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(root, "houseCARL.user.json")));
             svc.Stats();
 
+            // The DEFAULT lane — the cheap tier. conflict_tree stays false.
             string Read(FormKey fk, string? plugin = null, string[]? fields = null, int depth = 1, string? format = null)
                 => ReadTools.ReadRecord(svc, fk.ToString(), plugin, fields, depth, false, false, format);
+            // The lane that has already fetched every touching body — the precise tier rides it for free.
+            string ReadCt(FormKey fk, string? plugin = null)
+                => ReadTools.ReadRecord(svc, fk.ToString(), plugin, null, 1, true, false, null);
             string By(ModKey k) => $"{ReadSentences.DeclaredBy} {k.FileName}";
-
-            // ---- the pre-fix hazard, asserted before anything is claimed about the annotation ----
+            // ================= TIER 1 — the CHEAP annotation every read states from the index alone =========
             var aWinner = Read(cellA);
             Check("FIXTURE exhibits the bug: the winner's own Temporary reads EMPTY on a cell the base fills",
                 aWinner.Contains("winner=HcOcTop.esp", StringComparison.Ordinal)
@@ -204,94 +207,146 @@ public static class OwnedChildContentProbe
                 FieldLine(aBase, "Temporary") is { } tb && tb.Contains("3 item(s)", StringComparison.Ordinal),
                 FieldLine(aBase, "Temporary"));
 
-            // ---- FALSE-EMPTY: the annotation on each field the base declares, naming the declarer ----
-            Check("Temporary is annotated, naming the declaring plugin",
-                FieldLine(aWinner, "Temporary") is { } t1 && t1.Contains(By(baseKey), StringComparison.Ordinal),
+            Check("CHEAP: the child-bearing field says other plugins touch this record and were not read",
+                FieldLine(aWinner, "Temporary") is { } c1
+                && c1.Contains($"2 {ReadSentences.NotRead}", StringComparison.Ordinal),
                 FieldLine(aWinner, "Temporary"));
-            Check("Persistent is annotated too — the annotation is per FIELD, not per record",
-                FieldLine(aWinner, "Persistent") is { } p1 && p1.Contains(By(baseKey), StringComparison.Ordinal),
-                FieldLine(aWinner, "Persistent"));
-            Check("SINGULAR: Landscape is annotated — a singular owned child, not a list",
-                FieldLine(aWinner, "Landscape") is { } l1 && l1.Contains(By(baseKey), StringComparison.Ordinal),
-                FieldLine(aWinner, "Landscape"));
-            Check("NavigationMeshes — an owning field NOBODY declares — is NOT annotated",
-                FieldLine(aWinner, "NavigationMeshes") is { } n1 && !n1.Contains(ReadSentences.DeclaredBy, StringComparison.Ordinal),
+            Check("CHEAP: it claims nothing about WHO declares — no declarer naming on the default lane",
+                !aWinner.Contains(ReadSentences.DeclaredBy, StringComparison.Ordinal)
+                && !aWinner.Contains(ReadSentences.CarriedBy, StringComparison.Ordinal), Trim(aWinner));
+            Check("CHEAP: every child-bearing field carries it, including one nobody declares — 'not read' is true of all",
+                FieldLine(aWinner, "NavigationMeshes") is { } c2 && c2.Contains(ReadSentences.NotRead, StringComparison.Ordinal),
                 FieldLine(aWinner, "NavigationMeshes"));
-            Check("…and the plugin that touches the cell declaring NOTHING is not named a declarer",
-                FieldLine(aWinner, "Temporary") is { } t1b && !t1b.Contains("HcOcMid.esp", StringComparison.Ordinal),
-                FieldLine(aWinner, "Temporary"));
+            Check("CHEAP: the response states the not-read clause ONCE, and names the lane that answers precisely",
+                Occurrences(aWinner, ReadSentences.NotReadClause) == 1
+                && ReadSentences.NotReadClause.Contains("conflict_tree=true", StringComparison.Ordinal),
+                $"clause={Occurrences(aWinner, ReadSentences.NotReadClause)}");
+            Check("CHEAP: the cheap tier CANNOT read a body — its signature takes no overlay session",
+                typeof(LoadOrderService)
+                    .GetMethod("AnnotateOwnedChildContent", BindingFlags.NonPublic | BindingFlags.Static)!
+                    .GetParameters().All(x => x.ParameterType != typeof(LoadOrderResolver.OverlaySession)),
+                "AnnotateOwnedChildContent takes an OverlaySession — it can fetch bodies");
+
+            var cRead = Read(cellC);
+            Check("SOLE: a record only one plugin touches is not annotated at all",
+                FieldLine(cRead, "Temporary") is { } t5 && !t5.Contains(ReadSentences.NotRead, StringComparison.Ordinal),
+                FieldLine(cRead, "Temporary"));
+            var aNarrow = Read(cellA, fields: new[] { "EditorID" });
+            Check("UNREQUESTED: fields=[EditorID] carries no annotation and no clause",
+                !aNarrow.Contains(ReadSentences.NotRead, StringComparison.Ordinal)
+                && !aNarrow.Contains(ReadSentences.NotReadClause, StringComparison.Ordinal), Trim(aNarrow));
+            var weapRead = Read(weapon);
+            Check("NO-CHILDREN: a 3-toucher weapon read carries no annotation, and its field set is EMPTY",
+                weapRead.Contains("winner=HcOcTop.esp", StringComparison.Ordinal)
+                && !weapRead.Contains(ReadSentences.NotRead, StringComparison.Ordinal)
+                && FieldsOn(topDir, topKey, weapon).Count == 0, Trim(weapRead));
+
+            // ================= TIER 2 — the PRECISE answer, on the lane that already fetched the bodies =======
+            var aTree = ReadCt(cellA);
+            Check("PRECISE: conflict_tree names the declaring plugin instead of the cheap 'not read' note",
+                FieldLine(aTree, "Temporary") is { } p1
+                && p1.Contains(By(baseKey), StringComparison.Ordinal)
+                && !p1.Contains(ReadSentences.NotRead, StringComparison.Ordinal),
+                FieldLine(aTree, "Temporary"));
+            Check("PRECISE: a field NOBODY declares loses its note entirely — the cheap tier could not know that",
+                FieldLine(aTree, "NavigationMeshes") is { } p2
+                && !p2.Contains(ReadSentences.NotRead, StringComparison.Ordinal)
+                && !p2.Contains(ReadSentences.DeclaredBy, StringComparison.Ordinal),
+                FieldLine(aTree, "NavigationMeshes"));
+            Check("PRECISE: the plugin that touches the cell declaring NOTHING is not named a declarer",
+                FieldLine(aTree, "Temporary") is { } p3 && !p3.Contains("HcOcMid.esp", StringComparison.Ordinal),
+                FieldLine(aTree, "Temporary"));
+            Check("PRECISE: Persistent too — the annotation is per FIELD, not per record",
+                FieldLine(aTree, "Persistent") is { } p4 && p4.Contains(By(baseKey), StringComparison.Ordinal),
+                FieldLine(aTree, "Persistent"));
+
+            // ---- the two SHAPES say different things, because different things are true of them ----
+            Check("SINGULAR: Landscape is annotated with a COUNT, never a declarer name list",
+                FieldLine(aTree, "Landscape") is { } s1
+                && s1.Contains($"{ReadSentences.CarriedBy} 1 other plugin(s)", StringComparison.Ordinal)
+                && !s1.Contains(ReadSentences.DeclaredBy, StringComparison.Ordinal),
+                FieldLine(aTree, "Landscape"));
+            Check("SINGULAR: the response carries the singly-resolved clause for that shape",
+                Occurrences(aTree, ReadSentences.SingleResolved) == 1,
+                $"singular={Occurrences(aTree, ReadSentences.SingleResolved)}");
+            Check("COLLECTION: the response also carries the additive clause, once, for the list-shaped fields",
+                Occurrences(aTree, ReadSentences.MergeCollection) == 1,
+                $"collection={Occurrences(aTree, ReadSentences.MergeCollection)}");
+            Check("SHAPE: the classifier answers the two shapes off the TYPE, before any body is read",
+                ShapeOn(topDir, topKey, cellA, "Landscape") == OwnedChildShape.Singular
+                && ShapeOn(topDir, topKey, cellA, "Temporary") == OwnedChildShape.Collection
+                && ShapeOn(baseDir, baseKey, wrld, "TopCell") == OwnedChildShape.Singular
+                && ShapeOn(baseDir, baseKey, wrld, "SubCells") == OwnedChildShape.Collection,
+                $"Landscape={ShapeOn(topDir, topKey, cellA, "Landscape")} SubCells={ShapeOn(baseDir, baseKey, wrld, "SubCells")}");
+            var dOnly = ReadCt(cellD);
+            Check("SHAPE: a response with only COLLECTION fields annotated states only the additive clause",
+                Occurrences(dOnly, ReadSentences.MergeCollection) == 1
+                && Occurrences(dOnly, ReadSentences.SingleResolved) == 0,
+                $"collection={Occurrences(dOnly, ReadSentences.MergeCollection)} singular={Occurrences(dOnly, ReadSentences.SingleResolved)}");
 
             // ---- REACH-NOT-ELEMENT: empty block scaffolding is not a declaration of cells ----
-            var wsBase = Read(wrld, plugin: baseKey.FileName.String);
+            var wsBase = ReadCt(wrld, plugin: baseKey.FileName.String);
             Check("WRLD-SCAFFOLD: a worldspace declaring 2 EMPTY blocks is NOT named as declaring SubCells content",
                 FieldLine(wsBase, "SubCells") is { } w1 && !w1.Contains(ReadSentences.DeclaredBy, StringComparison.Ordinal),
                 FieldLine(wsBase, "SubCells"));
-            var wsWinner = Read(wrld);
+            var wsWinner = ReadCt(wrld);
             Check("…while the winner (2 empty blocks) IS annotated by the base's 1 block holding 3 real cells",
                 FieldLine(wsWinner, "SubCells") is { } w2 && w2.Contains(By(baseKey), StringComparison.Ordinal),
                 FieldLine(wsWinner, "SubCells"));
-            Check("REACH: DeclaresChild answers the CHILD question, not the element question, on both worldspace bodies",
+            Check("REACH: DeclaresChild answers the CHILD question, not the element question, on both bodies",
                 DeclaresOn(baseDir, baseKey, wrld, "SubCells") == true
                 && DeclaresOn(topDir, topKey, wrld, "SubCells") == false,
                 $"base={DeclaresOn(baseDir, baseKey, wrld, "SubCells")} top={DeclaresOn(topDir, topKey, wrld, "SubCells")}");
 
-            // ---- DISJOINT / EQUAL: the two shapes a count comparison stayed silent on ----
-            var bWinner = Read(cellB);
+            // ---- DISJOINT / EQUAL / SELF: the shapes a count comparison stayed silent on ----
+            var bTree = ReadCt(cellB);
             Check("DISJOINT: the winner declaring 4 of its OWN references is still annotated by the base's 1",
-                FieldLine(bWinner, "Temporary") is { } t3
+                FieldLine(bTree, "Temporary") is { } t3
                 && t3.Contains("4 item(s)", StringComparison.Ordinal) && t3.Contains(By(baseKey), StringComparison.Ordinal),
-                FieldLine(bWinner, "Temporary"));
-            var dWinner = Read(cellD);
+                FieldLine(bTree, "Temporary"));
             Check("EQUAL: one reference each side — both bodies declare, so the read is annotated",
-                FieldLine(dWinner, "Temporary") is { } t7 && t7.Contains(By(baseKey), StringComparison.Ordinal),
-                FieldLine(dWinner, "Temporary"));
-
-            // ---- SELF: the read body is never among its own "other plugins" ----
-            var eWinner = Read(cellE);
+                FieldLine(dOnly, "Temporary") is { } t7 && t7.Contains(By(baseKey), StringComparison.Ordinal),
+                FieldLine(dOnly, "Temporary"));
+            var eTree = ReadCt(cellE);
             Check("SELF: a body that is the ONLY declarer is not annotated, and never names itself",
-                FieldLine(eWinner, "Temporary") is { } t8
+                FieldLine(eTree, "Temporary") is { } t8
                 && t8.Contains("1 item(s)", StringComparison.Ordinal)
                 && !t8.Contains(ReadSentences.DeclaredBy, StringComparison.Ordinal),
-                FieldLine(eWinner, "Temporary"));
+                FieldLine(eTree, "Temporary"));
 
-            // ---- NOT-A-CELL / SOLE / UNREQUESTED / NO-CHILDREN ----
-            var topicRead = Read(topic);
+            var topicTree = ReadCt(topic);
             Check("NOT-A-CELL: DialogTopic.Responses is annotated (winner re-lists 1 of the base's 2)",
-                FieldLine(topicRead, "Responses") is { } r1 && r1.Contains(By(baseKey), StringComparison.Ordinal),
-                FieldLine(topicRead, "Responses"));
-            var cRead = Read(cellC);
-            Check("SOLE: a record only one plugin touches is not annotated",
-                FieldLine(cRead, "Temporary") is { } t5 && !t5.Contains(ReadSentences.DeclaredBy, StringComparison.Ordinal),
-                FieldLine(cRead, "Temporary"));
-            var aNarrow = Read(cellA, fields: new[] { "EditorID" });
-            Check("UNREQUESTED: fields=[EditorID] on the same cell carries no annotation and no response clause",
-                !aNarrow.Contains(ReadSentences.DeclaredBy, StringComparison.Ordinal)
-                && !aNarrow.Contains(ReadSentences.OwnedChildMerge, StringComparison.Ordinal), Trim(aNarrow));
-            var weapRead = Read(weapon);
-            Check("NO-CHILDREN: a 3-toucher weapon read carries no annotation, and its field set is EMPTY",
-                weapRead.Contains("winner=HcOcTop.esp", StringComparison.Ordinal)
-                && !weapRead.Contains(ReadSentences.DeclaredBy, StringComparison.Ordinal)
-                && FieldNamesOn(topDir, topKey, weapon).Count == 0, Trim(weapRead));
+                FieldLine(topicTree, "Responses") is { } r1 && r1.Contains(By(baseKey), StringComparison.Ordinal),
+                FieldLine(topicTree, "Responses"));
 
-            // ---- DEPTH ----
+            // ---- BY CONSTRUCTION: the getter -> concrete hop resolves for EVERY child-bearing type ----
+            var hopBad = new List<string>();
+            foreach (var t in typeof(Weapon).Assembly.GetTypes())
+            {
+                if (!t.IsClass || t.IsAbstract || t.Name.EndsWith("BinaryOverlay", StringComparison.Ordinal)) continue;
+                if (!typeof(Mutagen.Bethesda.Plugins.Records.IMajorRecord).IsAssignableFrom(t)) continue;
+                if (WriteEngine.ChildBearingProperties(t).Count == 0) continue;
+                var overlay = typeof(Weapon).Assembly.GetType(t.FullName + "BinaryOverlay");
+                if (overlay is null) { hopBad.Add($"{t.Name}: no overlay type to map from"); continue; }
+                var getter = WriteEngine.PrimaryGetter(overlay);
+                var back = getter is null ? null : WriteEngine.ConcreteOf(getter);
+                if (back != t) hopBad.Add($"{t.Name}: overlay maps to {back?.Name ?? "(null)"}");
+            }
+            Check("BY CONSTRUCTION: every concrete child-bearing type's overlay maps back to it (the hop the field set rides)",
+                hopBad.Count == 0, string.Join(" | ", hopBad));
+
+            // ---- DEPTH / TRANSPORTS ----
             var aDeep = Read(cellA, depth: 2);
             Check("DEPTH: at depth=2 the container's own summary line still carries the annotation",
-                FieldLine(aDeep, "Temporary") is { } t6 && t6.Contains(ReadSentences.DeclaredBy, StringComparison.Ordinal),
+                FieldLine(aDeep, "Temporary") is { } t6 && t6.Contains(ReadSentences.NotRead, StringComparison.Ordinal),
                 FieldLine(aDeep, "Temporary"));
-
-            // ---- RESPONSE-ONCE: the invariant clause is stated once, not per annotated field ----
-            Check("RESPONSE-ONCE (text): three annotated fields, ONE invariant clause in the response",
-                Occurrences(aWinner, ReadSentences.OwnedChildMerge) == 1
-                && Occurrences(aWinner, ReadSentences.DeclaredBy) == 3,
-                $"clause={Occurrences(aWinner, ReadSentences.OwnedChildMerge)} fields={Occurrences(aWinner, ReadSentences.DeclaredBy)}");
             var batch = ReadTools.BatchRecordDetail(svc, new[] { cellA.ToString(), cellB.ToString() });
-            Check("RESPONSE-ONCE (batch): two annotated records, still ONE invariant clause",
-                Occurrences(batch, ReadSentences.OwnedChildMerge) == 1, $"clause={Occurrences(batch, ReadSentences.OwnedChildMerge)}");
+            Check("RESPONSE-ONCE (batch): two annotated records, still ONE clause",
+                Occurrences(batch, ReadSentences.NotReadClause) == 1, $"clause={Occurrences(batch, ReadSentences.NotReadClause)}");
             var cleanBatch = ReadTools.BatchRecordDetail(svc, new[] { weapon.ToString() });
             Check("RESPONSE-ONCE: a response with nothing annotated carries NO clause",
-                Occurrences(cleanBatch, ReadSentences.OwnedChildMerge) == 0, Trim(cleanBatch));
+                Occurrences(cleanBatch, ReadSentences.NotReadClause) == 0, Trim(cleanBatch));
 
-            // ---- BOTH TRANSPORTS ----
             var aJson = Read(cellA, format: "json");
             string? jsonDisplay = null, jsonNote = null;
             using (var doc = JsonDocument.Parse(aJson))
@@ -302,18 +357,32 @@ public static class OwnedChildContentProbe
                         jsonDisplay = f.TryGetProperty("display", out var d) ? d.GetString() : null;
                         jsonNote = f.TryGetProperty("note", out var n) ? n.GetString() : null;
                     }
-                Check("JSON: the invariant clause is a response-level member, from the same source as text",
+                Check("JSON: the clause is a response-level member, from the same source as text",
                     doc.RootElement.TryGetProperty("owned_child_note", out var ocn)
-                    && ocn.GetString() == ReadSentences.OwnedChildMerge, "owned_child_note missing or drifted");
+                    && ocn.GetString() == ReadSentences.NotReadClause, "owned_child_note missing or drifted");
             }
-            Check("JSON: the per-field half rides `display`, naming the declarer",
-                jsonDisplay is not null && jsonDisplay.Contains(By(baseKey), StringComparison.Ordinal),
+            Check("JSON: the per-field half rides `display`",
+                jsonDisplay is not null && jsonDisplay.Contains(ReadSentences.NotRead, StringComparison.Ordinal),
                 jsonDisplay ?? "(no display)");
-            Check("TOKEN: the leaf's own note is unchanged on both lanes — the annotation never replaces the value half",
+            Check("TOKEN: the leaf's own note is unchanged on both lanes — the annotation never replaces the value",
                 jsonNote is not null && jsonNote.StartsWith("[list: 0 item(s)]", StringComparison.Ordinal)
                 && FieldLine(aWinner, "Temporary")!.StartsWith(
                        "Temporary = [list: 0 item(s)]" + ReadEngine.DepthExpandHint + "   (", StringComparison.Ordinal),
                 jsonNote ?? "(no note)");
+
+            // ---- ARTIFACTS: a to_file job carries the same tier its lane ran, clause IN the file ----
+            var artifact = Path.Combine(root, "cells.jsonl");
+            var inline = ReadTools.BatchRecordDetail(svc, new[] { cellA.ToString() }, to_file: artifact);
+            var fileText = File.ReadAllText(artifact);
+            // The manifest is JSON, and the writer escapes non-ASCII (an em-dash ships as —), so the clause is
+            // compared against the DECODED string values rather than the raw file text.
+            var fileDecoded = JsonStrings(File.ReadAllLines(artifact)[0]);
+            Check("ARTIFACT: the annotation reaches the FILE's rows, and its clause reaches the manifest",
+                fileText.Contains(ReadSentences.NotRead, StringComparison.Ordinal)
+                && fileDecoded.Contains(ReadSentences.NotReadClause, StringComparison.Ordinal),
+                $"note={fileText.Contains(ReadSentences.NotRead, StringComparison.Ordinal)} clause-in-manifest={fileDecoded.Contains(ReadSentences.NotReadClause, StringComparison.Ordinal)}");
+            Check("ARTIFACT: the manifest-only response does NOT state a clause over rows it did not render",
+                !inline.Contains(ReadSentences.NotReadClause, StringComparison.Ordinal), Trim(inline));
 
             // ---- UNREADABLE: a toucher whose body cannot be read is NAMED, not dropped ----
             CheckUnreadable(root, mods, baseDir, baseKey, topKey, cellA);
@@ -322,15 +391,22 @@ public static class OwnedChildContentProbe
             var sentenceBad = SentenceViolations();
             Check("SENTENCE: every ReadSentences const decides ([MustState] phrases or [NoClaims] with a reason) and states them",
                 sentenceBad.Count == 0, string.Join(" | ", sentenceBad));
-            var composed = ReadSentences.OwnedChildDeclarers(new[] { "A.esp", "B.esp", "C.esp", "D.esp" }, new[] { "E.esp" });
-            Check("SENTENCE: the composed per-field note is built from the SAME consts the net covers, and caps its names",
+            var composed = ReadSentences.DeclarersNote(OwnedChildShape.Collection,
+                new[] { "A.esp", "B.esp", "C.esp", "D.esp" }, new[] { "E.esp" });
+            Check("SENTENCE: the COLLECTION note is built from the consts the net covers, and caps its names",
                 composed is not null
                 && composed.Contains(ReadSentences.DeclaredBy, StringComparison.Ordinal)
                 && composed.Contains(ReadSentences.CouldNotRead, StringComparison.Ordinal)
                 && composed.Contains("(+1 more)", StringComparison.Ordinal)
                 && !composed.Contains("D.esp", StringComparison.Ordinal), composed ?? "(null)");
+            var singular = ReadSentences.DeclarersNote(OwnedChildShape.Singular,
+                new[] { "A.esp", "B.esp", "C.esp", "D.esp" }, Array.Empty<string>());
+            Check("SENTENCE: the SINGULAR note counts and never floods names — 484 declarers of a TopCell is noise",
+                singular is not null
+                && singular.Contains($"{ReadSentences.CarriedBy} 4 other plugin(s)", StringComparison.Ordinal)
+                && !singular.Contains("A.esp", StringComparison.Ordinal), singular ?? "(null)");
             Check("SENTENCE: nothing to say → null, so the caller has ONE place to decide",
-                ReadSentences.OwnedChildDeclarers(Array.Empty<string>(), Array.Empty<string>()) is null);
+                ReadSentences.DeclarersNote(OwnedChildShape.Collection, Array.Empty<string>(), Array.Empty<string>()) is null);
 
             Console.WriteLine();
             Console.WriteLine($"=== owned-child-content-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
@@ -372,7 +448,7 @@ public static class OwnedChildContentProbe
 
         using var svc = LoadOrderService.WithInstance(inst2, 0, new UserConfigStore(Path.Combine(root, "unreadable.user.json")));
         svc.Stats();                                                   // index built off the INTACT files
-        var before = ReadTools.ReadRecord(svc, cellA.ToString());
+        var before = ReadTools.ReadRecord(svc, cellA.ToString(), null, null, 1, true);   // precise lane — declarer naming lives there
         bool intact = FieldLine(before, "Temporary") is { } l
                       && l.Contains($"{ReadSentences.DeclaredBy} {baseKey.FileName}", StringComparison.Ordinal);
         Check("UNREADABLE: the fixture's intact read names the declarer (so the corrupted read has something to lose)",
@@ -381,7 +457,7 @@ public static class OwnedChildContentProbe
         // Corrupt the declaring plugin AFTER the index knows it touches the record, then read again.
         File.WriteAllBytes(Path.Combine(mods2, "BaseMod", baseKey.FileName.String), new byte[] { 0x00, 0x01, 0x02, 0x03 });
         string after;
-        try { after = ReadTools.ReadRecord(svc, cellA.ToString()); }
+        try { after = ReadTools.ReadRecord(svc, cellA.ToString(), null, null, 1, true); }
         catch (Exception ex) { after = "THREW " + ex.GetType().Name + ": " + ex.Message; }
         var line = FieldLine(after, "Temporary");
         var stats = svc.Stats();
@@ -417,11 +493,20 @@ public static class OwnedChildContentProbe
         return body is null ? null : OwnedChildContent.DeclaresChild(body, field);
     }
 
-    static IReadOnlyList<string> FieldNamesOn(string dir, ModKey key, FormKey fk)
+    static IReadOnlyDictionary<string, OwnedChildShape> FieldsOn(string dir, ModKey key, FormKey fk)
     {
         using var ov = SkyrimMod.CreateFromBinaryOverlay(Path.Combine(dir, key.FileName.String), SkyrimRelease.SkyrimSE);
         var body = ov.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == fk);
-        return body is null ? Array.Empty<string>() : OwnedChildContent.FieldNames(body);
+        return body is null ? new Dictionary<string, OwnedChildShape>() : OwnedChildContent.Fields(body);
+    }
+
+    /// <summary>The SHAPE the classifier gives one field — asked off a body, answered off its TYPE, so the two
+    /// sentence arms are chosen by structure rather than by a name list.</summary>
+    static OwnedChildShape ShapeOn(string dir, ModKey key, FormKey fk, string field)
+    {
+        using var ov = SkyrimMod.CreateFromBinaryOverlay(Path.Combine(dir, key.FileName.String), SkyrimRelease.SkyrimSE);
+        var body = ov.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == fk);
+        return body is null ? OwnedChildShape.None : OwnedChildContent.ShapeOf(body, field);
     }
 
     /// <summary>The rendered line for one field path, trimmed — the text lane's "  Path = value   (annotation)".</summary>
@@ -433,6 +518,25 @@ public static class OwnedChildContentProbe
             if (t.StartsWith(path + " = ", StringComparison.Ordinal)) return t;
         }
         return null;
+    }
+
+    /// <summary>Every string VALUE in a json document, concatenated — the write guard's own idiom, because the
+    /// writer escapes non-ASCII and a raw Contains would fail for the encoder's reasons, not the render's.</summary>
+    static string JsonStrings(string json)
+    {
+        var sb = new System.Text.StringBuilder();
+        void Walk(JsonElement e)
+        {
+            switch (e.ValueKind)
+            {
+                case JsonValueKind.String: sb.Append(e.GetString()).Append('\n'); break;
+                case JsonValueKind.Object: foreach (var p in e.EnumerateObject()) Walk(p.Value); break;
+                case JsonValueKind.Array: foreach (var v in e.EnumerateArray()) Walk(v); break;
+            }
+        }
+        using var doc = JsonDocument.Parse(json);
+        Walk(doc.RootElement);
+        return sb.ToString();
     }
 
     static int Occurrences(string haystack, string needle)

--- a/src/housecarl-generator/OwnedChildContentProbe.cs
+++ b/src/housecarl-generator/OwnedChildContentProbe.cs
@@ -1,0 +1,324 @@
+using System.Reflection;
+using System.Text.Json;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// #342 stage 1 — GUARD for the owned-child content annotation, over a synthetic MO2 instance driven through the
+/// REAL read tool (<c>housecarl_read_record</c>, both transports).
+///
+/// The bug: a parent's child records — placed references under a cell, INFOs under a topic — are declared per
+/// plugin and assembled by the game from every plugin that declares them. An override that touches the parent for
+/// an unrelated reason carries none and deletes none, so reading the winner reports an empty cell the game fills.
+/// Reproduced on a real order at <c>008EB5:Skyrim.esm</c>: winner Temporary 0, <c>Skyrim.esm</c>'s own body 201.
+///
+/// The fixture reproduces that shape and its neighbours, so every branch of the trigger has an arm:
+///   FALSE-EMPTY  — the winner touches cell A carrying no children; a lower plugin declares 3 Temporary,
+///                  1 Persistent and a Landscape. The annotation fires on each, naming the count and the plugin.
+///                  The pre-fix hazard is asserted first (the winner really does read 0) — a fixture that stopped
+///                  exhibiting it would make every arm below vacuous.
+///   SINGULAR     — Cell.Landscape is a SINGULAR owned child, not a list; present/absent is its count.
+///   NOT-A-CELL   — the same annotation on DialogTopic.Responses, because the field set is
+///                  <see cref="OwnedChildContent.FieldNames"/> over the write surface's pinned authority, never a
+///                  hand list of cell fields.
+///   WINNER-WINS  — cell B's winner declares MORE than the plugin below it: no annotation (the trigger is "another
+///                  body declares more", not "more than one plugin touches this").
+///   SOLE         — cell C is declared by one plugin: no annotation, no walk.
+///   UNREQUESTED  — fields=[EditorID] on cell A: no annotation (the walk is gated on the read's own field lines).
+///   NO-CHILDREN  — a weapon with three touchers: no annotation, and the field set for its type is EMPTY, which is
+///                  what makes this free on every read that is not one of the three owning types.
+///   OTHER-NOT-LOWER — a plugin=-scoped read of the BASE's cell B, where a HIGHER plugin declares more. The
+///                  additive assembly is over the whole touching set, so the workaround this bug's reporter reached
+///                  for is annotated too.
+///   TOKEN        — the annotation is display-only: the field's round-trip token/note is byte-identical to what it
+///                  was, on both transports.
+///   SENTENCE     — the content net over <see cref="ReadSentences"/>: every const decides ([MustState] phrases or
+///                  [NoClaims] with a reason) and still states the phrases it declares.
+///
+/// Run: <c>dotnet run --project src/housecarl-generator -- owned-child-content-guard</c>
+/// </summary>
+public static class OwnedChildContentProbe
+{
+    static int _pass, _fail;
+
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  #342 stage 1 — owned-child content annotation  ################");
+        Console.WriteLine();
+        _pass = _fail = 0;
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-owned-child-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            string instance = Path.Combine(root, "instance");
+            string profiles = Path.Combine(instance, "profiles", "Default");
+            string mods = Path.Combine(instance, "mods");
+            foreach (var d in new[] { profiles, mods, Path.Combine(root, "game", "Data") }) Directory.CreateDirectory(d);
+            File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+                "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                + Path.Combine(root, "game").Replace(@"\", @"\\") + ")\r\n");
+
+            // ---- BASE: the plugin that declares the children (Skyrim.esm's role in the report) ----
+            var baseKey = new ModKey("HcOcBase", ModType.Master);
+            var cellA = new FormKey(baseKey, 0xC01);      // the false-empty cell
+            var cellB = new FormKey(baseKey, 0xC02);      // the winner-declares-more cell
+            var cellC = new FormKey(baseKey, 0xC03);      // declared by exactly one plugin
+            var topic = new FormKey(baseKey, 0xD01);
+            var weapon = new FormKey(baseKey, 0xE01);
+            var baseDir = Path.Combine(mods, "BaseMod"); Directory.CreateDirectory(baseDir);
+            {
+                var m = new SkyrimMod(baseKey, SkyrimRelease.SkyrimSE);
+                var a = new Cell(cellA, SkyrimRelease.SkyrimSE) { EditorID = "HcOcCellA", Flags = Cell.Flag.IsInteriorCell };
+                for (int i = 0; i < 3; i++)
+                    a.Temporary.Add(new PlacedObject(new FormKey(baseKey, (uint)(0xC10 + i)), SkyrimRelease.SkyrimSE) { EditorID = $"HcOcTemp{i}" });
+                a.Persistent.Add(new PlacedObject(new FormKey(baseKey, 0xC1A), SkyrimRelease.SkyrimSE) { EditorID = "HcOcPers0" });
+                a.Landscape = new Landscape(new FormKey(baseKey, 0xC1B), SkyrimRelease.SkyrimSE) { EditorID = "HcOcLand" };
+                FileInterior(m, a);
+
+                var b = new Cell(cellB, SkyrimRelease.SkyrimSE) { EditorID = "HcOcCellB", Flags = Cell.Flag.IsInteriorCell };
+                b.Temporary.Add(new PlacedObject(new FormKey(baseKey, 0xC20), SkyrimRelease.SkyrimSE) { EditorID = "HcOcBTemp0" });
+                FileInterior(m, b);
+
+                var c = new Cell(cellC, SkyrimRelease.SkyrimSE) { EditorID = "HcOcCellC", Flags = Cell.Flag.IsInteriorCell };
+                c.Temporary.Add(new PlacedObject(new FormKey(baseKey, 0xC30), SkyrimRelease.SkyrimSE) { EditorID = "HcOcCTemp0" });
+                FileInterior(m, c);
+
+                var t = new DialogTopic(topic, SkyrimRelease.SkyrimSE) { EditorID = "HcOcTopic" };
+                for (int i = 0; i < 2; i++)
+                {
+                    var info = new DialogResponses(new FormKey(baseKey, (uint)(0xD10 + i)), SkyrimRelease.SkyrimSE);
+                    info.Responses.Add(new DialogResponse { Text = $"base line {i}" });
+                    t.Responses.Add(info);
+                }
+                m.DialogTopics.Add(t);
+
+                m.Weapons.Add(new Weapon(weapon, SkyrimRelease.SkyrimSE)
+                    { EditorID = "HcOcWeap", BasicStats = new WeaponBasicStats { Damage = 5 } });
+                m.BeginWrite.ToPath(Path.Combine(baseDir, baseKey.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            }
+
+            // ---- MID: a second toucher of cell A that also declares no children (so "other plugins" is a count,
+            //      not a synonym for "the master") ----
+            var midKey = new ModKey("HcOcMid", ModType.Plugin);
+            var midDir = Path.Combine(mods, "MidMod"); Directory.CreateDirectory(midDir);
+            {
+                using var baseOv = SkyrimMod.CreateFromBinaryOverlay(Path.Combine(baseDir, baseKey.FileName.String), SkyrimRelease.SkyrimSE);
+                var m = new SkyrimMod(midKey, SkyrimRelease.SkyrimSE);
+                FileInterior(m, new Cell(cellA, SkyrimRelease.SkyrimSE) { EditorID = "HcOcCellA", Flags = Cell.Flag.IsInteriorCell });
+                m.Weapons.GetOrAddAsOverride(baseOv.Weapons.First(w => w.FormKey == weapon)).BasicStats!.Damage = 7;
+                m.BeginWrite.ToPath(Path.Combine(midDir, midKey.FileName.String)).WithLoadOrder(new ISkyrimModGetter[] { baseOv }).Write();
+            }
+
+            // ---- TOP (the winner): the Occlusion.esp shape on cell A — touches the cell, carries no children.
+            //      On cell B it declares MORE than the base. On the topic it re-lists one INFO of two. ----
+            var topKey = new ModKey("HcOcTop", ModType.Plugin);
+            var topDir = Path.Combine(mods, "TopMod"); Directory.CreateDirectory(topDir);
+            {
+                using var baseOv = SkyrimMod.CreateFromBinaryOverlay(Path.Combine(baseDir, baseKey.FileName.String), SkyrimRelease.SkyrimSE);
+                var m = new SkyrimMod(topKey, SkyrimRelease.SkyrimSE);
+                FileInterior(m, new Cell(cellA, SkyrimRelease.SkyrimSE) { EditorID = "HcOcCellA", Flags = Cell.Flag.IsInteriorCell });
+
+                var b = new Cell(cellB, SkyrimRelease.SkyrimSE) { EditorID = "HcOcCellB", Flags = Cell.Flag.IsInteriorCell };
+                for (int i = 0; i < 4; i++)
+                    b.Temporary.Add(new PlacedObject(new FormKey(topKey, (uint)(0xB10 + i)), SkyrimRelease.SkyrimSE) { EditorID = $"HcOcTopTemp{i}" });
+                FileInterior(m, b);
+
+                var t = new DialogTopic(topic, SkyrimRelease.SkyrimSE) { EditorID = "HcOcTopic" };
+                var only = new DialogResponses(new FormKey(baseKey, 0xD10), SkyrimRelease.SkyrimSE);
+                only.Responses.Add(new DialogResponse { Text = "patched line 0" });
+                t.Responses.Add(only);
+                m.DialogTopics.Add(t);
+
+                m.Weapons.GetOrAddAsOverride(baseOv.Weapons.First(w => w.FormKey == weapon)).BasicStats!.Damage = 9;
+                m.BeginWrite.ToPath(Path.Combine(topDir, topKey.FileName.String)).WithLoadOrder(new ISkyrimModGetter[] { baseOv }).Write();
+            }
+
+            File.WriteAllText(Path.Combine(profiles, "loadorder.txt"),
+                "# header\r\n" + string.Join("\r\n", baseKey.FileName, midKey.FileName, topKey.FileName) + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "plugins.txt"),
+                string.Join("\r\n", "*" + baseKey.FileName, "*" + midKey.FileName, "*" + topKey.FileName) + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "modlist.txt"),
+                "# header\r\n" + string.Join("\r\n", "+TopMod", "+MidMod", "+BaseMod") + "\r\n");
+
+            using var svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(root, "houseCARL.user.json")));
+            svc.Stats();
+
+            string Read(FormKey fk, string? plugin = null, string[]? fields = null, int depth = 1, string? format = null)
+                => ReadTools.ReadRecord(svc, fk.ToString(), plugin, fields, depth, false, false, format);
+
+            // ---- the pre-fix hazard, asserted before anything is claimed about the annotation ----
+            var aWinner = Read(cellA);
+            Check("FIXTURE exhibits the bug: the winner's own Temporary reads EMPTY on a cell the base fills",
+                aWinner.Contains("winner=HcOcTop.esp", StringComparison.Ordinal)
+                && FieldLine(aWinner, "Temporary") is { } tw && tw.Contains("0 item(s)", StringComparison.Ordinal),
+                FieldLine(aWinner, "Temporary"));
+            var aBase = Read(cellA, plugin: baseKey.FileName.String);
+            Check("…and the base's own body carries 3 — the count the winner does not show",
+                FieldLine(aBase, "Temporary") is { } tb && tb.Contains("3 item(s)", StringComparison.Ordinal),
+                FieldLine(aBase, "Temporary"));
+
+            // ---- FALSE-EMPTY: the annotation on each of the three fields the base declares ----
+            Check("Temporary is annotated: 1 other plugin declares content, most 3, named",
+                FieldLine(aWinner, "Temporary") is { } t1
+                && t1.Contains("1 other plugin(s) touching this record also declare Temporary content", StringComparison.Ordinal)
+                && t1.Contains("(most: 3 in HcOcBase.esm)", StringComparison.Ordinal)
+                && t1.Contains(ReadSentences.OwnedChildMerge, StringComparison.Ordinal),
+                FieldLine(aWinner, "Temporary"));
+            Check("Persistent is annotated too (most: 1) — the annotation is per FIELD, not per record",
+                FieldLine(aWinner, "Persistent") is { } p1
+                && p1.Contains("also declare Persistent content", StringComparison.Ordinal)
+                && p1.Contains("(most: 1 in HcOcBase.esm)", StringComparison.Ordinal),
+                FieldLine(aWinner, "Persistent"));
+            // SINGULAR: Landscape holds ONE owned child record, not a list — present/absent is its count.
+            Check("SINGULAR: Landscape is annotated (most: 1) — a singular owned child, not a list",
+                FieldLine(aWinner, "Landscape") is { } l1
+                && l1.Contains("also declare Landscape content", StringComparison.Ordinal)
+                && l1.Contains("(most: 1 in HcOcBase.esm)", StringComparison.Ordinal),
+                FieldLine(aWinner, "Landscape"));
+            Check("NavigationMeshes — an owning field NOBODY declares — is NOT annotated",
+                FieldLine(aWinner, "NavigationMeshes") is { } n1 && !n1.Contains("also declare", StringComparison.Ordinal),
+                FieldLine(aWinner, "NavigationMeshes"));
+
+            // ---- TOKEN: display-only. The value half of the line is exactly what it was before the annotation. ----
+            Check("TOKEN: the annotated line still carries the leaf's own unchanged summary, annotation appended after it",
+                FieldLine(aWinner, "Temporary") is { } t2
+                && t2.StartsWith("Temporary = [list: 0 item(s)]" + ReadEngine.DepthExpandHint + "   (", StringComparison.Ordinal),
+                FieldLine(aWinner, "Temporary"));
+
+            // ---- NOT-A-CELL: the same annotation on a topic's INFOs (the field set is the pinned authority) ----
+            var topicRead = Read(topic);
+            Check("NOT-A-CELL: DialogTopic.Responses is annotated (winner re-lists 1 of the base's 2)",
+                FieldLine(topicRead, "Responses") is { } r1
+                && r1.Contains("also declare Responses content", StringComparison.Ordinal)
+                && r1.Contains("(most: 2 in HcOcBase.esm)", StringComparison.Ordinal),
+                FieldLine(topicRead, "Responses"));
+
+            // ---- WINNER-WINS: cell B's winner declares MORE than the plugin below it ----
+            var bWinner = Read(cellB);
+            Check("WINNER-WINS: no annotation when the read body declares the most (4 vs the base's 1)",
+                FieldLine(bWinner, "Temporary") is { } t3
+                && t3.Contains("4 item(s)", StringComparison.Ordinal)
+                && !t3.Contains("also declare", StringComparison.Ordinal),
+                FieldLine(bWinner, "Temporary"));
+
+            // ---- OTHER-NOT-LOWER: the plugin=-scoped read of the base sees the HIGHER plugin's declaration ----
+            var bBase = Read(cellB, plugin: baseKey.FileName.String);
+            Check("OTHER-NOT-LOWER: a plugin=-scoped read is annotated by a HIGHER plugin's declaration (most: 4 in HcOcTop.esp)",
+                FieldLine(bBase, "Temporary") is { } t4
+                && t4.Contains("also declare Temporary content", StringComparison.Ordinal)
+                && t4.Contains("(most: 4 in HcOcTop.esp)", StringComparison.Ordinal),
+                FieldLine(bBase, "Temporary"));
+
+            // ---- SOLE: one declarer, nothing to compare against ----
+            var cRead = Read(cellC);
+            Check("SOLE: a record only one plugin touches is not annotated",
+                FieldLine(cRead, "Temporary") is { } t5 && !t5.Contains("also declare", StringComparison.Ordinal),
+                FieldLine(cRead, "Temporary"));
+
+            // ---- UNREQUESTED: the walk is gated on the read's own field lines ----
+            var aNarrow = Read(cellA, fields: new[] { "EditorID" });
+            Check("UNREQUESTED: fields=[EditorID] on the same cell carries no annotation",
+                !aNarrow.Contains("also declare", StringComparison.Ordinal), Trim(aNarrow));
+
+            // ---- NO-CHILDREN: the type that owns nothing — the free path ----
+            var weapRead = Read(weapon);
+            Check("NO-CHILDREN: a 3-toucher weapon read carries no annotation",
+                weapRead.Contains("winner=HcOcTop.esp", StringComparison.Ordinal)
+                && !weapRead.Contains("also declare", StringComparison.Ordinal), Trim(weapRead));
+
+            // ---- DEPTH: the summary line still carries it when the container is expanded ----
+            var aDeep = Read(cellA, depth: 2);
+            Check("DEPTH: at depth=2 the container's own summary line still carries the annotation",
+                FieldLine(aDeep, "Temporary") is { } t6 && t6.Contains("also declare Temporary content", StringComparison.Ordinal),
+                FieldLine(aDeep, "Temporary"));
+
+            // ---- BOTH TRANSPORTS: one carrier (FieldValue.Display) — json states it as `display`, token untouched ----
+            var aJson = Read(cellA, format: "json");
+            string? jsonDisplay = null, jsonNote = null;
+            using (var doc = JsonDocument.Parse(aJson))
+                foreach (var f in doc.RootElement.GetProperty("fields").EnumerateArray())
+                    if (f.GetProperty("path").GetString() == "Temporary")
+                    {
+                        jsonDisplay = f.TryGetProperty("display", out var d) ? d.GetString() : null;
+                        jsonNote = f.TryGetProperty("note", out var n) ? n.GetString() : null;
+                    }
+            Check("JSON: the same sentence rides the json lane's `display`, from the same source",
+                jsonDisplay is not null && jsonDisplay.Contains(ReadSentences.OwnedChildMerge, StringComparison.Ordinal)
+                && jsonDisplay.Contains("(most: 3 in HcOcBase.esm)", StringComparison.Ordinal), jsonDisplay ?? "(no display)");
+            Check("JSON: the leaf's own note is unchanged — the annotation never replaces the value half",
+                jsonNote is not null && jsonNote.StartsWith("[list: 0 item(s)]", StringComparison.Ordinal), jsonNote ?? "(no note)");
+
+            // ---- SENTENCE: the content net over ReadSentences ----
+            var sentenceBad = SentenceViolations();
+            Check("SENTENCE: every ReadSentences const decides ([MustState] phrases or [NoClaims] with a reason) and states them",
+                sentenceBad.Count == 0, string.Join(" | ", sentenceBad));
+
+            Console.WriteLine();
+            Console.WriteLine($"=== owned-child-content-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
+            return _fail == 0 ? 0 : 1;
+        }
+        catch (Exception ex) { Console.WriteLine($"   FAIL (unexpected): {ex.GetType().Name}: {ex.Message}"); return 1; }
+        finally { try { Directory.Delete(root, recursive: true); } catch { } }
+    }
+
+    /// <summary>The rendered line for one field path, trimmed — the text lane's "  Path = value   (annotation)".</summary>
+    static string? FieldLine(string render, string path)
+    {
+        foreach (var line in render.Split('\n'))
+        {
+            var t = line.Trim();
+            if (t.StartsWith(path + " = ", StringComparison.Ordinal)) return t;
+        }
+        return null;
+    }
+
+    /// <summary>The content half of the response-layer net, over <see cref="ReadSentences"/>: every const must
+    /// DECIDE — declared phrases, or a stated reason there are none — and a sentence that declares a phrase must
+    /// still contain it. The write surface's own arm is the model; this owner is the read surface's, and an
+    /// undecorated const FAILS by name rather than passing in silence.</summary>
+    static List<string> SentenceViolations()
+    {
+        var bad = new List<string>();
+        foreach (var f in typeof(ReadSentences).GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static))
+        {
+            if (!f.IsLiteral || f.FieldType != typeof(string)) { bad.Add($"{f.Name}: not a string const (unreadable to this net)"); continue; }
+            var text = (string?)f.GetRawConstantValue() ?? "";
+            var must = f.GetCustomAttribute<MustStateAttribute>();
+            var none = f.GetCustomAttribute<NoClaimsAttribute>();
+            if (must is not null && none is not null) { bad.Add($"{f.Name}: declares BOTH [MustState] and [NoClaims] — pick one"); continue; }
+            if (must is null && none is null) { bad.Add($"{f.Name}: declares neither [MustState] phrases nor [NoClaims] with a reason"); continue; }
+            if (none is not null && none.Reason.Trim().Length == 0) bad.Add($"{f.Name}: [NoClaims] with no stated reason");
+            foreach (var phrase in must?.Phrases ?? Array.Empty<string>())
+                if (!text.Contains(phrase, StringComparison.Ordinal)) bad.Add($"{f.Name}: no longer states \"{phrase}\"");
+        }
+        return bad;
+    }
+
+    /// <summary>File an interior cell into its block/sub-block (Mutagen writes cells through the group tree, not a
+    /// flat list) — the merge guard's helper, same arithmetic.</summary>
+    static void FileInterior(SkyrimMod mod, Cell cell)
+    {
+        uint id = cell.FormKey.ID;
+        int blockN = (int)(id % 10), subN = (int)((id / 10) % 10);
+        var records = mod.Cells.Records;
+        var block = records.FirstOrDefault(b => b.BlockNumber == blockN);
+        if (block is null) { block = new CellBlock { BlockNumber = blockN, GroupType = GroupTypeEnum.InteriorCellBlock }; records.Add(block); }
+        var sub = block.SubBlocks.FirstOrDefault(s => s.BlockNumber == subN);
+        if (sub is null) { sub = new CellSubBlock { BlockNumber = subN, GroupType = GroupTypeEnum.InteriorCellSubBlock }; block.SubBlocks.Add(sub); }
+        sub.Cells.Add(cell);
+    }
+
+    static string Trim(string s) => s.Length <= 300 ? s.Replace('\n', '|') : s[..300].Replace('\n', '|') + "…";
+
+    static void Check(string label, bool ok, string? detail = null)
+    {
+        Console.WriteLine($"   [{(ok ? "PASS" : "FAIL")}] {label}");
+        if (ok) _pass++;
+        else { _fail++; if (detail is not null) Console.WriteLine($"          got: {detail}"); }
+    }
+}

--- a/src/housecarl-generator/OwnedChildContentProbe.cs
+++ b/src/housecarl-generator/OwnedChildContentProbe.cs
@@ -218,9 +218,24 @@ public static class OwnedChildContentProbe
                 FieldLine(aWinner, "NavigationMeshes") is { } c2 && c2.Contains(ReadSentences.NotRead, StringComparison.Ordinal),
                 FieldLine(aWinner, "NavigationMeshes"));
             Check("CHEAP: the response states the not-read clause ONCE, and names the lane that answers precisely",
-                Occurrences(aWinner, ReadSentences.NotReadClause) == 1
-                && ReadSentences.NotReadClause.Contains("conflict_tree=true", StringComparison.Ordinal),
-                $"clause={Occurrences(aWinner, ReadSentences.NotReadClause)}");
+                Occurrences(aWinner, ClauseHead(ReadSentences.NotReadFraming)) == 1
+                && ClauseLine(aWinner, ReadSentences.NotReadFraming) is { } cc
+                && cc.Contains("conflict_tree=true", StringComparison.Ordinal),
+                $"clause={Occurrences(aWinner, ClauseHead(ReadSentences.NotReadFraming))}");
+            // The clause NAMES its fields rather than pointing at them — the fix for a positional claim three
+            // transports independently falsified (manifest line 1, json's second key, a truncated field loop).
+            Check("CLAUSE-NAMES: the clause names the annotated fields, and points at no position at all",
+                ClauseLine(aWinner, ReadSentences.NotReadFraming) is { } cn
+                && cn.Contains("Temporary", StringComparison.Ordinal)
+                && cn.Contains("Persistent", StringComparison.Ordinal)
+                && !cn.Contains("above", StringComparison.OrdinalIgnoreCase)
+                && !cn.Contains("below", StringComparison.OrdinalIgnoreCase),
+                ClauseLine(aWinner, ReadSentences.NotReadFraming) ?? "(no clause)");
+            Check("CLAUSE-NAMES: the names are DERIVED — every field named is one the response annotated",
+                ClauseLine(aWinner, ReadSentences.NotReadFraming) is { } cd
+                && NamedFields(cd, ReadSentences.NotReadFraming).All(f => FieldLine(aWinner, f) is { } fl
+                                                                          && fl.Contains(ReadSentences.NotRead, StringComparison.Ordinal)),
+                ClauseLine(aWinner, ReadSentences.NotReadFraming) ?? "(no clause)");
             Check("CHEAP: the cheap tier CANNOT read a body — its signature takes no overlay session",
                 typeof(LoadOrderService)
                     .GetMethod("AnnotateOwnedChildContent", BindingFlags.NonPublic | BindingFlags.Static)!
@@ -234,7 +249,7 @@ public static class OwnedChildContentProbe
             var aNarrow = Read(cellA, fields: new[] { "EditorID" });
             Check("UNREQUESTED: fields=[EditorID] carries no annotation and no clause",
                 !aNarrow.Contains(ReadSentences.NotRead, StringComparison.Ordinal)
-                && !aNarrow.Contains(ReadSentences.NotReadClause, StringComparison.Ordinal), Trim(aNarrow));
+                && ClauseLine(aNarrow, ReadSentences.NotReadFraming) is null, Trim(aNarrow));
             var weapRead = Read(weapon);
             Check("NO-CHILDREN: a 3-toucher weapon read carries no annotation, and its field set is EMPTY",
                 weapRead.Contains("winner=HcOcTop.esp", StringComparison.Ordinal)
@@ -266,12 +281,24 @@ public static class OwnedChildContentProbe
                 && s1.Contains($"{ReadSentences.CarriedBy} 1 other plugin(s)", StringComparison.Ordinal)
                 && !s1.Contains(ReadSentences.DeclaredBy, StringComparison.Ordinal),
                 FieldLine(aTree, "Landscape"));
-            Check("SINGULAR: the response carries the singly-resolved clause for that shape",
-                Occurrences(aTree, ReadSentences.SingleResolved) == 1,
-                $"singular={Occurrences(aTree, ReadSentences.SingleResolved)}");
-            Check("COLLECTION: the response also carries the additive clause, once, for the list-shaped fields",
-                Occurrences(aTree, ReadSentences.MergeCollection) == 1,
-                $"collection={Occurrences(aTree, ReadSentences.MergeCollection)}");
+            Check("SINGULAR: the response carries the singly-resolved clause for that shape, naming its field",
+                Occurrences(aTree, ClauseHead(ReadSentences.SingleResolvedFraming)) == 1
+                && ClauseLine(aTree, ReadSentences.SingleResolvedFraming) is { } sc
+                && NamedFields(sc, ReadSentences.SingleResolvedFraming).SequenceEqual(new[] { "Landscape" }),
+                ClauseLine(aTree, ReadSentences.SingleResolvedFraming) ?? "(no singular clause)");
+            Check("COLLECTION: the response also carries the additive clause, once, naming the list-shaped fields",
+                Occurrences(aTree, ClauseHead(ReadSentences.MergeCollectionFraming)) == 1
+                && ClauseLine(aTree, ReadSentences.MergeCollectionFraming) is { } mc
+                && NamedFields(mc, ReadSentences.MergeCollectionFraming).SequenceEqual(new[] { "Persistent", "Temporary" }),
+                ClauseLine(aTree, ReadSentences.MergeCollectionFraming) ?? "(no collection clause)");
+            // FINDING 5 — the flagship: a winner carrying NOTHING, beside plugins that declare. "also declared by"
+            // asserted that this body declares too, which is false in exactly the case the feature exists for.
+            Check("LABEL: on a winner carrying 0 items the declarer label does NOT assert this body declares too",
+                FieldLine(aTree, "Temporary") is { } fs
+                && fs.Contains("0 item(s)", StringComparison.Ordinal)
+                && fs.Contains(By(baseKey), StringComparison.Ordinal)
+                && !fs.Contains("also ", StringComparison.OrdinalIgnoreCase),
+                FieldLine(aTree, "Temporary"));
             Check("SHAPE: the classifier answers the two shapes off the TYPE, before any body is read",
                 ShapeOn(topDir, topKey, cellA, "Landscape") == OwnedChildShape.Singular
                 && ShapeOn(topDir, topKey, cellA, "Temporary") == OwnedChildShape.Collection
@@ -280,9 +307,10 @@ public static class OwnedChildContentProbe
                 $"Landscape={ShapeOn(topDir, topKey, cellA, "Landscape")} SubCells={ShapeOn(baseDir, baseKey, wrld, "SubCells")}");
             var dOnly = ReadCt(cellD);
             Check("SHAPE: a response with only COLLECTION fields annotated states only the additive clause",
-                Occurrences(dOnly, ReadSentences.MergeCollection) == 1
-                && Occurrences(dOnly, ReadSentences.SingleResolved) == 0,
-                $"collection={Occurrences(dOnly, ReadSentences.MergeCollection)} singular={Occurrences(dOnly, ReadSentences.SingleResolved)}");
+                Occurrences(dOnly, ClauseHead(ReadSentences.MergeCollectionFraming)) == 1
+                && Occurrences(dOnly, ClauseHead(ReadSentences.SingleResolvedFraming)) == 0,
+                $"collection={Occurrences(dOnly, ClauseHead(ReadSentences.MergeCollectionFraming))} "
+                + $"singular={Occurrences(dOnly, ClauseHead(ReadSentences.SingleResolvedFraming))}");
 
             // ---- REACH-NOT-ELEMENT: empty block scaffolding is not a declaration of cells ----
             var wsBase = ReadCt(wrld, plugin: baseKey.FileName.String);
@@ -342,10 +370,57 @@ public static class OwnedChildContentProbe
                 FieldLine(aDeep, "Temporary"));
             var batch = ReadTools.BatchRecordDetail(svc, new[] { cellA.ToString(), cellB.ToString() });
             Check("RESPONSE-ONCE (batch): two annotated records, still ONE clause",
-                Occurrences(batch, ReadSentences.NotReadClause) == 1, $"clause={Occurrences(batch, ReadSentences.NotReadClause)}");
+                Occurrences(batch, ClauseHead(ReadSentences.NotReadFraming)) == 1,
+                $"clause={Occurrences(batch, ClauseHead(ReadSentences.NotReadFraming))}");
             var cleanBatch = ReadTools.BatchRecordDetail(svc, new[] { weapon.ToString() });
             Check("RESPONSE-ONCE: a response with nothing annotated carries NO clause",
-                Occurrences(cleanBatch, ReadSentences.NotReadClause) == 0, Trim(cleanBatch));
+                Occurrences(cleanBatch, ClauseHead(ReadSentences.NotReadFraming)) == 0, Trim(cleanBatch));
+
+            // ---- EMISSION (text): the clause is earned by a field LINE, not by the decision to annotate ----
+            // A cap that stops the field loop before the annotated field leaves a clause describing something the
+            // caller cannot see. Both directions, on the same record, moved only by max_chars.
+            var tightText = ReadTools.ReadRecord(svc, cellA.ToString(), null, null, 1, false, false, null, max_chars: 300);
+            Check("EMISSION (text): a cap that truncates the annotated field away states NO clause over it",
+                tightText.Contains("truncated: showing", StringComparison.Ordinal)
+                && !tightText.Contains(ReadSentences.NotRead, StringComparison.Ordinal)
+                && ClauseLine(tightText, ReadSentences.NotReadFraming) is null, Trim(tightText));
+            Check("EMISSION (text): …and the SAME read with room for the field states it, over that field",
+                aWinner.Contains(ReadSentences.NotRead, StringComparison.Ordinal)
+                && ClauseLine(aWinner, ReadSentences.NotReadFraming) is not null, Trim(aWinner));
+
+            // ---- RESERVE: the clauses come OUT of max_chars, not on top of it (finding 6) ----
+            // Measured on the SINGLE read, because the bulk lanes auto-spill when they truncate and that manifest
+            // block is appended outside any cap — a total-length claim there would be measuring the spill. Here the
+            // ceiling is tight: every cut is checked before a line is appended, so the response can exceed
+            // max_chars by its own longest line and by nothing else. fields= puts the annotated fields FIRST so
+            // they survive the cut (otherwise the emission gate correctly states nothing and there is no clause to
+            // budget for), with filler behind them to make the body outgrow the cap either way.
+            var padded = new[] { "Temporary", "Persistent", "Landscape", "NavigationMeshes" }
+                .Concat(Enumerable.Repeat(new[] { "Name", "Flags", "Grid", "Lighting", "OcclusionData", "MaxHeightData",
+                                                  "LightingTemplate", "WaterHeight", "Regions", "Location", "Water",
+                                                  "Owner", "FactionRank", "LockList" }, 4).SelectMany(x => x)).ToArray();
+            var cappedCheap = ReadTools.ReadRecord(svc, cellA.ToString(), null, padded, 1, false, false, null, 1400);
+            int longestLine = cappedCheap.Split('\n').Max(l => l.Length + 1);
+            Check("RESERVE: an annotated response answers INSIDE its max_chars — the clause is reserved, not appended",
+                cappedCheap.Contains("truncated: showing", StringComparison.Ordinal)
+                && ClauseLine(cappedCheap, ReadSentences.NotReadFraming) is not null
+                && cappedCheap.Length <= 1400 + longestLine,
+                $"len={cappedCheap.Length} cap=1400 longest-line={longestLine}");
+            Check("RESERVE: the cut still quotes the caller's OWN max_chars, not the reduced budget",
+                cappedCheap.Contains("max_chars=1400", StringComparison.Ordinal)
+                && !cappedCheap.Contains("max_chars=" + (1400 - ReadSentences.ClauseReserve(true, false, false)), StringComparison.Ordinal),
+                Trim(cappedCheap));
+            // The conflict_tree lane is Aaron's own repro. Its diff block cuts per NODE rather than per line, so its
+            // pre-existing slack is wider than one line and a total-length claim there would be measuring the diff,
+            // not this fix. What IS this fix on that lane: what the clauses actually cost fits what was held back.
+            var cappedTree = ReadTools.BatchRecordDetail(svc, new[] { cellA.ToString(), cellB.ToString() },
+                                                         conflict_tree: true, max_chars: 2000);
+            int clauseChars = new[] { ReadSentences.MergeCollectionFraming, ReadSentences.SingleResolvedFraming }
+                .Select(f => ClauseLine(cappedTree, f))
+                .Where(l => l is not null).Sum(l => l!.Length + 2);   // each clause is written as "\n" + clause + "\n"
+            Check("RESERVE: on the conflict_tree lane the stated clauses fit inside the chars reserved for them",
+                clauseChars > 0 && clauseChars <= ReadSentences.ClauseReserve(false, true, true),
+                $"clauses={clauseChars} reserve={ReadSentences.ClauseReserve(false, true, true)}");
 
             var aJson = Read(cellA, format: "json");
             string? jsonDisplay = null, jsonNote = null;
@@ -359,8 +434,23 @@ public static class OwnedChildContentProbe
                     }
                 Check("JSON: the clause is a response-level member, from the same source as text",
                     doc.RootElement.TryGetProperty("owned_child_note", out var ocn)
-                    && ocn.GetString() == ReadSentences.NotReadClause, "owned_child_note missing or drifted");
+                    && ocn.GetString() is { } s
+                    && s.StartsWith(ClauseHead(ReadSentences.NotReadFraming), StringComparison.Ordinal)
+                    && NamedFields(s, ReadSentences.NotReadFraming).Contains("Temporary"),
+                    "owned_child_note missing or drifted");
             }
+            // The single-read json object writes the clause AFTER the array it describes, and only over what that
+            // array carried — it used to be the object's SECOND key, ahead of `fields` (Aaron's finding 3).
+            Check("JSON: the clause is written after the fields array it is about, never ahead of it",
+                aJson.IndexOf("\"owned_child_note\"", StringComparison.Ordinal)
+                    > aJson.IndexOf("\"fields\"", StringComparison.Ordinal),
+                $"note-at={aJson.IndexOf("\"owned_child_note\"", StringComparison.Ordinal)} fields-at={aJson.IndexOf("\"fields\"", StringComparison.Ordinal)}");
+            var aJsonTight = ReadTools.ReadRecord(svc, cellA.ToString(), null, null, 1, false, false, "json", 300);
+            using (var doc = JsonDocument.Parse(aJsonTight))
+                Check("EMISSION (json single): a fields array truncated before the annotated field states NO clause",
+                    doc.RootElement.GetProperty("fields").EnumerateArray()
+                       .Any(f => f.TryGetProperty("note", out var n) && n.GetString()!.StartsWith("[truncated at max_chars", StringComparison.Ordinal))
+                    && !doc.RootElement.TryGetProperty("owned_child_note", out _), Trim(aJsonTight));
             Check("JSON: the per-field half rides `display`",
                 jsonDisplay is not null && jsonDisplay.Contains(ReadSentences.NotRead, StringComparison.Ordinal),
                 jsonDisplay ?? "(no display)");
@@ -379,10 +469,20 @@ public static class OwnedChildContentProbe
             var fileDecoded = JsonStrings(File.ReadAllLines(artifact)[0]);
             Check("ARTIFACT: the annotation reaches the FILE's rows, and its clause reaches the manifest",
                 fileText.Contains(ReadSentences.NotRead, StringComparison.Ordinal)
-                && fileDecoded.Contains(ReadSentences.NotReadClause, StringComparison.Ordinal),
-                $"note={fileText.Contains(ReadSentences.NotRead, StringComparison.Ordinal)} clause-in-manifest={fileDecoded.Contains(ReadSentences.NotReadClause, StringComparison.Ordinal)}");
+                && fileDecoded.Contains(ClauseHead(ReadSentences.NotReadFraming), StringComparison.Ordinal),
+                $"note={fileText.Contains(ReadSentences.NotRead, StringComparison.Ordinal)} "
+                + $"clause-in-manifest={fileDecoded.Contains(ClauseHead(ReadSentences.NotReadFraming), StringComparison.Ordinal)}");
+            // The manifest is line 1 and the rows are lines 2..N, so a clause that pointed "above" pointed away from
+            // its own subject for the one reader it was written for — an artifact re-opened with no conversation
+            // attached (Aaron's finding 2). It names the fields instead, which is true from line 1.
+            Check("ARTIFACT: the manifest clause names the annotated fields and claims no position",
+                ClauseLine(fileDecoded, ReadSentences.NotReadFraming) is { } ml
+                && NamedFields(ml, ReadSentences.NotReadFraming).Contains("Temporary")
+                && !ml.Contains("above", StringComparison.OrdinalIgnoreCase)
+                && !ml.Contains("below", StringComparison.OrdinalIgnoreCase),
+                ClauseLine(fileDecoded, ReadSentences.NotReadFraming) ?? "(no manifest clause)");
             Check("ARTIFACT: the manifest-only response does NOT state a clause over rows it did not render",
-                !inline.Contains(ReadSentences.NotReadClause, StringComparison.Ordinal), Trim(inline));
+                ClauseLine(inline, ReadSentences.NotReadFraming) is null, Trim(inline));
 
             // ---- THE PRECISE TIER INHERITS THE TREE RENDER'S SKIPS ----
             // A tree fetch is one whole-overlay enumeration per touching plugin. The annotation must never buy
@@ -569,6 +669,31 @@ public static class OwnedChildContentProbe
         using var doc = JsonDocument.Parse(json);
         Walk(doc.RootElement);
         return sb.ToString();
+    }
+
+    /// <summary>A response-level clause's field-INDEPENDENT head, up to the "{0}" its derived field list fills.
+    /// "Is this clause stated, and how often" is a question about the clause; WHICH fields it names is a separate
+    /// question with its own arms, so counting on the head keeps the two from masking each other.</summary>
+    static string ClauseHead(string framing) => framing[..framing.IndexOf("{0}", StringComparison.Ordinal)];
+
+    /// <summary>The rendered clause line for one framing, or null when the response does not state it.</summary>
+    static string? ClauseLine(string render, string framing)
+    {
+        var head = ClauseHead(framing);
+        foreach (var line in render.Split('\n'))
+            if (line.StartsWith(head, StringComparison.Ordinal)) return line;
+        return null;
+    }
+
+    /// <summary>The field names a rendered clause actually derived — the "({0})" list, parsed back out.</summary>
+    static IReadOnlyList<string> NamedFields(string clauseLine, string framing)
+    {
+        var rest = clauseLine[ClauseHead(framing).Length..];
+        int close = rest.IndexOf(')');
+        return close < 0
+            ? Array.Empty<string>()
+            : rest[..close].Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                           .Where(s => s != "…").ToList();
     }
 
     static int Occurrences(string haystack, string needle)

--- a/src/housecarl-generator/OwnedChildContentProbe.cs
+++ b/src/housecarl-generator/OwnedChildContentProbe.cs
@@ -12,33 +12,34 @@ namespace HousecarlGenerator;
 /// #342 stage 1 — GUARD for the owned-child content annotation, over a synthetic MO2 instance driven through the
 /// REAL read tool (<c>housecarl_read_record</c>, both transports).
 ///
-/// The bug: a parent's child records — placed references under a cell, INFOs under a topic — are declared per
-/// plugin and assembled by the game from every plugin that declares them. An override that touches the parent for
-/// an unrelated reason carries none and deletes none, so reading the winner reports an empty cell the game fills.
-/// Reproduced on a real order at <c>008EB5:Skyrim.esm</c>: winner Temporary 0, <c>Skyrim.esm</c>'s own body 201.
+/// The bug: a parent's child records — placed references under a cell, INFOs under a topic, cells under a
+/// worldspace — are declared per plugin and assembled by the game from every plugin that declares them. An
+/// override that touches the parent for an unrelated reason carries none and deletes none, so reading the winner
+/// reports an empty cell the game fills. Reproduced on a real order at <c>008EB5:Skyrim.esm</c>: winner
+/// Temporary 0, <c>Skyrim.esm</c>'s own body 201.
 ///
-/// The fixture reproduces that shape and its neighbours, so every branch of the trigger has an arm:
-///   FALSE-EMPTY  — the winner touches cell A carrying no children; a lower plugin declares 3 Temporary,
-///                  1 Persistent and a Landscape. The annotation fires on each, naming the count and the plugin.
-///                  The pre-fix hazard is asserted first (the winner really does read 0) — a fixture that stopped
-///                  exhibiting it would make every arm below vacuous.
-///   SINGULAR     — Cell.Landscape is a SINGULAR owned child, not a list; present/absent is its count.
-///   NOT-A-CELL   — the same annotation on DialogTopic.Responses, because the field set is
-///                  <see cref="OwnedChildContent.FieldNames"/> over the write surface's pinned authority, never a
-///                  hand list of cell fields.
-///   WINNER-WINS  — cell B's winner declares MORE than the plugin below it: no annotation (the trigger is "another
-///                  body declares more", not "more than one plugin touches this").
-///   SOLE         — cell C is declared by one plugin: no annotation, no walk.
-///   UNREQUESTED  — fields=[EditorID] on cell A: no annotation (the walk is gated on the read's own field lines).
-///   NO-CHILDREN  — a weapon with three touchers: no annotation, and the field set for its type is EMPTY, which is
-///                  what makes this free on every read that is not one of the three owning types.
-///   OTHER-NOT-LOWER — a plugin=-scoped read of the BASE's cell B, where a HIGHER plugin declares more. The
-///                  additive assembly is over the whole touching set, so the workaround this bug's reporter reached
-///                  for is annotated too.
-///   TOKEN        — the annotation is display-only: the field's round-trip token/note is byte-identical to what it
-///                  was, on both transports.
-///   SENTENCE     — the content net over <see cref="ReadSentences"/>: every const decides ([MustState] phrases or
-///                  [NoClaims] with a reason) and still states the phrases it declares.
+/// The trigger is a BOOLEAN — does any OTHER plugin touching this record declare at least one child record for
+/// this field — and two arms exist because the cheaper questions both produce wrong answers:
+///   REACH-NOT-ELEMENT — "has a top-level element" is true of a worldspace holding empty block scaffolding, whose
+///                  cells sit two container levels down. WRLD-SCAFFOLD holds that an empty-scaffold plugin is NOT
+///                  named a declarer while a real one is.
+///   DISJOINT     — "declares MORE than this body" says nothing when this body holds the biggest single list and
+///                  another declares a disjoint set the game also loads. DISJOINT + EQUAL hold that both annotate.
+/// The rest:
+///   FALSE-EMPTY  — the winner touches cell A carrying no children; a lower plugin declares Temporary, Persistent
+///                  and a Landscape. Each is annotated, naming the declarer. The pre-fix hazard is asserted first
+///                  — a fixture that stopped exhibiting it would make every arm below vacuous.
+///   SINGULAR     — Cell.Landscape is a SINGULAR owned child, not a list.
+///   NOT-A-CELL   — DialogTopic.Responses, because the field set is <see cref="OwnedChildContent.FieldNames"/>
+///                  over the write surface's pinned authority, never a hand list of cell fields.
+///   SOLE / SELF  — one declarer: no annotation, and the read body is never named among the "others".
+///   UNREQUESTED  — fields=[EditorID]: no annotation (the walk is gated on the read's own field lines).
+///   NO-CHILDREN  — a weapon with three touchers: no annotation, and the field set for its type is EMPTY.
+///   RESPONSE-ONCE— the invariant clause is stated ONCE per response, not per annotated field, on both lanes.
+///   UNREADABLE   — a toucher whose body cannot be read is NAMED, never silently dropped (a missing declarer
+///                  reads as "nobody else declares", the same wrong answer one level down).
+///   TOKEN        — display-only: the field's round-trip token/note is what it was, on both transports.
+///   SENTENCE     — the content net over <see cref="ReadSentences"/>, consts AND the composed per-field note.
 ///
 /// Run: <c>dotnet run --project src/housecarl-generator -- owned-child-content-guard</c>
 /// </summary>
@@ -66,10 +67,13 @@ public static class OwnedChildContentProbe
             // ---- BASE: the plugin that declares the children (Skyrim.esm's role in the report) ----
             var baseKey = new ModKey("HcOcBase", ModType.Master);
             var cellA = new FormKey(baseKey, 0xC01);      // the false-empty cell
-            var cellB = new FormKey(baseKey, 0xC02);      // the winner-declares-more cell
+            var cellB = new FormKey(baseKey, 0xC02);      // DISJOINT: both bodies declare, no overlap
             var cellC = new FormKey(baseKey, 0xC03);      // declared by exactly one plugin
+            var cellD = new FormKey(baseKey, 0xC04);      // EQUAL: both declare one reference
+            var cellE = new FormKey(baseKey, 0xC05);      // SELF: only the winner declares
             var topic = new FormKey(baseKey, 0xD01);
             var weapon = new FormKey(baseKey, 0xE01);
+            var wrld = new FormKey(baseKey, 0xF01);       // WRLD-SCAFFOLD: real cells vs empty blocks
             var baseDir = Path.Combine(mods, "BaseMod"); Directory.CreateDirectory(baseDir);
             {
                 var m = new SkyrimMod(baseKey, SkyrimRelease.SkyrimSE);
@@ -80,6 +84,8 @@ public static class OwnedChildContentProbe
                 a.Landscape = new Landscape(new FormKey(baseKey, 0xC1B), SkyrimRelease.SkyrimSE) { EditorID = "HcOcLand" };
                 FileInterior(m, a);
 
+                // DISJOINT: base declares 1, the winner will declare 4 OTHER references — the live set is 5, and a
+                // count comparison ("does anyone declare MORE than this body") said nothing at all here.
                 var b = new Cell(cellB, SkyrimRelease.SkyrimSE) { EditorID = "HcOcCellB", Flags = Cell.Flag.IsInteriorCell };
                 b.Temporary.Add(new PlacedObject(new FormKey(baseKey, 0xC20), SkyrimRelease.SkyrimSE) { EditorID = "HcOcBTemp0" });
                 FileInterior(m, b);
@@ -87,6 +93,14 @@ public static class OwnedChildContentProbe
                 var c = new Cell(cellC, SkyrimRelease.SkyrimSE) { EditorID = "HcOcCellC", Flags = Cell.Flag.IsInteriorCell };
                 c.Temporary.Add(new PlacedObject(new FormKey(baseKey, 0xC30), SkyrimRelease.SkyrimSE) { EditorID = "HcOcCTemp0" });
                 FileInterior(m, c);
+
+                // EQUAL: one reference each side — the count comparison's blind spot at parity.
+                var dCell = new Cell(cellD, SkyrimRelease.SkyrimSE) { EditorID = "HcOcCellD", Flags = Cell.Flag.IsInteriorCell };
+                dCell.Temporary.Add(new PlacedObject(new FormKey(baseKey, 0xC40), SkyrimRelease.SkyrimSE) { EditorID = "HcOcDTemp0" });
+                FileInterior(m, dCell);
+
+                // SELF: the base touches the cell declaring NOTHING; only the winner declares.
+                FileInterior(m, new Cell(cellE, SkyrimRelease.SkyrimSE) { EditorID = "HcOcCellE", Flags = Cell.Flag.IsInteriorCell });
 
                 var t = new DialogTopic(topic, SkyrimRelease.SkyrimSE) { EditorID = "HcOcTopic" };
                 for (int i = 0; i < 2; i++)
@@ -99,10 +113,20 @@ public static class OwnedChildContentProbe
 
                 m.Weapons.Add(new Weapon(weapon, SkyrimRelease.SkyrimSE)
                     { EditorID = "HcOcWeap", BasicStats = new WeaponBasicStats { Damage = 5 } });
+
+                // WRLD: ONE block holding THREE cells — real children, two container levels down.
+                var ws = new Worldspace(wrld, SkyrimRelease.SkyrimSE) { EditorID = "HcOcWrld" };
+                var blk = new WorldspaceBlock { BlockNumberX = 0, BlockNumberY = 0, GroupType = GroupTypeEnum.ExteriorCellBlock };
+                var sub = new WorldspaceSubBlock { BlockNumberX = 0, BlockNumberY = 0, GroupType = GroupTypeEnum.ExteriorCellSubBlock };
+                for (int i = 0; i < 3; i++)
+                    sub.Items.Add(new Cell(new FormKey(baseKey, (uint)(0xF10 + i)), SkyrimRelease.SkyrimSE) { EditorID = $"HcOcWsCell{i}" });
+                blk.Items.Add(sub); ws.SubCells.Add(blk);
+                m.Worldspaces.Add(ws);
+
                 m.BeginWrite.ToPath(Path.Combine(baseDir, baseKey.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
             }
 
-            // ---- MID: a second toucher of cell A that also declares no children (so "other plugins" is a count,
+            // ---- MID: a second toucher of cell A that also declares no children (so "other plugins" is a list,
             //      not a synonym for "the master") ----
             var midKey = new ModKey("HcOcMid", ModType.Plugin);
             var midDir = Path.Combine(mods, "MidMod"); Directory.CreateDirectory(midDir);
@@ -114,8 +138,8 @@ public static class OwnedChildContentProbe
                 m.BeginWrite.ToPath(Path.Combine(midDir, midKey.FileName.String)).WithLoadOrder(new ISkyrimModGetter[] { baseOv }).Write();
             }
 
-            // ---- TOP (the winner): the Occlusion.esp shape on cell A — touches the cell, carries no children.
-            //      On cell B it declares MORE than the base. On the topic it re-lists one INFO of two. ----
+            // ---- TOP (the winner): the Occlusion.esp shape on cell A. On the worldspace it declares TWO blocks
+            //      holding ZERO cells — the scaffolding an element-level answer would call a declarer. ----
             var topKey = new ModKey("HcOcTop", ModType.Plugin);
             var topDir = Path.Combine(mods, "TopMod"); Directory.CreateDirectory(topDir);
             {
@@ -128,11 +152,28 @@ public static class OwnedChildContentProbe
                     b.Temporary.Add(new PlacedObject(new FormKey(topKey, (uint)(0xB10 + i)), SkyrimRelease.SkyrimSE) { EditorID = $"HcOcTopTemp{i}" });
                 FileInterior(m, b);
 
+                var dCell = new Cell(cellD, SkyrimRelease.SkyrimSE) { EditorID = "HcOcCellD", Flags = Cell.Flag.IsInteriorCell };
+                dCell.Temporary.Add(new PlacedObject(new FormKey(topKey, 0xB40), SkyrimRelease.SkyrimSE) { EditorID = "HcOcTopDTemp0" });
+                FileInterior(m, dCell);
+
+                var e = new Cell(cellE, SkyrimRelease.SkyrimSE) { EditorID = "HcOcCellE", Flags = Cell.Flag.IsInteriorCell };
+                e.Temporary.Add(new PlacedObject(new FormKey(topKey, 0xB50), SkyrimRelease.SkyrimSE) { EditorID = "HcOcTopETemp0" });
+                FileInterior(m, e);
+
                 var t = new DialogTopic(topic, SkyrimRelease.SkyrimSE) { EditorID = "HcOcTopic" };
                 var only = new DialogResponses(new FormKey(baseKey, 0xD10), SkyrimRelease.SkyrimSE);
                 only.Responses.Add(new DialogResponse { Text = "patched line 0" });
                 t.Responses.Add(only);
                 m.DialogTopics.Add(t);
+
+                var ws = new Worldspace(wrld, SkyrimRelease.SkyrimSE) { EditorID = "HcOcWrld" };
+                for (int bx = 0; bx < 2; bx++)   // TWO blocks, each with a sub-block, holding NO cells at all
+                {
+                    var eb = new WorldspaceBlock { BlockNumberX = (short)bx, BlockNumberY = 0, GroupType = GroupTypeEnum.ExteriorCellBlock };
+                    eb.Items.Add(new WorldspaceSubBlock { BlockNumberX = (short)bx, BlockNumberY = 0, GroupType = GroupTypeEnum.ExteriorCellSubBlock });
+                    ws.SubCells.Add(eb);
+                }
+                m.Worldspaces.Add(ws);
 
                 m.Weapons.GetOrAddAsOverride(baseOv.Weapons.First(w => w.FormKey == weapon)).BasicStats!.Damage = 9;
                 m.BeginWrite.ToPath(Path.Combine(topDir, topKey.FileName.String)).WithLoadOrder(new ISkyrimModGetter[] { baseOv }).Write();
@@ -150,6 +191,7 @@ public static class OwnedChildContentProbe
 
             string Read(FormKey fk, string? plugin = null, string[]? fields = null, int depth = 1, string? format = null)
                 => ReadTools.ReadRecord(svc, fk.ToString(), plugin, fields, depth, false, false, format);
+            string By(ModKey k) => $"{ReadSentences.DeclaredBy} {k.FileName}";
 
             // ---- the pre-fix hazard, asserted before anything is claimed about the annotation ----
             var aWinner = Read(cellA);
@@ -158,105 +200,137 @@ public static class OwnedChildContentProbe
                 && FieldLine(aWinner, "Temporary") is { } tw && tw.Contains("0 item(s)", StringComparison.Ordinal),
                 FieldLine(aWinner, "Temporary"));
             var aBase = Read(cellA, plugin: baseKey.FileName.String);
-            Check("…and the base's own body carries 3 — the count the winner does not show",
+            Check("…and the base's own body carries 3 — the content the winner does not show",
                 FieldLine(aBase, "Temporary") is { } tb && tb.Contains("3 item(s)", StringComparison.Ordinal),
                 FieldLine(aBase, "Temporary"));
 
-            // ---- FALSE-EMPTY: the annotation on each of the three fields the base declares ----
-            Check("Temporary is annotated: 1 other plugin declares content, most 3, named",
-                FieldLine(aWinner, "Temporary") is { } t1
-                && t1.Contains("1 other plugin(s) touching this record also declare Temporary content", StringComparison.Ordinal)
-                && t1.Contains("(most: 3 in HcOcBase.esm)", StringComparison.Ordinal)
-                && t1.Contains(ReadSentences.OwnedChildMerge, StringComparison.Ordinal),
+            // ---- FALSE-EMPTY: the annotation on each field the base declares, naming the declarer ----
+            Check("Temporary is annotated, naming the declaring plugin",
+                FieldLine(aWinner, "Temporary") is { } t1 && t1.Contains(By(baseKey), StringComparison.Ordinal),
                 FieldLine(aWinner, "Temporary"));
-            Check("Persistent is annotated too (most: 1) — the annotation is per FIELD, not per record",
-                FieldLine(aWinner, "Persistent") is { } p1
-                && p1.Contains("also declare Persistent content", StringComparison.Ordinal)
-                && p1.Contains("(most: 1 in HcOcBase.esm)", StringComparison.Ordinal),
+            Check("Persistent is annotated too — the annotation is per FIELD, not per record",
+                FieldLine(aWinner, "Persistent") is { } p1 && p1.Contains(By(baseKey), StringComparison.Ordinal),
                 FieldLine(aWinner, "Persistent"));
-            // SINGULAR: Landscape holds ONE owned child record, not a list — present/absent is its count.
-            Check("SINGULAR: Landscape is annotated (most: 1) — a singular owned child, not a list",
-                FieldLine(aWinner, "Landscape") is { } l1
-                && l1.Contains("also declare Landscape content", StringComparison.Ordinal)
-                && l1.Contains("(most: 1 in HcOcBase.esm)", StringComparison.Ordinal),
+            Check("SINGULAR: Landscape is annotated — a singular owned child, not a list",
+                FieldLine(aWinner, "Landscape") is { } l1 && l1.Contains(By(baseKey), StringComparison.Ordinal),
                 FieldLine(aWinner, "Landscape"));
             Check("NavigationMeshes — an owning field NOBODY declares — is NOT annotated",
-                FieldLine(aWinner, "NavigationMeshes") is { } n1 && !n1.Contains("also declare", StringComparison.Ordinal),
+                FieldLine(aWinner, "NavigationMeshes") is { } n1 && !n1.Contains(ReadSentences.DeclaredBy, StringComparison.Ordinal),
                 FieldLine(aWinner, "NavigationMeshes"));
-
-            // ---- TOKEN: display-only. The value half of the line is exactly what it was before the annotation. ----
-            Check("TOKEN: the annotated line still carries the leaf's own unchanged summary, annotation appended after it",
-                FieldLine(aWinner, "Temporary") is { } t2
-                && t2.StartsWith("Temporary = [list: 0 item(s)]" + ReadEngine.DepthExpandHint + "   (", StringComparison.Ordinal),
+            Check("…and the plugin that touches the cell declaring NOTHING is not named a declarer",
+                FieldLine(aWinner, "Temporary") is { } t1b && !t1b.Contains("HcOcMid.esp", StringComparison.Ordinal),
                 FieldLine(aWinner, "Temporary"));
 
-            // ---- NOT-A-CELL: the same annotation on a topic's INFOs (the field set is the pinned authority) ----
+            // ---- REACH-NOT-ELEMENT: empty block scaffolding is not a declaration of cells ----
+            var wsBase = Read(wrld, plugin: baseKey.FileName.String);
+            Check("WRLD-SCAFFOLD: a worldspace declaring 2 EMPTY blocks is NOT named as declaring SubCells content",
+                FieldLine(wsBase, "SubCells") is { } w1 && !w1.Contains(ReadSentences.DeclaredBy, StringComparison.Ordinal),
+                FieldLine(wsBase, "SubCells"));
+            var wsWinner = Read(wrld);
+            Check("…while the winner (2 empty blocks) IS annotated by the base's 1 block holding 3 real cells",
+                FieldLine(wsWinner, "SubCells") is { } w2 && w2.Contains(By(baseKey), StringComparison.Ordinal),
+                FieldLine(wsWinner, "SubCells"));
+            Check("REACH: DeclaresChild answers the CHILD question, not the element question, on both worldspace bodies",
+                DeclaresOn(baseDir, baseKey, wrld, "SubCells") == true
+                && DeclaresOn(topDir, topKey, wrld, "SubCells") == false,
+                $"base={DeclaresOn(baseDir, baseKey, wrld, "SubCells")} top={DeclaresOn(topDir, topKey, wrld, "SubCells")}");
+
+            // ---- DISJOINT / EQUAL: the two shapes a count comparison stayed silent on ----
+            var bWinner = Read(cellB);
+            Check("DISJOINT: the winner declaring 4 of its OWN references is still annotated by the base's 1",
+                FieldLine(bWinner, "Temporary") is { } t3
+                && t3.Contains("4 item(s)", StringComparison.Ordinal) && t3.Contains(By(baseKey), StringComparison.Ordinal),
+                FieldLine(bWinner, "Temporary"));
+            var dWinner = Read(cellD);
+            Check("EQUAL: one reference each side — both bodies declare, so the read is annotated",
+                FieldLine(dWinner, "Temporary") is { } t7 && t7.Contains(By(baseKey), StringComparison.Ordinal),
+                FieldLine(dWinner, "Temporary"));
+
+            // ---- SELF: the read body is never among its own "other plugins" ----
+            var eWinner = Read(cellE);
+            Check("SELF: a body that is the ONLY declarer is not annotated, and never names itself",
+                FieldLine(eWinner, "Temporary") is { } t8
+                && t8.Contains("1 item(s)", StringComparison.Ordinal)
+                && !t8.Contains(ReadSentences.DeclaredBy, StringComparison.Ordinal),
+                FieldLine(eWinner, "Temporary"));
+
+            // ---- NOT-A-CELL / SOLE / UNREQUESTED / NO-CHILDREN ----
             var topicRead = Read(topic);
             Check("NOT-A-CELL: DialogTopic.Responses is annotated (winner re-lists 1 of the base's 2)",
-                FieldLine(topicRead, "Responses") is { } r1
-                && r1.Contains("also declare Responses content", StringComparison.Ordinal)
-                && r1.Contains("(most: 2 in HcOcBase.esm)", StringComparison.Ordinal),
+                FieldLine(topicRead, "Responses") is { } r1 && r1.Contains(By(baseKey), StringComparison.Ordinal),
                 FieldLine(topicRead, "Responses"));
-
-            // ---- WINNER-WINS: cell B's winner declares MORE than the plugin below it ----
-            var bWinner = Read(cellB);
-            Check("WINNER-WINS: no annotation when the read body declares the most (4 vs the base's 1)",
-                FieldLine(bWinner, "Temporary") is { } t3
-                && t3.Contains("4 item(s)", StringComparison.Ordinal)
-                && !t3.Contains("also declare", StringComparison.Ordinal),
-                FieldLine(bWinner, "Temporary"));
-
-            // ---- OTHER-NOT-LOWER: the plugin=-scoped read of the base sees the HIGHER plugin's declaration ----
-            var bBase = Read(cellB, plugin: baseKey.FileName.String);
-            Check("OTHER-NOT-LOWER: a plugin=-scoped read is annotated by a HIGHER plugin's declaration (most: 4 in HcOcTop.esp)",
-                FieldLine(bBase, "Temporary") is { } t4
-                && t4.Contains("also declare Temporary content", StringComparison.Ordinal)
-                && t4.Contains("(most: 4 in HcOcTop.esp)", StringComparison.Ordinal),
-                FieldLine(bBase, "Temporary"));
-
-            // ---- SOLE: one declarer, nothing to compare against ----
             var cRead = Read(cellC);
             Check("SOLE: a record only one plugin touches is not annotated",
-                FieldLine(cRead, "Temporary") is { } t5 && !t5.Contains("also declare", StringComparison.Ordinal),
+                FieldLine(cRead, "Temporary") is { } t5 && !t5.Contains(ReadSentences.DeclaredBy, StringComparison.Ordinal),
                 FieldLine(cRead, "Temporary"));
-
-            // ---- UNREQUESTED: the walk is gated on the read's own field lines ----
             var aNarrow = Read(cellA, fields: new[] { "EditorID" });
-            Check("UNREQUESTED: fields=[EditorID] on the same cell carries no annotation",
-                !aNarrow.Contains("also declare", StringComparison.Ordinal), Trim(aNarrow));
-
-            // ---- NO-CHILDREN: the type that owns nothing — the free path ----
+            Check("UNREQUESTED: fields=[EditorID] on the same cell carries no annotation and no response clause",
+                !aNarrow.Contains(ReadSentences.DeclaredBy, StringComparison.Ordinal)
+                && !aNarrow.Contains(ReadSentences.OwnedChildMerge, StringComparison.Ordinal), Trim(aNarrow));
             var weapRead = Read(weapon);
-            Check("NO-CHILDREN: a 3-toucher weapon read carries no annotation",
+            Check("NO-CHILDREN: a 3-toucher weapon read carries no annotation, and its field set is EMPTY",
                 weapRead.Contains("winner=HcOcTop.esp", StringComparison.Ordinal)
-                && !weapRead.Contains("also declare", StringComparison.Ordinal), Trim(weapRead));
+                && !weapRead.Contains(ReadSentences.DeclaredBy, StringComparison.Ordinal)
+                && FieldNamesOn(topDir, topKey, weapon).Count == 0, Trim(weapRead));
 
-            // ---- DEPTH: the summary line still carries it when the container is expanded ----
+            // ---- DEPTH ----
             var aDeep = Read(cellA, depth: 2);
             Check("DEPTH: at depth=2 the container's own summary line still carries the annotation",
-                FieldLine(aDeep, "Temporary") is { } t6 && t6.Contains("also declare Temporary content", StringComparison.Ordinal),
+                FieldLine(aDeep, "Temporary") is { } t6 && t6.Contains(ReadSentences.DeclaredBy, StringComparison.Ordinal),
                 FieldLine(aDeep, "Temporary"));
 
-            // ---- BOTH TRANSPORTS: one carrier (FieldValue.Display) — json states it as `display`, token untouched ----
+            // ---- RESPONSE-ONCE: the invariant clause is stated once, not per annotated field ----
+            Check("RESPONSE-ONCE (text): three annotated fields, ONE invariant clause in the response",
+                Occurrences(aWinner, ReadSentences.OwnedChildMerge) == 1
+                && Occurrences(aWinner, ReadSentences.DeclaredBy) == 3,
+                $"clause={Occurrences(aWinner, ReadSentences.OwnedChildMerge)} fields={Occurrences(aWinner, ReadSentences.DeclaredBy)}");
+            var batch = ReadTools.BatchRecordDetail(svc, new[] { cellA.ToString(), cellB.ToString() });
+            Check("RESPONSE-ONCE (batch): two annotated records, still ONE invariant clause",
+                Occurrences(batch, ReadSentences.OwnedChildMerge) == 1, $"clause={Occurrences(batch, ReadSentences.OwnedChildMerge)}");
+            var cleanBatch = ReadTools.BatchRecordDetail(svc, new[] { weapon.ToString() });
+            Check("RESPONSE-ONCE: a response with nothing annotated carries NO clause",
+                Occurrences(cleanBatch, ReadSentences.OwnedChildMerge) == 0, Trim(cleanBatch));
+
+            // ---- BOTH TRANSPORTS ----
             var aJson = Read(cellA, format: "json");
             string? jsonDisplay = null, jsonNote = null;
             using (var doc = JsonDocument.Parse(aJson))
+            {
                 foreach (var f in doc.RootElement.GetProperty("fields").EnumerateArray())
                     if (f.GetProperty("path").GetString() == "Temporary")
                     {
                         jsonDisplay = f.TryGetProperty("display", out var d) ? d.GetString() : null;
                         jsonNote = f.TryGetProperty("note", out var n) ? n.GetString() : null;
                     }
-            Check("JSON: the same sentence rides the json lane's `display`, from the same source",
-                jsonDisplay is not null && jsonDisplay.Contains(ReadSentences.OwnedChildMerge, StringComparison.Ordinal)
-                && jsonDisplay.Contains("(most: 3 in HcOcBase.esm)", StringComparison.Ordinal), jsonDisplay ?? "(no display)");
-            Check("JSON: the leaf's own note is unchanged — the annotation never replaces the value half",
-                jsonNote is not null && jsonNote.StartsWith("[list: 0 item(s)]", StringComparison.Ordinal), jsonNote ?? "(no note)");
+                Check("JSON: the invariant clause is a response-level member, from the same source as text",
+                    doc.RootElement.TryGetProperty("owned_child_note", out var ocn)
+                    && ocn.GetString() == ReadSentences.OwnedChildMerge, "owned_child_note missing or drifted");
+            }
+            Check("JSON: the per-field half rides `display`, naming the declarer",
+                jsonDisplay is not null && jsonDisplay.Contains(By(baseKey), StringComparison.Ordinal),
+                jsonDisplay ?? "(no display)");
+            Check("TOKEN: the leaf's own note is unchanged on both lanes — the annotation never replaces the value half",
+                jsonNote is not null && jsonNote.StartsWith("[list: 0 item(s)]", StringComparison.Ordinal)
+                && FieldLine(aWinner, "Temporary")!.StartsWith(
+                       "Temporary = [list: 0 item(s)]" + ReadEngine.DepthExpandHint + "   (", StringComparison.Ordinal),
+                jsonNote ?? "(no note)");
 
-            // ---- SENTENCE: the content net over ReadSentences ----
+            // ---- UNREADABLE: a toucher whose body cannot be read is NAMED, not dropped ----
+            CheckUnreadable(root, mods, baseDir, baseKey, topKey, cellA);
+
+            // ---- SENTENCE: the content net over ReadSentences, consts AND the composed note ----
             var sentenceBad = SentenceViolations();
             Check("SENTENCE: every ReadSentences const decides ([MustState] phrases or [NoClaims] with a reason) and states them",
                 sentenceBad.Count == 0, string.Join(" | ", sentenceBad));
+            var composed = ReadSentences.OwnedChildDeclarers(new[] { "A.esp", "B.esp", "C.esp", "D.esp" }, new[] { "E.esp" });
+            Check("SENTENCE: the composed per-field note is built from the SAME consts the net covers, and caps its names",
+                composed is not null
+                && composed.Contains(ReadSentences.DeclaredBy, StringComparison.Ordinal)
+                && composed.Contains(ReadSentences.CouldNotRead, StringComparison.Ordinal)
+                && composed.Contains("(+1 more)", StringComparison.Ordinal)
+                && !composed.Contains("D.esp", StringComparison.Ordinal), composed ?? "(null)");
+            Check("SENTENCE: nothing to say → null, so the caller has ONE place to decide",
+                ReadSentences.OwnedChildDeclarers(Array.Empty<string>(), Array.Empty<string>()) is null);
 
             Console.WriteLine();
             Console.WriteLine($"=== owned-child-content-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
@@ -264,6 +338,90 @@ public static class OwnedChildContentProbe
         }
         catch (Exception ex) { Console.WriteLine($"   FAIL (unexpected): {ex.GetType().Name}: {ex.Message}"); return 1; }
         finally { try { Directory.Delete(root, recursive: true); } catch { } }
+    }
+
+    /// <summary>UNREADABLE — the "could not look is not nothing there" rule, at the two ends where it is honestly
+    /// observable, plus the measured account of what happens when a declaring plugin stops being readable at all.
+    ///
+    /// <para>The end-to-end shape this started as does NOT exist, and finding that out is what the fixture is for.
+    /// Corrupting a declaring plugin after the index is built does not leave it a named-but-unfetchable toucher:
+    /// the next read's freshness re-check rebuilds, the plugin is EXCLUDED from the order (named in
+    /// <c>Stats().loadFailures</c>), the record's override depth drops and it is no longer a toucher at all — so
+    /// the annotation stops naming it because the ORDER changed, not because a read failed silently. That is the
+    /// load-order layer's existing, named behaviour and the arms below pin it rather than pretending otherwise.
+    /// The residual hazard the unknown-arm exists for — a plugin that opens at header level but faults while its
+    /// child group is walked — is not reachable from outside the process, so it is pinned at its two ends: the
+    /// unit answer (null, never false) and the sentence that names it.</para></summary>
+    static void CheckUnreadable(string root, string mods, string baseDir, ModKey baseKey, ModKey topKey, FormKey cellA)
+    {
+        var inst2 = Path.Combine(root, "unreadable");
+        var prof2 = Path.Combine(inst2, "profiles", "Default");
+        var mods2 = Path.Combine(inst2, "mods");
+        foreach (var d in new[] { prof2, mods2, Path.Combine(root, "game2", "Data") }) Directory.CreateDirectory(d);
+        File.WriteAllText(Path.Combine(inst2, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(root, "game2").Replace(@"\", @"\\") + ")\r\n");
+        foreach (var (src, name) in new[] { (baseDir, "BaseMod"), (Path.Combine(mods, "TopMod"), "TopMod") })
+        {
+            var dst = Path.Combine(mods2, name); Directory.CreateDirectory(dst);
+            foreach (var f in Directory.GetFiles(src)) File.Copy(f, Path.Combine(dst, Path.GetFileName(f)));
+        }
+        File.WriteAllText(Path.Combine(prof2, "loadorder.txt"), "# header\r\n" + baseKey.FileName + "\r\n" + topKey.FileName + "\r\n");
+        File.WriteAllText(Path.Combine(prof2, "plugins.txt"), "*" + baseKey.FileName + "\r\n*" + topKey.FileName + "\r\n");
+        File.WriteAllText(Path.Combine(prof2, "modlist.txt"), "# header\r\n+TopMod\r\n+BaseMod\r\n");
+
+        using var svc = LoadOrderService.WithInstance(inst2, 0, new UserConfigStore(Path.Combine(root, "unreadable.user.json")));
+        svc.Stats();                                                   // index built off the INTACT files
+        var before = ReadTools.ReadRecord(svc, cellA.ToString());
+        bool intact = FieldLine(before, "Temporary") is { } l
+                      && l.Contains($"{ReadSentences.DeclaredBy} {baseKey.FileName}", StringComparison.Ordinal);
+        Check("UNREADABLE: the fixture's intact read names the declarer (so the corrupted read has something to lose)",
+              intact, FieldLine(before, "Temporary"));
+
+        // Corrupt the declaring plugin AFTER the index knows it touches the record, then read again.
+        File.WriteAllBytes(Path.Combine(mods2, "BaseMod", baseKey.FileName.String), new byte[] { 0x00, 0x01, 0x02, 0x03 });
+        string after;
+        try { after = ReadTools.ReadRecord(svc, cellA.ToString()); }
+        catch (Exception ex) { after = "THREW " + ex.GetType().Name + ": " + ex.Message; }
+        var line = FieldLine(after, "Temporary");
+        var stats = svc.Stats();
+
+        // What actually happens, measured: the plugin leaves the ORDER. The annotation must then stop naming it —
+        // it no longer declares anything the game loads from this order — but the disappearance must be ACCOUNTED
+        // for where a caller can see it, which is the load-failure list, not swallowed in silence.
+        Check("UNREADABLE: an unopenable declarer leaves the order, and the load-order layer NAMES the failure",
+            stats.loadFailures.Any(f => f.Contains(baseKey.FileName.String, StringComparison.OrdinalIgnoreCase)),
+            $"loadFailures=[{string.Join(" | ", stats.loadFailures)}]");
+        Check("…and the annotation follows the order rather than naming a plugin that is no longer in it",
+            line is not null && !line.Contains(baseKey.FileName.String, StringComparison.OrdinalIgnoreCase),
+            line ?? Trim(after));
+
+        // The null rule, at the unit end: a field the body does not have is "I could not look", never "nothing
+        // there". This is the answer the service turns into a NAMED could-not-read plugin.
+        using var ov = SkyrimMod.CreateFromBinaryOverlay(Path.Combine(mods2, "TopMod", topKey.FileName.String), SkyrimRelease.SkyrimSE);
+        var topBody = ov.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == cellA);
+        Check("UNREADABLE: DeclaresChild on a field the body does not have answers NULL, never false",
+            topBody is not null && OwnedChildContent.DeclaresChild(topBody, "NoSuchFieldHere") is null,
+            $"{OwnedChildContent.DeclaresChild(topBody!, "NoSuchFieldHere")}");
+        Check("…and a body that HAS the field but declares nothing answers false, so the two stay distinguishable",
+            topBody is not null && OwnedChildContent.DeclaresChild(topBody, "Temporary") == false,
+            $"{OwnedChildContent.DeclaresChild(topBody!, "Temporary")}");
+    }
+
+    /// <summary>Ask <see cref="OwnedChildContent.DeclaresChild"/> directly of ONE plugin's own body — the unit-level
+    /// answer behind the WRLD arms, so a render change cannot make them pass for the wrong reason.</summary>
+    static bool? DeclaresOn(string dir, ModKey key, FormKey fk, string field)
+    {
+        using var ov = SkyrimMod.CreateFromBinaryOverlay(Path.Combine(dir, key.FileName.String), SkyrimRelease.SkyrimSE);
+        var body = ov.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == fk);
+        return body is null ? null : OwnedChildContent.DeclaresChild(body, field);
+    }
+
+    static IReadOnlyList<string> FieldNamesOn(string dir, ModKey key, FormKey fk)
+    {
+        using var ov = SkyrimMod.CreateFromBinaryOverlay(Path.Combine(dir, key.FileName.String), SkyrimRelease.SkyrimSE);
+        var body = ov.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == fk);
+        return body is null ? Array.Empty<string>() : OwnedChildContent.FieldNames(body);
     }
 
     /// <summary>The rendered line for one field path, trimmed — the text lane's "  Path = value   (annotation)".</summary>
@@ -277,6 +435,14 @@ public static class OwnedChildContentProbe
         return null;
     }
 
+    static int Occurrences(string haystack, string needle)
+    {
+        int n = 0;
+        for (int i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal)) n++;
+        return n;
+    }
+
     /// <summary>The content half of the response-layer net, over <see cref="ReadSentences"/>: every const must
     /// DECIDE — declared phrases, or a stated reason there are none — and a sentence that declares a phrase must
     /// still contain it. The write surface's own arm is the model; this owner is the read surface's, and an
@@ -286,7 +452,8 @@ public static class OwnedChildContentProbe
         var bad = new List<string>();
         foreach (var f in typeof(ReadSentences).GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static))
         {
-            if (!f.IsLiteral || f.FieldType != typeof(string)) { bad.Add($"{f.Name}: not a string const (unreadable to this net)"); continue; }
+            if (!f.IsLiteral) { bad.Add($"{f.Name}: not a const (unreadable to this net)"); continue; }
+            if (f.FieldType != typeof(string)) continue;   // a non-prose const (a cap) carries no sentence to check
             var text = (string?)f.GetRawConstantValue() ?? "";
             var must = f.GetCustomAttribute<MustStateAttribute>();
             var none = f.GetCustomAttribute<NoClaimsAttribute>();

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -136,6 +136,7 @@ internal static class Artifacts
         string[] schema;
         string? identity;
         string sort;
+        bool annotated = false;   // #342: did any ROW carry the owned-child annotation
 
         if (q.Groups is not null)                                             // group_by= → count-table rows
         {
@@ -157,6 +158,7 @@ internal static class Artifacts
                 string? matches = q.MatchedTargets is { } mt && i < mt.Count ? mt[i] : null;
                 var o = svc.ResolveReadOn(q, fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false, depth,
                                           resolveNames: resolveNames, linkMemo: linkMemo);
+                annotated |= o.OwnedChildNoted;   // #342: the rows' labels need their clause on line 1
                 if (o.Error is not null)
                     writer.WriteRow((w, _) =>
                     {
@@ -183,9 +185,21 @@ internal static class Artifacts
         }
 
         var (manifest, err) = writer.Save(path, "housecarl_cross_plugin_query", query, identity, schema, sort,
-                                          q.Groups is not null ? q.Groups.Count : q.Total, q.Epoch ?? "");
+                                          q.Groups is not null ? q.Groups.Count : q.Total, q.Epoch ?? "",
+                                          OwnedChildNotes(annotated));
         return err is not null ? (null, err) : (new SpillInfo(path, manifest!, reason), null);
     }
+
+    /// <summary>The response-level #342 statements an artifact's ROWS depend on. An artifact is re-entered with no
+    /// conversation attached, so a row's "N other plugins touch this record; their declarations were not read"
+    /// label has to travel with the sentence that says what a child record is and where the precise answer lives.
+    /// Only the CHEAP tier ever reaches a file: the artifact lanes read with conflict_tree off (it is a text-only
+    /// diff view), so a row can only ever carry the cheap note.</summary>
+    static IReadOnlyList<string>? OwnedChildNotes(bool annotated) =>
+        annotated ? new[] { ReadSentences.NotReadClause } : null;
+
+    static IReadOnlyList<string>? OwnedChildNotes(IReadOnlyList<ReadOutcome> outcomes) =>
+        OwnedChildNotes(outcomes.Any(o => o.OwnedChildNoted));
 
     /// <summary>Build + save the artifact for a batch_record_detail result — one row per input, in input order,
     /// exactly the rows the json render emits (per-item errors included: the artifact is the complete answer, and
@@ -206,7 +220,7 @@ internal static class Artifacts
         var epoch = outcomes.FirstOrDefault(o => o.Epoch is not null)?.Epoch ?? "";
         var (manifest, err) = writer.Save(path, "housecarl_batch_record_detail", query, "formid",
                                           new[] { "formid", "type", "editorid", "winner", "override_depth", "source", "fields" },
-                                          "input order", outcomes.Count, epoch);
+                                          "input order", outcomes.Count, epoch, OwnedChildNotes(outcomes));
         return err is not null ? (null, err) : (new SpillInfo(path, manifest!, reason), null);
     }
 

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -136,7 +136,7 @@ internal static class Artifacts
         string[] schema;
         string? identity;
         string sort;
-        bool annotated = false;   // #342: did any ROW carry the owned-child annotation
+        var annotated = new SortedSet<string>(StringComparer.Ordinal);   // #342: which fields the ROWS carry annotated
 
         if (q.Groups is not null)                                             // group_by= → count-table rows
         {
@@ -158,7 +158,8 @@ internal static class Artifacts
                 string? matches = q.MatchedTargets is { } mt && i < mt.Count ? mt[i] : null;
                 var o = svc.ResolveReadOn(q, fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false, depth,
                                           resolveNames: resolveNames, linkMemo: linkMemo);
-                annotated |= o.OwnedChildNoted;   // #342: the rows' labels need their clause on line 1
+                if (o.Error is null && o.OwnedChildFields is { } af)   // #342: the rows' labels need their clause on line 1
+                    foreach (var annotatedPath in af.Keys) annotated.Add(annotatedPath);
                 if (o.Error is not null)
                     writer.WriteRow((w, _) =>
                     {
@@ -194,12 +195,25 @@ internal static class Artifacts
     /// conversation attached, so a row's "N other plugins touch this record; their declarations were not read"
     /// label has to travel with the sentence that says what a child record is and where the precise answer lives.
     /// Only the CHEAP tier ever reaches a file: the artifact lanes read with conflict_tree off (it is a text-only
-    /// diff view), so a row can only ever carry the cheap note.</summary>
-    static IReadOnlyList<string>? OwnedChildNotes(bool annotated) =>
-        annotated ? new[] { ReadSentences.NotReadClause } : null;
+    /// diff view), so a row can only ever carry the cheap note.
+    ///
+    /// <para>The manifest is LINE 1 and the annotated rows are lines 2..N, so the clause's old "an annotated field
+    /// above" pointed the wrong way for exactly the reader it was added for (Aaron's finding 2). It now names the
+    /// annotated fields instead of pointing at them, which is true from line 1 and from anywhere else.</para></summary>
+    static IReadOnlyList<string>? OwnedChildNotes(IReadOnlyCollection<string> annotatedFields) =>
+        annotatedFields.Count == 0 ? null : new[] { ReadSentences.NotReadClause(annotatedFields) };
 
-    static IReadOnlyList<string>? OwnedChildNotes(IReadOnlyList<ReadOutcome> outcomes) =>
-        OwnedChildNotes(outcomes.Any(o => o.OwnedChildNoted));
+    /// <summary>The annotated field paths an artifact's rows CARRY. Rows are written uncapped (the file is the
+    /// answer), so every annotated field of every row reaches the file — but the set is collected from the rows all
+    /// the same, so the manifest cannot state a clause over an annotation no row wrote.</summary>
+    static SortedSet<string> AnnotatedFields(IEnumerable<ReadOutcome> outcomes)
+    {
+        var s = new SortedSet<string>(StringComparer.Ordinal);
+        foreach (var o in outcomes)
+            if (o.Error is null && o.OwnedChildFields is { } f)
+                foreach (var path in f.Keys) s.Add(path);
+        return s;
+    }
 
     /// <summary>Build + save the artifact for a batch_record_detail result — one row per input, in input order,
     /// exactly the rows the json render emits (per-item errors included: the artifact is the complete answer, and
@@ -220,7 +234,7 @@ internal static class Artifacts
         var epoch = outcomes.FirstOrDefault(o => o.Epoch is not null)?.Epoch ?? "";
         var (manifest, err) = writer.Save(path, "housecarl_batch_record_detail", query, "formid",
                                           new[] { "formid", "type", "editorid", "winner", "override_depth", "source", "fields" },
-                                          "input order", outcomes.Count, epoch, OwnedChildNotes(outcomes));
+                                          "input order", outcomes.Count, epoch, OwnedChildNotes(AnnotatedFields(outcomes)));
         return err is not null ? (null, err) : (new SpillInfo(path, manifest!, reason), null);
     }
 

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -342,12 +342,16 @@ static class JsonWire
         return Finish(ms);
     }
 
-    /// <summary>The #342 invariant clause on the json lane, written ONCE per response when any rendered record
-    /// carries a per-field declarer annotation — the same const the text lane states, so the two transports
-    /// cannot drift on what a child record is. Gated on the outcome's structural flag, never on the prose.</summary>
+    /// <summary>The #342 clause on the json lane, written ONCE per response when a rendered record carries the
+    /// annotation — the same const the text lane states, so the two transports cannot drift. Gated on the
+    /// outcome's structural flag, never on the prose.
+    ///
+    /// <para>json only ever states the CHEAP tier's clause: <c>conflict_tree=true</c> is refused in json mode (a
+    /// text-only diff view), so the lane that has the bodies to name declarers does not exist here. A json caller
+    /// who wants the precise answer takes the same route the clause names — the text lane.</para></summary>
     static void WriteOwnedChildNote(Utf8JsonWriter w, bool noted)
     {
-        if (noted) w.WriteString("owned_child_note", ReadSentences.OwnedChildMerge);
+        if (noted) w.WriteString("owned_child_note", ReadSentences.NotReadClause);
     }
 
     // ---- housecarl_batch_record_detail (P6) ---------------------------------------------------------

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -261,7 +261,11 @@ static class JsonWire
     /// BUDGET-AWARE: a fat record (deep list expansion) is field-truncated the same way the text render caps field
     /// lines — a sentinel field names the cut and the array closes, so the document stays valid JSON (never silently
     /// over budget — Q3).</summary>
-    static void WriteFieldsArray(Utf8JsonWriter w, RecordFields r, MemoryStream ms, int cap)
+    /// <param name="annotated">The #342 owned-child fields this outcome annotated, if any.</param>
+    /// <param name="emitted">Collects the annotated paths this array ACTUALLY carried — the response-level clause is
+    /// stated over these, so a field the truncation above dropped states nothing (Aaron's finding 1, json twin).</param>
+    static void WriteFieldsArray(Utf8JsonWriter w, RecordFields r, MemoryStream ms, int cap,
+                                 IReadOnlyDictionary<string, OwnedChildShape>? annotated = null, ICollection<string>? emitted = null)
     {
         w.WriteStartArray("fields");
         for (int i = 0; i < r.Fields.Count; i++)
@@ -294,6 +298,7 @@ static class JsonWire
                 w.WriteEndObject();
             }
             w.WriteEndObject();
+            if (annotated is not null && emitted is not null && annotated.ContainsKey(f.Path)) emitted.Add(f.Path);
         }
         w.WriteEndArray();
     }
@@ -301,15 +306,18 @@ static class JsonWire
     /// <summary>Serialize a resolved record: identity + winner/override_depth/source + the fields array. Shared by
     /// read_record, batch_record_detail, and the cross_plugin_query detail path (one shape, no drift). <paramref
     /// name="matches"/> carries the multi-target references= un-merge when present.</summary>
+    /// <param name="childFields">Collects the #342-annotated field paths this record's array carried, for the
+    /// response-level clause. Batch/query lanes pass ONE set across their rows and state the clause after the
+    /// records array; the single read passes its own and states it here.</param>
+    /// <param name="stateChildNote">Single-read lane only: this record object IS the response, so the clause
+    /// belongs on it — written AFTER <c>fields</c> and only over what <c>fields</c> carried. It used to be the
+    /// object's second key, ahead of the very array it described (Aaron's finding 3).</param>
     internal static void WriteReadRecord(Utf8JsonWriter w, ReadOutcome o, MemoryStream ms, int cap, string? matches = null,
-                                         string? epoch = null, bool ownedChildNote = false)
+                                         string? epoch = null, ICollection<string>? childFields = null, bool stateChildNote = false)
     {
         var r = o.Record!;
         w.WriteStartObject();
         if (epoch is not null) w.WriteString("epoch", epoch);   // single-read top level ONLY — see RenderRecord
-        // The single-read record object IS the response, so the #342 clause belongs on it; batch/query rows never
-        // repeat it per row (the caller passes false and the response object states it once), exactly as epoch does.
-        WriteOwnedChildNote(w, ownedChildNote);
         w.WriteString("formid", r.FormKey);
         w.WriteString("type", r.Type);
         WriteNullable(w, "editorid", r.EditorId);
@@ -317,7 +325,8 @@ static class JsonWire
         w.WriteNumber("override_depth", o.OverrideDepth);
         WriteNullable(w, "source", o.SourcePlugin);   // the body these field VALUES came from (scoped plugin vs winner)
         if (matches is not null) w.WriteString("matches", matches);
-        WriteFieldsArray(w, r, ms, cap);
+        WriteFieldsArray(w, r, ms, cap, o.OwnedChildFields, childFields);
+        if (stateChildNote && childFields is IReadOnlyCollection<string> { Count: > 0 } stated) WriteOwnedChildNote(w, stated);
         w.WriteEndObject();
     }
 
@@ -337,21 +346,22 @@ static class JsonWire
                 // A stamped refusal carries its stamp on the wire too (PR #305 review) — same contract as text.
                 w.WriteStartObject(); w.WriteString("error", o.Error); WriteNullable(w, "epoch", o.Epoch); w.WriteEndObject();
             }
-            else WriteReadRecord(w, o, ms, cap, epoch: o.Epoch, ownedChildNote: o.OwnedChildNoted);
+            else WriteReadRecord(w, o, ms, cap, epoch: o.Epoch,
+                                 childFields: new SortedSet<string>(StringComparer.Ordinal), stateChildNote: true);
         }
         return Finish(ms);
     }
 
-    /// <summary>The #342 clause on the json lane, written ONCE per response when a rendered record carries the
-    /// annotation — the same const the text lane states, so the two transports cannot drift. Gated on the
-    /// outcome's structural flag, never on the prose.
+    /// <summary>The #342 clause on the json lane, written ONCE per response over the annotated fields the document
+    /// actually CARRIES — the same source the text lane states, so the two transports cannot drift. Gated on the
+    /// paths that were written, never on the prose.
     ///
     /// <para>json only ever states the CHEAP tier's clause: <c>conflict_tree=true</c> is refused in json mode (a
     /// text-only diff view), so the lane that has the bodies to name declarers does not exist here. A json caller
     /// who wants the precise answer takes the same route the clause names — the text lane.</para></summary>
-    static void WriteOwnedChildNote(Utf8JsonWriter w, bool noted)
+    static void WriteOwnedChildNote(Utf8JsonWriter w, IReadOnlyCollection<string> fields)
     {
-        if (noted) w.WriteString("owned_child_note", ReadSentences.NotReadClause);
+        if (fields.Count > 0) w.WriteString("owned_child_note", ReadSentences.NotReadClause(fields));
     }
 
     // ---- housecarl_batch_record_detail (P6) ---------------------------------------------------------
@@ -377,23 +387,24 @@ static class JsonWire
             // (a malformed-FormID row never consulted a view and carries none).
             WriteNullable(w, "epoch", outcomes.FirstOrDefault(o => o.Epoch is not null)?.Epoch);
             w.WriteStartArray("records");
-            int rendered = 0; bool rowsTruncated = false; bool childNoted = false;   // #342: over rows RENDERED
+            int rendered = 0; bool rowsTruncated = false;
+            var childFields = new SortedSet<string>(StringComparer.Ordinal);   // #342: the fields the rows RENDERED carried
             foreach (var o in outcomes)
             {
                 if (manifestOnly) break;   // to_file: the rows are the FILE
                 w.Flush();
                 if (ms.Length >= cap) { rowsTruncated = true; break; }
                 if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", o.FormKey.ToString()); w.WriteString("error", o.Error); w.WriteEndObject(); }
-                else { WriteReadRecord(w, o, ms, cap); childNoted |= o.OwnedChildNoted; }
+                else WriteReadRecord(w, o, ms, cap, childFields: childFields);
                 rendered++;
             }
             w.WriteEndArray();
             w.WriteNumber("rendered", rendered);
             w.WriteBoolean("truncated", rowsTruncated);
-            // Over the rows this document actually carries — never the input list. A manifest-only (to_file) or
-            // truncated response renders no annotated field, and a clause pointing at "an annotated field above"
-            // with nothing above it is the text lane's own guarded mistake, one transport over.
-            WriteOwnedChildNote(w, childNoted);
+            // Over the annotated fields this document actually carries — never the input list, and never a field
+            // some row's own truncation dropped. A manifest-only (to_file) or truncated response carries none, and
+            // states none.
+            WriteOwnedChildNote(w, childFields);
             truncated = rowsTruncated;
             if (spill is not null) Artifacts.WriteSpillStateJson(w, spill);
             w.WriteEndObject();
@@ -979,7 +990,8 @@ static class JsonWire
                 WriteNotes(w, q, p5);
                 var linkMemo = resolveNames && detail ? new Dictionary<FormKey, ResolvedRef>() : null;
                 w.WriteStartArray("matches");
-                int rendered = 0; bool rowsTruncated = false; bool childNoted = false;   // #342: the clause once, after the rows
+                int rendered = 0; bool rowsTruncated = false;
+                var childFields = new SortedSet<string>(StringComparer.Ordinal);   // #342: the clause once, over the fields the rows carried
                 for (int i = 0; i < q.Keys.Count && !manifestOnly; i++)      // to_file: the rows are the FILE
                 {
                     w.Flush();
@@ -993,8 +1005,7 @@ static class JsonWire
                         // Pinned to the scan's build (PR #305 review) — the document's epoch names ONE build.
                         var o = svc.ResolveReadOn(q, fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false, depth, resolveNames: resolveNames, linkMemo: linkMemo);
                         if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", fk.ToString()); w.WriteString("error", o.Error); if (matches is not null) w.WriteString("matches", matches); w.WriteEndObject(); }
-                        else WriteReadRecord(w, o, ms, cap, matches);
-                        childNoted |= o.OwnedChildNoted;
+                        else WriteReadRecord(w, o, ms, cap, matches, childFields: childFields);
                     }
                     else
                     {
@@ -1006,7 +1017,7 @@ static class JsonWire
                 w.WriteEndArray();
                 w.WriteNumber("rendered", rendered);
                 w.WriteBoolean("truncated", rowsTruncated);
-                WriteOwnedChildNote(w, childNoted);
+                WriteOwnedChildNote(w, childFields);
                 truncated = rowsTruncated;
             }
             if (spill is not null && q.Error is null) Artifacts.WriteSpillStateJson(w, spill);
@@ -1092,7 +1103,8 @@ static class JsonWire
 
                 var linkMemo = resolveNames && detail ? new Dictionary<FormKey, ResolvedRef>() : null;
                 List<(string Formid, string Error)>? errors = null;
-                int rendered = 0; bool rowsTruncated = false; bool childNoted = false;   // #342: the clause once, after the rows
+                int rendered = 0; bool rowsTruncated = false;
+                var childFields = new SortedSet<string>(StringComparer.Ordinal);   // #342: the clause once, over the cells the rows carried
                 w.WriteStartArray("rows");
                 for (int i = 0; i < q.Keys.Count && !manifestOnly; i++)      // to_file: the rows are the FILE
                 {
@@ -1109,11 +1121,17 @@ static class JsonWire
                         w.WriteStartArray();
                         w.WriteStringValue(r.FormKey);
                         WriteCell(w, r.EditorId);
-                        foreach (var f in r.Fields) WriteCell(w, DenseCell(f));
+                        foreach (var f in r.Fields)
+                        {
+                            WriteCell(w, DenseCell(f));
+                            // A dense row writes every requested cell or none, so an annotated cell that reaches the
+                            // document is exactly one whose row was written — registered here all the same, so the
+                            // clause is earned at EMISSION on this lane too rather than from the outcome's intent.
+                            if (o.OwnedChildFields?.ContainsKey(f.Path) == true) childFields.Add(f.Path);
+                        }
                         if (anyScoped) WriteCell(w, o.SourcePlugin);          // the body this row's values were read from (winner_fields=true → the winner)
                         if (hasMatches) WriteCell(w, matches);
                         w.WriteEndArray();
-                        childNoted |= o.OwnedChildNoted;
                     }
                     else
                     {
@@ -1140,7 +1158,7 @@ static class JsonWire
                 }
                 w.WriteNumber("rendered", rendered);
                 w.WriteBoolean("truncated", rowsTruncated);
-                WriteOwnedChildNote(w, childNoted);
+                WriteOwnedChildNote(w, childFields);
                 truncated = rowsTruncated;
             }
             if (spill is not null && q.Error is null) Artifacts.WriteSpillStateJson(w, spill);

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -301,11 +301,15 @@ static class JsonWire
     /// <summary>Serialize a resolved record: identity + winner/override_depth/source + the fields array. Shared by
     /// read_record, batch_record_detail, and the cross_plugin_query detail path (one shape, no drift). <paramref
     /// name="matches"/> carries the multi-target references= un-merge when present.</summary>
-    internal static void WriteReadRecord(Utf8JsonWriter w, ReadOutcome o, MemoryStream ms, int cap, string? matches = null, string? epoch = null)
+    internal static void WriteReadRecord(Utf8JsonWriter w, ReadOutcome o, MemoryStream ms, int cap, string? matches = null,
+                                         string? epoch = null, bool ownedChildNote = false)
     {
         var r = o.Record!;
         w.WriteStartObject();
         if (epoch is not null) w.WriteString("epoch", epoch);   // single-read top level ONLY — see RenderRecord
+        // The single-read record object IS the response, so the #342 clause belongs on it; batch/query rows never
+        // repeat it per row (the caller passes false and the response object states it once), exactly as epoch does.
+        WriteOwnedChildNote(w, ownedChildNote);
         w.WriteString("formid", r.FormKey);
         w.WriteString("type", r.Type);
         WriteNullable(w, "editorid", r.EditorId);
@@ -333,9 +337,17 @@ static class JsonWire
                 // A stamped refusal carries its stamp on the wire too (PR #305 review) — same contract as text.
                 w.WriteStartObject(); w.WriteString("error", o.Error); WriteNullable(w, "epoch", o.Epoch); w.WriteEndObject();
             }
-            else WriteReadRecord(w, o, ms, cap, epoch: o.Epoch);
+            else WriteReadRecord(w, o, ms, cap, epoch: o.Epoch, ownedChildNote: o.OwnedChildNoted);
         }
         return Finish(ms);
+    }
+
+    /// <summary>The #342 invariant clause on the json lane, written ONCE per response when any rendered record
+    /// carries a per-field declarer annotation — the same const the text lane states, so the two transports
+    /// cannot drift on what a child record is. Gated on the outcome's structural flag, never on the prose.</summary>
+    static void WriteOwnedChildNote(Utf8JsonWriter w, bool noted)
+    {
+        if (noted) w.WriteString("owned_child_note", ReadSentences.OwnedChildMerge);
     }
 
     // ---- housecarl_batch_record_detail (P6) ---------------------------------------------------------
@@ -374,6 +386,7 @@ static class JsonWire
             w.WriteEndArray();
             w.WriteNumber("rendered", rendered);
             w.WriteBoolean("truncated", rowsTruncated);
+            WriteOwnedChildNote(w, outcomes.Any(o => o.OwnedChildNoted));
             truncated = rowsTruncated;
             if (spill is not null) Artifacts.WriteSpillStateJson(w, spill);
             w.WriteEndObject();
@@ -959,7 +972,7 @@ static class JsonWire
                 WriteNotes(w, q, p5);
                 var linkMemo = resolveNames && detail ? new Dictionary<FormKey, ResolvedRef>() : null;
                 w.WriteStartArray("matches");
-                int rendered = 0; bool rowsTruncated = false;
+                int rendered = 0; bool rowsTruncated = false; bool childNoted = false;   // #342: the clause once, after the rows
                 for (int i = 0; i < q.Keys.Count && !manifestOnly; i++)      // to_file: the rows are the FILE
                 {
                     w.Flush();
@@ -974,6 +987,7 @@ static class JsonWire
                         var o = svc.ResolveReadOn(q, fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false, depth, resolveNames: resolveNames, linkMemo: linkMemo);
                         if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", fk.ToString()); w.WriteString("error", o.Error); if (matches is not null) w.WriteString("matches", matches); w.WriteEndObject(); }
                         else WriteReadRecord(w, o, ms, cap, matches);
+                        childNoted |= o.OwnedChildNoted;
                     }
                     else
                     {
@@ -985,6 +999,7 @@ static class JsonWire
                 w.WriteEndArray();
                 w.WriteNumber("rendered", rendered);
                 w.WriteBoolean("truncated", rowsTruncated);
+                WriteOwnedChildNote(w, childNoted);
                 truncated = rowsTruncated;
             }
             if (spill is not null && q.Error is null) Artifacts.WriteSpillStateJson(w, spill);
@@ -1070,7 +1085,7 @@ static class JsonWire
 
                 var linkMemo = resolveNames && detail ? new Dictionary<FormKey, ResolvedRef>() : null;
                 List<(string Formid, string Error)>? errors = null;
-                int rendered = 0; bool rowsTruncated = false;
+                int rendered = 0; bool rowsTruncated = false; bool childNoted = false;   // #342: the clause once, after the rows
                 w.WriteStartArray("rows");
                 for (int i = 0; i < q.Keys.Count && !manifestOnly; i++)      // to_file: the rows are the FILE
                 {
@@ -1091,6 +1106,7 @@ static class JsonWire
                         if (anyScoped) WriteCell(w, o.SourcePlugin);          // the body this row's values were read from (winner_fields=true → the winner)
                         if (hasMatches) WriteCell(w, matches);
                         w.WriteEndArray();
+                        childNoted |= o.OwnedChildNoted;
                     }
                     else
                     {
@@ -1117,6 +1133,7 @@ static class JsonWire
                 }
                 w.WriteNumber("rendered", rendered);
                 w.WriteBoolean("truncated", rowsTruncated);
+                WriteOwnedChildNote(w, childNoted);
                 truncated = rowsTruncated;
             }
             if (spill is not null && q.Error is null) Artifacts.WriteSpillStateJson(w, spill);

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -377,20 +377,23 @@ static class JsonWire
             // (a malformed-FormID row never consulted a view and carries none).
             WriteNullable(w, "epoch", outcomes.FirstOrDefault(o => o.Epoch is not null)?.Epoch);
             w.WriteStartArray("records");
-            int rendered = 0; bool rowsTruncated = false;
+            int rendered = 0; bool rowsTruncated = false; bool childNoted = false;   // #342: over rows RENDERED
             foreach (var o in outcomes)
             {
                 if (manifestOnly) break;   // to_file: the rows are the FILE
                 w.Flush();
                 if (ms.Length >= cap) { rowsTruncated = true; break; }
                 if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", o.FormKey.ToString()); w.WriteString("error", o.Error); w.WriteEndObject(); }
-                else WriteReadRecord(w, o, ms, cap);
+                else { WriteReadRecord(w, o, ms, cap); childNoted |= o.OwnedChildNoted; }
                 rendered++;
             }
             w.WriteEndArray();
             w.WriteNumber("rendered", rendered);
             w.WriteBoolean("truncated", rowsTruncated);
-            WriteOwnedChildNote(w, outcomes.Any(o => o.OwnedChildNoted));
+            // Over the rows this document actually carries — never the input list. A manifest-only (to_file) or
+            // truncated response renders no annotated field, and a clause pointing at "an annotated field above"
+            // with nothing above it is the text lane's own guarded mistake, one transport over.
+            WriteOwnedChildNote(w, childNoted);
             truncated = rowsTruncated;
             if (spill is not null) Artifacts.WriteSpillStateJson(w, spill);
             w.WriteEndObject();
@@ -451,7 +454,7 @@ static class JsonWire
             w.WriteNumber("count", outcomes.Count);
             WriteNullable(w, "epoch", outcomes.FirstOrDefault(o => o.Epoch is not null)?.Epoch);
             w.WriteStartArray("records");
-            int rendered = 0; bool rowsTruncated = false;
+            int rendered = 0; bool rowsTruncated = false;   // summary rows carry no fields, so no #342 annotation
             foreach (var o in outcomes)
             {
                 if (manifestOnly) break;

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2321,10 +2321,11 @@ public sealed class LoadOrderService : IDisposable
         }
 
         var record = ReadEngine.ReadFields(rec, fields, depth, containerHint);   // materialise while the session (overlay) is open
-        record = AnnotateOwnedChildContent(record, rec, view, session, fk, source);           // #342: the additive-merge fact, DISPLAY-ONLY (same open session)
+        record = AnnotateOwnedChildContent(record, rec, view, session, fk, source, out bool childNoted);   // #342, DISPLAY-ONLY (same open session)
         if (resolveNames) record = AnnotateLinks(record, view, session, linkMemo ?? new());   // P7: identity of every FormLink token, DISPLAY-ONLY (same open session)
         var touching = conflictTree ? view.TouchingPlugins(fk) : null;
-        return new ReadOutcome(fk, record, source, winner.Value.WinnerPlugin, winner.Value.OverrideDepth, touching, null);
+        return new ReadOutcome(fk, record, source, winner.Value.WinnerPlugin, winner.Value.OverrideDepth, touching, null)
+               { OwnedChildNoted = childNoted };
     }
 
     /// <summary>resolve_names (P7): annotate every field whose <see cref="FieldValue.Token"/> is a form reference (a
@@ -2384,8 +2385,10 @@ public sealed class LoadOrderService : IDisposable
     /// fields array and the dense cells through that one carrier.</para></summary>
     static RecordFields AnnotateOwnedChildContent(RecordFields rf, IMajorRecordGetter body,
                                                   LoadOrderResolver.IndexView view,
-                                                  LoadOrderResolver.OverlaySession session, FormKey fk, string source)
+                                                  LoadOrderResolver.OverlaySession session, FormKey fk, string source,
+                                                  out bool noted)
     {
+        noted = false;
         // The pinned field set (write-surface-guard's own sweep, reached from a getter) — empty for all but three
         // record types, so this is where the overwhelming majority of reads leave, before any index lookup.
         var owning = OwnedChildContent.FieldNames(body);
@@ -2399,44 +2402,47 @@ public sealed class LoadOrderService : IDisposable
         if (hits is null) return rf;
 
         var touching = view.TouchingPlugins(fk);
-        if (touching is null || touching.Count <= 1) return rf;   // sole declarer: its own list IS the whole set
+        if (touching is null || touching.Count <= 1) return rf;   // sole declarer: its own body IS the whole set
 
-        var mine = new int?[hits.Count];
-        for (int h = 0; h < hits.Count; h++) mine[h] = OwnedChildContent.DeclaredCount(body, rf.Fields[hits[h]].Path);
+        // The question is a BOOLEAN about the OTHER bodies — "does anyone else declare children here" — not a
+        // comparison against this one. A count comparison was tried and rejected: it reported the wrong plugin as
+        // the largest declarer wherever children are container-nested (Worldspace.SubCells counts blocks), and it
+        // said nothing at all when this body simply held the biggest single list while another declared a DISJOINT
+        // set the game also loads. Both are the silent-wrong-answer class the annotation exists to close.
+        var declarers = new List<string>[hits.Count];
+        var unreadable = new List<string>[hits.Count];
+        for (int h = 0; h < hits.Count; h++) { declarers[h] = new List<string>(); unreadable[h] = new List<string>(); }
 
-        var others = new int[hits.Count];            // how many OTHER touchers declare any content for this field
-        var most = new int[hits.Count];              // …and the largest such declaration, with the plugin that made it
-        var mostPlugin = new string?[hits.Count];
         foreach (var p in touching)
         {
-            if (string.Equals(p, source, StringComparison.OrdinalIgnoreCase)) continue;
-            // Same view the touching list came from, so a plugin it names resolves here; a null is the excluded-
-            // plugin shape the view already vets and there is nothing to compare against. The field's own value is
-            // untouched either way — this annotation only ever ADDS a statement.
-            var other = view.GetRecord(session, p, fk);
-            if (other is null) continue;
+            if (string.Equals(p, source, StringComparison.OrdinalIgnoreCase)) continue;   // this body is not an "other"
+            // A body we cannot fetch is UNKNOWN, never "declares nothing" (#308's rule, one level down): dropping
+            // it silently would render as "nobody else declares content here", which is the wrong answer this
+            // annotation exists to prevent. The fetch is caught for the same reason it is not caught on the
+            // conflict-tree path — there, a fault fails a view the caller asked for; here it would fail a whole
+            // read over an ADDITIVE note, so it is named instead.
+            IMajorRecordGetter? other;
+            try { other = view.GetRecord(session, p, fk); } catch { other = null; }
             for (int h = 0; h < hits.Count; h++)
             {
-                if (OwnedChildContent.DeclaredCount(other, rf.Fields[hits[h]].Path) is not { } c || c == 0) continue;
-                others[h]++;
-                if (c > most[h]) { most[h] = c; mostPlugin[h] = p; }
+                var d = other is null ? null : OwnedChildContent.DeclaresChild(other, rf.Fields[hits[h]].Path);
+                if (d == true) declarers[h].Add(p);
+                else if (d is null) unreadable[h].Add(p);
             }
         }
 
         List<FieldValue>? rebuilt = null;
         for (int h = 0; h < hits.Count; h++)
         {
-            // Fires only when another body declares MORE than this one does. An unreadable count on THIS body
-            // (null) is not zero — it is "I could not look", and comparing it would manufacture the annotation out
-            // of a failed read rather than out of a real difference.
-            if (mine[h] is not { } m || most[h] <= m || mostPlugin[h] is not { } mp) continue;
+            if (ReadSentences.OwnedChildDeclarers(declarers[h], unreadable[h]) is not { } note) continue;
             rebuilt ??= new List<FieldValue>(rf.Fields);
             rebuilt[hits[h]] = rebuilt[hits[h]] with
             {
                 // These fields are containers and owned records; the only other producer of Display is the flags
                 // decode, which fires on [Flags] enum leaves alone — so there is no annotation here to displace.
-                Display = ReadSentences.OwnedChildContentNote(rf.Fields[hits[h]].Path, others[h], most[h], mp),
+                Display = note,
             };
+            noted = true;
         }
         return rebuilt is null ? rf : rf with { Fields = rebuilt };
     }
@@ -8406,6 +8412,12 @@ public sealed record ReadOutcome(
     /// RENDER's conflict-tree fill reads the SAME build the stamp names (PR #305 re-review; the pin that closed
     /// the cross-query fills closes the single-read/batch tree fills identically). Internal render plumbing.</summary>
     internal LoadOrderService.ViewPin? Pin { get; init; }
+
+    /// <summary>True when at least one field in <see cref="Record"/> carries the owned-child declarer annotation
+    /// (#342), so a response render can state the invariant clause ONCE. Carried STRUCTURALLY rather than
+    /// recovered by scanning the rendered prose for a marker: deciding a fact from note text is #308's shape, and
+    /// it is what this annotation exists to stop callers doing.</summary>
+    public bool OwnedChildNoted { get; init; }
 
     public static ReadOutcome Fail(FormKey fk, string error) => new(fk, null, null, null, 0, null, error);
 }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2321,6 +2321,7 @@ public sealed class LoadOrderService : IDisposable
         }
 
         var record = ReadEngine.ReadFields(rec, fields, depth, containerHint);   // materialise while the session (overlay) is open
+        record = AnnotateOwnedChildContent(record, rec, view, session, fk, source);           // #342: the additive-merge fact, DISPLAY-ONLY (same open session)
         if (resolveNames) record = AnnotateLinks(record, view, session, linkMemo ?? new());   // P7: identity of every FormLink token, DISPLAY-ONLY (same open session)
         var touching = conflictTree ? view.TouchingPlugins(fk) : null;
         return new ReadOutcome(fk, record, source, winner.Value.WinnerPlugin, winner.Value.OverrideDepth, touching, null);
@@ -2347,6 +2348,95 @@ public sealed class LoadOrderService : IDisposable
                 rebuilt ??= new List<FieldValue>(rf.Fields);
                 rebuilt[i] = f with { Link = ResolveRefOne(view, session, fk, memo) };
             }
+        }
+        return rebuilt is null ? rf : rf with { Fields = rebuilt };
+    }
+
+    /// <summary>#342 — annotate a read of a field that OWNS CHILD RECORDS when another plugin touching the record
+    /// declares more of them than the body being read does.
+    ///
+    /// <para><b>The wrong answer this exists to stop.</b> Placed references, a topic's INFOs and a worldspace's cells
+    /// are declared per plugin and assembled by the game from every plugin that declares them. An override that
+    /// touches a cell for an unrelated reason (occlusion, lighting, music) carries no references and deletes none —
+    /// so reading its <c>Persistent</c>/<c>Temporary</c> reports an empty cell that the game fills. Reproduced:
+    /// <c>008EB5:Skyrim.esm</c> reads Temporary 0 at its winner (<c>Occlusion.esp</c>, override depth 42) while
+    /// <c>Skyrim.esm</c>'s own body carries 201. A caller auditing "what is in this cell" through the winner got a
+    /// silent wrong answer, which is the Q3 class.</para>
+    ///
+    /// <para><b>What it does NOT do.</b> It does not union anything. The read that answers "what is actually live in
+    /// this parent" — every child at its own winner, minus the deleted and initially-disabled — is separate design
+    /// work; naive concatenation would multi-count the children that overlapping overrides both declare. This states
+    /// the fact and leaves the value exactly as the body declares it.</para>
+    ///
+    /// <para><b>Cost.</b> Nothing happens on a read whose record type owns no children — every type but Cell,
+    /// DialogTopic and Worldspace — and nothing happens on one whose requested fields miss the owning set. When it
+    /// does run it fetches each other touching body ONCE (not once per field) and reads a count off it, which is
+    /// strictly cheaper than the conflict tree's deep read of the same bodies.</para>
+    ///
+    /// <para><b>Every other toucher, not just the lower ones.</b> The additive assembly is over the whole touching
+    /// set, so a <c>plugin=</c>-scoped read of a base master — the workaround this bug's reporter reached for —
+    /// gets the same annotation when later plugins declare content it cannot see. For the default winner read the
+    /// two readings coincide: the winner is last, so every other toucher is below it.</para>
+    ///
+    /// <para>DISPLAY-ONLY, like the biped-slot decode and the resolve_names link it sits beside: it rides
+    /// <see cref="FieldValue.Display"/>, never the round-trip <see cref="FieldValue.Token"/>, so it is invisible to
+    /// the write surface, the read-proof oracle and the conflict diff — and it reaches the text render, the json
+    /// fields array and the dense cells through that one carrier.</para></summary>
+    static RecordFields AnnotateOwnedChildContent(RecordFields rf, IMajorRecordGetter body,
+                                                  LoadOrderResolver.IndexView view,
+                                                  LoadOrderResolver.OverlaySession session, FormKey fk, string source)
+    {
+        // The pinned field set (write-surface-guard's own sweep, reached from a getter) — empty for all but three
+        // record types, so this is where the overwhelming majority of reads leave, before any index lookup.
+        var owning = OwnedChildContent.FieldNames(body);
+        if (owning.Count == 0) return rf;
+
+        // …and of the lines THIS read produced, which are those fields. A depth>=2 read emits the same summary line
+        // at the bare field path before expanding its children, so the annotation lands in one place either way.
+        List<int>? hits = null;
+        for (int i = 0; i < rf.Fields.Count; i++)
+            if (owning.Contains(rf.Fields[i].Path, StringComparer.Ordinal)) (hits ??= new List<int>()).Add(i);
+        if (hits is null) return rf;
+
+        var touching = view.TouchingPlugins(fk);
+        if (touching is null || touching.Count <= 1) return rf;   // sole declarer: its own list IS the whole set
+
+        var mine = new int?[hits.Count];
+        for (int h = 0; h < hits.Count; h++) mine[h] = OwnedChildContent.DeclaredCount(body, rf.Fields[hits[h]].Path);
+
+        var others = new int[hits.Count];            // how many OTHER touchers declare any content for this field
+        var most = new int[hits.Count];              // …and the largest such declaration, with the plugin that made it
+        var mostPlugin = new string?[hits.Count];
+        foreach (var p in touching)
+        {
+            if (string.Equals(p, source, StringComparison.OrdinalIgnoreCase)) continue;
+            // Same view the touching list came from, so a plugin it names resolves here; a null is the excluded-
+            // plugin shape the view already vets and there is nothing to compare against. The field's own value is
+            // untouched either way — this annotation only ever ADDS a statement.
+            var other = view.GetRecord(session, p, fk);
+            if (other is null) continue;
+            for (int h = 0; h < hits.Count; h++)
+            {
+                if (OwnedChildContent.DeclaredCount(other, rf.Fields[hits[h]].Path) is not { } c || c == 0) continue;
+                others[h]++;
+                if (c > most[h]) { most[h] = c; mostPlugin[h] = p; }
+            }
+        }
+
+        List<FieldValue>? rebuilt = null;
+        for (int h = 0; h < hits.Count; h++)
+        {
+            // Fires only when another body declares MORE than this one does. An unreadable count on THIS body
+            // (null) is not zero — it is "I could not look", and comparing it would manufacture the annotation out
+            // of a failed read rather than out of a real difference.
+            if (mine[h] is not { } m || most[h] <= m || mostPlugin[h] is not { } mp) continue;
+            rebuilt ??= new List<FieldValue>(rf.Fields);
+            rebuilt[hits[h]] = rebuilt[hits[h]] with
+            {
+                // These fields are containers and owned records; the only other producer of Display is the flags
+                // decode, which fires on [Flags] enum leaves alone — so there is no annotation here to displace.
+                Display = ReadSentences.OwnedChildContentNote(rf.Fields[hits[h]].Path, others[h], most[h], mp),
+            };
         }
         return rebuilt is null ? rf : rf with { Fields = rebuilt };
     }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2321,7 +2321,7 @@ public sealed class LoadOrderService : IDisposable
         }
 
         var record = ReadEngine.ReadFields(rec, fields, depth, containerHint);   // materialise while the session (overlay) is open
-        record = AnnotateOwnedChildContent(record, rec, view, session, fk, source, out bool childNoted);   // #342, DISPLAY-ONLY (same open session)
+        record = AnnotateOwnedChildContent(record, rec, view, fk, out bool childNoted);   // #342 cheap tier — index only, DISPLAY-ONLY
         if (resolveNames) record = AnnotateLinks(record, view, session, linkMemo ?? new());   // P7: identity of every FormLink token, DISPLAY-ONLY (same open session)
         var touching = conflictTree ? view.TouchingPlugins(fk) : null;
         return new ReadOutcome(fk, record, source, winner.Value.WinnerPlugin, winner.Value.OverrideDepth, touching, null)
@@ -2353,8 +2353,8 @@ public sealed class LoadOrderService : IDisposable
         return rebuilt is null ? rf : rf with { Fields = rebuilt };
     }
 
-    /// <summary>#342 — annotate a read of a field that OWNS CHILD RECORDS when another plugin touching the record
-    /// declares more of them than the body being read does.
+    /// <summary>#342 CHEAP TIER — on a read of a field that OWNS CHILD RECORDS, say that other plugins touch this
+    /// record and that this read did not open them. Index only; no body is fetched.
     ///
     /// <para><b>The wrong answer this exists to stop.</b> Placed references, a topic's INFOs and a worldspace's cells
     /// are declared per plugin and assembled by the game from every plugin that declares them. An override that
@@ -2364,87 +2364,108 @@ public sealed class LoadOrderService : IDisposable
     /// <c>Skyrim.esm</c>'s own body carries 201. A caller auditing "what is in this cell" through the winner got a
     /// silent wrong answer, which is the Q3 class.</para>
     ///
-    /// <para><b>What it does NOT do.</b> It does not union anything. The read that answers "what is actually live in
-    /// this parent" — every child at its own winner, minus the deleted and initially-disabled — is separate design
-    /// work; naive concatenation would multi-count the children that overlapping overrides both declare. This states
-    /// the fact and leaves the value exactly as the body declares it.</para>
+    /// <para><b>Why this tier claims so little.</b> Naming WHICH plugins declare children requires their bodies,
+    /// and <see cref="LoadOrderResolver.GetRecord"/> fetches one by enumerating a whole overlay. Doing that per
+    /// toucher was built, measured on a real load order, and withdrawn: 27 ms → 588 ms for one Dawnstar cell,
+    /// 21 ms → 1.3 s for Tamriel, 6.3 s → 126 s for a 200-cell query, and an artifact job that never finished.
+    /// So this tier states only what the index settles for free, and <see cref="ResolveTreeFill"/> — the lane that
+    /// has already paid for every body — states which plugins actually declare.</para>
     ///
-    /// <para><b>Cost.</b> Nothing happens on a read whose record type owns no children — every type but Cell,
-    /// DialogTopic and Worldspace — and nothing happens on one whose requested fields miss the owning set. When it
-    /// does run it fetches each other touching body ONCE (not once per field) and reads a count off it, which is
-    /// strictly cheaper than the conflict tree's deep read of the same bodies.</para>
+    /// <para><b>What neither tier does.</b> Union anything. The read that answers "what is actually live in this
+    /// parent" — every child at its own winner, minus the deleted and initially-disabled — is separate design work;
+    /// naive concatenation would multi-count the children overlapping overrides both declare.</para>
     ///
-    /// <para><b>Every other toucher, not just the lower ones.</b> The additive assembly is over the whole touching
-    /// set, so a <c>plugin=</c>-scoped read of a base master — the workaround this bug's reporter reached for —
-    /// gets the same annotation when later plugins declare content it cannot see. For the default winner read the
-    /// two readings coincide: the winner is last, so every other toucher is below it.</para>
+    /// <para><b>Every other toucher, not just the lower ones.</b> Assembly is over the whole touching set, so a
+    /// <c>plugin=</c>-scoped read of a base master — the workaround this bug's reporter reached for — is annotated
+    /// too: the plugins ABOVE it declare children it cannot see.</para>
     ///
     /// <para>DISPLAY-ONLY, like the biped-slot decode and the resolve_names link it sits beside: it rides
     /// <see cref="FieldValue.Display"/>, never the round-trip <see cref="FieldValue.Token"/>, so it is invisible to
     /// the write surface, the read-proof oracle and the conflict diff — and it reaches the text render, the json
     /// fields array and the dense cells through that one carrier.</para></summary>
     static RecordFields AnnotateOwnedChildContent(RecordFields rf, IMajorRecordGetter body,
-                                                  LoadOrderResolver.IndexView view,
-                                                  LoadOrderResolver.OverlaySession session, FormKey fk, string source,
-                                                  out bool noted)
+                                                  LoadOrderResolver.IndexView view, FormKey fk, out bool noted)
     {
         noted = false;
         // The pinned field set (write-surface-guard's own sweep, reached from a getter) — empty for all but three
         // record types, so this is where the overwhelming majority of reads leave, before any index lookup.
-        var owning = OwnedChildContent.FieldNames(body);
+        var owning = OwnedChildContent.Fields(body);
         if (owning.Count == 0) return rf;
 
         // …and of the lines THIS read produced, which are those fields. A depth>=2 read emits the same summary line
         // at the bare field path before expanding its children, so the annotation lands in one place either way.
         List<int>? hits = null;
         for (int i = 0; i < rf.Fields.Count; i++)
-            if (owning.Contains(rf.Fields[i].Path, StringComparer.Ordinal)) (hits ??= new List<int>()).Add(i);
+            if (owning.ContainsKey(rf.Fields[i].Path)) (hits ??= new List<int>()).Add(i);
         if (hits is null) return rf;
 
         var touching = view.TouchingPlugins(fk);
-        if (touching is null || touching.Count <= 1) return rf;   // sole declarer: its own body IS the whole set
+        if (touching is null || touching.Count <= 1) return rf;   // sole toucher: its own body IS the whole story
 
-        // The question is a BOOLEAN about the OTHER bodies — "does anyone else declare children here" — not a
-        // comparison against this one. A count comparison was tried and rejected: it reported the wrong plugin as
-        // the largest declarer wherever children are container-nested (Worldspace.SubCells counts blocks), and it
-        // said nothing at all when this body simply held the biggest single list while another declared a DISJOINT
-        // set the game also loads. Both are the silent-wrong-answer class the annotation exists to close.
-        var declarers = new List<string>[hits.Count];
-        var unreadable = new List<string>[hits.Count];
-        for (int h = 0; h < hits.Count; h++) { declarers[h] = new List<string>(); unreadable[h] = new List<string>(); }
+        // INDEX ONLY — no body is opened here. Naming WHICH plugins declare children means fetching their bodies,
+        // and the resolver fetches one by enumerating a whole overlay: measured on a real load order, doing that
+        // per toucher took one Dawnstar cell read from 27 ms to 588 ms, a worldspace read to 2.5 s, and an
+        // unbounded artifact job past ten minutes. So the default read states only what the index settles for
+        // free — that other plugins touch this record and this read did not look at what they declare — and the
+        // conflict-tree lane, which has already paid for every body, states which ones do.
+        var note = ReadSentences.NotReadNote(touching.Count - 1);
+        var rebuilt = new List<FieldValue>(rf.Fields);
+        foreach (var i in hits)
+            // These fields are containers and owned records; the only other producer of Display is the flags
+            // decode, which fires on [Flags] enum leaves alone — so there is no annotation here to displace.
+            rebuilt[i] = rebuilt[i] with { Display = note };
+        noted = true;
+        return rf with { Fields = rebuilt };
+    }
 
-        foreach (var p in touching)
+    /// <summary>The PRECISE tier (#342): which other plugins actually declare child records for each annotated
+    /// field, computed off the bodies the conflict tree HAS ALREADY FETCHED.
+    ///
+    /// <para>This adds no record fetch of its own — that is the whole point. <see cref="ResolveTreeFill"/> walks
+    /// <c>tree.Nodes</c>, which <see cref="LoadOrderResolver.ResolveTree"/> materialised, and asks each body a
+    /// question it can answer in hand. A version that fetched its own bodies was measured and rejected (see the
+    /// cheap tier's comment).</para></summary>
+    public sealed record ChildDeclarers(OwnedChildShape Shape, IReadOnlyList<string> Declaring, IReadOnlyList<string> Unreadable);
+
+    /// <summary>A conflict-tree fill plus the per-field declarer answer read off the SAME bodies.</summary>
+    internal sealed record TreeFill(ConflictTreeView View, IReadOnlyDictionary<string, ChildDeclarers> ByField);
+
+    /// <summary>Fill the conflict tree AND, from the same nodes, answer which other plugins declare child records
+    /// for each of <paramref name="renderedPaths"/> that owns any. One session, one fetch per touching plugin —
+    /// the tree's own — serving both the diff view and the annotation.</summary>
+    internal TreeFill? ResolveTreeFill(ViewPin p, FormKey fk, IReadOnlyList<string>? fields,
+                                       string? sourcePlugin, IReadOnlyList<string> renderedPaths)
+    {
+        using var session = p.Resolver.OpenSession();
+        var tree = p.View.ResolveTree(session, fk);
+        if (tree is null) return null;
+
+        var owning = tree.Nodes.Count > 0 ? OwnedChildContent.Fields(tree.Nodes[0].Record) : null;
+        var wanted = owning is null || owning.Count == 0
+            ? new List<string>()
+            : renderedPaths.Where(owning.ContainsKey).Distinct(StringComparer.Ordinal).ToList();
+        var declaring = wanted.ToDictionary(f => f, _ => new List<string>(), StringComparer.Ordinal);
+        var unreadable = wanted.ToDictionary(f => f, _ => new List<string>(), StringComparer.Ordinal);
+
+        var nodes = new List<ConflictNodeView>(tree.Nodes.Count);
+        foreach (var n in tree.Nodes)
         {
-            if (string.Equals(p, source, StringComparison.OrdinalIgnoreCase)) continue;   // this body is not an "other"
-            // A body we cannot fetch is UNKNOWN, never "declares nothing" (#308's rule, one level down): dropping
-            // it silently would render as "nobody else declares content here", which is the wrong answer this
-            // annotation exists to prevent. The fetch is caught for the same reason it is not caught on the
-            // conflict-tree path — there, a fault fails a view the caller asked for; here it would fail a whole
-            // read over an ADDITIVE note, so it is named instead.
-            IMajorRecordGetter? other;
-            try { other = view.GetRecord(session, p, fk); } catch { other = null; }
-            for (int h = 0; h < hits.Count; h++)
+            nodes.Add(new ConflictNodeView(n.Plugin, ReadEngine.ReadFields(n.Record, fields, ConflictDiffDepth)));   // materialise while open
+            if (wanted.Count == 0 || string.Equals(n.Plugin, sourcePlugin, StringComparison.OrdinalIgnoreCase)) continue;
+            foreach (var f in wanted)
             {
-                var d = other is null ? null : OwnedChildContent.DeclaresChild(other, rf.Fields[hits[h]].Path);
-                if (d == true) declarers[h].Add(p);
-                else if (d is null) unreadable[h].Add(p);
+                // NULL is "I could not look", never "declares nothing" (#308's rule one level down): a body dropped
+                // in silence would render as "nobody else declares content here".
+                var d = OwnedChildContent.DeclaresChild(n.Record, f);
+                if (d == true) declaring[f].Add(n.Plugin);
+                else if (d is null) unreadable[f].Add(n.Plugin);
             }
         }
 
-        List<FieldValue>? rebuilt = null;
-        for (int h = 0; h < hits.Count; h++)
-        {
-            if (ReadSentences.OwnedChildDeclarers(declarers[h], unreadable[h]) is not { } note) continue;
-            rebuilt ??= new List<FieldValue>(rf.Fields);
-            rebuilt[hits[h]] = rebuilt[hits[h]] with
-            {
-                // These fields are containers and owned records; the only other producer of Display is the flags
-                // decode, which fires on [Flags] enum leaves alone — so there is no annotation here to displace.
-                Display = note,
-            };
-            noted = true;
-        }
-        return rebuilt is null ? rf : rf with { Fields = rebuilt };
+        var byField = new Dictionary<string, ChildDeclarers>(StringComparer.Ordinal);
+        foreach (var f in wanted)
+            byField[f] = new ChildDeclarers(owning![f], declaring[f], unreadable[f]);
+        return new TreeFill(new ConflictTreeView(nodes), byField);
     }
 
     /// <summary>How deep the conflict diff reads each touching body. The diff must compare CONTENT, not the

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2321,11 +2321,11 @@ public sealed class LoadOrderService : IDisposable
         }
 
         var record = ReadEngine.ReadFields(rec, fields, depth, containerHint);   // materialise while the session (overlay) is open
-        record = AnnotateOwnedChildContent(record, rec, view, fk, out bool childNoted);   // #342 cheap tier — index only, DISPLAY-ONLY
+        record = AnnotateOwnedChildContent(record, rec, view, fk, out var childFields);   // #342 cheap tier — index only, DISPLAY-ONLY
         if (resolveNames) record = AnnotateLinks(record, view, session, linkMemo ?? new());   // P7: identity of every FormLink token, DISPLAY-ONLY (same open session)
         var touching = conflictTree ? view.TouchingPlugins(fk) : null;
         return new ReadOutcome(fk, record, source, winner.Value.WinnerPlugin, winner.Value.OverrideDepth, touching, null)
-               { OwnedChildNoted = childNoted };
+               { OwnedChildFields = childFields };
     }
 
     /// <summary>resolve_names (P7): annotate every field whose <see cref="FieldValue.Token"/> is a form reference (a
@@ -2384,9 +2384,10 @@ public sealed class LoadOrderService : IDisposable
     /// the write surface, the read-proof oracle and the conflict diff — and it reaches the text render, the json
     /// fields array and the dense cells through that one carrier.</para></summary>
     static RecordFields AnnotateOwnedChildContent(RecordFields rf, IMajorRecordGetter body,
-                                                  LoadOrderResolver.IndexView view, FormKey fk, out bool noted)
+                                                  LoadOrderResolver.IndexView view, FormKey fk,
+                                                  out IReadOnlyDictionary<string, OwnedChildShape>? annotated)
     {
-        noted = false;
+        annotated = null;
         // The pinned field set (write-surface-guard's own sweep, reached from a getter) — empty for all but three
         // record types, so this is where the overwhelming majority of reads leave, before any index lookup.
         var owning = OwnedChildContent.Fields(body);
@@ -2410,11 +2411,18 @@ public sealed class LoadOrderService : IDisposable
         // conflict-tree lane, which has already paid for every body, states which ones do.
         var note = ReadSentences.NotReadNote(touching.Count - 1);
         var rebuilt = new List<FieldValue>(rf.Fields);
+        // The ANNOTATED paths and their shapes travel with the outcome, because the render decides its
+        // response-level clause off the fields it actually emitted — a path that never reaches the medium (a cap
+        // hit inside the field loop, a truncated json array, a manifest-only spill) must not earn a clause.
+        var map = new Dictionary<string, OwnedChildShape>(hits.Count, StringComparer.Ordinal);
         foreach (var i in hits)
+        {
             // These fields are containers and owned records; the only other producer of Display is the flags
             // decode, which fires on [Flags] enum leaves alone — so there is no annotation here to displace.
             rebuilt[i] = rebuilt[i] with { Display = note };
-        noted = true;
+            map[rebuilt[i].Path] = owning[rebuilt[i].Path];
+        }
+        annotated = map;
         return rf with { Fields = rebuilt };
     }
 
@@ -8434,11 +8442,20 @@ public sealed record ReadOutcome(
     /// the cross-query fills closes the single-read/batch tree fills identically). Internal render plumbing.</summary>
     internal LoadOrderService.ViewPin? Pin { get; init; }
 
-    /// <summary>True when at least one field in <see cref="Record"/> carries the owned-child declarer annotation
-    /// (#342), so a response render can state the invariant clause ONCE. Carried STRUCTURALLY rather than
-    /// recovered by scanning the rendered prose for a marker: deciding a fact from note text is #308's shape, and
-    /// it is what this annotation exists to stop callers doing.</summary>
-    public bool OwnedChildNoted { get; init; }
+    /// <summary>WHICH fields in <see cref="Record"/> carry the owned-child annotation (#342), each with its
+    /// <see cref="OwnedChildShape"/> — so a response render can state the invariant clause ONCE, over the fields it
+    /// ACTUALLY EMITTED, and name them. Null when this read annotated nothing.
+    ///
+    /// <para>Carried STRUCTURALLY rather than recovered by scanning the rendered prose for a marker: deciding a
+    /// fact from note text is #308's shape, and it is what this annotation exists to stop callers doing. It carries
+    /// the paths rather than a bool because a clause that merely knows "something was annotated" cannot tell
+    /// whether that something survived the medium's own truncation — the stranded-clause defect Aaron's review
+    /// found on three transports at once.</para></summary>
+    public IReadOnlyDictionary<string, OwnedChildShape>? OwnedChildFields { get; init; }
+
+    /// <summary>Did this read annotate anything at all — the cheap question, for callers that only need to know
+    /// whether a clause is POSSIBLE (the budget reservation) rather than which fields it would name.</summary>
+    public bool OwnedChildNoted => OwnedChildFields is { Count: > 0 };
 
     public static ReadOutcome Fail(FormKey fk, string error) => new(fk, null, null, null, 0, null, error);
 }

--- a/src/housecarl-mcp/ReadSentences.cs
+++ b/src/housecarl-mcp/ReadSentences.cs
@@ -40,14 +40,23 @@ internal static class ReadSentences
     [MustState("were not read")]
     internal const string NotRead = "other plugin(s) touch this record; their declarations for this field were not read";
 
-    /// <summary>The response-level half of the cheap tier, naming the lane that answers precisely. The remedy is
-    /// named only because it was RUN: <c>conflict_tree=true</c> fetches every touching body and states which
-    /// plugins declare content for these fields, measured on the same order the cost figures came from.</summary>
-    [MustState("declared per plugin", "conflict_tree=true")]
+    /// <summary>The response-level half of the cheap tier, naming the lane that answers precisely.
+    ///
+    /// <para><b>The remedy names the tool AND the format, because a bare parameter name is not runnable from most
+    /// of the surfaces that receive this sentence.</b> The clause ships from every lane that renders record fields.
+    /// <c>housecarl_records</c> has no <c>conflict_tree</c> parameter at all (and its
+    /// <c>project={"form":"tree"}</c> carries no declarer names either); <c>format=json</c> and <c>format=dense</c>
+    /// refuse <c>conflict_tree=true</c> as a text-only diff view; so does <c>to_file=</c>, which means every
+    /// artifact manifest carries this clause to a caller who cannot use a bare "pass conflict_tree=true" without a
+    /// refusal. Naming the two tools and the text mode is what makes the sentence executable from where it is
+    /// actually read — the remedy-never-run mistake is naming a spelling the recipient's surface rejects.</para></summary>
+    [MustState("declared per plugin", "conflict_tree=true", "housecarl_read_record", "text mode")]
     internal const string NotReadClause =
         "note: an annotated field above holds CHILD RECORDS, which are declared per plugin — so what one plugin's " +
         "body carries is not the whole story for that field. This read did not open the other plugins' bodies to " +
-        "see what they declare; pass conflict_tree=true for a read that does, and names them.";
+        "see what they declare. To get a read that does, and names them: housecarl_read_record or " +
+        "housecarl_batch_record_detail in text mode (the default) with conflict_tree=true — it is a text-only view, " +
+        "so json, dense and to_file reads refuse it.";
 
     /// <summary>The cheap tier's per-field line: the count the index knows, and the honest limit.</summary>
     internal static string NotReadNote(int others) => $"{others} {NotRead}";

--- a/src/housecarl-mcp/ReadSentences.cs
+++ b/src/housecarl-mcp/ReadSentences.cs
@@ -1,3 +1,5 @@
+using HousecarlCore;
+
 namespace HousecarlMcp;
 
 /// <summary>
@@ -5,41 +7,64 @@ namespace HousecarlMcp;
 /// on the other surface.
 ///
 /// <para><b>Why it starts here.</b> The read surface's response-layer migration is its own scheduled piece of
-/// work; this class is not it. It exists because the first read sentence that carries a CLAIM a caller acts on
+/// work; this class is not it. It exists because the first read sentences that carry CLAIMS a caller acts on
 /// arrived (#342's owned-child annotation), and the write surface's lesson is that a sentence born as a render
-/// literal is a sentence that gets copied and then drifts. So it is born here instead, with the same two nets
-/// the write sentences have: the CONTENT net (<see cref="MustStateAttribute"/> — the phrases whose loss changes
-/// what the caller is told, declared beside the sentence) and a REACH net in the probe that owns the feature
-/// (every const observed coming out of a real render, on both transports).</para>
+/// literal is a sentence that gets copied and then drifts. So they are born here, with the same two nets the
+/// write sentences have: the CONTENT net (<see cref="MustStateAttribute"/> — the phrases whose loss changes what
+/// the caller is told, declared beside the sentence) and a REACH net in the probe that owns the feature.</para>
 ///
-/// <para><b>The response/field split.</b> The invariant half — what a child record IS — is a fact about the
-/// response, not about one field, so it is stated ONCE per response. Carrying it per field cost 288 chars per
-/// annotated field per record, ~275 of them identical on every row: a 500-row cell query spent ~280 KB of an
-/// ~80 k budget restating the same sentence, and the rows that got truncated to make room were real data. The
-/// per-field annotation therefore carries only what differs per field — WHICH other plugins declare content —
-/// and the response carries the meaning.</para>
+/// <para><b>Two tiers, because the cheap question and the precise one cost differently.</b> Naming WHICH other
+/// plugins declare children means reading their bodies, and the resolver fetches a body by enumerating a whole
+/// overlay — measured on a real load order at 588 ms for one Dawnstar cell read and 2.5 s for a worldspace, with
+/// an unbounded artifact job never finishing. So the precise answer is stated only by the lane that has ALREADY
+/// fetched those bodies (<c>conflict_tree=true</c>), and every other read states the cheaper fact the index alone
+/// settles: how many other plugins touch the record, and that their declarations were not read.</para>
+///
+/// <para><b>Two shapes, because one sentence was false for two of its own fields.</b> A COLLECTION child field is
+/// assembled additively; a SINGULAR one (Cell.Landscape, Worldspace.TopCell) is one record several plugins
+/// OVERRIDE. "Not the merged total" is true of the first and false of the second — see
+/// <see cref="OwnedChildShape"/>. Each arm states what is true of its shape.</para>
+///
+/// <para><b>The response/field split.</b> The invariant half is a fact about the response, not about one field,
+/// so it is stated ONCE per response. Carried per field it cost 288 chars per annotated field per record, ~275 of
+/// them identical on every row — a bulk response spent its budget restating one sentence and truncated real rows
+/// to make room.</para>
 /// </summary>
 internal static class ReadSentences
 {
-    /// <summary>The response-level fact behind #342's annotation, and the part a caller acts on: an annotated
-    /// field shows ONE plugin's declaration of a parent's children, and the game does not treat it as the whole
-    /// set.
-    ///
-    /// <para>Deliberately names NO remedy. The read that would answer "what is actually live in this parent"
-    /// (a FormKey-keyed union with each child taken at its own winner) does not exist yet, and the obvious
-    /// workaround — re-reading with <c>plugin=</c> — is not load-order truth either: that body's own children can
-    /// themselves be overridden further up. A sentence that pointed at either would be promising capability the
-    /// surface does not have, so this one states the fact and stops.</para></summary>
-    [MustState("declared per plugin", "not the merged total")]
-    internal const string OwnedChildMerge =
-        "note: an annotated field above holds CHILD RECORDS — a cell's placed references, a topic's INFO lines, " +
-        "a worldspace's cells. Those are declared per plugin and the game assembles them from every plugin that " +
-        "declares them, so the value shown is one plugin's own declaration, not the merged total.";
+    // ---- tier 1: the cheap fact every read can state from the index alone ----------------------------
 
-    /// <summary>The per-field half's label. A pure label: on its own it asserts nothing a caller acts on — the
-    /// claim is the plugin names that follow it, and its meaning is <see cref="OwnedChildMerge"/>.</summary>
-    [NoClaims("a label; the claim is the plugin names it introduces, and their meaning is OwnedChildMerge")]
+    /// <summary>The per-field half of the cheap tier. It claims ONLY what the index knows — that other plugins
+    /// touch this record and this read did not look at what they declare. It must never imply they DO declare
+    /// content (unknown without reading them) nor that they don't.</summary>
+    [MustState("were not read")]
+    internal const string NotRead = "other plugin(s) touch this record; their declarations for this field were not read";
+
+    /// <summary>The response-level half of the cheap tier, naming the lane that answers precisely. The remedy is
+    /// named only because it was RUN: <c>conflict_tree=true</c> fetches every touching body and states which
+    /// plugins declare content for these fields, measured on the same order the cost figures came from.</summary>
+    [MustState("declared per plugin", "conflict_tree=true")]
+    internal const string NotReadClause =
+        "note: an annotated field above holds CHILD RECORDS, which are declared per plugin — so what one plugin's " +
+        "body carries is not the whole story for that field. This read did not open the other plugins' bodies to " +
+        "see what they declare; pass conflict_tree=true for a read that does, and names them.";
+
+    /// <summary>The cheap tier's per-field line: the count the index knows, and the honest limit.</summary>
+    internal static string NotReadNote(int others) => $"{others} {NotRead}";
+
+    // ---- tier 2: the precise answer, off bodies the conflict-tree lane already fetched ----------------
+
+    /// <summary>The per-field label for a COLLECTION child. A pure label: on its own it asserts nothing a caller
+    /// acts on — the claim is the plugin names it introduces, and their meaning is
+    /// <see cref="MergeCollection"/>.</summary>
+    [NoClaims("a label; the claim is the plugin names it introduces, and their meaning is MergeCollection")]
     internal const string DeclaredBy = "also declared by";
+
+    /// <summary>The per-field line for a SINGULAR child: a COUNT, deliberately not a name list. Landscape and
+    /// TopCell are overridden by hundreds of plugins on a real order ("+483 more" is noise, not information), and
+    /// which one wins is a load-order question the conflict tree answers properly.</summary>
+    [NoClaims("a label; the claim is SingleResolved, and the count is evidence rather than an assertion")]
+    internal const string CarriedBy = "also carried by";
 
     /// <summary>The Q3 half: a plugin touching this record whose body or field could not be read. Stated, never
     /// dropped — an unreadable body silently missing from the list would read as "nobody else declares", which is
@@ -47,23 +72,45 @@ internal static class ReadSentences
     [MustState("could NOT be read")]
     internal const string CouldNotRead = "could NOT be read";
 
-    /// <summary>How many declaring plugins the per-field annotation names before it summarises the rest. Three
-    /// names is enough to go look at; the rest are a count, because this rides EVERY annotated field of every row
-    /// in a bulk response.</summary>
+    /// <summary>The response-level fact for COLLECTION children: assembled additively, so one body's list is not
+    /// the total.
+    ///
+    /// <para>Deliberately names NO remedy for the total. The read that would answer "what is actually live in this
+    /// parent" (a FormKey-keyed union with each child at its own winner) does not exist yet, and re-reading with
+    /// <c>plugin=</c> is not load-order truth either — that body's own children can themselves be overridden
+    /// further up.</para></summary>
+    [MustState("declared per plugin", "not the merged total")]
+    internal const string MergeCollection =
+        "note: an annotated Persistent / Temporary / NavigationMeshes / Responses / SubCells field holds MANY child " +
+        "records — a cell's placed references, a topic's INFO lines, a worldspace's cells. Those are declared per " +
+        "plugin and the game assembles them from every plugin that declares them, so the value shown is one " +
+        "plugin's own declaration, not the merged total.";
+
+    /// <summary>The response-level fact for SINGULAR children, which is a DIFFERENT fact. One record, one FormKey:
+    /// the plugins that also carry it are overriding each other, and the one the game uses is decided by load
+    /// order. What the annotation tells a caller here is that the child EXISTS despite this body not carrying it —
+    /// not that anything is being merged.</summary>
+    [MustState("ONE child record", "does not remove it")]
+    internal const string SingleResolved =
+        "note: an annotated Landscape / TopCell field holds ONE child record with its own FormID. Plugins that also " +
+        "carry it are overriding each other and load order decides which version the game uses — so this body not " +
+        "carrying it does not remove it, and the count above is how many other plugins carry one, not a total.";
+
+    /// <summary>How many declaring plugins a COLLECTION field names before it summarises the rest. Three names is
+    /// enough to go look at; the rest are a count, because this rides EVERY annotated field of every row.</summary>
     internal const int DeclarerNameCap = 3;
 
-    /// <summary>The per-field annotation: which OTHER plugins touching this record declare child content for this
-    /// field, capped, plus any that could not be read. Returns null when there is nothing to say — no declarers
-    /// and nothing unreadable — so the caller has one place to decide, not two.</summary>
-    internal static string? OwnedChildDeclarers(IReadOnlyList<string> declarers, IReadOnlyList<string> unreadable)
+    /// <summary>The precise tier's per-field line, in the voice of the field's SHAPE. Returns null when there is
+    /// nothing to say, so the caller has one place to decide rather than two.</summary>
+    internal static string? DeclarersNote(OwnedChildShape shape, IReadOnlyList<string> declaring, IReadOnlyList<string> unreadable)
     {
-        if (declarers.Count == 0 && unreadable.Count == 0) return null;
-        var head = declarers.Count == 0
-            ? null
-            : $"{DeclaredBy} {string.Join(", ", declarers.Take(DeclarerNameCap))}"
-              + (declarers.Count > DeclarerNameCap ? $" (+{declarers.Count - DeclarerNameCap} more)" : "");
-        var tail = unreadable.Count == 0
-            ? null
+        if (declaring.Count == 0 && unreadable.Count == 0) return null;
+        string? head = declaring.Count == 0 ? null
+            : shape == OwnedChildShape.Singular
+                ? $"{CarriedBy} {declaring.Count} other plugin(s)"
+                : $"{DeclaredBy} {string.Join(", ", declaring.Take(DeclarerNameCap))}"
+                  + (declaring.Count > DeclarerNameCap ? $" (+{declaring.Count - DeclarerNameCap} more)" : "");
+        string? tail = unreadable.Count == 0 ? null
             : $"{unreadable.Count} other plugin(s) touching this record {CouldNotRead} "
               + $"({string.Join(", ", unreadable.Take(DeclarerNameCap))}"
               + (unreadable.Count > DeclarerNameCap ? ", …" : "") + ")";

--- a/src/housecarl-mcp/ReadSentences.cs
+++ b/src/housecarl-mcp/ReadSentences.cs
@@ -1,0 +1,42 @@
+namespace HousecarlMcp;
+
+/// <summary>
+/// ONE SOURCE PER SENTENCE for the READ surface's user-facing prose — the <see cref="WriteSentences"/> pattern,
+/// on the other surface.
+///
+/// <para><b>Why it starts here.</b> The read surface's response-layer migration is its own scheduled piece of
+/// work; this class is not it. It exists because the first read sentence that carries a CLAIM a caller acts on
+/// arrived (#342's owned-child annotation), and the write surface's lesson is that a sentence born as a render
+/// literal is a sentence that gets copied and then drifts. So it is born here instead, with the same two nets
+/// the write sentences have: the CONTENT net (<see cref="MustStateAttribute"/> — the phrases whose loss changes
+/// what the caller is told, declared beside the sentence) and a REACH net in the probe that owns the feature
+/// (the sentence is observed coming out of a real render, on both transports).</para>
+///
+/// <para>There is no <c>Twins</c> nested class here and no lane bookkeeping: a read annotation reaches both
+/// transports through ONE carrier — <see cref="HousecarlCore.FieldValue.Display"/>, which the text render, the
+/// json fields array and the dense cells all read off the same field — so "both lanes state it" is a property of
+/// the carrier rather than a claim two independent renders have to keep agreeing on.</para>
+/// </summary>
+internal static class ReadSentences
+{
+    /// <summary>The engine fact behind #342's annotation, and the part a caller acts on: what they are looking at
+    /// is ONE plugin's declaration of a parent's children, and the game does not treat it as the whole set.
+    ///
+    /// <para>Deliberately names NO remedy. The read that would answer "what is actually live in this parent"
+    /// (a FormKey-keyed union with each child taken at its own winner) does not exist yet, and the obvious
+    /// workaround — re-reading with <c>plugin=</c> — is not load-order truth either: that body's own children can
+    /// themselves be overridden further up. A sentence that pointed at either would be promising capability the
+    /// surface does not have, so this one states the fact and stops.</para></summary>
+    [MustState("declared per plugin", "not the merged total")]
+    internal const string OwnedChildMerge =
+        "child records are declared per plugin and the game assembles them from every plugin that declares them, " +
+        "so the value shown here is one plugin's own declaration, not the merged total";
+
+    /// <summary>The #342 annotation: the fact above, in front of the counted evidence for THIS field on THIS
+    /// record. <paramref name="others"/> is how many other plugins touching the record declare any content for the
+    /// field; <paramref name="most"/>/<paramref name="mostPlugin"/> the largest such declaration — the number that
+    /// makes a false-empty read obvious at a glance (a winner reading 0 beside "most: 201 in Skyrim.esm").</summary>
+    internal static string OwnedChildContentNote(string field, int others, int most, string mostPlugin) =>
+        $"{others} other plugin(s) touching this record also declare {field} content " +
+        $"(most: {most} in {mostPlugin}) — {OwnedChildMerge}";
+}

--- a/src/housecarl-mcp/ReadSentences.cs
+++ b/src/housecarl-mcp/ReadSentences.cs
@@ -29,6 +29,14 @@ namespace HousecarlMcp;
 /// so it is stated ONCE per response. Carried per field it cost 288 chars per annotated field per record, ~275 of
 /// them identical on every row — a bulk response spent its budget restating one sentence and truncated real rows
 /// to make room.</para>
+///
+/// <para><b>What a response-level clause may claim.</b> The clause made two claims every transport had to satisfy
+/// independently — a POSITIONAL one ("an annotated field above") and a PRESENCE one (that such a field is in the
+/// medium at all) — and each new medium falsified one of them. Both are now structural rather than promised: the
+/// clause NAMES its fields instead of pointing at them, so no ordering can invert it; and the caller states it
+/// only over fields the medium actually EMITTED, so no truncation, spill or manifest split can strand it over a
+/// body that does not show the field. The two conditions are independent — <see cref="ClauseReserve"/> decides the
+/// clause FITS, emission decides it is STATED — and each is pinned on its own.</para>
 /// </summary>
 internal static class ReadSentences
 {
@@ -49,14 +57,25 @@ internal static class ReadSentences
     /// refuse <c>conflict_tree=true</c> as a text-only diff view; so does <c>to_file=</c>, which means every
     /// artifact manifest carries this clause to a caller who cannot use a bare "pass conflict_tree=true" without a
     /// refusal. Naming the two tools and the text mode is what makes the sentence executable from where it is
-    /// actually read — the remedy-never-run mistake is naming a spelling the recipient's surface rejects.</para></summary>
+    /// actually read — the remedy-never-run mistake is naming a spelling the recipient's surface rejects.</para>
+    ///
+    /// <para><b>It NAMES its fields; it never points at them.</b> <c>{0}</c> is filled with the fields the response
+    /// actually annotated (<see cref="FieldList"/>). A clause that said "an annotated field ABOVE" made a
+    /// POSITIONAL claim every medium had to satisfy independently, and three of them falsified it: the artifact
+    /// manifest is line 1 with its rows below, the single-read json object wrote the clause ahead of its own
+    /// <c>fields</c> array, and a cap hit inside the text field loop truncated away the very field being pointed
+    /// at. Naming the fields is true from any position, in any medium.</para></summary>
     [MustState("declared per plugin", "conflict_tree=true", "housecarl_read_record", "text mode")]
-    internal const string NotReadClause =
-        "note: an annotated field above holds CHILD RECORDS, which are declared per plugin — so what one plugin's " +
-        "body carries is not the whole story for that field. This read did not open the other plugins' bodies to " +
-        "see what they declare. To get a read that does, and names them: housecarl_read_record or " +
-        "housecarl_batch_record_detail in text mode (the default) with conflict_tree=true — it is a text-only view, " +
-        "so json, dense and to_file reads refuse it.";
+    internal const string NotReadFraming =
+        "note: this response annotates field(s) that hold CHILD RECORDS ({0}). Child records are declared per " +
+        "plugin — so what one plugin's body carries is not the whole story for that field. This read did not open " +
+        "the other plugins' bodies to see what they declare. To get a read that does, and names them: " +
+        "housecarl_read_record or housecarl_batch_record_detail in text mode (the default) with conflict_tree=true " +
+        "— it is a text-only view, so json, dense and to_file reads refuse it.";
+
+    /// <summary>The cheap tier's response-level clause over the fields <paramref name="fields"/> the response
+    /// actually emitted an annotation for.</summary>
+    internal static string NotReadClause(IReadOnlyCollection<string> fields) => string.Format(NotReadFraming, FieldList(fields));
 
     /// <summary>The cheap tier's per-field line: the count the index knows, and the honest limit.</summary>
     internal static string NotReadNote(int others) => $"{others} {NotRead}";
@@ -65,15 +84,22 @@ internal static class ReadSentences
 
     /// <summary>The per-field label for a COLLECTION child. A pure label: on its own it asserts nothing a caller
     /// acts on — the claim is the plugin names it introduces, and their meaning is
-    /// <see cref="MergeCollection"/>.</summary>
+    /// <see cref="MergeCollection"/>.
+    ///
+    /// <para><b>No leading "also".</b> "also declared by" asserts that the body being read declares content TOO,
+    /// which is false in exactly the case this feature exists for: a winner carrying 0 references beside a base
+    /// carrying 201 rendered <c>Temporary = [list: 0 item(s)]   (also declared by HcOcBase.esm)</c>, which reads as
+    /// "this body declares some, and so do these" — the confident wrong reading the annotation was built to stop.
+    /// "declared by" is true whether or not this body declares, so it is true in both directions.</para></summary>
     [NoClaims("a label; the claim is the plugin names it introduces, and their meaning is MergeCollection")]
-    internal const string DeclaredBy = "also declared by";
+    internal const string DeclaredBy = "declared by";
 
     /// <summary>The per-field line for a SINGULAR child: a COUNT, deliberately not a name list. Landscape and
     /// TopCell are overridden by hundreds of plugins on a real order ("+483 more" is noise, not information), and
-    /// which one wins is a load-order question the conflict tree answers properly.</summary>
+    /// which one wins is a load-order question the conflict tree answers properly. No leading "also", for the
+    /// reason <see cref="DeclaredBy"/> states — the singular flagship is a body that carries NOTHING.</summary>
     [NoClaims("a label; the claim is SingleResolved, and the count is evidence rather than an assertion")]
-    internal const string CarriedBy = "also carried by";
+    internal const string CarriedBy = "carried by";
 
     /// <summary>The Q3 half: a plugin touching this record whose body or field could not be read. Stated, never
     /// dropped — an unreadable body silently missing from the list would read as "nobody else declares", which is
@@ -89,21 +115,65 @@ internal static class ReadSentences
     /// <c>plugin=</c> is not load-order truth either — that body's own children can themselves be overridden
     /// further up.</para></summary>
     [MustState("declared per plugin", "not the merged total")]
-    internal const string MergeCollection =
-        "note: an annotated Persistent / Temporary / NavigationMeshes / Responses / SubCells field holds MANY child " +
-        "records — a cell's placed references, a topic's INFO lines, a worldspace's cells. Those are declared per " +
-        "plugin and the game assembles them from every plugin that declares them, so the value shown is one " +
-        "plugin's own declaration, not the merged total.";
+    internal const string MergeCollectionFraming =
+        "note: this response annotates field(s) that hold MANY child records ({0}) — a cell's placed references, a " +
+        "topic's INFO lines, a worldspace's cells. Those are declared per plugin and the game assembles them from " +
+        "every plugin that declares them, so the value shown is one plugin's own declaration, not the merged total.";
+
+    /// <summary>The COLLECTION clause over the fields the response actually emitted an annotation for.</summary>
+    internal static string MergeCollection(IReadOnlyCollection<string> fields) => string.Format(MergeCollectionFraming, FieldList(fields));
 
     /// <summary>The response-level fact for SINGULAR children, which is a DIFFERENT fact. One record, one FormKey:
-    /// the plugins that also carry it are overriding each other, and the one the game uses is decided by load
-    /// order. What the annotation tells a caller here is that the child EXISTS despite this body not carrying it —
-    /// not that anything is being merged.</summary>
+    /// the plugins that carry it are overriding each other, and the one the game uses is decided by load order.
+    /// What the annotation tells a caller here is that the child EXISTS despite this body not carrying it — not
+    /// that anything is being merged.</summary>
     [MustState("ONE child record", "does not remove it")]
-    internal const string SingleResolved =
-        "note: an annotated Landscape / TopCell field holds ONE child record with its own FormID. Plugins that also " +
-        "carry it are overriding each other and load order decides which version the game uses — so this body not " +
-        "carrying it does not remove it, and the count above is how many other plugins carry one, not a total.";
+    internal const string SingleResolvedFraming =
+        "note: this response annotates field(s) that hold ONE child record with its own FormID ({0}). The plugins " +
+        "that carry it are overriding each other and load order decides which version the game uses — so this body " +
+        "not carrying it does not remove it, and the count in that annotation is how many other plugins carry one, " +
+        "not a total.";
+
+    /// <summary>The SINGULAR clause over the fields the response actually emitted an annotation for.</summary>
+    internal static string SingleResolved(IReadOnlyCollection<string> fields) => string.Format(SingleResolvedFraming, FieldList(fields));
+
+    /// <summary>The field names a response-level clause is ABOUT — derived from what the response annotated, never
+    /// a prose list.
+    ///
+    /// <para><b>Why derived.</b> The set these clauses describe is <see cref="OwnedChildContent.Fields"/>, i.e.
+    /// <c>WriteEngine.ChildBearingProperties</c> split by shape, and that set grows on a Mutagen bump with no edit
+    /// here — <see cref="OwnedChildContent"/> promises exactly that. A hand-written list ("Persistent / Temporary /
+    /// NavigationMeshes / Responses / SubCells") stays green under every net while describing fields that are not
+    /// the annotated one: a new collection-shaped owned child would be annotated correctly and then named
+    /// incorrectly. Naming what the response annotated cannot drift, because there is no second list to drift
+    /// from.</para>
+    ///
+    /// <para><b>Bounded on purpose.</b> The joined list is cut at <see cref="ClauseFieldsMaxChars"/> so a clause's
+    /// worst-case length is a CONSTANT — which is what lets <see cref="ClauseReserve"/> subtract it from the
+    /// caller's <c>max_chars</c> before the body renders instead of adding it on top afterwards.</para></summary>
+    internal static string FieldList(IReadOnlyCollection<string> fields)
+    {
+        var joined = string.Join(", ", fields);
+        return joined.Length <= ClauseFieldsMaxChars ? joined : joined[..ClauseFieldsMaxChars].TrimEnd(',', ' ') + ", …";
+    }
+
+    /// <summary>The char budget the derived field list gets inside a clause. Small on purpose: the list exists to
+    /// say WHICH fields, and against Mutagen 0.53.1 the whole child-bearing set is seven names.</summary>
+    internal const int ClauseFieldsMaxChars = 120;
+
+    /// <summary>Slack over a framing's own length: the "{0}" it loses (3), the ", …" an over-long list gains (3),
+    /// and the newlines the text lane wraps each clause in (2).</summary>
+    const int ClauseGlue = 8;
+
+    /// <summary>The worst-case chars the response-level clauses can cost, for the clause KINDS a response may still
+    /// state. Reserved out of <c>max_chars</c> before the body renders (#342 review, finding 6): these clauses are
+    /// load-bearing, so dropping them at the cap would be the wrong repair, and appending them past it made a
+    /// 2000-char batch return ~3100 with the overrun invisible to the <c>truncated</c> flag the auto-spill trigger
+    /// reads.</summary>
+    internal static int ClauseReserve(bool notRead, bool collection, bool singular) =>
+        (notRead ? NotReadFraming.Length + ClauseFieldsMaxChars + ClauseGlue : 0)
+        + (collection ? MergeCollectionFraming.Length + ClauseFieldsMaxChars + ClauseGlue : 0)
+        + (singular ? SingleResolvedFraming.Length + ClauseFieldsMaxChars + ClauseGlue : 0);
 
     /// <summary>How many declaring plugins a COLLECTION field names before it summarises the rest. Three names is
     /// enough to go look at; the rest are a count, because this rides EVERY annotated field of every row.</summary>

--- a/src/housecarl-mcp/ReadSentences.cs
+++ b/src/housecarl-mcp/ReadSentences.cs
@@ -10,17 +10,20 @@ namespace HousecarlMcp;
 /// literal is a sentence that gets copied and then drifts. So it is born here instead, with the same two nets
 /// the write sentences have: the CONTENT net (<see cref="MustStateAttribute"/> — the phrases whose loss changes
 /// what the caller is told, declared beside the sentence) and a REACH net in the probe that owns the feature
-/// (the sentence is observed coming out of a real render, on both transports).</para>
+/// (every const observed coming out of a real render, on both transports).</para>
 ///
-/// <para>There is no <c>Twins</c> nested class here and no lane bookkeeping: a read annotation reaches both
-/// transports through ONE carrier — <see cref="HousecarlCore.FieldValue.Display"/>, which the text render, the
-/// json fields array and the dense cells all read off the same field — so "both lanes state it" is a property of
-/// the carrier rather than a claim two independent renders have to keep agreeing on.</para>
+/// <para><b>The response/field split.</b> The invariant half — what a child record IS — is a fact about the
+/// response, not about one field, so it is stated ONCE per response. Carrying it per field cost 288 chars per
+/// annotated field per record, ~275 of them identical on every row: a 500-row cell query spent ~280 KB of an
+/// ~80 k budget restating the same sentence, and the rows that got truncated to make room were real data. The
+/// per-field annotation therefore carries only what differs per field — WHICH other plugins declare content —
+/// and the response carries the meaning.</para>
 /// </summary>
 internal static class ReadSentences
 {
-    /// <summary>The engine fact behind #342's annotation, and the part a caller acts on: what they are looking at
-    /// is ONE plugin's declaration of a parent's children, and the game does not treat it as the whole set.
+    /// <summary>The response-level fact behind #342's annotation, and the part a caller acts on: an annotated
+    /// field shows ONE plugin's declaration of a parent's children, and the game does not treat it as the whole
+    /// set.
     ///
     /// <para>Deliberately names NO remedy. The read that would answer "what is actually live in this parent"
     /// (a FormKey-keyed union with each child taken at its own winner) does not exist yet, and the obvious
@@ -29,14 +32,41 @@ internal static class ReadSentences
     /// surface does not have, so this one states the fact and stops.</para></summary>
     [MustState("declared per plugin", "not the merged total")]
     internal const string OwnedChildMerge =
-        "child records are declared per plugin and the game assembles them from every plugin that declares them, " +
-        "so the value shown here is one plugin's own declaration, not the merged total";
+        "note: an annotated field above holds CHILD RECORDS — a cell's placed references, a topic's INFO lines, " +
+        "a worldspace's cells. Those are declared per plugin and the game assembles them from every plugin that " +
+        "declares them, so the value shown is one plugin's own declaration, not the merged total.";
 
-    /// <summary>The #342 annotation: the fact above, in front of the counted evidence for THIS field on THIS
-    /// record. <paramref name="others"/> is how many other plugins touching the record declare any content for the
-    /// field; <paramref name="most"/>/<paramref name="mostPlugin"/> the largest such declaration — the number that
-    /// makes a false-empty read obvious at a glance (a winner reading 0 beside "most: 201 in Skyrim.esm").</summary>
-    internal static string OwnedChildContentNote(string field, int others, int most, string mostPlugin) =>
-        $"{others} other plugin(s) touching this record also declare {field} content " +
-        $"(most: {most} in {mostPlugin}) — {OwnedChildMerge}";
+    /// <summary>The per-field half's label. A pure label: on its own it asserts nothing a caller acts on — the
+    /// claim is the plugin names that follow it, and its meaning is <see cref="OwnedChildMerge"/>.</summary>
+    [NoClaims("a label; the claim is the plugin names it introduces, and their meaning is OwnedChildMerge")]
+    internal const string DeclaredBy = "also declared by";
+
+    /// <summary>The Q3 half: a plugin touching this record whose body or field could not be read. Stated, never
+    /// dropped — an unreadable body silently missing from the list would read as "nobody else declares", which is
+    /// the same wrong answer this annotation exists to prevent, one level down.</summary>
+    [MustState("could NOT be read")]
+    internal const string CouldNotRead = "could NOT be read";
+
+    /// <summary>How many declaring plugins the per-field annotation names before it summarises the rest. Three
+    /// names is enough to go look at; the rest are a count, because this rides EVERY annotated field of every row
+    /// in a bulk response.</summary>
+    internal const int DeclarerNameCap = 3;
+
+    /// <summary>The per-field annotation: which OTHER plugins touching this record declare child content for this
+    /// field, capped, plus any that could not be read. Returns null when there is nothing to say — no declarers
+    /// and nothing unreadable — so the caller has one place to decide, not two.</summary>
+    internal static string? OwnedChildDeclarers(IReadOnlyList<string> declarers, IReadOnlyList<string> unreadable)
+    {
+        if (declarers.Count == 0 && unreadable.Count == 0) return null;
+        var head = declarers.Count == 0
+            ? null
+            : $"{DeclaredBy} {string.Join(", ", declarers.Take(DeclarerNameCap))}"
+              + (declarers.Count > DeclarerNameCap ? $" (+{declarers.Count - DeclarerNameCap} more)" : "");
+        var tail = unreadable.Count == 0
+            ? null
+            : $"{unreadable.Count} other plugin(s) touching this record {CouldNotRead} "
+              + $"({string.Join(", ", unreadable.Take(DeclarerNameCap))}"
+              + (unreadable.Count > DeclarerNameCap ? ", …" : "") + ")";
+        return head is null ? tail : tail is null ? head : $"{head}; {tail}";
+    }
 }

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -786,23 +786,67 @@ static class Wire
         return sb.ToString().TrimEnd('\n');
     }
 
-    /// <summary>Which #342 clauses this response has earned — accumulated across the rows it actually RENDERED, so
-    /// a clause is never stated over a response whose annotated rows were truncated away or spilled to a file.
-    /// Three independent facts, because the tiers and the shapes say different things and a response can mix
-    /// them.</summary>
+    /// <summary>Which #342 clause a rendered field earns. The tier decides it: the cheap tier can only say "not
+    /// read"; the precise tier says what is true of the field's SHAPE.</summary>
+    internal enum ChildClause { NotRead, Collection, Singular }
+
+    /// <summary>Which #342 clauses this response has earned, and over WHICH fields — accumulated at EMISSION, as
+    /// each annotated field line is written, never where the annotation was decided.
+    ///
+    /// <para>That distinction is the whole fix. A response can annotate a field and then not show it: the field
+    /// loop hits <c>max_chars</c> before reaching it, the json fields array truncates, a <c>to_file</c> spill sends
+    /// the rows to a file. A clause committed when the annotation was DECIDED then describes a field the caller
+    /// cannot see. Registering at emission makes that unrepresentable — no field line, no clause.</para>
+    ///
+    /// <para><see cref="May"/> is the other half, and it runs the other way: it is set BEFORE a record's fields
+    /// render, so the clauses that record could still earn are RESERVED out of the caller's budget rather than
+    /// appended past it. Reserve decides a clause FITS; emission decides it is STATED.</para></summary>
     internal sealed class ChildNotes
     {
-        public bool NotRead, Collection, Singular;
-        public bool Any => NotRead || Collection || Singular;
+        readonly SortedSet<string> _notRead = new(StringComparer.Ordinal);
+        readonly SortedSet<string> _collection = new(StringComparer.Ordinal);
+        readonly SortedSet<string> _singular = new(StringComparer.Ordinal);
+        bool _mayNotRead, _mayCollection, _maySingular;
+
+        /// <summary>A clause kind this response may still state — reserved from here on.</summary>
+        public void May(ChildClause c)
+        {
+            if (c == ChildClause.NotRead) _mayNotRead = true;
+            else if (c == ChildClause.Collection) _mayCollection = true;
+            else _maySingular = true;
+        }
+
+        /// <summary>An annotated field line just went into the medium: this clause is now STATED, over this
+        /// field.</summary>
+        public void Emitted(ChildClause c, string field)
+        {
+            May(c);
+            (c == ChildClause.NotRead ? _notRead : c == ChildClause.Collection ? _collection : _singular).Add(field);
+        }
+
+        /// <summary>The chars to hold back from <c>max_chars</c> for the clauses this response may still state.</summary>
+        public int Reserve => ReadSentences.ClauseReserve(_mayNotRead, _mayCollection, _maySingular);
+
+        internal IReadOnlyCollection<string> Fields(ChildClause c) =>
+            c == ChildClause.NotRead ? _notRead : c == ChildClause.Collection ? _collection : _singular;
     }
 
     /// <summary>The #342 clauses, stated ONCE per response after the body — never per field, which cost ~275
-    /// identical chars on every annotated row and pushed real rows out of a bulk response's budget.</summary>
+    /// identical chars on every annotated row and pushed real rows out of a bulk response's budget. Each clause
+    /// NAMES the fields it was earned over, so it claims nothing about where in the response they are.</summary>
     internal static void AppendOwnedChildNotes(StringBuilder sb, ChildNotes n)
     {
-        if (n.NotRead) sb.Append('\n').Append(ReadSentences.NotReadClause).Append('\n');
-        if (n.Collection) sb.Append('\n').Append(ReadSentences.MergeCollection).Append('\n');
-        if (n.Singular) sb.Append('\n').Append(ReadSentences.SingleResolved).Append('\n');
+        foreach (var c in new[] { ChildClause.NotRead, ChildClause.Collection, ChildClause.Singular })
+        {
+            var fields = n.Fields(c);
+            if (fields.Count == 0) continue;
+            sb.Append('\n').Append(c switch
+            {
+                ChildClause.NotRead => ReadSentences.NotReadClause(fields),
+                ChildClause.Collection => ReadSentences.MergeCollection(fields),
+                _ => ReadSentences.SingleResolved(fields),
+            }).Append('\n');
+        }
     }
 
     /// <summary>Render one record, and its conflict tree when asked — fetching the tree ONCE and using it for both
@@ -813,6 +857,7 @@ static class Wire
     {
         var outcome = o;
         LoadOrderService.TreeFill? fill = null;
+        bool precise = false;
         // A tree fetch is one whole-overlay enumeration per touching plugin, so the prefetch takes the tree render's
         // own skips with it. SOLE TOUCHER is the one that mattered: measured on a real order, hoisting the fetch
         // above `tp.Count <= 1` took a conflict_tree read of an uncontested record from ~133 ms to ~273 ms, on a
@@ -822,33 +867,48 @@ static class Wire
         // The limit, stated because it is real: this cannot foresee a cap hit DURING this record's own field
         // render. A single read with a cap so tight that the fields themselves exhaust it still pays for the tree
         // and then truncates the diff — base skipped that fetch. Closing it would mean rendering the record twice
-        // or guessing its rendered size, and the annotation has to land BEFORE the fields are written.
+        // or guessing its rendered size. (What it no longer costs is a WRONG SENTENCE: the clause is stated off the
+        // field lines this render emitted, so a truncated annotation states nothing — Aaron's finding 1.)
         if (conflictTree && o.Pin is { } pin && o.Record is { } rec
-            && o.TouchingPlugins is { Count: > 1 } && sb.Length < cap)
+            && o.TouchingPlugins is { Count: > 1 } && sb.Length < cap - notes.Reserve)
         {
             fill = svc.ResolveTreeFill(pin, o.FormKey, fields, o.SourcePlugin, rec.Fields.Select(f => f.Path).ToList());
-            if (fill is { ByField.Count: > 0 }) outcome = ApplyPreciseChildNotes(o, rec, fill, notes);
+            if (fill is { ByField.Count: > 0 }) { outcome = ApplyPreciseChildNotes(o, rec, fill); precise = true; }
         }
-        if (outcome.OwnedChildNoted && fill is null) notes.NotRead = true;   // cheap tier stands
-        AppendRecord(sb, outcome, cap);
-        if (conflictTree) AppendConflictTree(sb, svc, outcome, fields, cap, fill?.View);
+        // Hold back the clauses this record could earn BEFORE its fields render, so an annotated response answers
+        // inside the caller's max_chars instead of overrunning it by up to three clauses (finding 6). Only a record
+        // that CAN annotate pays: one with no child-bearing field reserves nothing.
+        if (outcome.OwnedChildFields is { } annotated)
+            foreach (var shape in annotated.Values) notes.May(ClauseOf(shape, precise));
+        // The RESERVE is held back from the budget, never from the number the render QUOTES: a cut that told the
+        // caller "at max_chars=1124" when they passed 2000 would be a wrong sentence of its own.
+        AppendRecord(sb, outcome, cap, notes.Reserve, precise, notes);
+        if (conflictTree) AppendConflictTree(sb, svc, outcome, fields, cap, fill?.View, notes.Reserve);
     }
+
+    /// <summary>Which clause an annotated field earns: the cheap tier knows only that other plugins were not read,
+    /// whatever the field's shape; the precise tier knows what is true of the SHAPE.</summary>
+    static ChildClause ClauseOf(HousecarlCore.OwnedChildShape shape, bool precise) =>
+        !precise ? ChildClause.NotRead
+        : shape == HousecarlCore.OwnedChildShape.Singular ? ChildClause.Singular : ChildClause.Collection;
 
     /// <summary>Replace the cheap "not read" note on every child-bearing field with what the tree's bodies
     /// actually say — including replacing it with NOTHING when no other plugin declares content there, which the
-    /// cheap tier could not know.</summary>
-    static ReadOutcome ApplyPreciseChildNotes(ReadOutcome o, RecordFields rec, LoadOrderService.TreeFill fill, ChildNotes notes)
+    /// cheap tier could not know. The returned outcome's <see cref="ReadOutcome.OwnedChildFields"/> is rebuilt to
+    /// the fields that still carry an annotation, so the render states a clause only over one it emits.</summary>
+    static ReadOutcome ApplyPreciseChildNotes(ReadOutcome o, RecordFields rec, LoadOrderService.TreeFill fill)
     {
         var rebuilt = new List<FieldValue>(rec.Fields);
+        var annotated = new Dictionary<string, HousecarlCore.OwnedChildShape>(StringComparer.Ordinal);
         for (int i = 0; i < rebuilt.Count; i++)
         {
             if (!fill.ByField.TryGetValue(rebuilt[i].Path, out var d)) continue;
             var note = ReadSentences.DeclarersNote(d.Shape, d.Declaring, d.Unreadable);
             rebuilt[i] = rebuilt[i] with { Display = note };
             if (note is null) continue;
-            if (d.Shape == HousecarlCore.OwnedChildShape.Singular) notes.Singular = true; else notes.Collection = true;
+            annotated[rebuilt[i].Path] = d.Shape;
         }
-        return o with { Record = rec with { Fields = rebuilt } };
+        return o with { Record = rec with { Fields = rebuilt }, OwnedChildFields = annotated };
     }
 
     // ---- housecarl_batch_record_detail --------------------------------------------------------------
@@ -871,7 +931,7 @@ static class Wire
         foreach (var o in outcomes)
         {
             if (spill?.ManifestOnly ?? false) break;   // to_file: only the manifest renders — the rows are the FILE
-            if (sb.Length >= cap)
+            if (sb.Length >= cap - notes.Reserve)      // the clauses this response has already earned are SPOKEN FOR
             {
                 truncated = true;
                 sb.Append("... [truncated: rendered ").Append(rendered).Append(" of ").Append(outcomes.Count)
@@ -947,7 +1007,7 @@ static class Wire
         var notes = new ChildNotes();   // #342: accumulated over the rows actually rendered
         for (int i = 0; i < q.Keys.Count && !(spill?.ManifestOnly ?? false); i++)   // to_file: only the manifest renders — the rows are the FILE
         {
-            if (sb.Length >= cap)
+            if (sb.Length >= cap - notes.Reserve)      // the clauses this response has already earned are SPOKEN FOR
             {
                 truncated = true;
                 sb.Append("... [truncated: rendered ").Append(rendered).Append(" of ").Append(q.Keys.Count)
@@ -1359,7 +1419,12 @@ static class Wire
 
     // ---- shared building blocks ---------------------------------------------------------------------
 
-    static void AppendRecord(StringBuilder sb, ReadOutcome o, int cap)
+    /// <summary><paramref name="notes"/> (with <paramref name="precise"/> naming the #342 tier) registers a clause
+    /// as each ANNOTATED field line is written — so a field the cap truncates away earns nothing. Both are null on
+    /// the lanes that render a record outside a #342-annotated response (readback, verify).</summary>
+    /// <param name="reserve">Chars held back for the response-level clauses this render may still state: the field
+    /// loop stops that much earlier, while the notice still quotes the caller's own <paramref name="cap"/>.</param>
+    static void AppendRecord(StringBuilder sb, ReadOutcome o, int cap, int reserve = 0, bool precise = false, ChildNotes? notes = null)
     {
         var r = o.Record!;
         sb.Append("type=").Append(r.Type)
@@ -1370,7 +1435,7 @@ static class Wire
         sb.Append("fields (from ").Append(o.SourcePlugin).Append("):\n");
         for (int i = 0; i < r.Fields.Count; i++)
         {
-            if (sb.Length >= cap)                                          // depth= can produce many lines — cap them (Q3)
+            if (sb.Length >= cap - reserve)                                 // depth= can produce many lines — cap them (Q3)
             {
                 sb.Append("  ... [truncated: showing ").Append(i).Append(" of ").Append(r.Fields.Count)
                   .Append(" field lines at max_chars=").Append(cap)
@@ -1382,6 +1447,9 @@ static class Wire
             if (f.Display is not null) sb.Append("   (").Append(f.Display).Append(')');   // display-only annotation (e.g. decoded biped slots) — never the round-trip token
             if (f.Link is not null) sb.Append("   (").Append(LinkText(f.Link)).Append(')');   // resolve_names: target identity, DISPLAY-ONLY — never the round-trip token
             sb.Append('\n');
+            // The #342 clause is earned HERE, by a line that reached the caller — not where the annotation was decided.
+            if (notes is not null && o.OwnedChildFields is { } ann && ann.TryGetValue(f.Path, out var shape))
+                notes.Emitted(ClauseOf(shape, precise), f.Path);
         }
     }
 
@@ -1398,8 +1466,10 @@ static class Wire
     /// winner-relative field diff — each other plugin's only-the-fields-that-differ, as `path=theirs (winner X)`.
     /// Bodies come from <see cref="LoadOrderService.ResolveTree"/> (on-demand fetch, held by nothing). The diff
     /// is char-budget-bounded: over <paramref name="cap"/> it stops with an explicit notice (Q3).</summary>
+    /// <param name="reserve">Chars held back for the #342 response-level clauses — the same split
+    /// <see cref="AppendRecord"/> makes: budget against <c>cap - reserve</c>, quote <c>cap</c>.</param>
     static void AppendConflictTree(StringBuilder sb, LoadOrderService svc, ReadOutcome o, IReadOnlyList<string>? fields, int cap,
-                                   ConflictTreeView? prefetched = null)
+                                   ConflictTreeView? prefetched = null, int reserve = 0)
     {
         var tp = o.TouchingPlugins;
         if (tp is null) return;
@@ -1407,7 +1477,7 @@ static class Wire
           .Append(" this record (load order, winner last):\n");
         for (int i = 0; i < tp.Count; i++)
         {
-            if (sb.Length >= cap && i < tp.Count - 1)                      // budget gone mid-list — name the rest + the winner, stop
+            if (sb.Length >= cap - reserve && i < tp.Count - 1)            // budget gone mid-list — name the rest + the winner, stop
             {
                 sb.Append("  ... [").Append(tp.Count - i).Append(" more plugins omitted at max_chars=").Append(cap)
                   .Append("; winner (last in load order) = ").Append(tp[^1]).Append("; raise max_chars or narrow with fields=]\n");
@@ -1440,7 +1510,7 @@ static class Wire
           .Append("; identical fields omitted; list contents compared by content, element reorders flagged):\n");
         for (int n = 0; n < tree.Nodes.Count - 1; n++)                      // every node except the winner
         {
-            if (sb.Length >= cap)
+            if (sb.Length >= cap - reserve)
             {
                 sb.Append("  ... [truncated: response hit max_chars=").Append(cap)
                   .Append("; pass fields= to narrow the diff or raise max_chars]\n");
@@ -1463,7 +1533,7 @@ static class Wire
                     : "(no differences found, but the comparison was TRUNCATED at the expansion cap — NOT a verified ITM; narrow with fields= to fully compare)";
             // One node's joined deltas are unbounded (two divergent deep reads can carry thousands); slice
             // against the remaining char budget with the same explicit notice the other cuts use (Q3).
-            int room = cap - sb.Length;
+            int room = cap - reserve - sb.Length;
             if (line.Length > room)
                 line = string.Concat(line.AsSpan(0, Math.Max(0, room)),
                     " ... [delta line truncated at max_chars; narrow with fields= or raise max_chars]");

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -780,19 +780,64 @@ static class Wire
         // Header line, like every other text lane — and BEFORE the cap-bounded body, so a capped record never
         // overruns its budget to fit the stamp (third-round note).
         if (o.Epoch is not null) sb.Append("epoch=").Append(o.Epoch).Append('\n');   // §2.1.1: the build this read answered from
-        AppendRecord(sb, o, Cap(maxChars));
-        if (conflictTree) AppendConflictTree(sb, svc, o, fields, Cap(maxChars));
-        AppendOwnedChildNote(sb, o.OwnedChildNoted);
+        var notes = new ChildNotes();
+        AppendRecordBlock(sb, svc, o, fields, conflictTree, Cap(maxChars), notes);
+        AppendOwnedChildNotes(sb, notes);
         return sb.ToString().TrimEnd('\n');
     }
 
-    /// <summary>The #342 invariant clause, stated ONCE per response when any rendered record carries a per-field
-    /// declarer annotation — never per field, which cost ~275 identical chars on every annotated row and pushed
-    /// real rows out of a bulk response's budget. Emitted AFTER the body so it reads as a footnote to the fields
-    /// it explains, and gated on the outcome's structural flag rather than on the rendered text.</summary>
-    static void AppendOwnedChildNote(StringBuilder sb, bool noted)
+    /// <summary>Which #342 clauses this response has earned — accumulated across the rows it actually RENDERED, so
+    /// a clause is never stated over a response whose annotated rows were truncated away or spilled to a file.
+    /// Three independent facts, because the tiers and the shapes say different things and a response can mix
+    /// them.</summary>
+    internal sealed class ChildNotes
     {
-        if (noted) sb.Append('\n').Append(ReadSentences.OwnedChildMerge).Append('\n');
+        public bool NotRead, Collection, Singular;
+        public bool Any => NotRead || Collection || Singular;
+    }
+
+    /// <summary>The #342 clauses, stated ONCE per response after the body — never per field, which cost ~275
+    /// identical chars on every annotated row and pushed real rows out of a bulk response's budget.</summary>
+    internal static void AppendOwnedChildNotes(StringBuilder sb, ChildNotes n)
+    {
+        if (n.NotRead) sb.Append('\n').Append(ReadSentences.NotReadClause).Append('\n');
+        if (n.Collection) sb.Append('\n').Append(ReadSentences.MergeCollection).Append('\n');
+        if (n.Singular) sb.Append('\n').Append(ReadSentences.SingleResolved).Append('\n');
+    }
+
+    /// <summary>Render one record, and its conflict tree when asked — fetching the tree ONCE and using it for both
+    /// the diff view and the #342 precise tier, so the annotation costs no record fetch of its own. Without
+    /// conflict_tree the outcome keeps the cheap index-only annotation the service already put on it.</summary>
+    static void AppendRecordBlock(StringBuilder sb, LoadOrderService svc, ReadOutcome o, IReadOnlyList<string>? fields,
+                                  bool conflictTree, int cap, ChildNotes notes)
+    {
+        var outcome = o;
+        LoadOrderService.TreeFill? fill = null;
+        if (conflictTree && o.Pin is { } pin && o.Record is { } rec)
+        {
+            fill = svc.ResolveTreeFill(pin, o.FormKey, fields, o.SourcePlugin, rec.Fields.Select(f => f.Path).ToList());
+            if (fill is { ByField.Count: > 0 }) outcome = ApplyPreciseChildNotes(o, rec, fill, notes);
+        }
+        if (outcome.OwnedChildNoted && fill is null) notes.NotRead = true;   // cheap tier stands
+        AppendRecord(sb, outcome, cap);
+        if (conflictTree) AppendConflictTree(sb, svc, outcome, fields, cap, fill?.View);
+    }
+
+    /// <summary>Replace the cheap "not read" note on every child-bearing field with what the tree's bodies
+    /// actually say — including replacing it with NOTHING when no other plugin declares content there, which the
+    /// cheap tier could not know.</summary>
+    static ReadOutcome ApplyPreciseChildNotes(ReadOutcome o, RecordFields rec, LoadOrderService.TreeFill fill, ChildNotes notes)
+    {
+        var rebuilt = new List<FieldValue>(rec.Fields);
+        for (int i = 0; i < rebuilt.Count; i++)
+        {
+            if (!fill.ByField.TryGetValue(rebuilt[i].Path, out var d)) continue;
+            var note = ReadSentences.DeclarersNote(d.Shape, d.Declaring, d.Unreadable);
+            rebuilt[i] = rebuilt[i] with { Display = note };
+            if (note is null) continue;
+            if (d.Shape == HousecarlCore.OwnedChildShape.Singular) notes.Singular = true; else notes.Collection = true;
+        }
+        return o with { Record = rec with { Fields = rebuilt } };
     }
 
     // ---- housecarl_batch_record_detail --------------------------------------------------------------
@@ -804,6 +849,7 @@ static class Wire
     {
         truncated = false;
         int cap = Cap(maxChars);
+        var notes = new ChildNotes();   // #342: accumulated over the rows actually rendered, not over the input list
         var sb = new StringBuilder();
         sb.Append("batch: ").Append(outcomes.Count).Append(outcomes.Count == 1 ? " record" : " records");
         // The whole batch reads ONE captured build (ResolveBatch), so its epoch is response-level accounting —
@@ -824,10 +870,10 @@ static class Wire
             }
             sb.Append('\n');
             if (o.Error is not null) sb.Append("error: ").Append(o.Error).Append('\n');
-            else { AppendRecord(sb, o, cap); if (conflictTree) AppendConflictTree(sb, svc, o, fields, cap); }
+            else AppendRecordBlock(sb, svc, o, fields, conflictTree, cap, notes);
             rendered++;
         }
-        AppendOwnedChildNote(sb, outcomes.Any(o => o.OwnedChildNoted));
+        AppendOwnedChildNotes(sb, notes);
         if (spill is not null) Artifacts.AppendSpillStateText(sb, spill);
         return sb.ToString().TrimEnd('\n');
     }
@@ -887,7 +933,7 @@ static class Wire
         if (anyScoped) sb.Append("note: ").Append(JsonWire.ScopedFieldsNote(winnerFields, q.WhereWinner)).Append('\n');
 
         int rendered = 0;
-        bool childNoted = false;   // #342: any detail row annotated → the invariant clause once, at the end
+        var notes = new ChildNotes();   // #342: accumulated over the rows actually rendered
         for (int i = 0; i < q.Keys.Count && !(spill?.ManifestOnly ?? false); i++)   // to_file: only the manifest renders — the rows are the FILE
         {
             if (sb.Length >= cap)
@@ -910,8 +956,7 @@ static class Wire
                 sb.Append('\n');
                 if (matches is not null) sb.Append("  ").Append(fk).Append("  matches=").Append(matches).Append('\n');
                 if (o.Error is not null) sb.Append(fk).Append(": error: ").Append(o.Error).Append('\n');
-                else { AppendRecord(sb, o, cap); if (conflictTree) AppendConflictTree(sb, svc, o, fields, cap); }   // o carries the scan's pin
-                childNoted |= o.OwnedChildNoted;
+                else AppendRecordBlock(sb, svc, o, fields, conflictTree, cap, notes);   // o carries the scan's pin
             }
             else
             {
@@ -928,7 +973,7 @@ static class Wire
             }
             rendered++;
         }
-        AppendOwnedChildNote(sb, childNoted);
+        AppendOwnedChildNotes(sb, notes);
         if (spill is not null) Artifacts.AppendSpillStateText(sb, spill);
         return sb.ToString().TrimEnd('\n');
     }
@@ -1342,7 +1387,8 @@ static class Wire
     /// winner-relative field diff — each other plugin's only-the-fields-that-differ, as `path=theirs (winner X)`.
     /// Bodies come from <see cref="LoadOrderService.ResolveTree"/> (on-demand fetch, held by nothing). The diff
     /// is char-budget-bounded: over <paramref name="cap"/> it stops with an explicit notice (Q3).</summary>
-    static void AppendConflictTree(StringBuilder sb, LoadOrderService svc, ReadOutcome o, IReadOnlyList<string>? fields, int cap)
+    static void AppendConflictTree(StringBuilder sb, LoadOrderService svc, ReadOutcome o, IReadOnlyList<string>? fields, int cap,
+                                   ConflictTreeView? prefetched = null)
     {
         var tp = o.TouchingPlugins;
         if (tp is null) return;
@@ -1364,8 +1410,11 @@ static class Wire
         // item, cross-query detail row — carries the (resolver, view) it was answered from, so the tree fill and
         // the response's epoch stamp name the same build. The unpinned fallback exists only for a hand-built
         // outcome (guards).
-        var tree = o.Pin is { } p ? svc.ResolveTreePinned(p, o.FormKey, fields)
-                                  : svc.ResolveTree(o.FormKey, fields);    // materialised (no live overlay) — Option B
+        // The block helper already fetched this tree to answer #342's precise tier off the same bodies; re-fetching
+        // would double every touching plugin's overlay enumeration, which is the cost that tier exists to avoid.
+        var tree = prefetched
+                   ?? (o.Pin is { } p ? svc.ResolveTreePinned(p, o.FormKey, fields)
+                                      : svc.ResolveTree(o.FormKey, fields));   // materialised (no live overlay) — Option B
         if (tree is null || tree.Nodes.Count <= 1) return;
 
         var winnerNode = tree.Winner;                                       // Nodes[^1] = highest priority = the winner

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -782,7 +782,17 @@ static class Wire
         if (o.Epoch is not null) sb.Append("epoch=").Append(o.Epoch).Append('\n');   // §2.1.1: the build this read answered from
         AppendRecord(sb, o, Cap(maxChars));
         if (conflictTree) AppendConflictTree(sb, svc, o, fields, Cap(maxChars));
+        AppendOwnedChildNote(sb, o.OwnedChildNoted);
         return sb.ToString().TrimEnd('\n');
+    }
+
+    /// <summary>The #342 invariant clause, stated ONCE per response when any rendered record carries a per-field
+    /// declarer annotation — never per field, which cost ~275 identical chars on every annotated row and pushed
+    /// real rows out of a bulk response's budget. Emitted AFTER the body so it reads as a footnote to the fields
+    /// it explains, and gated on the outcome's structural flag rather than on the rendered text.</summary>
+    static void AppendOwnedChildNote(StringBuilder sb, bool noted)
+    {
+        if (noted) sb.Append('\n').Append(ReadSentences.OwnedChildMerge).Append('\n');
     }
 
     // ---- housecarl_batch_record_detail --------------------------------------------------------------
@@ -817,6 +827,7 @@ static class Wire
             else { AppendRecord(sb, o, cap); if (conflictTree) AppendConflictTree(sb, svc, o, fields, cap); }
             rendered++;
         }
+        AppendOwnedChildNote(sb, outcomes.Any(o => o.OwnedChildNoted));
         if (spill is not null) Artifacts.AppendSpillStateText(sb, spill);
         return sb.ToString().TrimEnd('\n');
     }
@@ -876,6 +887,7 @@ static class Wire
         if (anyScoped) sb.Append("note: ").Append(JsonWire.ScopedFieldsNote(winnerFields, q.WhereWinner)).Append('\n');
 
         int rendered = 0;
+        bool childNoted = false;   // #342: any detail row annotated → the invariant clause once, at the end
         for (int i = 0; i < q.Keys.Count && !(spill?.ManifestOnly ?? false); i++)   // to_file: only the manifest renders — the rows are the FILE
         {
             if (sb.Length >= cap)
@@ -899,6 +911,7 @@ static class Wire
                 if (matches is not null) sb.Append("  ").Append(fk).Append("  matches=").Append(matches).Append('\n');
                 if (o.Error is not null) sb.Append(fk).Append(": error: ").Append(o.Error).Append('\n');
                 else { AppendRecord(sb, o, cap); if (conflictTree) AppendConflictTree(sb, svc, o, fields, cap); }   // o carries the scan's pin
+                childNoted |= o.OwnedChildNoted;
             }
             else
             {
@@ -915,6 +928,7 @@ static class Wire
             }
             rendered++;
         }
+        AppendOwnedChildNote(sb, childNoted);
         if (spill is not null) Artifacts.AppendSpillStateText(sb, spill);
         return sb.ToString().TrimEnd('\n');
     }

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -813,7 +813,18 @@ static class Wire
     {
         var outcome = o;
         LoadOrderService.TreeFill? fill = null;
-        if (conflictTree && o.Pin is { } pin && o.Record is { } rec)
+        // A tree fetch is one whole-overlay enumeration per touching plugin, so the prefetch takes the tree render's
+        // own skips with it. SOLE TOUCHER is the one that mattered: measured on a real order, hoisting the fetch
+        // above `tp.Count <= 1` took a conflict_tree read of an uncontested record from ~133 ms to ~273 ms, on a
+        // record type where there is nothing to diff and nothing to name. ALREADY over budget is free to check and
+        // does fire on the bulk lanes, where earlier rows have filled the buffer.
+        //
+        // The limit, stated because it is real: this cannot foresee a cap hit DURING this record's own field
+        // render. A single read with a cap so tight that the fields themselves exhaust it still pays for the tree
+        // and then truncates the diff — base skipped that fetch. Closing it would mean rendering the record twice
+        // or guessing its rendered size, and the annotation has to land BEFORE the fields are written.
+        if (conflictTree && o.Pin is { } pin && o.Record is { } rec
+            && o.TouchingPlugins is { Count: > 1 } && sb.Length < cap)
         {
             fill = svc.ResolveTreeFill(pin, o.FormKey, fields, o.SourcePlugin, rec.Fields.Select(f => f.Path).ToList());
             if (fill is { ByField.Count: > 0 }) outcome = ApplyPreciseChildNotes(o, rec, fill, notes);


### PR DESCRIPTION
Part of #342 (stage 1). **No closing keyword** — stage 2 (the FormKey-keyed union read) stays routed to the W5 charter, and #342 is its tracker.

## The wrong answer

Placed references, a topic's INFO lines and a worldspace's cells are declared **per plugin**, and the game assembles a parent's children from every plugin that declares them. A plugin that overrides a cell for an unrelated reason — occlusion, lighting, music — carries no references and deletes none, so reading that winner's `Persistent`/`Temporary` reported an empty cell the game fills. Reproduced to the digit on a real order: `008EB5:Skyrim.esm` reads Temporary 0 at its winner (override depth 42) while `Skyrim.esm`'s own body carries 201. Anyone auditing "what is in this cell" through the winner got a confident wrong answer — the Q3 class.

## What ships

**Two tiers.** Every load-order read of a field that owns child records states, from the INDEX alone, that other plugins touch this record and that this read did not open them. `conflict_tree=true` — which has already fetched every touching body for its diff — additionally names *which* of them declare, computed off those same bodies, and now hands that tree to the diff block instead of fetching it twice.

**Two sentence arms, by field shape.** A COLLECTION child (`Persistent`, `Temporary`, `NavigationMeshes`, `Responses`, `SubCells`) is assembled additively. A SINGULAR one (`Cell.Landscape`, `Worldspace.TopCell`) is ONE record that plugins override — "not the merged total" is false there, so it says the child is resolved by load order and that this body not carrying it does not remove it, with a COUNT of carriers rather than a name flood (`TopCell` has 484 carriers on the real order).

**Field set by construction.** `WriteEngine.ChildBearingProperties` over the concrete record types — the write surface's pinned authority, reached from the getter through `PrimaryGetter`/`ConcreteOf`. Never a hand list.

**"Declares" means reaches a child record**, not "has a top-level element": a worldspace carrying empty block scaffolding declares no cells (measured — 2 blocks / 2 sub-blocks / 0 cells exposes 2 elements and enumerates 0 children).

Display-only throughout: the round-trip token is untouched. Artifacts carry the note on rows and the sentence on the manifest line, so a catalogue re-opened later still says what it means.

## Decision record — two escalations, both Aaron-ruled

**1. The trigger.** Stage 1 was chartered as "fires when a lower layer declares content the winner's list is empty or smaller than". Review showed the count comparison produced two wrong answers: `Worldspace.SubCells` counts BLOCKS (cells sit two container levels down), so a base declaring 1 block of 5 cells "lost" to an override declaring 2 blocks of 1 each — the winner went unannotated and the base named the smaller declarer as largest; and disjoint declarations went unreported entirely (base declares 3, winner declares 4 *different* ones, live set 7, read shows 4 in silence). Escalated under §4(b) rather than folded. **Ruled: the count comparison goes, the trigger becomes a boolean.** The correction that came back — "declares" must mean *reaches a child record*, not *has an element* — was verified against Mutagen before implementing, and is what the WRLD-SCAFFOLD arms hold.

**2. The heterogeneous field set.** Round 2 found the invariant clause was FALSE for two members of its own field set (`Landscape`, `TopCell` — singular children, not merged). Same class as round 1's SubCells finding, one round later, so it went up under the recurrence rule rather than being folded a third time. **Ruled: per-shape sentences**, on the ground that this is a bounded structural distinction the classifier already answers, not the per-field count patchwork previously rejected. A third instance of this class is a standing §4 escalation.

## Performance — the correction chain, stated plainly

The first measurement was **wrong, and the ruling made on it was corrected**:

1. Synthetic fixture, ~200-record plugins: +43.5 ms on a 42-toucher cell read. Ruled "not hot, don't gate".
2. Same fixture re-measured on the product path (with `corpus.json` present): the single-read figure was **3x low**. Self-flagged.
3. Realistic plugin sizes (20k-record master + nine 2k plugins): **7.2 ms → 109.3 ms**, 15x. `GetRecord` fetches a body by enumerating a whole overlay — a cost this repo already documents at `LoadOrderResolver.cs:828` (*"~100 s over 9k weapons"*), and which my fixture had almost none of.
4. Review measured the real order: **27 ms → 588 ms** (Dawnstar), **21 ms → 1.3 s** (Tamriel), **18 ms → 2.5 s** (WhiterunWorld), 6.3 s → 126 s for a 200-cell query, and a `to_file` catalogue that did not finish in 10 minutes.

Escalated; the pre-ruled fallback fired and the **two-tier split** was ruled in (a middle option — full naming on single reads, cheap tier only on bulk — was weighed and declined, because per-read seconds re-compound across a session). Post-split, paired on the real order (3800 plugins, 3.2M records):

| | baseline | branch |
|---|---|---|
| `cross_plugin_query` CELL conflicts_only `fields=[Temporary]` limit=200 | 5941 / 5601 ms | 5968 / 5613 ms |
| `read_record` Dawnstar (42 touchers), x5 | 111 ms | 95 ms |
| `read_record` Dawnstar, independent reviewer's A/B | 26 ms | 27 ms |
| `read_record` uncontested cell + `conflict_tree=true` | 133 ms | 273 ms → **fixed in round 3** |
| `read_record` Dawnstar + `conflict_tree=true` (42 touchers) | 899 ms | 849 ms (one fetch, not two) |

The `to_file` cell catalogue now completes: 26,906 rows in 35.8 min. **No delta is claimed for it** — I did not measure a pre-split completion to subtract, and its cost is dominated by the query's own per-row body fetch (#354), not by the annotation.

## Verification limits, stated rather than implied

- **The unreadable-toucher path is not reachable end-to-end.** Corrupting a declaring plugin does not leave a named-but-unfetchable toucher: the freshness re-check rebuilds, the plugin is excluded from the order, and it stops being a toucher at all. The guard pins that measured lifecycle instead, plus the null rule at its two reachable ends. The residual hazard the arm exists for — a plugin that opens at header level but faults walking its child group — is not constructible from outside the process.
- **The precise tier's budget skip is partial.** The prefetch cannot foresee a cap hit *during* the record's own field render, so a single read with a cap tight enough to exhaust itself still pays for a tree it then truncates. I wrote an arm for this, could not make it true, and deleted it rather than keep an unpinnable branch. Stated in the code.
- **`fields=["Temporary[0]"]` is not annotated** — the note lands on the container line. Dropped with grounds: an empty winner errors on the index rather than answering silently, and bracket-prefix matching would annotate every deep sub-path.

## Review rounds

Three rounds, two fresh agents each, own worktrees, seeded with the settled-decisions list only. Both escalations came out of them.

| round | found | outcome |
|---|---|---|
| 1 | SubCells counts blocks; disjoint sets unreported; clause repeated ~275 chars/row eating the bulk budget; two guard branches unpinned | 0 folded — escalated the trigger under §4(b) |
| 2 | Real-order perf collapse (independently, twice); the clause false for singular children; `to_file` artifacts shipped the label with the clause nowhere; stale count-trigger comments | 2 escalations, 4 folds, 2 refused |
| 3 | The prefetch defeating the tree's sole-toucher skip (regression from round 2's fold, both agents, with A/B numbers); json batch clause over unrendered rows (same); remedy naming a parameter the recipient surface refuses; "every read" overclaim; manifest notes not round-tripping | 6 folds, 1 dropped with grounds, 1 arm deleted as unsatisfiable |

**Two of round 3's findings were regressions introduced by round 2's fold.** Recorded because it is the honest signal about folding under pressure, not buried.

**Refused, with grounds:** annotating the out-of-load-order read path (stamped OUT-OF-LOAD-ORDER; a load-order statement does not belong there) and the SkyPatcher-overlay pole (unclaimed by the CHANGELOG). Both remain unannotated deliberately, and the CHANGELOG now says so instead of claiming "every read".

**Reviewers self-refused** several suspicions across rounds — `Display` collision, round-trip contamination, dense-cell loss, case-variant field paths, a stranded-clause path — so the triage was not one-directional.

## Guard

`owned-child-content-guard`, **48 arms**, in `ci-all` (124/124). RED-checked in both directions: collapsing the shape classifier reds 3; dropping the containment walk for an element test reds 2; the getter→concrete hop reds the Landscape arm; the null rule reds the unreadable arm; the artifact clause reds 1; a precise tier that names nobody reds 11; an unconditional response clause reds 2. A type-level arm pins the getter→concrete hop over **every** concrete child-bearing type, not a sample.

## Spawned, not fixed here

- #353 — a read served from a FAILURE-degraded order carries no in-band signal (found while fixturing the unreadable path).
- #354 — no targeted per-plugin record fetch; `GetRecord` enumerates a whole overlay per call. This is what forced the tier split, and closing it would let the precise tier run everywhere.

Both filed unrouted; routing is Aaron's at RUN_ORDER.
