### PR TITLE
fix(write): name patch= in the "no such patch to extend" remedy, and document it

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -15,13 +15,17 @@ when it changes.
   than a wording nit because there is no rename primitive: the name you get on the first write is the name you
   keep. `patch=` is now documented as well, in the core workflow beside `into=`.
 
-  The stronger remedy reaches `housecarl_apply` / `housecarl_create` / `housecarl_forward` and their 1.x
-  equivalents, and deliberately not the tools where it would be false. `housecarl_remove`'s `patch=` names an
-  **existing** patch, so it would send you to re-issue the call that just failed. `housecarl_copy` and
-  `housecarl_copy_npc_appearance` do create a fresh patch, but name it after the new EditorID rather than `Patch`.
-  And among the file-placing tools (`place_asset`, `compile_script`, `decompile_script`, `bsa_repack`, `nif_set`,
-  `write_seq`), `bsa_repack`'s `patch=` names the `.bsa` rather than the mod folder. All of those keep the shorter,
-  always-true remedy.
+  It offers the name without promising the filename, because houseCARL auto-suffixes a name already taken by an
+  active plugin — and that is the likely case, since the name you guessed at `into=` is usually one you saw in your
+  load order. Both names the sentence mentions carry that qualifier, the one you choose and the `Patch` default.
+
+  The rule for which tools say it: exactly those whose `patch=` names a **new** patch defaulting to `Patch` — the
+  field-write, record-creation and forward lanes. Everywhere else the shorter, always-true remedy stands, because
+  the naming sentence would be false there: a removal edits a patch that already exists and cannot create one; a
+  closure copy or an appearance copy names its fresh patch after the new EditorID; and the tools that place a file
+  into a patch folder each default to their own stem (`houseCARL_Scripts`, `houseCARL_Assets`, `houseCARL_SEQ`,
+  `houseCARL_Archive`) rather than to `Patch` — with `bsa_repack` a further case, where `patch=` names the `.bsa`
+  itself rather than the mod folder.
 
 - **Fixed: reading a cell's placed references could report an empty cell the game fills.** Placed references, a
   topic's INFO lines and a worldspace's cells are declared **per plugin**, and the game assembles a parent's

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -6,6 +6,17 @@ when it changes.
 
 ## Unreleased
 
+- **Fixed: the refusal for "no such patch to extend" now says how to give a new patch a name.** Guessing
+  `into="My Cool Patch.esp"` for a patch you have not created yet is refused, correctly — but the only remedy it
+  offered was to omit `into=` and create the patch fresh, which is precisely the call that produces a generically
+  named `Patch.esp`. The parameter that names a new patch, `patch=`, appeared in nothing you read. The refusal now
+  hands back the call you meant, with your own guessed name already in it — `pass patch="My Cool Patch"` — and says
+  what omitting it costs. This matters more than a wording nit because there is no rename primitive: the name you
+  get on the first write is the name you keep. `patch=` is now documented as well, in the core workflow beside
+  `into=`. The file-placing tools (`place_asset`, `compile_script`, `decompile_script`, `bsa_repack`, `nif_set`,
+  `copy_npc_appearance`) keep the shorter remedy on purpose: on `housecarl_bsa_repack`, `patch=` names the `.bsa`
+  rather than the mod folder, so pointing every caller at it would be wrong for that one.
+
 - **Fixed: reading a cell's placed references could report an empty cell the game fills.** Placed references, a
   topic's INFO lines and a worldspace's cells are declared **per plugin**, and the game assembles a parent's
   children from every plugin that declares them. So a plugin that overrides a cell for an unrelated reason —

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -9,13 +9,19 @@ when it changes.
 - **Fixed: the refusal for "no such patch to extend" now says how to give a new patch a name.** Guessing
   `into="My Cool Patch.esp"` for a patch you have not created yet is refused, correctly — but the only remedy it
   offered was to omit `into=` and create the patch fresh, which is precisely the call that produces a generically
-  named `Patch.esp`. The parameter that names a new patch, `patch=`, appeared in nothing you read. The refusal now
-  hands back the call you meant, with your own guessed name already in it — `pass patch="My Cool Patch"` — and says
-  what omitting it costs. This matters more than a wording nit because there is no rename primitive: the name you
-  get on the first write is the name you keep. `patch=` is now documented as well, in the core workflow beside
-  `into=`. The file-placing tools (`place_asset`, `compile_script`, `decompile_script`, `bsa_repack`, `nif_set`,
-  `copy_npc_appearance`) keep the shorter remedy on purpose: on `housecarl_bsa_repack`, `patch=` names the `.bsa`
-  rather than the mod folder, so pointing every caller at it would be wrong for that one.
+  named `Patch.esp`. `patch=`, the parameter that names a new patch, was documented only in the parameter list
+  itself and in no workflow doc you would read first. The refusal now hands back the call you meant, with your own
+  guessed name already in it — `pass patch="My Cool Patch"` — and says what omitting it costs. This matters more
+  than a wording nit because there is no rename primitive: the name you get on the first write is the name you
+  keep. `patch=` is now documented as well, in the core workflow beside `into=`.
+
+  The stronger remedy reaches `housecarl_apply` / `housecarl_create` / `housecarl_forward` and their 1.x
+  equivalents, and deliberately not the tools where it would be false. `housecarl_remove`'s `patch=` names an
+  **existing** patch, so it would send you to re-issue the call that just failed. `housecarl_copy` and
+  `housecarl_copy_npc_appearance` do create a fresh patch, but name it after the new EditorID rather than `Patch`.
+  And among the file-placing tools (`place_asset`, `compile_script`, `decompile_script`, `bsa_repack`, `nif_set`,
+  `write_seq`), `bsa_repack`'s `patch=` names the `.bsa` rather than the mod folder. All of those keep the shorter,
+  always-true remedy.
 
 - **Fixed: reading a cell's placed references could report an empty cell the game fills.** Placed references, a
   topic's INFO lines and a worldspace's cells are declared **per plugin**, and the game assembles a parent's

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -15,17 +15,16 @@ when it changes.
   than a wording nit because there is no rename primitive: the name you get on the first write is the name you
   keep. `patch=` is now documented as well, in the core workflow beside `into=`.
 
