### PR TITLE
fix(merge,compact): open donors through OpenOverlay so localized strings survive the write

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -6,21 +6,18 @@ when it changes.
 
 ## Unreleased
 
-- **`housecarl_merge_plugins` and `housecarl_compact_plugin` now say what they cost the runtime distributor layer.**
-  SPID, KID and SkyPatcher `.ini` lines, and Open Animation Replacer `.json` conditions, all address a record through
-  the plugin that defines it — an addressing model neither verb leaves intact, and one no plugin scan can see, because
-  those lines live in config files rather than in any record. The merge report already said the identify pass does not
-  read them; it now also says what follows from that, which is that a line naming a donor stops matching once you
-  deactivate that donor at the swap. The compact report said neither, and now says both — with the half that applies
-  to it, since a compaction keeps the plugin name and moves the object ids instead.
+- **`housecarl_merge_plugins` and `housecarl_compact_plugin` now say what they cost your runtime config files.**
+  Neither verb reads SPID, KID, SkyPatcher or Open Animation Replacer configs, and neither rewrites them — but both
+  can invalidate lines in them, and nothing said so. Merge now states that a line naming a donor stops matching once
+  you deactivate that donor at the swap. Compact states the half that applies to it: the plugin name survives a
+  compaction, so what breaks is a line addressing a record by an object id the compaction moved, once the compacted
+  plugin is the one loading.
 
