### PR TITLE
fix(remove): the not-found refusal names a lane removal has, not one it hasn't

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -18,9 +18,10 @@ saying it sets an expectation their install may contradict. Say what is known, a
   spelling — is refused, and that refusal ended "Omit into= to create it fresh, or check the name." Doing that got
   you a second refusal: removal has no fresh-patch lane, because it only drops a record the patch itself already
   carries, so there is nothing for a newly created one to remove. The refusal now says that instead, and names the
-  lane a removal does have — `target=<plugin filename>` + `in_place=true`, which removes the record from an existing
-  plugin in place (that lane's own first-touch confirmation still applies; see the in-place entry below for what it
-  refuses). Every write tool that *can* create a patch still says so, each on its own behalf. (#356)
+  lane a removal does have — `in_place="<plugin filename>"` on `housecarl_remove`, `target=<plugin filename>` +
+  `in_place=true` on the 1.x `housecarl_remove_record`, each tool naming the lane it declares. That lane removes the
+  record from an existing plugin in place; its own first-touch confirmation still applies, and see the in-place entry
+  below for what it refuses. Every write tool that *can* create a patch still says so, each on its own behalf. (#356)
 
 - **The record-editing lanes now refuse a localized plugin in place instead of scrambling its text.** Editing,
   removing from, creating into, or forwarding into an existing plugin **in place** re-serializes that whole plugin —

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,15 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **Fixed: `housecarl_remove` told you to create a patch it cannot create.** Naming a patch that does not exist —
+  `housecarl_remove(..., into="My Patch.esp")`, or `housecarl_remove_record(..., patch="My Patch.esp")` on the 1.x
+  spelling — is refused, and that refusal ended "Omit into= to create it fresh, or check the name." Doing that got
+  you a second refusal: removal has no fresh-patch lane, because it only drops a record the patch itself already
+  carries, so there is nothing for a newly created one to remove. The refusal now says that instead, and names the
+  lane a removal does have — `target=<plugin filename>` + `in_place=true`, which removes the record from an existing
+  plugin in place (that lane's own first-touch confirmation still applies; see the in-place entry below for what it
+  refuses). Every write tool that *can* create a patch still says so, each on its own behalf. (#356)
+
 - **The record-editing lanes now refuse a localized plugin in place instead of scrambling its text.** Editing,
   removing from, creating into, or forwarding into an existing plugin **in place** re-serializes that whole plugin —
   `housecarl_apply`, `housecarl_create`, `housecarl_remove` and `housecarl_forward` with `in_place="X.esp"` (and

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -16,9 +16,9 @@ saying it sets an expectation their install may contradict. Say what is known, a
 - **Fixed: `housecarl_remove` told you to create a patch it cannot create.** Naming a patch that does not exist —
   `housecarl_remove(..., into="My Patch.esp")`, or `housecarl_remove_record(..., patch="My Patch.esp")` on the 1.x
   spelling — is refused, and that refusal ended "Omit into= to create it fresh, or check the name." Doing that got
-  you a second refusal: removal has no fresh-patch lane, because it only drops a record the patch itself already
-  carries, so there is nothing for a newly created one to remove. The refusal now says that instead, and names the
-  lane a removal does have — `in_place="<plugin filename>"` on `housecarl_remove`, `target=<plugin filename>` +
+  you a second refusal: removal has no fresh-patch lane at all, because it only drops a record the patch itself
+  already carries. The refusal now says that instead, and names the lane a removal does have —
+  `in_place="<plugin filename>"` on `housecarl_remove`, `target=<plugin filename>` +
   `in_place=true` on the 1.x `housecarl_remove_record`, each tool naming the lane it declares. That lane removes the
   record from an existing plugin in place; its own first-touch confirmation still applies, and see the in-place entry
   below for what it refuses. Every write tool that *can* create a patch still says so, each on its own behalf. (#356)

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -19,9 +19,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
   you a second refusal: removal has no fresh-patch lane at all, because it only drops a record the patch itself
   already carries. The refusal now says that instead, and names the lane a removal does have —
   `in_place="<plugin filename>"` on `housecarl_remove`, `target=<plugin filename>` +
-  `in_place=true` on the 1.x `housecarl_remove_record`, each tool naming the lane it declares. That lane removes the
-  record from an existing plugin in place; its own first-touch confirmation still applies, and see the in-place entry
-  below for what it refuses. Every write tool that *can* create a patch still says so, each on its own behalf. (#356)
+  `in_place=true` on the 1.x `housecarl_remove_record`, each tool naming the lane it declares. Know what that lane
+  costs before you follow the suggestion: it rewrites your original file, with no houseCARL backup or undo, and its
+  one-time confirmation is per plugin and shared with the other in-place lanes — so if you have already acknowledged
+  that plugin, in any lane or any earlier session, the write happens with no further prompt. See the in-place entry
+  below for what that lane refuses. Every write tool that *can* create a patch still says so, each on its own
+  behalf. (#356)
 
 - **The record-editing lanes now refuse a localized plugin in place instead of scrambling its text.** Editing,
   removing from, creating into, or forwarding into an existing plugin **in place** re-serializes that whole plugin —

--- a/src/housecarl-generator/CopyServiceProbe.cs
+++ b/src/housecarl-generator/CopyServiceProbe.cs
@@ -191,6 +191,20 @@ public static class CopyServiceProbe
             var seedPaths = new[] { "HeadParts" };
             var noExcl = Array.Empty<WalkExclusion>();
 
+            // ---- 0. into= a patch that does not exist: this lane STATES it can create one fresh ---------------
+            //      The shared resolver's default used to carry that clause for every caller. It no longer claims
+            //      any create route (#356 — removal reached the same default and cannot create), so copy's own
+            //      statement is what puts the clause back, and deleting it silently weakens this refusal. Measured
+            //      here rather than assumed: omitting into= on this lane does create a patch, named off the new
+            //      EditorID (the clone arm below writes ClonePatch.esp the same way).
+            {
+                var ghost = svc.CopyClosure(srcNpcFk, new[] { "Src.esp" }, seedPaths, noExcl,
+                    targetFk, null, null, "NoSuchCopyPatch");
+                Check(ghost.EngineError is not null
+                      && ghost.EngineError.Contains("create it fresh", StringComparison.OrdinalIgnoreCase),
+                      $"copy's not-found refusal still offers the fresh-write route it does have ({ghost.EngineError})");
+            }
+
             // ---- 1. ATTACH onto an ACTIVE target, source DISABLED --------------------------------------------
             var att = svc.CopyClosure(srcNpcFk, new[] { "Src.esp" }, seedPaths, noExcl,
                 targetFk, null, "AttachPatch", null);

--- a/src/housecarl-generator/ExtendResolveProbe.cs
+++ b/src/housecarl-generator/ExtendResolveProbe.cs
@@ -418,8 +418,10 @@ internal static class ExtendResolveProbe
                 Check(refused.Contains(WriteSentences.RemoveInPlaceLane, StringComparison.Ordinal),
                       "the not-found refusal fires for this record too, naming the in-place lane");
 
-                // Following it lands on the first-touch CONSENT handshake, not a write and not an error — the
-                // sentence promises the lane, and this is the lane's own next step.
+                // Following it lands on the first-touch CONSENT handshake, not a write and not an error. That is
+                // what THIS fixture shows and all it shows: the plugin has never been acknowledged. Against one
+                // that has — consent is persisted and shared across the in-place lanes — the same call writes with
+                // no prompt, which is why the sentence does not promise a confirmation (#359).
                 var prompted = RemoveTools.Remove(svc, new[] { ipFid }, in_place: "RemoveHere.esp");
                 Check(prompted.Contains("first-time confirmation", StringComparison.Ordinal),
                       "following it reaches the in-place first-touch confirmation (a prompt, not a refusal)");

--- a/src/housecarl-generator/ExtendResolveProbe.cs
+++ b/src/housecarl-generator/ExtendResolveProbe.cs
@@ -324,6 +324,74 @@ internal static class ExtendResolveProbe
                       "housecarl_remove into a patch that does not exist still refuses, naming the .esp searched");
                 Check(r.Error is not null && !r.Error.Contains("patch=", StringComparison.Ordinal),
                       "…and does NOT name patch= (a removal cannot create a patch — the remedy would be false)");
+
+                // #356: the tail this lane USED to inherit. It offered "Omit into= to create it fresh" — and omitting
+                // the lane is refused with "patch is required", so the sentence handed callers a second refusal. The
+                // shared default no longer claims a create path at all, and this is the arm that keeps removal off it:
+                // a lane that starts stating CreatedByOmittingInto, or a default that starts assuming one, reddens here.
+                Check(r.Error is not null && !r.Error.Contains("create it fresh", StringComparison.OrdinalIgnoreCase),
+                      "…and no longer offers 'create it fresh' — the remedy this lane could not perform (#356)");
+                Check(r.Error is not null && r.Error.Contains(WriteSentences.ExtendCheckTheName, StringComparison.Ordinal),
+                      "…it falls back to the always-true default tail (check what you typed)");
+                Check(r.Error is not null && r.Error.Contains(WriteSentences.RemoveNoFreshPatch, StringComparison.Ordinal),
+                      "…and the LANE states why there is no create route here (a fresh patch carries nothing to remove)");
+                Check(r.Error is not null && r.Error.Contains(WriteSentences.RemoveInPlaceAlternative, StringComparison.Ordinal),
+                      "…and names the one lane a removal does have — target= + in_place=true");
+
+                // The missing-patch= refusal renders the SAME in-place sentence, from the same constant. It is the
+                // call the old tail sent callers to, so the two have to agree about what a caller does next — which
+                // is the whole reason this clause is shared rather than written out twice.
+                var bare = svc.RemoveRecords(new[] { fid }, null);
+                Check(!bare.Success && bare.Error is not null
+                      && bare.Error.Contains(WriteSentences.RemoveInPlaceAlternative, StringComparison.Ordinal),
+                      "…and remove's OTHER no-patch refusal names the same lane, from the same constant");
+            }
+
+            // ---- 8d2: the removal remedy is TRUE — following it removes the record -------------------------------
+            //      Same standard as arm 8b: a remedy is a claim about what a call does, so it is checked by MAKING
+            //      the call. Its own throwaway active plugin, never the master — arm 10 asserts that file is
+            //      byte-untouched, and an in-place removal would be exactly the write that falsifies it.
+            Console.WriteLine();
+            Console.WriteLine("--- 8d2: following the removal remedy (target= + in_place=true) removes the record ---");
+            {
+                var ipDir = Path.Combine(mods, "RemoveHereMod");
+                Directory.CreateDirectory(ipDir);
+                var ipPath = Path.Combine(ipDir, "RemoveHere.esp");
+                FormKey ipFk;
+                {
+                    var m = new SkyrimMod(new ModKey("RemoveHere", ModType.Plugin), SkyrimRelease.SkyrimSE);
+                    var w = m.Weapons.AddNew(); w.EditorID = "HcRemoveMe";
+                    w.BasicStats = new WeaponBasicStats { Damage = 3, Weight = 1 };
+                    ipFk = w.FormKey;
+                    m.BeginWrite.ToPath(ipPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+                }
+                File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + mKey.FileName + "\r\nGhostActive.esp\r\nRemoveHere.esp\r\n");
+                File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + mKey.FileName + "\r\n*GhostActive.esp\r\n*RemoveHere.esp\r\n");
+                File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+RemoveHereMod\r\n+OddlyNamedMod\r\n+MasterMod\r\n");
+                svc.Stats();                                                   // let the resolver see the changed order
+
+                string ipFid = $"{ipFk.ID:X6}:RemoveHere.esp";
+                var refused = svc.RemoveRecords(new[] { ipFid }, "GhostRemove");
+                Check(!refused.Success && refused.Error is not null
+                      && refused.Error.Contains(WriteSentences.RemoveInPlaceAlternative, StringComparison.Ordinal),
+                      "the not-found refusal fires for this record too, naming the in-place lane");
+
+                // Following it lands on the first-touch CONSENT handshake, not a write and not an error — the
+                // sentence promises the lane, and this is the lane's own next step.
+                var prompted = svc.RemoveRecords(new[] { ipFid }, null, "RemoveHere.esp", inPlace: true);
+                Check(!prompted.Success && prompted.NeedsAcknowledge,
+                      "following it reaches the in-place first-touch confirmation (a prompt, not a refusal)");
+
+                var done = svc.RemoveRecords(new[] { ipFid }, null, "RemoveHere.esp", inPlace: true, acknowledge: true);
+                Check(done.Success && done.InPlace && done.Removed.Count == 1,
+                      $"…and acknowledging it REMOVES the record ({done.Error})");
+                ISkyrimModGetter? back = null;
+                try
+                {
+                    back = SkyrimMod.CreateFromBinaryOverlay(ipPath, SkyrimRelease.SkyrimSE);
+                    Check(back.Weapons.All(w => w.FormKey != ipFk), "…and the record is GONE from the file on disk");
+                }
+                finally { (back as IDisposable)?.Dispose(); }
             }
 
             // ---- 9: FOREIGN — an un-owned "houseCARL - X" folder stays REFUSED + byte-untouched (Q3) ----

--- a/src/housecarl-generator/ExtendResolveProbe.cs
+++ b/src/housecarl-generator/ExtendResolveProbe.cs
@@ -343,11 +343,13 @@ internal static class ExtendResolveProbe
                 Check(r.Error is not null && !r.Error.Contains("in_place", StringComparison.Ordinal),
                       "…and at the SERVICE altitude names no in-place spelling (the tools own that sentence)");
 
-                // The missing-patch= refusal is 1.x-only reachable, so it states the 1.x spelling.
+                // remove's OTHER no-patch refusal renders the caller's own spelling on the same terms: a direct
+                // service call hands none, so it names none.
                 var bare = svc.RemoveRecords(new[] { fid }, null);
                 Check(!bare.Success && bare.Error is not null
-                      && bare.Error.Contains(WriteSentences.RemoveInPlaceLaneLegacy, StringComparison.Ordinal),
-                      "…and remove's OTHER no-patch refusal names the lane in the 1.x spelling it is reachable from");
+                      && bare.Error.Contains("patch is required", StringComparison.Ordinal)
+                      && !bare.Error.Contains("in_place", StringComparison.Ordinal),
+                      "…and the missing-patch= refusal names no spelling either when the caller hands none");
             }
 
             // ---- 8d3: the sentence is read at the TOOL altitude, and each tool spells its OWN lane ---------------
@@ -369,12 +371,20 @@ internal static class ExtendResolveProbe
                 Check(legacy.Contains(WriteSentences.RemoveInPlaceLaneLegacy, StringComparison.Ordinal),
                       "housecarl_remove_record names target= + in_place=true — the lane IT declares");
 
-                // What makes hardcoding the 1.x spelling in the service's "patch is required" arm safe: a 2.0
-                // caller never reaches it. Its own no-lane refusal fires first, in its own spelling.
+                // BOTH of remove's no-usable-patch refusals carry the handed-down spelling, not just the
+                // not-found one: the missing-patch= arm renders what its caller passed, so 1.x reaches it and
+                // gets the 1.x sentence. Nothing about which tool can reach which arm is load-bearing any more.
+                var legacyBare = WriteTools.RemoveRecord(svc, fid);
+                Check(legacyBare.Contains("patch is required", StringComparison.Ordinal)
+                      && legacyBare.Contains(WriteSentences.RemoveInPlaceLaneLegacy, StringComparison.Ordinal),
+                      "…and its missing-patch= refusal carries that same spelling, handed down the same way");
+
+                // The 2.0 tool refuses first, in its own spelling. Kept as a statement about the TOOL — it is
+                // no longer what makes anything in the service correct.
                 var noLane = RemoveTools.Remove(svc, new[] { fid });
                 Check(noLane.Contains("no lane named", StringComparison.Ordinal)
                       && !noLane.Contains("patch is required", StringComparison.Ordinal),
-                      "…and the service's 1.x-spelled 'patch is required' arm is unreachable from the 2.0 tool");
+                      "housecarl_remove answers a lane-less call itself, before the service's own arm");
             }
 
             // ---- 8d2: the removal remedy is TRUE — following it removes the record -------------------------------