-  It offers the name without promising the filename, because houseCARL auto-suffixes a name already taken by an
-  active plugin — and that is the likely case, since the name you guessed at `into=` is usually one you saw in your
-  load order. Both names the sentence mentions carry that qualifier, the one you choose and the `Patch` default.
+  It offers the name without promising the filename, because houseCARL auto-suffixes a name that is already taken —
+  either by a mod folder it already made under that name, or by an active plugin. **Read the patch name back off
+  the response**; both names the sentence mentions carry that qualifier, the one you choose and the `Patch` default.
 
   The rule for which tools say it: exactly those whose `patch=` names a **new** patch defaulting to `Patch` — the
   field-write, record-creation and forward lanes. Everywhere else the shorter, always-true remedy stands, because
   the naming sentence would be false there: a removal edits a patch that already exists and cannot create one; a
   closure copy or an appearance copy names its fresh patch after the new EditorID; and the tools that place a file
-  into a patch folder each default to their own stem (`houseCARL_Scripts`, `houseCARL_Assets`, `houseCARL_SEQ`,
-  `houseCARL_Archive`) rather than to `Patch` — with `bsa_repack` a further case, where `patch=` names the `.bsa`
-  itself rather than the mod folder.
+  into a patch folder each default to their own stem, never to `Patch` — with `bsa_repack` a further case, where
+  `patch=` names the `.bsa` itself rather than the mod folder.
 
 - **Fixed: reading a cell's placed references could report an empty cell the game fills.** Placed references, a
   topic's INFO lines and a worldspace's cells are declared **per plugin**, and the game assembles a parent's

--- a/plugin/codex/housecarl/SKILL.md
+++ b/plugin/codex/housecarl/SKILL.md
@@ -21,7 +21,7 @@ Use this skill for data-layer Skyrim Special Edition modding through the configu
    - `housecarl_bulk_apply` for several edits in one patch, dict merges, leveled-list entries, effects, or other composed structs.
    - `housecarl_create_record` (or `housecarl_bulk_create` for many at once) for a new top-level record — it needs an EditorID.
    - `housecarl_remove_record` only to drop a record or override from a houseCARL-owned patch — never from a source mod.
-4. Name the patch on the **first** write with `patch=<name>` — omit it and houseCARL names it `Patch`. After that, accumulate related edits into it with `into=<patch filename>`.
+4. Name the patch on the **first** write with `patch=<name>` — omit it and houseCARL names it `Patch`. Either way the name is auto-suffixed if it is already taken, so read the patch name back off the response. After that, accumulate related edits into it with `into=<patch filename>`.
 5. Prefer runtime, no-ESP INI systems when they fit the user's intent — `skypatcher-authoring`, `spid-authoring`, `kid-authoring` (see the helper skills below).
 
 ## The full tool surface

--- a/plugin/codex/housecarl/SKILL.md
+++ b/plugin/codex/housecarl/SKILL.md
@@ -21,7 +21,7 @@ Use this skill for data-layer Skyrim Special Edition modding through the configu
    - `housecarl_bulk_apply` for several edits in one patch, dict merges, leveled-list entries, effects, or other composed structs.
    - `housecarl_create_record` (or `housecarl_bulk_create` for many at once) for a new top-level record — it needs an EditorID.
    - `housecarl_remove_record` only to drop a record or override from a houseCARL-owned patch — never from a source mod.
-4. Accumulate related edits into one patch with `into=<patch filename>` after the first write returns a patch name.
+4. Name the patch on the **first** write with `patch=<name>` — omit it and houseCARL names it `Patch`. After that, accumulate related edits into it with `into=<patch filename>`.
 5. Prefer runtime, no-ESP INI systems when they fit the user's intent — `skypatcher-authoring`, `spid-authoring`, `kid-authoring` (see the helper skills below).
 
 ## The full tool surface

--- a/plugin/codex/housecarl/SKILL.md
+++ b/plugin/codex/housecarl/SKILL.md
@@ -21,7 +21,7 @@ Use this skill for data-layer Skyrim Special Edition modding through the configu
    - `housecarl_bulk_apply` for several edits in one patch, dict merges, leveled-list entries, effects, or other composed structs.
    - `housecarl_create_record` (or `housecarl_bulk_create` for many at once) for a new top-level record — it needs an EditorID.
    - `housecarl_remove_record` only to drop a record or override from a houseCARL-owned patch — never from a source mod.
-4. Name the patch on the **first** write with `patch=<name>` — omit it and houseCARL names it `Patch`. Either way the name is auto-suffixed if it is already taken, so read the patch name back off the response. After that, accumulate related edits into it with `into=<patch filename>`.
+4. Name the patch on the **first** write that creates one with `patch=<name>` (not `housecarl_remove_record`, whose `patch=` names one that already exists) — omit it and houseCARL names it `Patch`. Either way the name is auto-suffixed if it is already taken, so read the patch name back off the response. After that, accumulate related edits into it with `into=<patch filename>`.
 5. Prefer runtime, no-ESP INI systems when they fit the user's intent — `skypatcher-authoring`, `spid-authoring`, `kid-authoring` (see the helper skills below).
 
 ## The full tool surface

--- a/src/housecarl-generator/ExtendResolveProbe.cs
+++ b/src/housecarl-generator/ExtendResolveProbe.cs
@@ -31,6 +31,10 @@ namespace HousecarlGenerator;
 ///                  disambiguator (Q3 — never guess). Then into=&lt;a folder name&gt; picks one unambiguously.
 ///   MULTI-PLUGIN — into=&lt;a folder holding 2+ plugins&gt; (no &lt;stem&gt;.esp to single out) refuses, naming each plugin.
 ///   NOT-FOUND    — into= a name nothing holds/answers to → refuse, naming both places searched + "create it fresh".
+///   REMEDY       — that refusal's fresh-write escape NAMES patch=&lt;the guessed name&gt; on the RECORD lane (#343: the
+///                  bare "omit into=" it used to offer is the call that yields a generically-named Patch.esp), the
+///                  named call is then MADE to prove the sentence true, and the RIDER lane's copy still does NOT
+///                  name patch= (on bsa_repack that spelling binds to archive_name — the .bsa, not the patch).
 ///   FOREIGN      — a "houseCARL - X" folder with NO marker is still REFUSED (originals untouched, Q3) and left byte-intact.
 ///   ORIGINALS    — the master plugin is byte-untouched throughout (extends only ever wrote the patch folder).
 /// </summary>
@@ -210,6 +214,46 @@ internal static class ExtendResolveProbe
                     && r.Error.Contains("houseCARL - GhostPatch", StringComparison.Ordinal)
                     && r.Error.Contains("create it fresh", StringComparison.OrdinalIgnoreCase);
                 Check(!r.Success && named, "into=\"GhostPatch\" refuses, naming the .esp + the folder searched + 'create it fresh'");
