### PR TITLE
Refuse a localized plugin in place rather than re-serialize it into wrong text

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -6,25 +6,32 @@ when it changes.
 
 ## Unreleased
 
-- **The in-place write lanes now refuse a localized plugin instead of scrambling its text.** Any operation that
-  rewrites an existing plugin over itself — `housecarl_set_field` / `housecarl_bulk_apply` with `in_place=true`,
-  `housecarl_remove_record`, `housecarl_create_record` in place, and `housecarl_compact_plugin`'s rewrite of external
-  referencers under `repoint_externals=true` — re-serializes that plugin. A plugin flagged *localized* keeps its
-  names and descriptions in separate `.STRINGS` files and carries only numbers pointing into them; the re-serialize
-  renumbers those pointers, houseCARL saved only the plugin, and the rewritten plugin then read its text against the
-  old, unchanged `.STRINGS`. Every localized value came out attached to a different record — a weapon showing a
-  book's name — with the tool reporting success. It did not need anything unusual about where the strings lived: a
-  plugin whose `.STRINGS` sit right beside it, reading correctly everywhere else, was corrupted the same way.
+- **The in-place write lanes now refuse a localized plugin instead of scrambling its text.** Every operation that
+  rewrites an existing plugin over itself re-serializes it: `housecarl_set_field` and `housecarl_bulk_apply` with
+  `in_place=true`, `housecarl_remove_record`, `housecarl_create_record` and `housecarl_bulk_create` in place,
+  `housecarl_forward_record` in place, and `housecarl_compact_plugin`'s rewrite of external referencers under
+  `repoint_externals=true`. A plugin flagged *localized* keeps its names and descriptions in separate `.STRINGS`
+  files and carries only numbers pointing into them; the re-serialize renumbers those pointers, houseCARL saved only
+  the plugin, and the rewritten plugin then read its text against the old, unchanged `.STRINGS`. Values came back
+  attached to the wrong records — a weapon showing a book's name — with the tool reporting success. Not every value:
+  in the measured case some records kept their text, one went blank, and others picked up a different record's, which
+  is worse than a clean break, because spot-checking a few records can leave you thinking the file is fine. It did
+  not need anything unusual about where the strings lived, either: a plugin whose `.STRINGS` sit right beside it,
+  reading correctly everywhere else, was corrupted the same way.
 
   These lanes now stop before writing anything and tell you the plugin is localized and why houseCARL will not
-  re-emit it. Nothing is written, staged, or left behind. `housecarl_compact_plugin` checks the referencers it would
-  rewrite *before* it compacts anything, so it refuses the whole operation up front rather than renumbering your
-  plugin and then stopping partway through the plugins that point at it.
+  re-emit it. Nothing is written or staged, and your one-time in-place consent for that plugin is not spent on a
+  write that cannot happen. A dry run gives the same refusal the real call does, rather than reporting an edit that
+  would then be refused. `housecarl_compact_plugin` checks the referencers it would rewrite *before* it compacts
+  anything, so it refuses up front rather than renumbering your plugin and then stopping partway through the plugins
+  that point at it — and it refuses before asking you to confirm the rewrite, instead of after.
 
-  Only in-place rewrites are affected. Everything that writes a NEW plugin — the default patch lane,
-  `housecarl_merge_plugins`, and `housecarl_compact_plugin`'s default new-file lane — builds its output fresh with
-  the text stored inside the plugin, and is unaffected. In practice modders overwrite official masters and
-  translation mods rarely if ever, preferring new override plugins, so the refusal should be rare.
+  Writing a NEW plugin is unaffected: the default patch lane, `housecarl_merge_plugins`, and
+  `housecarl_compact_plugin`'s default new-file lane all build their output fresh with the text stored inside the
+  plugin. (Extending an existing patch with `into=` re-serializes that patch, so it is in-place in this sense — but
+  it only ever targets a folder houseCARL owns, and houseCARL does not author localized plugins.) In practice modders
+  overwrite official masters and translation mods rarely if ever, preferring new override plugins, so the refusal
+  should be rare.
 
   Making these lanes rewrite a localized plugin *correctly* is a larger change — it decides what an in-place edit is
   allowed to write besides the plugin file itself — and is being designed separately. Until then houseCARL refuses

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -28,9 +28,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
   the strings lived, either: a plugin whose `.STRINGS` sit right beside it, reading correctly everywhere else, was
   corrupted the same way.
 
-  These lanes now stop before writing anything and tell you the plugin is localized and why houseCARL will not
-  re-emit it. Nothing is written or staged, and your one-time in-place consent for that plugin is not spent on a
-  write that cannot happen. A dry run gives the same refusal the real call does, rather than reporting an edit that
+  These lanes now stop before writing anything and tell you the plugin is localized, why houseCARL will not re-emit
+  it, and what to do instead where there is something to do. Nothing is written or staged, and your one-time
+  in-place consent for that plugin is not spent on a write that cannot happen — the one exception being a plugin
+  whose header cannot be read at that moment (a lock from MO2 or xEdit, say), which the check treats as
+  not-localized: the call then proceeds, spends the acknowledgement, and is refused at the write instead. The file
+  is untouched either way. A dry run gives the same refusal the real call does, rather than reporting an edit that
   would then be refused. `housecarl_compact_plugin` checks the referencers it would rewrite *before* it compacts
   anything, so it refuses up front rather than renumbering your plugin and then stopping partway through the plugins
   that point at it — and it refuses before asking you to confirm the rewrite, instead of after.
@@ -41,16 +44,18 @@ saying it sets an expectation their install may contradict. Say what is known, a
   houseCARL read it, with the mod's `.STRINGS` set left describing nothing and any other language it shipped gone.
   If the strings resolved nowhere at all (see the bound described below), blanks get baked in instead. Neither is
   something to do silently to a file with no review step and no undo, so that lane now refuses up front and points at
-  the new-file lane. Compacting to a new plugin is unaffected and keeps your text — that output is not localized
-  either, so read it before you enable it.
+  the new-file lane, which now says the same thing in its own report rather than only when you are refused.
+  Compacting to a new plugin keeps your text wherever houseCARL can resolve your strings — see the bound below; its
+  output is not localized either, so read it before you enable it.
 
   Writing a NEW plugin is otherwise unaffected: the default patch lane, `housecarl_merge_plugins`, and
   `housecarl_compact_plugin`'s default new-file lane all build their output fresh with the text stored inside the
   plugin, and leave your original alone. (Extending an existing patch with `into=` does re-serialize that patch, so
   it is in-place in this sense — but it only ever targets a folder houseCARL owns, and houseCARL does not author
-  localized plugins.) The refusal fires on any plugin carrying the localized header flag, which in practice is
-  mostly official masters and translation mods — and those are edited by making a new override plugin, not in place,
-  so it should be rare.
+  localized plugins.) The refusal fires on any plugin carrying the localized header flag. Which of your plugins
+  carry it depends on your install: the official masters always do, and translated releases commonly do, because
+  that is what the translation toolchain emits. No houseCARL tool reports the flag today, so there is currently no
+  way to answer "will this hit me?" from inside houseCARL — xEdit shows it on the file header.
 
   Making these lanes rewrite a localized plugin *correctly* is a larger change — it decides what an in-place edit is
   allowed to write besides the plugin file itself — and is being designed separately. Until then houseCARL refuses

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -6,18 +6,20 @@ when it changes.
 
 ## Unreleased
 
-- **The in-place write lanes now refuse a localized plugin instead of scrambling its text.** Every operation that
-  rewrites an existing plugin over itself re-serializes it: `housecarl_set_field` and `housecarl_bulk_apply` with
-  `in_place=true`, `housecarl_remove_record`, `housecarl_create_record` and `housecarl_bulk_create` in place,
-  `housecarl_forward_record` in place, and `housecarl_compact_plugin`'s rewrite of external referencers under
-  `repoint_externals=true`. A plugin flagged *localized* keeps its names and descriptions in separate `.STRINGS`
-  files and carries only numbers pointing into them; the re-serialize renumbers those pointers, houseCARL saved only
-  the plugin, and the rewritten plugin then read its text against the old, unchanged `.STRINGS`. Values came back
-  attached to the wrong records — a weapon showing a book's name — with the tool reporting success. Not every value:
-  in the measured case some records kept their text, one went blank, and others picked up a different record's, which
-  is worse than a clean break, because spot-checking a few records can leave you thinking the file is fine. It did
-  not need anything unusual about where the strings lived, either: a plugin whose `.STRINGS` sit right beside it,
-  reading correctly everywhere else, was corrupted the same way.
+- **The record-editing lanes now refuse a localized plugin in place instead of scrambling its text.** Editing,
+  removing from, creating into, or forwarding into an existing plugin **in place** re-serializes that whole plugin —
+  `housecarl_apply`, `housecarl_create`, `housecarl_remove` and `housecarl_forward` with `in_place="X.esp"` (and
+  their 1.x spellings `housecarl_set_field` / `housecarl_bulk_apply` / `housecarl_create_record` /
+  `housecarl_bulk_create` / `housecarl_remove_record` / `housecarl_forward_record` with `in_place=true`), plus
+  `housecarl_compact_plugin`'s rewrite of external referencers under `repoint_externals=true`. A plugin flagged
+  *localized* keeps its names and descriptions in separate `.STRINGS` files and carries only numbers pointing into
+  them; the re-serialize renumbers those pointers, houseCARL saved only the plugin, and the rewritten plugin then
+  read its text against the old, unchanged `.STRINGS`. Values came back attached to the wrong records — a weapon
+  showing a book's name — with the tool reporting success. Not every value: in the measured case some records kept
+  their text, some went blank, and others picked up a different record's, which is worse than a clean break, because
+  spot-checking a few records can leave you thinking the file is fine. It did not need anything unusual about where
+  the strings lived, either: a plugin whose `.STRINGS` sit right beside it, reading correctly everywhere else, was
+  corrupted the same way.
 
   These lanes now stop before writing anything and tell you the plugin is localized and why houseCARL will not
   re-emit it. Nothing is written or staged, and your one-time in-place consent for that plugin is not spent on a
@@ -26,12 +28,20 @@ when it changes.
   anything, so it refuses up front rather than renumbering your plugin and then stopping partway through the plugins
   that point at it — and it refuses before asking you to confirm the rewrite, instead of after.
 
-  Writing a NEW plugin is unaffected: the default patch lane, `housecarl_merge_plugins`, and
+  **What this does not cover.** `housecarl_compact_plugin(in_place=true)` on a localized plugin still runs: a
+  compaction does not re-serialize your plugin, it builds a fresh one and writes that over the original, so it never
+  hits the check above. The compacted result comes back **non-localized**, with the text of whichever language
+  resolved baked into the plugin — leaving the mod's `.STRINGS` set orphaned and any other language it shipped gone.
+  If the strings did not resolve at all (see the bound described below), what gets baked in is blanks. Compact a
+  localized plugin to a new file and check it before swapping it in.
+
+  Writing a NEW plugin is otherwise unaffected: the default patch lane, `housecarl_merge_plugins`, and
   `housecarl_compact_plugin`'s default new-file lane all build their output fresh with the text stored inside the
-  plugin. (Extending an existing patch with `into=` re-serializes that patch, so it is in-place in this sense — but
-  it only ever targets a folder houseCARL owns, and houseCARL does not author localized plugins.) In practice modders
-  overwrite official masters and translation mods rarely if ever, preferring new override plugins, so the refusal
-  should be rare.
+  plugin, and leave your original alone. (Extending an existing patch with `into=` does re-serialize that patch, so
+  it is in-place in this sense — but it only ever targets a folder houseCARL owns, and houseCARL does not author
+  localized plugins.) The refusal fires on any plugin carrying the localized header flag, which in practice is
+  mostly official masters and translation mods — and those are edited by making a new override plugin, not in place,
+  so it should be rare.
 
   Making these lanes rewrite a localized plugin *correctly* is a larger change — it decides what an in-place edit is
   allowed to write besides the plugin file itself — and is being designed separately. Until then houseCARL refuses
@@ -66,11 +76,10 @@ when it changes.
   `.STRINGS` served from elsewhere, is therefore still read the old way and still writes blanks. So is a plugin whose
   strings are in neither place.
 
-  One case inside `housecarl_compact_plugin` is also untouched, and it is the worst of the three: with
-  `in_place=true` and `repoint_externals=true`, the pass that rewrites each **external referencer** still opens it the
-  old way and writes it back over the user's own file. A localized referencer loses every name and description
-  permanently — in place, on a plugin the user did not ask to compact, with the same silence this entry describes as
-  the bug. Tracked as #368. All three cases are unchanged by this fix. (#362)
+  Both of those cases are unchanged by this fix. A third — `housecarl_compact_plugin` rewriting each **external
+  referencer** under `in_place=true` + `repoint_externals=true`, over a plugin the user never asked to compact — is
+  no longer reachable: that whole operation is now refused up front when any referencer is localized (see the
+  in-place entry above). (#362)
 
 - **`housecarl_merge_plugins` now accepts a single donor, which renames a plugin.** Merging one plugin into a new
   name was refused ("merge needs at least TWO distinct donor plugins"), and no other tool renames one, so a

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -28,12 +28,14 @@ when it changes.
   anything, so it refuses up front rather than renumbering your plugin and then stopping partway through the plugins
   that point at it — and it refuses before asking you to confirm the rewrite, instead of after.
 
-  **What this does not cover.** `housecarl_compact_plugin(in_place=true)` on a localized plugin still runs: a
-  compaction does not re-serialize your plugin, it builds a fresh one and writes that over the original, so it never
-  hits the check above. The compacted result comes back **non-localized**, with the text of whichever language
-  resolved baked into the plugin — leaving the mod's `.STRINGS` set orphaned and any other language it shipped gone.
-  If the strings did not resolve at all (see the bound described below), what gets baked in is blanks. Compact a
-  localized plugin to a new file and check it before swapping it in.
+  **`housecarl_compact_plugin(in_place=true)` refuses a localized plugin too**, for a different reason. A compaction
+  does not re-serialize your plugin, it builds a fresh one and writes that over the original — so it never hits the
+  check above, and what it would produce is a **non-localized** plugin carrying whichever language resolved when
+  houseCARL read it, with the mod's `.STRINGS` set left describing nothing and any other language it shipped gone.
+  If the strings resolved nowhere at all (see the bound described below), blanks get baked in instead. Neither is
+  something to do silently to a file with no review step and no undo, so that lane now refuses up front and points at
+  the new-file lane. Compacting to a new plugin is unaffected and keeps your text — that output is not localized
+  either, so read it before you enable it.
 
   Writing a NEW plugin is otherwise unaffected: the default patch lane, `housecarl_merge_plugins`, and
   `housecarl_compact_plugin`'s default new-file lane all build their output fresh with the text stored inside the

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -6,6 +6,30 @@ when it changes.
 
 ## Unreleased
 
+- **The in-place write lanes now refuse a localized plugin instead of scrambling its text.** Any operation that
+  rewrites an existing plugin over itself — `housecarl_set_field` / `housecarl_bulk_apply` with `in_place=true`,
+  `housecarl_remove_record`, `housecarl_create_record` in place, and `housecarl_compact_plugin`'s rewrite of external
+  referencers under `repoint_externals=true` — re-serializes that plugin. A plugin flagged *localized* keeps its
+  names and descriptions in separate `.STRINGS` files and carries only numbers pointing into them; the re-serialize
+  renumbers those pointers, houseCARL saved only the plugin, and the rewritten plugin then read its text against the
+  old, unchanged `.STRINGS`. Every localized value came out attached to a different record — a weapon showing a
+  book's name — with the tool reporting success. It did not need anything unusual about where the strings lived: a
+  plugin whose `.STRINGS` sit right beside it, reading correctly everywhere else, was corrupted the same way.
+
+  These lanes now stop before writing anything and tell you the plugin is localized and why houseCARL will not
+  re-emit it. Nothing is written, staged, or left behind. `housecarl_compact_plugin` checks the referencers it would
+  rewrite *before* it compacts anything, so it refuses the whole operation up front rather than renumbering your
+  plugin and then stopping partway through the plugins that point at it.
+
+  Only in-place rewrites are affected. Everything that writes a NEW plugin — the default patch lane,
+  `housecarl_merge_plugins`, and `housecarl_compact_plugin`'s default new-file lane — builds its output fresh with
+  the text stored inside the plugin, and is unaffected. In practice modders overwrite official masters and
+  translation mods rarely if ever, preferring new override plugins, so the refusal should be rare.
+
+  Making these lanes rewrite a localized plugin *correctly* is a larger change — it decides what an in-place edit is
+  allowed to write besides the plugin file itself — and is being designed separately. Until then houseCARL refuses
+  rather than corrupt a file it cannot faithfully re-emit.
+
 - **`housecarl_merge_plugins` and `housecarl_compact_plugin` now say what they cost your runtime config files.**
   Neither verb reads SPID, KID, SkyPatcher or Open Animation Replacer configs, and neither rewrites them — but both
   can invalidate lines in them, and nothing said so. Merge now states that a line naming a donor stops matching once

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to houseCARL are documented here. Versioning is [semantic](h
 the `version` in `.claude-plugin/plugin.json` is bumped on each release, so installed users update only
 when it changes.
 
+**Writing an entry.** State what the tool now does or refuses. Where a change has a bound — a case it does
+not reach, a condition it depends on — **point at the bound rather than restating it**, so the two cannot
+drift apart. A scoped claim that names its bound is fine; an unpointed restatement is the defect, because it
+is a second copy of a fact that will be edited once. No frequency or coverage adjectives ("rare", "most",
+"only affects…"): how often something bites depends on the reader's install, which the entry cannot see, and
+saying it sets an expectation their install may contradict. Say what is known, and say how they can check.
+
 ## Unreleased
 
 - **The record-editing lanes now refuse a localized plugin in place instead of scrambling its text.** Editing,

--- a/src/housecarl-core/RemapEngine.cs
+++ b/src/housecarl-core/RemapEngine.cs
@@ -840,6 +840,40 @@ public static class RemapEngine
         public static RepointResult Fail(string error) => new(false, error, 0, 0);
     }
 
+    /// <summary>Which of <paramref name="pluginNames"/> are flagged LOCALIZED — the pre-flight for a repoint, run
+    /// BEFORE the compaction writes anything.
+    ///
+    /// <para><see cref="RepointInPlace"/> is reached only AFTER the compacted plugin is already on disk (the reason the
+    /// declared-master refusals below are so careful about it), and the in-place write refuses a localized target
+    /// outright (<see cref="WriteEngine.LocalizedTargetUnsupportedException"/> — it cannot re-emit one without
+    /// corrupting its text). A refusal discovered at that point would strand a half-completed compaction: the target
+    /// renumbered on disk, its referencers still pointing at the old FormIDs. So the caller asks this FIRST and refuses
+    /// the whole operation while everything is still untouched.</para>
+    ///
+    /// <para>Reads the header only, through the lazy overlay. A plugin whose header cannot be read is NOT reported as
+    /// localized: the identify pass that produced these names already enumerated each of them successfully, so a fault
+    /// here is a race rather than a normal state, and the write's own choke point remains the absolute backstop. This
+    /// pre-flight exists to keep the refusal EARLY, not to be the thing that makes it safe.</para></summary>
+    public static IReadOnlyList<string> LocalizedAmong(LoadOrderResolver resolver, IEnumerable<string> pluginNames)
+    {
+        var view = resolver.Capture();
+        var hits = new List<string>();
+        foreach (var name in pluginNames)
+        {
+            var path = view.PluginPath(name);
+            if (path is null) continue;
+            ISkyrimModGetter? ov = null;
+            try
+            {
+                ov = LoadOrderResolver.OpenOverlay(path, view.DataDir);
+                if (ov.ModHeader.Flags.HasFlag(SkyrimModHeader.HeaderFlag.Localized)) hits.Add(name);
+            }
+            catch { /* see the summary: unreadable here is not a localization claim, and the write still refuses. */ }
+            finally { if (ov is IDisposable d) { try { d.Dispose(); } catch { } } }
+        }
+        return hits;
+    }
+
     /// <summary>
     /// Repoint plugin <paramref name="pluginName"/>'s outgoing references against <paramref name="dict"/> IN PLACE — the
     /// streaming applier for an EXTERNAL referencer (a plugin outside the transform set that the identify-pass found
@@ -926,6 +960,11 @@ public static class RemapEngine
             }
 
             try { WriteEngine.WriteInPlace(targetMod, resolved, path); }
