### PR TITLE
merge_plugins: a single donor is accepted, and it is the rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ models — by construction, not a hand-maintained subset.
   new-patch lane above stays the default.
 - **Compact and merge plugins** — ESL-compact a plugin into the light-master FormID window, carrying its
   FormID-keyed assets (facegen, voice) along so a compacted mod's faces don't go dark; or merge several
-  plugins into one, renumbering only on collision and dropping now-unused masters — then guides the MO2
-  swap: enable the merged output, deactivate the donor plugins, and keep their asset folders enabled;
-  originals remain intact.
+  plugins into one, renumbering only on collision and dropping now-unused masters — or name a single
+  plugin to rename it, the same operation with nothing to combine — then guides the MO2 swap: enable the
+  merged output, deactivate the donor plugins, and keep their asset folders enabled; originals remain
+  intact.
 - **Copy an NPC's appearance into a standalone** — lift a face (head parts, tints, the FaceGen mesh and
   textures) from a donor NPC into a fresh record that carries no dependency on the donor's plugin — the
   build behind a portable follower or a face transplanted between mods.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -12,14 +12,18 @@ when it changes.
   behind that refusal: with one donor the collision set is simply empty, and the machinery a rename needs is the
   machinery a merge already runs — every donor record moves to the output's identity, and the facegen, voice, and
   `.seq` files follow the plugin **name** that forms part of their paths. Passing one donor now does exactly that,
-  keeping the object ids, and the report calls it a rename rather than a merge "from 1 donors". Zero donors still
+  keeping every object id already inside the writable range — an id below the `0x800` floor still renumbers, which
+  nothing can collide with either, and the per-donor line reports it — and the report calls it a rename rather than a
+  merge "from 1 donors". Zero donors still
   refuses, and the refusal names both shapes. The list of donors is a set, so a plugin named twice is one donor —
   also a rename.
 
   The costs of renaming are inherent, so they are reported rather than refused: the renamed plugin arrives in a new
-  mod folder beside the original (removing the old one is your call), any save that referenced the old plugin name
-  will not survive — the existing saves warning — and any plugin that references or overrides the donor, **its own
-  patches included**, is named in the warnings with the remedy, exactly as for a many-donor merge. (#345)
+  mod folder beside the original, and the swap instruction applies unchanged — deactivate the old **plugin**, but keep
+  its mod **folder** enabled, because the renamed records still load that mod's meshes, textures and scripts by path.
+  Any save that referenced the old plugin name will not survive — the existing saves warning — and any plugin that
+  references or overrides the donor, **its own patches included**, is named in the warnings with the remedy, exactly
+  as for a many-donor merge. (#345)
 
 - **Fixed: on a large load order, a mod's broken references could vanish from `housecarl_check_errors` entirely.**
   The dangling-reference listing budget (`limit=`, default 1000) is one counter spent plugin by plugin in load order,

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -22,8 +22,21 @@ when it changes.
   mod folder beside the original, and the swap instruction applies unchanged — deactivate the old **plugin**, but keep
   its mod **folder** enabled, because the renamed records still load that mod's meshes, textures and scripts by path.
   Any save that referenced the old plugin name will not survive — the existing saves warning — and any plugin that
-  references or overrides the donor, **its own patches included**, is named in the warnings with the remedy, exactly
-  as for a many-donor merge. (#345)
+  references or overrides the donor, **its own patches included**, is named in the warnings with the remedy.
+
+  The report now says what is true **of the operation you actually got**, because it decides which one that was in
+  one place. A rename names only the renumber cause that can apply to a single donor, since nothing can collide with
+  it; it leads its warnings with the remedy that keeps the result a rename — re-point the affected plugin, or rebuild
+  it — and offers combining second, because adding that plugin as a donor produces a combined plugin instead; and its
+  new mod folder is named `<output> renamed` rather than `<output> merged`. Renaming a plugin that originates no
+  records of its own, which is what most mis-named patches are, says exactly that instead of claiming records took a
+  new identity.
+
+  Two losses that were previously silent are now stated, for merges of any size. **A donor's light (ESL) header flag
+  is not carried**, so the output takes a full load-order slot where a light donor took none — the report says so and
+  names `housecarl_compact_plugin` along with its cost, that it renumbers object ids from `0x800` upward and so moves
+  the ids just reported as kept. **A donor's header Author and Description are not carried either**, and that is
+  stated plainly with no remedy offered, because none exists. (#345)
 
 - **Fixed: on a large load order, a mod's broken references could vanish from `housecarl_check_errors` entirely.**
   The dangling-reference listing budget (`limit=`, default 1000) is one counter spent plugin by plugin in load order,

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -6,6 +6,21 @@ when it changes.
 
 ## Unreleased
 
+- **`housecarl_merge_plugins` now accepts a single donor, which renames a plugin.** Merging one plugin into a new
+  name was refused ("merge needs at least TWO distinct donor plugins"), and no other tool renames one, so a
+  mis-named patch could only be fixed by replaying every edit into a freshly named plugin. There was never anything
+  behind that refusal: with one donor the collision set is simply empty, and the machinery a rename needs is the
+  machinery a merge already runs — every donor record moves to the output's identity, and the facegen, voice, and
+  `.seq` files follow the plugin **name** that forms part of their paths. Passing one donor now does exactly that,
+  keeping the object ids, and the report calls it a rename rather than a merge "from 1 donors". Zero donors still
+  refuses, and the refusal names both shapes. The list of donors is a set, so a plugin named twice is one donor —
+  also a rename.
+
+  The costs of renaming are inherent, so they are reported rather than refused: the renamed plugin arrives in a new
+  mod folder beside the original (removing the old one is your call), any save that referenced the old plugin name
+  will not survive — the existing saves warning — and any plugin that references or overrides the donor, **its own
+  patches included**, is named in the warnings with the remedy, exactly as for a many-donor merge. (#345)
+
 - **Fixed: on a large load order, a mod's broken references could vanish from `housecarl_check_errors` entirely.**
   The dangling-reference listing budget (`limit=`, default 1000) is one counter spent plugin by plugin in load order,
   and the base-game masters sit at index 0. A plugin whose findings collected an empty list was then dropped from the

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -20,9 +20,12 @@ when it changes.
 
   The costs of renaming are inherent, so they are reported rather than refused: the renamed plugin arrives in a new
   mod folder beside the original, and the swap instruction applies unchanged — deactivate the old **plugin**, but keep
-  its mod **folder** enabled, because the renamed records still load that mod's meshes, textures and scripts by path.
-  Any save that referenced the old plugin name will not survive — the existing saves warning — and any plugin that
-  references or overrides the donor, **its own patches included**, is named in the warnings with the remedy.
+  its mod **folder** enabled, because the renamed records still load that mod's *loose* meshes, textures and scripts
+  by path. Anything the donor ships inside a **`.bsa`** is the exception, and the report says so: an archive stops
+  loading once its same-named plugin is deactivated, so extract it into the mod folder with `housecarl_bsa_extract`
+  or keep it loading behind a same-named dummy plugin from `housecarl_create_plugin`. Any save that referenced the old
+  plugin name will not survive — the existing saves warning — and any plugin that references or overrides the donor,
+  **its own patches included**, is named in the warnings with the remedy.
 
   The report now says what is true **of the operation you actually got**, because it decides which one that was in
   one place. A rename names only the renumber cause that can apply to a single donor, since nothing can collide with
@@ -32,11 +35,15 @@ when it changes.
   records of its own, which is what most mis-named patches are, says exactly that instead of claiming records took a
   new identity.
 
-  Two losses that were previously silent are now stated, for merges of any size. **A donor's light (ESL) header flag
-  is not carried**, so the output takes a full load-order slot where a light donor took none — the report says so and
-  names `housecarl_compact_plugin` along with its cost, that it renumbers object ids from `0x800` upward and so moves
-  the ids just reported as kept. **A donor's header Author and Description are not carried either**, and that is
-  stated plainly with no remedy offered, because none exists. (#345)
+  Losses that were previously silent are now stated, for merges of any size, because the merged plugin is built with a
+  fresh header and nothing in a donor's header comes along. **Light (ESL) status is not carried** — counted by the
+  header flag *or* an `.esl` extension, since the engine treats the extension as light either way — so the output takes
+  a full load-order slot where a light donor took none. The report says so and names `housecarl_compact_plugin` along
+  with its cost, that it renumbers object ids from `0x800` upward and so moves the ids just reported as kept; where
+  that note appears, the closing "want it light?" line steps aside, so the recommendation you read carries its cost.
+  **Master status is not carried either** — counted by the flag or an `.esm` extension — so an esmified donor comes
+  back as a plain plugin and sorts in the plugin block. **Nor are the header Author and Description.** Those last two
+  are stated with no remedy offered, because the tool surface has none. (#345)
 
 - **Fixed: on a large load order, a mod's broken references could vanish from `housecarl_check_errors` entirely.**
   The dangling-reference listing budget (`limit=`, default 1000) is one counter spent plugin by plugin in load order,

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -28,8 +28,8 @@ It can:
   default.
 - **Compact and merge plugins** — ESL-compact a plugin into the light-master FormID window, carrying its
   FormID-keyed assets (facegen, voice) along so a compacted mod's faces don't go dark; or merge several
-  plugins into one (collision-only renumber, unused masters dropped), with the donor mods swapped out at the
-  MO2 layer and originals intact.
+  plugins into one (collision-only renumber, unused masters dropped), or rename a single plugin by naming
+  just it, with the donor mods swapped out at the MO2 layer and originals intact.
 - **Copy an NPC's appearance into a standalone** — lift a face (head parts, tints, the FaceGen mesh and
   textures) from a donor NPC into a fresh record with no dependency on the donor's plugin — the build behind
   a portable follower or a face moved between mods.

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -2147,7 +2147,8 @@ public static class WritePatchBuilder
         int PluginsScanned, int UnscannableRecords, IReadOnlyList<string> UnscannableSamples,
         long Bytes, string? Note = null,
         AssetRenameOutcome? AssetRename = null, VoiceCarryOutcome? VoiceRename = null, SeqRegenOutcome? SeqRegen = null,
-        IReadOnlyList<string>? LightDonors = null, IReadOnlyList<string>? HeaderMetaDonors = null)
+        IReadOnlyList<string>? LightDonors = null, IReadOnlyList<string>? HeaderMetaDonors = null,
+        IReadOnlyList<string>? MasterDonors = null)
     {
         public static MergeOutcome Fail(string error) =>
             new(false, error, "", "", Array.Empty<string>(), Array.Empty<string>(), 0, 0,
@@ -2562,7 +2563,8 @@ public static class WritePatchBuilder
     public sealed record MergeBuildResult(
         bool Success, string? Error, IReadOnlyList<string> Masters, int RecordsCopied, int RecordsRenumbered,
         IReadOnlyList<RemapEngine.MergeConflict> Conflicts, long Bytes,
-        IReadOnlyList<string>? LightDonors = null, IReadOnlyList<string>? HeaderMetaDonors = null)
+        IReadOnlyList<string>? LightDonors = null, IReadOnlyList<string>? HeaderMetaDonors = null,
+        IReadOnlyList<string>? MasterDonors = null)
     {
         public static MergeBuildResult Fail(string error) =>
             new(false, error, Array.Empty<string>(), 0, 0, Array.Empty<RemapEngine.MergeConflict>(), 0);
@@ -2593,6 +2595,7 @@ public static class WritePatchBuilder
         var donorSet = new HashSet<ModKey>(donorsByLoadOrder.Select(d => d.Key));
         var overlays = new List<IDisposable>();
         var lightDonors = new List<string>();                              // donors carrying header flags/fields the output will not
+        var masterDonors = new List<string>();
         var headerMetaDonors = new List<string>();
         try
         {
@@ -2611,7 +2614,15 @@ public static class WritePatchBuilder
                 // behind. Measured here, while the overlay is open, so the report can state the loss instead of the
                 // caller discovering it (a light donor silently costing a full load-order slot). Whether these should
                 // be CARRIED is a separate decision that is not this lane's to make.
-                if (ov.IsSmallMaster) lightDonors.Add(name);
+                //
+                // LIGHT and MASTER are each read BOTH ways, because either alone under-reports the loss. The header
+                // bit is not the whole model: this tool's own .esl-output refusal states that the engine force-treats
+                // the extension as light regardless of the bit, so a .esl donor with the bit unset still loses light
+                // status here. Symmetrically an esmified .esp carries the master bit without the extension, and a
+                // .esm carries the extension; both lose master status in a bare output.
+                if (ov.IsSmallMaster || ov.ModKey.Type == ModType.Light) lightDonors.Add(name);
+                if (ov.ModHeader.Flags.HasFlag(SkyrimModHeader.HeaderFlag.Master) || ov.ModKey.Type == ModType.Master)
+                    masterDonors.Add(name);
                 if (!string.IsNullOrWhiteSpace(ov.ModHeader.Author) || !string.IsNullOrWhiteSpace(ov.ModHeader.Description))
                     headerMetaDonors.Add(name);
             }
@@ -2689,7 +2700,7 @@ public static class WritePatchBuilder
         }
         catch { /* best-effort read-back; the union is a correct superset */ }
         return new MergeBuildResult(true, null, writtenMasters, mr.RecordsCopied, mr.RecordsRenumbered, mr.Conflicts, bytes,
-            lightDonors, headerMetaDonors);
+            lightDonors, headerMetaDonors, masterDonors);
     }
 
     /// <summary>

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -2146,7 +2146,8 @@ public static class WritePatchBuilder
         IReadOnlyList<string> ExternalPlugins, IReadOnlyList<string> ExternalOverriders,
         int PluginsScanned, int UnscannableRecords, IReadOnlyList<string> UnscannableSamples,
         long Bytes, string? Note = null,
-        AssetRenameOutcome? AssetRename = null, VoiceCarryOutcome? VoiceRename = null, SeqRegenOutcome? SeqRegen = null)
+        AssetRenameOutcome? AssetRename = null, VoiceCarryOutcome? VoiceRename = null, SeqRegenOutcome? SeqRegen = null,
+        IReadOnlyList<string>? LightDonors = null, IReadOnlyList<string>? HeaderMetaDonors = null)
     {
         public static MergeOutcome Fail(string error) =>
             new(false, error, "", "", Array.Empty<string>(), Array.Empty<string>(), 0, 0,
@@ -2560,7 +2561,8 @@ public static class WritePatchBuilder
     /// a dangling donor reference that would keep a donor as a master, an absent master, a serialize fault).</summary>
     public sealed record MergeBuildResult(
         bool Success, string? Error, IReadOnlyList<string> Masters, int RecordsCopied, int RecordsRenumbered,
-        IReadOnlyList<RemapEngine.MergeConflict> Conflicts, long Bytes)
+        IReadOnlyList<RemapEngine.MergeConflict> Conflicts, long Bytes,
+        IReadOnlyList<string>? LightDonors = null, IReadOnlyList<string>? HeaderMetaDonors = null)
     {
         public static MergeBuildResult Fail(string error) =>
             new(false, error, Array.Empty<string>(), 0, 0, Array.Empty<RemapEngine.MergeConflict>(), 0);
@@ -2590,6 +2592,8 @@ public static class WritePatchBuilder
         RemapEngine.MergeResult mr;
         var donorSet = new HashSet<ModKey>(donorsByLoadOrder.Select(d => d.Key));
         var overlays = new List<IDisposable>();
+        var lightDonors = new List<string>();                              // donors carrying header flags/fields the output will not
+        var headerMetaDonors = new List<string>();
         try
         {
             var mods = new List<(string, ISkyrimModGetter)>(donorsByLoadOrder.Count);
@@ -2603,6 +2607,13 @@ public static class WritePatchBuilder
                 }
                 overlays.Add((IDisposable)ov);
                 mods.Add((name, ov));
+                // The merged plugin is built as a bare SkyrimMod, so anything living in a donor's HEADER is left
+                // behind. Measured here, while the overlay is open, so the report can state the loss instead of the
+                // caller discovering it (a light donor silently costing a full load-order slot). Whether these should
+                // be CARRIED is a separate decision that is not this lane's to make.
+                if (ov.IsSmallMaster) lightDonors.Add(name);
+                if (!string.IsNullOrWhiteSpace(ov.ModHeader.Author) || !string.IsNullOrWhiteSpace(ov.ModHeader.Description))
+                    headerMetaDonors.Add(name);
             }
             mr = RemapEngine.MergeModsInto(m, mods, dict);
         }
@@ -2677,7 +2688,8 @@ public static class WritePatchBuilder
             writtenMasters = wr.ModHeader.MasterReferences.Select(x => x.Master.FileName.String).ToList();
         }
         catch { /* best-effort read-back; the union is a correct superset */ }