+
+                // #343: the fresh-write escape must NAME the parameter that gives the new patch a name, with the
+                // caller's own guessed name already in it — the bare "omit into=" it used to offer is precisely the
+                // call that produces a generically-named Patch.esp. Both halves of the sentence are asserted because
+                // both were measured before it was written: patch="GhostPatch" writes GhostPatch.esp (arm 8b below
+                // re-proves it end to end), and omitting both lanes writes Patch.esp.
+                bool remedy = r.Error is not null
+                    && r.Error.Contains("pass patch=\"GhostPatch\"", StringComparison.Ordinal)
+                    && r.Error.Contains("houseCARL names it \"Patch\"", StringComparison.Ordinal);
+                Check(remedy, "…and the remedy names patch=\"GhostPatch\" + what omitting it costs (#343)");
+            }
+
+            // ---- 8b: the remedy is TRUE — following it produces the patch the caller asked for ----
+            //      A remedy is a claim about what a call does, so it is checked by making the call, not by reading
+            //      the sentence (#343 is itself the class where a plausible remedy sent callers the wrong way).
+            Console.WriteLine();
+            Console.WriteLine("--- 8b: following the remedy produces GhostPatch.esp, not Patch.esp ---");
+            {
+                var r = svc.ApplyEdits(new[] { Wgt(2) }, "GhostPatch", null);
+                Check(r.Success && Ends(r.OutputPath, "houseCARL - GhostPatch", "GhostPatch.esp"),
+                      $"patch=\"GhostPatch\" writes the patch under that name ({Path.GetFileName(r.OutputPath)})");
+            }
+
+            // ---- 8c: the RIDER lane keeps the older tail — it must NOT name patch= ----
+            //      Measured, not assumed: patch= is the new patch's name on every RECORD-lane tool, but on
+            //      housecarl_bsa_repack — a rider — it binds to archive_name (the .bsa), because that tool declares
+            //      both spellings and §5.3 routes patch= to the artifact. Telling a rider caller to pass patch=
+            //      would rename their archive and leave the mod folder defaulted, so the record lane's sentence
+            //      stops at the record lane. This arm is what makes that a decision rather than an oversight.
+            Console.WriteLine();
+            Console.WriteLine("--- 8c: the rider lane's refusal does not name patch= ---");
+            {
+                string riderErr = "";
+                try { svc.ResolvePatchModFolder(null, "GhostRider", "houseCARL_Archive"); }
+                catch (InvalidOperationException ex) { riderErr = ex.Message; }
+                Check(riderErr.Contains("GhostRider.esp", StringComparison.Ordinal)
+                      && riderErr.Contains("create it fresh", StringComparison.OrdinalIgnoreCase),
+                      "the rider lane still refuses, naming the .esp searched + 'create it fresh'");
+                Check(!riderErr.Contains("patch=", StringComparison.Ordinal),
+                      "…and does NOT name patch= (on bsa_repack it names the .bsa, not the patch)");
             }
 
             // ---- 9: FOREIGN — an un-owned "houseCARL - X" folder stays REFUSED + byte-untouched (Q3) ----

--- a/src/housecarl-generator/ExtendResolveProbe.cs
+++ b/src/housecarl-generator/ExtendResolveProbe.cs
@@ -272,8 +272,21 @@ internal static class ExtendResolveProbe
                 var followed = svc.ApplyEdits(new[] { Wgt(4) }, "GhostActive", null);
                 Check(followed.Success && Ends(followed.OutputPath, "houseCARL - GhostActive_001", "GhostActive_001.esp"),
                       $"…and following it auto-suffixes off the active plugin ({Path.GetFileName(followed.OutputPath)})");
-                Check(r.Error is not null && !r.Error.Contains("under that name", StringComparison.Ordinal),
-                      "…which is why the sentence promises no filename — it says 'a name you choose', not 'that name'");
+
+                // The negative is pinned to what the CURRENT sentence must not contain, not to a phrase only an old
+                // one did: the refusal must not name the file the write actually produces. Its predecessor pinned
+                // the superseded wording, so it reddened for exactly one sabotage — restoring that wording — and
+                // would have stayed green on any new way of predicting the filename.
+                //
+                // Its reach, stated rather than implied: it catches a wording that echoes the name that really gets
+                // written (the suffixed stem). It does NOT catch one predicting the UNSUFFIXED name, because the
+                // refusal legitimately quotes "<stem>.esp" already as the plugin it searched for — no string test
+                // can tell that occurrence from a prediction. The property's real load is carried by the positive
+                // pin above plus the `followed` call, which make the collision observable; this is a second net,
+                // not the proof.
+                var written = Path.GetFileNameWithoutExtension(followed.OutputPath);      // "GhostActive_001"
+                Check(r.Error is not null && !r.Error.Contains(written, StringComparison.OrdinalIgnoreCase),
+                      $"…and the refusal never names the file the write produces ('{written}') — it promises no filename");
             }
 
             // ---- 8c: the RIDER lane keeps the older tail — it must NOT name patch= ----

--- a/src/housecarl-generator/ExtendResolveProbe.cs
+++ b/src/housecarl-generator/ExtendResolveProbe.cs
@@ -226,6 +226,12 @@ internal static class ExtendResolveProbe
                     && r.Error.Contains("pass patch=\"GhostPatch\"", StringComparison.Ordinal)
                     && r.Error.Contains("houseCARL names it \"Patch\"", StringComparison.Ordinal);
                 Check(remedy, "…and the remedy names patch=\"GhostPatch\" + what omitting it costs (#343)");
+
+                // The qualifier is load-bearing, not padding: it is the only thing keeping the sentence true in the
+                // collision case arm 8b2 exercises, and it must cover BOTH names the sentence mentions — the chosen
+                // one and the "Patch" default — because the same auto-suffix arm falsifies either.
+                Check(r.Error is not null && r.Error.Contains("either name auto-suffixed if already taken", StringComparison.Ordinal),
+                      "…and qualifies BOTH names it offers with the auto-suffix, rather than promising a filename");
             }
 
             // ---- 8b: the remedy is TRUE — following it produces the patch the caller asked for ----
@@ -237,6 +243,37 @@ internal static class ExtendResolveProbe
                 var r = svc.ApplyEdits(new[] { Wgt(2) }, "GhostPatch", null);
                 Check(r.Success && Ends(r.OutputPath, "houseCARL - GhostPatch", "GhostPatch.esp"),
                       $"patch=\"GhostPatch\" writes the patch under that name ({Path.GetFileName(r.OutputPath)})");