+            // The localized-target refusal is its own whole sentence, and it happens BEFORE the serialize — so the
+            // generic arm below would both misattribute it and append a sub-0x800 note about a cause that isn't this
+            // one. The service pre-flight (LocalizedAmong) normally refuses long before a referencer gets here; this is
+            // the backstop for the path that reaches it anyway.
+            catch (LocalizedTargetUnsupportedException ex) { return RepointResult.Fail(ex.Message); }
             catch (Exception ex)
             {
                 return RepointResult.Fail(

--- a/src/housecarl-core/RemapEngine.cs
+++ b/src/housecarl-core/RemapEngine.cs
@@ -852,8 +852,11 @@ public static class RemapEngine
     ///
     /// <para>Reads the header only, through the lazy overlay. A plugin whose header cannot be read is NOT reported as
     /// localized: the identify pass that produced these names already enumerated each of them successfully, so a fault
-    /// here is a race rather than a normal state, and the write's own choke point remains the absolute backstop. This
-    /// pre-flight exists to keep the refusal EARLY, not to be the thing that makes it safe.</para></summary>
+    /// here is a race rather than a normal state. Failing open costs the EARLINESS, not the safety — the write's choke
+    /// point still refuses, so nothing is corrupted, but by then the target is compacted and the caller is left with a
+    /// renumbered plugin whose referencer still points at the old FormIDs (reported per referencer, never silent).
+    /// That is the outcome this pre-flight exists to avoid, and the reason it is worth having on top of the write's
+    /// own refusal rather than relying on it.</para></summary>
     public static IReadOnlyList<string> LocalizedAmong(LoadOrderResolver resolver, IEnumerable<string> pluginNames)
     {
         var view = resolver.Capture();

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -3877,10 +3877,27 @@ public sealed class LocalizedTargetUnsupportedException : InvalidOperationExcept
     /// read a book's. The absolute was the easier sentence to write and the more dangerous one to act on, because a
     /// caller who checks a few records, finds them intact, and concludes the diagnosis does not fit their file is
     /// looking at precisely the failure being described.</para></summary>
-    public static string Text(string pluginFileName)
+    public static string Text(string pluginFileName, string? laneClause = null)
         => $"houseCARL did not write '{pluginFileName}' — the file is unchanged and nothing was staged. It is flagged " +
            "LOCALIZED: " + Why + " Measured, some records kept their text, some went blank, and others read text " +
-           "belonging to a different record. houseCARL refuses the write instead of corrupting the file.";
+           "belonging to a different record. houseCARL refuses the write instead of corrupting the file." +
+           (laneClause is null ? "" : " " + laneClause);
+
+    /// <summary>What the three lanes that HAVE a new-plugin equivalent append. Measured before it was named: the
+    /// compact guard's REMEDY arm runs the default lane against the localized fixture and reads the written patch back,
+    /// with the localized original byte-untouched. Deliberately "a NEW plugin" and not "a new override plugin" —
+    /// <c>create</c> shares this clause and authors new records rather than overrides.</summary>
+    public const string RemedyDefaultLane =
+        "This is the in-place lane only: drop in_place= and houseCARL writes the same change into a NEW plugin instead, " +
+        "leaving this file untouched.";
+
+    /// <summary>Remove's clause. It names NO remedy, because there is none to name: a new plugin can override a record
+    /// but cannot un-define one, so "do it in a patch instead" would be false here in a way it is not for the other
+    /// three. Stating the asymmetry is what this lane owes the caller. (Remove's remedy machinery is being reworked
+    /// separately; this deliberately adds nothing for that work to collide with.)</summary>
+    public const string RemoveNoEquivalent =
+        "This lane has no new-plugin form: a separate plugin can override a record but cannot un-define one, so there is " +
+        "no way to remove this record without rewriting the plugin that defines it.";
 
     /// <summary>The MECHANISM clause on its own, for the lanes that refuse over a plugin OTHER than the one they were
     /// asked about — compact refusing because a plugin that REFERENCES its target is localized, where "houseCARL did

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -3879,11 +3879,18 @@ public sealed class LocalizedTargetUnsupportedException : InvalidOperationExcept
     /// looking at precisely the failure being described.</para></summary>
     public static string Text(string pluginFileName)
         => $"houseCARL did not write '{pluginFileName}' — the file is unchanged and nothing was staged. It is flagged " +
-           "LOCALIZED, so its text is held in separate .STRINGS files and the plugin itself carries only indices into " +
-           "them. Re-serializing the plugin renumbers those indices, and this write commits the plugin file alone — so " +
-           "in the rewritten plugin a localized value would no longer reliably be its own record's: measured, some " +
-           "records kept their text, one went blank, and others read text belonging to a different record. houseCARL " +
-           "refuses the write instead of corrupting the file.";
+           "LOCALIZED: " + Why + " Measured, some records kept their text, some went blank, and others read text " +
+           "belonging to a different record. houseCARL refuses the write instead of corrupting the file.";
+
+    /// <summary>The MECHANISM clause on its own, for the lanes that refuse over a plugin OTHER than the one they were
+    /// asked about — compact refusing because a plugin that REFERENCES its target is localized, where "houseCARL did
+    /// not write 'X'" would name the wrong file. Same words, one source: the sentence that explains why a localized
+    /// plugin cannot be re-emitted is the same explanation wherever it is given, and two hand-written spellings of it
+    /// would drift apart the first time either was edited.</summary>
+    public const string Why =
+        "its text is held in separate .STRINGS files and the plugin itself carries only indices into them, so " +
+        "re-serializing it renumbers those indices while houseCARL commits the plugin file alone — a value in the " +
+        "rewritten plugin would no longer reliably be its own record's.";
 
     public LocalizedTargetUnsupportedException(string pluginFileName) : base(Text(pluginFileName)) { }
 }

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1809,6 +1809,11 @@ public static class WriteEngine
         if (!string.Equals(expected, actual, StringComparison.OrdinalIgnoreCase))
             throw new InvalidOperationException(
                 $"In-place output filename '{actual}' must match the target's ModKey filename '{expected}'.");
+        // The localized-target choke point (the backstop for every caller of this method). BEFORE the staging directory
+        // exists and before the serialize runs, so a refused write leaves nothing at all behind. See the exception's own
+        // summary for what the write does to a localized plugin and how it was measured.
+        if (targetMod.UsingLocalization)
+            throw new LocalizedTargetUnsupportedException(expected);
         Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
         var ordered = ownMasters as ISkyrimModGetter[] ?? ownMasters.ToArray();
         // Same composed-null-arm serialize guard as WritePatch (an in-place edit can compose a record too): a required
@@ -3818,6 +3823,35 @@ public sealed class NullArmSerializeException : InvalidOperationException
                "sub-field too (select the arm via compose). Nothing was written — the staged file was discarded and the " +
                "target is untouched. If no composition was involved, this is an engine/Mutagen inconsistency — surface it, " +
                "don't work around it.", inner)
+    {
+    }
+}
+
+/// <summary>The in-place write's refusal to re-serialize a plugin flagged LOCALIZED — thrown by
+/// <see cref="WriteEngine.WriteInPlace"/> before the staging directory is created, so nothing is written, staged, or
+/// cleaned up.
+///
+/// <para>WHY, measured (<c>repoint-strings-probe</c>): a localized plugin keeps its text in sibling
+/// <c>.STRINGS</c>/<c>.DLSTRINGS</c>/<c>.ILSTRINGS</c> files and carries only integer indices into them.
+/// <see cref="WriteEngine.WriteInPlace"/> stages the serialize, which emits a freshly numbered set of those files
+/// beside the staged plugin, and then commits THE PLUGIN ALONE — the emitted tables are discarded with the staging
+/// directory. The committed plugin's new indices are therefore read against the plugin's old, untouched strings file,
+/// and the values land on records they do not belong to: in the probe a weapon read a book's name. The probe's arm C
+/// shows this needs no strings-resolution problem of any kind — a plugin whose strings sit correctly beside it, read
+/// correctly through the ordinary open, is corrupted just the same.</para>
+///
+/// <para>So this is NOT the read-side blanking of a localized plugin whose strings resolve elsewhere; that one is a
+/// separate defect on the way IN. This is the round-trip's write half, and it is why resolving the strings correctly
+/// on the way in does not on its own make the rewrite faithful. Both are chartered to an attended engagement; until
+/// that lands, the write refuses rather than corrupt a file it cannot faithfully re-emit.</para></summary>
+public sealed class LocalizedTargetUnsupportedException : InvalidOperationException
+{
+    public LocalizedTargetUnsupportedException(string pluginFileName)
+        : base($"houseCARL did not write '{pluginFileName}' — the file is unchanged and nothing was staged. It is flagged " +
+               "LOCALIZED, so its text is held in separate .STRINGS files and the plugin itself carries only indices into " +
+               "them. Re-serializing the plugin renumbers those indices, and this write commits the plugin file alone — so " +
+               "the rewritten plugin would read its text against the old, unchanged strings files and every localized value " +
+               "would land on the wrong record. houseCARL refuses the write instead of corrupting the file.")
     {
     }
 }

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1826,6 +1826,27 @@ public static class WriteEngine
         CommitStagedPatch(staged, outputPath);
     }
 
+    /// <summary>Is the plugin at <paramref name="path"/> flagged LOCALIZED? The pre-flight form of
+    /// <see cref="WriteInPlace"/>'s choke point, for the lanes that must answer BEFORE they reach the write — a dry
+    /// run (whose job is to give the same answer the real call would) and the consent gate (which must not spend a
+    /// modder's one-time in-place acknowledgement on a write that is going to refuse).
+    ///
+    /// <para>Reads the header only, and deliberately with the BARE overlay: the localized FLAG is in the header, so
+    /// unlike reading the strings themselves this needs no game-Data fallback and cannot be wrong about the flag
+    /// because a strings source is missing. Any fault answers "not localized" and leaves the write's own choke point
+    /// to refuse — a pre-flight that threw would turn a readable-header failure into a different refusal.</para></summary>
+    public static bool PluginIsLocalized(string path)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+            return ov.ModHeader.Flags.HasFlag(SkyrimModHeader.HeaderFlag.Localized);
+        }
+        catch { return false; }
+        finally { if (ov is IDisposable d) { try { d.Dispose(); } catch { } } }
+    }
+
     /// <summary>Stage 1 of the in-place write — the probe-faithful re-serialize: own declared masters as the load order,
     /// the counter persisted verbatim (<c>NoNextFormIDProcessing</c>, NO floor), NO baseline force-include. Stages into
     /// the <c>.housecarl-tmp</c> sibling of the target (same parent ⇒ same NTFS volume ⇒ the stage-2 swap is atomic),
@@ -3831,7 +3852,8 @@ public sealed class NullArmSerializeException : InvalidOperationException
 /// <see cref="WriteEngine.WriteInPlace"/> before the staging directory is created, so nothing is written, staged, or
 /// cleaned up.
 ///
-/// <para>WHY, measured (<c>repoint-strings-probe</c>): a localized plugin keeps its text in sibling
+/// <para>WHY, measured (<c>repoint-strings-probe</c> — which now stops at this very refusal, so reproducing the
+/// measurement means disabling the check below and re-running; the probe's summary says so): a localized plugin keeps its text in sibling
 /// <c>.STRINGS</c>/<c>.DLSTRINGS</c>/<c>.ILSTRINGS</c> files and carries only integer indices into them.
 /// <see cref="WriteEngine.WriteInPlace"/> stages the serialize, which emits a freshly numbered set of those files
 /// beside the staged plugin, and then commits THE PLUGIN ALONE — the emitted tables are discarded with the staging
@@ -3846,14 +3868,24 @@ public sealed class NullArmSerializeException : InvalidOperationException
 /// that lands, the write refuses rather than corrupt a file it cannot faithfully re-emit.</para></summary>
 public sealed class LocalizedTargetUnsupportedException : InvalidOperationException
 {
-    public LocalizedTargetUnsupportedException(string pluginFileName)
-        : base($"houseCARL did not write '{pluginFileName}' — the file is unchanged and nothing was staged. It is flagged " +
-               "LOCALIZED, so its text is held in separate .STRINGS files and the plugin itself carries only indices into " +
-               "them. Re-serializing the plugin renumbers those indices, and this write commits the plugin file alone — so " +
-               "the rewritten plugin would read its text against the old, unchanged strings files and every localized value " +
-               "would land on the wrong record. houseCARL refuses the write instead of corrupting the file.")
-    {
-    }
+    /// <summary>The refusal sentence, in ONE place — the exception below throws it, and the lanes that predict the
+    /// refusal BEFORE reaching the write (a dry run, or the consent gate) state it without throwing. Two spellings of
+    /// this would drift, and the dry run's whole job is to give the same answer as the real call.
+    ///
+    /// <para>"would no longer reliably be its own record's" and not "would all land on the wrong record": the probe
+    /// measures a MIX — of five localized weapons in arm C, two kept their own text exactly, one went blank, and two
+    /// read a book's. The absolute was the easier sentence to write and the more dangerous one to act on, because a
+    /// caller who checks a few records, finds them intact, and concludes the diagnosis does not fit their file is
+    /// looking at precisely the failure being described.</para></summary>
+    public static string Text(string pluginFileName)
+        => $"houseCARL did not write '{pluginFileName}' — the file is unchanged and nothing was staged. It is flagged " +
+           "LOCALIZED, so its text is held in separate .STRINGS files and the plugin itself carries only indices into " +
+           "them. Re-serializing the plugin renumbers those indices, and this write commits the plugin file alone — so " +
+           "in the rewritten plugin a localized value would no longer reliably be its own record's: measured, some " +
+           "records kept their text, one went blank, and others read text belonging to a different record. houseCARL " +
+           "refuses the write instead of corrupting the file.";
+
+    public LocalizedTargetUnsupportedException(string pluginFileName) : base(Text(pluginFileName)) { }
 }
 
 /// <summary>A refusal whose cause is LIVE COLLECTION/RECORD STATE the schema-only pre-flight provably CANNOT see —

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -1513,6 +1513,10 @@ public static class WritePatchBuilder
             ISkyrimModGetter[] ownMasters = ResolveOwnMasters(view, targetMod, masterOverlays, out var missing);
             if (missing is not null) return RemovalOutcome.Fail(missing);
             try { WriteEngine.WriteInPlace(targetMod, ownMasters, targetPath); }
+            // The localized-target refusal names its own whole sentence; this lane's lead would put it after "failed
+            // (serialize or commit…)", which is a step the refusal happens before. (The lanes that render through
+            // SerializeFailure get the same treatment inside it.)
+            catch (LocalizedTargetUnsupportedException ex) { return RemovalOutcome.Fail(ex.Message); }
             catch (Exception ex)
                 { return RemovalOutcome.Fail($"writing '{fileName}' in place after removal failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}"); }
         }