--- a/src/housecarl-generator/ExtendResolveProbe.cs
+++ b/src/housecarl-generator/ExtendResolveProbe.cs
@@ -313,7 +313,7 @@ internal static class ExtendResolveProbe
 
             // ---- 8d: the REMOVAL lane must not get the naming sentence either ----
             //      Removal reaches the same refusal through ResolveOutputPath — the SAME branch arm 8 covers — so the
-            //      lane bit does not separate them; only the caller's own patchNamesFresh does. A removal edits an
+            //      lane bit does not separate them; only the caller's own FreshPatchRemedy does. A removal edits an
             //      artifact that already exists, so it cannot create a patch and the cost clause is false whichever
             //      spelling the tool gives the lane: 2.0's housecarl_remove calls it into=, while 1.x remove_record
             //      calls it patch= and means the EXISTING patch — there "pass patch=<the name you just passed>" would
@@ -337,7 +337,7 @@ internal static class ExtendResolveProbe
                 Check(r.Error is not null && r.Error.Contains(WriteSentences.ExtendCheckTheName, StringComparison.Ordinal),
                       "…it falls back to the always-true default tail (check what you typed)");
                 Check(r.Error is not null && r.Error.Contains(WriteSentences.RemoveNoFreshPatch, StringComparison.Ordinal),
-                      "…and the LANE states why there is no create route here (a fresh patch carries nothing to remove)");
+                      "…and the LANE states why there is no create route here (removal needs a patch that already carries it)");
                 // A direct SERVICE call names no in-place spelling at all — the two tools spell that lane
                 // differently, so the honest thing at this altitude is the half that is true at both.
                 Check(r.Error is not null && !r.Error.Contains("in_place", StringComparison.Ordinal),

--- a/src/housecarl-generator/ExtendResolveProbe.cs
+++ b/src/housecarl-generator/ExtendResolveProbe.cs
@@ -37,6 +37,9 @@ namespace HousecarlGenerator;
 ///                  true rather than read. The two arms that keep it honest are negative: the RIDER lane does NOT
 ///                  get it (on bsa_repack patch= binds to archive_name — the .bsa), and neither does the REMOVAL
 ///                  lane, which shares the record branch but whose patch= names an EXISTING patch.
+///   REMOVE-TAIL  — that removal lane offers no create route at all (#356: it used to inherit "omit into= to create
+///                  it fresh", which removal itself refuses), states why, and names the one lane it does have. Its
+///                  spelling is the calling TOOL'"'"'s, not the service'"'"'s, and the arms call the tools to see it.
 ///   FOREIGN      — a "houseCARL - X" folder with NO marker is still REFUSED (originals untouched, Q3) and left byte-intact.
 ///   ORIGINALS    — the master plugin is byte-untouched throughout (extends only ever wrote the patch folder).
 /// </summary>
@@ -335,24 +338,52 @@ internal static class ExtendResolveProbe
                       "…it falls back to the always-true default tail (check what you typed)");
                 Check(r.Error is not null && r.Error.Contains(WriteSentences.RemoveNoFreshPatch, StringComparison.Ordinal),
                       "…and the LANE states why there is no create route here (a fresh patch carries nothing to remove)");
-                Check(r.Error is not null && r.Error.Contains(WriteSentences.RemoveInPlaceAlternative, StringComparison.Ordinal),
-                      "…and names the one lane a removal does have — target= + in_place=true");
+                // A direct SERVICE call names no in-place spelling at all — the two tools spell that lane
+                // differently, so the honest thing at this altitude is the half that is true at both.
+                Check(r.Error is not null && !r.Error.Contains("in_place", StringComparison.Ordinal),
+                      "…and at the SERVICE altitude names no in-place spelling (the tools own that sentence)");
 