+            }
+
+            // ---- 8b2: the COLLISION case — the one the remedy used to mispromise ----
+            //      An ACTIVE plugin whose mod folder is named something else is exactly what a caller guesses into=
+            //      from, because the plugin name is what they saw in their load order. Nothing houseCARL owns answers
+            //      to it, so the not-found remedy fires — and the fresh write then auto-suffixes off the active
+            //      plugin, so a remedy promising the guessed name "under that name" was false precisely here. The
+            //      sentence now offers the name without promising the filename; this arm holds it to that.
+            Console.WriteLine();
+            Console.WriteLine("--- 8b2: an active plugin of the same name → the remedy must not promise the filename ---");
+            {
+                var oddDir = Path.Combine(mods, "OddlyNamedMod");
+                Directory.CreateDirectory(oddDir);
+                new SkyrimMod(new ModKey("GhostActive", ModType.Plugin), SkyrimRelease.SkyrimSE)
+                    .BeginWrite.ToPath(Path.Combine(oddDir, "GhostActive.esp"))
+                    .WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+                File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + mKey.FileName + "\r\nGhostActive.esp\r\n");
+                File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + mKey.FileName + "\r\n*GhostActive.esp\r\n");
+                File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+OddlyNamedMod\r\n+MasterMod\r\n");
+                svc.Stats();                                                   // let the resolver see the changed order
+
+                var r = svc.ApplyEdits(new[] { Wgt(4) }, null, "GhostActive");
+                Check(!r.Success && r.Error is not null
+                      && r.Error.Contains("pass patch=\"GhostActive\"", StringComparison.Ordinal),
+                      "into=\"GhostActive\" (an active plugin, foreign folder) still refuses with the naming remedy");
+
+                var followed = svc.ApplyEdits(new[] { Wgt(4) }, "GhostActive", null);
+                Check(followed.Success && Ends(followed.OutputPath, "houseCARL - GhostActive_001", "GhostActive_001.esp"),
+                      $"…and following it auto-suffixes off the active plugin ({Path.GetFileName(followed.OutputPath)})");
+                Check(r.Error is not null && !r.Error.Contains("under that name", StringComparison.Ordinal),
+                      "…which is why the sentence promises no filename — it says 'a name you choose', not 'that name'");
             }
 
             // ---- 8c: the RIDER lane keeps the older tail — it must NOT name patch= ----
@@ -260,11 +297,12 @@ internal static class ExtendResolveProbe
 
             // ---- 8d: the REMOVAL lane must not get the naming sentence either ----
             //      Removal reaches the same refusal through ResolveOutputPath — the SAME branch arm 8 covers — so the
-            //      lane bit does not separate them; only the caller's own patchNamesFresh does. For housecarl_remove
-            //      the naming sentence would be actively wrong twice over: patch= there names an EXISTING patch (it
-            //      IS the into= slot), so "pass patch=<the name you just passed>" re-issues the failing call, and
-            //      removal cannot create a patch at all, so the cost clause would be false as well. Withholding it is
-            //      the fix for a defect this branch briefly shipped; this arm is what stops it coming back.
+            //      lane bit does not separate them; only the caller's own patchNamesFresh does. A removal edits an
+            //      artifact that already exists, so it cannot create a patch and the cost clause is false whichever
+            //      spelling the tool gives the lane: 2.0's housecarl_remove calls it into=, while 1.x remove_record
+            //      calls it patch= and means the EXISTING patch — there "pass patch=<the name you just passed>" would
+            //      re-issue the very call that failed. Withholding it is the fix for a defect this branch briefly
+            //      shipped; this arm is what stops it coming back.
             Console.WriteLine();
             Console.WriteLine("--- 8d: the removal lane's refusal does not name patch= ---");
             {
@@ -272,7 +310,7 @@ internal static class ExtendResolveProbe
                 Check(!r.Success && r.Error is not null && r.Error.Contains("GhostRemove.esp", StringComparison.Ordinal),
                       "housecarl_remove into a patch that does not exist still refuses, naming the .esp searched");
                 Check(r.Error is not null && !r.Error.Contains("patch=", StringComparison.Ordinal),
-                      "…and does NOT name patch= (there it names an EXISTING patch — the remedy would loop)");
+                      "…and does NOT name patch= (a removal cannot create a patch — the remedy would be false)");
             }
 
             // ---- 9: FOREIGN — an un-owned "houseCARL - X" folder stays REFUSED + byte-untouched (Q3) ----

--- a/src/housecarl-generator/ExtendResolveProbe.cs
+++ b/src/housecarl-generator/ExtendResolveProbe.cs
@@ -31,10 +31,12 @@ namespace HousecarlGenerator;
 ///                  disambiguator (Q3 — never guess). Then into=&lt;a folder name&gt; picks one unambiguously.
 ///   MULTI-PLUGIN — into=&lt;a folder holding 2+ plugins&gt; (no &lt;stem&gt;.esp to single out) refuses, naming each plugin.
 ///   NOT-FOUND    — into= a name nothing holds/answers to → refuse, naming both places searched + "create it fresh".
-///   REMEDY       — that refusal's fresh-write escape NAMES patch=&lt;the guessed name&gt; on the RECORD lane (#343: the
-///                  bare "omit into=" it used to offer is the call that yields a generically-named Patch.esp), the
-///                  named call is then MADE to prove the sentence true, and the RIDER lane's copy still does NOT
-///                  name patch= (on bsa_repack that spelling binds to archive_name — the .bsa, not the patch).
+///   REMEDY       — that refusal's fresh-write escape NAMES patch=&lt;the guessed name&gt; for the callers whose patch=
+///                  really does name a fresh patch (#343: the bare "omit into=" it used to offer is the call that
+///                  yields a generically-named Patch.esp), and the named call is then MADE to prove the sentence
+///                  true rather than read. The two arms that keep it honest are negative: the RIDER lane does NOT
+///                  get it (on bsa_repack patch= binds to archive_name — the .bsa), and neither does the REMOVAL
+///                  lane, which shares the record branch but whose patch= names an EXISTING patch.
 ///   FOREIGN      — a "houseCARL - X" folder with NO marker is still REFUSED (originals untouched, Q3) and left byte-intact.
 ///   ORIGINALS    — the master plugin is byte-untouched throughout (extends only ever wrote the patch folder).
 /// </summary>
@@ -238,11 +240,11 @@ internal static class ExtendResolveProbe
             }
 
             // ---- 8c: the RIDER lane keeps the older tail — it must NOT name patch= ----