@@ -1913,7 +1917,13 @@ public static class WritePatchBuilder
     public static string SerializeFailure(string lead, Exception ex, LoadOrderResolver.OverlaySession session, string trailer = "")
     {
         for (Exception? b = ex; b is not null; b = b.InnerException)
+        {
             if (b is UnopenableBaselineMasterException ub) return ub.Message;
+            // Same reason as the baseline-master refusal above: the write refused a LOCALIZED target before it
+            // serialized or committed anything, so every lead here ("failed (serialize or commit…)") would attribute the
+            // refusal to a step that never ran. The exception's own message is the whole sentence.
+            if (b is LocalizedTargetUnsupportedException lt) return lt.Message;
+        }
         var body = lead + WriteEngine.Describe(ex) + UnopenableMasterClause(ex, session);
         if (trailer.Length == 0) return body;
         // Exactly ONE terminator before a lane's tail. A fixed trailer cannot do this alone: the clause already ends

--- a/src/housecarl-generator/CompactServiceGuardProbe.cs
+++ b/src/housecarl-generator/CompactServiceGuardProbe.cs
@@ -344,6 +344,15 @@ public static class CompactServiceGuardProbe
                 Check(!o2.Success && (o2.Error?.Contains(rf.Key.FileName.String, StringComparison.OrdinalIgnoreCase) ?? false),
                     $"REPOINT-LOC fixture: the referencer IS an external referencer of the target (plain compact names it) [{o2.Error}]");
 
+                // The refusal must come BEFORE the consent gate. Without acknowledge the caller would otherwise get
+                // "CONFIRM in-place rewrite (your ORIGINAL file(s) will be rewritten — no houseCARL backup or undo)"
+                // and be asked to accept an irreversible trade-off for a run that was never going to write anything.
+                var oNoAck = rlSvc.CompactPlugin(tgt.Key.FileName.String, inPlace: true, repointExternals: true);
+                Check(!oNoAck.Success && !oNoAck.NeedsAcknowledge
+                      && (oNoAck.Error?.Contains("LOCALIZED", StringComparison.Ordinal) ?? false),
+                    $"REPOINT-LOC refuses BEFORE the consent gate (no CONFIRM prompt for a rewrite that cannot happen) " +
+                    $"(refused={!oNoAck.Success} needsAck={oNoAck.NeedsAcknowledge}) [{oNoAck.Error}]");
+
                 // The BACKSTOP, driven directly: the pre-flight above is what a caller normally meets, but the repoint
                 // itself must refuse a localized target on its own — otherwise the pre-flight is the only thing standing
                 // between a localized referencer and a corrupting rewrite, and any path that reaches the repoint another

--- a/src/housecarl-generator/CompactServiceGuardProbe.cs
+++ b/src/housecarl-generator/CompactServiceGuardProbe.cs
@@ -43,6 +43,16 @@ public static class CompactServiceGuardProbe
         void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
 
         var root = Path.Combine(Path.GetTempPath(), "hc-compact-service-guard-" + Guid.NewGuid().ToString("N"));
+
+        // The REMEDY arm below drives the DEFAULT write lane, which pre-flights through the corpus rulebook. Generated
+        // into a directory OUTSIDE `root` (which the finally deletes) and the previous CorpusPath restored afterwards:
+        // CorpusPath is process-global, and leaving it pointing into a deleted temp dir would break whichever probe
+        // ci-all runs next. CorpusGenerator memoizes its reflection, so under ci-all this costs nothing.
+        var corpusDir = Path.Combine(Path.GetTempPath(), "hc-compact-guard-corpus");
+        var priorCorpusPath = CorpusRulebook.CorpusPath;
+        CorpusGenerator.GenerateAll(corpusDir, Path.Combine(corpusDir, "ref"));
+        CorpusRulebook.CorpusPath = Path.Combine(corpusDir, "corpus.json");
+
         try
         {
             string instance = Path.Combine(root, "instance");
@@ -306,6 +316,12 @@ public static class CompactServiceGuardProbe
                 Check(flagOk && noStringsFolder,
                     $"LOCALIZED compact output is written NON-localized with strings inline (flagClear={flagOk} noStringsFolder={noStringsFolder})");
 
+                // NEWFILE-NOTE: the new-file lane produces the same de-localized plugin the in-place lane is refused
+                // for, so it says so at the point the caller takes it. Non-fatal — the compaction still succeeds.
+                bool noteOn = o.Success && (o.Note?.Contains("is NOT localized", StringComparison.Ordinal) ?? false);
+                Check(noteOn, $"NEWFILE-NOTE a localized SOURCE compacted to a new file still succeeds AND is reported " +
+                              $"(success={o.Success} noted={noteOn}) [{o.Note}]");
+
                 // The arm above IS the measurement behind the in-place refusal's remedy: the same localized source,
                 // compacted to a NEW file, keeps its FULL+DESC. The refusal names that lane, so it is named against a
                 // measured result rather than an assumption — and this block asserts the lane still works, which is the
@@ -316,6 +332,21 @@ public static class CompactServiceGuardProbe
                 // here to borrow a refusal from — the compaction builds a fresh non-localized plugin, so the write's
                 // own localized check structurally cannot fire on this path. Deleting the service check makes this arm
                 // RED by letting the compaction run, which is the whole point.
+                // REMEDY: the clause three in-place lanes append names the default lane, so the default lane is
+                // measured here against this same localized plugin before any refusal points at it. An edit with no
+                // in_place lands in a NEW plugin and the localized original is byte-untouched — which is exactly and
+                // only what the clause claims. It deliberately does NOT assert the text came through: whether the
+                // strings resolve is the bound the changelog points at, and the clause never promised it.
+                var remedyBefore = File.ReadAllBytes(srcPath);
+                var remedyEdit = new[] { new BulkOp { Formid = $"000A01:{ls.Key.FileName}", FieldPath = "BasicStats.Damage",
+                                                     Verb = "Set", Value = "42" } };
+                var rem = locSvc.ApplyEdits(remedyEdit, "LocRemedyPatch", null);
+                bool remedyUntouched = File.ReadAllBytes(srcPath).AsSpan().SequenceEqual(remedyBefore);
+                bool remedyWrote = rem.Success && !rem.InPlace && File.Exists(rem.OutputPath);
+                Check(remedyWrote && remedyUntouched,
+                    $"REMEDY the default lane writes a NEW plugin against a localized target, original untouched " +
+                    $"(success={rem.Success} inPlace={rem.InPlace} originalUntouched={remedyUntouched}) [{rem.Error ?? rem.OutputPath}]");
+
                 var srcBefore = File.ReadAllBytes(srcPath);
                 var oip = locSvc.CompactPlugin(ls.Key.FileName.String, inPlace: true, acknowledge: false);
                 bool untouched = File.ReadAllBytes(srcPath).AsSpan().SequenceEqual(srcBefore);
@@ -325,6 +356,15 @@ public static class CompactServiceGuardProbe
                 Check(named && preConsent && untouched && noStaging,
                     $"TARGET-LOC compacting a LOCALIZED plugin IN PLACE is refused before the consent prompt, file untouched " +
                     $"(refused={!oip.Success} named={named} preConsent={preConsent} untouched={untouched} noStaging={noStaging}) [{oip.Error}]");
+            }
+
+            // NEWFILE-NOTE, other direction: the SAME lane over a NON-localized source says nothing about localization.
+            // Without this the note could be unconditional and the arm above would not notice.
+            {
+                var plainOut = svc.CompactPlugin(selfKey.FileName.String);
+                bool quiet = plainOut.Success && !(plainOut.Note?.Contains("localized", StringComparison.OrdinalIgnoreCase) ?? false);
+                Check(quiet, $"NEWFILE-NOTE a NON-localized source compacts to a new file with no localization note " +
+                             $"(success={plainOut.Success} quiet={quiet}) [{plainOut.Note}]");
             }
 
             // ---- REPOINT-LOC: a repoint that would REWRITE a localized external referencer is refused UP FRONT ----
@@ -433,7 +473,7 @@ public static class CompactServiceGuardProbe
                     $"repointed {o.Repointed.Count(x => x.Success)}/{o.Repointed.Count}){(o.Success ? "" : "; ERR " + o.Error)}");
             }
         }
-        finally { try { Directory.Delete(root, true); } catch { } }
+        finally { CorpusRulebook.CorpusPath = priorCorpusPath; try { Directory.Delete(root, true); } catch { } }
 
         Console.WriteLine();
         Console.WriteLine($"=== compact-service-guard: {(fail == 0 ? "PASS" : $"FAIL ({fail})")} ===");

--- a/src/housecarl-generator/CompactServiceGuardProbe.cs
+++ b/src/housecarl-generator/CompactServiceGuardProbe.cs
@@ -305,6 +305,26 @@ public static class CompactServiceGuardProbe
                 }
                 Check(flagOk && noStringsFolder,
                     $"LOCALIZED compact output is written NON-localized with strings inline (flagClear={flagOk} noStringsFolder={noStringsFolder})");
+
+                // The arm above IS the measurement behind the in-place refusal's remedy: the same localized source,
+                // compacted to a NEW file, keeps its FULL+DESC. The refusal names that lane, so it is named against a
+                // measured result rather than an assumption — and this block asserts the lane still works, which is the
+                // "new-file compact is untouched" direction of the in-place refusal below.
+                //
+                // TARGET-LOC: the same plugin compacted IN PLACE is refused, BEFORE the consent prompt and with the
+                // file untouched. Isolation, per the lesson the per-lane in-place arms taught: there is no backstop
+                // here to borrow a refusal from — the compaction builds a fresh non-localized plugin, so the write's
+                // own localized check structurally cannot fire on this path. Deleting the service check makes this arm
+                // RED by letting the compaction run, which is the whole point.
+                var srcBefore = File.ReadAllBytes(srcPath);
+                var oip = locSvc.CompactPlugin(ls.Key.FileName.String, inPlace: true, acknowledge: false);
+                bool untouched = File.ReadAllBytes(srcPath).AsSpan().SequenceEqual(srcBefore);
+                bool noStaging = !Directory.Exists(Path.Combine(Path.GetDirectoryName(srcPath)!, ".housecarl-tmp"));
+                bool preConsent = !oip.NeedsAcknowledge;
+                bool named = !oip.Success && (oip.Error?.StartsWith("houseCARL did not compact", StringComparison.Ordinal) ?? false);
+                Check(named && preConsent && untouched && noStaging,
+                    $"TARGET-LOC compacting a LOCALIZED plugin IN PLACE is refused before the consent prompt, file untouched " +
+                    $"(refused={!oip.Success} named={named} preConsent={preConsent} untouched={untouched} noStaging={noStaging}) [{oip.Error}]");
             }
 
             // ---- REPOINT-LOC: a repoint that would REWRITE a localized external referencer is refused UP FRONT ----
@@ -314,7 +334,11 @@ public static class CompactServiceGuardProbe
             //      that only checked for an error would pass just as well on a refusal issued halfway through.
             {
                 var rlRoot = Path.Combine(root, "reploc");
-                var tgt = new LocalizedStringsFixture.Spec("RlTgt", new ModKey("HcCsRlTgt", ModType.Plugin), "TGT NAME", "TGT DESC");
+                // The TARGET is deliberately non-localized: the in-place lane refuses a localized target outright, so a
+                // localized one here would be refused by THAT check and this arm would never reach the referencer
+                // pre-flight it is named for. Only the referencer is localized.
+                var tgt = new LocalizedStringsFixture.Spec("RlTgt", new ModKey("HcCsRlTgt", ModType.Plugin), "TGT NAME", "TGT DESC",
+                                                          Localized: false);
                 var rf = new LocalizedStringsFixture.Spec("RlRef", new ModKey("HcCsRlRef", ModType.Plugin), "REF NAME", "REF DESC",
                                                           LinksTo: LocalizedStringsFixture.WeaponKey(tgt));
                 var fx = LocalizedStringsFixture.Build(rlRoot, new[] { tgt, rf });
@@ -375,31 +399,20 @@ public static class CompactServiceGuardProbe
                 }
             }
 
-            // ---- REPOINT-PLAIN: the same shape with a NON-localized referencer still compacts and repoints ----
-            //      The other direction. The target here IS localized and compacts in place fine — the compacted plugin
-            //      is built fresh and non-localized with its strings inline — so this also pins that the refusal is
-            //      about the plugins being REWRITTEN as referencers, not about localization anywhere in the operation.
+            // ---- REPOINT-PLAIN: a NON-localized target with a NON-localized referencer still compacts and repoints ----
+            //      The other direction for the REFERENCER pre-flight: nothing localized anywhere, so neither the
+            //      referencer check nor the target check may fire and the full opt-in path must work end to end.
+            //      The target is non-localized here BECAUSE the in-place lane now refuses a localized one — this arm
+            //      would otherwise be measuring that refusal instead of the repoint it is named for.
             {
                 var rpRoot = Path.Combine(root, "repplain");
-                var tgt = new LocalizedStringsFixture.Spec("RpTgt", new ModKey("HcCsRpTgt", ModType.Plugin), "TGT NAME", "TGT DESC");
-                var fx = LocalizedStringsFixture.Build(rpRoot, new[] { tgt });
-
-                // The referencer, written NON-localized beside the fixture's plugins and appended to its profile.
-                var refKey = new ModKey("HcCsRpRef", ModType.Plugin);
-                var refDir = Path.Combine(fx.Mods, "RpRef");
-                Directory.CreateDirectory(refDir);
-                var refPath = Path.Combine(refDir, refKey.FileName.String);
+                var tgt = new LocalizedStringsFixture.Spec("RpTgt", new ModKey("HcCsRpTgt", ModType.Plugin), "TGT NAME", "TGT DESC",
+                                                          Localized: false);
+                var rf = new LocalizedStringsFixture.Spec("RpRef", new ModKey("HcCsRpRef", ModType.Plugin), "REF NAME", "REF DESC",
+                                                          LinksTo: LocalizedStringsFixture.WeaponKey(tgt), Localized: false);
+                var fx = LocalizedStringsFixture.Build(rpRoot, new[] { tgt, rf });
                 var tgtPath = Path.Combine(fx.Mods, tgt.ModFolder, tgt.Key.FileName.String);
-                using (var tov = SkyrimMod.CreateFromBinaryOverlay(tgtPath, SkyrimRelease.SkyrimSE))
-                {
-                    var rm = new SkyrimMod(refKey, SkyrimRelease.SkyrimSE);
-                    var fl = new FormList(new FormKey(refKey, 0xA01), SkyrimRelease.SkyrimSE) { EditorID = "RpRefList" };
-                    fl.Items.Add(LocalizedStringsFixture.WeaponKey(tgt).ToLink<ISkyrimMajorRecordGetter>());
-                    rm.FormLists.Add(fl);
-                    rm.ModHeader.Stats.NextFormID = 0xA02;
-                    rm.BeginWrite.ToPath(refPath).WithLoadOrder(new ISkyrimModGetter[] { tov }).NoNextFormIDProcessing().Write();
-                }
-                LocalizedStringsFixture.AppendPlugin(fx, "RpRef", refKey.FileName.String);
+                var refPath = Path.Combine(fx.Mods, rf.ModFolder, rf.Key.FileName.String);
 
                 var rpStore = new UserConfigStore(Path.Combine(rpRoot, "houseCARL.user.json"));
                 using var rpSvc = LoadOrderService.WithInstance(fx.Instance, 0, rpStore);
@@ -416,7 +429,7 @@ public static class CompactServiceGuardProbe
                 }
                 Check(o.Success && o.InPlace && tgtWeapAfter is not null && refLinkAfter == tgtWeapAfter
                       && o.Repointed.Count == 1 && o.Repointed[0].Success,
-                    $"REPOINT-PLAIN a NON-localized referencer still compacts + repoints (weapon -> {tgtWeapAfter}, ref -> {refLinkAfter}, " +
+                    $"REPOINT-PLAIN nothing localized: compacts in place + repoints (weapon -> {tgtWeapAfter}, ref -> {refLinkAfter}, " +
                     $"repointed {o.Repointed.Count(x => x.Success)}/{o.Repointed.Count}){(o.Success ? "" : "; ERR " + o.Error)}");
             }
         }

--- a/src/housecarl-generator/CompactServiceGuardProbe.cs
+++ b/src/housecarl-generator/CompactServiceGuardProbe.cs
@@ -306,6 +306,110 @@ public static class CompactServiceGuardProbe
                 Check(flagOk && noStringsFolder,
                     $"LOCALIZED compact output is written NON-localized with strings inline (flagClear={flagOk} noStringsFolder={noStringsFolder})");
             }
+
+            // ---- REPOINT-LOC: a repoint that would REWRITE a localized external referencer is refused UP FRONT ----
+            //      houseCARL cannot re-serialize a localized plugin without corrupting its text, and the referencer
+            //      rewrites happen only AFTER the target is already compacted on disk. So the refusal has to come
+            //      before the compaction starts, and the arm's real assertion is that NOTHING was written — an arm
+            //      that only checked for an error would pass just as well on a refusal issued halfway through.
+            {
+                var rlRoot = Path.Combine(root, "reploc");
+                var tgt = new LocalizedStringsFixture.Spec("RlTgt", new ModKey("HcCsRlTgt", ModType.Plugin), "TGT NAME", "TGT DESC");
+                var rf = new LocalizedStringsFixture.Spec("RlRef", new ModKey("HcCsRlRef", ModType.Plugin), "REF NAME", "REF DESC",
+                                                          LinksTo: LocalizedStringsFixture.WeaponKey(tgt));
+                var fx = LocalizedStringsFixture.Build(rlRoot, new[] { tgt, rf });
+                var rlStore = new UserConfigStore(Path.Combine(rlRoot, "houseCARL.user.json"));
+                using var rlSvc = LoadOrderService.WithInstance(fx.Instance, 0, rlStore);
+                rlSvc.Stats();
+
+                var tgtPath = Path.Combine(fx.Mods, tgt.ModFolder, tgt.Key.FileName.String);
+                var refPath = Path.Combine(fx.Mods, rf.ModFolder, rf.Key.FileName.String);
+                var tgtBefore = File.ReadAllBytes(tgtPath);
+                var refBefore = File.ReadAllBytes(refPath);
+
+                var o = rlSvc.CompactPlugin(tgt.Key.FileName.String, inPlace: true, repointExternals: true, acknowledge: true);
+                bool named = !o.Success && (o.Error?.Contains("LOCALIZED", StringComparison.Ordinal) ?? false)
+                                        && (o.Error?.Contains(rf.Key.FileName.String, StringComparison.OrdinalIgnoreCase) ?? false);
+                bool tgtUntouched = File.ReadAllBytes(tgtPath).AsSpan().SequenceEqual(tgtBefore);
+                bool refUntouched = File.ReadAllBytes(refPath).AsSpan().SequenceEqual(refBefore);
+                bool noStaging = !Directory.Exists(Path.Combine(Path.GetDirectoryName(tgtPath)!, ".housecarl-tmp"))
+                                 && !Directory.Exists(Path.Combine(Path.GetDirectoryName(refPath)!, ".housecarl-tmp"));
+                Check(named && tgtUntouched && refUntouched && noStaging,
+                    $"REPOINT-LOC refused up front, naming the localized referencer; target AND referencer untouched " +
+                    $"(named={named} targetUntouched={tgtUntouched} refUntouched={refUntouched} noStaging={noStaging}) [{o.Error}]");
+
+                // The identify pass really did see the referencer — otherwise the refusal above could be firing on an
+                // empty referencer set and the arm would pass on a fixture with no external reference in it at all.
+                var o2 = rlSvc.CompactPlugin(tgt.Key.FileName.String);
+                Check(!o2.Success && (o2.Error?.Contains(rf.Key.FileName.String, StringComparison.OrdinalIgnoreCase) ?? false),
+                    $"REPOINT-LOC fixture: the referencer IS an external referencer of the target (plain compact names it) [{o2.Error}]");
+
+                // The BACKSTOP, driven directly: the pre-flight above is what a caller normally meets, but the repoint
+                // itself must refuse a localized target on its own — otherwise the pre-flight is the only thing standing
+                // between a localized referencer and a corrupting rewrite, and any path that reaches the repoint another
+                // way is unprotected. Straight at RemapEngine, with the service's refusal bypassed entirely.
+                using (var rr = LoadOrderResolver.Build(new[]
+                {
+                    Path.Combine(fx.Data, "Skyrim.esm"),
+                    tgtPath,
+                    refPath,
+                }))
+                {
+                    var refBefore2 = File.ReadAllBytes(refPath);
+                    var rep = RemapEngine.RepointInPlace(rr, rf.Key.FileName.String,
+                        new Dictionary<FormKey, FormKey> { [LocalizedStringsFixture.WeaponKey(tgt)] = new FormKey(tgt.Key, 0x900) });
+                    bool untouched = File.ReadAllBytes(refPath).AsSpan().SequenceEqual(refBefore2);
+                    bool verbatim = !rep.Success && (rep.Error?.StartsWith("houseCARL did not write", StringComparison.Ordinal) ?? false);
+                    Check(verbatim && untouched,
+                        $"REPOINT-LOC backstop: RepointInPlace itself refuses the localized referencer verbatim, file untouched " +
+                        $"(refused={!rep.Success} verbatim={verbatim} untouched={untouched}) [{rep.Error}]");
+                }
+            }
+
+            // ---- REPOINT-PLAIN: the same shape with a NON-localized referencer still compacts and repoints ----
+            //      The other direction. The target here IS localized and compacts in place fine — the compacted plugin
+            //      is built fresh and non-localized with its strings inline — so this also pins that the refusal is
+            //      about the plugins being REWRITTEN as referencers, not about localization anywhere in the operation.
+            {
+                var rpRoot = Path.Combine(root, "repplain");
+                var tgt = new LocalizedStringsFixture.Spec("RpTgt", new ModKey("HcCsRpTgt", ModType.Plugin), "TGT NAME", "TGT DESC");
+                var fx = LocalizedStringsFixture.Build(rpRoot, new[] { tgt });
+
+                // The referencer, written NON-localized beside the fixture's plugins and appended to its profile.
+                var refKey = new ModKey("HcCsRpRef", ModType.Plugin);
+                var refDir = Path.Combine(fx.Mods, "RpRef");
+                Directory.CreateDirectory(refDir);
+                var refPath = Path.Combine(refDir, refKey.FileName.String);
+                var tgtPath = Path.Combine(fx.Mods, tgt.ModFolder, tgt.Key.FileName.String);
+                using (var tov = SkyrimMod.CreateFromBinaryOverlay(tgtPath, SkyrimRelease.SkyrimSE))
+                {
+                    var rm = new SkyrimMod(refKey, SkyrimRelease.SkyrimSE);
+                    var fl = new FormList(new FormKey(refKey, 0xA01), SkyrimRelease.SkyrimSE) { EditorID = "RpRefList" };
+                    fl.Items.Add(LocalizedStringsFixture.WeaponKey(tgt).ToLink<ISkyrimMajorRecordGetter>());
+                    rm.FormLists.Add(fl);
+                    rm.ModHeader.Stats.NextFormID = 0xA02;
+                    rm.BeginWrite.ToPath(refPath).WithLoadOrder(new ISkyrimModGetter[] { tov }).NoNextFormIDProcessing().Write();
+                }
+                LocalizedStringsFixture.AppendPlugin(fx, "RpRef", refKey.FileName.String);
+
+                var rpStore = new UserConfigStore(Path.Combine(rpRoot, "houseCARL.user.json"));
+                using var rpSvc = LoadOrderService.WithInstance(fx.Instance, 0, rpStore);
+                rpSvc.Stats();
+
+                var o = rpSvc.CompactPlugin(tgt.Key.FileName.String, inPlace: true, repointExternals: true, acknowledge: true);
+                FormKey? tgtWeapAfter = null, refLinkAfter = null;
+                if (o.Success)
+                {
+                    using (var tb = SkyrimMod.CreateFromBinaryOverlay(tgtPath, SkyrimRelease.SkyrimSE))
+                        tgtWeapAfter = tb.Weapons.FirstOrDefault(w => w.EditorID == LocalizedStringsFixture.WeaponEdid(tgt))?.FormKey;
+                    using (var rb = SkyrimMod.CreateFromBinaryOverlay(refPath, SkyrimRelease.SkyrimSE))
+                        refLinkAfter = rb.FormLists.First().Items.FirstOrDefault()?.FormKey;
+                }
+                Check(o.Success && o.InPlace && tgtWeapAfter is not null && refLinkAfter == tgtWeapAfter
+                      && o.Repointed.Count == 1 && o.Repointed[0].Success,
+                    $"REPOINT-PLAIN a NON-localized referencer still compacts + repoints (weapon -> {tgtWeapAfter}, ref -> {refLinkAfter}, " +
+                    $"repointed {o.Repointed.Count(x => x.Success)}/{o.Repointed.Count}){(o.Success ? "" : "; ERR " + o.Error)}");
+            }
         }
         finally { try { Directory.Delete(root, true); } catch { } }
 