-                // The missing-patch= refusal renders the SAME in-place sentence, from the same constant. It is the
-                // call the old tail sent callers to, so the two have to agree about what a caller does next — which
-                // is the whole reason this clause is shared rather than written out twice.
+                // The missing-patch= refusal is 1.x-only reachable, so it states the 1.x spelling.
                 var bare = svc.RemoveRecords(new[] { fid }, null);
                 Check(!bare.Success && bare.Error is not null
-                      && bare.Error.Contains(WriteSentences.RemoveInPlaceAlternative, StringComparison.Ordinal),
-                      "…and remove's OTHER no-patch refusal names the same lane, from the same constant");
+                      && bare.Error.Contains(WriteSentences.RemoveInPlaceLaneLegacy, StringComparison.Ordinal),
+                      "…and remove's OTHER no-patch refusal names the lane in the 1.x spelling it is reachable from");
+            }
+
+            // ---- 8d3: the sentence is read at the TOOL altitude, and each tool spells its OWN lane ---------------
+            //      The service cannot tell its two callers apart, and they declare different parameters: 2.0's
+            //      housecarl_remove takes in_place="<file>" and no target= at all, while 1.x remove_record takes
+            //      target= plus a bool. One shared sentence is therefore wrong on one of them — which is #356's own
+            //      defect one layer up, and invisible to every arm that calls the service directly. These call the
+            //      TOOLS.
+            Console.WriteLine();
+            Console.WriteLine("--- 8d3: each remove TOOL's refusal names the lane IT declares ---");
+            {
+                var modern = RemoveTools.Remove(svc, new[] { fid }, into: "GhostRemove");
+                Check(modern.Contains(WriteSentences.RemoveInPlaceLane, StringComparison.Ordinal),
+                      "housecarl_remove names in_place=\"<plugin filename>\" — the lane it actually declares");
+                Check(!modern.Contains("target=", StringComparison.Ordinal),
+                      "…and never names target=, which that tool does not declare");
+
+                var legacy = WriteTools.RemoveRecord(svc, fid, patch: "GhostRemove");
+                Check(legacy.Contains(WriteSentences.RemoveInPlaceLaneLegacy, StringComparison.Ordinal),
+                      "housecarl_remove_record names target= + in_place=true — the lane IT declares");
+
+                // What makes hardcoding the 1.x spelling in the service's "patch is required" arm safe: a 2.0
+                // caller never reaches it. Its own no-lane refusal fires first, in its own spelling.
+                var noLane = RemoveTools.Remove(svc, new[] { fid });
+                Check(noLane.Contains("no lane named", StringComparison.Ordinal)
+                      && !noLane.Contains("patch is required", StringComparison.Ordinal),
+                      "…and the service's 1.x-spelled 'patch is required' arm is unreachable from the 2.0 tool");
             }
 
             // ---- 8d2: the removal remedy is TRUE — following it removes the record -------------------------------
+            //      Driven through housecarl_remove, in the spelling that tool declares (arm 8d3's subject).
             //      Same standard as arm 8b: a remedy is a claim about what a call does, so it is checked by MAKING
             //      the call. Its own throwaway active plugin, never the master — arm 10 asserts that file is
             //      byte-untouched, and an in-place removal would be exactly the write that falsifies it.
             Console.WriteLine();
-            Console.WriteLine("--- 8d2: following the removal remedy (target= + in_place=true) removes the record ---");
+            Console.WriteLine("--- 8d2: following the removal remedy (in_place=\"<plugin filename>\") removes the record ---");
             {
                 var ipDir = Path.Combine(mods, "RemoveHereMod");
                 Directory.CreateDirectory(ipDir);
@@ -371,20 +402,21 @@ internal static class ExtendResolveProbe
                 svc.Stats();                                                   // let the resolver see the changed order
 
                 string ipFid = $"{ipFk.ID:X6}:RemoveHere.esp";
-                var refused = svc.RemoveRecords(new[] { ipFid }, "GhostRemove");
-                Check(!refused.Success && refused.Error is not null
-                      && refused.Error.Contains(WriteSentences.RemoveInPlaceAlternative, StringComparison.Ordinal),
+                // Driven through the 2.0 TOOL, not the service: the sentence under test is the one that tool
+                // renders, in the spelling that tool declares, so following it has to mean passing what it says.
+                var refused = RemoveTools.Remove(svc, new[] { ipFid }, into: "GhostRemove");
+                Check(refused.Contains(WriteSentences.RemoveInPlaceLane, StringComparison.Ordinal),
                       "the not-found refusal fires for this record too, naming the in-place lane");
 
                 // Following it lands on the first-touch CONSENT handshake, not a write and not an error — the
                 // sentence promises the lane, and this is the lane's own next step.
-                var prompted = svc.RemoveRecords(new[] { ipFid }, null, "RemoveHere.esp", inPlace: true);
-                Check(!prompted.Success && prompted.NeedsAcknowledge,
+                var prompted = RemoveTools.Remove(svc, new[] { ipFid }, in_place: "RemoveHere.esp");
+                Check(prompted.Contains("first-time confirmation", StringComparison.Ordinal),
                       "following it reaches the in-place first-touch confirmation (a prompt, not a refusal)");
 
-                var done = svc.RemoveRecords(new[] { ipFid }, null, "RemoveHere.esp", inPlace: true, acknowledge: true);
-                Check(done.Success && done.InPlace && done.Removed.Count == 1,
-                      $"…and acknowledging it REMOVES the record ({done.Error})");
+                var done = RemoveTools.Remove(svc, new[] { ipFid }, in_place: "RemoveHere.esp", acknowledge: true);
+                Check(done.Contains("removed 1 record from RemoveHere.esp IN PLACE", StringComparison.Ordinal),
+                      $"…and acknowledging it REMOVES the record ({done})");
                 ISkyrimModGetter? back = null;
                 try
                 {
@@ -392,6 +424,28 @@ internal static class ExtendResolveProbe
                     Check(back.Weapons.All(w => w.FormKey != ipFk), "…and the record is GONE from the file on disk");
                 }
                 finally { (back as IDisposable)?.Dispose(); }
+            }
+
+            // ---- 8e: every lane that STATES a fresh-write path is held to saying it ------------------------------
+            //      The shared default used to carry the create clause, so these call sites were free-riding on it and
+            //      an arm would have proved nothing. Now the default claims nothing and each lane states its own, so
+            //      a deleted statement is a silently weakened refusal — the #356 shape, one lane over. apply is
+            //      covered by arm 8; forward and create are cheap on this fixture; the two copy lanes need an NPC
+            //      universe, so they are pinned in their own probes (copy-service-guard, npc-copy-guard).
+            Console.WriteLine();
+            Console.WriteLine("--- 8e: forward and create still state that patch= names a fresh patch ---");
+            {
+                // A name nothing holds — arm 8b's remedy call created "GhostPatch", so reusing it would resolve.
+                var fwd = svc.ForwardRecords(new[] { fid }, mKey.FileName, null, "GhostFwd");
+                Check(!fwd.Success && fwd.Error is not null
+                      && fwd.Error.Contains("pass patch=\"GhostFwd\"", StringComparison.Ordinal),
+                      "housecarl_forward's not-found refusal names patch=<the guessed name>");
+
+                var cre = svc.CreateRecordsBatch(new[] { new CreateOp { RecordType = "Keyword", Editorid = "HcExtKw" } },
+                                                 null, "GhostCre");
+                Check(!cre.Success && cre.Error is not null
+                      && cre.Error.Contains("pass patch=\"GhostCre\"", StringComparison.Ordinal),
+                      "housecarl_create's does too");
             }
 
             // ---- 9: FOREIGN — an un-owned "houseCARL - X" folder stays REFUSED + byte-untouched (Q3) ----

--- a/src/housecarl-generator/NpcCopyProbe.cs
+++ b/src/housecarl-generator/NpcCopyProbe.cs
@@ -248,6 +248,18 @@ public static class NpcCopyProbe
             using var svc = LoadOrderService.WithInstance(inst, 0, new UserConfigStore(Path.Combine(root, "user.json")));
             svc.Stats();
 
+            // ================= 0. into= a patch that does not exist ============================================
+            //      Same statement as copy's, for the same reason (#356): the shared resolver's default no longer
+            //      offers any create route, so this lane's own CreatedByOmittingInto is what keeps the clause on
+            //      this refusal — and nothing else would notice if it were deleted.
+            {
+                var ghost = svc.CopyNpcAppearance(donorNpcFk.ToString(), "Donor.esp", null,
+                                                  targetFk.ToString(), null, null, null, "NoSuchFacePatch");
+                Check(!ghost.Success && ghost.Error is not null
+                      && ghost.Error.Contains("create it fresh", StringComparison.OrdinalIgnoreCase),
+                      $"copy_npc_appearance's not-found refusal still offers its fresh-write route ({ghost.Error})");
+            }
+
             // ================= 1. APPLY — disabled donor's appearance onto the active follower =================
             {
                 var o = svc.CopyNpcAppearance(donorNpcFk.ToString(), "Donor.esp", null,

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -2371,11 +2371,11 @@ public static class WriteSurfaceGuardProbe
         // …and remove's no-usable-patch REFUSALS, which are where the extend not-found tail reaches a caller (#356).
         // Driven off the real service and the real TOOL rather than a built outcome: the sentence is chosen from what
         // the caller stated about itself, so an outcome constructed here would be this probe handing itself the
-        // answer. The 1.x-spelled clause is observed through the service's own missing-patch arm — the only place it
-        // renders — and the 2.0 one through housecarl_remove, because the tool is what supplies it. Every call here
-        // is a refusal, so the fixture the later arms read is untouched.
-        var noPatch = fx.Svc.RemoveRecords(new[] { fx.SubjectFid }, null);
-        Observe(WriteTools.RenderRemoval(noPatch), JsonWire.RenderRemovalOutcome(noPatch, 0, "into"));
+        // answer. Each spelling is observed through the TOOL that supplies it — now the only place either renders,
+        // since the service hands both down rather than choosing. Every call here is a refusal, so the fixture the
+        // later arms read is untouched. (housecarl_remove_record is text-only, so its claim is "reaches a render",
+        // like copy's.)
+        Observe(WriteTools.RemoveRecord(fx.Svc, fx.SubjectFid), "{}");
         Observe(RemoveTools.Remove(fx.Svc, new[] { fx.SubjectFid }, into: "W2TwinNoSuchPatch"),
                 RemoveTools.Remove(fx.Svc, new[] { fx.SubjectFid }, into: "W2TwinNoSuchPatch", format: "json"));
 

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -2368,6 +2368,17 @@ public static class WriteSurfaceGuardProbe
             "total_removed", $"removed {rmOutcome.Removed.Count} records");
         Observe(WriteTools.RenderRemoval(rmOutcome, 60), JsonWire.RenderRemovalOutcome(rmOutcome, 60, "into"));
 
+        // …and remove's two no-usable-patch REFUSALS, which are where the extend not-found tail reaches a caller
+        // (#356). Driven off the real service rather than a built outcome: the sentence under test is chosen inside
+        // the resolver from what the LANE stated about itself, so an outcome constructed here would be this probe
+        // handing itself the answer. Both refusals write nothing, so the fixture the later arms read is untouched.
+        foreach (var refusal in new[]
+                 {
+                     fx.Svc.RemoveRecords(new[] { fx.SubjectFid }, "W2TwinNoSuchPatch"),   // into= names nothing → the not-found tail
+                     fx.Svc.RemoveRecords(new[] { fx.SubjectFid }, null),                  // no lane at all → the missing-patch= refusal
+                 })
+            Observe(WriteTools.RenderRemoval(refusal), JsonWire.RenderRemovalOutcome(refusal, 0, "into"));
+
         // ---- the three post-write report blocks -------------------------------------------------------
         // Rendered off a built outcome for the same reason the report-budget arm above builds one: a report big
         // enough to cut means dozens of voiced lines, and the claim under test is the RENDERERS' agreement, not the

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -2368,16 +2368,16 @@ public static class WriteSurfaceGuardProbe
             "total_removed", $"removed {rmOutcome.Removed.Count} records");
         Observe(WriteTools.RenderRemoval(rmOutcome, 60), JsonWire.RenderRemovalOutcome(rmOutcome, 60, "into"));
 
-        // …and remove's two no-usable-patch REFUSALS, which are where the extend not-found tail reaches a caller
-        // (#356). Driven off the real service rather than a built outcome: the sentence under test is chosen inside
-        // the resolver from what the LANE stated about itself, so an outcome constructed here would be this probe
-        // handing itself the answer. Both refusals write nothing, so the fixture the later arms read is untouched.
-        foreach (var refusal in new[]
-                 {
-                     fx.Svc.RemoveRecords(new[] { fx.SubjectFid }, "W2TwinNoSuchPatch"),   // into= names nothing → the not-found tail
-                     fx.Svc.RemoveRecords(new[] { fx.SubjectFid }, null),                  // no lane at all → the missing-patch= refusal
-                 })
-            Observe(WriteTools.RenderRemoval(refusal), JsonWire.RenderRemovalOutcome(refusal, 0, "into"));
+        // …and remove's no-usable-patch REFUSALS, which are where the extend not-found tail reaches a caller (#356).
+        // Driven off the real service and the real TOOL rather than a built outcome: the sentence is chosen from what
+        // the caller stated about itself, so an outcome constructed here would be this probe handing itself the
+        // answer. The 1.x-spelled clause is observed through the service's own missing-patch arm — the only place it
+        // renders — and the 2.0 one through housecarl_remove, because the tool is what supplies it. Every call here
+        // is a refusal, so the fixture the later arms read is untouched.
+        var noPatch = fx.Svc.RemoveRecords(new[] { fx.SubjectFid }, null);
+        Observe(WriteTools.RenderRemoval(noPatch), JsonWire.RenderRemovalOutcome(noPatch, 0, "into"));
+        Observe(RemoveTools.Remove(fx.Svc, new[] { fx.SubjectFid }, into: "W2TwinNoSuchPatch"),
+                RemoveTools.Remove(fx.Svc, new[] { fx.SubjectFid }, into: "W2TwinNoSuchPatch", format: "json"));
 
         // ---- the three post-write report blocks -------------------------------------------------------
         // Rendered off a built outcome for the same reason the report-budget arm above builds one: a report big

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -5572,7 +5572,7 @@ public sealed class LoadOrderService : IDisposable
     /// → mod.Remove → re-serialize, with clean-masters riding along). The default lane never touches originals (only the
     /// patch folder is written).</summary>
     public WritePatchBuilder.RemovalOutcome RemoveRecords(IReadOnlyList<string> formids, string? patch,
-        string? target = null, bool inPlace = false, bool acknowledge = false)
+        string? target = null, bool inPlace = false, bool acknowledge = false, string? inPlaceRemedy = null)
     {
         if (formids is null || formids.Count == 0)
             return WritePatchBuilder.RemovalOutcome.Fail("no formids supplied — pass the FormID(s) of the record(s) to remove.");
@@ -5592,8 +5592,11 @@ public sealed class LoadOrderService : IDisposable
                 "target= is only meaningful with in_place=true (it names the plugin to remove from in place). For the default lane omit target=; use patch= to name the houseCARL patch.");
         if (!inPlace && string.IsNullOrWhiteSpace(patch))
             return WritePatchBuilder.RemovalOutcome.Fail(
+                // The legacy spelling is hardcoded here because this arm is 1.x-ONLY: housecarl_remove refuses
+                // "no lane named" — in its own correct spelling — before the service is reached. Measured, and
+                // pinned by the extend-resolver guard's tool-altitude arm.
                 "patch is required — name the houseCARL patch to remove the record from (removal only targets a patch that already carries it). "
-                + WriteSentences.RemoveInPlaceAlternative);
+                + WriteSentences.RemoveInPlaceLaneLegacy);
 
         // Parse every formid first, collecting ALL problems (all-or-nothing, like the edit path). Pure — outside the gate.
         var keys = new List<FormKey>(formids.Count);