-        return new MergeBuildResult(true, null, writtenMasters, mr.RecordsCopied, mr.RecordsRenumbered, mr.Conflicts, bytes);
+        return new MergeBuildResult(true, null, writtenMasters, mr.RecordsCopied, mr.RecordsRenumbered, mr.Conflicts, bytes,
+            lightDonors, headerMetaDonors);
     }
 
     /// <summary>

--- a/src/housecarl-generator/MergeServiceGuardProbe.cs
+++ b/src/housecarl-generator/MergeServiceGuardProbe.cs
@@ -330,18 +330,22 @@ public static class MergeServiceGuardProbe
                 Check(r1 is { Kept: 8, Renumbered: 0 }, $"RENAME nothing can collide: A keeps all 8 ids (kept {r1?.Kept}, renumbered {r1?.Renumbered})");
                 Check(o1.RecordsCopied == 9 && o1.RecordsRenumbered == 8,
                     $"RENAME accounting: 8 originating + 1 base override (copied {o1.RecordsCopied} expected 9, renumbered {o1.RecordsRenumbered} expected 8)");
-                Check(o1.Conflicts.Count == 0, $"RENAME no cross-donor conflicts are possible with one donor (got {o1.Conflicts.Count})");
+                // Every arm below is gated on ok1 and short-circuits, so a regression that refuses the rename turns them
+                // all RED with their own reason instead of throwing on the first null OutputPath and taking the rest of
+                // the block with it. A check that cannot report is not a check.
+                bool ok1 = o1.Success && !string.IsNullOrEmpty(o1.OutputPath);
+                Check(ok1 && o1.Conflicts.Count == 0, $"RENAME no cross-donor conflicts are possible with one donor (got {o1.Conflicts.Count})");
 
                 // ASSETS carry on the plugin-NAME folder segment, which is exactly what a rename changes — this is the
                 // arm that fails if anyone ever makes the carry conditional on a collision.
-                var outDir1 = Path.GetDirectoryName(o1.OutputPath)!;
+                var outDir1 = ok1 ? Path.GetDirectoryName(o1.OutputPath)! : "";
                 var face1 = FaceGenPath.Both(new FormKey(renamedKey, 0xA20)).ToList();