--- a/src/housecarl-generator/InPlaceProbe.cs
+++ b/src/housecarl-generator/InPlaceProbe.cs
@@ -58,6 +58,7 @@ public static class InPlaceProbe
     const string MasterName = "HcInPlaceMaster.esm";
     const string UserName = "HcInPlaceUser.esp";
     const string HighName = "HcInPlaceHigh.esp";
+    const string LocName = "HcInPlaceLoc.esp";
 
     public static int RunGuard(string[] args)
     {
@@ -79,6 +80,7 @@ public static class InPlaceProbe
         string masterPath = Path.Combine(tmpDir, MasterName);
         string userPristine = Path.Combine(tmpDir, "pristine", UserName);
         string highPath = Path.Combine(tmpDir, HighName);
+        string locPristine = Path.Combine(tmpDir, "locpristine", LocName);
         Directory.CreateDirectory(Path.GetDirectoryName(userPristine)!);
 
         var masterKey = new ModKey("HcInPlaceMaster", ModType.Master);
@@ -109,6 +111,18 @@ public static class InPlaceProbe
             var hkw = h.Keywords.AddNew(); hkw.EditorID = "HcIP_HighKw";
             hkwFk = hkw.FormKey;
             h.BeginWrite.ToPath(highPath).WithLoadOrder(new ISkyrimModGetter[] { mOv }).Write();
+
+            // The LOCALIZED twin of the user override (arms LOC-A/LOC-B). Mutagen writes its .STRINGS beside it and
+            // they STAY there: this fixture is the plugin whose strings are exactly where they belong.
+            var lo = new SkyrimMod(new ModKey("HcInPlaceLoc", ModType.Plugin), SkyrimRelease.SkyrimSE) { UsingLocalization = true };
+            var low = lo.Weapons.GetOrAddAsOverride(mOv.Weapons.First(x => x.FormKey == wfk));
+            low.BasicStats!.Damage = 20; low.Name = "LocSword";
+            Directory.CreateDirectory(Path.GetDirectoryName(locPristine)!);
+            lo.BeginWrite.ToPath(locPristine).WithLoadOrder(new ISkyrimModGetter[] { mOv }).Write();
+            if (!Directory.Exists(Path.Combine(Path.GetDirectoryName(locPristine)!, "Strings")))
+                throw new InvalidOperationException(
+                    "guard fixture: the localized twin produced no Strings folder — it is NOT a localized plugin, and " +
+                    "arms LOC-A/LOC-B would both pass vacuously.");
         }
         Console.WriteLine($"-- setup: master {MasterName} (weapon {wfk}), user override (dmg 20, 'UserSword', counter 0x123), higher override (dmg 99, 'HighSword') --");
         Console.WriteLine();
@@ -631,6 +645,70 @@ public static class InPlaceProbe
                 $"refused={!o.Success} named={named} untouched={untouched}  [{Trim(o.Error)}]"));
         }
 
+        // ===== LOC-A / LOC-B — the write's LOCALIZED choke point, both directions =====
+        // A localized plugin holds its text in sibling .STRINGS files and carries only indices into them. The in-place
+        // re-serialize renumbers those indices and commits the plugin file alone, so the rewritten plugin would read its
+        // text against the old, unchanged strings — values landing on other records. WriteInPlace refuses such a target
+        // BEFORE it creates its staging directory, which is what the residue check below actually pins: a refusal that
+        // staged first and cleaned up afterwards would pass a bytes-only assertion just as well.
+        //
+        // Deliberately the shape that has NOTHING wrong with its strings — they sit right beside the plugin and read
+        // correctly through the ordinary open. The guard is not about where strings resolve from; it is about the write
+        // discarding the tables it just emitted.
+        //
+        // LOC-B is the other direction on the same edit: the non-localized twin still writes. Without it, deleting the
+        // localized read (or hard-coding the refusal) would leave LOC-A green.
+        {
+            var locT = FreshLocalized(tmpDir, "LOCA", locPristine);
+            var before = File.ReadAllBytes(locT);
+            var stringsBefore = StringsSnapshot(Path.GetDirectoryName(locT)!);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, locT });
+            var o = WritePatchBuilder.ApplyInPlace(r, rulebook,
+                new[] { new WritePatchBuilder.PatchEdit { Target = wfk, Path = new[] { "BasicStats", "Damage" }, Verb = "Set", Value = "55" } },
+                locT, LocName);
+            bool untouched = File.ReadAllBytes(locT).AsSpan().SequenceEqual(before);
+            bool stringsSame = StringsSnapshot(Path.GetDirectoryName(locT)!) == stringsBefore;
+            bool noStaging = !Directory.Exists(Path.Combine(Path.GetDirectoryName(locT)!, ".housecarl-tmp"));
+            bool named = !o.Success && (o.Error?.Contains("LOCALIZED", StringComparison.Ordinal) ?? false);
+            bool pass = named && untouched && stringsSame && noStaging;
+            results.Add(("LOC-A in-place REFUSES a localized target; plugin, strings and staging all untouched", pass,
+                $"refused={!o.Success} named={named} pluginUntouched={untouched} stringsUntouched={stringsSame} noStagingResidue={noStaging}  [{Trim(o.Error)}]"));
+
+            var plainT = FreshUser(tmpDir, "LOCB", userPristine);
+            using var r2 = LoadOrderResolver.Build(new[] { masterPath, plainT });
+            var o2 = WritePatchBuilder.ApplyInPlace(r2, rulebook,
+                new[] { new WritePatchBuilder.PatchEdit { Target = wfk, Path = new[] { "BasicStats", "Damage" }, Verb = "Set", Value = "55" } },
+                plainT, UserName);
+            int dmg2 = ReadDamage(plainT, wfk);
+            bool pass2 = o2.Success && dmg2 == 55;
+            results.Add(("LOC-B the same edit on the NON-localized twin still writes (the guard fires on localization only)", pass2,
+                $"success={o2.Success} dmg={dmg2}(want 55)  [{o2.Error ?? "ok"}]"));
+        }
+
+        // ===== LOC-C / LOC-D — the REMOVE lane renders the refusal too, and still removes from a plain target =====
+        // The remove lane does not share the edit lane's SerializeFailure render, so it carries the refusal through its
+        // own arm. Without LOC-C that arm is an untested branch; without LOC-D, deleting the lane's normal render would
+        // not show up here.
+        {
+            var locT = FreshLocalized(tmpDir, "LOCC", locPristine);
+            var before = File.ReadAllBytes(locT);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, locT });
+            var o = WritePatchBuilder.RemoveRecordsInPlace(r, new[] { wfk }, locT, LocName);
+            bool untouched = File.ReadAllBytes(locT).AsSpan().SequenceEqual(before);
+            // The refusal is the exception's OWN sentence, not the lane's "failed (serialize or commit…)" lead — the
+            // write refuses before either of those runs, so a lead naming them would say a thing that did not happen.
+            bool verbatim = !o.Success && (o.Error?.StartsWith("houseCARL did not write", StringComparison.Ordinal) ?? false);
+            results.Add(("LOC-C remove-in-place refuses a localized target with the refusal's own sentence, file untouched",
+                verbatim && untouched,
+                $"refused={!o.Success} verbatim={verbatim} untouched={untouched}  [{Trim(o.Error)}]"));
+
+            var plainT = FreshUser(tmpDir, "LOCD", userPristine);
+            using var r2 = LoadOrderResolver.Build(new[] { masterPath, plainT });
+            var o2 = WritePatchBuilder.RemoveRecordsInPlace(r2, new[] { wfk }, plainT, UserName);
+            results.Add(("LOC-D remove-in-place on the NON-localized twin still removes", o2.Success && o2.Removed.Count == 1,
+                $"success={o2.Success} removed={o2.Removed.Count}(want 1)  [{o2.Error ?? "ok"}]"));
+        }
+
         Console.WriteLine("── ARMS ──");
         bool all = true;
         foreach (var (name, pass, detail) in results)
@@ -774,6 +852,33 @@ public static class InPlaceProbe
     }
 
     // ---- helpers -------------------------------------------------------------------------------------------
+
+    /// <summary>A fresh copy of the LOCALIZED pristine plugin AND its sibling <c>Strings\</c> folder — both, because
+    /// a copy without the strings would be a plugin whose text resolves nowhere, which is a different fixture.</summary>
+    static string FreshLocalized(string tmpDir, string arm, string pristine)
+    {
+        var dir = Path.Combine(tmpDir, "arm-" + arm);
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, LocName);
+        File.Copy(pristine, path, overwrite: true);
+        var srcStrings = Path.Combine(Path.GetDirectoryName(pristine)!, "Strings");
+        var dstStrings = Path.Combine(dir, "Strings");
+        Directory.CreateDirectory(dstStrings);
+        foreach (var f in Directory.GetFiles(srcStrings))
+            File.Copy(f, Path.Combine(dstStrings, Path.GetFileName(f)), overwrite: true);
+        return path;
+    }
+
+    /// <summary>Name+length+bytes of every file in a plugin folder's <c>Strings\</c>, as one comparable string — the
+    /// strings half of "nothing was touched". Missing folder answers a distinct token, so a DELETED strings folder can
+    /// never compare equal to a present one.</summary>
+    static string StringsSnapshot(string folder)
+    {
+        var dir = Path.Combine(folder, "Strings");
+        if (!Directory.Exists(dir)) return "<no Strings folder>";
+        return string.Join(";", Directory.GetFiles(dir).OrderBy(f => f, StringComparer.Ordinal)
+            .Select(f => Path.GetFileName(f) + ":" + Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(File.ReadAllBytes(f)))));
+    }
 
     static string FreshUser(string tmpDir, string arm, string pristine)
     {

--- a/src/housecarl-generator/InPlaceProbe.cs
+++ b/src/housecarl-generator/InPlaceProbe.cs
@@ -673,8 +673,12 @@ public static class InPlaceProbe
             // refusal after "failed (serialize or commit…)" — a step it happens before. A Contains check passes either
             // way, so it would leave that render untested.
             bool named = !o.Success && (o.Error?.StartsWith("houseCARL did not write", StringComparison.Ordinal) ?? false);
+            // stringsSame is a WITNESS, not a test: the staged write emits into .housecarl-tmp\Strings, never into the
+            // plugin's own Strings\, so this stays true with or without the refusal (measured by disabling the choke
+            // point — it printed pluginUntouched=False noStagingResidue=False stringsUntouched=True). It is reported
+            // because "the strings are still there" is worth seeing; the arm's teeth are the other three.
             bool pass = named && untouched && stringsSame && noStaging;
-            results.Add(("LOC-A in-place REFUSES a localized target verbatim; plugin, strings and staging all untouched", pass,
+            results.Add(("LOC-A in-place REFUSES a localized target verbatim; plugin untouched, no staging residue", pass,
                 $"refused={!o.Success} verbatim={named} pluginUntouched={untouched} stringsUntouched={stringsSame} noStagingResidue={noStaging}  [{Trim(o.Error)}]"));
 
             var plainT = FreshUser(tmpDir, "LOCB", userPristine);
@@ -710,6 +714,44 @@ public static class InPlaceProbe
             var o2 = WritePatchBuilder.RemoveRecordsInPlace(r2, new[] { wfk }, plainT, UserName);
             results.Add(("LOC-D remove-in-place on the NON-localized twin still removes", o2.Success && o2.Removed.Count == 1,
                 $"success={o2.Success} removed={o2.Removed.Count}(want 1)  [{o2.Error ?? "ok"}]"));
+        }
+
+        // ===== LOC-E / LOC-F / LOC-G — the SERVICE predicts the write's refusal instead of meeting it =====
+        // The choke point lives in the write, which the dry run never reaches and which the consent gate runs after.
+        // Left there alone: a dry run on a localized target reports the edit landing and the masters the file would
+        // carry, while the real call refuses — and the first acknowledged real call spends the modder's one-time
+        // in-place consent for a plugin houseCARL was never going to write. The service pre-flight answers first.
+        {
+            var locE = FreshLocalized(tmpDir, "LOCE", locPristine);
+            var storePath = Path.Combine(tmpDir, "LOCE.user.json");
+            using var r = LoadOrderResolver.Build(new[] { masterPath, locE });
+            var svc = LoadOrderService.ForGuard(r, new UserConfigStore(storePath));
+            svc.Stats();
+            var edit = new[] { new BulkOp { Formid = fmtWfk, FieldPath = "BasicStats.Damage", Verb = "Set", Value = "55" } };
+
+            // A dry run's contract is to give EXACTLY the answer the real call gives.
+            var dry = svc.ApplyEdits(edit, null, null, fullReadback: false, target: LocName, inPlace: true,
+                                     acknowledge: false, dryRun: true);
+            bool dryPass = !dry.Success && (dry.Error?.StartsWith("houseCARL did not write", StringComparison.Ordinal) ?? false);
+            results.Add(("LOC-E an in-place DRY RUN on a localized target refuses, as the real call does", dryPass,
+                $"refused={!dry.Success} verbatim={dryPass}  [{Trim(dry.Error) ?? "(reported success — WRONG)"}]"));
+
+            // acknowledge=true is the branch that PERSISTS consent before the write is attempted.
+            var real = svc.ApplyEdits(edit, null, null, fullReadback: false, target: LocName, inPlace: true,
+                                      acknowledge: true);
+            bool spent = new UserConfigStore(storePath).IsInPlaceAcknowledged(locE);
+            results.Add(("LOC-F the refused write does NOT spend the plugin's one-time in-place consent", !real.Success && !spent,
+                $"refused={!real.Success} consentRecorded={spent}(want False)  [{Trim(real.Error)}]"));
+
+            // The other direction on the same seam: the plain twin's dry run still reports what it would do.
+            var plainG = FreshUser(tmpDir, "LOCG", userPristine);
+            using var rg = LoadOrderResolver.Build(new[] { masterPath, plainG });
+            var svcG = LoadOrderService.ForGuard(rg, new UserConfigStore(Path.Combine(tmpDir, "LOCG.user.json")));
+            svcG.Stats();
+            var dryG = svcG.ApplyEdits(edit, null, null, fullReadback: false, target: UserName, inPlace: true,
+                                       acknowledge: false, dryRun: true);
+            results.Add(("LOC-G the NON-localized twin's in-place dry run still reports what it would do", dryG.Success && dryG.DryRun,
+                $"success={dryG.Success} dryRun={dryG.DryRun}  [{dryG.Error ?? "ok"}]"));
         }
 
         Console.WriteLine("── ARMS ──");

--- a/src/housecarl-generator/InPlaceProbe.cs
+++ b/src/housecarl-generator/InPlaceProbe.cs
@@ -754,11 +754,13 @@ public static class InPlaceProbe
                 $"success={dryG.Success} dryRun={dryG.DryRun}  [{dryG.Error ?? "ok"}]"));
         }
 
-        // ===== LOC-H / LOC-I / LOC-J — the pre-flight is called from FOUR lanes; one arm covers one of them =====
-        // LOC-E/F only drive ApplyEdits. The remove, forward and create entries each carry their own copy of the
-        // check, so deleting any of those three left every arm green — the write's choke point would still refuse, but
-        // the consent would already be spent and (for forward) a dry run would still report an edit that then refuses.
-        // One arm per call site, since the call sites are what can go missing.
+        // ===== LOC-H / LOC-I / LOC-J — the pre-flight is called from FOUR lanes; LOC-E/F cover one of them =====
+        // These assert on the CONSENT RECORD, not on the refusal. Measured: deleting the remove lane's pre-flight and
+        // asserting only "refused, verbatim" left the arm GREEN, because the write's own choke point refuses with the
+        // same sentence — the arm was pinning the backstop, not the thing it named. What actually separates the two is
+        // that the pre-flight answers BEFORE the gate persists the acknowledgement: without it the lane runs the gate,
+        // records consent for a plugin houseCARL then refuses to write, and the modder's one-time confirmation for that
+        // file is gone. One arm per call site, since the call sites are what can go missing.
         {
             string StoreFor(string arm) => Path.Combine(tmpDir, arm + ".user.json");
             bool RefusedVerbatim(string? err) => err?.StartsWith("houseCARL did not write", StringComparison.Ordinal) ?? false;
@@ -769,8 +771,9 @@ public static class InPlaceProbe
                 var svc = LoadOrderService.ForGuard(r, new UserConfigStore(StoreFor("LOCH")));
                 svc.Stats();
                 var o = svc.RemoveRecords(new[] { fmtWfk }, null, target: LocName, inPlace: true, acknowledge: true);
-                results.Add(("LOC-H the REMOVE lane's own pre-flight refuses a localized target", !o.Success && RefusedVerbatim(o.Error),
-                    $"refused={!o.Success} verbatim={RefusedVerbatim(o.Error)}  [{Trim(o.Error)}]"));
+                bool spent = new UserConfigStore(StoreFor("LOCH")).IsInPlaceAcknowledged(locH);
+                results.Add(("LOC-H the REMOVE lane's own pre-flight answers before consent is recorded", !o.Success && RefusedVerbatim(o.Error) && !spent,
+                    $"refused={!o.Success} verbatim={RefusedVerbatim(o.Error)} consentRecorded={spent}(want False)  [{Trim(o.Error)}]"));
             }
 
             var locI = FreshLocalized(tmpDir, "LOCI", locPristine);
@@ -779,8 +782,9 @@ public static class InPlaceProbe
                 var svc = LoadOrderService.ForGuard(r, new UserConfigStore(StoreFor("LOCI")));
                 svc.Stats();
                 var o = svc.ForwardRecords(new[] { fmtWfk }, HighName, null, null, target: LocName, inPlace: true, acknowledge: true);