@@ -5625,9 +5628,14 @@ public sealed class LoadOrderService : IDisposable
             // lane is itself refused, so the sentence sent callers to a second refusal. What this lane can honestly
             // offer instead is measured — a patch created first carries no override of the record, so removal refuses
             // there too; the in-place lane does remove it, behind the first-touch confirmation.
+            //
+            // The in-place half comes from the TOOL (inPlaceRemedy), because the two tools spell that lane
+            // differently and the service cannot tell which one called it. Null — a direct service call — offers
+            // only the half that is true at every altitude, rather than guessing a spelling.
             string outPath;
             try { outPath = ResolveOutputPath(patchName: null, into: patch, out _, out _,
-                                              laneClause: WriteSentences.RemoveNoFreshPatch + " " + WriteSentences.RemoveInPlaceAlternative); }
+                                              laneClause: WriteSentences.RemoveNoFreshPatch
+                                                          + (inPlaceRemedy is null ? "" : " " + inPlaceRemedy)); }
             catch (Exception ex) { return WritePatchBuilder.RemovalOutcome.Fail(ex.Message); }
 
             return WritePatchBuilder.RemoveRecords(resolver, keys, outPath);
@@ -8015,6 +8023,9 @@ public sealed class LoadOrderService : IDisposable
         // THIS arm only. The ambiguous and multi-plugin arms above already name a working call, and the foreign-folder
         // arm's remedy is #359's open design question, not this one's.
         //
+        // It is rendered BEFORE the fallback above, not after: the lane's own diagnosis is what makes the fallback
+        // the right thing left to do, and reading the instruction first was the order two reviewers stumbled on.
+        //
         // Note what the sentence does NOT do: predict the resulting filename. UniqueStem takes a stem only when it
         // is free on BOTH of IsStemFree's tests — no "houseCARL - <stem>" folder already exists, AND no active
         // plugin is named "<stem>.esp" — and suffixes it otherwise. Either trigger is ordinary: the folder arm is
@@ -8025,7 +8036,7 @@ public sealed class LoadOrderService : IDisposable
             $"cannot extend: no houseCARL plugin '{espName}' in any houseCARL folder, and no houseCARL folder named " +
             $"'{ModFolderName(stem)}'" +
             (string.Equals(bareName, ModFolderName(stem), StringComparison.OrdinalIgnoreCase) ? "" : $" or '{bareName}'") +
-            ". " + freshPatch switch
+            ". " + (laneClause is null ? "" : laneClause + " ") + freshPatch switch
             {
                 FreshPatchRemedy.NamedByPatchParam =>
                     $"Omit into= and pass patch=\"{stem}\" to create it fresh under a name you choose, or omit patch= "
@@ -8033,7 +8044,7 @@ public sealed class LoadOrderService : IDisposable
                     + "Or check the name.",
                 FreshPatchRemedy.CreatedByOmittingInto => "Omit into= to create it fresh, or check the name.",
                 _ => WriteSentences.ExtendCheckTheName,
-            } + (laneClause is null ? "" : " " + laneClause));
+            });
     }
 
     /// <summary>houseCARL-OWNED mod folders under ModsDir holding a plugin file named <paramref name="espFileName"/> at

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -5629,7 +5629,10 @@ public sealed class LoadOrderService : IDisposable
             // The lane clause is what #356 was: None used to render "Omit into= to create it fresh", and omitting the
             // lane is itself refused, so the sentence sent callers to a second refusal. What this lane can honestly
             // offer instead is measured — a patch created first carries no override of the record, so removal refuses
-            // there too; the in-place lane does remove it, behind the first-touch confirmation.
+            // there too; the in-place lane does remove it. Note what that lane costs, because the sentence does not
+            // say it: its consent is once per plugin, persisted, and shared with the edit and create in-place lanes,
+            // so a caller who follows this against an already-acknowledged plugin gets no prompt. #359 owns whether
+            // the remedy should say so.
             //
             // The in-place half comes from the TOOL (inPlaceRemedy), because the two tools spell that lane
             // differently and the service cannot tell which one called it. Null — a direct service call — offers

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -8021,10 +8021,12 @@ public sealed class LoadOrderService : IDisposable
         // (removal's is the in-place lane, which no other caller here has) hands the sentence in rather than having
         // it inferred from a semantic bit — the shape LocalizedTargetUnsupportedException.Text already uses. It rides
         // THIS arm only: the foreign-folder arm's remedy is #359's open design question, and the ambiguous and
-        // multi-plugin arms name a call rather than a lane. Note what that is NOT a claim that those two arms are
-        // correct — they instruct every caller to "pass into=", which housecarl_remove_record does not declare and no
-        // alias row maps onto its patch= (the table runs old→new only). That is this same defect one arm over, it is
-        // on main untouched by this change, and it is filed rather than fixed here.
+        // multi-plugin arms name a call rather than a lane. That is NOT a claim that those two arms are correct.
+        // They instruct every caller to "pass into=", which housecarl_remove_record does not declare, and the alias
+        // table has no row whose OLD spelling is "into" — it is bidirectional, so the miss is that specific row's
+        // absence rather than any one-way rule. Measured: that tool answers "unknown parameter: into". Same defect
+        // as this one, one arm over; it is on main untouched by this change, and filed as #377 rather than fixed
+        // here.
         //
         // It is rendered BEFORE the fallback above, not after: the lane's own diagnosis is what makes the fallback
         // the right thing left to do, and reading the instruction first was the order two reviewers stumbled on.

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -5591,12 +5591,14 @@ public sealed class LoadOrderService : IDisposable
             return WritePatchBuilder.RemovalOutcome.Fail(
                 "target= is only meaningful with in_place=true (it names the plugin to remove from in place). For the default lane omit target=; use patch= to name the houseCARL patch.");
         if (!inPlace && string.IsNullOrWhiteSpace(patch))