-            //      Measured, not assumed: patch= is the new patch's name on every RECORD-lane tool, but on
+            //      Measured, not assumed: patch= is the new patch's name on the record-lane write tools, but on
             //      housecarl_bsa_repack — a rider — it binds to archive_name (the .bsa), because that tool declares
             //      both spellings and §5.3 routes patch= to the artifact. Telling a rider caller to pass patch=
-            //      would rename their archive and leave the mod folder defaulted, so the record lane's sentence
-            //      stops at the record lane. This arm is what makes that a decision rather than an oversight.
+            //      would rename their archive and leave the mod folder defaulted, so the naming sentence does not
+            //      reach this lane. This arm is what makes that a decision rather than an oversight.
             Console.WriteLine();
             Console.WriteLine("--- 8c: the rider lane's refusal does not name patch= ---");
             {
@@ -254,6 +256,23 @@ internal static class ExtendResolveProbe
                       "the rider lane still refuses, naming the .esp searched + 'create it fresh'");
                 Check(!riderErr.Contains("patch=", StringComparison.Ordinal),
                       "…and does NOT name patch= (on bsa_repack it names the .bsa, not the patch)");
+            }
+
+            // ---- 8d: the REMOVAL lane must not get the naming sentence either ----
+            //      Removal reaches the same refusal through ResolveOutputPath — the SAME branch arm 8 covers — so the
+            //      lane bit does not separate them; only the caller's own patchNamesFresh does. For housecarl_remove
+            //      the naming sentence would be actively wrong twice over: patch= there names an EXISTING patch (it
+            //      IS the into= slot), so "pass patch=<the name you just passed>" re-issues the failing call, and
+            //      removal cannot create a patch at all, so the cost clause would be false as well. Withholding it is
+            //      the fix for a defect this branch briefly shipped; this arm is what stops it coming back.
+            Console.WriteLine();
+            Console.WriteLine("--- 8d: the removal lane's refusal does not name patch= ---");
+            {
+                var r = svc.RemoveRecords(new[] { fid }, "GhostRemove");
+                Check(!r.Success && r.Error is not null && r.Error.Contains("GhostRemove.esp", StringComparison.Ordinal),
+                      "housecarl_remove into a patch that does not exist still refuses, naming the .esp searched");
+                Check(r.Error is not null && !r.Error.Contains("patch=", StringComparison.Ordinal),
+                      "…and does NOT name patch= (there it names an EXISTING patch — the remedy would loop)");
             }
 
             // ---- 9: FOREIGN — an un-owned "houseCARL - X" folder stays REFUSED + byte-untouched (Q3) ----

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -7843,11 +7843,23 @@ public sealed class LoadOrderService : IDisposable
                     $"cannot extend: mod folder '{cand}' exists but was NOT created by houseCARL (no marker) — " +
                     "refusing to write into a folder houseCARL doesn't own (originals untouched, Q3). Use a different patch name.");
         }
+        // The fresh-write remedy differs BY LANE, and only because it was measured to (#343). "Omit into= to create
+        // it fresh" was the whole remedy, and it is exactly the call that yields a generically-named Patch.esp —
+        // while patch=, the way to name a new patch, appeared in nothing a caller reads. On the RECORD lane every
+        // tool spells that name patch= (§5.3; on the not-yet-renamed ones patch= binds to their declared
+        // patch_name=), so the remedy hands back the working call with the caller's own guessed name in it. The
+        // RIDER lane (needEsp:false — place_asset / compile / decompile / bsa_repack / nif_set / copy_npc_appearance)
+        // keeps the older, weaker, still-true tail: on housecarl_bsa_repack patch= binds to archive_name — the .bsa,
+        // not the mod folder, because that tool declares both spellings — so naming patch= there would rename the
+        // caller's archive and leave the folder defaulted. A sentence true on one lane is not shipped to the other.
         throw new InvalidOperationException(
             $"cannot extend: no houseCARL plugin '{espName}' in any houseCARL folder, and no houseCARL folder named " +
             $"'{ModFolderName(stem)}'" +
             (string.Equals(bareName, ModFolderName(stem), StringComparison.OrdinalIgnoreCase) ? "" : $" or '{bareName}'") +
-            ". Omit into= to create it fresh, or check the name.");
+            ". " + (needEsp
+                ? $"Omit into= and pass patch=\"{stem}\" to create it fresh under that name "
+                  + "(omit both and houseCARL names it \"Patch\"), or check the name."
+                : "Omit into= to create it fresh, or check the name."));
     }
 
     /// <summary>houseCARL-OWNED mod folders under ModsDir holding a plugin file named <paramref name="espFileName"/> at

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -7867,17 +7867,20 @@ public sealed class LoadOrderService : IDisposable
         // patch=, meaning the EXISTING patch — where the sentence would tell the caller to re-issue the call that
         // just failed). (2) It creates one but names it something else: copy and copy_npc_appearance default their
         // stem to the new EditorID or houseCARL_NpcCopy, and every RIDER lane defaults to the stem its own call site
-        // passes (houseCARL_Scripts / _Assets / _SEQ / _Archive), never "Patch". (3) The spelling means a different
-        // artifact on that tool: on housecarl_bsa_repack a bare patch= binds to archive_name — the .bsa, not the mod
-        // folder — because it declares both and §5.3 routes patch= to the artifact.
+        // passes, never "Patch" — deliberately not listed here, because a list of them is what keeps going stale;
+        // the call sites are the authority. (3) The spelling means a different artifact on that tool: on
+        // housecarl_bsa_repack a bare patch= binds to archive_name — the .bsa, not the mod folder — because it
+        // declares both and §5.3 routes patch= to the artifact.
         //
         // Hence the default is FALSE and the tail is the weaker, always-true one: a caller added later without a
         // thought about any of this gets a sentence that is merely less helpful, never wrong.
         //