-                results.Add(("LOC-I the FORWARD lane's own pre-flight refuses a localized target", !o.Success && RefusedVerbatim(o.Error),
-                    $"refused={!o.Success} verbatim={RefusedVerbatim(o.Error)}  [{Trim(o.Error)}]"));
+                bool spent = new UserConfigStore(StoreFor("LOCI")).IsInPlaceAcknowledged(locI);
+                results.Add(("LOC-I the FORWARD lane's own pre-flight answers before consent is recorded", !o.Success && RefusedVerbatim(o.Error) && !spent,
+                    $"refused={!o.Success} verbatim={RefusedVerbatim(o.Error)} consentRecorded={spent}(want False)  [{Trim(o.Error)}]"));
             }
 
             var locJ = FreshLocalized(tmpDir, "LOCJ", locPristine);
@@ -790,8 +794,9 @@ public static class InPlaceProbe
                 svc.Stats();
                 var o = svc.CreateRecords("Keyword", "HcIP_LocKw", Array.Empty<BulkOp>(), null, null, false, null, null, null,
                                           target: LocName, inPlace: true, acknowledge: true);
-                results.Add(("LOC-J the CREATE lane's own pre-flight refuses a localized target", !o.Success && RefusedVerbatim(o.Error),
-                    $"refused={!o.Success} verbatim={RefusedVerbatim(o.Error)}  [{Trim(o.Error)}]"));
+                bool spent = new UserConfigStore(StoreFor("LOCJ")).IsInPlaceAcknowledged(locJ);
+                results.Add(("LOC-J the CREATE lane's own pre-flight answers before consent is recorded", !o.Success && RefusedVerbatim(o.Error) && !spent,
+                    $"refused={!o.Success} verbatim={RefusedVerbatim(o.Error)} consentRecorded={spent}(want False)  [{Trim(o.Error)}]"));
             }
         }
 

--- a/src/housecarl-generator/InPlaceProbe.cs
+++ b/src/housecarl-generator/InPlaceProbe.cs
@@ -754,6 +754,47 @@ public static class InPlaceProbe
                 $"success={dryG.Success} dryRun={dryG.DryRun}  [{dryG.Error ?? "ok"}]"));
         }
 
+        // ===== LOC-H / LOC-I / LOC-J — the pre-flight is called from FOUR lanes; one arm covers one of them =====
+        // LOC-E/F only drive ApplyEdits. The remove, forward and create entries each carry their own copy of the
+        // check, so deleting any of those three left every arm green — the write's choke point would still refuse, but
+        // the consent would already be spent and (for forward) a dry run would still report an edit that then refuses.
+        // One arm per call site, since the call sites are what can go missing.
+        {
+            string StoreFor(string arm) => Path.Combine(tmpDir, arm + ".user.json");
+            bool RefusedVerbatim(string? err) => err?.StartsWith("houseCARL did not write", StringComparison.Ordinal) ?? false;
+
+            var locH = FreshLocalized(tmpDir, "LOCH", locPristine);
+            using (var r = LoadOrderResolver.Build(new[] { masterPath, locH }))
+            {
+                var svc = LoadOrderService.ForGuard(r, new UserConfigStore(StoreFor("LOCH")));
+                svc.Stats();
+                var o = svc.RemoveRecords(new[] { fmtWfk }, null, target: LocName, inPlace: true, acknowledge: true);
+                results.Add(("LOC-H the REMOVE lane's own pre-flight refuses a localized target", !o.Success && RefusedVerbatim(o.Error),
+                    $"refused={!o.Success} verbatim={RefusedVerbatim(o.Error)}  [{Trim(o.Error)}]"));
+            }
+
+            var locI = FreshLocalized(tmpDir, "LOCI", locPristine);
+            using (var r = LoadOrderResolver.Build(new[] { masterPath, locI, highPath }))
+            {
+                var svc = LoadOrderService.ForGuard(r, new UserConfigStore(StoreFor("LOCI")));
+                svc.Stats();
+                var o = svc.ForwardRecords(new[] { fmtWfk }, HighName, null, null, target: LocName, inPlace: true, acknowledge: true);
+                results.Add(("LOC-I the FORWARD lane's own pre-flight refuses a localized target", !o.Success && RefusedVerbatim(o.Error),
+                    $"refused={!o.Success} verbatim={RefusedVerbatim(o.Error)}  [{Trim(o.Error)}]"));
+            }
+
+            var locJ = FreshLocalized(tmpDir, "LOCJ", locPristine);
+            using (var r = LoadOrderResolver.Build(new[] { masterPath, locJ }))
+            {
+                var svc = LoadOrderService.ForGuard(r, new UserConfigStore(StoreFor("LOCJ")));
+                svc.Stats();
+                var o = svc.CreateRecords("Keyword", "HcIP_LocKw", Array.Empty<BulkOp>(), null, null, false, null, null, null,
+                                          target: LocName, inPlace: true, acknowledge: true);
+                results.Add(("LOC-J the CREATE lane's own pre-flight refuses a localized target", !o.Success && RefusedVerbatim(o.Error),
+                    $"refused={!o.Success} verbatim={RefusedVerbatim(o.Error)}  [{Trim(o.Error)}]"));
+            }
+        }
+
         Console.WriteLine("── ARMS ──");
         bool all = true;
         foreach (var (name, pass, detail) in results)

--- a/src/housecarl-generator/InPlaceProbe.cs
+++ b/src/housecarl-generator/InPlaceProbe.cs
@@ -732,16 +732,18 @@ public static class InPlaceProbe
             // A dry run's contract is to give EXACTLY the answer the real call gives.
             var dry = svc.ApplyEdits(edit, null, null, fullReadback: false, target: LocName, inPlace: true,
                                      acknowledge: false, dryRun: true);
-            bool dryPass = !dry.Success && (dry.Error?.StartsWith("houseCARL did not write", StringComparison.Ordinal) ?? false);
-            results.Add(("LOC-E an in-place DRY RUN on a localized target refuses, as the real call does", dryPass,
-                $"refused={!dry.Success} verbatim={dryPass}  [{Trim(dry.Error) ?? "(reported success — WRONG)"}]"));
+            bool dryPass = !dry.Success && (dry.Error?.StartsWith("houseCARL did not write", StringComparison.Ordinal) ?? false)
+                           && (dry.Error?.Contains(LocalizedTargetUnsupportedException.RemedyDefaultLane, StringComparison.Ordinal) ?? false);
+            results.Add(("LOC-E an in-place DRY RUN on a localized target refuses, with the lane's remedy, as the real call does", dryPass,
+                $"refused={!dry.Success} verbatimWithRemedy={dryPass}  [{Trim(dry.Error) ?? "(reported success — WRONG)"}]"));
 
             // acknowledge=true is the branch that PERSISTS consent before the write is attempted.
             var real = svc.ApplyEdits(edit, null, null, fullReadback: false, target: LocName, inPlace: true,
                                       acknowledge: true);
             bool spent = new UserConfigStore(storePath).IsInPlaceAcknowledged(locE);
-            results.Add(("LOC-F the refused write does NOT spend the plugin's one-time in-place consent", !real.Success && !spent,
-                $"refused={!real.Success} consentRecorded={spent}(want False)  [{Trim(real.Error)}]"));
+            bool realRemedy = real.Error?.Contains(LocalizedTargetUnsupportedException.RemedyDefaultLane, StringComparison.Ordinal) ?? false;
+            results.Add(("LOC-F the refused write does NOT spend consent, and carries the same remedy the dry run gave", !real.Success && !spent && realRemedy,
+                $"refused={!real.Success} consentRecorded={spent}(want False) sameRemedy={realRemedy}  [{Trim(real.Error)}]"));
 
             // The other direction on the same seam: the plain twin's dry run still reports what it would do.
             var plainG = FreshUser(tmpDir, "LOCG", userPristine);
@@ -772,8 +774,10 @@ public static class InPlaceProbe
                 svc.Stats();
                 var o = svc.RemoveRecords(new[] { fmtWfk }, null, target: LocName, inPlace: true, acknowledge: true);
                 bool spent = new UserConfigStore(StoreFor("LOCH")).IsInPlaceAcknowledged(locH);
-                results.Add(("LOC-H the REMOVE lane's own pre-flight answers before consent is recorded", !o.Success && RefusedVerbatim(o.Error) && !spent,
-                    $"refused={!o.Success} verbatim={RefusedVerbatim(o.Error)} consentRecorded={spent}(want False)  [{Trim(o.Error)}]"));
+                bool clause = (o.Error?.Contains(LocalizedTargetUnsupportedException.RemoveNoEquivalent, StringComparison.Ordinal) ?? false)
+                              && !(o.Error?.Contains(LocalizedTargetUnsupportedException.RemedyDefaultLane, StringComparison.Ordinal) ?? false);
+                results.Add(("LOC-H the REMOVE lane's own pre-flight answers before consent, with THIS lane's clause", !o.Success && RefusedVerbatim(o.Error) && !spent && clause,
+                    $"refused={!o.Success} verbatim={RefusedVerbatim(o.Error)} consentRecorded={spent}(want False) laneClause={clause}  [{Trim(o.Error)}]"));
             }
 
             var locI = FreshLocalized(tmpDir, "LOCI", locPristine);
@@ -783,8 +787,9 @@ public static class InPlaceProbe
                 svc.Stats();
                 var o = svc.ForwardRecords(new[] { fmtWfk }, HighName, null, null, target: LocName, inPlace: true, acknowledge: true);
                 bool spent = new UserConfigStore(StoreFor("LOCI")).IsInPlaceAcknowledged(locI);
-                results.Add(("LOC-I the FORWARD lane's own pre-flight answers before consent is recorded", !o.Success && RefusedVerbatim(o.Error) && !spent,
-                    $"refused={!o.Success} verbatim={RefusedVerbatim(o.Error)} consentRecorded={spent}(want False)  [{Trim(o.Error)}]"));
+                bool clause = o.Error?.Contains(LocalizedTargetUnsupportedException.RemedyDefaultLane, StringComparison.Ordinal) ?? false;
+                results.Add(("LOC-I the FORWARD lane's own pre-flight answers before consent, with THIS lane's clause", !o.Success && RefusedVerbatim(o.Error) && !spent && clause,
+                    $"refused={!o.Success} verbatim={RefusedVerbatim(o.Error)} consentRecorded={spent}(want False) laneClause={clause}  [{Trim(o.Error)}]"));
             }
 
             var locJ = FreshLocalized(tmpDir, "LOCJ", locPristine);
@@ -795,8 +800,9 @@ public static class InPlaceProbe
                 var o = svc.CreateRecords("Keyword", "HcIP_LocKw", Array.Empty<BulkOp>(), null, null, false, null, null, null,
                                           target: LocName, inPlace: true, acknowledge: true);
                 bool spent = new UserConfigStore(StoreFor("LOCJ")).IsInPlaceAcknowledged(locJ);
-                results.Add(("LOC-J the CREATE lane's own pre-flight answers before consent is recorded", !o.Success && RefusedVerbatim(o.Error) && !spent,
-                    $"refused={!o.Success} verbatim={RefusedVerbatim(o.Error)} consentRecorded={spent}(want False)  [{Trim(o.Error)}]"));
+                bool clause = o.Error?.Contains(LocalizedTargetUnsupportedException.RemedyDefaultLane, StringComparison.Ordinal) ?? false;
+                results.Add(("LOC-J the CREATE lane's own pre-flight answers before consent, with THIS lane's clause", !o.Success && RefusedVerbatim(o.Error) && !spent && clause,
+                    $"refused={!o.Success} verbatim={RefusedVerbatim(o.Error)} consentRecorded={spent}(want False) laneClause={clause}  [{Trim(o.Error)}]"));
             }
         }
 

--- a/src/housecarl-generator/InPlaceProbe.cs
+++ b/src/housecarl-generator/InPlaceProbe.cs
@@ -669,10 +669,13 @@ public static class InPlaceProbe
             bool untouched = File.ReadAllBytes(locT).AsSpan().SequenceEqual(before);
             bool stringsSame = StringsSnapshot(Path.GetDirectoryName(locT)!) == stringsBefore;
             bool noStaging = !Directory.Exists(Path.Combine(Path.GetDirectoryName(locT)!, ".housecarl-tmp"));
-            bool named = !o.Success && (o.Error?.Contains("LOCALIZED", StringComparison.Ordinal) ?? false);
+            // StartsWith, not Contains: the edit lane renders through SerializeFailure, whose lead would put this
+            // refusal after "failed (serialize or commit…)" — a step it happens before. A Contains check passes either
+            // way, so it would leave that render untested.
+            bool named = !o.Success && (o.Error?.StartsWith("houseCARL did not write", StringComparison.Ordinal) ?? false);
             bool pass = named && untouched && stringsSame && noStaging;
-            results.Add(("LOC-A in-place REFUSES a localized target; plugin, strings and staging all untouched", pass,
-                $"refused={!o.Success} named={named} pluginUntouched={untouched} stringsUntouched={stringsSame} noStagingResidue={noStaging}  [{Trim(o.Error)}]"));
+            results.Add(("LOC-A in-place REFUSES a localized target verbatim; plugin, strings and staging all untouched", pass,
+                $"refused={!o.Success} verbatim={named} pluginUntouched={untouched} stringsUntouched={stringsSame} noStagingResidue={noStaging}  [{Trim(o.Error)}]"));
 
             var plainT = FreshUser(tmpDir, "LOCB", userPristine);
             using var r2 = LoadOrderResolver.Build(new[] { masterPath, plainT });

--- a/src/housecarl-generator/LocalizedStringsFixture.cs
+++ b/src/housecarl-generator/LocalizedStringsFixture.cs
@@ -28,7 +28,11 @@ internal static class LocalizedStringsFixture
     /// <param name="Name">The localized FULL the weapon carries.</param>
     /// <param name="Desc">The localized DESC the weapon carries.</param>
     /// <param name="StringsNowhere">Delete the strings rather than relocating them to game-Data (the residual case).</param>
-    internal sealed record Spec(string ModFolder, ModKey Key, string Name, string Desc, bool StringsNowhere = false);
+    /// <param name="LinksTo">A record in an EARLIER spec's plugin to point a FormList at — the external-referencer
+    /// shape. The link makes that plugin a declared master of this one, which is what puts this plugin in the
+    /// identify pass's answer when the other one is compacted.</param>
+    internal sealed record Spec(string ModFolder, ModKey Key, string Name, string Desc, bool StringsNowhere = false,
+                                FormKey? LinksTo = null);
 
     /// <param name="Instance">The MO2 instance dir to hand <c>LoadOrderService.WithInstance</c>.</param>
     /// <param name="Mods">The instance's mods dir.</param>
@@ -38,6 +42,10 @@ internal static class LocalizedStringsFixture
     /// <summary>The EditorID of the localized weapon in the plugin built from <paramref name="spec"/> — the handle every
     /// arm reads back by, since a merge/compact renumbers the FormKey but never the EditorID.</summary>
     internal static string WeaponEdid(Spec spec) => spec.Key.Name + "Weap";
+
+    /// <summary>The FormKey of that weapon — what a later spec's <see cref="Spec.LinksTo"/> points at. Fixed rather
+    /// than discovered, because the referencer has to be built naming it before the fixture has written anything.</summary>
+    internal static FormKey WeaponKey(Spec spec) => new(spec.Key, 0xA01);
 
     /// <summary>Build the instance under <paramref name="root"/>. The specs are listed in load order, after Skyrim.esm.</summary>
     internal static Built Build(string root, IReadOnlyList<Spec> specs)
@@ -58,6 +66,11 @@ internal static class LocalizedStringsFixture
             .BeginWrite.ToPath(Path.Combine(data, skyrimKey.FileName.String))
             .WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
 
+        // Plugins already written, kept open as the load order for the ones still to come: a spec that LinksTo an
+        // earlier plugin can only be serialized against a context that can resolve the link.
+        var written = new List<ISkyrimModGetter>();
+        try
+        {
         foreach (var spec in specs)
         {
             var modDir = Path.Combine(mods, spec.ModFolder);
@@ -71,9 +84,15 @@ internal static class LocalizedStringsFixture
                 Description = spec.Desc,
                 BasicStats = new WeaponBasicStats { Damage = 7 },
             });
-            m.ModHeader.Stats.NextFormID = 0xA02;
+            if (spec.LinksTo is { } into)
+            {
+                var fl = new FormList(new FormKey(spec.Key, 0xA02), SkyrimRelease.SkyrimSE) { EditorID = spec.Key.Name + "List" };
+                fl.Items.Add(into.ToLink<ISkyrimMajorRecordGetter>());
+                m.FormLists.Add(fl);
+            }
+            m.ModHeader.Stats.NextFormID = 0xA03;
             m.BeginWrite.ToPath(Path.Combine(modDir, spec.Key.FileName.String))
-                .WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write();
+                .WithLoadOrder(written.ToArray()).NoNextFormIDProcessing().Write();
 
             // The plugin now has its strings beside it, which is the state the bare overlay reads CORRECTLY. Move them
             // out (or drop them) so the plugin's own folder carries no strings source — the state under test.
@@ -94,7 +113,11 @@ internal static class LocalizedStringsFixture
                 foreach (var f in Directory.GetFiles(own)) File.Move(f, Path.Combine(target, Path.GetFileName(f)));
                 Directory.Delete(own, true);
             }
+
+            written.Add(SkyrimMod.CreateFromBinaryOverlay(Path.Combine(modDir, spec.Key.FileName.String), SkyrimRelease.SkyrimSE));
         }
+        }
+        finally { foreach (var w in written) { if (w is IDisposable d) { try { d.Dispose(); } catch { } } } }
 
         var order = new[] { skyrimKey.FileName.String }.Concat(specs.Select(s => s.Key.FileName.String)).ToArray();
         File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + string.Join("\r\n", order) + "\r\n");
@@ -103,6 +126,21 @@ internal static class LocalizedStringsFixture
             "# header\r\n" + string.Join("\r\n", specs.Reverse().Select(s => "+" + s.ModFolder)) + "\r\n");
 
         return new Built(instance, mods, data);
+    }
+
+    /// <summary>Add an already-written plugin to a built instance's profile — for a plugin this fixture did NOT build
+    /// (the non-localized referencer arms need one, and every plugin this builder makes is localized by definition).
+    /// Appended to loadorder/plugins (lowest priority, so it sorts after the specs) and prepended to modlist, which is
+    /// MO2's highest-priority-first list.</summary>
+    internal static void AppendPlugin(Built built, string modFolder, string pluginFileName)
+    {
+        var profiles = Path.Combine(built.Instance, "profiles", "Default");
+        File.AppendAllText(Path.Combine(profiles, "loadorder.txt"), pluginFileName + "\r\n");
+        File.AppendAllText(Path.Combine(profiles, "plugins.txt"), "*" + pluginFileName + "\r\n");
+        var modlist = Path.Combine(profiles, "modlist.txt");
+        var lines = File.ReadAllLines(modlist).ToList();
+        lines.Insert(lines.Count > 0 && lines[0].StartsWith("#") ? 1 : 0, "+" + modFolder);
+        File.WriteAllText(modlist, string.Join("\r\n", lines) + "\r\n");
     }
 
     /// <summary>Read a written plugin's weapon FULL/DESC back with the BARE overlay — deliberately bare, and deliberately