-                Check(face1.Count == 2 && face1.All(x => File.Exists(Path.Combine(outDir1, x.Item2))) && o1.AssetRename?.FacegenFilesCarried == 2,
+                Check(ok1 && face1.Count == 2 && face1.All(x => File.Exists(Path.Combine(outDir1, x.Item2))) && o1.AssetRename?.FacegenFilesCarried == 2,
                     $"RENAME facegen pair carried to the renamed-name folder (files {o1.AssetRename?.FacegenFilesCarried})");
-                Check(File.Exists(Path.Combine(outDir1, "Sound", "Voice", renamedKey.FileName.String, "MaleEvenToned", "HcQ_HcT_00000A11_1.fuz"))
+                Check(ok1 && File.Exists(Path.Combine(outDir1, "Sound", "Voice", renamedKey.FileName.String, "MaleEvenToned", "HcQ_HcT_00000A11_1.fuz"))
                       && o1.VoiceRename?.FilesCarried == 1,
                     $"RENAME voice carried to the renamed-name folder (files {o1.VoiceRename?.FilesCarried})");
-                Check(o1.SeqRegen is { Written: true } && File.Exists(Path.Combine(outDir1, "SEQ", "HcMgRenamed.seq")),
+                Check(ok1 && o1.SeqRegen is { Written: true } && File.Exists(Path.Combine(outDir1, "SEQ", "HcMgRenamed.seq")),
                     $"RENAME .seq regenerated under the new name (written {o1.SeqRegen?.Written})");
 
                 // The side effects are REPORTED, not refused: B patches A and is now OUTSIDE the set, so it joins the

--- a/src/housecarl-generator/MergeServiceGuardProbe.cs
+++ b/src/housecarl-generator/MergeServiceGuardProbe.cs
@@ -22,7 +22,13 @@ namespace HousecarlGenerator;
 ///               active until the MO2 swap, so nothing breaks at write time); RenderMerge carries both to user output.
 ///   ASSETS    — facegen + voice land under the MERGED plugin-name folders (the folder segment IS the plugin name — the
 ///               carry every merge needs even with zero id collisions); the .seq regenerates (A shipped one).
-///   REFUSE    — one donor / unknown donor / output already active / output == donor, all loud, nothing written.
+///   RENAME    — the SINGLE-donor arm (#345): donor A alone into a new name is a rename — every A key remaps to the
+///               output ModKey with its object id kept, facegen/voice/seq carry to the NEW plugin-name folders, the
+///               donor file is byte-untouched, and the plugins that reference/override A (including B, now outside
+///               the set) are still WARNed. The headline says RENAME; the multi-donor headline does not. A donor name
+///               repeated is still ONE donor — the list is a set, in both arms.
+///   REFUSE    — ZERO donors / unknown donor / output already active / output == donor / .esl output, all loud,
+///               nothing written.
 ///   UNTOUCHED — the donor files are byte-identical after the merge (new-file lane only).
 /// Run: dotnet run --project src/housecarl-generator merge-service-guard
 /// </summary>
@@ -247,6 +253,10 @@ public static class MergeServiceGuardProbe
                 Check(rendered.Contains("deactivate the donor PLUGINS") && rendered.Contains("KEEP the donor mod folders enabled")
                       && !rendered.Contains("DISABLE the donor mods"),
                     "SWAP instruction is plugin-level (donor mod folders stay enabled)");
+                // The OTHER direction of the #345 headline conditional: many donors must keep the combining form and
+                // must NOT claim a rename. Pinned here so the arm below can't pass by the branch collapsing to one text.
+                Check(rendered.Contains("from 2 donors") && !rendered.Contains("a RENAME of"),
+                    "MERGE headline is the multi-donor form, never the rename arm");
                 // ASSETS: facegen pair + voice under the MERGED plugin-name folders; .seq regenerated (A shipped one).
                 var outDir = Path.GetDirectoryName(o.OutputPath)!;
                 var newFace = FaceGenPath.Both(new FormKey(mergedKey, 0xA20)).ToList();
@@ -265,9 +275,18 @@ public static class MergeServiceGuardProbe
 
             // ---- REFUSE arms (each loud, nothing written) ----
             {
-                var r = svc.MergePlugins(new[] { "HcMgA.esp" }, "HcMgX.esp");
-                Check(!r.Success && (r.Error?.Contains("at least TWO", StringComparison.OrdinalIgnoreCase) ?? false),
-                    $"REFUSE one donor ({r.Error?.Split('—')[0].Trim()})");
+                // ZERO donors still refuses — the guard's boundary moved from 2 to 1, it did not disappear. Both the
+                // empty list and a list that is only blanks land here (the trim/drop runs before the count).
+                var r = svc.MergePlugins(Array.Empty<string>(), "HcMgX.esp");
+                Check(!r.Success && (r.Error?.Contains("at least ONE", StringComparison.OrdinalIgnoreCase) ?? false)
+                                 && (r.Error?.Contains("rename", StringComparison.OrdinalIgnoreCase) ?? false),
+                    $"REFUSE zero donors, remedy names both shapes ({r.Error?.Split('—')[0].Trim()})");
+                r = svc.MergePlugins(new[] { "  ", "" }, "HcMgX.esp");
+                Check(!r.Success && (r.Error?.Contains("at least ONE", StringComparison.OrdinalIgnoreCase) ?? false),
+                    $"REFUSE blank-only donor list ({r.Error?.Split('—')[0].Trim()})");
+                r = svc.MergePlugins(null, "HcMgX.esp");
+                Check(!r.Success && (r.Error?.Contains("at least ONE", StringComparison.OrdinalIgnoreCase) ?? false),
+                    $"REFUSE null donor list ({r.Error?.Split('—')[0].Trim()})");
                 r = svc.MergePlugins(new[] { "HcMgA.esp", "HcMgNope.esp" }, "HcMgX.esp");
                 Check(!r.Success && (r.Error?.Contains("not an active plugin", StringComparison.OrdinalIgnoreCase) ?? false),
                     $"REFUSE unknown donor ({r.Error?.Split('—')[0].Trim()})");
@@ -281,6 +300,72 @@ public static class MergeServiceGuardProbe
                 Check(!r.Success && (r.Error?.Contains(".esl", StringComparison.OrdinalIgnoreCase) ?? false)
                                  && (r.Error?.Contains("compact", StringComparison.OrdinalIgnoreCase) ?? false),
                     $"REFUSE .esl output with the compact-after remedy ({r.Error?.Split('—')[0].Trim()})");
+            }
+
+            // ---- RENAME: donor A ALONE into a new name (#345). Same walk, empty collision set. ----
+            {
+                var renamedKey = new ModKey("HcMgRenamed", ModType.Plugin);
+                var o1 = svc.MergePlugins(new[] { "HcMgA.esp" }, "HcMgRenamed.esp");
+                Check(o1.Success && o1.Donors.Count == 1,
+                    $"RENAME single donor accepted ({(o1.Success ? $"{o1.Donors.Count} donor" : "ERR " + o1.Error)})");
+
+                bool keysOk = false, mastersOk1 = false;
+                if (o1.Success && File.Exists(o1.OutputPath))
+                {
+                    using var rm = SkyrimMod.CreateFromBinaryOverlay(o1.OutputPath, SkyrimRelease.SkyrimSE);
+                    // REMAP-TO-OUTPUT: every one of A's originating records is under the OUTPUT ModKey, at its OWN
+                    // object id — the rename claim in one assertion. A's records are NOT still keyed to HcMgA.esp.
+                    keysOk = rm.Weapons.Any(w => w.EditorID == "HcMgAWeap" && w.FormKey == new FormKey(renamedKey, 0xA01))
+                          && rm.DialogTopics.Any(t => t.FormKey == new FormKey(renamedKey, 0xA10))
+                          && rm.Npcs.Any(n => n.FormKey == new FormKey(renamedKey, 0xA20))
+                          && rm.Quests.Any(q => q.FormKey == new FormKey(renamedKey, 0xA30))
+                          && !rm.EnumerateMajorRecords().Any(x => x.FormKey.ModKey == aKey);
+                    var ms = rm.ModHeader.MasterReferences.Select(x => x.Master.FileName.String).ToList();
+                    mastersOk1 = ms.Count == 1 && string.Equals(ms[0], baseKey.FileName.String, StringComparison.OrdinalIgnoreCase);
+                }
+                Check(keysOk, "RENAME every A record remaps to the output ModKey at its own object id, none left on HcMgA.esp");
+                Check(mastersOk1, $"RENAME masters = base only, the donor is not a master of its own rename ({string.Join(",", o1.Masters)})");
+
+                var r1 = o1.DonorRemaps.FirstOrDefault(d => d.Donor == "HcMgA.esp");
+                Check(r1 is { Kept: 8, Renumbered: 0 }, $"RENAME nothing can collide: A keeps all 8 ids (kept {r1?.Kept}, renumbered {r1?.Renumbered})");
+                Check(o1.RecordsCopied == 9 && o1.RecordsRenumbered == 8,
+                    $"RENAME accounting: 8 originating + 1 base override (copied {o1.RecordsCopied} expected 9, renumbered {o1.RecordsRenumbered} expected 8)");
+                Check(o1.Conflicts.Count == 0, $"RENAME no cross-donor conflicts are possible with one donor (got {o1.Conflicts.Count})");
+
+                // ASSETS carry on the plugin-NAME folder segment, which is exactly what a rename changes — this is the
+                // arm that fails if anyone ever makes the carry conditional on a collision.
+                var outDir1 = Path.GetDirectoryName(o1.OutputPath)!;
+                var face1 = FaceGenPath.Both(new FormKey(renamedKey, 0xA20)).ToList();
+                Check(face1.Count == 2 && face1.All(x => File.Exists(Path.Combine(outDir1, x.Item2))) && o1.AssetRename?.FacegenFilesCarried == 2,
+                    $"RENAME facegen pair carried to the renamed-name folder (files {o1.AssetRename?.FacegenFilesCarried})");
+                Check(File.Exists(Path.Combine(outDir1, "Sound", "Voice", renamedKey.FileName.String, "MaleEvenToned", "HcQ_HcT_00000A11_1.fuz"))
+                      && o1.VoiceRename?.FilesCarried == 1,
+                    $"RENAME voice carried to the renamed-name folder (files {o1.VoiceRename?.FilesCarried})");
+                Check(o1.SeqRegen is { Written: true } && File.Exists(Path.Combine(outDir1, "SEQ", "HcMgRenamed.seq")),
+                    $"RENAME .seq regenerated under the new name (written {o1.SeqRegen?.Written})");
+
+                // The side effects are REPORTED, not refused: B patches A and is now OUTSIDE the set, so it joins the
+                // external referencer AND overrider warnings alongside Dep/Ovr. Renaming a patched plugin warns about
+                // its patch — the existing WARN-and-proceed posture, unchanged.
+                Check(o1.ExternalPlugins.Contains("HcMgDep.esp") && o1.ExternalPlugins.Contains("HcMgB.esp"),
+                    $"RENAME external referencers named, including the donor's own patch (refs [{string.Join(",", o1.ExternalPlugins)}])");
+                Check(o1.ExternalOverriders.Contains("HcMgOvr.esp") && o1.ExternalOverriders.Contains("HcMgB.esp"),
+                    $"RENAME external overriders named, including the donor's own patch (ovr [{string.Join(",", o1.ExternalOverriders)}])");
+
+                var rendered1 = WriteTools.RenderMerge(o1);
+                Check(rendered1.Contains("a RENAME of HcMgA.esp") && !rendered1.Contains("1 donors"),
+                    "RENAME headline names the operation and never says '1 donors'");
+                Check(rendered1.Contains("existing SAVES") && rendered1.Contains("deactivate the donor PLUGINS"),
+                    "RENAME still carries the saves warning and the MO2 swap instruction");
+
+                Check(aBytesBefore.SequenceEqual(File.ReadAllBytes(Path.Combine(aDir, aKey.FileName.String))),
+                    "RENAME donor file byte-identical (new-file lane, the rename is a COPY under a new name)");
+
+                // The donor list is a SET in both arms: a name repeated is one donor, so this is a rename too. Pinned
+                // deliberately (#345) — the Distinct() above the count guard decides it, and it must not drift silently.
+                var oDup = svc.MergePlugins(new[] { "HcMgA.esp", "HcMgA.esp" }, "HcMgDup.esp");
+                Check(oDup.Success && oDup.Donors.Count == 1,
+                    $"RENAME a donor named twice is ONE donor, still a rename ({(oDup.Success ? $"{oDup.Donors.Count} donor" : "ERR " + oDup.Error)})");
             }
         }
         finally { try { Directory.Delete(root, true); } catch { } }

--- a/src/housecarl-generator/MergeServiceGuardProbe.cs
+++ b/src/housecarl-generator/MergeServiceGuardProbe.cs
@@ -26,7 +26,9 @@ namespace HousecarlGenerator;
 ///               output ModKey with its object id kept, facegen/voice/seq carry to the NEW plugin-name folders, the
 ///               donor file is byte-untouched, and the plugins that reference/override A (including B, now outside
 ///               the set) are still WARNed. The headline says RENAME; the multi-donor headline does not. A donor name
-///               repeated is still ONE donor — the list is a set, in both arms.
+///               repeated is still ONE donor — the list is a set, in both arms. One arm runs against BuildMergeRemap
+///               directly: "nothing can collide" is not "every id is kept", and a below-floor donor cannot be written
+///               here to prove it through the service (Mutagen rejects sub-0x800 originating records on write).
 ///   REFUSE    — ZERO donors / unknown donor / output already active / output == donor / .esl output, all loud,
 ///               nothing written.
 ///   UNTOUCHED — the donor files are byte-identical after the merge (new-file lane only).
@@ -327,14 +329,16 @@ public static class MergeServiceGuardProbe
                 Check(mastersOk1, $"RENAME masters = base only, the donor is not a master of its own rename ({string.Join(",", o1.Masters)})");
 
                 var r1 = o1.DonorRemaps.FirstOrDefault(d => d.Donor == "HcMgA.esp");
-                Check(r1 is { Kept: 8, Renumbered: 0 }, $"RENAME nothing can collide: A keeps all 8 ids (kept {r1?.Kept}, renumbered {r1?.Renumbered})");
+                Check(r1 is { Kept: 8, Renumbered: 0 }, $"RENAME no collisions with one donor: A's in-window ids are all kept (kept {r1?.Kept}, renumbered {r1?.Renumbered})");
                 Check(o1.RecordsCopied == 9 && o1.RecordsRenumbered == 8,
                     $"RENAME accounting: 8 originating + 1 base override (copied {o1.RecordsCopied} expected 9, renumbered {o1.RecordsRenumbered} expected 8)");
                 // Every arm below is gated on ok1 and short-circuits, so a regression that refuses the rename turns them
                 // all RED with their own reason instead of throwing on the first null OutputPath and taking the rest of
                 // the block with it. A check that cannot report is not a check.
                 bool ok1 = o1.Success && !string.IsNullOrEmpty(o1.OutputPath);
-                Check(ok1 && o1.Conflicts.Count == 0, $"RENAME no cross-donor conflicts are possible with one donor (got {o1.Conflicts.Count})");
+                // (No arm asserts "one donor reports zero conflicts": two distinct source records would have to remap
+                // onto one key for a single donor to conflict, which BuildMergeRemap makes impossible — gutting the
+                // conflict machinery entirely leaves such an arm green, so it would pin nothing.)
 
                 // ASSETS carry on the plugin-NAME folder segment, which is exactly what a rename changes — this is the
                 // arm that fails if anyone ever makes the carry conditional on a collision.
@@ -367,6 +371,31 @@ public static class MergeServiceGuardProbe
 
                 // The donor list is a SET in both arms: a name repeated is one donor, so this is a rename too. Pinned
                 // deliberately (#345) — the Distinct() above the count guard decides it, and it must not drift silently.
+                // "Nothing can collide" is NOT "every id is kept": BuildMergeRemap keeps an id only while it sits
+                // inside the write window, so a lone donor's below-floor id is renumbered with no collision anywhere.
+                // Measured on the PLANNER directly, because Mutagen refuses to write a donor carrying a sub-0x800
+                // originating record at all (LowerFormKeyRangeDisallowedException — verified while trying to fixture
+                // one); such plugins come from other tools, and houseCARL reads them fine. This is the arm the prose
+                // rests on — every written-fixture id is >= 0xA01, so no arm over them could tell a correct claim from
+                // an over-broad one.
+                {
+                    var soloKey = new ModKey("HcMgSolo", ModType.Plugin);
+                    var soloOut = new ModKey("HcMgSoloRenamed", ModType.Plugin);
+                    var soloDonors = new List<(string Donor, IReadOnlyList<FormKey> Keys)>
+                    {
+                        ("HcMgSolo.esp", new[] { new FormKey(soloKey, 0xC01), new FormKey(soloKey, 0x123) })
+                    };
+                    var solo = RemapEngine.BuildMergeRemap(soloDonors, soloOut, RemapEngine.EslFloor, FormIdRange.ObjectIdMax);
+                    var dSolo = solo.Donors.FirstOrDefault();
+                    bool floorOk = solo.Success
+                        && solo.Dict[new FormKey(soloKey, 0xC01)] == new FormKey(soloOut, 0xC01)      // in-window: id kept
+                        && solo.Dict[new FormKey(soloKey, 0x123)].ID >= RemapEngine.EslFloor          // below floor: moved up
+                        && solo.Dict[new FormKey(soloKey, 0x123)].ModKey == soloOut
+                        && dSolo is { Kept: 1, Renumbered: 1 };
+                    Check(floorOk,
+                        $"RENAME a below-floor id renumbers even with nothing to collide with (kept {dSolo?.Kept}, renumbered {dSolo?.Renumbered})");
+                }
+
                 var oDup = svc.MergePlugins(new[] { "HcMgA.esp", "HcMgA.esp" }, "HcMgDup.esp");
                 Check(oDup.Success && oDup.Donors.Count == 1,
                     $"RENAME a donor named twice is ONE donor, still a rename ({(oDup.Success ? $"{oDup.Donors.Count} donor" : "ERR " + oDup.Error)})");

--- a/src/housecarl-generator/MergeServiceGuardProbe.cs
+++ b/src/housecarl-generator/MergeServiceGuardProbe.cs
@@ -315,12 +315,15 @@ public static class MergeServiceGuardProbe
                 if (o1.Success && File.Exists(o1.OutputPath))
                 {
                     using var rm = SkyrimMod.CreateFromBinaryOverlay(o1.OutputPath, SkyrimRelease.SkyrimSE);
-                    // REMAP-TO-OUTPUT: every one of A's originating records is under the OUTPUT ModKey, at its OWN
-                    // object id — the rename claim in one assertion. A's records are NOT still keyed to HcMgA.esp.
-                    keysOk = rm.Weapons.Any(w => w.EditorID == "HcMgAWeap" && w.FormKey == new FormKey(renamedKey, 0xA01))
-                          && rm.DialogTopics.Any(t => t.FormKey == new FormKey(renamedKey, 0xA10))
-                          && rm.Npcs.Any(n => n.FormKey == new FormKey(renamedKey, 0xA20))
-                          && rm.Quests.Any(q => q.FormKey == new FormKey(renamedKey, 0xA30))
+                    // REMAP-TO-OUTPUT: EVERY one of A's originating keys, nested children included, is present under
+                    // the OUTPUT ModKey at its own object id. The positive set is what pins this — the negative below
+                    // is equally satisfied by a record that was DROPPED, and the nested INFOs (0xA11/0xA12) and the
+                    // celled placed ref (0xA40 under 0xA41) are exactly where a walk regression loses one.
+                    var expectedKeys = new[] { 0xA01u, 0xA10u, 0xA11u, 0xA12u, 0xA20u, 0xA30u, 0xA40u, 0xA41u }
+                        .Select(id => new FormKey(renamedKey, id)).ToHashSet();
+                    var presentKeys = rm.EnumerateMajorRecords().Select(r => r.FormKey).ToHashSet();
+                    keysOk = expectedKeys.All(presentKeys.Contains)
+                          && rm.Weapons.Any(w => w.EditorID == "HcMgAWeap" && w.FormKey == new FormKey(renamedKey, 0xA01))
                           && !rm.EnumerateMajorRecords().Any(x => x.FormKey.ModKey == aKey);
                     var ms = rm.ModHeader.MasterReferences.Select(x => x.Master.FileName.String).ToList();
                     mastersOk1 = ms.Count == 1 && string.Equals(ms[0], baseKey.FileName.String, StringComparison.OrdinalIgnoreCase);
@@ -399,6 +402,14 @@ public static class MergeServiceGuardProbe
                 var oDup = svc.MergePlugins(new[] { "HcMgA.esp", "HcMgA.esp" }, "HcMgDup.esp");
                 Check(oDup.Success && oDup.Donors.Count == 1,
                     $"RENAME a donor named twice is ONE donor, still a rename ({(oDup.Success ? $"{oDup.Donors.Count} donor" : "ERR " + oDup.Error)})");
+
+                // Two IDENTICAL strings collapse under ANY comparer, so the arm above cannot see the comparer — and the
+                // comparer IS the set rule. Only a case-differing duplicate pins it: drop OrdinalIgnoreCase and this
+                // call merges a plugin with ITSELF, reporting nine self-conflicts and announcing "2 donors".
+                var oCase = svc.MergePlugins(new[] { "HcMgA.esp", "HCMGA.ESP" }, "HcMgCase.esp");
+                Check(oCase.Success && oCase.Donors.Count == 1 && oCase.Conflicts.Count == 0
+                      && WriteTools.RenderMerge(oCase).Contains("a RENAME of"),
+                    $"RENAME donor names differing only by CASE are ONE donor ({(oCase.Success ? $"{oCase.Donors.Count} donor, {oCase.Conflicts.Count} conflicts" : "ERR " + oCase.Error)})");
             }
         }
         finally { try { Directory.Delete(root, true); } catch { } }

--- a/src/housecarl-generator/MergeServiceGuardProbe.cs
+++ b/src/housecarl-generator/MergeServiceGuardProbe.cs
@@ -29,6 +29,13 @@ namespace HousecarlGenerator;
 ///               repeated is still ONE donor — the list is a set, in both arms. One arm runs against BuildMergeRemap
 ///               directly: "nothing can collide" is not "every id is kept", and a below-floor donor cannot be written
 ///               here to prove it through the service (Mutagen rejects sub-0x800 originating records on write).
+///   SHAPE     — the render classifies rename-vs-combine ONCE and every sentence that varies consumes it: the
+///               headline (derived from the accounting, so a PURE-OVERRIDE donor claims no re-keying), the per-donor
+///               renumber cause, the two external-referencer remedy orderings, and the mod-folder default. Each has
+///               arms on BOTH sides — the multi-donor checks above are the negatives.
+///   HEADER    — a donor's light (ESL) flag and its Author/Description are NOT carried into the output. Measured on
+///               the written file, then REPORTED: the ESL note carries the compact remedy's own cost (it renumbers
+///               from the floor), and the header-text note names no remedy because the surface has none.
 ///   REFUSE    — ZERO donors / unknown donor / output already active / output == donor / .esl output, all loud,
 ///               nothing written.
 ///   UNTOUCHED — the donor files are byte-identical after the merge (new-file lane only).
@@ -159,13 +166,26 @@ public static class MergeServiceGuardProbe
                 m.BeginWrite.ToPath(Path.Combine(ovrDir, ovrKey.FileName.String)).WithLoadOrder(new ISkyrimModGetter[] { aOv }).Write();
             }
 