+            // Renders the caller's own spelling, exactly like the not-found arm below: null names no lane. This
+            // arm used to hardcode the 1.x sentence, justified by its being 1.x-only reachable — which was true,
+            // but "true for the one caller that reaches it today" is a roster with one row, and it made a fact
+            // about a DIFFERENT file (that housecarl_remove refuses before the service is called) load-bearing
+            // here. Handing it down costs nothing and removes both.
             return WritePatchBuilder.RemovalOutcome.Fail(
-                // The legacy spelling is hardcoded here because this arm is 1.x-ONLY: housecarl_remove refuses
-                // "no lane named" — in its own correct spelling — before the service is reached. Measured, and
-                // pinned by the extend-resolver guard's tool-altitude arm.
-                "patch is required — name the houseCARL patch to remove the record from (removal only targets a patch that already carries it). "
-                + WriteSentences.RemoveInPlaceLaneLegacy);
+                "patch is required — name the houseCARL patch to remove the record from (removal only targets a patch that already carries it)."
+                + (inPlaceRemedy is null ? "" : " " + inPlaceRemedy));
 
         // Parse every formid first, collecting ALL problems (all-or-nothing, like the edit path). Pure — outside the gate.
         var keys = new List<FormKey>(formids.Count);
@@ -7998,21 +8000,19 @@ public sealed class LoadOrderService : IDisposable
         // working call with the caller's own guessed name in it.
         //
         // THE RULE, not a roster: each operation states its OWN fresh-write path, because it is not inferable here
-        // and the lane bit does not separate it. Three independent ways a shared assumption goes false — which is why
-        // an enumeration was the wrong shape, and why this comment's own list of tools was wrong twice before it
-        // became a rule. (1) The operation does not create a patch at all: a REMOVAL edits an artifact that already
-        // exists, so both halves are false there whichever spelling that tool gives the lane (2.0's housecarl_remove
-        // says into=; 1.x remove_record says patch=, meaning the EXISTING patch — where the sentence would tell the
-        // caller to re-issue the call that just failed). (2) It creates one but names it something else: copy and
-        // copy_npc_appearance default their stem to the new EditorID or houseCARL_NpcCopy, and every RIDER lane
-        // defaults to the stem its own call site passes, never "Patch" — deliberately not listed here, because a list
-        // of them is what keeps going stale; the call sites are the authority. (3) The spelling means a different
-        // artifact on that tool: on housecarl_bsa_repack a bare patch= binds to archive_name — the .bsa, not the mod
-        // folder — because it declares both and §5.3 routes patch= to the artifact.
+        // and the lane bit does not separate it. Three independent ways a shared assumption goes false, stated as
+        // PROPERTIES rather than as tools that have them — this comment's own list of tools was wrong twice before it
+        // became a rule, and naming them here just moves the roster into prose. (1) The operation cannot create a
+        // patch at all: it edits an artifact that must already exist, so a create remedy is false for it whatever it
+        // spells the lane. (2) It creates one, but names it off something other than the "Patch" default — a
+        // caller-supplied identifier, or a stem its own call site fixes. (3) The spelling names a DIFFERENT artifact
+        // on that operation, because it declares more than one output name and §5.3 routes patch= to the artifact.
+        // Which operation is which is answered at the call sites, which are the authority; a reader who wants the set
+        // greps the enum, and gets an answer that cannot be stale.
         //
         // Hence the DEFAULT claims no fresh-write path at all (#356). It used to be case (1)'s opposite — the weaker
-        // "Omit into= to create it fresh", justified as "merely less helpful, never wrong" — and removal, the one
-        // caller that cannot create anything, reached exactly that default and told its callers to omit the lane,
+        // "Omit into= to create it fresh", justified as "merely less helpful, never wrong" — and the removal lane,
+        // which cannot create anything, reached exactly that default and told its callers to omit the lane,
         // which is itself refused. A default that is wrong for a whole class of caller is not a weak default, so the
         // safe sentence is now the one that promises nothing: a caller added later without a thought about any of
         // this gets "Check the name.", and every stronger claim is one an operation makes for itself.

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -8020,8 +8020,11 @@ public sealed class LoadOrderService : IDisposable
         // laneClause is the same statement one step further: a lane whose next step is its OWN
         // (removal's is the in-place lane, which no other caller here has) hands the sentence in rather than having
         // it inferred from a semantic bit — the shape LocalizedTargetUnsupportedException.Text already uses. It rides
-        // THIS arm only. The ambiguous and multi-plugin arms above already name a working call, and the foreign-folder
-        // arm's remedy is #359's open design question, not this one's.
+        // THIS arm only: the foreign-folder arm's remedy is #359's open design question, and the ambiguous and
+        // multi-plugin arms name a call rather than a lane. Note what that is NOT a claim that those two arms are
+        // correct — they instruct every caller to "pass into=", which housecarl_remove_record does not declare and no
+        // alias row maps onto its patch= (the table runs old→new only). That is this same defect one arm over, it is
+        // on main untouched by this change, and it is filed rather than fixed here.
         //
         // It is rendered BEFORE the fallback above, not after: the lane's own diagnosis is what makes the fallback
         // the right thing left to do, and reading the instruction first was the order two reviewers stumbled on.

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4704,7 +4704,7 @@ public sealed class LoadOrderService : IDisposable
             // one disk side effect the pre-serialize pipeline otherwise has. The fresh-lane name is a preview: the
             // real write re-picks a free stem, so a concurrent write can shift the auto-suffix.
             string outPath; bool extend, created;
-            try { outPath = ResolveOutputPath(patchName, into, out extend, out created, create: !dryRun, patchNamesFresh: true); }
+            try { outPath = ResolveOutputPath(patchName, into, out extend, out created, create: !dryRun, FreshPatchRemedy.NamedByPatchParam); }
             catch (Exception ex) { return WritePatchBuilder.PatchOutcome.Fail(ex.Message); }
 
             // P8b: pre-resolve any CopyFrom source that is OFF-ORDER (from_plugin on disk but NOT in the active order —
@@ -5236,7 +5236,8 @@ public sealed class LoadOrderService : IDisposable
                 if (!walk.Success) return ClosureCopyOutcome.Fail(walk: walk.Refusal, sources: consulted);
 
                 string outPath; bool extend, created;
-                try { outPath = ResolveOutputPath(patchName ?? (into is null ? newEditorid?.Trim() : null), into, out extend, out created); }
+                try { outPath = ResolveOutputPath(patchName ?? (into is null ? newEditorid?.Trim() : null), into, out extend, out created,
+                                                  freshPatch: FreshPatchRemedy.CreatedByOmittingInto); }
                 catch (Exception ex) { return ClosureCopyOutcome.Fail(engine: ex.Message, sources: consulted); }
                 var patchModKey = ModKey.FromFileName(Path.GetFileName(outPath));
 
@@ -5591,7 +5592,8 @@ public sealed class LoadOrderService : IDisposable
                 "target= is only meaningful with in_place=true (it names the plugin to remove from in place). For the default lane omit target=; use patch= to name the houseCARL patch.");
         if (!inPlace && string.IsNullOrWhiteSpace(patch))
             return WritePatchBuilder.RemovalOutcome.Fail(
-                "patch is required — name the houseCARL patch to remove the record from (removal only targets a patch that already carries it). To remove from an existing plugin IN PLACE instead, pass target=<plugin filename> + in_place=true.");
+                "patch is required — name the houseCARL patch to remove the record from (removal only targets a patch that already carries it). "
+                + WriteSentences.RemoveInPlaceAlternative);
 
         // Parse every formid first, collecting ALL problems (all-or-nothing, like the edit path). Pure — outside the gate.
         var keys = new List<FormKey>(formids.Count);
@@ -5615,11 +5617,17 @@ public sealed class LoadOrderService : IDisposable
                 return RemoveRecordsInPlace(resolver, keys, target!.Trim(), acknowledge);
 
             // Resolve + ownership-gate the patch path via the into= (extend) path — must exist + carry the houseCARL marker.
-            // patchNamesFresh stays FALSE (the default) and must: removal cannot create a patch at all, and this tool's
+            // FreshPatchRemedy.None (the default) and must: removal cannot create a patch at all, and this tool's
             // patch= names an EXISTING one — it IS the into= slot — so the naming remedy would tell the caller to
             // re-issue the exact call that just failed. Pinned by the extend-resolver guard's remove arm.
+            //
+            // The lane clause is what #356 was: None used to render "Omit into= to create it fresh", and omitting the
+            // lane is itself refused, so the sentence sent callers to a second refusal. What this lane can honestly
+            // offer instead is measured — a patch created first carries no override of the record, so removal refuses
+            // there too; the in-place lane does remove it, behind the first-touch confirmation.
             string outPath;
-            try { outPath = ResolveOutputPath(patchName: null, into: patch, out _, out _); }
+            try { outPath = ResolveOutputPath(patchName: null, into: patch, out _, out _,
+                                              laneClause: WriteSentences.RemoveNoFreshPatch + " " + WriteSentences.RemoveInPlaceAlternative); }
             catch (Exception ex) { return WritePatchBuilder.RemovalOutcome.Fail(ex.Message); }
 
             return WritePatchBuilder.RemoveRecords(resolver, keys, outPath);
@@ -5775,7 +5783,7 @@ public sealed class LoadOrderService : IDisposable
 
                 // #225: a dry run resolves the would-be output path WITHOUT creating the mod folder (see ApplyEdits).
                 string outPath; bool extend, created;
-                try { outPath = ResolveOutputPath(patchName, into, out extend, out created, create: !dryRun, patchNamesFresh: true); }
+                try { outPath = ResolveOutputPath(patchName, into, out extend, out created, create: !dryRun, FreshPatchRemedy.NamedByPatchParam); }
                 catch (Exception ex) { return WritePatchBuilder.ForwardOutcome.Fail(ex.Message); }
 
                 var outcome = WritePatchBuilder.ForwardRecords(resolver, specs, outPath, extend, fullReadback, dryRun, sourceParam, offOrder);
@@ -6656,7 +6664,8 @@ public sealed class LoadOrderService : IDisposable
                 // ---- 3. output patch (folder-per-patch or into= extend — the record lane's resolver + ownership gate) ----
                 string outPath; bool extend, created;
                 var defaultStem = clone ? newEditorid!.Trim() : "houseCARL_NpcCopy";
-                try { outPath = ResolveOutputPath(patchName ?? (into is null ? defaultStem : null), into, out extend, out created); }
+                try { outPath = ResolveOutputPath(patchName ?? (into is null ? defaultStem : null), into, out extend, out created,
+                                                  freshPatch: FreshPatchRemedy.CreatedByOmittingInto); }
                 catch (Exception ex) { return NpcCopyOutcome.Fail(ex.Message); }
                 var patchFileName = Path.GetFileName(outPath);
                 var patchModKey = ModKey.FromFileName(patchFileName);