--- a/src/housecarl-generator/LocalizedStringsFixture.cs
+++ b/src/housecarl-generator/LocalizedStringsFixture.cs
@@ -71,51 +71,51 @@ internal static class LocalizedStringsFixture
         var written = new List<ISkyrimModGetter>();
         try
         {
-        foreach (var spec in specs)
-        {
-            var modDir = Path.Combine(mods, spec.ModFolder);
-            Directory.CreateDirectory(modDir);
+            foreach (var spec in specs)
+            {
+                var modDir = Path.Combine(mods, spec.ModFolder);
+                Directory.CreateDirectory(modDir);
 
-            var m = new SkyrimMod(spec.Key, SkyrimRelease.SkyrimSE) { UsingLocalization = true };
-            m.Weapons.Add(new Weapon(new FormKey(spec.Key, 0xA01), SkyrimRelease.SkyrimSE)
-            {
-                EditorID = WeaponEdid(spec),
-                Name = spec.Name,
-                Description = spec.Desc,
-                BasicStats = new WeaponBasicStats { Damage = 7 },
-            });
-            if (spec.LinksTo is { } into)
-            {
-                var fl = new FormList(new FormKey(spec.Key, 0xA02), SkyrimRelease.SkyrimSE) { EditorID = spec.Key.Name + "List" };
-                fl.Items.Add(into.ToLink<ISkyrimMajorRecordGetter>());
-                m.FormLists.Add(fl);
+                var m = new SkyrimMod(spec.Key, SkyrimRelease.SkyrimSE) { UsingLocalization = true };
+                m.Weapons.Add(new Weapon(new FormKey(spec.Key, 0xA01), SkyrimRelease.SkyrimSE)
+                {
+                    EditorID = WeaponEdid(spec),
+                    Name = spec.Name,
+                    Description = spec.Desc,
+                    BasicStats = new WeaponBasicStats { Damage = 7 },
+                });
+                if (spec.LinksTo is { } into)
+                {
+                    var fl = new FormList(new FormKey(spec.Key, 0xA02), SkyrimRelease.SkyrimSE) { EditorID = spec.Key.Name + "List" };
+                    fl.Items.Add(into.ToLink<ISkyrimMajorRecordGetter>());
+                    m.FormLists.Add(fl);
+                }
+                m.ModHeader.Stats.NextFormID = 0xA03;
+                m.BeginWrite.ToPath(Path.Combine(modDir, spec.Key.FileName.String))
+                    .WithLoadOrder(written.ToArray()).NoNextFormIDProcessing().Write();
+
+                // The plugin now has its strings beside it, which is the state the bare overlay reads CORRECTLY. Move them
+                // out (or drop them) so the plugin's own folder carries no strings source — the state under test.
+                var own = Path.Combine(modDir, "Strings");
+                if (!Directory.Exists(own))
+                    throw new InvalidOperationException(
+                        $"fixture: '{spec.Key.FileName}' was written with UsingLocalization but produced no Strings folder — " +
+                        "the fixture would then be a NON-localized plugin and every arm below would pass vacuously.");
+                if (spec.StringsNowhere) Directory.Delete(own, true);
+                else
+                {
+                    var target = Path.Combine(data, "Strings");
+                    Directory.CreateDirectory(target);
+                    // GetFiles, not EnumerateFiles: the loop MOVES files out of the directory it is walking, and a lazy
+                    // enumerator can skip an entry under that mutation — which the Delete below would then destroy rather
+                    // than relocate. It fails toward a RED arm rather than a false green, but a flaky fixture is worse
+                    // than either.
+                    foreach (var f in Directory.GetFiles(own)) File.Move(f, Path.Combine(target, Path.GetFileName(f)));
+                    Directory.Delete(own, true);
+                }
+
+                written.Add(SkyrimMod.CreateFromBinaryOverlay(Path.Combine(modDir, spec.Key.FileName.String), SkyrimRelease.SkyrimSE));
             }
-            m.ModHeader.Stats.NextFormID = 0xA03;
-            m.BeginWrite.ToPath(Path.Combine(modDir, spec.Key.FileName.String))
-                .WithLoadOrder(written.ToArray()).NoNextFormIDProcessing().Write();
-
-            // The plugin now has its strings beside it, which is the state the bare overlay reads CORRECTLY. Move them
-            // out (or drop them) so the plugin's own folder carries no strings source — the state under test.
-            var own = Path.Combine(modDir, "Strings");
-            if (!Directory.Exists(own))
-                throw new InvalidOperationException(
-                    $"fixture: '{spec.Key.FileName}' was written with UsingLocalization but produced no Strings folder — " +
-                    "the fixture would then be a NON-localized plugin and every arm below would pass vacuously.");
-            if (spec.StringsNowhere) Directory.Delete(own, true);
-            else
-            {
-                var target = Path.Combine(data, "Strings");
-                Directory.CreateDirectory(target);
-                // GetFiles, not EnumerateFiles: the loop MOVES files out of the directory it is walking, and a lazy
-                // enumerator can skip an entry under that mutation — which the Delete below would then destroy rather
-                // than relocate. It fails toward a RED arm rather than a false green, but a flaky fixture is worse
-                // than either.
-                foreach (var f in Directory.GetFiles(own)) File.Move(f, Path.Combine(target, Path.GetFileName(f)));
-                Directory.Delete(own, true);
-            }
-
-            written.Add(SkyrimMod.CreateFromBinaryOverlay(Path.Combine(modDir, spec.Key.FileName.String), SkyrimRelease.SkyrimSE));
-        }
         }
         finally { foreach (var w in written) { if (w is IDisposable d) { try { d.Dispose(); } catch { } } } }
 

--- a/src/housecarl-generator/LocalizedStringsFixture.cs
+++ b/src/housecarl-generator/LocalizedStringsFixture.cs
@@ -31,8 +31,11 @@ internal static class LocalizedStringsFixture
     /// <param name="LinksTo">A record in an EARLIER spec's plugin to point a FormList at — the external-referencer
     /// shape. The link makes that plugin a declared master of this one, which is what puts this plugin in the
     /// identify pass's answer when the other one is compacted.</param>
+    /// <param name="Localized">Build this one NON-localized. Needed because the in-place lanes now refuse a localized
+    /// plugin outright: an arm about the REFERENCER check has to give the operation a target it will accept, or the
+    /// target check answers first and the arm measures that instead of what it is named for.</param>
     internal sealed record Spec(string ModFolder, ModKey Key, string Name, string Desc, bool StringsNowhere = false,
-                                FormKey? LinksTo = null);
+                                FormKey? LinksTo = null, bool Localized = true);
 
     /// <param name="Instance">The MO2 instance dir to hand <c>LoadOrderService.WithInstance</c>.</param>
     /// <param name="Mods">The instance's mods dir.</param>
@@ -76,7 +79,7 @@ internal static class LocalizedStringsFixture
                 var modDir = Path.Combine(mods, spec.ModFolder);
                 Directory.CreateDirectory(modDir);
 
-                var m = new SkyrimMod(spec.Key, SkyrimRelease.SkyrimSE) { UsingLocalization = true };
+                var m = new SkyrimMod(spec.Key, SkyrimRelease.SkyrimSE) { UsingLocalization = spec.Localized };
                 m.Weapons.Add(new Weapon(new FormKey(spec.Key, 0xA01), SkyrimRelease.SkyrimSE)
                 {
                     EditorID = WeaponEdid(spec),
@@ -97,11 +100,19 @@ internal static class LocalizedStringsFixture
                 // The plugin now has its strings beside it, which is the state the bare overlay reads CORRECTLY. Move them
                 // out (or drop them) so the plugin's own folder carries no strings source — the state under test.
                 var own = Path.Combine(modDir, "Strings");
-                if (!Directory.Exists(own))
+                if (spec.Localized && !Directory.Exists(own))
                     throw new InvalidOperationException(
                         $"fixture: '{spec.Key.FileName}' was written with UsingLocalization but produced no Strings folder — " +
                         "the fixture would then be a NON-localized plugin and every arm below would pass vacuously.");
-                if (spec.StringsNowhere) Directory.Delete(own, true);
+                if (!spec.Localized)
+                {
+                    // Nothing to relocate: its text is already inside the plugin. Assert that, so a spec that silently
+                    // started producing strings would fail here rather than quietly becoming a localized fixture.
+                    if (Directory.Exists(own))
+                        throw new InvalidOperationException(
+                            $"fixture: '{spec.Key.FileName}' was written NON-localized but produced a Strings folder.");
+                }
+                else if (spec.StringsNowhere) Directory.Delete(own, true);
                 else
                 {
                     var target = Path.Combine(data, "Strings");

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -61,6 +61,9 @@ if (args.Length > 0 && args[0] == "class-parents") return ClassParentsEmitter.Ru
 // Localized-strings read fix (Heisen 2026-06-24): DLC master resolved to a strings-less mod folder reads Name EMPTY.
 if (args.Length > 0 && args[0] == "strings-resolve-probe") return StringsResolveProbe.Run(args[1..]);
 
+// EXPLORATORY (#368): the MUTABLE strings-aware open + the mutate → WriteInPlace round-trip.
+if (args.Length > 0 && args[0] == "repoint-strings-probe") return RepointStringsProbe.Run(args[1..]);
+
 // One-shot verify (decision #1): confirm the xEdit 4-char signature reflection path.
 if (args.Length > 0 && args[0] == "sig") return Probe.RunSig();
 

--- a/src/housecarl-generator/RepointStringsProbe.cs
+++ b/src/housecarl-generator/RepointStringsProbe.cs
@@ -10,8 +10,20 @@ using Mutagen.Bethesda.Strings;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// EXPLORATORY probe (#368): does the MUTABLE open honour the same strings overrides OpenOverlay wires for reads, and
-/// does the mutate → WriteInPlace round-trip preserve the resolved strings ON DISK? Not a guard — throwaway evidence.
+/// EXPLORATORY probe: does the MUTABLE open honour the same strings overrides OpenOverlay wires for reads, and does the
+/// mutate → WriteInPlace round-trip preserve the resolved strings ON DISK? Not a guard — the evidence behind the
+/// in-place lane's localized refusal.
+///
+/// <para>ON A CURRENT BUILD EVERY ARM STOPS AT THE REFUSAL, which is the whole point of the refusal: the write will not
+/// re-serialize a localized plugin. To reproduce the ORIGINAL measurement — the one the refusal cites, where a weapon
+/// comes back reading a book's name — disable the choke point in <c>WriteEngine.WriteInPlace</c> and re-run. The arms
+/// are kept intact so that measurement stays reproducible rather than becoming a claim in a comment.</para>
+///
+/// <para>The measurement, for the record: with the guard bypassed, ARM A (strings relocated to game-Data, bare open)
+/// comes back blank and STAYS blank when re-read with the game-Data folder; ARM B (the same fixture, strings-aware
+/// open) reads every value correctly in memory and writes a MIX of correct, blank, and other-record text; ARM C
+/// (strings sitting correctly beside the plugin — nothing wrong with it at all) is scrambled the same way. The emitted
+/// .STRINGS and .DLSTRINGS differ byte-wise from the ones the committed plugin is left resolving against.</para>
 ///
 /// Run: dotnet run --project src/housecarl-generator repoint-strings-probe
 /// </summary>
@@ -149,6 +161,15 @@ public static class RepointStringsProbe
             {
                 var tgtOv = SkyrimMod.CreateFromBinaryOverlay(tgtPath, SkyrimRelease.SkyrimSE);
                 try { WriteEngine.WriteInPlace(mut, new ISkyrimModGetter[] { tgtOv }, refPath); }
+                catch (LocalizedTargetUnsupportedException ex)
+                {
+                    // The shipped behaviour. The corruption this probe measured is why the refusal exists, so on a
+                    // current build the arm stops HERE rather than reproducing it — see the class summary for how to
+                    // get the original measurement back.
+                    Console.WriteLine("  REFUSED by the in-place write's localized choke point — nothing written.");
+                    Console.WriteLine("  " + ex.Message);
+                    return 0;
+                }
                 finally { ((IDisposable)tgtOv).Dispose(); }
             }
 

--- a/src/housecarl-generator/RepointStringsProbe.cs
+++ b/src/housecarl-generator/RepointStringsProbe.cs
@@ -1,0 +1,198 @@
+using System.Reflection;
+using HousecarlCore;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Binary.Parameters;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Strings;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// EXPLORATORY probe (#368): does the MUTABLE open honour the same strings overrides OpenOverlay wires for reads, and
+/// does the mutate → WriteInPlace round-trip preserve the resolved strings ON DISK? Not a guard — throwaway evidence.
+///
+/// Run: dotnet run --project src/housecarl-generator repoint-strings-probe
+/// </summary>
+public static class RepointStringsProbe
+{
+    const int Records = 5;
+
+    public static int Run(string[] args)
+    {
+        Console.WriteLine("== API: SkyrimMod.CreateFromBinary overloads ==");
+        foreach (var m in typeof(SkyrimMod).GetMethods(BindingFlags.Public | BindingFlags.Static)
+                                           .Where(x => x.Name == "CreateFromBinary"))
+            Console.WriteLine("   " + m.ReturnType.Name + " CreateFromBinary(" +
+                string.Join(", ", m.GetParameters().Select(p => p.ParameterType.Name + " " + p.Name)) + ")");
+
+        Console.WriteLine();
+        Console.WriteLine("== API: BinaryWriteParameters public properties ==");
+        foreach (var pr in typeof(Mutagen.Bethesda.Plugins.Binary.Parameters.BinaryWriteParameters)
+                           .GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            Console.WriteLine("   " + pr.PropertyType.Name + " " + pr.Name);
+
+        Console.WriteLine();
+        Console.WriteLine("== ARM A: today's bare CreateFromBinary (the reported bug) ==");
+        int a = Arm(strings: false);
+        Console.WriteLine();
+        Console.WriteLine("== ARM B: CreateFromBinary + the same StringsParam overrides OpenOverlay wires ==");
+        int b = Arm(strings: true);
+        Console.WriteLine();
+        Console.WriteLine("== ARM C: strings LEFT BESIDE the plugin — the ordinary localized plugin, bare open ==");
+        int c = Arm(strings: false, relocate: false);
+        return a + b + c;
+    }
+
+    static int Arm(bool strings, bool relocate = true)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hc-repoint-strings-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            // ---- fixture: game-Data with Skyrim.esm; ZTgt.esp; localized ZRef.esp linking into ZTgt ----
+            var data = Path.Combine(root, "game", "Data");
+            var refDir = Path.Combine(root, "mods", "ZRefMod");
+            var tgtDir = Path.Combine(root, "mods", "ZTgtMod");
+            Directory.CreateDirectory(data); Directory.CreateDirectory(refDir); Directory.CreateDirectory(tgtDir);
+
+            var skyrimKey = new ModKey("Skyrim", ModType.Master);
+            new SkyrimMod(skyrimKey, SkyrimRelease.SkyrimSE)
+                .BeginWrite.ToPath(Path.Combine(data, skyrimKey.FileName.String))
+                .WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            var tgtKey = new ModKey("ZTgt", ModType.Plugin);
+            var tgtPath = Path.Combine(tgtDir, tgtKey.FileName.String);
+            var tgtOld = new FormKey(tgtKey, 0x801);
+            var tgtNew = new FormKey(tgtKey, 0x900);
+            {
+                var t = new SkyrimMod(tgtKey, SkyrimRelease.SkyrimSE);
+                t.Weapons.Add(new Weapon(tgtOld, SkyrimRelease.SkyrimSE) { EditorID = "ZTgtWeap" });
+                t.ModHeader.Stats.NextFormID = 0x802;
+                t.BeginWrite.ToPath(tgtPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>())
+                    .NoNextFormIDProcessing().Write();
+            }
+
+            var refKey = new ModKey("ZRef", ModType.Plugin);
+            var refPath = Path.Combine(refDir, refKey.FileName.String);
+            {
+                var r = new SkyrimMod(refKey, SkyrimRelease.SkyrimSE) { UsingLocalization = true };
+                var fl = new FormList(new FormKey(refKey, 0xA01), SkyrimRelease.SkyrimSE) { EditorID = "ZRefList" };
+                fl.Items.Add(tgtOld.ToLink<ISkyrimMajorRecordGetter>());
+                r.FormLists.Add(fl);
+                // SEVERAL localized records, not one: a single string cannot show an index that drifts under the
+                // re-serialize, and index drift against the pre-existing .STRINGS is the failure this arm must be able
+                // to see (the committed plugin keeps resolving out of the OLD strings file — see the tmp dump below).
+                for (int i = 0; i < Records; i++)
+                    r.Weapons.Add(new Weapon(new FormKey(refKey, (uint)(0xA02 + i)), SkyrimRelease.SkyrimSE)
+                    {
+                        EditorID = "ZRefWeap" + i,
+                        Name = "REF NAME " + i,
+                        Description = "REF DESC " + i,
+                        BasicStats = new WeaponBasicStats { Damage = (ushort)(7 + i) },
+                    });
+                // A SECOND record type, interleaved in FormID with the first: string indices are handed out in emission
+                // order, so a round-trip that reorders records across groups would move them. One group cannot show that.
+                for (int i = 0; i < Records; i++)
+                    r.Books.Add(new Book(new FormKey(refKey, (uint)(0xB02 + i)), SkyrimRelease.SkyrimSE)
+                    {
+                        EditorID = "ZRefBook" + i,
+                        Name = "BOOK NAME " + i,
+                        BookText = "BOOK TEXT " + i,
+                    });
+                r.ModHeader.Stats.NextFormID = (uint)(0xB02 + Records);
+                var tgtOv = SkyrimMod.CreateFromBinaryOverlay(tgtPath, SkyrimRelease.SkyrimSE);
+                try
+                {
+                    r.BeginWrite.ToPath(refPath).WithLoadOrder(new ISkyrimModGetter[] { tgtOv })
+                        .NoNextFormIDProcessing().Write();
+                }
+                finally { ((IDisposable)tgtOv).Dispose(); }
+            }
+
+            // Relocate ZRef's strings into game-Data\Strings — the state under test.
+            var own = Path.Combine(refDir, "Strings");
+            if (!Directory.Exists(own)) { Console.Error.WriteLine("FIXTURE BROKEN: no Strings folder beside ZRef"); return 1; }
+            var gdStrings = Path.Combine(data, "Strings");
+            Directory.CreateDirectory(gdStrings);
+            if (relocate)
+            {
+                foreach (var f in Directory.GetFiles(own)) File.Move(f, Path.Combine(gdStrings, Path.GetFileName(f)));
+                Directory.Delete(own, true);
+            }
+            var srcStrings = relocate ? gdStrings : own;
+            var stringsBefore = Directory.GetFiles(srcStrings).ToDictionary(Path.GetFileName!, File.ReadAllBytes);
+
+            Console.WriteLine("  BEFORE (OpenOverlay + dataDir): " + ReadAll(refPath, data));
+
+            // ---- the open under test ----
+            SkyrimMod mut;
+            if (strings)
+            {
+                var prm = BinaryReadParameters.Default with
+                {
+                    StringsParam = new StringsReadParameters
+                    {
+                        BsaFolderOverride = data,
+                        StringsFolderOverride = gdStrings,
+                    },
+                };
+                mut = SkyrimMod.CreateFromBinary(refPath, SkyrimRelease.SkyrimSE, prm);
+            }
+            else mut = SkyrimMod.CreateFromBinary(refPath, SkyrimRelease.SkyrimSE);
+            Console.WriteLine("  IN MEMORY after the open      : " +
+                string.Join(" | ", mut.Weapons.OrderBy(w => w.EditorID).Select(w => $"{w.EditorID}='{w.Name?.String}'")));
+
+            // ---- mutate + re-serialize over the user's own file ----
+            mut.RemapLinks(new Dictionary<FormKey, FormKey> { [tgtOld] = tgtNew });
+            {
+                var tgtOv = SkyrimMod.CreateFromBinaryOverlay(tgtPath, SkyrimRelease.SkyrimSE);
+                try { WriteEngine.WriteInPlace(mut, new ISkyrimModGetter[] { tgtOv }, refPath); }
+                finally { ((IDisposable)tgtOv).Dispose(); }
+            }
+
+            Console.WriteLine("  AFTER  (OpenOverlay + dataDir): " + ReadAll(refPath, data));
+            Console.WriteLine("  AFTER  (OpenOverlay, no dir)  : " + ReadAll(refPath, null));
+
+            // ---- what the staged write left behind, and whether the game-Data strings still match ----
+            Console.WriteLine("  beside ZRef.esp: " + string.Join(", ", Tree(refDir)));
+            // The committed plugin keeps resolving out of the PRE-EXISTING game-Data .STRINGS (the staged write's own
+            // emitted strings are discarded with the staging dir). So the re-emitted index table MUST still agree with
+            // that file, or the plugin reads the wrong string per index — a silent wrong answer, not a blank one.
+            var emitted = Path.Combine(refDir, ".housecarl-tmp", "Strings");
+            if (Directory.Exists(emitted))
+                foreach (var f in Directory.GetFiles(emitted))
+                {
+                    var name = Path.GetFileName(f);
+                    var same = stringsBefore.TryGetValue(name, out var before) && before.SequenceEqual(File.ReadAllBytes(f));
+                    Console.WriteLine($"  emitted {name} == pre-existing: {same}");
+                }
+            var stringsAfter = Directory.Exists(srcStrings)
+                ? Directory.GetFiles(srcStrings).ToDictionary(Path.GetFileName!, File.ReadAllBytes)
+                : new Dictionary<string, byte[]>();
+            Console.WriteLine("  source Strings unchanged      : " +
+                (stringsBefore.Count == stringsAfter.Count &&
+                 stringsBefore.All(kv => stringsAfter.TryGetValue(kv.Key, out var v) && v.SequenceEqual(kv.Value))));
+            return 0;
+        }
+        finally { try { Directory.Delete(root, true); } catch { } }
+    }
+
+    static string ReadAll(string pluginPath, string? dataDir)
+    {
+        var ov = LoadOrderResolver.OpenOverlay(pluginPath, dataDir);
+        try
+        {
+            var ws = string.Join(" | ", ov.Weapons.OrderBy(w => w.EditorID)
+                .Select(w => $"{w.EditorID}='{w.Name?.String}'/'{w.Description?.String}'"));
+            var link = ov.FormLists.First().Items.First().FormKey;
+            return $"{ws} link={link} flags={ov.ModHeader.Flags}";
+        }
+        finally { ((IDisposable)ov).Dispose(); }
+    }
+
+    static IEnumerable<string> Tree(string dir)
+        => Directory.EnumerateFileSystemEntries(dir, "*", SearchOption.AllDirectories)
+                    .Select(p => Path.GetRelativePath(dir, p) + (Directory.Exists(p) ? "\\" : ""));
+}

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -5325,6 +5325,14 @@ public sealed class LoadOrderService : IDisposable
                 "plugin filename (e.g. 'CoolWeapons.esp'). in-place edits the file the game actually loads. Nothing was written.")
                 with { Epoch = view.Epoch };
 
+        // (1c) LOCALIZED target — refuse BEFORE the consent gate and before the dry-run branch below. houseCARL
+        //      cannot re-serialize a localized plugin without scrambling its text (WriteInPlace refuses outright), and
+        //      that refusal has to be predicted HERE rather than met at the write: the gate would otherwise spend the
+        //      modder's one-time in-place acknowledgement on a write that was never going to happen, and a dry run —
+        //      whose contract is to give exactly the answer the real call gives — would report the edit landing.
+        if (WriteEngine.PluginIsLocalized(targetPath))
+            return WritePatchBuilder.PatchOutcome.Fail(LocalizedTargetUnsupportedException.Text(targetName));
+
         // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path. NOT a
         //     sticky mode: each in-place write still names its own target=, so this only stops re-explaining the
         //     trade-off; it never makes an ambiguous request route to in-place.
@@ -5640,6 +5648,14 @@ public sealed class LoadOrderService : IDisposable
                 "plugin filename (e.g. 'CoolWeapons.esp'). in-place removes from the file the game actually loads. Nothing was written.")
                 with { Epoch = view.Epoch };   // decided off the capture above — stamped like every post-capture outcome
 