-        // Note what the sentence does NOT do: predict the resulting filename. UniqueStem auto-suffixes a stem whose
-        // .esp is already an active plugin — and that is the correlated case, since a caller guessing into= usually
-        // guessed it off a plugin name in their load order. The qualifier scopes BOTH names the sentence mentions,
-        // the chosen one and the "Patch" default, because the same arm falsifies either.
+        // Note what the sentence does NOT do: predict the resulting filename. UniqueStem takes a stem only when it
+        // is free on BOTH of IsStemFree's tests — no "houseCARL - <stem>" folder already exists, AND no active
+        // plugin is named "<stem>.esp" — and suffixes it otherwise. Either trigger is ordinary: the folder arm is
+        // the repeat caller who passes patch= again instead of into=, the active-plugin arm the caller who guessed
+        // into= off a name in their load order. The qualifier scopes BOTH names the sentence mentions, the chosen
+        // one and the "Patch" default, because either can be suffixed by either trigger.
         throw new InvalidOperationException(
             $"cannot extend: no houseCARL plugin '{espName}' in any houseCARL folder, and no houseCARL folder named " +
             $"'{ModFolderName(stem)}'" +

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4704,7 +4704,7 @@ public sealed class LoadOrderService : IDisposable
             // one disk side effect the pre-serialize pipeline otherwise has. The fresh-lane name is a preview: the
             // real write re-picks a free stem, so a concurrent write can shift the auto-suffix.
             string outPath; bool extend, created;
-            try { outPath = ResolveOutputPath(patchName, into, out extend, out created, create: !dryRun); }
+            try { outPath = ResolveOutputPath(patchName, into, out extend, out created, create: !dryRun, patchNamesFresh: true); }
             catch (Exception ex) { return WritePatchBuilder.PatchOutcome.Fail(ex.Message); }
 
             // P8b: pre-resolve any CopyFrom source that is OFF-ORDER (from_plugin on disk but NOT in the active order —
@@ -5606,6 +5606,9 @@ public sealed class LoadOrderService : IDisposable
                 return RemoveRecordsInPlace(resolver, keys, target!.Trim(), acknowledge);
 
             // Resolve + ownership-gate the patch path via the into= (extend) path — must exist + carry the houseCARL marker.
+            // patchNamesFresh stays FALSE (the default) and must: removal cannot create a patch at all, and this tool's
+            // patch= names an EXISTING one — it IS the into= slot — so the naming remedy would tell the caller to
+            // re-issue the exact call that just failed. Pinned by the extend-resolver guard's remove arm.
             string outPath;
             try { outPath = ResolveOutputPath(patchName: null, into: patch, out _, out _); }
             catch (Exception ex) { return WritePatchBuilder.RemovalOutcome.Fail(ex.Message); }
@@ -5755,7 +5758,7 @@ public sealed class LoadOrderService : IDisposable
 
                 // #225: a dry run resolves the would-be output path WITHOUT creating the mod folder (see ApplyEdits).
                 string outPath; bool extend, created;
-                try { outPath = ResolveOutputPath(patchName, into, out extend, out created, create: !dryRun); }
+                try { outPath = ResolveOutputPath(patchName, into, out extend, out created, create: !dryRun, patchNamesFresh: true); }
                 catch (Exception ex) { return WritePatchBuilder.ForwardOutcome.Fail(ex.Message); }
 
                 var outcome = WritePatchBuilder.ForwardRecords(resolver, specs, outPath, extend, fullReadback, dryRun, sourceParam, offOrder);
@@ -6769,7 +6772,7 @@ public sealed class LoadOrderService : IDisposable
                 return CommitCreateInPlace(resolver, rulebook, specs, target!.Trim(), acknowledge);
 
             string outPath; bool extend, created;
-            try { outPath = ResolveOutputPath(patchName, into, out extend, out created); }
+            try { outPath = ResolveOutputPath(patchName, into, out extend, out created, patchNamesFresh: true); }
             catch (Exception ex) { return WritePatchBuilder.CreateOutcome.Fail(ex.Message); }
 
             var outcome = WritePatchBuilder.CreateRecords(resolver, rulebook, specs, outPath, extend, fullReadback);
@@ -7148,8 +7151,12 @@ public sealed class LoadOrderService : IDisposable
     /// Runs under <see cref="_gate"/> like its sibling <see cref="ResolvePatchModFolder"/> (hunt F2): the UniqueStem
     /// check-then-create is only race-free when every folder allocation is serialized on the one gate.
     /// <paramref name="createdFolder"/> reports whether THIS call created the fresh folder, so a refused write can
-    /// remove it again (hunt F4 — "NO patch written" must not leave an orphan folder accreting _001/_002 on retry).</summary>
-    string ResolveOutputPath(string? patchName, string? into, out bool extend, out bool createdFolder, bool create = true)
+    /// remove it again (hunt F4 — "NO patch written" must not leave an orphan folder accreting _001/_002 on retry).
+    /// <paramref name="patchNamesFresh"/> is passed through to the not-found refusal's remedy: the calling operation
+    /// states whether ITS <c>patch=</c> names a fresh patch defaulting to "Patch". Defaults to false — the weaker,
+    /// always-true remedy — so a caller added later without considering it cannot inherit a false sentence.</summary>
+    string ResolveOutputPath(string? patchName, string? into, out bool extend, out bool createdFolder, bool create = true,
+                             bool patchNamesFresh = false)
     {
         lock (_gate)
         {
@@ -7165,7 +7172,7 @@ public sealed class LoadOrderService : IDisposable
                 // the canonical fast path only short-circuits a folder that actually holds <stem>.esp; we then pick the .esp
                 // to extend inside the resolved folder: the <stem>.esp it holds, or — via the by-folder catch-all, where the
                 // folder & plugin names differ — the folder's single plugin (Q3-refuse if it holds none or several).
-                var folder = ResolveOwnedPatchFolder(into, needEsp: true);
+                var folder = ResolveOwnedPatchFolder(into, needEsp: true, patchNamesFresh);
                 var direct = Path.Combine(folder, PatchStem(into) + ".esp");
                 if (File.Exists(direct)) return direct;
                 var sole = SoleEspInFolder(folder, out var why);
@@ -7804,8 +7811,11 @@ public sealed class LoadOrderService : IDisposable
     /// Ownership-gated at every step — a plugin houseCARL didn't make stays refused (no foreign-plugin door; that's the
     /// separate in-place lane). <paramref name="needEsp"/> tightens the canonical fast path for the RECORD lane (the folder
     /// must actually hold &lt;stem&gt;.esp to short-circuit, else fall through); the rider lane targets the folder itself, so
-    /// it short-circuits on folder-exists+owned. Caller holds <see cref="_gate"/>.</summary>
-    string ResolveOwnedPatchFolder(string into, bool needEsp)
+    /// it short-circuits on folder-exists+owned. Caller holds <see cref="_gate"/>.
+    /// <paramref name="patchNamesFresh"/> is the calling operation's own statement that, for IT, <c>patch=</c> names a
+    /// NEW patch and defaults to "Patch" — which decides only the not-found refusal's remedy (see the throw). It is a
+    /// separate bit from <paramref name="needEsp"/> on purpose: the lanes and the naming semantics do not coincide.</summary>
+    string ResolveOwnedPatchFolder(string into, bool needEsp, bool patchNamesFresh = false)
     {
         var stem = PatchStem(into);                             // strips a trailing .esp/.esm/.esl; no directory parts (can't escape ModsDir)
         var espName = stem + ".esp";
@@ -7843,22 +7853,24 @@ public sealed class LoadOrderService : IDisposable
                     $"cannot extend: mod folder '{cand}' exists but was NOT created by houseCARL (no marker) — " +
                     "refusing to write into a folder houseCARL doesn't own (originals untouched, Q3). Use a different patch name.");
         }
-        // The fresh-write remedy differs BY LANE, and only because it was measured to (#343). "Omit into= to create
-        // it fresh" was the whole remedy, and it is exactly the call that yields a generically-named Patch.esp —
-        // while patch=, the way to name a new patch, appeared in nothing a caller reads. On the RECORD lane every
-        // tool spells that name patch= (§5.3; on the not-yet-renamed ones patch= binds to their declared
-        // patch_name=), so the remedy hands back the working call with the caller's own guessed name in it. The
-        // RIDER lane (needEsp:false — place_asset / compile / decompile / bsa_repack / nif_set / copy_npc_appearance)
-        // keeps the older, weaker, still-true tail: on housecarl_bsa_repack patch= binds to archive_name — the .bsa,
-        // not the mod folder, because that tool declares both spellings — so naming patch= there would rename the
-        // caller's archive and leave the folder defaulted. A sentence true on one lane is not shipped to the other.
+        // The fresh-write remedy is the CALLER'S to authorize (#343). "Omit into= to create it fresh" was the whole
+        // remedy, and it is exactly the call that yields a generically-named Patch.esp — while patch=, the way to
+        // name a new patch, was in no doc a caller reads. The stronger sentence names patch= and hands back the
+        // working call with the caller's own guessed name in it. It is NOT inferable here, because "patch= names the
+        // fresh patch, defaulting to Patch" is true of some callers of this resolver and false of others, and the
+        // lane bit does not separate them: housecarl_remove takes no into= at all and its patch= names an EXISTING
+        // patch, so this sentence would tell it to re-issue the call that just failed; copy and copy_npc_appearance
+        // DO create fresh, but default their stem to the new EditorID / houseCARL_NpcCopy rather than to Patch; and
+        // on the rider housecarl_bsa_repack patch= binds to archive_name — the .bsa, not the mod folder. So each
+        // caller states whether the sentence is true of it, and the DEFAULT is the weaker, always-true tail: a
+        // caller added later without a thought about this gets a sentence that is merely less helpful, never wrong.
         throw new InvalidOperationException(
             $"cannot extend: no houseCARL plugin '{espName}' in any houseCARL folder, and no houseCARL folder named " +
             $"'{ModFolderName(stem)}'" +
             (string.Equals(bareName, ModFolderName(stem), StringComparison.OrdinalIgnoreCase) ? "" : $" or '{bareName}'") +
-            ". " + (needEsp
+            ". " + (patchNamesFresh
                 ? $"Omit into= and pass patch=\"{stem}\" to create it fresh under that name "
-                  + "(omit both and houseCARL names it \"Patch\"), or check the name."
+                  + "(omit patch= too and houseCARL names it \"Patch\"), or check the name."
                 : "Omit into= to create it fresh, or check the name."));
     }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -7856,21 +7856,36 @@ public sealed class LoadOrderService : IDisposable
         // The fresh-write remedy is the CALLER'S to authorize (#343). "Omit into= to create it fresh" was the whole
         // remedy, and it is exactly the call that yields a generically-named Patch.esp — while patch=, the way to
         // name a new patch, was in no doc a caller reads. The stronger sentence names patch= and hands back the
-        // working call with the caller's own guessed name in it. It is NOT inferable here, because "patch= names the
-        // fresh patch, defaulting to Patch" is true of some callers of this resolver and false of others, and the
-        // lane bit does not separate them: housecarl_remove takes no into= at all and its patch= names an EXISTING
-        // patch, so this sentence would tell it to re-issue the call that just failed; copy and copy_npc_appearance
-        // DO create fresh, but default their stem to the new EditorID / houseCARL_NpcCopy rather than to Patch; and
-        // on the rider housecarl_bsa_repack patch= binds to archive_name — the .bsa, not the mod folder. So each
-        // caller states whether the sentence is true of it, and the DEFAULT is the weaker, always-true tail: a
-        // caller added later without a thought about this gets a sentence that is merely less helpful, never wrong.
+        // working call with the caller's own guessed name in it.
+        //
+        // THE RULE, not a roster: it reaches exactly the operations whose patch= names a NEW patch defaulting to
+        // "Patch", and each states that for itself, because it is not inferable here and the lane bit does not
+        // separate it. Three independent ways it goes false — which is why an enumeration was the wrong shape, and
+        // why this comment's own list of tools was wrong twice before it became a rule. (1) The operation does not
+        // create a patch at all: a REMOVAL edits an artifact that already exists, so both halves are false there
+        // whichever spelling that tool gives the lane (2.0's housecarl_remove says into=; 1.x remove_record says
+        // patch=, meaning the EXISTING patch — where the sentence would tell the caller to re-issue the call that
+        // just failed). (2) It creates one but names it something else: copy and copy_npc_appearance default their
+        // stem to the new EditorID or houseCARL_NpcCopy, and every RIDER lane defaults to the stem its own call site
+        // passes (houseCARL_Scripts / _Assets / _SEQ / _Archive), never "Patch". (3) The spelling means a different
+        // artifact on that tool: on housecarl_bsa_repack a bare patch= binds to archive_name — the .bsa, not the mod
+        // folder — because it declares both and §5.3 routes patch= to the artifact.
+        //
+        // Hence the default is FALSE and the tail is the weaker, always-true one: a caller added later without a
+        // thought about any of this gets a sentence that is merely less helpful, never wrong.
+        //
+        // Note what the sentence does NOT do: predict the resulting filename. UniqueStem auto-suffixes a stem whose
+        // .esp is already an active plugin — and that is the correlated case, since a caller guessing into= usually
+        // guessed it off a plugin name in their load order. The qualifier scopes BOTH names the sentence mentions,
+        // the chosen one and the "Patch" default, because the same arm falsifies either.
         throw new InvalidOperationException(
             $"cannot extend: no houseCARL plugin '{espName}' in any houseCARL folder, and no houseCARL folder named " +
             $"'{ModFolderName(stem)}'" +
             (string.Equals(bareName, ModFolderName(stem), StringComparison.OrdinalIgnoreCase) ? "" : $" or '{bareName}'") +
             ". " + (patchNamesFresh
-                ? $"Omit into= and pass patch=\"{stem}\" to create it fresh under that name "
-                  + "(omit patch= too and houseCARL names it \"Patch\"), or check the name."
+                ? $"Omit into= and pass patch=\"{stem}\" to create it fresh under a name you choose, or omit patch= "
+                  + "too and houseCARL names it \"Patch\" — either name auto-suffixed if already taken. "
+                  + "Or check the name."
                 : "Omit into= to create it fresh, or check the name."));
     }
 


### PR DESCRIPTION
Fixes #343

## The defect

Guessing `into=` for a patch that does not exist yet is refused, correctly. Its only remedy was *"Omit into= to create it fresh"* — which is exactly the call that produces a generically-named `Patch.esp`. `patch=`, the parameter that names a new patch, appeared in no workflow doc. That costs more than a wording nit: there is no rename primitive, so the name you get on the first write is the name you keep.

Two changes, per the triage ruling on the issue: the remedy names `patch=`, and `patch=` gets one user-facing doc line (`plugin/codex/housecarl/SKILL.md`, in the core-workflow step beside `into=` — its one home).

## Measured before written, and after

Every claim below came from running the call against the real service on a synthetic MO2 instance, not from reading the code.

| probe | result |
|---|---|
| `into="My Cool Patch.esp"` before it exists | reproduces the reported refusal verbatim |
| `patch="My Cool Patch"` | → `houseCARL - My Cool Patch\My Cool Patch.esp` |
| omit both lanes | → `Patch.esp` — the old remedy's advice **is** the defect |
| `into=` after `patch=` created it | extends the same file |
| `patch=` binding, per tool, through the real alias layer | `patch_name` everywhere except `bsa_repack`, where it binds to `archive_name` (the `.bsa`) |
| `into="GhostActive"` where `GhostActive.esp` is an active plugin, then `patch="GhostActive"` | → `GhostActive_001.esp` — `UniqueStem` auto-suffixes |

The final sentence, as delivered:

> `cannot extend: no houseCARL plugin 'My Cool Patch.esp' in any houseCARL folder, and no houseCARL folder named 'houseCARL - My Cool Patch' or 'My Cool Patch.esp'. Omit into= and pass patch="My Cool Patch" to create it fresh under a name you choose, or omit patch= too and houseCARL names it "Patch" — either name auto-suffixed if already taken. Or check the name.`

It hands back the call the caller meant, with their own guessed name in it (extension stripped, as `PatchStem` does), and promises no filename.

## Who says it, and why that is a rule rather than a list

The refusal is thrown from one shared resolver with several callers whose `patch=` means different things. The stronger sentence reaches exactly the operations whose `patch=` names a **new** patch defaulting to `Patch` — the field-write, create and forward lanes — and each states that for itself. The default is **false**, so a caller added later inherits the weaker, always-true tail rather than a false sentence.

Three ways it goes false, which is why an enumeration was the wrong shape: a removal cannot create a patch at all; `copy` and `copy_npc_appearance` create one but name it after the new EditorID / `houseCARL_NpcCopy`; and the file-placing lanes each default to their own stem (`houseCARL_Scripts`, `_Assets`, `_SEQ`, `_Archive`), with `bsa_repack` additionally binding `patch=` to the `.bsa`.

## Review rounds

**Two rounds, then a class-stop — not the three-round cap.**

**Round 1** — one high, two mediums, two lows. The high: my first cut keyed the sentence on the record-lane/rider-lane bit, but `housecarl_remove` reaches the same refusal *through the record lane*, and a removal cannot create a patch — so the remedy told that caller to re-issue the call that had just failed. Folded by making the bit the calling operation's own statement, defaulting to false. The mediums (a wrong rider enumeration; a `"Patch"` default claim false for the copy lanes) and one low folded with it.

**Refused, round 1:** the reviewer claimed `CopyTools.cs:89` documents a `"Patch"` default contradicting the code. It does not — that text is `ApplyTools`'. Nothing folded on it.

**Round 2** — one medium, three lows, and the medium was the same failure class as round 1's high: *the remedy asserts something the write can falsify*, this time via `UniqueStem`'s auto-suffix. Under CLAUDE.md §5 #11 a class recurring in two consecutive rounds is a design signal, not a fix queue, so the rounds stopped there and the seam went to Aaron rather than into a third fold.

**Round 2 self-refused** one of its own candidates: `WritePatchBuilder.cs:404/2235/2760` still carry the old bare tail, but that arm is a race guard (the path vanishing between resolve and write), not a reachable second home for the sentence. Agreed and not folded.

**Directed completion** (advisor ruling, §4 outcome (b) — the triage ruling had assumed a refusal can hand back the working call with its resulting filename named; it cannot, and the goal survives dropping the prediction):

- The sentence stops predicting the filename, and the qualifier scopes **both** names it offers — the ruling caught that my proposed fix still predicted the default-lane name, which the same collision arm falsifies.
- Both classes folded structurally: the roster in the comment and CHANGELOG became a stated rule, absorbing round 2's three lows including the rider grounds (now naming both the `bsa_repack` alias *and* the non-`Patch` rider defaults).
- One false claim of mine corrected: `housecarl_remove` does declare `into=` (`RemoveTools.cs:59`). The create-half falsity stands and is what the arm now says.

No round 3 (§11: no new rounds after directed folds).

## Guards

`extend-resolve-guard` grows from 8 arms to 14. Every branch is RED-checked in both directions — five sabotages, each reddening exactly its own arms and nothing else:

| sabotage | reddens |
|---|---|
| record lane forced onto the rider sentence | arm 8's remedy pin |
| rider lane forced onto the record sentence | 8c |
| removal lane opted into the naming sentence | 8d |
| `patch=` ignored in `ResolveOutputPath` | the seed arm |
| pre-ruling wording restored | 8's qualifier pin + 8b2 |

Arm 8b and the new 8b2 **make the calls the sentence names** rather than reading it — including the collision case that falsified the previous wording.

`ci-all` 124/124.

## Filed separately

Two confirmed defects outside this branch, both measured here, both unrouted and unmilestoned:

- #356 — `housecarl_remove`'s refusal offers a remedy removal cannot perform (present on `main`; this branch stops making it worse but does not fix it).
- #357 — the file-placing lanes have no discoverable way to name the patch folder they create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)