-  Both reports state the addressing *model* and quote no single spelling, because the four systems do not share one:
-  SkyPatcher is prefix-pipe, SPID and KID are suffix-tilde, and OAR is a JSON field pair. Naming the file kinds is what
-  makes the advice actionable; quoting one syntax for all of them would send you grepping for a string three of the
-  four never contain. Merge's sentence is also scoped to the records that actually changed identity — a record a donor
-  merely *overrode* keeps its master's FormID, so a config line addressing it is untouched, and the report says so
-  rather than telling you to rewrite a line that still works. Neither verb rewrites those files, and neither claims to
-  have looked at them. (#364)
+  Both sentences deliberately describe only what the operation did, and say nothing about how any of those config
+  formats are written. Earlier drafts tried to be helpful about the syntax and got it wrong twice — the four systems
+  share neither a file format nor a way of naming a record, and each attempt would have sent you looking for something
+  three of them never contain. What the reports owe you is what *they* changed; the bundled skills are where the
+  grammars live. (#364)
 
 - **Fixed: `housecarl_merge_plugins` and `housecarl_compact_plugin` blanked every localized name and description.**
   Both verbs opened their donor / source plugins with an overlay that looks for `Strings\` only in the plugin's own
@@ -29,10 +26,14 @@ when it changes.
   to — therefore read every `FULL` and `DESC` as empty, and the merged or compacted output was written with those
   blanks baked in. Nothing failed and nothing warned: the result loaded, and the loss was visible only in game or by
   diffing. Both opens now go through the same strings-aware path the rest of houseCARL reads with, which falls back to
-  the game `Data` folder when the plugin's own folder carries no strings source and leaves plugins that do carry one
-  untouched. This fix closes the case where the strings exist but were being looked for in the wrong folder. It does
-  not change what happens when the lookup finds nothing wherever it looks — a plugin whose strings are in *neither*
-  place, for instance — and such a plugin still reads, and writes, empty. (#362)
+  the game `Data` folder when the plugin's own folder carries no strings source, and leaves plugins that do carry one
+  untouched.
+
+  That redirect has a bound worth knowing, because it decides whether this fix reaches your case: it applies only when
+  the plugin's own folder carries no strings source at all, and **any** `.bsa` sitting beside the plugin counts as one
+  — whatever that archive actually holds. A localized plugin in a mod folder that ships an asset-only `.bsa`, with its
+  `.STRINGS` served from elsewhere, is therefore still read the old way and still writes blanks. So is a plugin whose
+  strings are in neither place. Both are unchanged by this fix. (#362)
 
 - **`housecarl_merge_plugins` now accepts a single donor, which renames a plugin.** Merging one plugin into a new
   name was refused ("merge needs at least TWO distinct donor plugins"), and no other tool renames one, so a

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -6,6 +6,17 @@ when it changes.
 
 ## Unreleased
 
+- **Fixed: `housecarl_merge_plugins` and `housecarl_compact_plugin` blanked every localized name and description.**
+  Both verbs opened their donor / source plugins with an overlay that looks for `Strings\` only in the plugin's own
+  folder. A localized plugin whose `.STRINGS` are served from elsewhere — the common case, where a cleaned or
+  translated master's strings live in the game's `Data` folder rather than in the mod folder MO2 resolves the plugin
+  to — therefore read every `FULL` and `DESC` as empty, and the merged or compacted output was written with those
+  blanks baked in. Nothing failed and nothing warned: the result loaded, and the loss was visible only in game or by
+  diffing. Both opens now go through the same strings-aware path the rest of houseCARL reads with, which falls back to
+  the game `Data` folder when the plugin's own folder carries no strings source and leaves plugins that do carry one
+  untouched. A plugin whose strings are in *neither* place still reads empty — there is nowhere left to look — and
+  that case is unchanged by this fix. (#362)
+
 - **`housecarl_merge_plugins` now accepts a single donor, which renames a plugin.** Merging one plugin into a new
   name was refused ("merge needs at least TWO distinct donor plugins"), and no other tool renames one, so a
   mis-named patch could only be fixed by replaying every edit into a freshly named plugin. There was never anything

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -6,6 +6,14 @@ when it changes.
 
 ## Unreleased
 
+- **`housecarl_merge_plugins` and `housecarl_compact_plugin` now say what they cost the runtime distributor layer.**
+  SPID, KID, SkyPatcher and OAR configs address a record as `<plugin>|<FormID>` — an addressing model neither verb
+  leaves intact, and one no plugin scan can see, since those lines live in `.ini` files rather than in any record. The
+  merge report already said the identify pass does not read them; it now also says what follows from that, which is
+  that a line naming a donor stops matching the moment you deactivate that donor at the swap. The compact report said
+  neither, and now says both — with the half that applies to it, since a compaction keeps the plugin name and moves
+  the object ids instead. Neither verb rewrites those files, and neither claims to have looked at them. (#364)
+
 - **Fixed: `housecarl_merge_plugins` and `housecarl_compact_plugin` blanked every localized name and description.**
   Both verbs opened their donor / source plugins with an overlay that looks for `Strings\` only in the plugin's own
   folder. A localized plugin whose `.STRINGS` are served from elsewhere — the common case, where a cleaned or

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -7,12 +7,20 @@ when it changes.
 ## Unreleased
 
 - **`housecarl_merge_plugins` and `housecarl_compact_plugin` now say what they cost the runtime distributor layer.**
-  SPID, KID, SkyPatcher and OAR configs address a record as `<plugin>|<FormID>` — an addressing model neither verb
-  leaves intact, and one no plugin scan can see, since those lines live in `.ini` files rather than in any record. The
-  merge report already said the identify pass does not read them; it now also says what follows from that, which is
-  that a line naming a donor stops matching the moment you deactivate that donor at the swap. The compact report said
-  neither, and now says both — with the half that applies to it, since a compaction keeps the plugin name and moves
-  the object ids instead. Neither verb rewrites those files, and neither claims to have looked at them. (#364)
+  SPID, KID and SkyPatcher `.ini` lines, and Open Animation Replacer `.json` conditions, all address a record through
+  the plugin that defines it — an addressing model neither verb leaves intact, and one no plugin scan can see, because
+  those lines live in config files rather than in any record. The merge report already said the identify pass does not
+  read them; it now also says what follows from that, which is that a line naming a donor stops matching once you
+  deactivate that donor at the swap. The compact report said neither, and now says both — with the half that applies
+  to it, since a compaction keeps the plugin name and moves the object ids instead.
+
+  Both reports state the addressing *model* and quote no single spelling, because the four systems do not share one:
+  SkyPatcher is prefix-pipe, SPID and KID are suffix-tilde, and OAR is a JSON field pair. Naming the file kinds is what
+  makes the advice actionable; quoting one syntax for all of them would send you grepping for a string three of the
+  four never contain. Merge's sentence is also scoped to the records that actually changed identity — a record a donor
+  merely *overrode* keeps its master's FormID, so a config line addressing it is untouched, and the report says so
+  rather than telling you to rewrite a line that still works. Neither verb rewrites those files, and neither claims to
+  have looked at them. (#364)
 
 - **Fixed: `housecarl_merge_plugins` and `housecarl_compact_plugin` blanked every localized name and description.**
   Both verbs opened their donor / source plugins with an overlay that looks for `Strings\` only in the plugin's own
@@ -22,8 +30,9 @@ when it changes.
   blanks baked in. Nothing failed and nothing warned: the result loaded, and the loss was visible only in game or by
   diffing. Both opens now go through the same strings-aware path the rest of houseCARL reads with, which falls back to
   the game `Data` folder when the plugin's own folder carries no strings source and leaves plugins that do carry one
-  untouched. A plugin whose strings are in *neither* place still reads empty — there is nowhere left to look — and
-  that case is unchanged by this fix. (#362)
+  untouched. This fix closes the case where the strings exist but were being looked for in the wrong folder. It does
+  not change what happens when the lookup finds nothing wherever it looks — a plugin whose strings are in *neither*
+  place, for instance — and such a plugin still reads, and writes, empty. (#362)
 
 - **`housecarl_merge_plugins` now accepts a single donor, which renames a plugin.** Merging one plugin into a new
   name was refused ("merge needs at least TWO distinct donor plugins"), and no other tool renames one, so a

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -33,7 +33,13 @@ when it changes.
   the plugin's own folder carries no strings source at all, and **any** `.bsa` sitting beside the plugin counts as one
   — whatever that archive actually holds. A localized plugin in a mod folder that ships an asset-only `.bsa`, with its
   `.STRINGS` served from elsewhere, is therefore still read the old way and still writes blanks. So is a plugin whose
-  strings are in neither place. Both are unchanged by this fix. (#362)
+  strings are in neither place.
+
+  One case inside `housecarl_compact_plugin` is also untouched, and it is the worst of the three: with
+  `in_place=true` and `repoint_externals=true`, the pass that rewrites each **external referencer** still opens it the
+  old way and writes it back over the user's own file. A localized referencer loses every name and description
+  permanently — in place, on a plugin the user did not ask to compact, with the same silence this entry describes as
+  the bug. Tracked as #368. All three cases are unchanged by this fix. (#362)
 
 - **`housecarl_merge_plugins` now accepts a single donor, which renames a plugin.** Merging one plugin into a new
   name was refused ("merge needs at least TWO distinct donor plugins"), and no other tool renames one, so a

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -666,6 +666,14 @@ public sealed class LoadOrderResolver : IDisposable
         public string? PluginPath(string pluginName)
             => _r._nameToIdx.TryGetValue(pluginName, out int idx) ? _r._paths[idx] : null;
 
+        /// <summary>The real game-Data folder this order resolved — see <see cref="LoadOrderResolver.DataDir"/>. Paired
+        /// with <see cref="PluginPath"/>: a caller OUTSIDE this assembly that opens a plugin file itself must pass this
+        /// to <see cref="LoadOrderResolver.OpenOverlay"/>, or a localized plugin whose own folder carries no strings
+        /// source reads every TranslatedString EMPTY (the HCBR-2026-06-24 class). The resolver's own DataDir is
+        /// internal, so the write lanes that hold a captured view — merge and compact, which open donor/source plugins
+        /// directly — reach it here.</summary>
+        public string? DataDir => _r.DataDir;
+
         /// <summary>O(1): the winning plugin + override depth for a FormKey. null if the FormKey isn't in the order.</summary>
         public WinnerInfo? ResolveWinner(FormKey fk)
             => _s.Index.TryGetValue(fk, out var e) ? new WinnerInfo(fk, _r._names[e.winner], e.count) : null;

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -2486,7 +2486,7 @@ public static class WritePatchBuilder
     /// </summary>
     public static CompactBuildResult CompactBuild(
         string srcPath, ModKey modKey, IReadOnlyDictionary<FormKey, FormKey> dict,
-        Func<string, string?> resolveMasterPath, string outPath, bool esl, uint floor)
+        Func<string, string?> resolveMasterPath, string outPath, bool esl, uint floor, string? dataDir)
     {
         // 1. Build P′ in memory, then DISPOSE the source overlay (the in-place lane overwrites srcPath — its handle must
         //    be released before the atomic swap).
@@ -2496,7 +2496,12 @@ public static class WritePatchBuilder
         ISkyrimModGetter? srcOv = null;
         try
         {
-            srcOv = SkyrimMod.CreateFromBinaryOverlay(srcPath, SkyrimRelease.SkyrimSE);
+            // The strings-aware factory, not a bare open (#362): a LOCALIZED source whose own folder carries no strings
+            // source reads every TranslatedString EMPTY (the HCBR-2026-06-24 class OpenOverlay exists for) — and the
+            // renumber below copies those empty values into P′, which is then written with the blanks baked in. The
+            // in-place lane already routes through here for its read-back; the compact SOURCE open is the same hazard
+            // one step earlier, where the loss is written rather than merely displayed.
+            srcOv = LoadOrderResolver.OpenOverlay(srcPath, dataDir);
             declaredMasters = srcOv.ModHeader.MasterReferences.Select(m => m.Master.FileName.String).ToList();
             pPrime = new SkyrimMod(modKey, SkyrimRelease.SkyrimSE) { IsSmallMaster = esl };
             ren = RemapEngine.RenumberModInto(pPrime, srcOv, dict);
@@ -2586,7 +2591,7 @@ public static class WritePatchBuilder
     public static MergeBuildResult MergeBuild(
         IReadOnlyList<(string Name, string Path, ModKey Key)> donorsByLoadOrder, ModKey outKey,
         IReadOnlyDictionary<FormKey, FormKey> dict, IReadOnlyList<string> masters,
-        Func<string, string?> resolveMasterPath, string outPath)
+        Func<string, string?> resolveMasterPath, string outPath, string? dataDir)
     {
         // 1. Open every donor overlay, build M in memory, dispose the donors before the write (no handle at rest;
         //    merge never writes over a donor, but the discipline is uniform).
@@ -2603,7 +2608,10 @@ public static class WritePatchBuilder
             foreach (var (name, path, _) in donorsByLoadOrder)
             {
                 ISkyrimModGetter ov;
-                try { ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE); }
+                // The strings-aware factory, not a bare open (#362): a LOCALIZED donor whose own folder carries no
+                // strings source reads every TranslatedString EMPTY (the HCBR-2026-06-24 class OpenOverlay exists for),
+                // and the merge below copies those empty values into M, which is then written with the blanks baked in.
+                try { ov = LoadOrderResolver.OpenOverlay(path, dataDir); }
                 catch (Exception ex)
                 {
                     return MergeBuildResult.Fail($"cannot open donor '{name}' to merge it ({WriteEngine.Describe(ex)}) — nothing written.");

--- a/src/housecarl-generator/CompactServiceGuardProbe.cs
+++ b/src/housecarl-generator/CompactServiceGuardProbe.cs
@@ -25,6 +25,12 @@ namespace HousecarlGenerator;
 ///   FLAG-ONLY — an override-only plugin: esl=true copies verbatim + sets the light flag (renum 0); esl=false refuses.
 ///   CONSENT   — in_place + repoint without acknowledge returns the CONFIRM prompt (no write); WITH acknowledge it
 ///               compacts the target IN PLACE and repoints the external referencer to the new key (the full opt-in path).
+///   LOCALIZED — (#362) a source whose .STRINGS live in the game-Data folder rather than its own mod folder keeps its
+///               FULL+DESC through the compact. Its own instance: the fixture turns on a game-Data Skyrim.esm, which
+///               the order above has none of. A baseline arm reads the source with the BARE overlay first and requires
+///               it to come back EMPTY — without that, the arm would pass on a fixture that was never localized. A
+///               further arm pins that P′ is written non-localized with its strings inline, which is what makes the
+///               read-back a read of the written bytes.
 /// Run: dotnet run --project src/housecarl-generator compact-service-guard
 /// </summary>
 public static class CompactServiceGuardProbe
@@ -250,6 +256,45 @@ public static class CompactServiceGuardProbe
                                  && depRefAfter == libWeapAfter
                                  && o.Repointed.Count == 1 && o.Repointed[0].Success;
                 Check(repointOk, $"CONSENT in_place+repoint with ack: Lib weapon -> {libWeapAfter}, Dep ref -> {depRefAfter}, repointed {o.Repointed.Count(r => r.Success)}/{o.Repointed.Count}{(o.Success ? "" : "; ERR " + o.Error)}");
+            }
+
+            // ---- LOCALIZED (#362): a source whose .STRINGS live in the game-Data folder, not its own mod folder ----
+            //      Its own instance, because the fixture's load-bearing part is a game-Data Skyrim.esm (see
+            //      LocalizedStringsFixture) and the order above deliberately has none.
+            {
+                var locRoot = Path.Combine(root, "loc");
+                var ls = new LocalizedStringsFixture.Spec("LocSrc", new ModKey("HcCsLoc", ModType.Plugin), "LOC NAME", "LOC DESC");
+                var fx = LocalizedStringsFixture.Build(locRoot, new[] { ls });
+                var locStore = new UserConfigStore(Path.Combine(locRoot, "houseCARL.user.json"));
+                using var locSvc = LoadOrderService.WithInstance(fx.Instance, 0, locStore);
+                locSvc.Stats();
+
+                // The fixture really is the blanking shape — see the twin arm in merge-service-guard for why this is
+                // not optional: without it the arms below pass on a fixture that was never localized.
+                var srcPath = Path.Combine(fx.Mods, ls.ModFolder, ls.Key.FileName.String);
+                var bare = LocalizedStringsFixture.ReadBackBare(srcPath, LocalizedStringsFixture.WeaponEdid(ls));
+                Check(string.IsNullOrEmpty(bare.Name) && string.IsNullOrEmpty(bare.Desc),
+                    $"LOCALIZED fixture: the source read with the BARE overlay is blank (Name='{bare.Name}' Desc='{bare.Desc}')");
+
+                var o = locSvc.CompactPlugin(ls.Key.FileName.String);
+                var rb = o.Success && File.Exists(o.OutputPath)
+                    ? LocalizedStringsFixture.ReadBackBare(o.OutputPath, LocalizedStringsFixture.WeaponEdid(ls))
+                    : (Name: null, Desc: null);
+                Check(o.Success && rb.Name == ls.Name && rb.Desc == ls.Desc,
+                    $"LOCALIZED compact carries FULL+DESC into P′ (Name='{rb.Name}' Desc='{rb.Desc}'{(o.Success ? "" : ", ERR " + o.Error)})");
+
+                // The compacted output is a bare SkyrimMod too — non-localized, strings inline. Same reasoning as the
+                // merge guard's twin: it is what makes the read-back above a read of the bytes rather than of a
+                // folder-adjacent lookup, and it rules out compact shipping a localized plugin with no strings.
+                bool flagOk = false, noStringsFolder = false;
+                if (o.Success && File.Exists(o.OutputPath))
+                {
+                    using var ov = SkyrimMod.CreateFromBinaryOverlay(o.OutputPath, SkyrimRelease.SkyrimSE);
+                    flagOk = !ov.UsingLocalization;
+                    noStringsFolder = !Directory.Exists(Path.Combine(Path.GetDirectoryName(o.OutputPath)!, "Strings"));
+                }
+                Check(flagOk && noStringsFolder,
+                    $"LOCALIZED compact output is written NON-localized with strings inline (flagClear={flagOk} noStringsFolder={noStringsFolder})");
             }
         }
         finally { try { Directory.Delete(root, true); } catch { } }

--- a/src/housecarl-generator/CompactServiceGuardProbe.cs
+++ b/src/housecarl-generator/CompactServiceGuardProbe.cs
@@ -130,6 +130,18 @@ public static class CompactServiceGuardProbe
                 }
                 Check(o.Success && !o.InPlace && o.Esl && o.RecordsRenumbered == 3 && o.ExternalPlugins.Count == 0 && windowOk && lightOk,
                     $"CLEAN new-file compact (renum {o.RecordsRenumbered}, inWindow {windowOk}, light {lightOk}, ext {o.ExternalPlugins.Count}{(o.Success ? "" : "; ERR " + o.Error)})");
+
+                // The runtime distributor layer addresses records by FormID, which is exactly what a compaction moves,
+                // and the identify pass reads plugins only — so the report says both, on every compaction rather than
+                // only when the external-referencer list came back populated (this one is the clean case, and it is
+                // still the case where a _DISTR.ini goes quietly dead).
+                var rendered = WriteTools.RenderCompact(o);
+                Check(rendered.Contains("does not read INI distributor configs (SPID/KID/SkyPatcher/OAR)")
+                      && rendered.Contains("address a record as <plugin>|<FormID>")
+                      && rendered.Contains("The plugin name is unchanged")
+                      && rendered.Contains("no longer addresses that record")
+                      && rendered.Contains("nothing rewrites the .ini files"),
+                    "CLEAN the distributor-config loss is stated beside the identify-pass coverage");
             }
 
             // ---- ESL-OFF: esl=false -> renumbered, NOT light-flagged ----

--- a/src/housecarl-generator/CompactServiceGuardProbe.cs
+++ b/src/housecarl-generator/CompactServiceGuardProbe.cs
@@ -136,18 +136,10 @@ public static class CompactServiceGuardProbe
                 // only when the external-referencer list came back populated (this one is the clean case, and it is
                 // still the case where a _DISTR.ini goes quietly dead).
                 var rendered = WriteTools.RenderCompact(o);
-                Check(rendered.Contains("SPID/KID/SkyPatcher .ini lines, Open Animation Replacer .json conditions")
-                      && rendered.Contains("address a record through the plugin that defines it plus its FormID")
-                      && rendered.Contains("The plugin name is unchanged")
-                      && rendered.Contains("stops addressing that record once the compacted plugin is the one loading")
-                      && rendered.Contains("nothing rewrites those files"),
-                    "CLEAN the distributor-config loss is stated beside the identify-pass coverage");
-                // Two ways this sentence could go wrong and still read fluently. It must not quote one system's
-                // spelling as if the four shared one (they do not — see the twin arm in merge-service-guard), and in
-                // THIS lane it must not claim a break that has not happened: the compacted plugin is a new file, the
-                // original is still active, and every config line still matches until the MO2 swap instructed above.
-                Check(!rendered.Contains("<plugin>|<FormID>") && !rendered.Contains("no longer addresses that record"),
-                    "CLEAN the sentence quotes no single spelling, and claims no break before the swap");
+                // PRESENCE, against the shared constant — see the twin arm in merge-service-guard for why the absence
+                // assertions this replaces were worthless.
+                Check(rendered.Contains(WriteSentences.CompactRuntimeConfigs),
+                    "CLEAN the runtime-config loss reaches user output, verbatim from the shared sentence");
             }
 
             // ---- ESL-OFF: esl=false -> renumbered, NOT light-flagged ----

--- a/src/housecarl-generator/CompactServiceGuardProbe.cs
+++ b/src/housecarl-generator/CompactServiceGuardProbe.cs
@@ -136,12 +136,18 @@ public static class CompactServiceGuardProbe
                 // only when the external-referencer list came back populated (this one is the clean case, and it is
                 // still the case where a _DISTR.ini goes quietly dead).
                 var rendered = WriteTools.RenderCompact(o);
-                Check(rendered.Contains("does not read INI distributor configs (SPID/KID/SkyPatcher/OAR)")
-                      && rendered.Contains("address a record as <plugin>|<FormID>")
+                Check(rendered.Contains("SPID/KID/SkyPatcher .ini lines, Open Animation Replacer .json conditions")
+                      && rendered.Contains("address a record through the plugin that defines it plus its FormID")
                       && rendered.Contains("The plugin name is unchanged")
-                      && rendered.Contains("no longer addresses that record")
-                      && rendered.Contains("nothing rewrites the .ini files"),
+                      && rendered.Contains("stops addressing that record once the compacted plugin is the one loading")
+                      && rendered.Contains("nothing rewrites those files"),
                     "CLEAN the distributor-config loss is stated beside the identify-pass coverage");
+                // Two ways this sentence could go wrong and still read fluently. It must not quote one system's
+                // spelling as if the four shared one (they do not — see the twin arm in merge-service-guard), and in
+                // THIS lane it must not claim a break that has not happened: the compacted plugin is a new file, the
+                // original is still active, and every config line still matches until the MO2 swap instructed above.
+                Check(!rendered.Contains("<plugin>|<FormID>") && !rendered.Contains("no longer addresses that record"),
+                    "CLEAN the sentence quotes no single spelling, and claims no break before the swap");
             }
 
             // ---- ESL-OFF: esl=false -> renumbered, NOT light-flagged ----

--- a/src/housecarl-generator/LocalizedStringsFixture.cs
+++ b/src/housecarl-generator/LocalizedStringsFixture.cs
@@ -87,7 +87,11 @@ internal static class LocalizedStringsFixture
             {
                 var target = Path.Combine(data, "Strings");
                 Directory.CreateDirectory(target);
-                foreach (var f in Directory.EnumerateFiles(own)) File.Move(f, Path.Combine(target, Path.GetFileName(f)));
+                // GetFiles, not EnumerateFiles: the loop MOVES files out of the directory it is walking, and a lazy
+                // enumerator can skip an entry under that mutation — which the Delete below would then destroy rather
+                // than relocate. It fails toward a RED arm rather than a false green, but a flaky fixture is worse
+                // than either.
+                foreach (var f in Directory.GetFiles(own)) File.Move(f, Path.Combine(target, Path.GetFileName(f)));
                 Directory.Delete(own, true);
             }
         }
@@ -110,5 +114,15 @@ internal static class LocalizedStringsFixture
         using var ov = SkyrimMod.CreateFromBinaryOverlay(pluginPath, SkyrimRelease.SkyrimSE);
         var w = ov.Weapons.FirstOrDefault(x => x.EditorID == weaponEdid);
         return (w?.Name?.String, w?.Description?.String);
+    }
+
+    /// <summary>Whether the written plugin carries the weapon at all. An arm whose expectation is a BLANK string needs
+    /// this: <see cref="ReadBackBare"/> answers (null, null) both for "the record is present and its strings did not
+    /// resolve" and for "the record is not there", and only the first is the state such an arm means to pin. Without
+    /// it, a change that dropped the record entirely would read as the pinned behaviour.</summary>
+    internal static bool CarriesWeapon(string pluginPath, string weaponEdid)
+    {
+        using var ov = SkyrimMod.CreateFromBinaryOverlay(pluginPath, SkyrimRelease.SkyrimSE);
+        return ov.Weapons.Any(x => x.EditorID == weaponEdid);
     }
 }

--- a/src/housecarl-generator/LocalizedStringsFixture.cs
+++ b/src/housecarl-generator/LocalizedStringsFixture.cs
@@ -1,0 +1,114 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// Shared fixture for the localized-strings arms of the merge and compact service guards (#362). Builds a synthetic MO2
+/// instance in the shape the bug needs and nothing else:
+///
+///   • a real (empty) <c>Skyrim.esm</c> in the game-Data folder — WITHOUT it <c>LoadOrderResolver.ComputeDataDir</c>
+///     returns null, every <c>OpenOverlay</c> silently degrades to the folder-adjacent default, and an arm built on a
+///     Skyrim.esm-less order would pass whether or not the fix is present. It is the load-bearing part of the fixture.
+///   • one localized plugin per spec, each in its OWN MO2 mod folder, carrying a weapon with a localized
+///     <c>Name</c>/<c>Description</c>. Mutagen writes the <c>.STRINGS</c>/<c>.DLSTRINGS</c>/<c>.ILSTRINGS</c> beside the
+///     plugin; this fixture then MOVES them into the game-Data <c>Strings\</c> folder, which is what makes each plugin a
+///     localized plugin whose own folder carries no strings source — the "Cleaned Base Game Masters" / translation-mod
+///     pattern, and exactly the read the bare overlay gets wrong.
+///
+/// A spec with <see cref="Spec.StringsNowhere"/> has its strings DELETED instead of relocated: the residual case, where
+/// the strings exist in neither the plugin's own folder nor game-Data, so no <c>dataDir</c> can resolve them.
+/// </summary>
+internal static class LocalizedStringsFixture
+{
+    /// <param name="ModFolder">The MO2 mod folder to create (also the plugin's mod-folder name in modlist.txt).</param>
+    /// <param name="Key">The plugin's ModKey.</param>
+    /// <param name="Name">The localized FULL the weapon carries.</param>
+    /// <param name="Desc">The localized DESC the weapon carries.</param>
+    /// <param name="StringsNowhere">Delete the strings rather than relocating them to game-Data (the residual case).</param>
+    internal sealed record Spec(string ModFolder, ModKey Key, string Name, string Desc, bool StringsNowhere = false);
+
+    /// <param name="Instance">The MO2 instance dir to hand <c>LoadOrderService.WithInstance</c>.</param>
+    /// <param name="Mods">The instance's mods dir.</param>
+    /// <param name="Data">The game-Data dir — what the resolver's DataDir must resolve to.</param>
+    internal sealed record Built(string Instance, string Mods, string Data);
+
+    /// <summary>The EditorID of the localized weapon in the plugin built from <paramref name="spec"/> — the handle every
+    /// arm reads back by, since a merge/compact renumbers the FormKey but never the EditorID.</summary>
+    internal static string WeaponEdid(Spec spec) => spec.Key.Name + "Weap";
+
+    /// <summary>Build the instance under <paramref name="root"/>. The specs are listed in load order, after Skyrim.esm.</summary>
+    internal static Built Build(string root, IReadOnlyList<Spec> specs)
+    {
+        string instance = Path.Combine(root, "instance");
+        string profiles = Path.Combine(instance, "profiles", "Default");
+        string mods = Path.Combine(instance, "mods");
+        string data = Path.Combine(root, "game", "Data");
+        Directory.CreateDirectory(profiles); Directory.CreateDirectory(mods); Directory.CreateDirectory(data);
+        File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(root, "game").Replace(@"\", @"\\") + ")\r\n");
+
+        // Skyrim.esm in the game-Data folder — the anchor ComputeDataDir derives DataDir from. Real (an empty SkyrimMod),
+        // not a stub text file: the index would class an unopenable plugin as excluded, which is a different fixture.
+        var skyrimKey = new ModKey("Skyrim", ModType.Master);
+        new SkyrimMod(skyrimKey, SkyrimRelease.SkyrimSE)
+            .BeginWrite.ToPath(Path.Combine(data, skyrimKey.FileName.String))
+            .WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+        foreach (var spec in specs)
+        {
+            var modDir = Path.Combine(mods, spec.ModFolder);
+            Directory.CreateDirectory(modDir);
+
+            var m = new SkyrimMod(spec.Key, SkyrimRelease.SkyrimSE) { UsingLocalization = true };
+            m.Weapons.Add(new Weapon(new FormKey(spec.Key, 0xA01), SkyrimRelease.SkyrimSE)
+            {
+                EditorID = WeaponEdid(spec),
+                Name = spec.Name,
+                Description = spec.Desc,
+                BasicStats = new WeaponBasicStats { Damage = 7 },
+            });
+            m.ModHeader.Stats.NextFormID = 0xA02;
+            m.BeginWrite.ToPath(Path.Combine(modDir, spec.Key.FileName.String))
+                .WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write();
+
+            // The plugin now has its strings beside it, which is the state the bare overlay reads CORRECTLY. Move them
+            // out (or drop them) so the plugin's own folder carries no strings source — the state under test.
+            var own = Path.Combine(modDir, "Strings");
+            if (!Directory.Exists(own))
+                throw new InvalidOperationException(
+                    $"fixture: '{spec.Key.FileName}' was written with UsingLocalization but produced no Strings folder — " +
+                    "the fixture would then be a NON-localized plugin and every arm below would pass vacuously.");
+            if (spec.StringsNowhere) Directory.Delete(own, true);
+            else
+            {
+                var target = Path.Combine(data, "Strings");
+                Directory.CreateDirectory(target);
+                foreach (var f in Directory.EnumerateFiles(own)) File.Move(f, Path.Combine(target, Path.GetFileName(f)));
+                Directory.Delete(own, true);
+            }
+        }
+
+        var order = new[] { skyrimKey.FileName.String }.Concat(specs.Select(s => s.Key.FileName.String)).ToArray();
+        File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + string.Join("\r\n", order) + "\r\n");
+        File.WriteAllText(Path.Combine(profiles, "plugins.txt"), string.Join("\r\n", order.Select(o => "*" + o)) + "\r\n");
+        File.WriteAllText(Path.Combine(profiles, "modlist.txt"),
+            "# header\r\n" + string.Join("\r\n", specs.Reverse().Select(s => "+" + s.ModFolder)) + "\r\n");
+
+        return new Built(instance, mods, data);
+    }
+
+    /// <summary>Read a written plugin's weapon FULL/DESC back with the BARE overlay — deliberately bare, and deliberately
+    /// from the OUTPUT's own folder. Merge and compact both build a fresh, NON-localized <c>SkyrimMod</c>, so a correct
+    /// output carries its strings INLINE and this read must see them with no dataDir and no strings folder anywhere near
+    /// it. A read that comes back empty here is the blanking #362 describes, whichever end produced it.</summary>
+    internal static (string? Name, string? Desc) ReadBackBare(string pluginPath, string weaponEdid)
+    {
+        using var ov = SkyrimMod.CreateFromBinaryOverlay(pluginPath, SkyrimRelease.SkyrimSE);
+        var w = ov.Weapons.FirstOrDefault(x => x.EditorID == weaponEdid);
+        return (w?.Name?.String, w?.Description?.String);
+    }
+}

--- a/src/housecarl-generator/MergeServiceGuardProbe.cs
+++ b/src/housecarl-generator/MergeServiceGuardProbe.cs
@@ -316,6 +316,14 @@ public static class MergeServiceGuardProbe
                 Check(rendered.Contains("it reads record links and record identity, NOT declared masters")
                       && rendered.Contains("only lists a donor as a master"),
                     "WARN the identify-pass line states what the pass does NOT read");
+                // "Not read" is not the same fact as "and here is what that costs". The runtime distributor layer
+                // addresses records by plugin name, which a merge takes away, so the loss is stated as well as the
+                // gap in coverage — on every merge, not only when the referencer list came back populated.
+                Check(rendered.Contains("SkyPatcher/OAR")
+                      && rendered.Contains("address a record as <plugin>|<FormID>")
+                      && rendered.Contains("stops matching once you deactivate that donor at the swap")
+                      && rendered.Contains("nothing rewrites the .ini files"),
+                    "WARN the distributor-config loss is stated, not just the pass's blindness to it");
                 // The swap instruction must stay PLUGIN-level (PR #158 independent review #1): "disable the donor MODS"
                 // (compact's instruction) would yank the donors' path-referenced assets out of the VFS — the merged
                 // records still load meshes/textures/scripts from the donor folders.

--- a/src/housecarl-generator/MergeServiceGuardProbe.cs
+++ b/src/housecarl-generator/MergeServiceGuardProbe.cs
@@ -43,6 +43,16 @@ namespace HousecarlGenerator;
 ///   REFUSE    — ZERO donors / unknown donor / output already active / output == donor / .esl output, all loud,
 ///               nothing written.
 ///   UNTOUCHED — the donor files are byte-identical after the merge (new-file lane only).
+///   LOCALIZED — (#362) donors whose .STRINGS live in the game-Data folder rather than their own mod folder keep their
+///               FULL+DESC through the merge, in BOTH the rename and the combine shape (one fix, no donor-count
+///               conditional). Its own instance: the fixture turns on a game-Data Skyrim.esm, which the order above
+///               has none of. A baseline arm reads the donor with the BARE overlay first and requires it to come back
+///               EMPTY — without that, every arm here would pass on a fixture that was never localized. A further arm
+///               pins that the OUTPUT is written non-localized with its strings inline, which is what makes the
+///               read-backs a read of the written bytes.
+///   RESIDUAL  — (#362, measured not fixed) a donor whose strings are in NEITHER place: OpenOverlay's fallback is
+///               game-Data and nothing else, so no dataDir resolves it, and the merge still writes blanks and still
+///               reports success. Pinned as the current behaviour so the residual is measured rather than asserted.
 /// Run: dotnet run --project src/housecarl-generator merge-service-guard
 /// </summary>
 public static class MergeServiceGuardProbe
@@ -566,6 +576,92 @@ public static class MergeServiceGuardProbe
                 Check(oCase.Success && oCase.Donors.Count == 1 && oCase.Conflicts.Count == 0
                       && WriteTools.RenderMerge(oCase).Contains("a RENAME of"),
                     $"RENAME donor names differing only by CASE are ONE donor ({(oCase.Success ? $"{oCase.Donors.Count} donor, {oCase.Conflicts.Count} conflicts" : "ERR " + oCase.Error)})");
+            }
+
+            // ---- LOCALIZED (#362): donors whose .STRINGS live in the game-Data folder, not their own mod folder ----
+            //      Its own instance, because the fixture's load-bearing part is a game-Data Skyrim.esm (see
+            //      LocalizedStringsFixture) and the order above deliberately has none.
+            {
+                var locRoot = Path.Combine(root, "loc");
+                var la = new LocalizedStringsFixture.Spec("LocA", new ModKey("HcMgLocA", ModType.Plugin), "LOC A NAME", "LOC A DESC");
+                var lb = new LocalizedStringsFixture.Spec("LocB", new ModKey("HcMgLocB", ModType.Plugin), "LOC B NAME", "LOC B DESC");
+                var fx = LocalizedStringsFixture.Build(locRoot, new[] { la, lb });
+                var locStore = new UserConfigStore(Path.Combine(locRoot, "houseCARL.user.json"));
+                using var locSvc = LoadOrderService.WithInstance(fx.Instance, 0, locStore);
+                locSvc.Stats();
+
+                // The fixture really is the blanking shape: read the donor ON DISK with the bare overlay and it comes
+                // back empty. Without this arm every arm below would pass just as well on a non-localized fixture, or
+                // on one whose strings never left the mod folder — the two ways this fixture could go quietly vacuous.
+                var donorPath = Path.Combine(fx.Mods, la.ModFolder, la.Key.FileName.String);
+                var bare = LocalizedStringsFixture.ReadBackBare(donorPath, LocalizedStringsFixture.WeaponEdid(la));
+                Check(string.IsNullOrEmpty(bare.Name) && string.IsNullOrEmpty(bare.Desc),
+                    $"LOCALIZED fixture: the donor read with the BARE overlay is blank (Name='{bare.Name}' Desc='{bare.Desc}')");
+
+                // RENAME — the single-donor shape (#345). Every localized value in the plugin rides on this one open,
+                // so a bare open here blanks the whole renamed plugin.
+                {
+                    var lo = locSvc.MergePlugins(new[] { la.Key.FileName.String }, "HcMgLocRen.esp");
+                    var rb = lo.Success && File.Exists(lo.OutputPath)
+                        ? LocalizedStringsFixture.ReadBackBare(lo.OutputPath, LocalizedStringsFixture.WeaponEdid(la))
+                        : (Name: null, Desc: null);
+                    Check(lo.Success && rb.Name == la.Name && rb.Desc == la.Desc,
+                        $"LOCALIZED single-donor merge (RENAME) carries FULL+DESC (Name='{rb.Name}' Desc='{rb.Desc}'{(lo.Success ? "" : ", ERR " + lo.Error)})");
+                }
+
+                // COMBINE — the multi-donor shape, both donors localized: neither is blanked, and the fix is not
+                // keyed on donor count (settled decision 4 — one fix, no shape conditional).
+                {
+                    var lo = locSvc.MergePlugins(new[] { la.Key.FileName.String, lb.Key.FileName.String }, "HcMgLocComb.esp");
+                    var rbA = lo.Success && File.Exists(lo.OutputPath)
+                        ? LocalizedStringsFixture.ReadBackBare(lo.OutputPath, LocalizedStringsFixture.WeaponEdid(la))
+                        : (Name: null, Desc: null);
+                    var rbB = lo.Success && File.Exists(lo.OutputPath)
+                        ? LocalizedStringsFixture.ReadBackBare(lo.OutputPath, LocalizedStringsFixture.WeaponEdid(lb))
+                        : (Name: null, Desc: null);
+                    Check(lo.Success && rbA.Name == la.Name && rbA.Desc == la.Desc && rbB.Name == lb.Name && rbB.Desc == lb.Desc,
+                        $"LOCALIZED multi-donor merge carries FULL+DESC for EVERY donor (A='{rbA.Name}'/'{rbA.Desc}' B='{rbB.Name}'/'{rbB.Desc}'{(lo.Success ? "" : ", ERR " + lo.Error)})");
+                }
+
+                // OUTPUT-NOT-LOCALIZED — the written merge is a bare SkyrimMod, so it carries no localized header flag
+                // and its strings are inline. This is what makes every read-back above legitimate with no dataDir and
+                // no Strings folder beside the output: if the output were flagged localized without a strings writer,
+                // the reads would be measuring a folder-adjacent lookup instead of the bytes, and a merge would be
+                // shipping a plugin whose strings live nowhere.
+                {
+                    var lo = locSvc.MergePlugins(new[] { la.Key.FileName.String }, "HcMgLocFlag.esp");
+                    bool flagOk = false, noStringsFolder = false;
+                    if (lo.Success && File.Exists(lo.OutputPath))
+                    {
+                        using var ov = SkyrimMod.CreateFromBinaryOverlay(lo.OutputPath, SkyrimRelease.SkyrimSE);
+                        flagOk = !ov.UsingLocalization;
+                        noStringsFolder = !Directory.Exists(Path.Combine(Path.GetDirectoryName(lo.OutputPath)!, "Strings"));
+                    }
+                    Check(flagOk && noStringsFolder,
+                        $"LOCALIZED output is written NON-localized with strings inline (flagClear={flagOk} noStringsFolder={noStringsFolder})");
+                }
+            }
+
+            // ---- RESIDUAL (#362, measured not fixed): a localized donor whose strings exist NEITHER beside it NOR in
+            //      game-Data. OpenOverlay's fallback is the game-Data folder and nothing else, so there is no dataDir
+            //      that resolves this one — the merge still succeeds and still writes blanks, with no warning. Pinned
+            //      here so the residual is a measured fact in the PR rather than a claim, and so a later change to it
+            //      is a deliberate one. Asserting the CURRENT behaviour, not endorsing it.
+            {
+                var resRoot = Path.Combine(root, "res");
+                var lr = new LocalizedStringsFixture.Spec("LocGone", new ModKey("HcMgLocGone", ModType.Plugin),
+                    "GONE NAME", "GONE DESC", StringsNowhere: true);
+                var fx = LocalizedStringsFixture.Build(resRoot, new[] { lr });
+                var resStore = new UserConfigStore(Path.Combine(resRoot, "houseCARL.user.json"));
+                using var resSvc = LoadOrderService.WithInstance(fx.Instance, 0, resStore);
+                resSvc.Stats();
+
+                var lo = resSvc.MergePlugins(new[] { lr.Key.FileName.String }, "HcMgResRen.esp");
+                var rb = lo.Success && File.Exists(lo.OutputPath)
+                    ? LocalizedStringsFixture.ReadBackBare(lo.OutputPath, LocalizedStringsFixture.WeaponEdid(lr))
+                    : (Name: "unwritten", Desc: "unwritten");
+                Check(lo.Success && string.IsNullOrEmpty(rb.Name) && string.IsNullOrEmpty(rb.Desc),
+                    $"RESIDUAL strings resolvable NOWHERE still merge to blanks, silently (success={lo.Success} Name='{rb.Name}' Desc='{rb.Desc}')");
             }
         }
         finally { try { Directory.Delete(root, true); } catch { } }

--- a/src/housecarl-generator/MergeServiceGuardProbe.cs
+++ b/src/housecarl-generator/MergeServiceGuardProbe.cs
@@ -316,22 +316,18 @@ public static class MergeServiceGuardProbe
                 Check(rendered.Contains("it reads record links and record identity, NOT declared masters")
                       && rendered.Contains("only lists a donor as a master"),
                     "WARN the identify-pass line states what the pass does NOT read");
-                // "Not read" is not the same fact as "and here is what that costs". The runtime distributor layer
-                // addresses records by plugin name, which a merge takes away, so the loss is stated as well as the
-                // gap in coverage — on every merge, not only when the referencer list came back populated.
-                Check(rendered.Contains("SPID/KID/SkyPatcher .ini lines")
-                      && rendered.Contains("Open Animation Replacer .json conditions")
-                      && rendered.Contains("address a record through the plugin that defines it")
-                      && rendered.Contains("stops matching once you deactivate that donor at the swap")
-                      && rendered.Contains("Nothing rewrites those files"),
-                    "WARN the distributor-config loss is stated, not just the pass's blindness to it");
-                // The sentence must state the addressing MODEL and never one system's literal spelling. The four named
-                // systems do not share one: SkyPatcher is prefix-pipe, SPID and KID are suffix-tilde, OAR is a JSON
-                // field pair — and spid-authoring's skill lists confusing the first two as a known trap. A caller told
-                // to look for Plugin.esp|FormID would grep for a string three of the four never contain and conclude
-                // they were unaffected, which is the failure the sentence exists to prevent.
-                Check(!rendered.Contains("<plugin>|<FormID>") && !rendered.Contains("the .ini files"),
-                    "WARN the sentence quotes no single spelling as if the four shared one");
+                // "Not read" is not the same fact as "and here is what that costs" — the loss is stated as well as the
+                // gap in coverage, on every merge rather than only when the referencer list came back populated.
+                //
+                // PRESENCE, against the shared constant — not an absence assertion over the open space of things the
+                // sentence might wrongly say. The arms this replaces asserted !Contains("<plugin>|<FormID>"), which
+                // only ever detected the one literal the previous commit wrote: a reviewer quoted a REAL SkyPatcher
+                // spelling and they stayed green. An absence arm over an unbounded string space cannot fail
+                // meaningfully (the winnerTokenFree class). What keeps the sentence honest is the claim rule at its
+                // definition and WriteSurfaceGuardProbe's [MustState] walk; what this arm owes is that the render
+                // actually carries it.
+                Check(rendered.Contains(WriteSentences.MergeRuntimeConfigs),
+                    "WARN the runtime-config loss reaches user output, verbatim from the shared sentence");
                 // The swap instruction must stay PLUGIN-level (PR #158 independent review #1): "disable the donor MODS"
                 // (compact's instruction) would yank the donors' path-referenced assets out of the VFS — the merged
                 // records still load meshes/textures/scripts from the donor folders.
@@ -571,14 +567,13 @@ public static class MergeServiceGuardProbe
                       && renderedOvr.Contains("its 1 override is now served by a plugin under a new name")
                       && !renderedOvr.Contains("records move to the new plugin's identity"),
                     $"RENAME a pure-override donor states the override COUNT it read (copied {oOvr.RecordsCopied}, renumbered {oOvr.RecordsRenumbered})");
-                // The distributor sentence obeys the same rule as the headline above it, on the same donor. This one
-                // originates NOTHING: its single override keeps its master's FormKey, so a config line addressing that
-                // record names the MASTER and the merge does not touch it. A sentence claiming the records are the
-                // output's now would tell this caller to rewrite a line that still works — the report contradicting
-                // its own accounting three lines up.
-                Check(renderedOvr.Contains("a record a donor merely overrode is addressed by its master and is unaffected")
-                      && !renderedOvr.Contains("the records are HcMgOvrRenamed.esp's now"),
-                    "RENAME the distributor sentence exempts overrides instead of claiming every record moved");
+                // The runtime-config sentence carries no per-record claim at all, so it reads identically for a donor
+                // that originates nothing — which is the point. Scoping it to "a line that names a donor" already
+                // excludes a record the donor merely OVERRODE, because such a line names that record's MASTER. An
+                // earlier draft spelled the exemption out and, in doing so, claimed the output owned records this
+                // very donor does not have; the accounting line above is the one that speaks about records.
+                Check(renderedOvr.Contains(WriteSentences.MergeRuntimeConfigs),
+                    "RENAME the runtime-config sentence is unchanged by a donor that originates nothing");
 
                 // The third thing the accounting can say. An empty donor takes neither of the arms above, and the
                 // middle arm used to claim overrides it never read — which was wrong for exactly this plugin.

--- a/src/housecarl-generator/MergeServiceGuardProbe.cs
+++ b/src/housecarl-generator/MergeServiceGuardProbe.cs
@@ -319,11 +319,19 @@ public static class MergeServiceGuardProbe
                 // "Not read" is not the same fact as "and here is what that costs". The runtime distributor layer
                 // addresses records by plugin name, which a merge takes away, so the loss is stated as well as the
                 // gap in coverage — on every merge, not only when the referencer list came back populated.
-                Check(rendered.Contains("SkyPatcher/OAR")
-                      && rendered.Contains("address a record as <plugin>|<FormID>")
+                Check(rendered.Contains("SPID/KID/SkyPatcher .ini lines")
+                      && rendered.Contains("Open Animation Replacer .json conditions")
+                      && rendered.Contains("address a record through the plugin that defines it")
                       && rendered.Contains("stops matching once you deactivate that donor at the swap")
-                      && rendered.Contains("nothing rewrites the .ini files"),
+                      && rendered.Contains("Nothing rewrites those files"),
                     "WARN the distributor-config loss is stated, not just the pass's blindness to it");
+                // The sentence must state the addressing MODEL and never one system's literal spelling. The four named
+                // systems do not share one: SkyPatcher is prefix-pipe, SPID and KID are suffix-tilde, OAR is a JSON
+                // field pair — and spid-authoring's skill lists confusing the first two as a known trap. A caller told
+                // to look for Plugin.esp|FormID would grep for a string three of the four never contain and conclude
+                // they were unaffected, which is the failure the sentence exists to prevent.
+                Check(!rendered.Contains("<plugin>|<FormID>") && !rendered.Contains("the .ini files"),
+                    "WARN the sentence quotes no single spelling as if the four shared one");
                 // The swap instruction must stay PLUGIN-level (PR #158 independent review #1): "disable the donor MODS"
                 // (compact's instruction) would yank the donors' path-referenced assets out of the VFS — the merged
                 // records still load meshes/textures/scripts from the donor folders.
@@ -563,6 +571,14 @@ public static class MergeServiceGuardProbe
                       && renderedOvr.Contains("its 1 override is now served by a plugin under a new name")
                       && !renderedOvr.Contains("records move to the new plugin's identity"),
                     $"RENAME a pure-override donor states the override COUNT it read (copied {oOvr.RecordsCopied}, renumbered {oOvr.RecordsRenumbered})");
+                // The distributor sentence obeys the same rule as the headline above it, on the same donor. This one
+                // originates NOTHING: its single override keeps its master's FormKey, so a config line addressing that
+                // record names the MASTER and the merge does not touch it. A sentence claiming the records are the
+                // output's now would tell this caller to rewrite a line that still works — the report contradicting
+                // its own accounting three lines up.
+                Check(renderedOvr.Contains("a record a donor merely overrode is addressed by its master and is unaffected")
+                      && !renderedOvr.Contains("the records are HcMgOvrRenamed.esp's now"),
+                    "RENAME the distributor sentence exempts overrides instead of claiming every record moved");
 
                 // The third thing the accounting can say. An empty donor takes neither of the arms above, and the
                 // middle arm used to claim overrides it never read — which was wrong for exactly this plugin.
@@ -668,8 +684,13 @@ public static class MergeServiceGuardProbe
                 var rb = lo.Success && File.Exists(lo.OutputPath)
                     ? LocalizedStringsFixture.ReadBackBare(lo.OutputPath, LocalizedStringsFixture.WeaponEdid(lr))
                     : (Name: "unwritten", Desc: "unwritten");
-                Check(lo.Success && string.IsNullOrEmpty(rb.Name) && string.IsNullOrEmpty(rb.Desc),
-                    $"RESIDUAL strings resolvable NOWHERE still merge to blanks, silently (success={lo.Success} Name='{rb.Name}' Desc='{rb.Desc}')");
+                // The record must be THERE and blank. A blank read alone is also what an ABSENT record returns, so
+                // without this the arm would report the residual as pinned even if the merge had dropped the record
+                // altogether — an arm that passes for the wrong reason is the one failure a guard cannot survive.
+                bool carried = lo.Success && File.Exists(lo.OutputPath)
+                               && LocalizedStringsFixture.CarriesWeapon(lo.OutputPath, LocalizedStringsFixture.WeaponEdid(lr));
+                Check(lo.Success && carried && string.IsNullOrEmpty(rb.Name) && string.IsNullOrEmpty(rb.Desc),
+                    $"RESIDUAL strings resolvable NOWHERE still merge to blanks, silently (success={lo.Success} carried={carried} Name='{rb.Name}' Desc='{rb.Desc}')");
             }
         }
         finally { try { Directory.Delete(root, true); } catch { } }

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -2458,6 +2458,14 @@ public static class WriteSurfaceGuardProbe
         // the shared source rather than from this probe.
         foreach (var render in CopyOutcomeRenders()) Observe(render, "{}");
 
+        // ---- merge/compact's runtime-config reminder --------------------------------------------------
+        // One transport, same claim as copy's: "reaches a render". Both verbs' SUCCESS paths run against the real
+        // service in merge-service-guard / compact-service-guard, which is where the sentence's behaviour is pinned;
+        // what those fixtures cannot do is prove the constant is still WIRED, because they live in other probes. The
+        // outcome is constructed and handed to the REAL renderer — the renderer is the code under test, and the
+        // sentence still comes from the shared source rather than from this probe.
+        foreach (var render in MergeCompactOutcomeRenders()) Observe(render, "{}");
+
         // ---- the coverage assertion — what stops this arm being theatre ------------------------------
         var missingText = twins.Select(t => t.Name).Where(n => !seenText.Contains(n)).ToList();
         var missingJson = twins.Select(t => t.Name).Where(n => !seenJson.Contains(n)).ToList();
@@ -2735,6 +2743,28 @@ public static class WriteSurfaceGuardProbe
     /// positive test for an absence, which no value reader can express.)</summary>
     static bool HasRoot(JsonDocument? doc, string member)
         => doc is not null && doc.RootElement.TryGetProperty(member, out _);
+
+    /// <summary>Render one successful merge and one successful compact outcome, so the reach half of the
+    /// <c>[MustState]</c> walk covers the runtime-config reminder both verbs carry. Deliberately the plainest
+    /// outcomes that reach the sentence — it is keyed on neither donor count nor any accounting, so a richer
+    /// fixture would prove nothing more here, and the behavioural arms live in the two service guards.</summary>
+    static List<string> MergeCompactOutcomeRenders()
+    {
+        var outPath = Path.Combine(Path.GetTempPath(), "MergeFolder", "Merged.esp");
+        var merge = new WritePatchBuilder.MergeOutcome(
+            true, null, outPath, "Merged.esp",
+            new[] { "DonorA.esp" }, new[] { "Skyrim.esm" }, 1, 1,
+            Array.Empty<RemapEngine.MergeDonorRemap>(), Array.Empty<RemapEngine.MergeConflict>(),
+            Array.Empty<string>(), Array.Empty<string>(), 3, 0, Array.Empty<string>(), 1024);
+
+        var compactPath = Path.Combine(Path.GetTempPath(), "CompactFolder", "Compacted.esp");
+        var compact = new WritePatchBuilder.CompactOutcome(
+            true, null, false, compactPath, "Compacted.esp", false, true,
+            new[] { "Skyrim.esm" }, 1, 1, 1024,
+            Array.Empty<string>(), Array.Empty<WritePatchBuilder.RepointReport>(), 3, 0, Array.Empty<string>());
+
+        return new List<string> { WriteTools.RenderMerge(merge), WriteTools.RenderCompact(compact) };
+    }
 
     /// <summary>Render copy outcomes covering the sentences the service-level fixture cannot reach. Two of copy's
     /// four pinned sentences describe states the operation prevents — a failed read-back and a self-mastered patch

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -6077,7 +6077,7 @@ public sealed class LoadOrderService : IDisposable
             }
 
             // 6. build + write the compacted plugin.
-            var build = WritePatchBuilder.CompactBuild(srcPath, modKey, remapDict, view.PluginPath, outPath, esl, floor);
+            var build = WritePatchBuilder.CompactBuild(srcPath, modKey, remapDict, view.PluginPath, outPath, esl, floor, view.DataDir);
             if (!build.Success)
             {
                 if (!inPlace && createdFresh) RemoveOrNameRiderResidue(rf);   // a refused build leaves no orphan folder
@@ -6314,7 +6314,7 @@ public sealed class LoadOrderService : IDisposable
 
             // ---- 6. build + write M ----
             var build = WritePatchBuilder.MergeBuild(
-                donorInfos.Select(d => (d.Name, d.Path, d.Key)).ToList(), outKey, plan.Dict, masterSet, view.PluginPath, outPath);
+                donorInfos.Select(d => (d.Name, d.Path, d.Key)).ToList(), outKey, plan.Dict, masterSet, view.PluginPath, outPath, view.DataDir);
             if (!build.Success)
             {
                 if (rf.CreatedFresh) RemoveOrNameRiderResidue(rf);        // a refused build leaves no orphan folder

--- a/src/housecarl-mcp/WriteSentences.cs
+++ b/src/housecarl-mcp/WriteSentences.cs
@@ -135,9 +135,12 @@ internal static class WriteSentences
     //
     // THE CLAIM RULE, and why these two sentences are so bare.
     //
-    // Every clause below states EITHER (i) something this tool itself did or did not do, OR (ii) a break ENTAILED by
-    // what this operation did, scoped by the addressed line's own content. Nothing describes an external grammar.
-    // No quoted syntax, no addressing-model taxonomy, no "each in its own spelling" exhaustiveness.
+    // Every clause below states ONE of exactly three things:
+    //   (i)   something this tool itself did or did not do;
+    //   (ii)  a break ENTAILED by what this operation did, scoped by the addressed line's own content;
+    //   (iii) a per-system fact, stated ONLY where a bundled skill states it verbatim, cited by file and line beside
+    //         the constant — quoted, never derived, and never generalised to the systems whose skills are silent.
+    // Nothing else. No quoted syntax, no addressing-model taxonomy, no exhaustiveness.
     //
     // That rule exists because the earlier drafts kept getting the grammars wrong, one layer at a time. The first
     // claimed all four address a record as <plugin>|<FormID> — true of SkyPatcher alone; SPID and KID are
@@ -155,14 +158,41 @@ internal static class WriteSentences
     // and that no bundled skill documents a fallback keeping such a line matched once that plugin deactivates —
     // SkyPatcher's skill states the opposite outright, that a form it cannot resolve is silently skipped.
 
-    /// <summary>Merge's reminder. The break is entailed by the swap this same report instructs: deactivating a donor
-    /// is what stops a line that NAMES that donor from matching. Deliberately no override/master carve-out — a line
-    /// addressing a record the donor merely overrode names the MASTER, so "names a donor" already excludes it by
-    /// construction, and spelling that out would be a claim about addressing rather than about this operation.</summary>
-    [MustState("Nothing here rewrites those files", "stops matching once you deactivate that donor at the swap")]
+    /// <summary>Merge's reminder.
+    ///
+    /// <para>The middle clause says the records MOVED, and stops there. It used to say a line naming a donor "stops
+    /// matching", which was wrong twice over. Factually: for a line that names the donor as an EXCLUSION — SPID's
+    /// plain-plugin-name Form filter under the <c>-</c> modifier
+    /// (<c>spid-authoring/references/filters.md:97-107</c>), SkyPatcher's <c>filterByModNamesExcluded</c>
+    /// (<c>skypatcher-authoring/references/grammar-core.md:204</c>) — the line does not go dead, its scope WIDENS, and
+    /// the donor's records start receiving exactly what they were excluded from. Over-application is the harder of the
+    /// two symptoms to notice, and the caller was being sent to look for the other one. And structurally: "stops
+    /// matching" is a claim about how those systems EVALUATE a line whose named plugin is gone, which is rule (iii)
+    /// territory with no skill behind it — none documents unresolvable-filter semantics, so the pre-commit check that
+    /// found no fallback was absence of evidence and never reached the exclusion shape at all.</para>
+    ///
+    /// <para>What survives is the operation's own fact: the records now live under the merged plugin's name, so a line
+    /// naming a donor no longer describes them. Direction-neutral by construction — it names neither a dead line nor an
+    /// over-applying one, because which of those a caller gets depends on the system and on the line, and the skills own
+    /// that. Both line shapes are covered on purpose: addressing a record IN the donor and filtering ON the donor are
+    /// the same fact from this side, since both name the plugin the records no longer belong to. Still no override/master
+    /// carve-out — a line naming a record the donor merely overrode names the MASTER, which the scoping excludes already.</para>
+    ///
+    /// <para>The third clause is the only rule-(iii) claim on the surface, and it is SkyPatcher-only for a reason: its
+    /// skill states the filename gate verbatim — <c>Plugin.esm.ini</c> / <c>Plugin.esp.ini</c> load "<i>Only</i> when
+    /// that plugin is active in the load order; otherwise skipped" (<c>grammar-core.md:93</c>, restated at 218-219 as
+    /// deciding "whether the file loads at all"). The generalised form — "any config file named for the donor" — was
+    /// considered and REFUSED: SPID and KID document filename rules with no activity gate, so the general claim is
+    /// underivable from our sources and would be wrong-shaped for a SPID file that merely happens to be named after a
+    /// donor. It earns its place because it is the one break the rest of the sentence cannot reach: every line in that
+    /// file goes dark, including the lines that never mention a donor at all.</para></summary>
+    [MustState("Nothing here rewrites those files", "no longer describes those records", "stops loading at the swap")]
     internal const string MergeRuntimeConfigs =
-        "Nothing here rewrites those files. A line in one of them that names a donor stops matching once you " +
-        "deactivate that donor at the swap.\n";
+        "Nothing here rewrites those files. After the swap a donor's records live under the merged plugin's name, so a " +
+        "line that names a donor — whether to address a record in it or to filter on it — no longer describes those " +
+        "records. Separately, a SkyPatcher config file whose NAME is a donor's filename (Plugin.esp.ini) is read only " +
+        "while that plugin is active, so it stops loading at the swap: every line in it, including the lines that never " +
+        "name a donor.\n";
 
     /// <summary>Compact's. The plugin name survives a compaction, so the half that moves is the object id — and only
     /// the ids this run actually moved, which the accounting above states. "once the compacted plugin is the one

--- a/src/housecarl-mcp/WriteSentences.cs
+++ b/src/housecarl-mcp/WriteSentences.cs
@@ -131,6 +131,50 @@ internal static class WriteSentences
     [MustState("no houseCARL backup or undo")]
     internal const string NoBackupOrUndo = "no houseCARL backup or undo";
 
+    // ---- the runtime-config reminder (merge + compact) -----------------------------------------------
+    //
+    // THE CLAIM RULE, and why these two sentences are so bare.
+    //
+    // Every clause below states EITHER (i) something this tool itself did or did not do, OR (ii) a break ENTAILED by
+    // what this operation did, scoped by the addressed line's own content. Nothing describes an external grammar.
+    // No quoted syntax, no addressing-model taxonomy, no "each in its own spelling" exhaustiveness.
+    //
+    // That rule exists because the earlier drafts kept getting the grammars wrong, one layer at a time. The first
+    // claimed all four address a record as <plugin>|<FormID> — true of SkyPatcher alone; SPID and KID are
+    // suffix-tilde, and spid-authoring's own skill lists confusing those two as a known trap ("a SkyPatcher-style ID
+    // won't resolve"), while OAR is not an .ini at all. The correction claimed they address "through the plugin that
+    // defines it plus its FormID" — also false, because every one of them also takes an EditorID, and merge and
+    // compact both PRESERVE EditorIDs, so those lines do not break. Two rounds, two wrong models. A sentence that
+    // describes someone else's grammar is a sentence that has to be re-verified against four skills every time
+    // anything changes; a sentence that describes only what THIS operation did to a line that names a donor is true
+    // by construction.
+    //
+    // The system list is an enumeration for findability, not a claim about what they are. "Runtime config files" and
+    // not "distributor configs": OAR is an animation-condition system, and calling it a distributor was itself one of
+    // the false claims. Verified before shipping (2026-08-18) that each of the four has a line form naming a plugin,
+    // and that no bundled skill documents a fallback keeping such a line matched once that plugin deactivates —
+    // SkyPatcher's skill states the opposite outright, that a form it cannot resolve is silently skipped.
+
+    /// <summary>Merge's reminder. The break is entailed by the swap this same report instructs: deactivating a donor
+    /// is what stops a line that NAMES that donor from matching. Deliberately no override/master carve-out — a line
+    /// addressing a record the donor merely overrode names the MASTER, so "names a donor" already excludes it by
+    /// construction, and spelling that out would be a claim about addressing rather than about this operation.</summary>
+    [MustState("Nothing here rewrites those files", "stops matching once you deactivate that donor at the swap")]
+    internal const string MergeRuntimeConfigs =
+        "Nothing here rewrites those files. A line in one of them that names a donor stops matching once you " +
+        "deactivate that donor at the swap.\n";
+
+    /// <summary>Compact's. The plugin name survives a compaction, so the half that moves is the object id — and only
+    /// the ids this run actually moved, which the accounting above states. "once the compacted plugin is the one
+    /// loading" rather than a flat present tense: in the new-file lane nothing has broken yet, since the original is
+    /// still active until the swap; in the in-place lane it is already the one loading. One clause, both lanes.</summary>
+    [MustState("does not read", "nothing here rewrites them", "no longer reaches that record")]
+    internal const string CompactRuntimeConfigs =
+        "That pass reads plugins; it does not read runtime config files (SPID, KID, SkyPatcher, Open Animation " +
+        "Replacer), and nothing here rewrites them. The plugin name is unchanged, but a line in one of them that " +
+        "addresses a record by an object id this compaction moved no longer reaches that record once the compacted " +
+        "plugin is the one loading.\n";
+
     /// <summary>The mod-folder line for an IN-PLACE write: the target is a mod the user already runs, so there is
     /// nothing to enable — only a re-sort, and only if the edit moved a winner. (compact's copy had lost "in your
     /// load order"; same sentence, one reading.)</summary>

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -1001,9 +1001,17 @@ public static class WriteTools
         // line loses here is the FormID half — the ids this same report just listed as renumbered. Phrased against
         // what the renumber moved rather than asserting a break, so it stays true for a compaction that moved nothing
         // (an override-only plugin taking the light flag) without needing an arm per shape.
-        sb.Append("That pass reads plugins; it does not read INI distributor configs (SPID/KID/SkyPatcher/OAR), which ")
-          .Append("address a record as <plugin>|<FormID>. The plugin name is unchanged, but a line naming an object id ")
-          .Append("this compaction moved no longer addresses that record, and nothing rewrites the .ini files.\n");
+        //
+        // "once the compacted plugin is the one loading" rather than a flat present tense: in the NEW-FILE lane
+        // nothing has broken yet — the original is still active and every config line still matches until the MO2 swap
+        // this same report instructs. One clause that is true of both lanes (in place, it is already the one loading)
+        // rather than a branch per lane. The addressing MODEL is stated and no single spelling is quoted, for the
+        // reason RenderMerge's twin gives at length.
+        sb.Append("That pass reads plugins; it does not read the runtime distributor configs — SPID/KID/SkyPatcher ")
+          .Append(".ini lines, Open Animation Replacer .json conditions — which address a record through the plugin ")
+          .Append("that defines it plus its FormID. The plugin name is unchanged, but a line naming an object id this ")
+          .Append("compaction moved stops addressing that record once the compacted plugin is the one loading, and ")
+          .Append("nothing rewrites those files.\n");
 
         AppendFacegenCarry(sb, o.AssetRename, o.InPlace);
         AppendVoiceCarry(sb, o.VoiceRename, o.InPlace);
@@ -1176,16 +1184,27 @@ public static class WriteTools
         // absolute. What the pass reads is record links and record identity — it never opens a plugin header, so a
         // dependent that merely DECLARES a donor as a master is invisible to it, and loses a master at the swap.
         sb.Append("identify-pass scanned ").Append(o.PluginsScanned).Append(" plugin(s) — it reads record links and ")
-          .Append("record identity, NOT declared masters or INI distributor configs (SPID/KID/SkyPatcher/OAR), so a plugin ")
-          .Append("that only lists a donor as a master, or only names one in an .ini, is not counted above.\n");
+          .Append("record identity, NOT declared masters or runtime distributor configs (SPID/KID/SkyPatcher/OAR), so a ")
+          .Append("plugin that only lists a donor as a master, or only names one in such a config, is not counted above.\n");
         // The caveat above says those configs are not READ. This says what that costs, which is the half a caller
-        // cannot derive from "not counted": a distributor line addresses a record as <plugin>|<FormID>, so the donor's
-        // plugin NAME is half of every address pointing into it, and a merge rewrites no .ini. Stated unconditionally
-        // — it is the addressing model plus the swap this same report instructs, not a prediction about any file, and
-        // there is nothing a later call could come back and falsify.
-        sb.Append("Those configs address a record as <plugin>|<FormID>, so a line naming a donor stops matching once ")
-          .Append("you deactivate that donor at the swap: the records are ").Append(o.OutputName)
-          .Append("'s now, and nothing rewrites the .ini files.\n");
+        // cannot derive from "not counted": every one of them addresses a record through the plugin that defines it,
+        // and a merge takes that plugin's NAME away while rewriting none of the files.
+        //
+        // The MODEL is stated, never one system's literal spelling. The four do not share a syntax — SkyPatcher is
+        // prefix-pipe Plugin.esp|0x123, SPID and KID are suffix-tilde 0x123~Plugin.esp, OAR is a JSON pluginName/formID
+        // pair — and spid-authoring's own skill lists confusing the first two as a known trap ("a SkyPatcher-style ID
+        // won't resolve"). Quoting one spelling for all of them would send a caller grepping for a string three of the
+        // four never contain, and conclude they were unaffected. Naming the FILE KINDS is what makes it actionable.
+        //
+        // Scoped to what the merge actually re-keyed, for the reason the headline above is: a donor's originating
+        // records take the output's identity, but a record the donor merely OVERRODE keeps its master's FormKey, so a
+        // config line addressing that record names the master and is untouched by the merge. Claiming all of them
+        // would tell the caller to rewrite lines that still work.
+        sb.Append("Those configs address a record through the plugin that defines it — SPID/KID/SkyPatcher .ini lines ")
+          .Append("and Open Animation Replacer .json conditions, each in its own spelling — so a line naming a donor ")
+          .Append("stops matching once you deactivate that donor at the swap. A donor's OWN records answer to ")
+          .Append(o.OutputName).Append(" now; a record a donor merely overrode is addressed by its master and is ")
+          .Append("unaffected. Nothing rewrites those files.\n");
 
         AppendFacegenCarry(sb, o.AssetRename, inPlace: false);
         AppendVoiceCarry(sb, o.VoiceRename, inPlace: false);

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -997,6 +997,13 @@ public static class WriteTools
               .Append("'external referencers: none' may be incomplete — verify in xEdit. Samples: ").Append(string.Join("; ", o.UnscannableSamples)).Append('\n');
         }
         sb.Append("identify-pass scanned ").Append(o.PluginsScanned).Append(" plugin(s) for external references.\n");
+        // Compact's break is the other half of merge's. The plugin NAME survives a compaction, so what a distributor
+        // line loses here is the FormID half — the ids this same report just listed as renumbered. Phrased against
+        // what the renumber moved rather than asserting a break, so it stays true for a compaction that moved nothing
+        // (an override-only plugin taking the light flag) without needing an arm per shape.
+        sb.Append("That pass reads plugins; it does not read INI distributor configs (SPID/KID/SkyPatcher/OAR), which ")
+          .Append("address a record as <plugin>|<FormID>. The plugin name is unchanged, but a line naming an object id ")
+          .Append("this compaction moved no longer addresses that record, and nothing rewrites the .ini files.\n");
 
         AppendFacegenCarry(sb, o.AssetRename, o.InPlace);
         AppendVoiceCarry(sb, o.VoiceRename, o.InPlace);
@@ -1169,8 +1176,16 @@ public static class WriteTools
         // absolute. What the pass reads is record links and record identity — it never opens a plugin header, so a
         // dependent that merely DECLARES a donor as a master is invisible to it, and loses a master at the swap.
         sb.Append("identify-pass scanned ").Append(o.PluginsScanned).Append(" plugin(s) — it reads record links and ")
-          .Append("record identity, NOT declared masters or INI distributor configs (SPID/KID/SkyPatcher), so a plugin ")
+          .Append("record identity, NOT declared masters or INI distributor configs (SPID/KID/SkyPatcher/OAR), so a plugin ")
           .Append("that only lists a donor as a master, or only names one in an .ini, is not counted above.\n");
+        // The caveat above says those configs are not READ. This says what that costs, which is the half a caller
+        // cannot derive from "not counted": a distributor line addresses a record as <plugin>|<FormID>, so the donor's
+        // plugin NAME is half of every address pointing into it, and a merge rewrites no .ini. Stated unconditionally
+        // — it is the addressing model plus the swap this same report instructs, not a prediction about any file, and
+        // there is nothing a later call could come back and falsify.
+        sb.Append("Those configs address a record as <plugin>|<FormID>, so a line naming a donor stops matching once ")
+          .Append("you deactivate that donor at the swap: the records are ").Append(o.OutputName)
+          .Append("'s now, and nothing rewrites the .ini files.\n");
 
         AppendFacegenCarry(sb, o.AssetRename, inPlace: false);
         AppendVoiceCarry(sb, o.VoiceRename, inPlace: false);

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -997,21 +997,10 @@ public static class WriteTools
               .Append("'external referencers: none' may be incomplete — verify in xEdit. Samples: ").Append(string.Join("; ", o.UnscannableSamples)).Append('\n');
         }
         sb.Append("identify-pass scanned ").Append(o.PluginsScanned).Append(" plugin(s) for external references.\n");
-        // Compact's break is the other half of merge's. The plugin NAME survives a compaction, so what a distributor
-        // line loses here is the FormID half — the ids this same report just listed as renumbered. Phrased against
-        // what the renumber moved rather than asserting a break, so it stays true for a compaction that moved nothing
-        // (an override-only plugin taking the light flag) without needing an arm per shape.
-        //
-        // "once the compacted plugin is the one loading" rather than a flat present tense: in the NEW-FILE lane
-        // nothing has broken yet — the original is still active and every config line still matches until the MO2 swap
-        // this same report instructs. One clause that is true of both lanes (in place, it is already the one loading)
-        // rather than a branch per lane. The addressing MODEL is stated and no single spelling is quoted, for the
-        // reason RenderMerge's twin gives at length.
-        sb.Append("That pass reads plugins; it does not read the runtime distributor configs — SPID/KID/SkyPatcher ")
-          .Append(".ini lines, Open Animation Replacer .json conditions — which address a record through the plugin ")
-          .Append("that defines it plus its FormID. The plugin name is unchanged, but a line naming an object id this ")
-          .Append("compaction moved stops addressing that record once the compacted plugin is the one loading, and ")
-          .Append("nothing rewrites those files.\n");
+        // Compact's break is the other half of merge's: the plugin NAME survives a compaction, so what moves is the
+        // object id — and only the ids this run actually moved, which the accounting above states. Bounded by the same
+        // claim rule; see WriteSentences.CompactRuntimeConfigs for it and for the two wrong models that produced it.
+        sb.Append(WriteSentences.CompactRuntimeConfigs);
 
         AppendFacegenCarry(sb, o.AssetRename, o.InPlace);
         AppendVoiceCarry(sb, o.VoiceRename, o.InPlace);
@@ -1184,27 +1173,13 @@ public static class WriteTools
         // absolute. What the pass reads is record links and record identity — it never opens a plugin header, so a
         // dependent that merely DECLARES a donor as a master is invisible to it, and loses a master at the swap.
         sb.Append("identify-pass scanned ").Append(o.PluginsScanned).Append(" plugin(s) — it reads record links and ")
-          .Append("record identity, NOT declared masters or runtime distributor configs (SPID/KID/SkyPatcher/OAR), so a ")
-          .Append("plugin that only lists a donor as a master, or only names one in such a config, is not counted above.\n");
-        // The caveat above says those configs are not READ. This says what that costs, which is the half a caller
-        // cannot derive from "not counted": every one of them addresses a record through the plugin that defines it,
-        // and a merge takes that plugin's NAME away while rewriting none of the files.
-        //
-        // The MODEL is stated, never one system's literal spelling. The four do not share a syntax — SkyPatcher is
-        // prefix-pipe Plugin.esp|0x123, SPID and KID are suffix-tilde 0x123~Plugin.esp, OAR is a JSON pluginName/formID
-        // pair — and spid-authoring's own skill lists confusing the first two as a known trap ("a SkyPatcher-style ID
-        // won't resolve"). Quoting one spelling for all of them would send a caller grepping for a string three of the
-        // four never contain, and conclude they were unaffected. Naming the FILE KINDS is what makes it actionable.
-        //
-        // Scoped to what the merge actually re-keyed, for the reason the headline above is: a donor's originating
-        // records take the output's identity, but a record the donor merely OVERRODE keeps its master's FormKey, so a
-        // config line addressing that record names the master and is untouched by the merge. Claiming all of them
-        // would tell the caller to rewrite lines that still work.
-        sb.Append("Those configs address a record through the plugin that defines it — SPID/KID/SkyPatcher .ini lines ")
-          .Append("and Open Animation Replacer .json conditions, each in its own spelling — so a line naming a donor ")
-          .Append("stops matching once you deactivate that donor at the swap. A donor's OWN records answer to ")
-          .Append(o.OutputName).Append(" now; a record a donor merely overrode is addressed by its master and is ")
-          .Append("unaffected. Nothing rewrites those files.\n");
+          .Append("record identity, NOT declared masters or runtime config files (SPID, KID, SkyPatcher, Open Animation ")
+          .Append("Replacer), so a plugin that only lists a donor as a master, or only names one in such a file, is not ")
+          .Append("counted above.\n");
+        // The caveat above says those files are not READ. This says what that costs — the half a caller cannot derive
+        // from "not counted". Both clauses are bounded by the claim rule stated at WriteSentences.MergeRuntimeConfigs:
+        // this tool's own behaviour, plus a break entailed by the swap this same report instructs.
+        sb.Append(WriteSentences.MergeRuntimeConfigs);
 
         AppendFacegenCarry(sb, o.AssetRename, inPlace: false);
         AppendVoiceCarry(sb, o.VoiceRename, inPlace: false);


### PR DESCRIPTION
`Fixes #362`. Carries #364's minimum reminder sentence as its own commit (referenced, not closed — the detect-and-name half stays open at W5).

## The defect

`merge_plugins` and `compact_plugin` opened their donor/source plugins with the bare `SkyrimMod.CreateFromBinaryOverlay(path, release)`, which finds `Strings\` only in the plugin's own folder. A localized plugin whose `.STRINGS` are served from elsewhere read every `TranslatedString` empty, and both verbs wrote those blanks into the output. Silent data loss on two shipped write verbs (Q3). `LoadOrderResolver.OpenOverlay` exists for this class and the in-place lane already routed through it; these two opens did not.

## The write-lane `dataDir` verification

Answered at source before writing the fix, as the routing ruling required. All three resolved as expected, so the engagement stayed in scope.

**(a) Are the tool-layer call sites simple enough for parameter threading?** Yes. Both callers (`LoadOrderService.cs:6080`, `:6317`) already hold the captured `IndexView` they pass `PluginPath` from. The resolver's own `DataDir` is `internal` and `housecarl-core` is `InternalsVisibleTo` only `housecarl-generator`, so the MCP layer cannot read it directly — hence one expression-bodied `IndexView.DataDir` property beside the existing `PluginPath`, plus a `string? dataDir` parameter on each builder. No redesign.

**(b) Are `OpenOverlay`'s fallback semantics right for a donor in an MO2 mod folder?** Yes — the same resolution the read index and the in-place lane already use. It redirects only when the plugin's own folder carries no strings source, so a donor with its own `Strings\` or `.bsa` is never redirected away from it. That gate has a bound, filed as #369 (below).

**(c) What is the OUTPUT's localization state?** Written non-localized, strings inline — the expected answer, so no STOP. Both builders construct a fresh bare `SkyrimMod`; `RemapEngine` never touches `ModHeader.Flags`; `UsingLocalization` appears nowhere in production code; and the write passes no strings writer. Verified at source **and** pinned by arms, because it is what keeps the existing bare read-back opens correct.

## Arms

A shared localized fixture whose load-bearing part is a game-Data `Skyrim.esm` — without one `ComputeDataDir` returns null, every `OpenOverlay` degrades to the folder-adjacent default, and the arms would pass with or without the fix.

- Merge: single-donor (the rename shape) and multi-donor both carry `Name`/`DESC` for every donor. One fix, no donor-count conditional.
- Compact: source carries `Name`/`DESC` into P'.
- Baseline arms read the donor/source with the **bare** overlay first and require EMPTY, so a fixture that stopped being localized fails loudly instead of passing vacuously.
- Output-not-localized arms pin (c).
- A `RESIDUAL` arm pins the unfixed case as measured behaviour (below).

RED-checked in both directions from a committed state: reverting either call site blanks rename/combine/compact; nulling `view.DataDir` at the service call sites reddens the same three; sabotaging the fixture's strings relocation reddens both baselines. Restores anchor-verified. `ci-all` 124/124.

## Review rounds

Two rounds, then a **§11 class-recurrence stop** — escalated rather than folded a third time. The stop and its directed completion are the reason this PR looks the way it does.

**Round 1** (2 agents) — 2 mediums, 2 lows, every one in the #364 sentence, none in the fix. The sentence claimed all four config systems address a record as `Plugin.esp|FormID` (true of SkyPatcher alone — SPID/KID are suffix-tilde, OAR is `config.json`; `spid-authoring/SKILL.md:107` lists confusing the first two as a known trap); claimed overrides took the output's identity (they keep their master's FormKey) three lines under an accounting line saying so; claimed compact's break present-tense before the swap; and the changelog claimed a false exhaustiveness. Also two guard defects of mine — a `RESIDUAL` arm that a *missing* record would have satisfied, and a fixture mutating a directory while lazily enumerating it. **Refused nothing**: every finding reproduced at source or under measurement, and the override claim was probed (not reworded) first — the rendered report contradicted itself on the pure-override donor.

**Round 2** (2 agents) — the same class again, one layer down: the *corrected* model was still false, because all four systems also accept EditorIDs and both verbs preserve them, so those lines never break. Plus the changelog claiming a closure the fix lacks, and — worst — **the two arms added in the round-1 fold did not work**. They asserted `!Contains("<plugin>|<FormID>")`, the literal from the commit they were fixing, so a reviewer quoting a real SkyPatcher spelling left them green.

That is the same failure class in two consecutive rounds, so the rounds stopped there.

**Directed completion (advisor lane, no round 3).** The class dies by a **claim rule** pinned in-code at both sentences: every clause states either something this tool did, or a break entailed by what this operation did, scoped by the addressed line's own content — nothing describes an external grammar. Both sentences were rewritten under it and moved into `WriteSentences`, which brings them under the existing `[MustState]` walk: content pinned by declared phrases, wiring pinned by the reach arm. The dead `!Contains` arms are **deleted, not rebuilt** — an absence assertion over an open string space cannot fail meaningfully.

Before committing, verified per the directive that each of the four systems has a line form naming a plugin, and that **no bundled skill documents a fallback keeping such a line matched after that plugin deactivates** — SkyPatcher's skill states the opposite outright, that a form it cannot resolve is silently skipped. All four stay in the claim.

## Residuals and spawned issues

- **#368** (filed) — `compact_plugin(in_place, repoint_externals, acknowledge)` blanks a localized external referencer **permanently**: `RemapEngine.cs:874` opens it bare and re-serializes over the user's own file, keeping the localized header flag with no strings source. Found by a reviewer, reproduced independently before filing. Outside the ruled scope, and its fix is not this one-liner (`RepointInPlace` needs a mutable mod; `OpenOverlay` returns a getter).
- **#369** (filed) — `FolderHasOwnStrings` counts **any** `.bsa` beside the plugin as a strings source, so an asset-only archive suppresses the redirect and the plugin still blanks. Pre-existing `OpenOverlay` contract. The changelog states this as a bound rather than claiming a closure.
- **#363** (commented) — merge/compact drop the localized-strings layer entirely (output is non-localized, strings inlined). Correct, and what makes this fix usable, but it is another header-layer property that does not survive; left on the issue that owns the carry decision.
- **Open question, unfixed by design:** a localized donor whose strings are resolvable **nowhere** still merges to blanks, silently — `OpenOverlay`'s fallback is game-Data and nothing else. Pinned by the `RESIDUAL` arm as current behaviour rather than asserted. No warning feature grown here without a ruling.
- **Second strings residual, out of scope:** nothing in production sets `TargetLanguage`, so Mutagen's English default governs every houseCARL read — a non-English `.STRINGS` set reads blank regardless of `dataDir`. Pre-existing across the whole read surface (settled decision 1).

## Changelog

Two `## Unreleased` entries — the fix (with its bound stated), and the reminder sentences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