+        // (1c) LOCALIZED target — refuse BEFORE the consent gate and before the dry-run branch below. houseCARL
+        //      cannot re-serialize a localized plugin without scrambling its text (WriteInPlace refuses outright), and
+        //      that refusal has to be predicted HERE rather than met at the write: the gate would otherwise spend the
+        //      modder's one-time in-place acknowledgement on a write that was never going to happen, and a dry run —
+        //      whose contract is to give exactly the answer the real call gives — would report the edit landing.
+        if (WriteEngine.PluginIsLocalized(targetPath))
+            return WritePatchBuilder.RemovalOutcome.Fail(LocalizedTargetUnsupportedException.Text(targetName));
+
         // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared
         //     with the edit + create lanes: acknowledging a plugin once covers editing, creating into, AND removing from
         //     it in place — it's the same "touch your original" trade-off).
@@ -5792,6 +5808,14 @@ public sealed class LoadOrderService : IDisposable
                 $"in-place target '{target}' is not an active plugin in the load order — name a plugin enabled in MO2, by its " +
                 "plugin filename (e.g. 'CoolWeapons.esp'). in-place forwards into the file the game actually loads. Nothing was written.")
                 with { Epoch = view.Epoch };   // decided off the capture above — stamped like every post-capture outcome
+
+        // (1c) LOCALIZED target — refuse BEFORE the consent gate and before the dry-run branch below. houseCARL
+        //      cannot re-serialize a localized plugin without scrambling its text (WriteInPlace refuses outright), and
+        //      that refusal has to be predicted HERE rather than met at the write: the gate would otherwise spend the
+        //      modder's one-time in-place acknowledgement on a write that was never going to happen, and a dry run —
+        //      whose contract is to give exactly the answer the real call gives — would report the edit landing.
+        if (WriteEngine.PluginIsLocalized(targetPath))
+            return WritePatchBuilder.ForwardOutcome.Fail(LocalizedTargetUnsupportedException.Text(targetName));
 
         // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared
         //     with the edit/create/remove lanes: it's the same "touch your original" trade-off).
@@ -6042,6 +6066,32 @@ public sealed class LoadOrderService : IDisposable
             // 4. consent gate — any in-place overwrite (the target, and/or the external referencers) needs acknowledge=true.
             bool willOverwriteTarget = inPlace;
             bool willRepoint = id.HasExternalReferencers && repointExternals;
+
+            // Before the consent gate, not after it: houseCARL cannot re-serialize a localized plugin without
+            // scrambling its text, so a run whose referencer rewrites include one is never going to happen — and the
+            // gate below would otherwise ask the modder to accept an irreversible rewrite of their originals to
+            // authorize it. Also before ANY write, because the referencer rewrites run only after the compacted plugin
+            // is already on disk: a refusal discovered there would leave the target renumbered and its referencers
+            // still on the old FormIDs, which nothing downstream can undo.
+            //
+            // No remedy named. "Repoint them yourself first" was measured and is FALSE: the new FormIDs do not exist
+            // until the compaction runs and this verb never discloses the mapping, so a caller cannot repoint to them —
+            // and a referencer repointed to guessed ids stops matching the identify pass, so the follow-up compaction
+            // SUCCEEDS and reports a clean run over links that now point nowhere. A dead end stated plainly beats a
+            // remedy that ends in silent breakage.
+            if (willRepoint)
+            {
+                var localized = RemapEngine.LocalizedAmong(resolver, id.ExternalPlugins);
+                if (localized.Count > 0)
+                    return WritePatchBuilder.CompactOutcome.Fail(
+                        $"refused — compacting '{name}' means rewriting the plugins that reference it, and " +
+                        $"{(localized.Count == 1 ? "one of them is" : $"{localized.Count} of them are")} flagged LOCALIZED: " +
+                        $"{string.Join(", ", localized.Take(25))}{(localized.Count > 25 ? $", … (+{localized.Count - 25} more)" : "")}. " +
+                        "A localized plugin holds its text in separate .STRINGS files and carries only indices into them; " +
+                        "rewriting one renumbers those indices while houseCARL commits the plugin file alone, so a value in " +
+                        "it would no longer reliably be its own record's. NOTHING was written and nothing was staged — " +
+                        $"'{name}' is untouched. houseCARL cannot compact '{name}' while a localized plugin references it.");
+            }
             if ((willOverwriteTarget || willRepoint) && !acknowledge)
             {
                 var c = new System.Text.StringBuilder();
@@ -6062,25 +6112,6 @@ public sealed class LoadOrderService : IDisposable
             // the same guarantee inside RepointInPlace's own all-or-nothing write.
             if (inPlace && InPlaceParentUnwritable(srcPath, out var unwritable))
                 return WritePatchBuilder.CompactOutcome.Fail(unwritable);
-
-            // pre-flight the referencers this run would REWRITE: houseCARL cannot re-serialize a localized plugin
-            // without corrupting its text, and the rewrites happen only AFTER the compacted plugin is on disk — so a
-            // localized referencer discovered then would leave the target renumbered and its referencers still pointing
-            // at the old FormIDs. Refuse the whole operation here, with everything still untouched.
-            if (willRepoint)
-            {
-                var localized = RemapEngine.LocalizedAmong(resolver, id.ExternalPlugins);
-                if (localized.Count > 0)
-                    return WritePatchBuilder.CompactOutcome.Fail(
-                        $"refused — {localized.Count} of the plugin(s) that reference records '{name}' would renumber " +
-                        $"{(localized.Count == 1 ? "is" : "are")} flagged LOCALIZED: {string.Join(", ", localized.Take(25))}" +
-                        $"{(localized.Count > 25 ? $", … (+{localized.Count - 25} more)" : "")}. A localized plugin holds its " +
-                        "text in separate .STRINGS files and carries only indices into them; rewriting one renumbers those " +
-                        "indices while houseCARL commits the plugin file alone, so its text would end up on the wrong " +
-                        "records. Repointing runs only after '" + name + "' has already been rewritten, so this refuses up " +
-                        "front rather than renumber it and then stop partway through its referencers. NOTHING was written — " +
-                        $"'{name}' is untouched. Repoint those plugins yourself, then compact.");
-            }
 
             // 5. output location — in-place (overwrite the original) or a NEW file keeping the source's EXACT basename in
             //    a fresh houseCARL mod folder (so its masters still resolve; the user swaps the folder in MO2 to use it).
@@ -6845,6 +6876,14 @@ public sealed class LoadOrderService : IDisposable
                 $"in-place target '{target}' is not an active plugin in the load order — name a plugin enabled in MO2, by its " +
                 "plugin filename (e.g. 'CoolWeapons.esp'). in-place creates into the file the game actually loads. Nothing was written.")
                 with { Epoch = view.Epoch };   // decided off the capture above — stamped like every post-capture outcome
+
+        // (1c) LOCALIZED target — refuse BEFORE the consent gate and before the dry-run branch below. houseCARL
+        //      cannot re-serialize a localized plugin without scrambling its text (WriteInPlace refuses outright), and
+        //      that refusal has to be predicted HERE rather than met at the write: the gate would otherwise spend the
+        //      modder's one-time in-place acknowledgement on a write that was never going to happen, and a dry run —
+        //      whose contract is to give exactly the answer the real call gives — would report the edit landing.
+        if (WriteEngine.PluginIsLocalized(targetPath))
+            return WritePatchBuilder.CreateOutcome.Fail(LocalizedTargetUnsupportedException.Text(targetName));
 
         // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared with
         //     the edit lane: acknowledging a plugin once covers BOTH editing and creating into it in place — it's the same

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -6063,6 +6063,25 @@ public sealed class LoadOrderService : IDisposable
             if (inPlace && InPlaceParentUnwritable(srcPath, out var unwritable))
                 return WritePatchBuilder.CompactOutcome.Fail(unwritable);
 
+            // pre-flight the referencers this run would REWRITE: houseCARL cannot re-serialize a localized plugin
+            // without corrupting its text, and the rewrites happen only AFTER the compacted plugin is on disk — so a
+            // localized referencer discovered then would leave the target renumbered and its referencers still pointing
+            // at the old FormIDs. Refuse the whole operation here, with everything still untouched.
+            if (willRepoint)
+            {
+                var localized = RemapEngine.LocalizedAmong(resolver, id.ExternalPlugins);
+                if (localized.Count > 0)
+                    return WritePatchBuilder.CompactOutcome.Fail(
+                        $"refused — {localized.Count} of the plugin(s) that reference records '{name}' would renumber " +
+                        $"{(localized.Count == 1 ? "is" : "are")} flagged LOCALIZED: {string.Join(", ", localized.Take(25))}" +
+                        $"{(localized.Count > 25 ? $", … (+{localized.Count - 25} more)" : "")}. A localized plugin holds its " +
+                        "text in separate .STRINGS files and carries only indices into them; rewriting one renumbers those " +
+                        "indices while houseCARL commits the plugin file alone, so its text would end up on the wrong " +
+                        "records. Repointing runs only after '" + name + "' has already been rewritten, so this refuses up " +
+                        "front rather than renumber it and then stop partway through its referencers. NOTHING was written — " +
+                        $"'{name}' is untouched. Repoint those plugins yourself, then compact.");
+            }
+
             // 5. output location — in-place (overwrite the original) or a NEW file keeping the source's EXACT basename in
             //    a fresh houseCARL mod folder (so its masters still resolve; the user swaps the folder in MO2 to use it).
             string outPath; bool createdFresh = false; RiderFolder rf = default;

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -5331,7 +5331,7 @@ public sealed class LoadOrderService : IDisposable
         //      modder's one-time in-place acknowledgement on a write that was never going to happen, and a dry run —
         //      whose contract is to give exactly the answer the real call gives — would report the edit landing.
         if (WriteEngine.PluginIsLocalized(targetPath))
-            return WritePatchBuilder.PatchOutcome.Fail(LocalizedTargetUnsupportedException.Text(targetName))
+            return WritePatchBuilder.PatchOutcome.Fail(LocalizedTargetUnsupportedException.Text(targetName, LocalizedTargetUnsupportedException.RemedyDefaultLane))
                 with { Epoch = view.Epoch };   // decided off the capture above — stamped like every post-capture outcome
 
         // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path. NOT a
@@ -5654,7 +5654,7 @@ public sealed class LoadOrderService : IDisposable
         //      modder's one-time in-place acknowledgement on a write that was never going to happen. (This lane has no
         //      dry run; the two that do also need the refusal predicted ahead of it — see ApplyEditsInPlace.)
         if (WriteEngine.PluginIsLocalized(targetPath))
-            return WritePatchBuilder.RemovalOutcome.Fail(LocalizedTargetUnsupportedException.Text(targetName))
+            return WritePatchBuilder.RemovalOutcome.Fail(LocalizedTargetUnsupportedException.Text(targetName, LocalizedTargetUnsupportedException.RemoveNoEquivalent))
                 with { Epoch = view.Epoch };   // decided off the capture above — stamped like every post-capture outcome
 
         // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared
@@ -5816,7 +5816,7 @@ public sealed class LoadOrderService : IDisposable
         //      modder's one-time in-place acknowledgement on a write that was never going to happen, and a dry run —
         //      whose contract is to give exactly the answer the real call gives — would report the edit landing.
         if (WriteEngine.PluginIsLocalized(targetPath))
-            return WritePatchBuilder.ForwardOutcome.Fail(LocalizedTargetUnsupportedException.Text(targetName))
+            return WritePatchBuilder.ForwardOutcome.Fail(LocalizedTargetUnsupportedException.Text(targetName, LocalizedTargetUnsupportedException.RemedyDefaultLane))
                 with { Epoch = view.Epoch };   // decided off the capture above — stamped like every post-capture outcome
 
         // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared
@@ -6025,12 +6025,14 @@ public sealed class LoadOrderService : IDisposable
             // precisely is separate machinery that does not exist yet, and neither outcome above may happen silently.
             // The NEW-FILE lane is untouched: its output is a plugin the modder reviews before swapping it in, which is
             // the distinction this whole refusal rests on.
-            if (inPlace && WriteEngine.PluginIsLocalized(srcPath))
+            // Read once: the in-place lane refuses on it, and the new-file lane reports on it (below).
+            bool srcLocalized = WriteEngine.PluginIsLocalized(srcPath);
+            if (inPlace && srcLocalized)
                 return WritePatchBuilder.CompactOutcome.Fail(
                     $"houseCARL did not compact '{name}' in place — the file is unchanged and nothing was staged. It is " +
                     "flagged LOCALIZED, so its text lives in separate .STRINGS files rather than in the plugin. A " +
-                    "compaction does not rewrite the plugin, it builds a NEW one and writes that over the original, and " +
-                    "the rebuilt plugin is not localized: what it would carry is whichever language resolved when " +
+                    "compaction does not re-serialize your plugin, it builds a NEW one and writes that over the original, " +
+                    "and the rebuilt plugin is not localized: what it would carry is whichever language resolved when " +
                     "houseCARL read it, written into the plugin itself — or blanks, if those strings resolved nowhere. " +
                     "Either way the file the game loads would stop being the translated plugin you have, with no backup " +
                     $"and nothing to undo it. Re-run without in_place to compact '{name}' into a NEW plugin instead: the " +
@@ -6235,6 +6237,17 @@ public sealed class LoadOrderService : IDisposable
             //    write, Q3) — any miss is surfaced in Note.
             var markerNotes = new List<string>();
             if (offOrderNote is not null) markerNotes.Add(offOrderNote);
+            // The new-file lane produces the SAME de-localized plugin the in-place lane is refused for; only where it
+            // lands differs. A caller who never meets that refusal was getting no word of it, so the standard the
+            // refusal invokes was being applied to one lane and not the other — and the quiet one is the lane the
+            // refusal recommends. Own-behaviour only: it does NOT claim the strings resolved, because when they resolve
+            // nowhere this same path writes blanks and the sentence has to stay true there too.
+            if (!inPlace && srcLocalized)
+                markerNotes.Add(
+                    $"'{name}' is flagged LOCALIZED — its text lives in separate .STRINGS files. The compacted plugin " +
+                    "houseCARL wrote is NOT localized: it carries whatever this read of the source produced, written " +
+                    "into the plugin itself, and the source's .STRINGS files do not describe it. Read the output before " +
+                    "you enable it in place of the original.");
             if (flagOnlyNote is not null) markerNotes.Add(flagOnlyNote);
             if (inPlace) { var n = MergeEditedInPlaceMarker(Path.GetDirectoryName(srcPath)); if (n is not null) markerNotes.Add(n); }
             foreach (var r in repointed.Where(r => r.Success))
@@ -6912,7 +6925,7 @@ public sealed class LoadOrderService : IDisposable
         //      modder's one-time in-place acknowledgement on a write that was never going to happen. (This lane has no
         //      dry run; the two that do also need the refusal predicted ahead of it — see ApplyEditsInPlace.)
         if (WriteEngine.PluginIsLocalized(targetPath))
-            return WritePatchBuilder.CreateOutcome.Fail(LocalizedTargetUnsupportedException.Text(targetName))
+            return WritePatchBuilder.CreateOutcome.Fail(LocalizedTargetUnsupportedException.Text(targetName, LocalizedTargetUnsupportedException.RemedyDefaultLane))
                 with { Epoch = view.Epoch };   // decided off the capture above — stamped like every post-capture outcome
 
         // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared with

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -5327,11 +5327,12 @@ public sealed class LoadOrderService : IDisposable
 
         // (1c) LOCALIZED target — refuse BEFORE the consent gate and before the dry-run branch below. houseCARL
         //      cannot re-serialize a localized plugin without scrambling its text (WriteInPlace refuses outright), and
-        //      that refusal has to be predicted HERE rather than met at the write: the gate would otherwise spend the
+        //      that refusal has to be PREDICTED here rather than met at the write: the gate would otherwise spend the
         //      modder's one-time in-place acknowledgement on a write that was never going to happen, and a dry run —
         //      whose contract is to give exactly the answer the real call gives — would report the edit landing.
         if (WriteEngine.PluginIsLocalized(targetPath))
-            return WritePatchBuilder.PatchOutcome.Fail(LocalizedTargetUnsupportedException.Text(targetName));
+            return WritePatchBuilder.PatchOutcome.Fail(LocalizedTargetUnsupportedException.Text(targetName))
+                with { Epoch = view.Epoch };   // decided off the capture above — stamped like every post-capture outcome
 
         // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path. NOT a
         //     sticky mode: each in-place write still names its own target=, so this only stops re-explaining the
@@ -5648,13 +5649,13 @@ public sealed class LoadOrderService : IDisposable
                 "plugin filename (e.g. 'CoolWeapons.esp'). in-place removes from the file the game actually loads. Nothing was written.")
                 with { Epoch = view.Epoch };   // decided off the capture above — stamped like every post-capture outcome
 
