### PR TITLE
docs(spid-authoring): add "Verifying a distribution actually happened"

### DIFF
--- a/.claude/skills/spid-authoring/SKILL.md
+++ b/.claude/skills/spid-authoring/SKILL.md
@@ -99,6 +99,21 @@ debugging session. If the user is on a SPID version newer than 7.3.0 and asks ab
 the reference, surface that the reference may be behind and offer to re-derive from the current
 SPID documentation.
 
+## Verifying a distribution actually happened
+
+A parsed `_DISTR.ini` and a clean SPID log are **not** proof that an NPC got the thing. The log
+shows what SPID looked up; only a live actor shows what SPID applied.
+
+- **SPID does not distribute to the player.** Asserting on `Game.GetPlayer()` returns false even
+  for a working distribution — verify against sampled NPCs instead.
+- **Distribution happens at NPC load**, so an actor already baked into a pre-existing save proves
+  nothing about a rule added afterwards — verify against actors that load after the rule exists.
+- **A dynamic keyword IS reachable.** A keyword SPID creates at runtime has no plugin FormID, but
+  `Keyword.GetKeyword("<name>")` (SKSE) finds it — which is what makes a no-ESP keyword
+  distribution verifiable from script at all.
+- **Sample somewhere NPCs must be.** An interior cell with known occupants beats an exterior spawn
+  marker: finding no NPC within scan range there is inconclusive, not a failing distribution.
+
 ## Common mistakes
 
 - **Miscounting pipe positions.** The sections are positional; a chance written one pipe early lands

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **`spid-authoring` now covers verifying a distribution on a live actor.** A parsed `_DISTR.ini` and a
+  clean SPID log show what SPID looked up, not what an actor received. The skill's new "Verifying a
+  distribution actually happened" section says what to assert instead — and why the player is the wrong
+  actor to assert on.
+
 - **Fixed: `housecarl_remove` told you to create a patch it cannot create.** Naming a patch that does not exist —
   `housecarl_remove(..., into="My Patch.esp")`, or `housecarl_remove_record(..., patch="My Patch.esp")` on the 1.x
   spelling — is refused, and that refusal ended "Omit into= to create it fresh, or check the name." Doing that got


### PR DESCRIPTION
Fixes #383

The `spid-authoring` skill covers authoring and interpreting `_DISTR.ini` files but had nothing on positively verifying that a rule landed on an actor — and verification is where three real SPID behaviors bite. This adds one section between the fabrication warning and "Common mistakes", carrying the measured facts:

- **SPID never distributes to the player** — asserting on `Game.GetPlayer()` reports failure for a working distribution; sample NPCs instead.
- **Distribution happens at NPC load** — an actor baked into a pre-existing save proves nothing about a rule added afterwards.
- **A runtime-created keyword has no plugin FormID but is reachable** via `Keyword.GetKeyword("<name>")` (SKSE), which is what makes a no-ESP keyword distribution verifiable from script at all.
- One sampling note: an interior cell with known occupants beats an exterior spawn marker, where an empty scan is inconclusive rather than a failure.

All three were measured in-game on SPID 7.3.2 / Skyrim SE 1.6.1170 via a scripted headless run (keyword distribution to interior NPCs, asserted through a Papyrus global calling `Keyword.GetKeyword` + `HasKeyword` on sampled actors; the player-exclusion finding came from the same rig first asserting on the player and failing against a distribution the NPC sample then proved working).

Doc-only: `SKILL.md` plus a `## Unreleased` changelog line, per CONTRIBUTING. No tool behavior changes, so no new probe/guard; the eval set is untouched since the trigger surface (description/frontmatter) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014t8MT7C46f2x7KpUTgVCKS