-            // ---- profile files (load order: Base, A, B, Dep, Ovr — B AFTER A: the patch wins) ----
+            // A donor whose HEADER carries things the merged output is built without: the light (ESL) flag, an Author
+            // and a Description. Renaming it is how the two header-loss NOTE lines are measured; A and B carry none of
+            // it, so the multi-donor merge is the negative arm for both.
+            var eslKey = new ModKey("HcMgEsl", ModType.Plugin);
+            var eslDir = Path.Combine(mods, "EslMod"); Directory.CreateDirectory(eslDir);
+            {
+                var m = new SkyrimMod(eslKey, SkyrimRelease.SkyrimSE) { IsSmallMaster = true };
+                m.ModHeader.Author = "HcMgAuthor";
+                m.ModHeader.Description = "HcMgDescription";
+                m.Weapons.Add(new Weapon(new FormKey(eslKey, 0x801), SkyrimRelease.SkyrimSE) { EditorID = "HcMgEslWeap" });
+                m.BeginWrite.ToPath(Path.Combine(eslDir, eslKey.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            }
+
+            // ---- profile files (load order: Base, A, B, Dep, Ovr, Esl — B AFTER A: the patch wins) ----
             File.WriteAllText(Path.Combine(profiles, "loadorder.txt"),
-                "# header\r\n" + string.Join("\r\n", baseKey.FileName, aKey.FileName, bKey.FileName, depKey.FileName, ovrKey.FileName) + "\r\n");
+                "# header\r\n" + string.Join("\r\n", baseKey.FileName, aKey.FileName, bKey.FileName, depKey.FileName, ovrKey.FileName, eslKey.FileName) + "\r\n");
             File.WriteAllText(Path.Combine(profiles, "plugins.txt"),
-                string.Join("\r\n", "*" + baseKey.FileName, "*" + aKey.FileName, "*" + bKey.FileName, "*" + depKey.FileName, "*" + ovrKey.FileName) + "\r\n");
+                string.Join("\r\n", "*" + baseKey.FileName, "*" + aKey.FileName, "*" + bKey.FileName, "*" + depKey.FileName, "*" + ovrKey.FileName, "*" + eslKey.FileName) + "\r\n");
             File.WriteAllText(Path.Combine(profiles, "modlist.txt"),
-                "# header\r\n" + string.Join("\r\n", "+OvrMod", "+DepMod", "+BMod", "+AMod", "+BaseMod") + "\r\n");
+                "# header\r\n" + string.Join("\r\n", "+EslMod", "+OvrMod", "+DepMod", "+BMod", "+AMod", "+BaseMod") + "\r\n");
 
             var store = new UserConfigStore(Path.Combine(root, "houseCARL.user.json"));
             using var svc = LoadOrderService.WithInstance(instance, 0, store);
@@ -259,6 +279,18 @@ public static class MergeServiceGuardProbe
                 // must NOT claim a rename. Pinned here so the arm below can't pass by the branch collapsing to one text.
                 Check(rendered.Contains("from 2 donors") && !rendered.Contains("a RENAME of"),
                     "MERGE headline is the multi-donor form, never the rename arm");
+                // The NEGATIVE side of every shape-varying sentence and of both header-loss notes. Each has its
+                // positive twin in the RENAME block; a branch that collapsed to one text would fail one side or other.
+                Check(rendered.Contains("renumbered (id collisions / below-floor)"),
+                    "MERGE per-donor line names BOTH renumber causes (donors can collide)");
+                Check(rendered.Contains("include them in the merge set (re-run with them added), or re-point them"),
+                    "MERGE external-referencer remedy leads with include-in-set");
+                Check(rendered.Contains("Include them in the merge set, or rebuild them against"),
+                    "MERGE external-overrider remedy leads with include-in-set");
+                Check(!rendered.Contains("LIGHT (ESL) header flag") && !rendered.Contains("Author/Description"),
+                    "MERGE no header-loss notes when no donor carried those header fields");
+                Check(Path.GetFileName(Path.GetDirectoryName(o.OutputPath))!.EndsWith(" merged"),
+                    $"MERGE mod folder defaults to '<output> merged' ({Path.GetFileName(Path.GetDirectoryName(o.OutputPath))})");
                 // ASSETS: facegen pair + voice under the MERGED plugin-name folders; .seq regenerated (A shipped one).
                 var outDir = Path.GetDirectoryName(o.OutputPath)!;
                 var newFace = FaceGenPath.Both(new FormKey(mergedKey, 0xA20)).ToList();
@@ -366,6 +398,21 @@ public static class MergeServiceGuardProbe
                 var rendered1 = WriteTools.RenderMerge(o1);
                 Check(rendered1.Contains("a RENAME of HcMgA.esp") && !rendered1.Contains("1 donors"),
                     "RENAME headline names the operation and never says '1 donors'");
+                // The headline is DERIVED from the accounting: A originates 8, so it must claim 8 records moving.
+                Check(rendered1.Contains("8 records move to the new plugin's identity"),
+                    "RENAME headline's record claim is derived from the accounting, not asserted beside it");
+                // Shape-varying sentences, positive side. One donor cannot collide, so only one cause may be named…
+                Check(rendered1.Contains("renumbered (below-floor)") && !rendered1.Contains("id collisions / below-floor"),
+                    "RENAME per-donor line names ONLY the cause that can apply to one donor");
+                // …and the remedy that PRESERVES the rename must lead, with combining offered second.
+                Check(rendered1.Contains("re-point them at 'HcMgRenamed.esp' before the swap")
+                      && rendered1.IndexOf("re-point them at", StringComparison.Ordinal)
+                         < rendered1.IndexOf("re-run with them added as donors", StringComparison.Ordinal),
+                    "RENAME external-referencer remedy leads with re-point, combining offered second");
+                Check(rendered1.Contains("Rebuild them against 'HcMgRenamed.esp'"),
+                    "RENAME external-overrider remedy leads with rebuild");
+                Check(Path.GetFileName(Path.GetDirectoryName(o1.OutputPath))!.EndsWith(" renamed"),
+                    $"RENAME mod folder defaults to '<output> renamed' ({Path.GetFileName(Path.GetDirectoryName(o1.OutputPath))})");
                 Check(rendered1.Contains("existing SAVES") && rendered1.Contains("deactivate the donor PLUGINS"),
                     "RENAME still carries the saves warning and the MO2 swap instruction");
 
@@ -398,6 +445,37 @@ public static class MergeServiceGuardProbe
                     Check(floorOk,
                         $"RENAME a below-floor id renumbers even with nothing to collide with (kept {dSolo?.Kept}, renumbered {dSolo?.Renumbered})");
                 }