-        // (1c) LOCALIZED target — refuse BEFORE the consent gate and before the dry-run branch below. houseCARL
-        //      cannot re-serialize a localized plugin without scrambling its text (WriteInPlace refuses outright), and
-        //      that refusal has to be predicted HERE rather than met at the write: the gate would otherwise spend the
-        //      modder's one-time in-place acknowledgement on a write that was never going to happen, and a dry run —
-        //      whose contract is to give exactly the answer the real call gives — would report the edit landing.
+        // (1c) LOCALIZED target — refuse BEFORE the consent gate. houseCARL cannot re-serialize a localized plugin
+        //      without scrambling its text (WriteInPlace refuses outright), and the gate would otherwise spend the
+        //      modder's one-time in-place acknowledgement on a write that was never going to happen. (This lane has no
+        //      dry run; the two that do also need the refusal predicted ahead of it — see ApplyEditsInPlace.)
         if (WriteEngine.PluginIsLocalized(targetPath))
-            return WritePatchBuilder.RemovalOutcome.Fail(LocalizedTargetUnsupportedException.Text(targetName));
+            return WritePatchBuilder.RemovalOutcome.Fail(LocalizedTargetUnsupportedException.Text(targetName))
+                with { Epoch = view.Epoch };   // decided off the capture above — stamped like every post-capture outcome
 
         // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared
         //     with the edit + create lanes: acknowledging a plugin once covers editing, creating into, AND removing from
@@ -5811,11 +5812,12 @@ public sealed class LoadOrderService : IDisposable
 
         // (1c) LOCALIZED target — refuse BEFORE the consent gate and before the dry-run branch below. houseCARL
         //      cannot re-serialize a localized plugin without scrambling its text (WriteInPlace refuses outright), and
-        //      that refusal has to be predicted HERE rather than met at the write: the gate would otherwise spend the
+        //      that refusal has to be PREDICTED here rather than met at the write: the gate would otherwise spend the
         //      modder's one-time in-place acknowledgement on a write that was never going to happen, and a dry run —
         //      whose contract is to give exactly the answer the real call gives — would report the edit landing.
         if (WriteEngine.PluginIsLocalized(targetPath))
-            return WritePatchBuilder.ForwardOutcome.Fail(LocalizedTargetUnsupportedException.Text(targetName));
+            return WritePatchBuilder.ForwardOutcome.Fail(LocalizedTargetUnsupportedException.Text(targetName))
+                with { Epoch = view.Epoch };   // decided off the capture above — stamped like every post-capture outcome
 
         // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared
         //     with the edit/create/remove lanes: it's the same "touch your original" trade-off).
@@ -6087,9 +6089,8 @@ public sealed class LoadOrderService : IDisposable
                         $"refused — compacting '{name}' means rewriting the plugins that reference it, and " +
                         $"{(localized.Count == 1 ? "one of them is" : $"{localized.Count} of them are")} flagged LOCALIZED: " +
                         $"{string.Join(", ", localized.Take(25))}{(localized.Count > 25 ? $", … (+{localized.Count - 25} more)" : "")}. " +
-                        "A localized plugin holds its text in separate .STRINGS files and carries only indices into them; " +
-                        "rewriting one renumbers those indices while houseCARL commits the plugin file alone, so a value in " +
-                        "it would no longer reliably be its own record's. NOTHING was written and nothing was staged — " +
+                        "For a localized plugin " + LocalizedTargetUnsupportedException.Why +
+                        " NOTHING was written and nothing was staged — " +
                         $"'{name}' is untouched. houseCARL cannot compact '{name}' while a localized plugin references it.");
             }
             if ((willOverwriteTarget || willRepoint) && !acknowledge)
@@ -6877,13 +6878,13 @@ public sealed class LoadOrderService : IDisposable
                 "plugin filename (e.g. 'CoolWeapons.esp'). in-place creates into the file the game actually loads. Nothing was written.")
                 with { Epoch = view.Epoch };   // decided off the capture above — stamped like every post-capture outcome
 
-        // (1c) LOCALIZED target — refuse BEFORE the consent gate and before the dry-run branch below. houseCARL
-        //      cannot re-serialize a localized plugin without scrambling its text (WriteInPlace refuses outright), and
-        //      that refusal has to be predicted HERE rather than met at the write: the gate would otherwise spend the
-        //      modder's one-time in-place acknowledgement on a write that was never going to happen, and a dry run —
-        //      whose contract is to give exactly the answer the real call gives — would report the edit landing.
+        // (1c) LOCALIZED target — refuse BEFORE the consent gate. houseCARL cannot re-serialize a localized plugin
+        //      without scrambling its text (WriteInPlace refuses outright), and the gate would otherwise spend the
+        //      modder's one-time in-place acknowledgement on a write that was never going to happen. (This lane has no
+        //      dry run; the two that do also need the refusal predicted ahead of it — see ApplyEditsInPlace.)
         if (WriteEngine.PluginIsLocalized(targetPath))
-            return WritePatchBuilder.CreateOutcome.Fail(LocalizedTargetUnsupportedException.Text(targetName));
+            return WritePatchBuilder.CreateOutcome.Fail(LocalizedTargetUnsupportedException.Text(targetName))
+                with { Epoch = view.Epoch };   // decided off the capture above — stamped like every post-capture outcome
 
         // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared with
         //     the edit lane: acknowledging a plugin once covers BOTH editing and creating into it in place — it's the same

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -6008,6 +6008,35 @@ public sealed class LoadOrderService : IDisposable
             try { modKey = ModKey.FromFileName(name); }
             catch (Exception ex) { return WritePatchBuilder.CompactOutcome.Fail($"'{name}' is not a valid plugin filename ({ex.Message})."); }
 
+            // LOCALIZED TARGET, in-place only. Earliest possible: before the identify pass, before the consent gate,
+            // before anything is written or staged. Early on purpose — a caller whose target ALSO has external
+            // referencers would otherwise meet the referencer refusal first, follow its "re-run with
+            // repoint_externals=true" remedy, and only then be told the operation was never possible.
+            //
+            // This is NOT the in-place write's choke point reaching further: it cannot fire here. A compaction does not
+            // re-serialize the target, it builds a FRESH plugin and writes that over the original, so the mod handed to
+            // the write is never flagged localized and the check keyed on it never sees this case. What makes it
+            // refusable is what the rebuild DOES to a localized plugin, and there are two outcomes, both silent and both
+            // landing on a file with no review step and no undo: when the strings resolve, the result is DE-LOCALIZED —
+            // one language baked into the plugin, the mod's .STRINGS set no longer describing it, and nobody chose that;
+            // when they do not, the same path bakes in blanks.
+            //
+            // Keyed on the header FLAG, deliberately wider than the strings-resolve-nowhere case. Detecting that case
+            // precisely is separate machinery that does not exist yet, and neither outcome above may happen silently.
+            // The NEW-FILE lane is untouched: its output is a plugin the modder reviews before swapping it in, which is
+            // the distinction this whole refusal rests on.
+            if (inPlace && WriteEngine.PluginIsLocalized(srcPath))
+                return WritePatchBuilder.CompactOutcome.Fail(
+                    $"houseCARL did not compact '{name}' in place — the file is unchanged and nothing was staged. It is " +
+                    "flagged LOCALIZED, so its text lives in separate .STRINGS files rather than in the plugin. A " +
+                    "compaction does not rewrite the plugin, it builds a NEW one and writes that over the original, and " +
+                    "the rebuilt plugin is not localized: what it would carry is whichever language resolved when " +
+                    "houseCARL read it, written into the plugin itself — or blanks, if those strings resolved nowhere. " +
+                    "Either way the file the game loads would stop being the translated plugin you have, with no backup " +
+                    $"and nothing to undo it. Re-run without in_place to compact '{name}' into a NEW plugin instead: the " +
+                    "same renumber, left in its own mod folder for you to check and enable yourself. That output is not " +
+                    "localized either — read it before you swap it in.");
+
             // 1. originating record keys + the remap into the (light, by default) window.
             if (!WritePatchBuilder.TryReadOriginatingKeys(srcPath, modKey, out var keys, out var keyErr))
                 return WritePatchBuilder.CompactOutcome.Fail(keyErr!);


### PR DESCRIPTION
Interim refusal for the localized in-place write. **No closing keywords** — #368 and #373 both stay open for the attended engagement that fixes the round-trip properly.

## Why this is a refusal and not the fix

The kickoff made an empirical check binding before writing anything: does the mutable open honour the same strings overrides `OpenOverlay` wires for reads, and does the mutate → `WriteInPlace` round-trip preserve them on disk? It does not, and the routed fix shape does not hold.

Three arms, synthetic MO2 instance with a real `Skyrim.esm` in game-Data, two record types so a moved string index has somewhere to show itself:

| Arm | Setup | Result |
|---|---|---|
| **A** | today's bare `CreateFromBinary`, strings relocated to game-Data | blank, and still blank when re-read *with* the game-Data folder — the reported loss, end to end |
| **B** | `CreateFromBinary` **+ the same `StringsParam` overrides** | reads perfectly **in memory**; on disk a mix of correct, blank, and *another record's text* |
| **C** | strings left **beside the plugin** — a healthy localized plugin | same scramble: a weapon reads a book's name |

The overload exists and honours the overrides — arm B's in-memory read is exact. The write is what breaks: `WriteInPlace` stages the serialize, Mutagen emits a **renumbered** string table into the staging directory, and `CommitStagedPatch` commits the plugin alone. The committed plugin's new indices then resolve against its old, untouched `.STRINGS`.

Arm C is the load-bearing one: it needs no strings-resolution problem at all, so this is not #368's read side. Filed as **#373** (write side), with the six other `WriteInPlace` call sites listed as suspected-not-measured — two of them are new-file-lane re-emits, so the suspected class is not confined to `in_place=`.

Fixing it faithfully decides what the in-place lane may write besides the plugin file, which is the in-place consent lane's design — stop condition 1. Escalated; the ruling demoted #368 into an attended engagement and scoped this PR to a refusal.

## What lands

**Choke point.** `WriteEngine.WriteInPlace` refuses a `UsingLocalization` target before it creates its staging directory — one site, covering all seven callers. The refusal is its own whole sentence and every lane renders it verbatim: the lanes that go through `SerializeFailure` get the treatment the baseline-master refusal already had there, and the remove and repoint lanes carry their own arm, because their leads say "failed (serialize or commit)" about steps this refusal happens before.

**Service pre-flight, ahead of the consent gate**, in all four in-place lanes. The choke point alone was too late for two promises: a dry run never reaches the write, so `in_place` + `dry_run` on a localized plugin reported the edit landing while the real call refused; and the service persists the one-time in-place acknowledgement *before* attempting the write, so the first acknowledged call spent it on a plugin houseCARL would never write. The repo had already settled this shape — `InPlaceParentUnwritable` is deliberately kept in the dry-run path because predicting the real refusal is the dry run's job.

**Compact pre-flight.** Its referencer rewrites run only *after* the compacted plugin is on disk, so a refusal discovered there strands a half-completed compaction — target renumbered, referencers still on the old FormIDs. `RemapEngine.LocalizedAmong` checks them before anything is written, above the consent gate so the modder is not asked to authorise an irreversible rewrite that cannot happen.

**Compact's own target** (directed fold, post-rounds). The in-place compaction was the one lane the refusal did not reach, and it reaches it for a different reason than the others: a compaction does not re-serialize the target, it builds a **fresh** plugin and writes that over the original, so the mod handed to the write is never flagged localized and the write's check structurally cannot see this case. What makes it refusable is what the rebuild *does* — when the strings resolve the result is **de-localized** (one language baked in, the mod's `.STRINGS` set no longer describing it, nobody having chosen that); when they do not, blanks. Both land silently on a file with no review step and no undo. Keyed on the header flag, deliberately wider than the strings-resolve-nowhere case, which is separate machinery this PR does not absorb. Placed before the identify pass, the consent gate and any write — early on purpose, so a target that also has external referencers is not sent round the referencer refusal's remedy first.

The **new-file compact lane is untouched**, and is what the refusal points at: its output is a plugin the modder reviews before enabling. The remedy is measured, not assumed — the arm directly above the new one compacts the same localized fixture to a new file and reads its `FULL`+`DESC` back intact — and the sentence names the lane without promising the output's nature, since that output is not localized either.

The other six `WriteInPlace` callers need no pre-flight: their `WriteInPlace` call is the first thing each puts on disk, verified per call site.

## Review rounds — 2, then class-stop

**Round 1 — 3 fresh agents, isolated worktrees. 17 findings: 11 folded, 4 refused, 2 surfaced.**

Folded, the two that mattered being defects this branch introduced: the dry-run/real divergence and the spent consent (above); and the compact refusal named a remedy measured **false** — "repoint those plugins yourself, then compact" cannot be done, because the new FormIDs do not exist until the compaction runs and the verb never discloses the mapping, and a referencer repointed to guessed ids stops matching the identify pass, so the follow-up compaction *succeeds* and reports a clean run over links pointing nowhere. It states the dead end instead. Also: "every localized value would land on the wrong record" was refuted by this branch's own probe (arm C is 2 correct, 1 blank, 2 wrong — the mix being the more dangerous finding); the changelog missed lanes; the evidence probe died on its own guard, so the citation pointed at something that would not run.

Refused: **compact in-place on a localized *target* can still blank it** — that is #371's no-source class, routed to W5 by ruling and named in this engagement's stop condition 2, and a different mechanism (read-side blank, not index drift); the **`into=` extend lane** has no localized check — real, but a different choke point (`WritePatch`), reachable only by localizing a houseCARL-owned patch and extending it, so the changelog claim was scoped honestly instead; **no dedicated arms for the forward/create render paths** — both render through `SerializeFailure`, which LOC-A pins, and the two *distinct* render paths each have one; **`LocalizedAmong` fails open** — deliberate, though the reviewer was right that "absolute backstop" overclaimed, so the doc now says failing open costs the earliness, not the safety.

**Round 2 — 2 fresh agents, isolated worktrees. 15 findings: 12 folded, 2 refused, 1 filed.**

Folded: the four new refusals were **unstamped** (every other post-capture outcome in those lanes carries the index epoch, including the refusal three lines above each); the changelog contradicted itself inside one release block, its `#362` bullet still describing the referencer blanking as live while the new entry says it is refused; the entry implied compact in-place was covered when it structurally is not; lane list corrected to the 2.0 spellings and the `in_place="X.esp"` form; the mechanism clause moved to a single constant, since the compact refusal was a second hand-written spelling of it; per-lane comments no longer claim a dry-run branch in the two lanes that have none.

Refused: the earlier compact refusal's "**or handle them yourself first**" is not false — it names removing or redirecting the references, which needs no FormIDs that do not exist yet; the contradiction is with the *other* half of that sentence, pre-existing and filed as **#374** rather than folded here. And the consent guarantee stays unhedged: falsifying it needs a header read to throw on a plugin the resolver just enumerated, and the file is untouched either way.

**Class-stop, no round 3.** Two classes recurred across both rounds: *prose claiming coverage the code does not have* (round 1's magnitude overclaim, round 2's lane enumeration), and *arms not isolating what they name* (round 1's `stringsSame`; round 2's per-lane arms). Both are folded, and the design signal behind the first is stated below.

## Sabotage RED-checks — 11, each from a committed state, each restored and verified by anchor grep

| Sabotage | Result |
|---|---|
| choke point disabled | LOC-A/C + backstop RED — referencer came back `untouched=False`, actually rewritten |
| compact pre-flight disabled | REPOINT-LOC RED with `targetUntouched=False` (the stranding) while `refUntouched=True` — backstop still caught it |
| `SerializeFailure` branch removed | LOC-A RED, LOC-C green |
| remove-lane catch removed | LOC-C RED, LOC-A green |
| repoint-lane catch removed | backstop RED, showing the misattributed sub-0x800 rider |
| `PluginIsLocalized` → false | LOC-E/F RED, LOC-A/C green |
| `PluginIsLocalized` → true | LOC-B/D/G RED (over-refusal caught) |
| `LocalizedAmong` → hits everything | REPOINT-PLAIN + CONSENT RED |
| remove / forward / create pre-flight each deleted alone | LOC-H / LOC-I / LOC-J RED in isolation, the other two green |
| compact target check disabled | TARGET-LOC RED — the localized plugin compacted in place |
| compact target check fires on every target | CONSENT ×2 + REPOINT-LOC + REPOINT-PLAIN RED (over-refusal caught) |

One of these changed the branch: sabotage 9 found LOC-H/I/J **green** with the lane's pre-flight deleted, because the write's choke point refuses with the same sentence — the arms were pinning the backstop, not the call site they were named for. They now assert the consent record, which is what actually separates the two layers, and the re-run isolates each lane.

`ci-all` **124/124** at the branch tip.

## Directed fold after the rounds

The compact-target refusal above landed as a directed fold once the rounds had closed (§11 permits this; no round 3 was opened). It closed the one gap I had flagged for you rather than acted on. Restructuring came with it: both repoint arms needed a **non-localized target**, because with a localized one the new check answers first and they would have been measuring it instead of the referencer pre-flight they are named for — so the fixture gained a per-spec `Localized` flag that asserts in both directions that the plugin it built is the kind it meant to build.

Noted on #373 for the attended engagement: **both** compact lanes de-localize a localized target today, the new-file lane included — values correct when the strings resolve, but the output's nature changed either way. Whether that is ever the right product is part of the same "what may a write put on disk beside the plugin" question.

## For your review

One thing left standing, deliberately: the **recurring-prose class**. The reason the changelog kept being wrong across both rounds is that the refusal's coverage boundary is genuinely ragged — five lanes and two mechanisms, plus compact's target, which is refused for a different reason than everything else. Any prose that enumerates "the in-place lanes" will keep drifting until that boundary is one thing, which is the attended engagement's territory. Both recurring classes had their generators closed by the round-2 folds, so no §4 escalation is owed now; a third instance of either would be one.

Refs #368, #373, #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)