@@ -6880,7 +6889,7 @@ public sealed class LoadOrderService : IDisposable
                 return CommitCreateInPlace(resolver, rulebook, specs, target!.Trim(), acknowledge);
 
             string outPath; bool extend, created;
-            try { outPath = ResolveOutputPath(patchName, into, out extend, out created, patchNamesFresh: true); }
+            try { outPath = ResolveOutputPath(patchName, into, out extend, out created, freshPatch: FreshPatchRemedy.NamedByPatchParam); }
             catch (Exception ex) { return WritePatchBuilder.CreateOutcome.Fail(ex.Message); }
 
             var outcome = WritePatchBuilder.CreateRecords(resolver, rulebook, specs, outPath, extend, fullReadback);
@@ -7268,11 +7277,12 @@ public sealed class LoadOrderService : IDisposable
     /// check-then-create is only race-free when every folder allocation is serialized on the one gate.
     /// <paramref name="createdFolder"/> reports whether THIS call created the fresh folder, so a refused write can
     /// remove it again (hunt F4 — "NO patch written" must not leave an orphan folder accreting _001/_002 on retry).
-    /// <paramref name="patchNamesFresh"/> is passed through to the not-found refusal's remedy: the calling operation
-    /// states whether ITS <c>patch=</c> names a fresh patch defaulting to "Patch". Defaults to false — the weaker,
-    /// always-true remedy — so a caller added later without considering it cannot inherit a false sentence.</summary>
+    /// <paramref name="freshPatch"/> and <paramref name="laneClause"/> are passed through to the not-found refusal's
+    /// remedy: the calling operation states how ITS own fresh-write path works, and adds any next step that is its
+    /// alone. Both default to claiming nothing, so a caller added later without considering them cannot inherit a
+    /// sentence that is false for it (#356 — removal inherited exactly that).</summary>
     string ResolveOutputPath(string? patchName, string? into, out bool extend, out bool createdFolder, bool create = true,
-                             bool patchNamesFresh = false)
+                             FreshPatchRemedy freshPatch = FreshPatchRemedy.None, string? laneClause = null)
     {
         lock (_gate)
         {
@@ -7288,7 +7298,7 @@ public sealed class LoadOrderService : IDisposable
                 // the canonical fast path only short-circuits a folder that actually holds <stem>.esp; we then pick the .esp
                 // to extend inside the resolved folder: the <stem>.esp it holds, or — via the by-folder catch-all, where the
                 // folder & plugin names differ — the folder's single plugin (Q3-refuse if it holds none or several).
-                var folder = ResolveOwnedPatchFolder(into, needEsp: true, patchNamesFresh);
+                var folder = ResolveOwnedPatchFolder(into, needEsp: true, freshPatch, laneClause);
                 var direct = Path.Combine(folder, PatchStem(into) + ".esp");
                 if (File.Exists(direct)) return direct;
                 var sole = SoleEspInFolder(folder, out var why);
@@ -7366,7 +7376,10 @@ public sealed class LoadOrderService : IDisposable
                 // into= behaves exactly like record into= (before this, a renamed folder fell to a misleading "folder not
                 // found"). needEsp:false — a rider targets the FOLDER itself (it writes scripts / a .bsa / loose files into
                 // it, not an .esp), so it does NOT require a <stem>.esp to be present.
-                var folder = ResolveOwnedPatchFolder(into, needEsp: false);
+                // CreatedByOmittingInto, stated here rather than inherited: omitting into= on this lane DOES create a
+                // fresh folder (measured — the branch below returns CreatedFresh), but patch= names the rider's own
+                // artifact on bsa_repack (the .bsa), so the naming remedy is the wrong one and always was.
+                var folder = ResolveOwnedPatchFolder(into, needEsp: false, FreshPatchRemedy.CreatedByOmittingInto);
                 return new RiderFolder(folder, folder, CreatedFresh: false);   // reused — the user owns it; cleanup leaves it
             }
 
@@ -7928,10 +7941,12 @@ public sealed class LoadOrderService : IDisposable
     /// separate in-place lane). <paramref name="needEsp"/> tightens the canonical fast path for the RECORD lane (the folder
     /// must actually hold &lt;stem&gt;.esp to short-circuit, else fall through); the rider lane targets the folder itself, so
     /// it short-circuits on folder-exists+owned. Caller holds <see cref="_gate"/>.
-    /// <paramref name="patchNamesFresh"/> is the calling operation's own statement that, for IT, <c>patch=</c> names a
-    /// NEW patch and defaults to "Patch" — which decides only the not-found refusal's remedy (see the throw). It is a
-    /// separate bit from <paramref name="needEsp"/> on purpose: the lanes and the naming semantics do not coincide.</summary>
-    string ResolveOwnedPatchFolder(string into, bool needEsp, bool patchNamesFresh = false)
+    /// <paramref name="freshPatch"/> is the calling operation's own statement about how — or whether — IT can create a
+    /// patch, which decides only the not-found refusal's remedy (see the throw); <paramref name="laneClause"/> is that
+    /// same lane's own extra next step, appended to that one arm. Both are separate from <paramref name="needEsp"/> on
+    /// purpose: the lanes and the naming semantics do not coincide.</summary>
+    string ResolveOwnedPatchFolder(string into, bool needEsp,
+                                   FreshPatchRemedy freshPatch = FreshPatchRemedy.None, string? laneClause = null)
     {
         var stem = PatchStem(into);                             // strips a trailing .esp/.esm/.esl; no directory parts (can't escape ModsDir)
         var espName = stem + ".esp";
@@ -7974,22 +7989,31 @@ public sealed class LoadOrderService : IDisposable
         // name a new patch, was in no doc a caller reads. The stronger sentence names patch= and hands back the
         // working call with the caller's own guessed name in it.
         //
-        // THE RULE, not a roster: it reaches exactly the operations whose patch= names a NEW patch defaulting to
-        // "Patch", and each states that for itself, because it is not inferable here and the lane bit does not
-        // separate it. Three independent ways it goes false — which is why an enumeration was the wrong shape, and
-        // why this comment's own list of tools was wrong twice before it became a rule. (1) The operation does not
-        // create a patch at all: a REMOVAL edits an artifact that already exists, so both halves are false there
-        // whichever spelling that tool gives the lane (2.0's housecarl_remove says into=; 1.x remove_record says
-        // patch=, meaning the EXISTING patch — where the sentence would tell the caller to re-issue the call that
-        // just failed). (2) It creates one but names it something else: copy and copy_npc_appearance default their
-        // stem to the new EditorID or houseCARL_NpcCopy, and every RIDER lane defaults to the stem its own call site
-        // passes, never "Patch" — deliberately not listed here, because a list of them is what keeps going stale;
-        // the call sites are the authority. (3) The spelling means a different artifact on that tool: on
-        // housecarl_bsa_repack a bare patch= binds to archive_name — the .bsa, not the mod folder — because it
-        // declares both and §5.3 routes patch= to the artifact.
+        // THE RULE, not a roster: each operation states its OWN fresh-write path, because it is not inferable here
+        // and the lane bit does not separate it. Three independent ways a shared assumption goes false — which is why
+        // an enumeration was the wrong shape, and why this comment's own list of tools was wrong twice before it
+        // became a rule. (1) The operation does not create a patch at all: a REMOVAL edits an artifact that already
+        // exists, so both halves are false there whichever spelling that tool gives the lane (2.0's housecarl_remove
+        // says into=; 1.x remove_record says patch=, meaning the EXISTING patch — where the sentence would tell the
+        // caller to re-issue the call that just failed). (2) It creates one but names it something else: copy and
+        // copy_npc_appearance default their stem to the new EditorID or houseCARL_NpcCopy, and every RIDER lane
+        // defaults to the stem its own call site passes, never "Patch" — deliberately not listed here, because a list
+        // of them is what keeps going stale; the call sites are the authority. (3) The spelling means a different
+        // artifact on that tool: on housecarl_bsa_repack a bare patch= binds to archive_name — the .bsa, not the mod
+        // folder — because it declares both and §5.3 routes patch= to the artifact.
         //
-        // Hence the default is FALSE and the tail is the weaker, always-true one: a caller added later without a
-        // thought about any of this gets a sentence that is merely less helpful, never wrong.
+        // Hence the DEFAULT claims no fresh-write path at all (#356). It used to be case (1)'s opposite — the weaker
+        // "Omit into= to create it fresh", justified as "merely less helpful, never wrong" — and removal, the one
+        // caller that cannot create anything, reached exactly that default and told its callers to omit the lane,
+        // which is itself refused. A default that is wrong for a whole class of caller is not a weak default, so the
+        // safe sentence is now the one that promises nothing: a caller added later without a thought about any of
+        // this gets "Check the name.", and every stronger claim is one an operation makes for itself.
+        //
+        // laneClause is the same statement one step further: a lane whose next step is its OWN
+        // (removal's is the in-place lane, which no other caller here has) hands the sentence in rather than having
+        // it inferred from a semantic bit — the shape LocalizedTargetUnsupportedException.Text already uses. It rides
+        // THIS arm only. The ambiguous and multi-plugin arms above already name a working call, and the foreign-folder
+        // arm's remedy is #359's open design question, not this one's.
         //
         // Note what the sentence does NOT do: predict the resulting filename. UniqueStem takes a stem only when it
         // is free on BOTH of IsStemFree's tests — no "houseCARL - <stem>" folder already exists, AND no active
@@ -8001,11 +8025,15 @@ public sealed class LoadOrderService : IDisposable
             $"cannot extend: no houseCARL plugin '{espName}' in any houseCARL folder, and no houseCARL folder named " +
             $"'{ModFolderName(stem)}'" +
             (string.Equals(bareName, ModFolderName(stem), StringComparison.OrdinalIgnoreCase) ? "" : $" or '{bareName}'") +
-            ". " + (patchNamesFresh
-                ? $"Omit into= and pass patch=\"{stem}\" to create it fresh under a name you choose, or omit patch= "
-                  + "too and houseCARL names it \"Patch\" — either name auto-suffixed if already taken. "
-                  + "Or check the name."
-                : "Omit into= to create it fresh, or check the name."));
+            ". " + freshPatch switch
+            {
+                FreshPatchRemedy.NamedByPatchParam =>
+                    $"Omit into= and pass patch=\"{stem}\" to create it fresh under a name you choose, or omit patch= "
+                    + "too and houseCARL names it \"Patch\" — either name auto-suffixed if already taken. "
+                    + "Or check the name.",
+                FreshPatchRemedy.CreatedByOmittingInto => "Omit into= to create it fresh, or check the name.",
+                _ => WriteSentences.ExtendCheckTheName,
+            } + (laneClause is null ? "" : " " + laneClause));
     }
 
     /// <summary>houseCARL-OWNED mod folders under ModsDir holding a plugin file named <paramref name="espFileName"/> at