+
+                // HEADER LOSS, positive side: the merged plugin is built as a bare mod, so a donor's light flag and
+                // its Author/Description do not come along. Both are stated rather than refused, and the ESL note's
+                // compact remedy carries the consequence that makes it honest — compact renumbers from the floor.
+                var oEsl = svc.MergePlugins(new[] { "HcMgEsl.esp" }, "HcMgEslRenamed.esp");
+                bool eslDropped = false;
+                if (oEsl.Success && !string.IsNullOrEmpty(oEsl.OutputPath) && File.Exists(oEsl.OutputPath))
+                {
+                    using var em = SkyrimMod.CreateFromBinaryOverlay(oEsl.OutputPath, SkyrimRelease.SkyrimSE);
+                    eslDropped = !em.IsSmallMaster                                        // the loss is REAL, not just claimed
+                              && string.IsNullOrEmpty(em.ModHeader.Author)
+                              && string.IsNullOrEmpty(em.ModHeader.Description);
+                }
+                var renderedEsl = oEsl.Success ? WriteTools.RenderMerge(oEsl) : "";
+                Check(eslDropped, $"RENAME the donor's light flag and header text really are absent from the output (success {oEsl.Success})");
+                Check(renderedEsl.Contains("HcMgEsl.esp carried the LIGHT (ESL) header flag")
+                      && renderedEsl.Contains("takes a full load-order slot")
+                      && renderedEsl.Contains("renumbers object ids from 0x800 upward"),
+                    "RENAME the light-flag loss is REPORTED, with the compact remedy's own cost stated");
+                Check(renderedEsl.Contains("header Author/Description carried by HcMgEsl.esp")
+                      && !renderedEsl.Contains("housecarl_create_plugin on"),
+                    "RENAME the header-text loss is stated bare — no remedy invented for it");
+
+                // A PURE-OVERRIDE donor originates nothing, so the headline must not claim records took a new
+                // identity — the mis-named patch this capability exists for is exactly this shape.
+                var oOvr = svc.MergePlugins(new[] { "HcMgOvr.esp" }, "HcMgOvrRenamed.esp");
+                var renderedOvr = oOvr.Success ? WriteTools.RenderMerge(oOvr) : "";
+                Check(oOvr.Success && oOvr.RecordsRenumbered == 0
+                      && renderedOvr.Contains("it originates no records of its own, so nothing is re-keyed")
+                      && !renderedOvr.Contains("records move to the new plugin's identity"),
+                    $"RENAME a pure-override donor claims no re-keying (renumbered {oOvr.RecordsRenumbered}, success {oOvr.Success})");
 
                 var oDup = svc.MergePlugins(new[] { "HcMgA.esp", "HcMgA.esp" }, "HcMgDup.esp");
                 Check(oDup.Success && oDup.Donors.Count == 1,

--- a/src/housecarl-generator/MergeServiceGuardProbe.cs
+++ b/src/housecarl-generator/MergeServiceGuardProbe.cs
@@ -33,9 +33,13 @@ namespace HousecarlGenerator;
 ///               headline (derived from the accounting, so a PURE-OVERRIDE donor claims no re-keying), the per-donor
 ///               renumber cause, the two external-referencer remedy orderings, and the mod-folder default. Each has
 ///               arms on BOTH sides — the multi-donor checks above are the negatives.
-///   HEADER    — a donor's light (ESL) flag and its Author/Description are NOT carried into the output. Measured on
+///   HEADER    — nothing in a donor's header comes into the output: light (ESL) status, MASTER status, and
+///               Author/Description. Light and master are each counted BY FLAG OR BY EXTENSION (the engine treats
+///               .esl/.esm that way whatever the bit says), which is why one donor exists per spelling. Measured on
 ///               the written file, then REPORTED: the ESL note carries the compact remedy's own cost (it renumbers
-///               from the floor), and the header-text note names no remedy because the surface has none.
+///               from the floor) and suppresses the flat closing pointer so the costed advice is the one read last;
+///               master and header-text name no remedy because the surface has none. All three are keyed on what the
+///               DONORS carried, never on the donor count — a mixed multi-donor merge raises them too.
 ///   REFUSE    — ZERO donors / unknown donor / output already active / output == donor / .esl output, all loud,
 ///               nothing written.
 ///   UNTOUCHED — the donor files are byte-identical after the merge (new-file lane only).
@@ -179,13 +183,41 @@ public static class MergeServiceGuardProbe
                 m.BeginWrite.ToPath(Path.Combine(eslDir, eslKey.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
             }
 
-            // ---- profile files (load order: Base, A, B, Dep, Ovr, Esl — B AFTER A: the patch wins) ----
+            // Light and master status each arrive TWO ways, and the loss is the same either way: the header bit, or
+            // the extension (the engine force-treats .esl as light and .esm as a master regardless of the bit — the
+            // model this tool's own .esl-output refusal states). One donor per spelling, so an arm can tell a
+            // flag-only reading from the real one.
+            var eslExtKey = new ModKey("HcMgEslExt", ModType.Light);      // .esl extension, header bit NOT set
+            var eslExtDir = Path.Combine(mods, "EslExtMod"); Directory.CreateDirectory(eslExtDir);
+            {
+                var m = new SkyrimMod(eslExtKey, SkyrimRelease.SkyrimSE);
+                m.Weapons.Add(new Weapon(new FormKey(eslExtKey, 0x802), SkyrimRelease.SkyrimSE) { EditorID = "HcMgEslExtWeap" });
+                m.BeginWrite.ToPath(Path.Combine(eslExtDir, eslExtKey.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            }
+            // A donor with NO records at all — what housecarl_create_plugin produces, and what this report's own swap
+            // instruction tells the caller to make so a donor .bsa keeps loading. Renaming one is the third thing the
+            // headline's accounting can be asked to describe.
+            var emptyKey = new ModKey("HcMgEmpty", ModType.Plugin);
+            var emptyDir = Path.Combine(mods, "EmptyMod"); Directory.CreateDirectory(emptyDir);
+            {
+                var m = new SkyrimMod(emptyKey, SkyrimRelease.SkyrimSE);
+                m.BeginWrite.ToPath(Path.Combine(emptyDir, emptyKey.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            }
+            var esmKey = new ModKey("HcMgEsm", ModType.Master);           // .esm extension + the master flag
+            var esmDir = Path.Combine(mods, "EsmMod"); Directory.CreateDirectory(esmDir);
+            {
+                var m = new SkyrimMod(esmKey, SkyrimRelease.SkyrimSE);
+                m.Weapons.Add(new Weapon(new FormKey(esmKey, 0xD01), SkyrimRelease.SkyrimSE) { EditorID = "HcMgEsmWeap" });
+                m.BeginWrite.ToPath(Path.Combine(esmDir, esmKey.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            }
+
+            // ---- profile files (load order: Base, A, B, Dep, Ovr, Esl, EslExt, Esm — B AFTER A: the patch wins) ----
             File.WriteAllText(Path.Combine(profiles, "loadorder.txt"),
-                "# header\r\n" + string.Join("\r\n", baseKey.FileName, aKey.FileName, bKey.FileName, depKey.FileName, ovrKey.FileName, eslKey.FileName) + "\r\n");
+                "# header\r\n" + string.Join("\r\n", baseKey.FileName, aKey.FileName, bKey.FileName, depKey.FileName, ovrKey.FileName, eslKey.FileName, eslExtKey.FileName, esmKey.FileName, emptyKey.FileName) + "\r\n");
             File.WriteAllText(Path.Combine(profiles, "plugins.txt"),
-                string.Join("\r\n", "*" + baseKey.FileName, "*" + aKey.FileName, "*" + bKey.FileName, "*" + depKey.FileName, "*" + ovrKey.FileName, "*" + eslKey.FileName) + "\r\n");
+                string.Join("\r\n", "*" + baseKey.FileName, "*" + aKey.FileName, "*" + bKey.FileName, "*" + depKey.FileName, "*" + ovrKey.FileName, "*" + eslKey.FileName, "*" + eslExtKey.FileName, "*" + esmKey.FileName, "*" + emptyKey.FileName) + "\r\n");
             File.WriteAllText(Path.Combine(profiles, "modlist.txt"),
-                "# header\r\n" + string.Join("\r\n", "+EslMod", "+OvrMod", "+DepMod", "+BMod", "+AMod", "+BaseMod") + "\r\n");
+                "# header\r\n" + string.Join("\r\n", "+EmptyMod", "+EsmMod", "+EslExtMod", "+EslMod", "+OvrMod", "+DepMod", "+BMod", "+AMod", "+BaseMod") + "\r\n");
 
             var store = new UserConfigStore(Path.Combine(root, "houseCARL.user.json"));
             using var svc = LoadOrderService.WithInstance(instance, 0, store);
@@ -269,6 +301,11 @@ public static class MergeServiceGuardProbe
                 var rendered = WriteTools.RenderMerge(o);
                 Check(rendered.Contains("WARNING") && rendered.Contains("HcMgDep.esp") && rendered.Contains("HcMgOvr.esp"),
                     "WARN both warnings reach the rendered user output");
+                // The pass's own coverage, stated by the pass — a dependent that only DECLARES a donor as a master is
+                // invisible here, and the sentence has to say so whether the list came back empty or full.
+                Check(rendered.Contains("it reads record links and record identity, NOT declared masters")
+                      && rendered.Contains("only lists a donor as a master"),
+                    "WARN the identify-pass line states what the pass does NOT read");
                 // The swap instruction must stay PLUGIN-level (PR #158 independent review #1): "disable the donor MODS"
                 // (compact's instruction) would yank the donors' path-referenced assets out of the VFS — the merged
                 // records still load meshes/textures/scripts from the donor folders.
@@ -287,8 +324,11 @@ public static class MergeServiceGuardProbe
                     "MERGE external-referencer remedy leads with include-in-set");
                 Check(rendered.Contains("Include them in the merge set, or rebuild them against"),
                     "MERGE external-overrider remedy leads with include-in-set");
-                Check(!rendered.Contains("LIGHT (ESL) header flag") && !rendered.Contains("Author/Description"),
-                    "MERGE no header-loss notes when no donor carried those header fields");
+                Check(!rendered.Contains("LIGHT (ESL) status") && !rendered.Contains("MASTER status")
+                      && !rendered.Contains("Author/Description"),
+                    "MERGE no header-loss notes when no donor carried any of those header properties");
+                Check(rendered.Contains("Want it light?"),
+                    "MERGE keeps the closing compact pointer when no qualified ESL note replaced it");
                 Check(Path.GetFileName(Path.GetDirectoryName(o.OutputPath))!.EndsWith(" merged"),
                     $"MERGE mod folder defaults to '<output> merged' ({Path.GetFileName(Path.GetDirectoryName(o.OutputPath))})");
                 // ASSETS: facegen pair + voice under the MERGED plugin-name folders; .seq regenerated (A shipped one).
@@ -460,22 +500,60 @@ public static class MergeServiceGuardProbe
                 }
                 var renderedEsl = oEsl.Success ? WriteTools.RenderMerge(oEsl) : "";
                 Check(eslDropped, $"RENAME the donor's light flag and header text really are absent from the output (success {oEsl.Success})");
-                Check(renderedEsl.Contains("HcMgEsl.esp carried the LIGHT (ESL) header flag")
+                Check(renderedEsl.Contains("HcMgEsl.esp carried the LIGHT (ESL) status")
                       && renderedEsl.Contains("takes a full load-order slot")
                       && renderedEsl.Contains("renumbers object ids from 0x800 upward"),
                     "RENAME the light-flag loss is REPORTED, with the compact remedy's own cost stated");
                 Check(renderedEsl.Contains("header Author/Description carried by HcMgEsl.esp")
                       && !renderedEsl.Contains("housecarl_create_plugin on"),
                     "RENAME the header-text loss is stated bare — no remedy invented for it");
+                // ONE home for the compact recommendation: where the qualified note fired, the flat closing tail must
+                // not repeat it un-costed. Its negative is the plain merge, which has no note and so keeps the tail.
+                Check(!renderedEsl.Contains("Want it light?"),
+                    "RENAME the flat 'want it light' tail steps aside when the qualified ESL note fired");
+
+                // Light and master each arrive by EXTENSION as well as by flag; a flag-only reading misses these two
+                // donors entirely, which is the whole reason they exist.
+                var oEslExt = svc.MergePlugins(new[] { "HcMgEslExt.esl" }, "HcMgEslExtRenamed.esp");
+                var renderedEslExt = oEslExt.Success ? WriteTools.RenderMerge(oEslExt) : "";
+                Check(oEslExt.Success && renderedEslExt.Contains("HcMgEslExt.esl carried the LIGHT (ESL) status"),
+                    $"RENAME a .esl-EXTENSION donor counts as light even with the header bit unset (success {oEslExt.Success})");
+                var oEsm = svc.MergePlugins(new[] { "HcMgEsm.esm" }, "HcMgEsmRenamed.esp");
+                var renderedEsm = oEsm.Success ? WriteTools.RenderMerge(oEsm) : "";
+                Check(oEsm.Success && renderedEsm.Contains("HcMgEsm.esm carried MASTER status")
+                      && renderedEsm.Contains("is NOT flagged as a master")
+                      && !renderedEsm.Contains("run housecarl_"),
+                    $"RENAME the master-status loss is stated, with no remedy invented (success {oEsm.Success})");
+
+                // The residual the advisor flagged: both notes are keyed on what the DONORS carried, never on the
+                // donor count. A flagged donor merged WITH a plain one must still raise them, or the property-keying
+                // has quietly become count-keying (PR #346 R5 / PR #360 F2 class).
+                var oMixed = svc.MergePlugins(new[] { "HcMgEsl.esp", "HcMgEsm.esm" }, "HcMgMixed.esp");
+                var renderedMixed = oMixed.Success ? WriteTools.RenderMerge(oMixed) : "";
+                Check(oMixed.Success && oMixed.Donors.Count == 2
+                      && renderedMixed.Contains("carried the LIGHT (ESL) status")
+                      && renderedMixed.Contains("carried MASTER status")
+                      && renderedMixed.Contains("header Author/Description carried by")
+                      && renderedMixed.Contains("from 2 donors"),
+                    $"MERGE all three header-loss notes fire on the MULTI-donor path too (donors {oMixed.Donors.Count})");
 
                 // A PURE-OVERRIDE donor originates nothing, so the headline must not claim records took a new
                 // identity — the mis-named patch this capability exists for is exactly this shape.
                 var oOvr = svc.MergePlugins(new[] { "HcMgOvr.esp" }, "HcMgOvrRenamed.esp");
                 var renderedOvr = oOvr.Success ? WriteTools.RenderMerge(oOvr) : "";
-                Check(oOvr.Success && oOvr.RecordsRenumbered == 0
-                      && renderedOvr.Contains("it originates no records of its own, so nothing is re-keyed")
+                Check(oOvr.Success && oOvr.RecordsRenumbered == 0 && oOvr.RecordsCopied == 1
+                      && renderedOvr.Contains("its 1 override is now served by a plugin under a new name")
                       && !renderedOvr.Contains("records move to the new plugin's identity"),
-                    $"RENAME a pure-override donor claims no re-keying (renumbered {oOvr.RecordsRenumbered}, success {oOvr.Success})");
+                    $"RENAME a pure-override donor states the override COUNT it read (copied {oOvr.RecordsCopied}, renumbered {oOvr.RecordsRenumbered})");
+
+                // The third thing the accounting can say. An empty donor takes neither of the arms above, and the
+                // middle arm used to claim overrides it never read — which was wrong for exactly this plugin.
+                var oEmpty = svc.MergePlugins(new[] { "HcMgEmpty.esp" }, "HcMgEmptyRenamed.esp");
+                var renderedEmpty = oEmpty.Success ? WriteTools.RenderMerge(oEmpty) : "";
+                Check(oEmpty.Success && oEmpty.RecordsCopied == 0 && oEmpty.RecordsRenumbered == 0
+                      && renderedEmpty.Contains("it carries no records at all, so nothing moved and nothing is overridden")
+                      && !renderedEmpty.Contains("override is now served") && !renderedEmpty.Contains("overrides are now served"),
+                    $"RENAME an EMPTY donor claims neither moves nor overrides (copied {oEmpty.RecordsCopied}, success {oEmpty.Success})");
 
                 var oDup = svc.MergePlugins(new[] { "HcMgA.esp", "HcMgA.esp" }, "HcMgDup.esp");
                 Check(oDup.Success && oDup.Donors.Count == 1,

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -6170,7 +6170,7 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
-    /// <summary>Merge two or more ACTIVE plugins into ONE new plugin (housecarl_merge_plugins — the A4 orchestration
+    /// <summary>Merge one or more ACTIVE plugins into ONE new plugin (housecarl_merge_plugins — the A4 orchestration
     /// over the compact spine). Merge = a RECORDS operation: the donors' records combine into a fresh plugin under a
     /// NEW name (collision-only renumber — the first donor in load order keeps its object IDs; cross-donor conflicts
     /// on the same record resolve to the LOAD-ORDER WINNER and are reported; a losing donor's un-relisted nested
@@ -6182,16 +6182,26 @@ public sealed class LoadOrderService : IDisposable
     /// active until the user swaps; the remedy is to include the patch in the merge set or repoint it before disabling
     /// the donors). The FormID-keyed assets follow per donor: EVERY donor NPC's facegen and EVERY voiced line move to
     /// the new plugin-name folders (the plugin NAME is part of those paths, so this is the full donor set, not just
-    /// collisions), and a <c>.seq</c> is refreshed when any donor shipped one.</summary>
+    /// collisions), and a <c>.seq</c> is refreshed when any donor shipped one. With a SINGLE donor there is nothing to
+    /// combine and the operation IS a rename (#345): the same records under a new plugin identity, keeping their object
+    /// ids since nothing can collide. Its side effects are inherent to any rename and are REPORTED, never refused — the
+    /// output lands in a NEW mod folder beside the donor's (removing the old one is the user's call), and the existing
+    /// saves warning covers the break that a changed plugin name causes.</summary>
     public WritePatchBuilder.MergeOutcome MergePlugins(
         IReadOnlyList<string>? plugins, string? outputName, string? patchName = null)
     {
         // ---- 0. argument shape (Q3 — every refusal names the fix) ----
         var donorsRaw = (plugins ?? Array.Empty<string>()).Select(p => (p ?? "").Trim()).Where(p => p.Length > 0)
             .Distinct(StringComparer.OrdinalIgnoreCase).ToList();
-        if (donorsRaw.Count < 2)
+        // ONE donor is legitimate and IS the rename (#345): the remap moves every donor key to the output ModKey
+        // whether or not anything collided, and the facegen/voice carry + .seq refresh are per-DONOR (the plugin NAME
+        // is a folder segment of those paths), so the single-donor path needs no machinery the multi-donor path
+        // lacks — it is the same walk with an empty collision set. The donor list stays a SET: duplicate names
+        // collapse here exactly as they do for many donors, so plugins=["A.esp","A.esp"] is one donor, a rename.
+        if (donorsRaw.Count == 0)
             return WritePatchBuilder.MergeOutcome.Fail(
-                "merge needs at least TWO distinct donor plugins — pass plugins=[\"A.esp\", \"B.esp\", …].");
+                "merge needs at least ONE donor plugin — pass plugins=[\"A.esp\"] to move one plugin's records to a new " +
+                "name (a rename), or plugins=[\"A.esp\", \"B.esp\", …] to combine several.");
         var outName = (outputName ?? "").Trim();
         if (outName.Length == 0)
             return WritePatchBuilder.MergeOutcome.Fail(

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -6183,10 +6183,12 @@ public sealed class LoadOrderService : IDisposable
     /// the donors). The FormID-keyed assets follow per donor: EVERY donor NPC's facegen and EVERY voiced line move to
     /// the new plugin-name folders (the plugin NAME is part of those paths, so this is the full donor set, not just
     /// collisions), and a <c>.seq</c> is refreshed when any donor shipped one. With a SINGLE donor there is nothing to
-    /// combine and the operation IS a rename (#345): the same records under a new plugin identity, keeping their object
-    /// ids since nothing can collide. Its side effects are inherent to any rename and are REPORTED, never refused — the
-    /// output lands in a NEW mod folder beside the donor's (removing the old one is the user's call), and the existing
-    /// saves warning covers the break that a changed plugin name causes.</summary>
+    /// combine and the operation IS a rename (#345): the same records under a new plugin identity, keeping every object
+    /// id already inside the writable range — nothing can collide, but an id BELOW the write floor renumbers exactly as
+    /// it does for the first donor of any merge, and the per-donor line reports it. Its side effects are inherent to any rename and are REPORTED, never refused — the
+    /// output lands in a NEW mod folder beside the donor's and the swap instruction applies unchanged (deactivate the old
+    /// PLUGIN, keep its mod FOLDER enabled — the renamed records still load that mod's path-keyed assets), and the
+    /// existing saves warning covers the break that a changed plugin name causes.</summary>
     public WritePatchBuilder.MergeOutcome MergePlugins(
         IReadOnlyList<string>? plugins, string? outputName, string? patchName = null)
     {
@@ -6196,7 +6198,8 @@ public sealed class LoadOrderService : IDisposable
         // ONE donor is legitimate and IS the rename (#345): the remap moves every donor key to the output ModKey
         // whether or not anything collided, and the facegen/voice carry + .seq refresh are per-DONOR (the plugin NAME
         // is a folder segment of those paths), so the single-donor path needs no machinery the multi-donor path
-        // lacks — it is the same walk with an empty collision set. The donor list stays a SET: duplicate names
+        // lacks — it is the same walk with an empty collision set (below-floor ids still renumber: BuildMergeRemap queues
+        // them with the collisions, so "nothing can collide" is not "every id is kept"). The donor list stays a SET: duplicate names
         // collapse here exactly as they do for many donors, so plugins=["A.esp","A.esp"] is one donor, a rename.
         if (donorsRaw.Count == 0)
             return WritePatchBuilder.MergeOutcome.Fail(
@@ -6369,8 +6372,9 @@ public sealed class LoadOrderService : IDisposable
             // Q3 — surface the one behavior delta the any-donor SEQ gate can introduce: SeqFile.Build lists EVERY SGE
             // quest in M, so a quest from a donor that shipped NO .seq (and thus wasn't auto-starting) gains an entry.
             string? note = seqRegen.Written
-                ? "the regenerated .seq lists EVERY start-game-enabled quest in the merge — including any from a donor that " +
-                  "shipped no .seq of its own (such quests were NOT auto-starting before the merge; they will now)."
+                ? "the regenerated .seq lists EVERY start-game-enabled quest in the output — including quests no donor's own .seq " +
+                  "listed, whether because that donor shipped none or because its .seq was trimmed. Such quests were NOT " +
+                  "auto-starting before; they will now."
                 : null;
 
             return new WritePatchBuilder.MergeOutcome(

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -6382,7 +6382,7 @@ public sealed class LoadOrderService : IDisposable
                 true, null, outPath, outName, donorNames, build.Masters, build.RecordsCopied, build.RecordsRenumbered,
                 plan.Donors, build.Conflicts, id.ExternalPlugins, id.ExternalOverriders,
                 id.PluginsScanned, id.UnscannableRecords, id.UnscannableSamples, build.Bytes, note,
-                assetRename, voiceRename, seqRegen, build.LightDonors, build.HeaderMetaDonors);
+                assetRename, voiceRename, seqRegen, build.LightDonors, build.HeaderMetaDonors, build.MasterDonors);
         }
     }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -6306,7 +6306,8 @@ public sealed class LoadOrderService : IDisposable
 
             // ---- 5. output folder (fresh houseCARL mod folder; the merge is ALWAYS a new file — no in-place lane) ----
             RiderFolder rf;
-            try { rf = ResolvePatchModFolder(patchName, null, Path.GetFileNameWithoutExtension(outName) + " merged"); }
+            try { rf = ResolvePatchModFolder(patchName, null,
+                Path.GetFileNameWithoutExtension(outName) + (donorInfos.Count == 1 ? " renamed" : " merged")); }
             catch (InvalidOperationException ex) { return WritePatchBuilder.MergeOutcome.Fail(ex.Message); }
             WriteOwnerMeta(rf.ModFolder, outName);
             var outPath = Path.Combine(rf.OutputDir, outName);
@@ -6381,7 +6382,7 @@ public sealed class LoadOrderService : IDisposable
                 true, null, outPath, outName, donorNames, build.Masters, build.RecordsCopied, build.RecordsRenumbered,
                 plan.Donors, build.Conflicts, id.ExternalPlugins, id.ExternalOverriders,
                 id.PluginsScanned, id.UnscannableRecords, id.UnscannableSamples, build.Bytes, note,
-                assetRename, voiceRename, seqRegen);
+                assetRename, voiceRename, seqRegen, build.LightDonors, build.HeaderMetaDonors);
         }
     }
 

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -497,7 +497,8 @@ public static class WriteTools
          "MERGE one or more ACTIVE plugins into ONE NEW plugin — a RECORDS operation (the zMerge/'Merge Plugins' job): the " +
          "donors' records combine under a new filename; the donor FILES and their mods are NEVER touched (new-file lane only, " +
          "no in-place). TO RENAME a plugin, pass ONE donor: with nothing to combine the merge IS a rename — the same records " +
-         "under a new plugin name, object ids kept (nothing can collide), facegen/voice/seq carried to the new name. " +
+         "under a new plugin name, keeping every object id already inside the writable range (nothing can collide; an id " +
+         "BELOW the 0x800 floor still renumbers, and the per-donor line reports it), facegen/voice/seq carried to the new name. " +
          "RENUMBER is collision-only (zMerge's default): the donor EARLIEST in the load order keeps its FormID " +
          "object ids; later donors renumber only ids already taken (all records necessarily move to the new plugin's identity). " +
          "Cross-donor conflicts on the SAME record resolve to the LOAD-ORDER WINNER and are each REPORTED; a losing donor's " +
@@ -1134,8 +1135,9 @@ public static class WriteTools
         AppendSeqRegen(sb, o.SeqRegen, inPlace: false);
 
         if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
-        sb.Append("reminders: existing SAVES that depend on the donors will not survive the swap (records moved to a new ")
-          .Append("plugin name + new FormIDs) — best for a new game. FormIDs compiled into Papyrus (.pex hardcoded / ")
+        sb.Append("reminders: existing SAVES that depend on the donors will not survive the swap (the records now live under a ")
+          .Append("different plugin name, and any id that had to be renumbered moved with it) — best for a new game. ")
+          .Append("FormIDs compiled into Papyrus (.pex hardcoded / ")
           .Append("GetFormFromFile) and any Mutagen-delta residual are NOT remappable — verify scripted records. Want it ")
           .Append("light? Run housecarl_compact_plugin on '").Append(o.OutputName).Append("' (the tools compose).");
         return sb.ToString();

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -526,7 +526,7 @@ public static class WriteTools
             string[] plugins,
         [Description("The NEW merged plugin's filename to create (e.g. 'MyMerge.esp') — must NOT already exist in the load order. The donors keep their names and files untouched.")]
             string output,
-        [Description("Optional. Base name for the NEW mod folder (auto-suffixed if taken). Defaults to '<output> merged'.")]
+        [Description("Optional. Base name for the NEW mod folder (auto-suffixed if taken). Defaults to '<output> merged' — or '<output> renamed' for a single donor, since that folder name is what you will see in MO2 from then on.")]
             string? patch_name = null) => Guard.Tool("housecarl_merge_plugins", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
@@ -1063,14 +1063,27 @@ public static class WriteTools
         var file = Path.GetFileName(o.OutputPath);
         var modFolder = Path.GetFileName(Path.GetDirectoryName(o.OutputPath) ?? "");
         var sb = new StringBuilder();
-        // ONE donor is the RENAME case (#345), and the headline is where the caller learns which operation they got.
-        // "from 1 donors" would be both ungrammatical and a misdescription: nothing was combined. The claim stays
-        // inside what this layer knows — the donor count and the names — and every later line (ids kept/renumbered,
-        // masters, the external-referencer WARNs, the saves reminder) is computed the same way for both arms.
-        if (o.Donors.Count == 1)
+        // The operation's SHAPE is classified ONCE here and consumed by every sentence that varies with it — this
+        // headline, the per-donor renumber cause, and the external-referencer remedy order. One donor is the RENAME
+        // case (#345): "from 1 donors" would be both ungrammatical and a misdescription, nothing having been combined.
+        // Sentences that do NOT vary by shape (masters, the swap, the asset carries, the saves reminder) read the same
+        // for both and are deliberately left alone.
+        bool isRename = o.Donors.Count == 1;
+        if (isRename)
+        {
+            // What a rename did to the records is exactly what the accounting line below reports, so this sentence is
+            // DERIVED from it rather than asserting alongside it. A pure-override donor — the mis-named patch this
+            // capability exists for — originates nothing, so nothing is re-keyed, and claiming "its records under a
+            // new identity" would be false in the very case the feature was asked for.
             sb.Append("wrote ").Append(file).Append(" (new plugin; ").Append(o.Bytes).Append(" bytes) — a RENAME of ")
-              .Append(o.Donors[0]).Append(": one donor, so there is nothing to combine and this is that plugin's records ")
-              .Append("under a new identity.\n");
+              .Append(o.Donors[0]).Append(": one donor, so there is nothing to combine — ");
+            if (o.RecordsRenumbered > 0)
+                sb.Append(o.RecordsRenumbered).Append(o.RecordsRenumbered == 1 ? " record moves" : " records move")
+                  .Append(" to the new plugin's identity.\n");
+            else
+                sb.Append("it originates no records of its own, so nothing is re-keyed; the same overrides are now ")
+                  .Append("served by a plugin under a new name.\n");
+        }
         else
             sb.Append("wrote merged ").Append(file).Append(" (new plugin; ").Append(o.Bytes).Append(" bytes) from ")
               .Append(o.Donors.Count).Append(" donors: ").Append(string.Join(", ", o.Donors)).Append('\n');
@@ -1092,7 +1105,9 @@ public static class WriteTools
         sb.Append(".\n");
         foreach (var d in o.DonorRemaps)
             sb.Append("  ").Append(d.Donor).Append(": ").Append(d.Kept).Append(" object id(s) kept, ")
-              .Append(d.Renumbered).Append(" renumbered (id collisions / below-floor)\n");
+              .Append(d.Renumbered)                                       // one donor has nothing to collide WITH, so
+              .Append(isRename ? " renumbered (below-floor)\n"            // only one of the two causes can apply
+                               : " renumbered (id collisions / below-floor)\n");
         sb.Append(WriteSentences.Masters(o.Masters));
 
         if (o.Conflicts.Count == 0)
@@ -1112,8 +1127,14 @@ public static class WriteTools
         if (o.ExternalPlugins.Count > 0)
         {
             sb.Append("WARNING — ").Append(o.ExternalPlugins.Count).Append(" plugin(s) OUTSIDE the merge REFERENCE donor records. Their references break ")
-              .Append("the moment you deactivate the donor plugins: include them in the merge set (re-run with them added), or re-point them at '")
-              .Append(o.OutputName).Append("' before the swap:\n");
+              // Adding the patch to the donor set yields a COMBINED plugin — a different operation from the one that
+              // was asked for — so a rename leads with the remedy that keeps it a rename, and offers combining second.
+              .Append(isRename
+                  ? "the moment you deactivate the donor plugin: re-point them at '"
+                  : "the moment you deactivate the donor plugins: include them in the merge set (re-run with them added), or re-point them at '")
+              .Append(o.OutputName)
+              .Append(isRename ? "' before the swap — or, to combine them instead, re-run with them added as donors:\n"
+                               : "' before the swap:\n");
             foreach (var pl in o.ExternalPlugins.Take(25)) sb.Append("  ! ").Append(pl).Append('\n');
             if (o.ExternalPlugins.Count > 25) sb.Append("  ! … (+").Append(o.ExternalPlugins.Count - 25).Append(" more)\n");
         }
@@ -1121,8 +1142,11 @@ public static class WriteTools
         if (o.ExternalOverriders.Count > 0)
         {
             sb.Append("WARNING — ").Append(o.ExternalOverriders.Count).Append(" plugin(s) OUTSIDE the merge OVERRIDE a donor record; those overrides ")
-              .Append("orphan once you deactivate the donor plugins (an override can't be auto-repointed — identity, not a link). Include them in the merge set, or rebuild them against '")
-              .Append(o.OutputName).Append("':\n");
+              .Append(isRename
+                  ? "orphan once you deactivate the donor plugin (an override can't be auto-repointed — identity, not a link). Rebuild them against '"
+                  : "orphan once you deactivate the donor plugins (an override can't be auto-repointed — identity, not a link). Include them in the merge set, or rebuild them against '")
+              .Append(o.OutputName)
+              .Append(isRename ? "', or re-run with them added as donors to combine them instead:\n" : "':\n");
             foreach (var pl in o.ExternalOverriders.Take(25)) sb.Append("  ! ").Append(pl).Append('\n');
             if (o.ExternalOverriders.Count > 25) sb.Append("  ! … (+").Append(o.ExternalOverriders.Count - 25).Append(" more)\n");
         }
@@ -1134,6 +1158,29 @@ public static class WriteTools
         AppendFacegenCarry(sb, o.AssetRename, inPlace: false);
         AppendVoiceCarry(sb, o.VoiceRename, inPlace: false);
         AppendSeqRegen(sb, o.SeqRegen, inPlace: false);
+
+        // The merged plugin is built as a bare mod, so what lived in a donor's HEADER does not come along. These two
+        // lines are keyed on what the DONORS carried, not on the donor count — the loss is identical for one donor or
+        // ten, and it was measured while each donor overlay was open. Q3: a silent header loss is exactly the kind of
+        // degraded result that has to be stated. Whether these should be CARRIED is a separate decision.
+        if (o.LightDonors is { Count: > 0 } light)
+        {
+            sb.Append("NOTE — ").Append(string.Join(", ", light.Take(10)));
+            if (light.Count > 10) sb.Append(" (+").Append(light.Count - 10).Append(" more)");
+            sb.Append(light.Count == 1 ? " carried" : " carried").Append(" the LIGHT (ESL) header flag; ")
+              .Append(o.OutputName).Append(" does NOT — it is written as a full plugin and takes a full load-order slot. ")
+              .Append("To make it light again run housecarl_compact_plugin on '").Append(o.OutputName)
+              .Append("' (its esl defaults true) — but that renumbers object ids from 0x800 upward, so the ids listed as ")
+              .Append("kept above will move.\n");
+        }
+        if (o.HeaderMetaDonors is { Count: > 0 } meta)
+        {
+            // No remedy is named because none exists on the surface: author=/description= belong to create_plugin, and
+            // only at create time. A bare statement of the loss is the honest whole of what can be said about it.
+            sb.Append("NOTE — the header Author/Description carried by ").Append(string.Join(", ", meta.Take(10)));
+            if (meta.Count > 10) sb.Append(" (+").Append(meta.Count - 10).Append(" more)");
+            sb.Append(" are not carried across; ").Append(o.OutputName).Append("'s are empty.\n");
+        }
 
         if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
         sb.Append("reminders: existing SAVES that depend on the donors will not survive the swap (the records now live under a ")

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -499,8 +499,9 @@ public static class WriteTools
          "no in-place). TO RENAME a plugin, pass ONE donor: with nothing to combine the merge IS a rename — the same records " +
          "under a new plugin name, keeping every object id already inside the writable range (nothing can collide; an id " +
          "BELOW the 0x800 floor still renumbers, and the per-donor line reports it), facegen/voice/seq carried to the new name. " +
-         "RENUMBER is collision-only (zMerge's default): the donor EARLIEST in the load order keeps its FormID " +
-         "object ids; later donors renumber only ids already taken (all records necessarily move to the new plugin's identity). " +
+         "RENUMBER is collision-first (zMerge's default): the donor EARLIEST in the load order keeps its FormID " +
+         "object ids; later donors renumber ids already taken, and ANY donor's ids below the 0x800 floor renumber too " +
+         "(all records necessarily move to the new plugin's identity). " +
          "Cross-donor conflicts on the SAME record resolve to the LOAD-ORDER WINNER and are each REPORTED; a losing donor's " +
          "nested children the winner doesn't re-list (a base mod's dialogue lines under a patched topic; placed refs under a " +
          "patched cell) are GRAFTED into the winner's copy — so merging a mod WITH its patches is the intended use. ASSETS " +

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -494,9 +494,11 @@ public static class WriteTools
 
     [McpServerTool(Name = "housecarl_merge_plugins", Title = "Merge plugins into one new plugin"),
      Description(
-         "MERGE two or more ACTIVE plugins into ONE NEW plugin — a RECORDS operation (the zMerge/'Merge Plugins' job): the " +
+         "MERGE one or more ACTIVE plugins into ONE NEW plugin — a RECORDS operation (the zMerge/'Merge Plugins' job): the " +
          "donors' records combine under a new filename; the donor FILES and their mods are NEVER touched (new-file lane only, " +
-         "no in-place). RENUMBER is collision-only (zMerge's default): the donor EARLIEST in the load order keeps its FormID " +
+         "no in-place). TO RENAME a plugin, pass ONE donor: with nothing to combine the merge IS a rename — the same records " +
+         "under a new plugin name, object ids kept (nothing can collide), facegen/voice/seq carried to the new name. " +
+         "RENUMBER is collision-only (zMerge's default): the donor EARLIEST in the load order keeps its FormID " +
          "object ids; later donors renumber only ids already taken (all records necessarily move to the new plugin's identity). " +
          "Cross-donor conflicts on the SAME record resolve to the LOAD-ORDER WINNER and are each REPORTED; a losing donor's " +
          "nested children the winner doesn't re-list (a base mod's dialogue lines under a patched topic; placed refs under a " +
@@ -518,7 +520,7 @@ public static class WriteTools
          "afterward (the tools compose).")]
     public static string MergePlugins(
         LoadOrderService svc,
-        [Description("The donor plugin filenames to merge (at least two, e.g. [\"CoolMod.esp\", \"CoolMod Patch.esp\"]) — each must be active in your load order. Argument order does not matter: houseCARL uses LOAD order for id priority and conflict resolution.")]
+        [Description("The donor plugin filenames to merge (at least one, e.g. [\"CoolMod.esp\", \"CoolMod Patch.esp\"]) — each must be active in your load order. A SINGLE donor renames it into output=. This is a SET: a name repeated is still one donor. Argument order does not matter: houseCARL uses LOAD order for id priority and conflict resolution.")]
             string[] plugins,
         [Description("The NEW merged plugin's filename to create (e.g. 'MyMerge.esp') — must NOT already exist in the load order. The donors keep their names and files untouched.")]
             string output,
@@ -1059,8 +1061,17 @@ public static class WriteTools
         var file = Path.GetFileName(o.OutputPath);
         var modFolder = Path.GetFileName(Path.GetDirectoryName(o.OutputPath) ?? "");
         var sb = new StringBuilder();
-        sb.Append("wrote merged ").Append(file).Append(" (new plugin; ").Append(o.Bytes).Append(" bytes) from ")
-          .Append(o.Donors.Count).Append(" donors: ").Append(string.Join(", ", o.Donors)).Append('\n');
+        // ONE donor is the RENAME case (#345), and the headline is where the caller learns which operation they got.
+        // "from 1 donors" would be both ungrammatical and a misdescription: nothing was combined. The claim stays
+        // inside what this layer knows — the donor count and the names — and every later line (ids kept/renumbered,
+        // masters, the external-referencer WARNs, the saves reminder) is computed the same way for both arms.
+        if (o.Donors.Count == 1)
+            sb.Append("wrote ").Append(file).Append(" (new plugin; ").Append(o.Bytes).Append(" bytes) — a RENAME of ")
+              .Append(o.Donors[0]).Append(": one donor, so there is nothing to combine and this is that plugin's records ")
+              .Append("under a new identity.\n");
+        else
+            sb.Append("wrote merged ").Append(file).Append(" (new plugin; ").Append(o.Bytes).Append(" bytes) from ")
+              .Append(o.Donors.Count).Append(" donors: ").Append(string.Join(", ", o.Donors)).Append('\n');
         sb.Append("mod folder: ").Append(modFolder).Append("  — review in xEdit, then enable + sort it in MO2.\n");
         // The swap is PLUGIN-level, not mod-level (merge is a RECORDS op): the merged records still reference the donors'
         // meshes/textures/scripts/BSA contents BY PATH, and those files live in the donor mod folders — only the

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -517,9 +517,11 @@ public static class WriteTools
          "breaks (facegen/voice/seq); every other donor asset (meshes, textures, scripts, BSA contents) is still referenced " +
          "BY PATH from the merged records and loads from the donor folders. Caveat: a donor .bsa stops auto-loading once its " +
          "same-named plugin is inactive — extract it into the mod folder (housecarl_bsa_extract) or load it via a same-named " +
-         "dummy plugin (housecarl_create_plugin). Existing SAVES that depend on the donors will NOT survive (new plugin name " +
-         "+ renumbered FormIDs) — best for a new game. Want it light/ESL? Run housecarl_compact_plugin on the merged plugin " +
-         "afterward (the tools compose).")]
+         "dummy plugin (housecarl_create_plugin). Existing SAVES that depend on the donors will NOT survive (the records now " +
+         "live under a different plugin name, and any id that had to be renumbered moved with it) — best for a new game. " +
+         "A donor's HEADER does not come along: light (ESL) status, master status, and Author/Description are dropped, and " +
+         "the report names each one it actually dropped. Want it light/ESL? Run housecarl_compact_plugin on the merged " +
+         "plugin afterward (the tools compose) — but it renumbers object ids from 0x800 upward, so ids the merge kept move.")]
     public static string MergePlugins(
         LoadOrderService svc,
         [Description("The donor plugin filenames to merge (at least one, e.g. [\"CoolMod.esp\", \"CoolMod Patch.esp\"]) — each must be active in your load order. A SINGLE donor renames it into output=. This is a SET: a name repeated is still one donor. Argument order does not matter: houseCARL uses LOAD order for id priority and conflict resolution.")]
@@ -1077,12 +1079,21 @@ public static class WriteTools
             // new identity" would be false in the very case the feature was asked for.
             sb.Append("wrote ").Append(file).Append(" (new plugin; ").Append(o.Bytes).Append(" bytes) — a RENAME of ")
               .Append(o.Donors[0]).Append(": one donor, so there is nothing to combine — ");
+            // Three arms, because there are three things the accounting can say and each sentence may claim only the
+            // quantity it read. The middle arm previously asserted overrides it never looked at, which made it wrong
+            // for a donor with no records at all — and an empty plugin is not hypothetical: the swap instruction in
+            // this same report tells the caller to create one to keep a donor .bsa loading.
+            int headlineOverrides = o.RecordsCopied - o.RecordsRenumbered;
             if (o.RecordsRenumbered > 0)
                 sb.Append(o.RecordsRenumbered).Append(o.RecordsRenumbered == 1 ? " record moves" : " records move")
                   .Append(" to the new plugin's identity.\n");
+            else if (headlineOverrides > 0)
+                sb.Append("it originates no records of its own, so nothing is re-keyed; its ").Append(headlineOverrides)
+                  .Append(headlineOverrides == 1 ? " override is" : " overrides are")
+                  .Append(" now served by a plugin under a new name.\n");
             else
-                sb.Append("it originates no records of its own, so nothing is re-keyed; the same overrides are now ")
-                  .Append("served by a plugin under a new name.\n");
+                sb.Append("it carries no records at all, so nothing moved and nothing is overridden — an empty plugin ")
+                  .Append("under a new name.\n");
         }
         else
             sb.Append("wrote merged ").Append(file).Append(" (new plugin; ").Append(o.Bytes).Append(" bytes) from ")