@@ -8577,6 +8605,27 @@ public sealed class LoadOrderService : IDisposable
     {
         lock (_gate) { _resolver?.Dispose(); _resolver = null; _assetResolver?.Dispose(); _assetResolver = null; }
     }
+}
+
+/// <summary>How a calling operation can produce a patch that does not exist yet — the operation's OWN statement,
+/// which is the only thing the shared <c>into=</c> resolver's not-found refusal may say about creating one. It is
+/// never inferred there: the write lane and the naming semantics do not coincide (a rider's <c>patch=</c> can name a
+/// .bsa; <c>copy</c>'s fresh stem is an EditorID), and a resolver that guessed would be keeping the roster this
+/// enum exists to replace. The rule and the three ways an assumption goes false are stated at the throw.</summary>
+internal enum FreshPatchRemedy
+{
+    /// <summary>The DEFAULT, and the safe one: this operation claims no fresh-write path, so the refusal offers
+    /// none. Removal is the caller that needs it — it edits a patch that must already exist — and #356 is what the
+    /// old default cost: it told removal's callers to omit the lane, which removal itself refuses.</summary>
+    None = 0,
+
+    /// <summary>Omitting <c>into=</c> creates one, under a stem this call site chooses rather than "Patch" — the
+    /// copy lanes (the new EditorID / houseCARL_NpcCopy) and every rider lane (its own artifact stem).</summary>
+    CreatedByOmittingInto,
+
+    /// <summary><c>patch=</c> on this tool names a NEW patch and defaults to "Patch" (#343) — so the refusal can
+    /// hand back a working call with the caller's own guessed name already in it.</summary>
+    NamedByPatchParam,
 }
 
 /// <summary>The outcome of a read_record resolve+read. <see cref="Error"/> non-null ⇒ the read failed (with a

--- a/src/housecarl-mcp/RemoveTools.cs
+++ b/src/housecarl-mcp/RemoveTools.cs
@@ -101,7 +101,11 @@ public static class RemoveTools
 
         // LANE-as-name maps onto the 1.x service contract: into= IS the patch lane's artifact, in_place= the
         // target+bool pair (§5.2). The service's own exclusivity checks stay as the second line of defence.
-        var outcome = svc.RemoveRecords(targets, hasInto ? into : null, in_place, hasInPlace, acknowledge);
+        // The in-place remedy this tool's refusals may name is THIS tool's spelling — one string. The service
+        // renders it but cannot pick it: housecarl_remove_record reaches the same refusal and spells the lane
+        // target= + in_place=true, and nothing at that altitude tells the two apart.
+        var outcome = svc.RemoveRecords(targets, hasInto ? into : null, in_place, hasInPlace, acknowledge,
+                                        WriteSentences.RemoveInPlaceLane);
         // The lane the CALL named — stated, not derived from the outcome's flags (PR #311 review [medium]).
         return json
             ? JsonWire.RenderRemovalOutcome(outcome, max_chars, hasInPlace ? "in_place" : "into")

--- a/src/housecarl-mcp/WriteSentences.cs
+++ b/src/housecarl-mcp/WriteSentences.cs
@@ -606,13 +606,17 @@ internal static class WriteSentences
     internal const string ExtendCheckTheName = "Check the name.";
 
     /// <summary>Removal's own half of that refusal: why no create remedy is offered here. Measured before it was
-    /// written — creating the patch first does NOT leave anything to remove: a fresh patch carries no override of
-    /// the record, and removal refuses it with "not carried by patch". So the honest sentence is that the create
-    /// route does not exist for this lane, not a route the caller would have to discover is a dead end.</summary>
-    [MustState("will not create a patch here", "nothing to remove")]
+    /// written — creating a patch first does not give a removal anything to work on: a patch houseCARL makes here
+    /// carries no override of the record, and removal refuses it with "not carried by patch".
+    ///
+    /// <para>It states the RULE and stops, rather than predicting what a patch created next would contain. The
+    /// longer version said "a patch created now would have nothing to remove", and a caller CAN falsify that in two
+    /// calls — <c>housecarl_apply(patch="X", …)</c> writes an override of the record, after which removing it from
+    /// X succeeds (measured; it nets out to nothing, but the sentence would still have been wrong). Predicting a
+    /// subsequent call's result is the #343/#358 class this lane's whole fix exists to stay out of.</para></summary>
+    [MustState("will not create a patch here", "only drops a record the patch ITSELF already carries")]
     internal const string RemoveNoFreshPatch =
-        "houseCARL will not create a patch here: a removal only drops a record the patch ITSELF carries, so a patch "
-      + "created now would have nothing to remove.";
+        "houseCARL will not create a patch here: a removal only drops a record the patch ITSELF already carries.";
 
     /// <summary>The other lane a removal has, in the spelling <c>housecarl_remove</c> declares — one string naming
     /// the file being rewritten. Measured through the TOOL, not the service: the named call reaches the first-touch

--- a/src/housecarl-mcp/WriteSentences.cs
+++ b/src/housecarl-mcp/WriteSentences.cs
@@ -614,15 +614,29 @@ internal static class WriteSentences
         "houseCARL will not create a patch here: a removal only drops a record the patch ITSELF carries, so a patch "
       + "created now would have nothing to remove.";
 
-    /// <summary>The other lane a removal has, stated once and rendered by BOTH of remove's refusals that reach a
-    /// caller who named no usable patch — the missing-patch= one and the into=-not-found one (#356). It was the
-    /// first refusal's own text, made shared rather than rewritten, because it is the same claim in both places and
-    /// a second copy is how the two drift. Measured: the named call reaches the first-touch in-place confirmation
-    /// and, once acknowledged, removes the record — so this promises a lane that works, not one that is refused.
-    /// It deliberately does not spell the confirmation out; that is the in-place lane's own sentence, and it is
-    /// the sentence a caller who follows this one gets next.</summary>
-    [MustState("in_place=true", "target=<plugin filename>")]
-    internal const string RemoveInPlaceAlternative =
+    /// <summary>The other lane a removal has, in the spelling <c>housecarl_remove</c> declares — one string naming
+    /// the file being rewritten. Measured through the TOOL, not the service: the named call reaches the first-touch
+    /// in-place confirmation and, once acknowledged, removes the record. It deliberately does not spell the
+    /// confirmation out; that is the in-place lane's own sentence, and it is what a caller who follows this one
+    /// gets next.
+    ///
+    /// <para>There are two spellings because there are two tools, and the SERVICE cannot tell which one called it.
+    /// So each tool hands its own down (<c>housecarl_remove</c> this one, <c>housecarl_remove_record</c>
+    /// <see cref="RemoveInPlaceLaneLegacy"/>) rather than the resolver picking — the same caller-states rule the
+    /// fresh-patch remedy follows, one altitude up. Sharing ONE sentence is what #356's own fix got wrong first:
+    /// the 1.x pair was correct where it already rendered, and reusing it on the 2.0 tool named a parameter that
+    /// tool does not declare. It worked only because the 1.x→2.0 lane shim silently re-spelled it, and that shim is
+    /// scaffolding due to retire.</para></summary>
+    [MustState("pass in_place=\"<plugin filename>\"")]
+    internal const string RemoveInPlaceLane =
+        "To remove from an existing plugin IN PLACE instead, pass in_place=\"<plugin filename>\".";
+
+    /// <summary>The same lane in <c>housecarl_remove_record</c>'s 1.x spelling — a bool plus a separate
+    /// <c>target=</c>. Rendered by that tool's not-found refusal and by the service's <c>patch is required</c>
+    /// refusal, which is reachable ONLY from 1.x (measured: the 2.0 tool refuses "no lane named" first, in its own
+    /// correct spelling, so that arm never renders for a 2.0 caller).</summary>
+    [MustState("pass target=<plugin filename> + in_place=true")]
+    internal const string RemoveInPlaceLaneLegacy =
         "To remove from an existing plugin IN PLACE instead, pass target=<plugin filename> + in_place=true.";
 
     /// <summary>Sentences the SAME outcome must carry on BOTH transports. Reflected over by the write-surface

--- a/src/housecarl-mcp/WriteSentences.cs
+++ b/src/housecarl-mcp/WriteSentences.cs
@@ -619,10 +619,14 @@ internal static class WriteSentences
         "houseCARL will not create a patch here: a removal only drops a record the patch ITSELF already carries.";
 
     /// <summary>The other lane a removal has, in the spelling <c>housecarl_remove</c> declares — one string naming
-    /// the file being rewritten. Measured through the TOOL, not the service: the named call reaches the first-touch
-    /// in-place confirmation and, once acknowledged, removes the record. It deliberately does not spell the
-    /// confirmation out; that is the in-place lane's own sentence, and it is what a caller who follows this one
-    /// gets next.
+    /// the file being rewritten. Measured through the TOOL, not the service: against a plugin never acknowledged
+    /// before, the named call reaches the first-touch confirmation and, once acknowledged, removes the record.
+    ///
+    /// <para>It does not spell the confirmation out, and it must not be read as promising one. That consent is
+    /// PERSISTED, survives the session, and is shared across the edit / create / remove in-place lanes — so a
+    /// caller who follows this sentence against a plugin they have acknowledged before, in any lane, rewrites the
+    /// original with no prompt at all. Whether this remedy should carry a consent caveat of its own is #359's
+    /// chartered design question, not something to settle by widening the sentence here.</para>
     ///
     /// <para>There are two spellings because there are two tools, and the SERVICE cannot tell which one called it.
     /// So each tool hands its own down (<c>housecarl_remove</c> this one, <c>housecarl_remove_record</c>

--- a/src/housecarl-mcp/WriteSentences.cs
+++ b/src/housecarl-mcp/WriteSentences.cs
@@ -596,6 +596,35 @@ internal static class WriteSentences
         "source_provider= only applies to a Data-relative source resolved through the VFS. The source you passed is an "
       + "on-disk path, which already names one exact copy — drop source_provider=, or pass source= the Data-relative path.";
 