@@ -1138,7 +1149,7 @@ public static class WriteTools
             foreach (var pl in o.ExternalPlugins.Take(25)) sb.Append("  ! ").Append(pl).Append('\n');
             if (o.ExternalPlugins.Count > 25) sb.Append("  ! … (+").Append(o.ExternalPlugins.Count - 25).Append(" more)\n");
         }
-        else sb.Append("external referencers: none — nothing outside the merge points at a donor record.\n");
+        else sb.Append("external referencers: none — no plugin outside the merge has a record that links to a donor record.\n");
         if (o.ExternalOverriders.Count > 0)
         {
             sb.Append("WARNING — ").Append(o.ExternalOverriders.Count).Append(" plugin(s) OUTSIDE the merge OVERRIDE a donor record; those overrides ")
@@ -1153,7 +1164,13 @@ public static class WriteTools
         if (o.UnscannableRecords > 0)
             sb.Append("note: ").Append(o.UnscannableRecords).Append(" record(s) couldn't be scanned in the external-reference pass, so a ")
               .Append("'none' above may be incomplete — verify in xEdit. Samples: ").Append(string.Join("; ", o.UnscannableSamples)).Append('\n');
-        sb.Append("identify-pass scanned ").Append(o.PluginsScanned).Append(" plugin(s) for external references.\n");
+        // The coverage caveat belongs to the PASS, not to either outcome: a "none" and a populated list are incomplete
+        // in the same way, so stating it here covers both rather than qualifying one branch and leaving the other
+        // absolute. What the pass reads is record links and record identity — it never opens a plugin header, so a
+        // dependent that merely DECLARES a donor as a master is invisible to it, and loses a master at the swap.
+        sb.Append("identify-pass scanned ").Append(o.PluginsScanned).Append(" plugin(s) — it reads record links and ")
+          .Append("record identity, NOT declared masters or INI distributor configs (SPID/KID/SkyPatcher), so a plugin ")
+          .Append("that only lists a donor as a master, or only names one in an .ini, is not counted above.\n");
 
         AppendFacegenCarry(sb, o.AssetRename, inPlace: false);
         AppendVoiceCarry(sb, o.VoiceRename, inPlace: false);
@@ -1163,15 +1180,26 @@ public static class WriteTools
         // lines are keyed on what the DONORS carried, not on the donor count — the loss is identical for one donor or
         // ten, and it was measured while each donor overlay was open. Q3: a silent header loss is exactly the kind of
         // degraded result that has to be stated. Whether these should be CARRIED is a separate decision.
+        bool lightNoteShown = o.LightDonors is { Count: > 0 };
         if (o.LightDonors is { Count: > 0 } light)
         {
             sb.Append("NOTE — ").Append(string.Join(", ", light.Take(10)));
             if (light.Count > 10) sb.Append(" (+").Append(light.Count - 10).Append(" more)");
-            sb.Append(light.Count == 1 ? " carried" : " carried").Append(" the LIGHT (ESL) header flag; ")
+            sb.Append(" carried the LIGHT (ESL) status; ")
               .Append(o.OutputName).Append(" does NOT — it is written as a full plugin and takes a full load-order slot. ")
               .Append("To make it light again run housecarl_compact_plugin on '").Append(o.OutputName)
               .Append("' (its esl defaults true) — but that renumbers object ids from 0x800 upward, so the ids listed as ")
               .Append("kept above will move.\n");
+        }
+        if (o.MasterDonors is { Count: > 0 } masters)
+        {
+            // No remedy: nothing on the surface flags an existing plugin as a master. Bare statement, as for the
+            // header text below — an invented remedy would be the worse failure.
+            sb.Append("NOTE — ").Append(string.Join(", ", masters.Take(10)));
+            if (masters.Count > 10) sb.Append(" (+").Append(masters.Count - 10).Append(" more)");
+            sb.Append(" carried MASTER status; ").Append(o.OutputName)
+              .Append(" is NOT flagged as a master — it loads as a plain plugin, in the plugin block rather than the ")
+              .Append("master block, so anything depending on that ordering will see it move.\n");
         }
         if (o.HeaderMetaDonors is { Count: > 0 } meta)
         {
@@ -1186,8 +1214,13 @@ public static class WriteTools
         sb.Append("reminders: existing SAVES that depend on the donors will not survive the swap (the records now live under a ")
           .Append("different plugin name, and any id that had to be renumbered moved with it) — best for a new game. ")
           .Append("FormIDs compiled into Papyrus (.pex hardcoded / ")
-          .Append("GetFormFromFile) and any Mutagen-delta residual are NOT remappable — verify scripted records. Want it ")
-          .Append("light? Run housecarl_compact_plugin on '").Append(o.OutputName).Append("' (the tools compose).");
+          .Append("GetFormFromFile) and any Mutagen-delta residual are NOT remappable — verify scripted records.");
+        // ONE home for the compact recommendation per response. When the light note fired it already named the tool
+        // WITH the cost that makes the advice honest (it renumbers from the floor); repeating it flat here would
+        // leave the caller's last reading of it the one without the cost. With no light note there is no other
+        // pointer, so the tail stays.
+        if (!lightNoteShown)
+            sb.Append(" Want it light? Run housecarl_compact_plugin on '").Append(o.OutputName).Append("' (the tools compose).");
         return sb.ToString();
     }
 


### PR DESCRIPTION
Closes #345.

`housecarl_merge_plugins` refused fewer than two distinct donors, and nothing else on the surface renames a plugin — so a mis-named patch could only be fixed by replaying every edit into a newly named plugin. One donor is now accepted, and that is the rename.

## The binding pre-fold check: no reason exists

The charter required confirming there was no undocumented reason for the two-donor guard before touching it. Seven artifacts, none stating one:

| Artifact | What it says about the minimum |
|---|---|
| Birth commit `00cee8a` (message + diff) | Lists `>=2 donors` inside a validation enumeration. **No rationale.** Its asset note argues the other way: "a merge renames the plugin and the plugin NAME is a folder segment of facegen/voice paths, so EVERY donor NPC/voiced line carries" |
| `COMPACT_MERGE_PLAN_2026-06-26.md` §5 | Merge's refuse-loud list is the ESL ceiling, sub-model records, an unparseable donor. **No donor-count refusal** |
| `MERGE_REFERENCE_RESEARCH_2026-06-26.md` | Full zMerge/xEdit source dive. **No minimum-donor concept in any reference tool** |
| Handoff 2026-06-27 | Locked sub-decisions: winner+report, de-scope edit-combining, direction deferred. **No donor count** |
| Handoff 2026-07-07 (PR #158) | The three A4 scope calls: WARN-and-proceed, no ESL in v1, override auto-fix out. **No donor count.** Notes "RenumberModInto ≈ the single-donor reg=null case" |
| `git log -L 6185,6200` | The guard has **exactly one commit** — its birth. Never revisited |
| Repo-wide grep (.cs/.md/.json) | No comment, doc or CHANGELOG line justifies it. Only the probe pinned it, pinning *behaviour* |

It sat under `// ---- 0. argument shape ----`, which is all it ever was.

## Verified, not inherited

The triage claim that the machinery is single-donor-correct was checked against source. `BuildMergeRemap` writes every originating key into the dict on the keep path, so a lone donor's records move to the output ModKey holding their object ids — the collision set is simply empty. The facegen/voice carry and the `.seq` gate already loop per **donor**, because the plugin NAME is a folder segment of those paths, which is the one thing a rename changes.

## Decisions this PR pins

- **The count guard moved from 2 to 1, it did not disappear.** Zero donors still refuses, and the refusal names both shapes.
- **The donor list stays a SET.** `plugins=["A.esp","A.esp"]` is one donor and renames. Duplicates already collapsed silently for many donors (`["A","A","B"]` merges two today), so making duplicates special *only* for one donor would be machinery the multi-donor path does not have. The same reasoning covers a blank or null element in the list: the trim/drop is pre-existing and uniform, and the count boundary is the only thing that moved.
- **The report states which operation it performed**, deciding the shape once and consuming it at the sentences that vary — the headline ("from 1 donors" is both ungrammatical and a misdescription), the renumber cause, the remedy ordering, the folder default. Every one of those has arms on both sides. See the directed completion below for how that scope was arrived at.

## Review rounds

**Round 1 — 3 fresh agents, isolated worktrees. 12 findings: 5 folded, 2 refused, 3 to the issue lane, 2 low declined.**

All three converged on one class — prose claiming more than the write does:

- **"object ids kept (nothing can collide)"** was the headline promise and is false: `BuildMergeRemap` keeps an id only inside the write window, so a below-floor id renumbers with no collision anywhere. Folded, **and given an arm**. That arm runs against `BuildMergeRemap` directly: a donor carrying a sub-`0x800` originating record cannot be written at all (`LowerFormKeyRangeDisallowedException`, verified by trying to fixture one), so the service-level test the claim appeared to need does not exist. One agent reported having built that fixture; that account did not hold up. Such plugins come from other tools and houseCARL reads them fine, so the case is reachable even though the fixture is not.
- **The CHANGELOG and doc comment invited removing the old mod folder** while the tool's own output says to keep it enabled — and the output is right, because the renamed records still load that mod's assets by path. Both now match the report.
- **The saves reminder blamed "new FormIDs".** Rename a pure-override patch and no FormID moves at all, so the report contradicted itself in one response. The conclusion was never in doubt; the reason now matches it.
- **The `.seq` note named only one of two ways a quest gains an entry.** Broadened for both arms rather than made conditional.
- **Removed a vacuous arm** asserting a one-donor merge reports zero conflicts — gutting the conflict machinery entirely left it green.

Refused: *"the saves/swap arm has no coverage"* — suppressing the reminder for the one-donor arm turns it RED; reproduced. And the merge-vocabulary nits (body sentences still saying "merged"; the folder named `<output> merged`) — true, no action changes, and each fix costs a conditional plus arms in both directions.

**Round 2 — 2 fresh agents. 10 findings: 2 folded on the branch (both test-evidence), 7 dispositioned by the directed completion below, 1 left with #363.**

Both folds were arms that claimed more than they verified:

- **The set-semantics arm could not see the comparer.** It passed two identical strings, which `Distinct()` collapses under any comparer. Replacing `OrdinalIgnoreCase` with the default left the whole guard green while `["HcMgA.esp","HCMGA.ESP"]` merged a plugin with itself, reported nine self-conflicts and announced "2 donors". A case-differing duplicate now pins it.
- **The remap arm was labelled "every A record" and read back four of eight keys.** Its negative is satisfied just as well by a record that was *dropped*, so a walk regression losing a nested INFO or the celled placed ref would have left every RENAME arm green.

## Class-stop, and the directed completion that answered it

**Round 2 returned round 1's class, so there was no round 3 and no third instance was folded.** The recurring class: *the rename inherits merge-shaped text and merge-shaped losses* — a report written for "combine N plugins" also serving an operation that is not a combination. That went to the advisor lane, which ruled a **directed completion**: kill the class by classifying the operation's shape **once**, rather than folding instances.

**The escape hatch ran first, as the ruling required.** Counting the shape-varying sites in `RenderMerge` — every sentence asked "does this differ between rename and combine?" — found **two beyond the headline pair**: the per-donor renumber cause, and the external-referencer remedy order. Masters, the swap instruction, the asset carries and the saves reminder do not vary and were left alone. At two sites a classifier type would be over-machinery, **so the hatch fell to sentence-local** — with the shape bound once into a local and consumed at each site, which is the ruling's "decide once" structure at the scale the count justifies, rather than count tests scattered per sentence.

Disposition of the seven, as directed:

| # | Instance | Done |
|---|---|---|
| 1 | ESL flag dropped | **Report line rides this PR**; the carry decision stays #363. The remedy it names was measured first (`compact_plugin`'s `esl` defaults true) and carries its own cost — it renumbers from `0x800`, moving the ids reported kept two lines above |
| 2 | `Author`/`Description` dropped | **Report line**, stating the loss bare. **No remedy named** — none exists (`author=`/`description=` are `create_plugin`'s, at create time only, verified). No issue number in tool output |
| 3 | "records under a new identity" | Headline is now **derived from the accounting line below it**, so a pure-override donor — what most mis-named patches are — says it originates no records rather than claiming a re-keying that did not happen |
| 4 | Two renumber causes | Shape-true: one donor names only "(below-floor)" |
| 5 | Remedy ordering | A rename leads with re-point / rebuild — the remedies that keep it a rename — and offers combining second. Combine's ordering is unchanged |
| 6 | `.esl` refusal wording | Stays with #363, as filed |
| 7 | `<output> merged` folder | Default is `<output> renamed` for one donor, and the `patch_name=` `[Description]` naming it moved in the same change. **Checked first that nothing consumes the old default** — no probe, no `meta.ini` breadcrumb, no doc; its only consumer was its own call site |

**Refusal accounting is unchanged by the completion** — it folded the seven the ruling dispositioned and nothing else. Round 1's two refusals still stand, and the merge-vocabulary nits refused there stay refused on their own ground; the completion changed the economics for the *shape-varying* sentences only, which is what it was scoped to.

**What was never in doubt:** five agents across two rounds found no defect in what gets *written* on the single-donor path. Every finding was in the report or the header metadata.

## Filed to the issue lane (outside this branch, the #324 shape)

- **#362 — high.** `merge_plugins` / `compact_plugin` blank every localized string: donors open with the bare overlay, bypassing `LoadOrderResolver.OpenOverlay`. The codebase documents this exact hazard at `WritePatchBuilder.cs:1043-1047` and routes *that* lane through the fix; `MergeBuild:2599` and `CompactBuild:2497` do not. Silent data loss in a write verb, pre-existing on both.
- **#363** — the ESL/ESM header flag drop, plus the `.esl` refusal wording.
- **#364** — compact/merge never mention the runtime INI distributor layer (SPID/KID/SkyPatcher/OAR), whose lines address records as `Plugin.esp|FormID` and which the identify pass cannot see.

All three unrouted and unmilestoned, per the #361 precedent.

## Evidence

Guard `merge-service-guard` **23 → 56 arms**; `ci-all` **124/124**.

**Twenty-two sabotages** across the engagement, each run from a committed state, each restored with the restore verified by grepping for a string the fold introduced. Every conditional the completion added was collapsed **both ways**, and the multi-donor checks are the negatives:

| Completion sabotage | Result |
|---|---|
| Shape classifier forced to RENAME for every merge | RED — 4 multi-donor arms |
| Shape classifier forced to COMBINE for every merge | RED — 7 rename arms |
| Headline claims re-keying when nothing originates | RED — pure-override arm |
| Headline claims no re-keying when records moved | RED — derived-claim arm |
| Folder default forced to `merged` for a rename | RED — rename folder arm |
| Folder default forced to `renamed` for a combine | RED — merge folder arm |
| Light-flag loss never detected | RED — ESL note arm |
| Light-flag loss reported for every donor | RED — merge no-notes arm |
| Header-text loss never detected | RED — header-text arm |
| Header-text loss reported for every donor | RED — merge no-notes arm |
| Compact remedy's cost clause dropped from the ESL note | RED — ESL note arm |

The eleven from the rounds:

| Sabotage | Result |
|---|---|
| Force the multi-donor headline for one donor | RED — rename headline arm |
| Force the rename headline for many donors | RED — multi-donor headline arm |
| Restore the old `>= 2` guard | RED — 14 of 15 RENAME arms |
| Drop the zero-donor refusal | RED — all three refusal arms |
| Facegen carry made multi-donor-only | RED — rename facegen arm |
| Voice carry / seq gate made multi-donor-only | RED — rename voice, rename seq |
| Identify pass given an empty target set | RED — both rename external-referencer arms |
| Drop the donor `Distinct()` entirely | RED — duplicate-name arm |
| Replace the `Distinct` comparer with the default | RED — the case-differing arm, reporting "2 donor, 9 conflicts" |
| Planner keeps below-floor ids | RED — below-floor arm |
| Lose a nested INFO on the rename path only | RED — the remap arm, among 12 |

One defect in the probe itself was caught by this and fixed on the branch: restoring the old guard originally turned only 5 arms RED and then *stopped the block*, because it threw on the refusal outcome's null `OutputPath`. The arms past that point are now gated and short-circuit, so the same sabotage reports 14. A check that cannot report is not a check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