+    // ---- the into=-extend not-found refusal (#356) ---------------------------------------------------
+    /// <summary>The whole remedy an operation that has stated nothing about creating a patch may offer: check what
+    /// you typed. It is the DEFAULT tail of the shared not-found refusal, and it is deliberately the weakest thing
+    /// that is true for every caller — the tail it replaced offered "Omit into= to create it fresh", which removal
+    /// inherited and could not honour. A stronger claim is one an operation makes for itself
+    /// (<c>FreshPatchRemedy</c>), never one the resolver assumes on its behalf.</summary>
+    [MustState("Check the name")]
+    internal const string ExtendCheckTheName = "Check the name.";
+
+    /// <summary>Removal's own half of that refusal: why no create remedy is offered here. Measured before it was
+    /// written — creating the patch first does NOT leave anything to remove: a fresh patch carries no override of
+    /// the record, and removal refuses it with "not carried by patch". So the honest sentence is that the create
+    /// route does not exist for this lane, not a route the caller would have to discover is a dead end.</summary>
+    [MustState("will not create a patch here", "nothing to remove")]
+    internal const string RemoveNoFreshPatch =
+        "houseCARL will not create a patch here: a removal only drops a record the patch ITSELF carries, so a patch "
+      + "created now would have nothing to remove.";
+
+    /// <summary>The other lane a removal has, stated once and rendered by BOTH of remove's refusals that reach a
+    /// caller who named no usable patch — the missing-patch= one and the into=-not-found one (#356). It was the
+    /// first refusal's own text, made shared rather than rewritten, because it is the same claim in both places and
+    /// a second copy is how the two drift. Measured: the named call reaches the first-touch in-place confirmation
+    /// and, once acknowledged, removes the record — so this promises a lane that works, not one that is refused.
+    /// It deliberately does not spell the confirmation out; that is the in-place lane's own sentence, and it is
+    /// the sentence a caller who follows this one gets next.</summary>
+    [MustState("in_place=true", "target=<plugin filename>")]
+    internal const string RemoveInPlaceAlternative =
+        "To remove from an existing plugin IN PLACE instead, pass target=<plugin filename> + in_place=true.";
+
     /// <summary>Sentences the SAME outcome must carry on BOTH transports. Reflected over by the write-surface
     /// guard's twin arm — see this class's summary. Members are whole invariant strings on purpose: a sentence
     /// interpolating a cap or a filename cannot be compared verbatim across lanes, so parameterised twins stay on

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -246,7 +246,10 @@ public static class WriteTools
             bool acknowledge = false) => Guard.Tool("housecarl_remove_record", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        return RenderRemoval(svc.RemoveRecords(new[] { formid }, patch, target, in_place, acknowledge));
+        // This tool's own lane spelling (a bool + target=), handed down rather than assumed by the service —
+        // housecarl_remove reaches the same refusal and declares no target= at all.
+        return RenderRemoval(svc.RemoveRecords(new[] { formid }, patch, target, in_place, acknowledge,
+                                               WriteSentences.RemoveInPlaceLaneLegacy));
     });
 
     [McpServerTool(Name = "housecarl_create_record", Title = "Create a brand-new record"),


### PR DESCRIPTION
RUN_ORDER step 3, item 9. The remove lane's "cannot extend" refusal ended with a remedy removal cannot perform.

## What was wrong

`housecarl_remove(..., into="My Patch.esp")` naming a patch that does not exist refused with:

> cannot extend: no houseCARL plugin 'My Patch.esp' … **Omit into= to create it fresh, or check the name.**

Omitting the lane is itself refused. Both refusals were reproduced verbatim on `main` at `6b16d41` before anything was changed — the issue's 2026-08-17 measurement still stood after #358, #365, #370 and #375 landed.

The tail came from the shared `into=`-extend resolver, whose default was the weaker of #343's two sentences, defended in the rule comment as *"merely less helpful, never wrong"*. It was wrong for a whole class of caller — the ones that cannot create a patch — and removal is that class.

## What changed

**The default claims no fresh-write path at all.** `bool patchNamesFresh` became `FreshPatchRemedy` with three states, defaulting to `None` → `"Check the name."`. Each lane that can create one now states so for itself: `apply`/`create`/`forward` that `patch=` names a new patch, the two copy lanes and every rider lane that omitting `into=` does. A caller added later without a thought gets a sentence that is true, rather than one that happens to fit the lanes that existed when it was written.

Sweep confirmed removal was the only non-creating caller reaching the old default (7 call sites).

**Removal states its own next step**, handed in at the call site — the shape `LocalizedTargetUnsupportedException.Text` already uses. It says there is no create route here and names the lane a removal does have.

**Each remove *tool* supplies its own spelling for that lane.** `housecarl_remove` declares `in_place="<plugin filename>"` and no `target=`; `housecarl_remove_record` declares `target=` plus a bool. The service cannot tell its two callers apart, so it renders what it is handed and names no spelling when called directly.

## Measurement

Every remedy sentence was measured against the real service before it was written, and the ones a caller acts on were measured again through the tools.

- **The issue's own suggested remedy is false.** "Create the patch first, then remove from it" — a patch created here carries no override of the record, and removal refuses with `not carried by patch 'MadeItFirst.esp'`. Not written.
- **The in-place lane is a true remedy.** Following it reaches the first-touch confirmation; acknowledging it removes the record, verified gone from the file on disk.
- **No tool lists houseCARL-owned patches**, so `"Check the name."` points nowhere and stays bare rather than naming a tool that cannot answer.
- **The `patch is required` refusal is 1.x-only reachable** — `housecarl_remove` refuses "no lane named" first, in its own spelling — which is what makes hardcoding the legacy wording there safe. Arm-pinned, because that unreachability is the load-bearing fact.

## Review rounds

**Round 1 — 3 agents, 11 findings: 7 folded, 2 refused, 2 taken as corrections.**

All three independently found the same defect, and it was the branch's: the reused in-place sentence was measured at the **service** layer, the one altitude where it is trivially correct. At the altitude a caller reads it, `housecarl_remove` declares no `target=`, so the refusal named a parameter that tool does not have. It resolved only because the 1.x→2.0 lane shim silently re-spells the old pair, and that shim is scaffolding due to retire — the tool's own sibling refusal already used the right spelling, so one response could hand a caller both. This is #356's own class inside the fix for #356.

Folded by moving the spelling to the tools (above). The arms moved to the tool altitude with it — the previous ones called the service in its 1.x argument shape and structurally could not see this class. The `[MustState]` reach check then caught the same mistake a second time inside the probe, where the observation drove the service instead of the tool.

Agent C's medium, also folded: the branch converted implicit defaults into explicit per-lane statements, and sabotaging two of them stayed green — `copy` and `copy_npc_appearance` could silently lose their create clause. Now pinned in their own probes, with `forward` and `create` added to the extend-resolver guard. Writing those arms immediately caught a fixture error: an earlier arm had already created the patch name being tested as absent.

*Refused, with grounds:* that the remedy should pre-empt a caller who **adds** the in-place lane rather than replacing `into=` — the sentence says "instead", and the resulting collision refusal names the fix itself; and that the not-found arm should withhold the in-place clause when `into=` happens to name a foreign **active** plugin — that lane is consent-gated, and whether a refusal may recommend it at all is #359's fork, out of scope here.

**Round 2 — 2 agents, 10 findings: 3 folded, 2 filed, 1 escalated, rest noted.** (A third agent died on an API error before doing any work and was relaunched fresh.)

Folded: the no-create clause was predicting what a *next* call would hold ("a patch created now would have nothing to remove") — falsifiable in two calls by `apply(patch="X")` then `remove(into="X")`, which the branch had itself measured. It nets out to nothing, which is why it was written, but predicting a subsequent call's result is the #343/#358 class this lane exists to stay out of; it now states the rule and stops. The changelog carried the same overreach. And the doctrine comment justified #377 with a false supporting fact (that the alias table runs old→new only — it is bidirectional; the miss is that no row has `into` as its OLD spelling).

**Stop rule:** round 2 hit §5 #11's recurring-class terminator, so there is no round 3 — see below.

**14 sabotage RED-checks**, each from a committed state, each restored and verified by grepping for a string the fold introduced. Every branch of the new conditional is checked in both directions: default regains the create clause, lane clause dropped, shared clause re-inlined, each of the three enum states removed from its lane, the 2.0 tool handing down the legacy spelling, and each new constant gutted.

`ci-all` 124/124 green on the branch.

## Filed rather than fixed here

Both are confirmed defects in code this branch does not touch (CLAUDE.md §2, the #324 shape). Both are **unrouted** — the routing-and-milestone stroke is Aaron's.

- **#377** — the resolver's *ambiguous* and *multi-plugin* arms tell every caller to `pass into=`, which `housecarl_remove_record` does not declare and no alias row bridges. This branch's own class, one arm over.
- **#378** — the in-place removal lane records the one-time consent *before* the not-carried check, so a refused call spends it and the next in-place write to that plugin proceeds unprompted. The localized refusal sits ahead of that gate for exactly this stated reason. Worth noting for prioritisation: this fix makes that arm easier to reach, since a caller who mistyped a *patch* name is now told to name a *plugin*.

## Deposited on #359 — the remedy's consent caveat, and the fallback itself

Aaron's review (F1, high) found the earlier version of this section priced the remedy wrongly. It said the
in-place lane "cannot fire without an explicit confirmation naming the file — a wasted round trip, not a write."

**That is true only for a plugin that has never been acknowledged.** The in-place consent is persisted, survives
the session, and is shared across the edit / create / remove in-place lanes. A caller who follows this remedy
against a plugin they acknowledged at any earlier point, in any lane, **rewrites the original with no prompt at
all**. The typo case is where it bites: a caller who mistyped a *patch* name is pointed at a *plugin* filename,
and the filename in their hand is usually one of their own mods.

The refusal sentence is deliberately unchanged. Whether the recommendation must carry its own consent caveat —
given that the lane's first-touch prompt may already be spent — is #359's chartered fork, and the finding is
deposited there.

The false pricing has been corrected in every home it had on this branch, not just here: the constant's own doc,
the call-site comment, the probe comment, and the changelog entry, which now states plainly that an
already-acknowledged plugin is rewritten with no further prompt.

Also recorded on #359 (Aaron's F3 — recorded, not folded): clause **order** was never the real variable. The
always-true fallback is nearly empty of content, so wherever it sits it reads as filler while the lane clause does
the work. What the shared fallback should *be* is the same refusal-remedy fork, and belongs with it.

The two consecutive ordering findings that stopped the rounds under §5 #11 stand as reported; nothing was folded a
third time.

Fixes #356
