### PR TITLE
check_errors: the response says what it is missing, stays inside max_chars, and exclude= lands

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -37,18 +37,37 @@ saying it sets an expectation their install may contradict. Say what is known, a
   there, and it was the one every overrun got. Every other part of the answer is now inside the cap: the two
   `counts_only=true` histograms (which took `limit=` as their only bound, so a wide tally could run many times past
   the `max_chars` it was given), the list of plugins whose records could not be read, and the list of plugins that
-  could not be parsed — the last of which `format='json'` wrote with no bound at all. A histogram is emitted with
-  rows or not at all, and where rows were dropped it says how many and which knob to move. The two
+  could not be parsed — the last of which `format='json'` wrote with no bound at all. A `counts_only=true` histogram
+  can lose its ROWS to `max_chars`, but never the line saying how many are missing and which knob moves them: that
+  line is held back out of `max_chars` alongside the accounting, so the pressure that dropped the rows cannot drop
+  the report of it, and an axis with nothing to tally says that instead of nothing at all. Each axis holds back
+  about 120 characters for its line whether or not anything is cut, which is body room you do not get; on a
+  3800-plugin order at the defaults a `counts_only=true` response uses about 10,800 of its 80,000. The two
   `counts_only=true` axes are cut independently: `limit=` stopping the by-TARGET axis no longer stops the by-SOURCE
   one, which used to render none of its rows under a "raise `max_chars=`" that would not have moved them. In
   `format='json'` each histogram object now carries `cut_by` — `"limit"`, `"max_chars"`, or `null` where the axis
-  is whole — so the two formats name the same cause for the same result.
+  is whole — so the two formats name the same cause for the same result. A `format='json'` response exactly one
+  character past its cap also now reports the overrun; the length it compared was short by the cost of closing the
+  document, so the smallest overrun there is was the one that said nothing.
   A report section is now emitted whole or not at all: what a section says besides its dangling entries — a
   scan error, the masters it declares that are missing, how many records could not be read — is a finding in
   its own right, and used to be dropped a line at a time with nothing recording it. The two things a cut can
   drop are a whole section and a single finding, and the line above states both — including on
   `findings=["missing_masters"]`, which lists no dangling refs at all and so makes no claim about them, but
   still says how many plugin sections of how many it rendered.
+
+- **Changed: `housecarl_check_errors`'s `format='json'` names the plugins that lost findings in one place, and names
+  ten of them.** The top-level `dangling_not_listed_by_source` object is gone; the same roster is now
+  `accounting.dangling_missing_by_source`, beside the counts it belongs to;
+  `accounting.dangling_missing_by_source_total` states how many source plugins there were in all. It carries the
+  ten with the most findings, where the field it replaces carried two hundred. Both changes follow from the
+  accounting being held back out of `max_chars` before the response is built: a field written from a second
+  source could disagree with the counts beside it, and a two-hundred-row roster cannot be held back — measured
+  on a sweep whose findings come from two hundred plugins, reserving two hundred rows raises what a
+  `format='json'` response must carry whatever the budget from 2,812 characters to 20,864, which is room taken
+  from every response whether or not anything was dropped. Ten is what the text render has always named. If
+  you were reading the wider list, read
+  `accounting.dangling_missing_by_source_total` for the count and re-run with `plugins=` to get the rest.
 
 - **New: `exclude=` on `housecarl_check_errors` leaves plugins out of the sweep.** Pass plugin filenames with
   their extension, or a group name: `base_masters` (the five the game ships with) or `implicit` (every plugin
@@ -65,11 +84,13 @@ saying it sets an expectation their install may contradict. Say what is known, a
   out at all and a call that asked for that group is refused rather than quietly excluding nothing; a call that
   named plugins instead is unaffected, because those need no profile read.
 
-- **Changed: `housecarl_validate_scripts` says what a `max_chars` cut dropped from its excluded-plugin list.**
-  That list is now charged to `max_chars` like the rest of the response, so a tight one can cut it short or drop
-  it whole. Where that happens the response says which list did not fit and how many plugins the index could not
-  parse are therefore unnamed — the count is the ones it did NOT name, so a response that named some of them says
-  so, instead of a bare "truncated" marker under a heading that may itself be gone.
+- **Changed: `housecarl_validate_scripts`'s TEXT response says what a `max_chars` cut dropped from its
+  excluded-plugin list.** In that render the list is now charged to `max_chars` like the rest of the response, so
+  a tight one can cut it short or drop it whole. Where that happens the response says which list did not fit and
+  how many plugins the index could not parse are therefore unnamed — the count is the ones it did NOT name, so a
+  response that named some of them says so, instead of a bare "truncated" marker under a heading that may itself
+  be gone. `format='json'` is unchanged here: its copy of that list is not charged to `max_chars`, and this entry
+  makes no claim about it.
 
 - **New: `source_provider=` reaches a mod MO2 is not currently loading.** `housecarl_place_asset` and
   `housecarl_bulk_place_asset` resolve a named provider against the mods MO2 loads, and — when no provider of that

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -60,9 +60,10 @@ saying it sets an expectation their install may contradict. Say what is known, a
   named plugins instead is unaffected, because those need no profile read.
 
 - **Changed: `housecarl_validate_scripts` says what a `max_chars` cut dropped from its excluded-plugin list.**
-  That list is now charged to `max_chars` like the rest of the response, so a tight one can drop it whole. Where
-  that happens the response says which list did not fit and how many plugins the index could not parse are
-  therefore unnamed, instead of a bare "truncated" marker under a heading that may itself be gone.
+  That list is now charged to `max_chars` like the rest of the response, so a tight one can cut it short or drop
+  it whole. Where that happens the response says which list did not fit and how many plugins the index could not
+  parse are therefore unnamed — the count is the ones it did NOT name, so a response that named some of them says
+  so, instead of a bare "truncated" marker under a heading that may itself be gone.
 
 - **New: `source_provider=` reaches a mod MO2 is not currently loading.** `housecarl_place_asset` and
   `housecarl_bulk_place_asset` resolve a named provider against the mods MO2 loads, and — when no provider of that

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,38 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **Fixed: `housecarl_check_errors` now says how many findings its answer is missing, and stays inside
+  `max_chars`.** The response used to describe what it left out from two separate places, in two different
+  units: the listing budget said how many refs `limit=` never listed, and a truncation notice said how many
+  plugin sections `max_chars` dropped. Neither could see the other, so neither answered "how many of these can
+  I actually see" — on a 3800-plugin order at the defaults the two together reported 3996 not listed and 554
+  of 1000 shown, while 530 of 4996 was the answer. There is now one line, and it states that number first,
+  then splits it by cause and names the knob that moves each. Two things follow from computing it after the
+  response is built rather than where a loop stops. A cut landing inside the LAST report section used to print
+  nothing at all — no notice, and the response ran past `max_chars` while doing it; it is now reported like any
+  other. And `format='json'` used to check its budget once per plugin, so a single plugin with more findings
+  than the cap could hold wrote all of them: one real plugin returned 202,425 characters against an 80,000 cap
+  and reported `truncated: false`, which was true, because the cap had not been applied. The check is now per
+  finding.
+  The accounting and the boundary footer are held back out of `max_chars` before the listing is built, so
+  neither is appended past it. That costs the listing about 1,400 characters of an 80,000 budget. The one case
+  where a response is still longer than the `max_chars` you gave it is a `max_chars` too small to hold the
+  accounting itself, and there the response says so and names the number that fits.
+  A report section is now emitted whole or not at all: what a section says besides its dangling entries — a
+  scan error, the masters it declares that are missing, how many records could not be read — is a finding in
+  its own right, and used to be dropped a line at a time with nothing recording it. The two things a cut can
+  drop are a whole section and a single finding, and the line above states both.
+
+- **New: `exclude=` on `housecarl_check_errors` leaves plugins out of the sweep.** Pass plugin filenames with
+  their extension, or a group name: `base_masters` (the five the game ships with) or `implicit` (every plugin
+  the order force-loads because `plugins.txt` does not list it — this is where Creation Club plugins and
+  `_ResourcePack.esl` are, and it includes the base masters). An excluded plugin is not walked, does not spend
+  `limit=`, and is in no total; the response says the scope was narrowed. What the response calls the vanilla
+  BASELINE does not change with it — that stays the base-master set Mutagen defines, whatever you exclude.
+  A value that is neither a filename nor a group name, a name nothing in scope matches, and an exclusion that
+  removes everything are each refused before the sweep runs; the `exclude=` description lists the group names,
+  and each refusal names what it expected.
+
 - **New: `source_provider=` reaches a mod MO2 is not currently loading.** `housecarl_place_asset` and
   `housecarl_bulk_place_asset` resolve a named provider against the mods MO2 loads, and — when no provider of that
   name is among them — against the MO2 mod folder of that name on disk: the loose file first, then that folder's own

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -41,8 +41,9 @@ saying it sets an expectation their install may contradict. Say what is known, a
   can lose its ROWS to `max_chars`, but never the line saying how many are missing and which knob moves them: that
   line is held back out of `max_chars` alongside the accounting, so the pressure that dropped the rows cannot drop
   the report of it, and an axis with nothing to tally says that instead of nothing at all. Each axis holds back
-  about 120 characters for its line whether or not anything is cut, which is body room you do not get; on a
-  3800-plugin order at the defaults a `counts_only=true` response uses about 10,800 of its 80,000. The two
+  about 120 characters for its line while it renders, which is body room its rows do not get — an axis that
+  turns out to have nothing to say gives that room back, so on a 3800-plugin order at the defaults, where both
+  axes render whole, the response is the same 10,530 characters it was before. The two
   `counts_only=true` axes are cut independently: `limit=` stopping the by-TARGET axis no longer stops the by-SOURCE
   one, which used to render none of its rows under a "raise `max_chars=`" that would not have moved them. In
   `format='json'` each histogram object now carries `cut_by` — `"limit"`, `"max_chars"`, or `null` where the axis

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -27,13 +27,17 @@ saying it sets an expectation their install may contradict. Say what is known, a
   and reported `truncated: false`, which was true, because the cap had not been applied. The check is now per
   finding.
   The accounting and the boundary footer are held back out of `max_chars` before the listing is built, so
-  neither is appended past it. That costs the listing about 1,400 characters of an 80,000 budget. The one case
+  neither is appended past it. That costs the listing a few hundred characters of an 80,000 budget. The one case
   where a response is still longer than the `max_chars` you gave it is a `max_chars` too small to hold the
-  accounting itself, and there the response says so and names the number that fits.
+  accounting itself; there the response says so and names the number that clears it, and setting `max_chars` to
+  that number does clear it. `counts_only=true` is inside the cap too now — its two histograms took `limit=` as
+  their only bound, so a wide tally could run many times past the `max_chars` it was given.
   A report section is now emitted whole or not at all: what a section says besides its dangling entries — a
   scan error, the masters it declares that are missing, how many records could not be read — is a finding in
   its own right, and used to be dropped a line at a time with nothing recording it. The two things a cut can
-  drop are a whole section and a single finding, and the line above states both.
+  drop are a whole section and a single finding, and the line above states both — including on
+  `findings=["missing_masters"]`, which lists no dangling refs at all and so makes no claim about them, but
+  still says how many plugin sections of how many it rendered.
 
 - **New: `exclude=` on `housecarl_check_errors` leaves plugins out of the sweep.** Pass plugin filenames with
   their extension, or a group name: `base_masters` (the five the game ships with) or `implicit` (every plugin
@@ -41,9 +45,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
   `_ResourcePack.esl` are, and it includes the base masters). An excluded plugin is not walked, does not spend
   `limit=`, and is in no total; the response says the scope was narrowed. What the response calls the vanilla
   BASELINE does not change with it — that stays the base-master set Mutagen defines, whatever you exclude.
-  A value that is neither a filename nor a group name, a name nothing in scope matches, and an exclusion that
-  removes everything are each refused before the sweep runs; the `exclude=` description lists the group names,
-  and each refusal names what it expected.
+  A value that is neither a filename nor a group name, a filename YOU NAMED that nothing in scope matches, and
+  an exclusion that removes everything are each refused before the sweep runs, and each refusal names what it
+  expected. A group is a filter rather than a claim, so a group whose members are not all in your scope is not
+  an error — `plugins=` narrowed to one plugin with `exclude=["base_masters"]` drops whichever base masters are
+  there and says nothing about the rest. If the MO2 profile's plugin list cannot be read, `implicit` cannot be
+  worked out at all and the call is refused rather than quietly excluding nothing.
 
 - **New: `source_provider=` reaches a mod MO2 is not currently loading.** `housecarl_place_asset` and
   `housecarl_bulk_place_asset` resolve a named provider against the mods MO2 loads, and — when no provider of that

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -27,7 +27,8 @@ saying it sets an expectation their install may contradict. Say what is known, a
   and reported `truncated: false`, which was true, because the cap had not been applied. The check is now per
   finding.
   The accounting and the boundary footer are held back out of `max_chars` before the listing is built, so
-  neither is appended past it. That costs the listing a few hundred characters of an 80,000 budget. The one case
+  neither is appended past it. That costs the listing a little of its room: on a 3800-plugin order at the
+  defaults the response lists 537 findings and ends just inside 80,000 characters. The one case
   where a response is still longer than the `max_chars` you gave it is a `max_chars` too small to hold the
   accounting itself; there the response says so and names the number that clears it, and setting `max_chars` to
   that number does clear it. `counts_only=true` is inside the cap too now — its two histograms took `limit=` as

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -36,7 +36,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
   `counts_only=true` histograms (which took `limit=` as their only bound, so a wide tally could run many times past
   the `max_chars` it was given), the list of plugins whose records could not be read, and the list of plugins that
   could not be parsed — the last of which `format='json'` wrote with no bound at all. A histogram is emitted with
-  rows or not at all, and where rows were dropped it says how many and which knob to move.
+  rows or not at all, and where rows were dropped it says how many and which knob to move. The two
+  `counts_only=true` axes are cut independently: `limit=` stopping the by-TARGET axis no longer stops the by-SOURCE
+  one, which used to render none of its rows under a "raise `max_chars=`" that would not have moved them. In
+  `format='json'` each histogram object now carries `cut_by` — `"limit"`, `"max_chars"`, or `null` where the axis
+  is whole — so the two formats name the same cause for the same result.
   A report section is now emitted whole or not at all: what a section says besides its dangling entries — a
   scan error, the masters it declares that are missing, how many records could not be read — is a finding in
   its own right, and used to be dropped a line at a time with nothing recording it. The two things a cut can

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -18,7 +18,7 @@ saying it sets an expectation their install may contradict. Say what is known, a
   units: the listing budget said how many refs `limit=` never listed, and a truncation notice said how many
   plugin sections `max_chars` dropped. Neither could see the other, so neither answered "how many of these can
   I actually see" — on a 3800-plugin order at the defaults the two together reported 3996 not listed and 554
-  of 1000 shown, while 530 of 4996 was the answer. There is now one line, and it states that number first,
+  of 1000 shown, while 554 of 4996 was the answer. There is now one line, and it states that number first,
   then splits it by cause and names the knob that moves each. Two things follow from computing it after the
   response is built rather than where a loop stops. A cut landing inside the LAST report section used to print
   nothing at all — no notice, and the response ran past `max_chars` while doing it; it is now reported like any
@@ -28,11 +28,15 @@ saying it sets an expectation their install may contradict. Say what is known, a
   finding.
   The accounting and the boundary footer are held back out of `max_chars` before the listing is built, so
   neither is appended past it. That costs the listing a little of its room: on a 3800-plugin order at the
-  defaults the response lists 537 findings and ends just inside 80,000 characters. The one case
-  where a response is still longer than the `max_chars` you gave it is a `max_chars` too small to hold the
-  accounting itself; there the response says so and names the number that clears it, and setting `max_chars` to
-  that number does clear it. `counts_only=true` is inside the cap too now — its two histograms took `limit=` as
-  their only bound, so a wide tally could run many times past the `max_chars` it was given.
+  defaults the response lists 538 findings and ends just inside 80,000 characters. The one case
+  where a response is still longer than the `max_chars` you gave it is a `max_chars` too small to hold what the
+  response must carry whatever the budget — its header, that accounting, the boundary; there the response says so,
+  states its own length including the sentence saying it, and names the number that clears it, and setting
+  `max_chars` to that number does clear it. Every other part of the answer is now inside the cap: the two
+  `counts_only=true` histograms (which took `limit=` as their only bound, so a wide tally could run many times past
+  the `max_chars` it was given), the list of plugins whose records could not be read, and the list of plugins that
+  could not be parsed — the last of which `format='json'` wrote with no bound at all. A histogram is emitted with
+  rows or not at all, and where rows were dropped it says how many and which knob to move.
   A report section is now emitted whole or not at all: what a section says besides its dangling entries — a
   scan error, the masters it declares that are missing, how many records could not be read — is a finding in
   its own right, and used to be dropped a line at a time with nothing recording it. The two things a cut can
@@ -50,8 +54,15 @@ saying it sets an expectation their install may contradict. Say what is known, a
   an exclusion that removes everything are each refused before the sweep runs, and each refusal names what it
   expected. A group is a filter rather than a claim, so a group whose members are not all in your scope is not
   an error — `plugins=` narrowed to one plugin with `exclude=["base_masters"]` drops whichever base masters are
-  there and says nothing about the rest. If the MO2 profile's plugin list cannot be read, `implicit` cannot be
-  worked out at all and the call is refused rather than quietly excluding nothing.
+  there and says nothing about the rest, and the count the response states is what YOUR scope lost, not how many
+  plugins the group name stands for. If the MO2 profile's plugin list cannot be read, `implicit` cannot be worked
+  out at all and a call that asked for that group is refused rather than quietly excluding nothing; a call that
+  named plugins instead is unaffected, because those need no profile read.
+
+- **Changed: `housecarl_validate_scripts` says what a `max_chars` cut dropped from its excluded-plugin list.**
+  That list is now charged to `max_chars` like the rest of the response, so a tight one can drop it whole. Where
+  that happens the response says which list did not fit and how many plugins the index could not parse are
+  therefore unnamed, instead of a bare "truncated" marker under a heading that may itself be gone.
 
 - **New: `source_provider=` reaches a mod MO2 is not currently loading.** `housecarl_place_asset` and
   `housecarl_bulk_place_asset` resolve a named provider against the mods MO2 loads, and — when no provider of that

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -30,9 +30,13 @@ saying it sets an expectation their install may contradict. Say what is known, a
   neither is appended past it. That costs the listing a little of its room: on a 3800-plugin order at the
   defaults the response lists 538 findings and ends just inside 80,000 characters. There are two cases
   where a response is still longer than the `max_chars` you gave it. One is a `max_chars` too small to hold what the
-  response must carry whatever the budget — its header, that accounting, the boundary; there the response says so,
-  states its own length including the sentence saying it, and names the number that clears it, and setting
-  `max_chars` to that number does clear it. The other is a `format='json'` response running over by one body unit
+  response must carry whatever the budget — its header, that accounting, the closing line for anything it cut short,
+  the boundary; there the response says so, states its own length including the sentence saying it, and names the
+  number that clears it. That number is the smallest `max_chars` the response fits in, within a few characters:
+  setting `max_chars` to it clears the notice, and it is measured off what the response actually carries rather than
+  counting the notice itself or a lane's spare room. On a 3800-plugin order, `counts_only=true` at `max_chars=1200`
+  returns 1,540 characters and names 1,277; that call returns 1,269. The other is a `format='json'` response running
+  over by one body unit
   whose size is not known before it is written; it now says THAT instead — the fixed-part explanation is false
   there, and it was the one every overrun got. Every other part of the answer is now inside the cap: the two
   `counts_only=true` histograms (which took `limit=` as their only bound, so a wide tally could run many times past
@@ -40,10 +44,14 @@ saying it sets an expectation their install may contradict. Say what is known, a
   could not be parsed — the last of which `format='json'` wrote with no bound at all. A `counts_only=true` histogram
   can lose its ROWS to `max_chars`, but never the line saying how many are missing and which knob moves them: that
   line is held back out of `max_chars` alongside the accounting, so the pressure that dropped the rows cannot drop
-  the report of it, and an axis with nothing to tally says that instead of nothing at all. Each axis holds back
-  about 120 characters for its line while it renders, which is body room its rows do not get — an axis that
-  turns out to have nothing to say gives that room back, so on a 3800-plugin order at the defaults, where both
-  axes render whole, the response is the same 10,530 characters it was before. The two
+  the report of it, and an axis with nothing to tally says that instead of nothing at all. Each axis holds back its
+  own line — 145 and 144 characters, plus 77 for the mode note the first axis carries — which is body room its rows
+  do not get; an axis that turns out to have nothing to say gives that room back, so on a 3800-plugin order at the
+  defaults, where both axes render whole, the response is the same 10,530 characters it was before. A
+  `counts_only=true` response with nothing to account for — nothing unread, nothing unparseable, no listing — no
+  longer holds room for the accounting line either, because that lane cannot write one; measured on a two-axis
+  result of that shape, 186 characters go back to the histograms, worth three rows at a cap that bites. A response
+  whose sweep DID have something to account for reserves what it always did. The two
   `counts_only=true` axes are cut independently: `limit=` stopping the by-TARGET axis no longer stops the by-SOURCE
   one, which used to render none of its rows under a "raise `max_chars=`" that would not have moved them. In
   `format='json'` each histogram object now carries `cut_by` — `"limit"`, `"max_chars"`, or `null` where the axis

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -28,11 +28,13 @@ saying it sets an expectation their install may contradict. Say what is known, a
   finding.
   The accounting and the boundary footer are held back out of `max_chars` before the listing is built, so
   neither is appended past it. That costs the listing a little of its room: on a 3800-plugin order at the
-  defaults the response lists 538 findings and ends just inside 80,000 characters. The one case
-  where a response is still longer than the `max_chars` you gave it is a `max_chars` too small to hold what the
+  defaults the response lists 538 findings and ends just inside 80,000 characters. There are two cases
+  where a response is still longer than the `max_chars` you gave it. One is a `max_chars` too small to hold what the
   response must carry whatever the budget — its header, that accounting, the boundary; there the response says so,
   states its own length including the sentence saying it, and names the number that clears it, and setting
-  `max_chars` to that number does clear it. Every other part of the answer is now inside the cap: the two
+  `max_chars` to that number does clear it. The other is a `format='json'` response running over by one body unit
+  whose size is not known before it is written; it now says THAT instead — the fixed-part explanation is false
+  there, and it was the one every overrun got. Every other part of the answer is now inside the cap: the two
   `counts_only=true` histograms (which took `limit=` as their only bound, so a wide tally could run many times past
   the `max_chars` it was given), the list of plugins whose records could not be read, and the list of plugins that
   could not be parsed — the last of which `format='json'` wrote with no bound at all. A histogram is emitted with

--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -80,8 +80,8 @@ public static class ErrorCheck
     /// plugin BEFORE the base-game masters (#344 — see <see cref="BaseMasters"/>), whose dangling refs are permanent
     /// vanilla leftovers: on a large order the baseline used to be able to consume it at load-order index 0, and a
     /// plugin that collects an empty list is dropped from <see cref="ErrorCheckResult.Reports"/> entirely. What the
-    /// budget DID drop is reported per source plugin (<see cref="ErrorCheckResult.ListingOmitted"/>), never as a bare
-    /// "capped" flag. A bad/excluded scope name fails
+    /// budget DID drop is reported per source plugin by the response layer, which subtracts against what it actually
+    /// emitted so the claim covers the render's own cut too. A bad/excluded scope name fails
     /// LOUD (Q3) with no partial result.
     /// <para><paramref name="offOrder"/> — plugin FILES to sweep that are NOT in the active order (name + on-disk path;
     /// the caller located them), the pre-enable verify lane (HCBR-2026-07-14-02 gap 3: a patch houseCARL just wrote is
@@ -179,7 +179,6 @@ public static class ErrorCheck
         var reports = new List<PluginErrors>();
         int totalDangling = 0, totalMissing = 0, totalUnscannable = 0;
         int danglingBudget = limit;
-        bool capped = false;
 
         // #344 — the LISTING BUDGET's phase order. limit= is ONE counter, and it used to be spent plugin by plugin in
         // LOAD ORDER with the base-game masters at index 0: on a large order the vanilla baseline could consume it
@@ -252,7 +251,6 @@ public static class ErrorCheck
                                 dangling.Add(new DanglingRef(fk, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID, target));
                                 danglingBudget--;
                             }
-                            else capped = true;
                         }
                     }
                     catch (Exception ex)
@@ -357,7 +355,6 @@ public static class ErrorCheck
                                         dangling.Add(new DanglingRef(rec.FormKey, RecordNaming.StripOverlay(rec.GetType().Name), rec.EditorID, target));
                                         danglingBudget--;
                                     }
-                                    else capped = true;
                                 }
                             }
                             catch (Exception ex)
@@ -433,35 +430,18 @@ public static class ErrorCheck
         // layer that knows, so it states the fact rather than leaving a subtraction to stand in for it.
         bool nonBaseInScope = targets.Any(t => !IsBaseMaster(t));
 
-        // Q3 — what the budget DROPPED, by plugin. The old global "capped at limit" line named no plugin, which is the
-        // silent half of this defect: a plugin whose entire list was dropped has no report section to read the loss
-        // off. Built only where a listing was actually attempted — under counts_only nothing is listed BY DESIGN, and
-        // reporting the whole sweep as "omitted" there would read as a failure rather than as the mode working.
-        List<SweepCount>? listingOmitted = null;
-        if (bySource is not null && !countsOnly)
-        {
-            var listed = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-            // Accumulate, never assign: plugins= is not de-duplicated upstream (a repeated or case-variant name is
-            // swept twice, pre-existing on main), and an overwrite kept only the last section's count while bySource
-            // had summed both — reporting refs as budget-dropped on a sweep that never capped (round-1 review).
-            foreach (var p in reports)
-                if (p.Dangling.Count > 0)
-                    listed[p.Plugin] = (listed.TryGetValue(p.Plugin, out var had) ? had : 0) + p.Dangling.Count;
-            var acc = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-            foreach (var kv in bySource)
-            {
-                int shown = listed.TryGetValue(kv.Key, out var c) ? c : 0;
-                if (kv.Value > shown) acc[kv.Key] = kv.Value - shown;
-            }
-            listingOmitted = SweepFindings.Histogram(acc);
-        }
+        // What the budget dropped, by plugin, is NOT computed here any more. It was `bySource` minus what the
+        // reports listed — the BUDGET's omission — and the render then dropped more without either sentence
+        // knowing. HousecarlMcp.CheckAccounting now subtracts against what the RESPONSE emitted, which covers both
+        // truncators at once and is the one place either is claimed (#361). Everything it needs is below:
+        // DanglingBySource is the per-plugin truth, and the reports carry what the budget admitted.
 
         return new ErrorCheckResult(reports, targets.Count + offOrderScanned.Count, totalDangling, totalMissing,
-                                    totalUnscannable, capped, view.ExcludedPlugins, null, offOrderScanned,
+                                    totalUnscannable, view.ExcludedPlugins, null, offOrderScanned,
                                     filterNote, classes, histogram is null ? null : SweepFindings.Histogram(histogram),
                                     countsOnly, view.Epoch,
                                     bySource is null ? null : SweepFindings.Histogram(bySource),
-                                    baselineDangling, baseSwept, listingOmitted, nonBaseInScope);
+                                    baselineDangling, baseSwept, nonBaseInScope, limit);
     }
 
     /// <summary>The off-order file's record stream, type-scoped when the caller asked for one (#282) — the overlay
@@ -569,7 +549,6 @@ public sealed record ErrorCheckResult(
     int TotalDangling,
     int TotalMissingMasters,
     int TotalUnscannableRecords,
-    bool Capped,
     IReadOnlyDictionary<string, string> ExcludedPlugins,
     string? Error,
     IReadOnlyList<string>? OffOrderScanned = null,
@@ -581,11 +560,12 @@ public sealed record ErrorCheckResult(
     IReadOnlyList<SweepCount>? DanglingBySource = null,
     int BaselineDangling = 0,
     IReadOnlyList<string>? BaseMastersSwept = null,
-    IReadOnlyList<SweepCount>? ListingOmitted = null,
-    bool NonBaseInScope = false)
+    bool NonBaseInScope = false,
+    int Limit = 0)   // the listing budget this sweep was GIVEN. Carried so the response can name the knob it is telling the caller to raise without being passed it a second time — a render-side copy defaults, and a default that disagrees with the sweep puts a wrong number in front of the caller
+
 {
     public bool Success => Error is null;
     public static ErrorCheckResult Fail(string error) =>
-        new(Array.Empty<PluginErrors>(), 0, 0, 0, 0, false,
+        new(Array.Empty<PluginErrors>(), 0, 0, 0, 0,
             new Dictionary<string, string>(), error);
 }

--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -126,16 +126,10 @@ public static class ErrorCheck
         // The claim fires only under a RECORD scope — that is the one thing here that makes a reported count a subset of
         // its own label. A findings= class filter leaves every number complete for what it names (an excluded class
         // renders "NOT CHECKED"), so claiming otherwise over a true whole-order total would be false (re-review finding 3).
-        var excludedNote = exclude is not null
-            ? $"exclude= left out {exclude.Names.Count} plugin(s)"
-            : null;
-        var filterNote = SweepFindings.FilterNote(
-            recordScope is null ? null
-                : wantMasters
-                    ? "the dangling / unscannable counts below are for THIS narrowed scope; the missing-master count is "
-                      + "PLUGIN-level (read off the master table) and is NOT narrowed by it."
-                    : SweepFindings.ScopedCountsClaim,
-            recordScope?.Label, SweepFindings.Describe(classes), excludedNote);
+        // The exclude= narrowing note is composed BELOW, after the exclusion has actually run: its number is what
+        // THIS SCOPE lost, and read off the resolved set it was the size of the group the token expanded to.
+        // plugins=["MyMod.esp"] exclude=["base_masters"] said "left out 5 plugin(s)" over a sweep that removed none.
+        int excludedFromScope = 0;
         // counts_only=: the dangling-by-target-plugin tally, over EVERY dangling ref in scope (never limit-capped).
         // Built only when the walk that fills it actually RUNS — with 'dangling' excluded there is nothing to tally, and
         // an empty-but-present histogram would render as "nothing found" for a walk that never happened (PR #288 review,
@@ -204,14 +198,30 @@ public static class ErrorCheck
 
             int before = targets.Count;
             targets.RemoveAll(drop.Contains);
+            excludedFromScope = before - targets.Count;
             if (offOrder is { Count: > 0 })
+            {
+                int offBefore = offOrder.Count;
                 offOrder = offOrder.Where(o => !drop.Contains(o.Name)).ToList();
+                excludedFromScope += offBefore - offOrder.Count;
+            }
             if (targets.Count == 0 && (offOrder is null || offOrder.Count == 0))
                 return ErrorCheckResult.Fail(
                     $"exclude= removed every plugin this sweep would have covered ({before} in scope, all excluded) — " +
                     "there is nothing left to check. Narrow exclude=, or widen plugins=.")
                        with { Epoch = view.Epoch };
         }
+
+        var filterNote = SweepFindings.FilterNote(
+            recordScope is null ? null
+                : wantMasters
+                    ? "the dangling / unscannable counts below are for THIS narrowed scope; the missing-master count is "
+                      + "PLUGIN-level (read off the master table) and is NOT narrowed by it."
+                    : SweepFindings.ScopedCountsClaim,
+            recordScope?.Label, SweepFindings.Describe(classes),
+            // Stated whenever the caller PASSED an exclusion, zero included: a group with no members in this order
+            // still narrowed nothing, and an exclude= that leaves no trace reads as one that was ignored.
+            exclude is not null ? $"exclude= left out {excludedFromScope} plugin(s)" : null);
 
         var reports = new List<PluginErrors>();
         int totalDangling = 0, totalMissing = 0, totalUnscannable = 0;

--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -586,10 +586,11 @@ public sealed record PluginErrors(
 /// leftovers rather than anything a load order introduced — and <paramref name="BaseMastersSwept"/> names WHICH base
 /// masters this sweep actually looked at (empty = none, so "0 baseline findings" and "no baseline was swept" stay
 /// distinguishable; a render must name this subset rather than <see cref="ErrorCheck.BaseMasters"/>, which would
-/// attribute a count to plugins the sweep never opened).
-/// <paramref name="ListingOmitted"/> names, per source plugin, the dangling refs found but NOT listed because the
-/// budget ran out (empty = nothing was dropped; null = nothing was listed to begin with, i.e. counts_only or no walk):
-/// the Q3 answer to "which plugins lost entries", which a global capped flag cannot give.</para></summary>
+/// attribute a count to plugins the sweep never opened).</para>
+/// <para>Which plugins LOST entries is no longer a field here: it is a fact about the RESPONSE, not about the sweep,
+/// and it is computed in the render's accounting against what that response emitted. Carried on the result it could
+/// only ever report the listing budget's own omissions, so a plugin whose entries the budget listed and max_chars
+/// then dropped appeared in no sentence at all.</para></summary>
 public sealed record ErrorCheckResult(
     IReadOnlyList<PluginErrors> Reports,
     int PluginsScanned,

--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -105,7 +105,7 @@ public static class ErrorCheck
                                        IReadOnlyList<(string Name, string Path)>? offOrder = null,
                                        SweepScope? recordScope = null,
                                        ErrorFindingClass classes = ErrorFindingClass.All, bool countsOnly = false,
-                                       IReadOnlyCollection<string>? exclude = null)
+                                       SweepExclusion.Resolved? exclude = null)
         => Run(resolver, resolver.Capture(), scope, limit, offOrder, recordScope, classes, countsOnly, exclude);
 
     /// <summary>The view-threaded body (PR #305 re-review): a caller that already captured — the service, which
@@ -116,7 +116,7 @@ public static class ErrorCheck
                                        IReadOnlyList<(string Name, string Path)>? offOrder = null,
                                        SweepScope? recordScope = null,
                                        ErrorFindingClass classes = ErrorFindingClass.All, bool countsOnly = false,
-                                       IReadOnlyCollection<string>? exclude = null)
+                                       SweepExclusion.Resolved? exclude = null)
     {
         bool wantDangling = classes.HasFlag(ErrorFindingClass.Dangling);
         bool wantMasters = classes.HasFlag(ErrorFindingClass.MissingMasters);
@@ -126,8 +126,8 @@ public static class ErrorCheck
         // The claim fires only under a RECORD scope — that is the one thing here that makes a reported count a subset of
         // its own label. A findings= class filter leaves every number complete for what it names (an excluded class
         // renders "NOT CHECKED"), so claiming otherwise over a true whole-order total would be false (re-review finding 3).
-        var excludedNote = exclude is { Count: > 0 }
-            ? $"exclude= left out {exclude.Count} plugin(s)"
+        var excludedNote = exclude is not null
+            ? $"exclude= left out {exclude.Names.Count} plugin(s)"
             : null;
         var filterNote = SweepFindings.FilterNote(
             recordScope is null ? null
@@ -183,17 +183,19 @@ public static class ErrorCheck
 
         // #344's exclusion axis. Applied to the SWEEP, not to the listing: a plugin the caller excluded costs no
         // record walk and no budget, which is the half of #344 the phase order could not reach.
-        if (exclude is { Count: > 0 })
+        // Runs whenever the caller PASSED an exclusion, even one that expands to nothing — otherwise a group with
+        // no members in this order left no trace at all and the response never mentioned exclude= had been written.
+        if (exclude is not null)
         {
             // Case-insensitive here, explicitly, rather than relying on whatever comparer the caller's collection
             // happens to carry: plugin filenames are matched case-insensitively everywhere else in this sweep.
-            var drop = new HashSet<string>(exclude, StringComparer.OrdinalIgnoreCase);
-            // A name that matches nothing in scope is a REFUSAL, not a no-op. The silent reading hands back exactly
-            // the wall of findings the caller asked not to see, with nothing to tell them their spelling missed —
-            // the same rule plugins= already follows for a name that is not in the order.
+            var drop = new HashSet<string>(exclude.Names, StringComparer.OrdinalIgnoreCase);
+            // Only the names the CALLER TYPED are held against the scope. A typed name that matches nothing is a
+            // typo and refuses; a GROUP member that is not here is the ordinary case — see SweepExclusion.Resolved
+            // for the refusal this separation removes.
             var inScope = new HashSet<string>(targets, StringComparer.OrdinalIgnoreCase);
             foreach (var name in offOrder ?? Array.Empty<(string Name, string Path)>()) inScope.Add(name.Name);
-            foreach (var name in exclude)
+            foreach (var name in exclude.TypedNames)
                 if (!inScope.Contains(name))
                     return ErrorCheckResult.Fail(
                         $"exclude= names '{name}', which is not in the scope this sweep would cover.{view.AbsenceClause(name)} " +

--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -196,18 +196,23 @@ public static class ErrorCheck
                         "Nothing was swept — an exclusion that matches nothing would return the findings you asked to leave out.")
                            with { Epoch = view.Epoch };
 
-            int before = targets.Count;
+            int targetsBefore = targets.Count;
+            int offBefore = offOrder?.Count ?? 0;
+            // What the refusal below claims about: the WHOLE scope this sweep would have covered, captured before
+            // either filter runs. Read off targets alone it was 0 over a plugins= that resolved entirely off-order —
+            // that path leaves targets deliberately empty (see the offOrder branch above), so the refusal told a
+            // caller their one-plugin scope had held nothing.
+            int scopeBefore = targetsBefore + offBefore;
             targets.RemoveAll(drop.Contains);
-            excludedFromScope = before - targets.Count;
+            excludedFromScope = targetsBefore - targets.Count;
             if (offOrder is { Count: > 0 })
             {
-                int offBefore = offOrder.Count;
                 offOrder = offOrder.Where(o => !drop.Contains(o.Name)).ToList();
                 excludedFromScope += offBefore - offOrder.Count;
             }
             if (targets.Count == 0 && (offOrder is null || offOrder.Count == 0))
                 return ErrorCheckResult.Fail(
-                    $"exclude= removed every plugin this sweep would have covered ({before} in scope, all excluded) — " +
+                    $"exclude= removed every plugin this sweep would have covered ({scopeBefore} in scope, all excluded) — " +
                     "there is nothing left to check. Narrow exclude=, or widen plugins=.")
                        with { Epoch = view.Epoch };
         }

--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -104,8 +104,9 @@ public static class ErrorCheck
     public static ErrorCheckResult Run(LoadOrderResolver resolver, IReadOnlyList<string>? scope, int limit,
                                        IReadOnlyList<(string Name, string Path)>? offOrder = null,
                                        SweepScope? recordScope = null,
-                                       ErrorFindingClass classes = ErrorFindingClass.All, bool countsOnly = false)
-        => Run(resolver, resolver.Capture(), scope, limit, offOrder, recordScope, classes, countsOnly);
+                                       ErrorFindingClass classes = ErrorFindingClass.All, bool countsOnly = false,
+                                       IReadOnlyCollection<string>? exclude = null)
+        => Run(resolver, resolver.Capture(), scope, limit, offOrder, recordScope, classes, countsOnly, exclude);
 
     /// <summary>The view-threaded body (PR #305 re-review): a caller that already captured — the service, which
     /// vets the scope and stamps refusals off ITS view — hands that view in, so the membership gate, the sweep,
@@ -114,7 +115,8 @@ public static class ErrorCheck
                                        IReadOnlyList<string>? scope, int limit,
                                        IReadOnlyList<(string Name, string Path)>? offOrder = null,
                                        SweepScope? recordScope = null,
-                                       ErrorFindingClass classes = ErrorFindingClass.All, bool countsOnly = false)
+                                       ErrorFindingClass classes = ErrorFindingClass.All, bool countsOnly = false,
+                                       IReadOnlyCollection<string>? exclude = null)
     {
         bool wantDangling = classes.HasFlag(ErrorFindingClass.Dangling);
         bool wantMasters = classes.HasFlag(ErrorFindingClass.MissingMasters);
@@ -124,13 +126,16 @@ public static class ErrorCheck
         // The claim fires only under a RECORD scope — that is the one thing here that makes a reported count a subset of
         // its own label. A findings= class filter leaves every number complete for what it names (an excluded class
         // renders "NOT CHECKED"), so claiming otherwise over a true whole-order total would be false (re-review finding 3).
+        var excludedNote = exclude is { Count: > 0 }
+            ? $"exclude= left out {exclude.Count} plugin(s)"
+            : null;
         var filterNote = SweepFindings.FilterNote(
             recordScope is null ? null
                 : wantMasters
                     ? "the dangling / unscannable counts below are for THIS narrowed scope; the missing-master count is "
                       + "PLUGIN-level (read off the master table) and is NOT narrowed by it."
                     : SweepFindings.ScopedCountsClaim,
-            recordScope?.Label, SweepFindings.Describe(classes));
+            recordScope?.Label, SweepFindings.Describe(classes), excludedNote);
         // counts_only=: the dangling-by-target-plugin tally, over EVERY dangling ref in scope (never limit-capped).
         // Built only when the walk that fills it actually RUNS — with 'dangling' excluded there is nothing to tally, and
         // an empty-but-present histogram would render as "nothing found" for a walk that never happened (PR #288 review,
@@ -174,6 +179,36 @@ public static class ErrorCheck
             targets = new List<string>();
             foreach (var n in resolver.PluginNames)
                 if (!view.ExcludedPlugins.ContainsKey(n)) targets.Add(n);
+        }
+
+        // #344's exclusion axis. Applied to the SWEEP, not to the listing: a plugin the caller excluded costs no
+        // record walk and no budget, which is the half of #344 the phase order could not reach.
+        if (exclude is { Count: > 0 })
+        {
+            // Case-insensitive here, explicitly, rather than relying on whatever comparer the caller's collection
+            // happens to carry: plugin filenames are matched case-insensitively everywhere else in this sweep.
+            var drop = new HashSet<string>(exclude, StringComparer.OrdinalIgnoreCase);
+            // A name that matches nothing in scope is a REFUSAL, not a no-op. The silent reading hands back exactly
+            // the wall of findings the caller asked not to see, with nothing to tell them their spelling missed —
+            // the same rule plugins= already follows for a name that is not in the order.
+            var inScope = new HashSet<string>(targets, StringComparer.OrdinalIgnoreCase);
+            foreach (var name in offOrder ?? Array.Empty<(string Name, string Path)>()) inScope.Add(name.Name);
+            foreach (var name in exclude)
+                if (!inScope.Contains(name))
+                    return ErrorCheckResult.Fail(
+                        $"exclude= names '{name}', which is not in the scope this sweep would cover.{view.AbsenceClause(name)} " +
+                        "Nothing was swept — an exclusion that matches nothing would return the findings you asked to leave out.")
+                           with { Epoch = view.Epoch };
+
+            int before = targets.Count;
+            targets.RemoveAll(drop.Contains);
+            if (offOrder is { Count: > 0 })
+                offOrder = offOrder.Where(o => !drop.Contains(o.Name)).ToList();
+            if (targets.Count == 0 && (offOrder is null || offOrder.Count == 0))
+                return ErrorCheckResult.Fail(
+                    $"exclude= removed every plugin this sweep would have covered ({before} in scope, all excluded) — " +
+                    "there is nothing left to check. Narrow exclude=, or widen plugins=.")
+                       with { Epoch = view.Epoch };
         }
 
         var reports = new List<PluginErrors>();

--- a/src/housecarl-core/SweepExclusion.cs
+++ b/src/housecarl-core/SweepExclusion.cs
@@ -44,36 +44,54 @@ public static class SweepExclusion
     public static bool IsPluginName(string value) =>
         PluginExtensions.Any(e => value.EndsWith(e, StringComparison.OrdinalIgnoreCase));
 
-    /// <summary>Resolve <paramref name="exclude"/> into the set of plugin filenames to leave out of the sweep.
+    /// <summary>A resolved <c>exclude=</c>, keeping the two kinds of value APART.
+    ///
+    /// <para>They earn different treatment and conflating them produced a refusal naming a plugin the caller never
+    /// typed. A NAME is a claim that a specific plugin is in scope, so one that matches nothing is a typo and must
+    /// refuse. A GROUP is a filter — "whichever of these are here, drop them" — so a member that is not in scope is
+    /// the ordinary case, not an error. Expanded together and validated as one list, <c>plugins=["MyMod.esp"]</c>
+    /// with <c>exclude=["base_masters"]</c> refused with "exclude= names 'Update.esm', which is not in the scope
+    /// this sweep would cover" — a value the caller never wrote, from a group they cannot subtract from, with no
+    /// action available to them. Every narrowed scope refused every group token.</para></summary>
+    /// <param name="Names">every filename to leave out, groups expanded.</param>
+    /// <param name="TypedNames">only the filenames the CALLER wrote — the ones a scope must actually contain.</param>
+    public sealed record Resolved(IReadOnlyCollection<string> Names, IReadOnlyList<string> TypedNames);
+
+    /// <summary>Resolve <paramref name="exclude"/> into the plugin filenames to leave out of the sweep.
     /// <paramref name="implicitNames"/> comes from the layer that reads the MO2 composition, because that is where
     /// the fact lives; passing it in keeps this parsable without a live order.
     ///
     /// <para>Every malformed value refuses BEFORE the sweep runs and names what was expected (Q3): a typo'd
     /// exclusion that silently excluded nothing would hand back a wall of findings the caller asked not to see,
-    /// with no hint that their spelling missed.</para></summary>
-    public static (HashSet<string> Names, string? Error) Resolve(
+    /// with no hint that their spelling missed.</para>
+    ///
+    /// <para>Returns null only when the caller passed no exclusion at all. A caller who DID pass one gets a
+    /// Resolved back even when it expands to nothing, so the sweep can still say the scope was narrowed rather
+    /// than proceeding as though exclude= had never been written.</para></summary>
+    public static (Resolved? Set, string? Error) Resolve(
         IReadOnlyList<string>? exclude, IReadOnlyList<string> implicitNames)
     {
+        if (exclude is null || exclude.Count == 0) return (null, null);
         var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        if (exclude is null || exclude.Count == 0) return (names, null);
+        var typed = new List<string>();
 
         foreach (var raw in exclude)
         {
             var v = raw?.Trim() ?? "";
             if (v.Length == 0)
-                return (names, $"a blank value in exclude= — pass a plugin filename (e.g. 'CoolMod.esp') or one of: {string.Join(", ", Tokens)}.");
-            if (IsPluginName(v)) { names.Add(v); continue; }
+                return (null, $"a blank value in exclude= — pass a plugin filename (e.g. 'CoolMod.esp') or one of: {string.Join(", ", Tokens)}.");
+            if (IsPluginName(v)) { names.Add(v); typed.Add(v); continue; }
 
             if (v.Equals(BaseMastersToken, StringComparison.OrdinalIgnoreCase))
                 foreach (var m in ErrorCheck.BaseMasters) names.Add(m);
             else if (v.Equals(ImplicitToken, StringComparison.OrdinalIgnoreCase))
                 foreach (var m in implicitNames) names.Add(m);
             else
-                return (names,
+                return (null,
                     $"exclude= value '{v}' is neither a plugin filename nor a known group. A plugin filename carries " +
                     $"its extension ('CoolMod.esp'); the groups are: {string.Join(", ", Tokens)}. " +
                     "Nothing was swept — fix the value and re-run.");
         }
-        return (names, null);
+        return (new Resolved(names, typed), null);
     }
 }

--- a/src/housecarl-core/SweepExclusion.cs
+++ b/src/housecarl-core/SweepExclusion.cs
@@ -1,0 +1,79 @@
+namespace HousecarlCore;
+
+/// <summary>
+/// The sweep's EXCLUSION axis (<c>exclude=</c>, #344): plugins the caller does not want swept at all.
+///
+/// <para><b>Why an axis rather than a classification.</b> #344's complaint is that the dangling-ref budget is spent
+/// on the vanilla baseline before mod findings are reached. The budget half of that was fixed at the sweep layer;
+/// this is the other half — the caller saying which plugins are not their problem today. It is deliberately NOT a
+/// "skip the boring ones" rule baked into the sweep: the baseline the response splits out stays Mutagen's
+/// <see cref="ErrorCheck.BaseMasters"/> exactly, by construction, and what counts as noise is the caller's judgement
+/// (ruled 2026-08-18). Creation Club and <c>_ResourcePack.esl</c> live here, under <see cref="ImplicitToken"/>, and
+/// nowhere in the sweep's own definitions.</para>
+///
+/// <para><b>Names and tokens share one namespace, without a sigil, and that follows §5.5 rather than excepting it.</b>
+/// The rule sigils a pole token only where the co-resident name space can legally contain the bare token. These
+/// values are Bethesda plugin filenames, which are extension-mandatory — the exact ground of §5.5's standing S1
+/// exemption, stated again in SPEC's §3.1 amendment. So the discriminator is the extension itself: a value carrying
+/// one is a NAME, a value without one is a TOKEN, and an unknown token refuses by name rather than being matched
+/// loosely against a plugin whose stem happens to look like it.</para>
+/// </summary>
+public static class SweepExclusion
+{
+    /// <summary>Mutagen's base masters — the five the game ships with. Excluding them is the "I know vanilla has
+    /// permanent dangling refs, do not spend my sweep on them" request that #344 is about.</summary>
+    public const string BaseMastersToken = "base_masters";
+
+    /// <summary>Every plugin the order loads that <c>plugins.txt</c> does not list — the force-loaded set. This is
+    /// where Creation Club plugins and <c>_ResourcePack.esl</c> are, and it is a SUPERSET of
+    /// <see cref="BaseMastersToken"/>: the base masters are force-loaded too. The token is named for what the set
+    /// actually is rather than for Creation Club, because "not listed in plugins.txt" is what houseCARL can observe
+    /// and "is a Creation Club plugin" is not.</summary>
+    public const string ImplicitToken = "implicit";
+
+    /// <summary>The accepted tokens, in the order a refusal lists them. The ONE place they are enumerated — the
+    /// parameter's own description is held against this list by a guard arm, so the caller-facing spelling and the
+    /// accepted spelling cannot drift (the second-spelling problem #341 is about, on a surface no wire-name guard
+    /// reaches — see #386).</summary>
+    public static readonly string[] Tokens = { BaseMastersToken, ImplicitToken };
+
+    static readonly string[] PluginExtensions = { ".esp", ".esm", ".esl" };
+
+    /// <summary>Is this value a plugin NAME (it carries a plugin extension) rather than a token? The whole
+    /// discriminator, and the reason no sigil is needed.</summary>
+    public static bool IsPluginName(string value) =>
+        PluginExtensions.Any(e => value.EndsWith(e, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>Resolve <paramref name="exclude"/> into the set of plugin filenames to leave out of the sweep.
+    /// <paramref name="implicitNames"/> comes from the layer that reads the MO2 composition, because that is where
+    /// the fact lives; passing it in keeps this parsable without a live order.
+    ///
+    /// <para>Every malformed value refuses BEFORE the sweep runs and names what was expected (Q3): a typo'd
+    /// exclusion that silently excluded nothing would hand back a wall of findings the caller asked not to see,
+    /// with no hint that their spelling missed.</para></summary>
+    public static (HashSet<string> Names, string? Error) Resolve(
+        IReadOnlyList<string>? exclude, IReadOnlyList<string> implicitNames)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (exclude is null || exclude.Count == 0) return (names, null);
+
+        foreach (var raw in exclude)
+        {
+            var v = raw?.Trim() ?? "";
+            if (v.Length == 0)
+                return (names, $"a blank value in exclude= — pass a plugin filename (e.g. 'CoolMod.esp') or one of: {string.Join(", ", Tokens)}.");
+            if (IsPluginName(v)) { names.Add(v); continue; }
+
+            if (v.Equals(BaseMastersToken, StringComparison.OrdinalIgnoreCase))
+                foreach (var m in ErrorCheck.BaseMasters) names.Add(m);
+            else if (v.Equals(ImplicitToken, StringComparison.OrdinalIgnoreCase))
+                foreach (var m in implicitNames) names.Add(m);
+            else
+                return (names,
+                    $"exclude= value '{v}' is neither a plugin filename nor a known group. A plugin filename carries " +
+                    $"its extension ('CoolMod.esp'); the groups are: {string.Join(", ", Tokens)}. " +
+                    "Nothing was swept — fix the value and re-run.");
+        }
+        return (names, null);
+    }
+}

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -1042,11 +1042,34 @@ public static class CheckErrorsProbe
         var heldBody = new BoundedBody(null, 100, () => heldSb.Length);
         heldBody.Reserve(SweepSubject.HistogramBySource, 40);
         bool refusedWhileHeld = !heldBody.Emit(SweepSubject.HistogramByTarget, 61, () => heldSb.Append(new string('h', 61)));
+        int fixedWhileHeld = heldBody.FixedPart(heldSb.Length);
         heldBody.Release(SweepSubject.HistogramBySource);
         bool landsOnceReleased = heldBody.Emit(SweepSubject.UnreadRows, 61, () => heldSb.Append(new string('h', 61)));
         Check("EMISSION-A-RESERVE-IS-ROOM-THE-ROWS-CANNOT-HAVE: a unit that would spend a standing closing-disclosure reserve is refused, and the identical unit lands once that reserve is released",
-            refusedWhileHeld && landsOnceReleased && heldSb.Length == 61 && heldBody.ReservedTotal == 40,
-            $"refusedWhileHeld={refusedWhileHeld} landsOnceReleased={landsOnceReleased} len={heldSb.Length} reserved={heldBody.ReservedTotal}");
+            refusedWhileHeld && landsOnceReleased && heldSb.Length == 61 && fixedWhileHeld == 40,
+            $"refusedWhileHeld={refusedWhileHeld} landsOnceReleased={landsOnceReleased} len={heldSb.Length} fixedWhileHeld={fixedWhileHeld}");
+
+        // The number the overrun notice branches on, driven directly, in the two directions it can be wrong.
+        // Everything a cap could have refused is SUBTRACTED, so an unconditional write nobody reserved is still
+        // inside the fixed part; and room a subject GAVE BACK is outside it, because nothing wrote it. Told the
+        // gross reserve instead, this number was too large by every release and too small by every unreserved
+        // unconditional line — and the discriminator it feeds took the wrong branch in the gap between.
+        var measSb = new System.Text.StringBuilder();
+        var measBody = new BoundedBody(null, 500, () => measSb.Length);
+        measSb.Append(new string('h', 30));                                                        // the header
+        measBody.Reserve(SweepSubject.HistogramByTarget, 40);
+        measBody.Reserve(SweepSubject.HistogramBySource, 40);
+        measBody.Fixed(SweepSubject.HistogramByTarget, () => measSb.Append(new string('n', 10)));   // an axis's note
+        int afterNote = measBody.FixedPart(measSb.Length);
+        bool rowLanded = measBody.Emit(SweepSubject.HistogramByTarget, 25, () => measSb.Append(new string('r', 25)));
+        int afterRow = measBody.FixedPart(measSb.Length);
+        measSb.Append(new string('u', 7));                                                          // never reserved
+        measBody.Close(SweepSubject.HistogramByTarget, () => measSb.Append(new string('c', 12)));    // its cut line
+        measBody.Release(SweepSubject.HistogramBySource);                                            // rendered whole
+        int finalFixed = measBody.FixedPart(measSb.Length);
+        Check("EMISSION-THE-FIXED-PART-IS-WHAT-THE-BODY-DID-NOT-WRITE: the number the overrun notice branches on is the response less what the emitter let through — a row does not raise it, an unreserved unconditional line does, and room a subject gave back is not in it at all",
+            rowLanded && afterNote == 110 && afterRow == 110 && finalFixed == 59 && measSb.Length == 84,
+            $"rowLanded={rowLanded} afterNote={afterNote} (want 110) afterRow={afterRow} (want 110) final={finalFixed} (want 59) len={measSb.Length} (want 84)");
 
         // A subject that stopped STAYS stopped, even when room comes back. Releasing a sibling's reserve lowers
         // what every test has to leave standing, so the budget on its own would let a stopped subject through
@@ -1562,20 +1585,38 @@ public static class CheckErrorsProbe
         //
         // json is deliberately NOT swept here: its entries carry no measured cost by design, so a body overshoot is
         // a real thing that happens in that lane and the same claim would be false about it.
-        var overrunCauseBad = new List<string>();
-        int overrunCaps = 0;
-        for (int cap = 200; cap <= 2000; cap += 20)
+        //
+        // TWO fixtures, and the second is the one this arm could not reach before. countsForHisto has non-null axes
+        // and no excluded or unread rows, so the only unconditional line it writes is the counts_only note — and
+        // the worst-case accounting slack happened to cover it. The NOTES lane writes a note AND a not-computed
+        // line for an absent axis, and carries rows for two subjects that reserve nothing, so the un-reserved
+        // unconditional text stood ~184 chars clear of anything: 96 of its 855 over-cap caps got the body-overshoot
+        // sentence over a response that emitted no body unit at all.
+        //
+        // And the band is SEARCHED, not sampled: from cap 1 to the first cap the fixture fits in, so there is no
+        // rung to pick badly. The defect lived in caps 859-954 of a fixture whose old ladder started at 200 and
+        // stepped 20 — it would have been caught there, and the ladder-gap class is retired anyway.
+        var notesLane = ErrorCheck.Run(rm, null, 1000, null, null, ErrorFindingClass.MissingMasters, true) with
         {
-            var t = Wire.RenderCheckErrors(countsForHisto, cap);
-            if (t.Length <= cap) continue;
-            overrunCaps++;
-            if (!t.Contains("does not fit in that many chars", StringComparison.Ordinal))
-                overrunCauseBad.Add($"text@{cap} len={t.Length} says [{OverrunNotice(t)}]");
-        }
-        Check("OVERRUN-IN-THE-TEXT-LANE-IS-ALWAYS-A-CAP-TOO-SMALL: every text response longer than its cap says the FIXED PART did not fit — the reserved closing disclosures are part of that fixed part, and this lane measures every body unit before writing it, so nothing else can put it over",
-            overrunCauseBad.Count == 0 && overrunCaps > 0,
-            overrunCauseBad.Count == 0 ? $"{overrunCaps} over-cap responses, every one naming the fixed part"
-                                       : string.Join("; ", overrunCauseBad.Take(3)) + $" ({overrunCauseBad.Count} of {overrunCaps} over-cap caps)");
+            Reports = UnreadSized(rm, 4).Reports,
+            ExcludedPlugins = ExcludedSized(ErrorCheck.Run(rm, null, 1000), 4).ExcludedPlugins,
+        };
+        Check("OVERRUN-IN-THE-TEXT-LANE-IS-ALWAYS-A-CAP-TOO-SMALL: every text response longer than its cap says the FIXED PART did not fit — the axes' own unconditional lines and their reserved closing disclosures are part of that fixed part, and this lane measures every body unit before writing it, so nothing else can put it over",
+            OverrunAlwaysNamesTheFixedPart(new (string, ErrorCheckResult)[]
+                { ("axes", countsForHisto), ("notes", notesLane) }, out var overrunCauseFail), overrunCauseFail);
+
+        // The remedy's NUMBER, held against the smallest cap that actually works rather than against the fact that
+        // it works at all. RemedyClearsTheNotice says the number is big enough; nothing said it was not far too
+        // big, and it was: the raise-to summed the overrun notice's own length — which disappears the moment the
+        // response fits — with a fixed part carrying the json lane's whole 1024-char entry slack. Measured at 234
+        // chars over the true first fitting cap in text and 1,278 (85%) in json, on the fixture below.
+        var raiseFixture = countsForHisto with
+        {
+            Reports = UnreadSized(rm, 4).Reports.Take(1).ToList(),
+            ExcludedPlugins = ExcludedSized(ErrorCheck.Run(rm, null, 1000), 4).ExcludedPlugins,
+        };
+        Check($"OVERRUN-REMEDY-IS-THE-SMALLEST-CAP-THAT-FITS: the number the notice names is the smallest max_chars this response fits in, within {RaiseToSlack} chars — never below it (the remedy has to work) and never materially above it (a caller who follows it pays for the room)",
+            RemedyIsNearTheSmallestFittingCap(raiseFixture, out var raiseFail), raiseFail);
 
         // ---- a record scope can admit nothing from a base master the sweep opened. "Swept" has to mean examined.
         var modOnlyScope = ErrorCheck.Run(rb, null, 1000, null, new SweepScope(null, "HcCeModNpc", null, null));
@@ -2062,6 +2103,95 @@ public static class CheckErrorsProbe
         return set;
     }
 
+    /// <summary>Every text response longer than its cap names the FIXED PART as the cause, over the SEARCHED band:
+    /// every cap from 1 up to the first one the fixture fits in. Sampled rungs cannot hold this — the class of
+    /// defect it catches is a BAND a few hundred chars wide, and where a fixture's band sits moves whenever the
+    /// header does.
+    ///
+    /// <para>Each fixture must produce at least one over-cap response, or the arm passes on a fixture it never
+    /// tested.</para></summary>
+    static bool OverrunAlwaysNamesTheFixedPart((string Lane, ErrorCheckResult Result)[] fixtures, out string detail)
+    {
+        var bad = new List<string>();
+        var counted = new List<string>();
+        foreach (var (lane, r) in fixtures)
+        {
+            int fits = FirstFittingCap(c => Wire.RenderCheckErrors(r, c));
+            if (fits < 0) { bad.Add($"{lane}: no cap up to 40000 renders inside itself"); continue; }
+            int over = 0, wrong = 0;
+            for (int cap = 1; cap < fits; cap++)
+            {
+                var t = Wire.RenderCheckErrors(r, cap);
+                if (t.Length <= cap) continue;
+                over++;
+                if (t.Contains("does not fit in that many chars", StringComparison.Ordinal)) continue;
+                wrong++;
+                if (wrong <= 2) bad.Add($"{lane}@{cap} len={t.Length} says [{OverrunNotice(t)}]");
+            }
+            if (over == 0) bad.Add($"{lane}: no over-cap response below {fits} — the fixture tests nothing");
+            counted.Add($"{lane} {over} over-cap caps below {fits}" + (wrong > 0 ? $", {wrong} MISCLASSIFIED" : ""));
+        }
+        detail = bad.Count == 0 ? string.Join("; ", counted) : string.Join("; ", bad.Take(4));
+        return bad.Count == 0;
+    }
+
+    /// <summary>How far above the smallest cap that fits the remedy's number is allowed to sit. It is
+    /// <c>CheckAccounting.RaiseSlack</c> (8, the digit-width headroom that stops the notice returning one char
+    /// wider) plus one more digit of the same, and nothing else — not a comfort margin. Measured on the fixture
+    /// below the true gap is 7-8 chars in both transports.</summary>
+    const int RaiseToSlack = 16;
+
+    /// <summary>The remedy's number, held against a SEARCHED answer: the smallest max_chars at which this result
+    /// renders inside its cap with no notice at all. Both transports.
+    ///
+    /// <para>Never below it, or the caller follows the remedy and gets the notice back — which is
+    /// <see cref="RemedyClearsTheNotice"/>'s claim, and this subsumes it with the number rather than the outcome.
+    /// Never materially above it either: "raise it to at least N" reads as the size of what the response must
+    /// carry, and a caller who takes it at its word buys that much context.</para></summary>
+    static bool RemedyIsNearTheSmallestFittingCap(ErrorCheckResult r, out string detail)
+    {
+        var bad = new List<string>();
+        var seen = new List<string>();
+        foreach (var (lane, render) in new (string, Func<int, string>)[]
+                 { ("text", c => Wire.RenderCheckErrors(r, c)), ("json", c => JsonWire.RenderCheckErrors(r, c)) })
+        {
+            int smallest = FirstFittingCap(render);
+            if (smallest < 0) { bad.Add($"{lane}: no cap up to 40000 renders inside itself"); continue; }
+            foreach (int cap in new[] { 120, 250, 400, 700, 1200, 2000 })
+            {
+                if (RaiseTo(render(cap)) is not { } says) continue;
+                if (says < smallest) bad.Add($"{lane}@{cap} says raise to {says}, below the smallest fitting cap {smallest}");
+                else if (says - smallest > RaiseToSlack) bad.Add($"{lane}@{cap} says raise to {says}, {says - smallest} over the smallest fitting cap {smallest}");
+                else seen.Add($"{lane}@{cap}+{says - smallest}");
+            }
+        }
+        detail = bad.Count == 0 ? "every remedy within " + RaiseToSlack + " of the searched answer: " + string.Join(" ", seen)
+                                : string.Join("; ", bad.Take(3));
+        return bad.Count == 0 && seen.Count > 0;
+    }
+
+    /// <summary>The smallest max_chars at which a render fits inside its own cap AND names no overrun, searched
+    /// rather than reasoned about. -1 if none up to 40000.</summary>
+    static int FirstFittingCap(Func<int, string> render)
+    {
+        for (int cap = 1; cap <= 40000; cap++)
+        {
+            var s = render(cap);
+            if (s.Length <= cap && !s.Contains("raise it to at least", StringComparison.Ordinal)) return cap;
+        }
+        return -1;
+    }
+
+    /// <summary>The number an overrun notice tells the caller to raise max_chars to, or null where there is no
+    /// notice. One reader for both transports — json carries the same sentence as a string value.</summary>
+    static int? RaiseTo(string rendered)
+    {
+        int at = rendered.IndexOf("raise it to at least ", StringComparison.Ordinal);
+        if (at < 0) return null;
+        var digits = new string(rendered[(at + 21)..].TakeWhile(char.IsDigit).ToArray());
+        return int.TryParse(digits, out int n) ? n : null;
+    }
+
     /// <summary>Follow the overrun notice's own remedy: read the number it tells the caller to raise max_chars to,
     /// re-render at exactly that, and see whether the notice is gone. A remedy is a claim about a call that has not
     /// happened, so the only honest way to hold it is to make the call (CLAUDE.md §5 #11).</summary>
@@ -2071,10 +2201,12 @@ public static class CheckErrorsProbe
         foreach (int cap in new[] { 120, 250, 400, 700, 1200, 2000, 3000 })
         {
             var text = Wire.RenderCheckErrors(r, cap);
-            int at = text.IndexOf("raise it to at least ", StringComparison.Ordinal);
-            if (at < 0) { if (text.Length > cap) bad.Add($"text@{cap} over by {text.Length - cap} with no notice"); continue; }
-            var digits = new string(text[(at + 21)..].TakeWhile(char.IsDigit).ToArray());
-            if (!int.TryParse(digits, out int raised)) { bad.Add($"text@{cap} notice names no number"); continue; }
+            if (RaiseTo(text) is not { } raised)
+            {
+                if (text.Length > cap) bad.Add($"text@{cap} over by {text.Length - cap} with no notice");
+                else if (text.Contains("raise it to at least", StringComparison.Ordinal)) bad.Add($"text@{cap} notice names no number");
+                continue;
+            }
             var again = Wire.RenderCheckErrors(r, raised);
             if (again.Contains("raise it to at least", StringComparison.Ordinal))
                 bad.Add($"text@{cap} said raise to {raised}; at {raised} the notice fired again (len {again.Length})");

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -2144,8 +2144,9 @@ public static class CheckErrorsProbe
     /// header does.</para>
     ///
     /// <para><b>What it costs, measured rather than assumed:</b> eight fixtures times twelve thousand caps times
-    /// two transports is a hundred and ninety-two thousand renders, and it takes the guard from 6.0 seconds to
-    /// 11.4 — which is why it is enumerated rather than sampled.</para></summary>
+    /// two transports is a hundred and ninety-two thousand renders. Inside <c>ci-all</c> that takes this guard
+    /// from under 1.4 seconds (it was not in the slowest eight) to 6.1, and the whole run from 0.73 to 0.83 of a
+    /// minute. Six seconds is why it is enumerated rather than sampled.</para></summary>
     static readonly int[] CapLadder = Enumerable.Range(1, 12000).Append(40000).ToArray();
 
     /// <summary>The cap invariant, swept: for a range of max_chars values, NEITHER transport may return more than it

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -916,9 +916,21 @@ public static class CheckErrorsProbe
                 .ToList(),
         };
         bool capTailsOk = CapSweep(capTails, out var tailsFail);
+        // The histogram ROWS were unpinned for the same reason: the counts_only fixture's two axes are a few
+        // hundred chars, which fits inside the floor at every cap in the ladder, so unbounding them changed
+        // nothing any arm could see. Two hundred rows of long keys is the shape the live order actually has —
+        // 3800 plugins — and it is what makes the budget test on those loops observable.
+        var capHist = ErrorCheck.Run(rm, null, 1000, null, null, ErrorFindingClass.All, true) with
+        {
+            Histogram = Enumerable.Range(0, 200)
+                .Select(i => new SweepCount($"HcCeHistogramTargetPlugin{i:000}.esp", 200 - i)).ToList(),
+            DanglingBySource = Enumerable.Range(0, 200)
+                .Select(i => new SweepCount($"HcCeHistogramSourcePlugin{i:000}.esp", 200 - i)).ToList(),
+        };
+        bool capHistOk = CapSweep(capHist, out var histFail);
         Check("RESPONSE-NEVER-EXCEEDS-MAX-CHARS (#361): the accounting and the boundary are RESERVED before the body renders, so neither is appended past the cap — across a sweep of caps, in every lane, in both transports",
-            capListing && capFat && capCounts && capMasters && capTailsOk,
-            $"listing=[{capFail}] fat-head=[{fatFail}] counts_only=[{countsFail}] masters-only=[{mastersFail}] fat-tails=[{tailsFail}]");
+            capListing && capFat && capCounts && capMasters && capTailsOk && capHistOk,
+            $"listing=[{capFail}] fat-head=[{fatFail}] counts_only=[{countsFail}] masters-only=[{mastersFail}] fat-tails=[{tailsFail}] fat-histograms=[{histFail}]");
 
         // The surface the floor formulation deliberately cannot see: anything emitted UNCONDITIONALLY is inside the
         // floor CapSweep measures against. A histogram's title, its empty-case sentence and its "more rows" line are

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -1171,6 +1171,22 @@ public static class CheckErrorsProbe
         Check("OVERRUN-REMEDY-CLEARS-IT: raising max_chars to the number the notice names actually removes the notice — a remedy is a claim about a call that has not happened, so the arm makes the call",
             RemedyClearsTheNotice(manyAmple, out var remedyFail), remedyFail);
 
+        // The notice reports a LENGTH, and it is itself part of the response it measures. Measured without itself it
+        // understated by its own length — 1,109 stated on a response of 1,281 — so the arm holds the stated number
+        // against the response actually returned, in both transports, over the caps where the notice fires.
+        var lenBad = new List<string>();
+        foreach (int cap in new[] { 120, 250, 400, 700, 1200 })
+        {
+            var t = Wire.RenderCheckErrors(manyAmple, cap);
+            int stated = StatedLength(t);
+            if (stated != t.Length) lenBad.Add($"text@{cap} says {stated}, is {t.Length}");
+            var j = JsonWire.RenderCheckErrors(manyAmple, cap);
+            int jStated = StatedLength(j.Replace("\\u0027", "'"));
+            if (jStated != j.Length) lenBad.Add($"json@{cap} says {jStated}, is {j.Length}");
+        }
+        Check("OVERRUN-NOTICE-STATES-THE-WHOLE-RESPONSE: the length the notice reports is the length the caller receives, notice included — a sentence about a length that leaves itself out is wrong by its own size",
+            lenBad.Count == 0, lenBad.Count == 0 ? "every notice stated its response's true length" : string.Join("; ", lenBad));
+
         // ---- the two honesty-layer row counts, both directions. They can each be a no-op and print
         //      "0 of 1 plugin(s) that could not be parsed are named above" over a response that named it.
         var withExcluded = ErrorCheck.Run(rm, null, 1000) with
@@ -1484,6 +1500,26 @@ public static class CheckErrorsProbe
         Arm("EXCLUDE-WIRE-JSON-AGREES: the json transport of the same excluded sweep reports the same narrowed totals — one exclusion, one sweep, two renders",
             jsonScanned == 1 && jsonDangling == 2, $"scanned={jsonScanned} dangling={jsonDangling}");
 
+        // The `implicit` group is the only value whose members come from a READ that can fail, and the refusal for
+        // that failure is gated on the caller having asked for that group. Both directions, over a real fault: the
+        // profile's plugins.txt held open exclusively, which is what the gate's own error message is about.
+        string pluginsTxt = Path.Combine(profiles, "plugins.txt");
+        string lockedImplicit, lockedName;
+        using (var hold = new FileStream(pluginsTxt, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            lockedImplicit = ReadTools.CheckErrorsTool(svc, exclude: new[] { SweepExclusion.ImplicitToken });
+            lockedName = ReadTools.CheckErrorsTool(svc, exclude: new[] { "Skyrim.esm" });
+        }
+        Arm("EXCLUDE-WIRE-IMPLICIT-READ-FAILURE-REFUSES: when the profile composition cannot be read, the caller who asked for the implicit GROUP is refused and told why — a group defined by a read that did not happen is not a group that is empty",
+            lockedImplicit.Contains("exclude= could not be resolved", StringComparison.Ordinal)
+            && lockedImplicit.Contains(SweepExclusion.ImplicitToken, StringComparison.Ordinal),
+            First(lockedImplicit));
+        Arm("EXCLUDE-WIRE-NAME-UNAFFECTED-BY-THE-COMPOSITION-READ: the same failure does NOT refuse a caller who named a plugin, because that value needs no composition — a refusal naming a group they never wrote is one they cannot act on",
+            lockedName.Contains("scanned 1 plugin ", StringComparison.Ordinal)
+            && lockedName.Contains("2 dangling ref(s)", StringComparison.Ordinal)
+            && !lockedName.Contains("could not be resolved", StringComparison.Ordinal),
+            First(lockedName));
+
         // Q3 at the surface: a bad value refuses through the tool, not just in the resolver's unit test.
         var refused = ReadTools.CheckErrorsTool(svc, exclude: new[] { "vanilla" });
         Arm("EXCLUDE-WIRE-REFUSAL-REACHES-THE-CALLER: an unknown group refuses at the TOOL surface, naming the value and the real token set, rather than sweeping with the exclusion quietly dropped",
@@ -1586,6 +1622,17 @@ public static class CheckErrorsProbe
             if (rows > 0 && rows < r.Reports.Count) return cap;
         }
         return last;
+    }
+
+    /// <summary>The length the overrun notice claims for the response it sits in, or -1 where it makes no claim.
+    /// </summary>
+    static int StatedLength(string response)
+    {
+        const string lead = "This response is ";
+        int at = response.IndexOf(lead, StringComparison.Ordinal);
+        if (at < 0) return -1;
+        var digits = new string(response[(at + lead.Length)..].TakeWhile(char.IsDigit).ToArray());
+        return int.TryParse(digits, out var n) ? n : -1;
     }
 
     /// <summary>The number the <c>exclude=</c> narrowing note states, or -1 where it states none. Read as a NUMBER

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -948,9 +948,16 @@ public static class CheckErrorsProbe
                 .Select(i => new SweepCount($"HcCeHistogramSourcePlugin{i:000}.esp", 200 - i)).ToList(),
         };
         bool capHistOk = CapSweep(capHist, out var histFail);
+        // The excluded roster, FAT. Nothing in this battery carried one: ExcludedSized is used only by
+        // FLOOR-IGNORES-BODY-SIZE, which renders at cap=1, where no row is let out at all. A parse reason is an
+        // exception message with no length of its own, and the json lane wrote its rows at cost 0 while the text twin
+        // measured unit.Length — 5,453 chars against a 5,000 cap on three 1,200-char reasons, with the text lane
+        // inside the same cap. The width is chosen so the band the row bites in falls inside the ladder.
+        var capExcluded = ExcludedSized(ErrorCheck.Run(rm, null, 1000), 1200);
+        bool capExcludedOk = CapSweep(capExcluded, out var excludedFail);
         Check("RESPONSE-NEVER-EXCEEDS-MAX-CHARS (#361): the accounting and the boundary are RESERVED before the body renders, so neither is appended past the cap — across a sweep of caps, in every lane, in both transports",
-            capListing && capFat && capCounts && capMasters && capTailsOk && capHistOk && capWideOk,
-            $"listing=[{capFail}] fat-head=[{fatFail}] counts_only=[{countsFail}] masters-only=[{mastersFail}] fat-tails=[{tailsFail}] fat-histograms=[{histFail}] escaped-names=[{wideFail}]");
+            capListing && capFat && capCounts && capMasters && capTailsOk && capHistOk && capWideOk && capExcludedOk,
+            $"listing=[{capFail}] fat-head=[{fatFail}] counts_only=[{countsFail}] masters-only=[{mastersFail}] fat-tails=[{tailsFail}] fat-histograms=[{histFail}] escaped-names=[{wideFail}] fat-excluded=[{excludedFail}]");
 
         // The surface the floor formulation deliberately cannot see: anything emitted UNCONDITIONALLY is inside the
         // floor CapSweep measures against. A histogram's title, its empty-case sentence and its "more rows" line are
@@ -1215,6 +1222,38 @@ public static class CheckErrorsProbe
             Wire.RenderCheckErrors(mastersMany, 0) is var mastersManyWhole
             && !mastersManyWhole.Contains("[accounting:", StringComparison.Ordinal),
             AccountingLine(Wire.RenderCheckErrors(mastersMany, 0)));
+
+        // ---- the overrun notice's CAUSE, one arm per branch of the conditional that picks it.
+        //      Both overruns say "raise it to at least", so a cell reading that phrase cannot tell them apart —
+        //      which is how the fixed-part explanation shipped over a body-unit overshoot whose fixed part fit with
+        //      344 chars to spare. What each arm asserts is a FIXTURE-KNOWN length: the floor (the response with no
+        //      body in it) against the cap, which is the same quantity the render branches on.
+        var overshotBase = ErrorCheck.Run(rm, null, 1000);
+        // A json entry whose EditorID is longer than the whole json reserve. Entries carry no measured cost by
+        // design (see BoundedBody), so the post-check stops the body only AFTER this one has landed.
+        var overshot = overshotBase with
+        {
+            Reports = overshotBase.Reports.Take(1).Select(x => new PluginErrors(
+                x.Plugin,
+                new[] { new DanglingRef(x.Dangling[0].Source, "Npc", new string('E', 4000), x.Dangling[0].Target) },
+                x.MissingMasters, 0, Array.Empty<string>(), null)).ToList(),
+        };
+        int overshotFloor = JsonWire.RenderCheckErrors(overshot, 1).Length;   // the fixture's irreducible response
+        const int OvershotCap = 4000;                                        // comfortably above that floor
+        const int TooSmallCap = 1200;                                        // comfortably below it
+        var overshotJson = JsonWire.RenderCheckErrors(overshot, OvershotCap);
+        var tooSmallJson = JsonWire.RenderCheckErrors(overshot, TooSmallCap);
+        Check("OVERRUN-NOTICE-NAMES-THE-OVERRUN-IT-HAD: with the fixed part fitting the cap and a body unit running past what was left, the notice says the fixed part FIT — the other explanation is false there, and it is the one every overrun used to get",
+            overshotFloor < OvershotCap && overshotJson.Length > OvershotCap
+            && overshotJson.Contains("does fit, but one body unit was written before its size could be measured", StringComparison.Ordinal)
+            && !overshotJson.Contains("does not fit in that many chars", StringComparison.Ordinal),
+            $"floor={overshotFloor} cap={OvershotCap} len={overshotJson.Length} notice=[{OverrunNotice(overshotJson)}]");
+
+        Check("OVERRUN-NOTICE-STILL-NAMES-A-CAP-TOO-SMALL: the other branch of the same conditional — a cap below the fixture's own floor still gets the fixed-part explanation, so the arm above cannot pass by making that sentence unreachable",
+            TooSmallCap < overshotFloor && tooSmallJson.Length > TooSmallCap
+            && tooSmallJson.Contains("does not fit in that many chars", StringComparison.Ordinal)
+            && !tooSmallJson.Contains("does fit, but one body unit", StringComparison.Ordinal),
+            $"floor={overshotFloor} cap={TooSmallCap} len={tooSmallJson.Length} notice=[{OverrunNotice(tooSmallJson)}]");
 
         // ---- the overrun notice, in BOTH directions and followed to the letter.
         Check("OVERRUN-NOTICE-ONLY-WHEN-OVER: a response inside its cap never claims to be longer than it — the notice is measured off the finished response, not predicted from the reserve",
@@ -1720,6 +1759,14 @@ public static class CheckErrorsProbe
             if (rows > 0 && rows < r.Reports.Count) return cap;
         }
         return last;
+    }
+
+    /// <summary>The overrun notice as the response spells it, for an arm's failure detail. Never for an assertion:
+    /// every overrun carries one, so its presence proves nothing (the pinned rule at the top of this file).</summary>
+    static string OverrunNotice(string response)
+    {
+        int at = response.IndexOf("This response is ", StringComparison.Ordinal);
+        return at < 0 ? "<none>" : response[at..Math.Min(response.Length, at + 240)];
     }
 
     /// <summary>The length the overrun notice claims for the response it sits in, or -1 where it makes no claim.

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -898,6 +898,66 @@ public static class CheckErrorsProbe
             && oneJson.GetProperty("truncated").GetBoolean(),
             $"chars={JsonWire.RenderCheckErrors(oneSection, OneCut).Length} cap={OneCut} truncated={oneJson.GetProperty("truncated").GetBoolean()} overrun={oneJson.TryGetProperty("max_chars_overrun", out _)} entries={oneJson.GetProperty("plugins").EnumerateArray().Sum(pl => pl.GetProperty("dangling").GetArrayLength())} of {oneSection.TotalDangling}");
 
+        // ---- #344's exclusion axis. Applied to the SWEEP, so an excluded plugin costs no walk and no budget — the
+        //      half of #344 the phase order could not reach. The BASELINE definition is untouched by it.
+        var exBase = ErrorCheck.Run(rb, null, 1000, null, null, ErrorFindingClass.All, false,
+                                    new[] { "Skyrim.esm" });
+        var exBaseText = Wire.RenderCheckErrors(exBase, 0);
+        Check("EXCLUDE-NAME: a named plugin is left out of the sweep entirely — its findings are gone from the TOTALS, not merely from the listing, and the response says the scope was narrowed",
+            exBase.Success && exBase.TotalDangling == 2 && exBase.Reports.All(x => x.Plugin != "Skyrim.esm")
+            && exBase.BaseMastersSwept is { Count: 0 }
+            && exBaseText.Contains("exclude= left out 1 plugin(s)", StringComparison.Ordinal)
+            && !exBaseText.Contains("baseline:", StringComparison.Ordinal),
+            $"total={exBase.TotalDangling} sections=[{string.Join(",", exBase.Reports.Select(x => x.Plugin))}] note={exBase.FilterNote}");
+
+        var (baseTok, baseTokErr) = SweepExclusion.Resolve(new[] { SweepExclusion.BaseMastersToken }, Array.Empty<string>());
+        Check("EXCLUDE-TOKEN-BASE-MASTERS: the group resolves to Mutagen's base-master set exactly — the same list the baseline split is defined by, never a second hand-kept copy",
+            baseTokErr is null && baseTok.SetEquals(ErrorCheck.BaseMasters),
+            $"err={baseTokErr} resolved=[{string.Join(",", baseTok)}]");
+
+        var (implTok, implTokErr) = SweepExclusion.Resolve(
+            new[] { SweepExclusion.ImplicitToken }, new[] { "Skyrim.esm", "ccBGSSSE001-Fish.esm", "_ResourcePack.esl" });
+        Check("EXCLUDE-TOKEN-IMPLICIT: the group resolves to what the ORDER force-loads — where Creation Club and _ResourcePack live — and it is a superset of the base masters rather than a rival definition of vanilla",
+            implTokErr is null && implTok.Contains("ccBGSSSE001-Fish.esm") && implTok.Contains("_ResourcePack.esl")
+            && implTok.Contains("Skyrim.esm"),
+            $"err={implTokErr} resolved=[{string.Join(",", implTok)}]");
+
+        var (_, unknownErr) = SweepExclusion.Resolve(new[] { "vanilla" }, Array.Empty<string>());
+        Check("EXCLUDE-UNKNOWN-GROUP-REFUSES: a value that is neither a filename nor a known group refuses BEFORE the sweep and names both what a filename looks like and every group there is",
+            unknownErr is not null && unknownErr.Contains("'vanilla'", StringComparison.Ordinal)
+            && SweepExclusion.Tokens.All(t => unknownErr.Contains(t, StringComparison.Ordinal))
+            && unknownErr.Contains("Nothing was swept", StringComparison.Ordinal),
+            unknownErr ?? "<no refusal>");
+
+        // §3.1's standing S1 exemption is PINNED, not asserted: tokens carry no sigil because a plugin name is
+        // extension-mandatory, so an extensionless spelling must refuse by name and never fuzzy-match a plugin whose
+        // stem it resembles. The with-extension control sits beside it, or the arm proves only that nothing matches.
+        var (_, stemErr) = SweepExclusion.Resolve(new[] { "Skyrim" }, Array.Empty<string>());
+        var (stemOk, stemOkErr) = SweepExclusion.Resolve(new[] { "Skyrim.esm" }, Array.Empty<string>());
+        Check("EXCLUDE-EXTENSIONLESS-NEVER-FUZZY-MATCHES: 'Skyrim' is refused as an unknown group and never resolved to Skyrim.esm; 'Skyrim.esm' is taken as the name it is",
+            stemErr is not null && stemErr.Contains("'Skyrim'", StringComparison.Ordinal)
+            && stemOkErr is null && stemOk.SetEquals(new[] { "Skyrim.esm" }),
+            $"stem=[{stemErr}] withExt=[{stemOkErr}] resolved=[{string.Join(",", stemOk)}]");
+
+        var exMiss = ErrorCheck.Run(rb, null, 1000, null, null, ErrorFindingClass.All, false, new[] { "HcCeNotHere.esp" });
+        Check("EXCLUDE-NAME-NOT-IN-SCOPE-REFUSES: an exclusion matching nothing is a refusal, not a no-op — the silent reading returns exactly the findings the caller asked to leave out, with nothing to say the spelling missed",
+            !exMiss.Success && exMiss.Error is not null
+            && exMiss.Error.Contains("HcCeNotHere.esp", StringComparison.Ordinal)
+            && exMiss.Error.Contains("not in the scope this sweep would cover", StringComparison.Ordinal)
+            && exMiss.Reports.Count == 0,
+            exMiss.Error ?? "<no refusal>");
+
+        var exAll = ErrorCheck.Run(rb, null, 1000, null, null, ErrorFindingClass.All, false,
+                                   new[] { "Skyrim.esm", "HcCeBaseMod.esp" });
+        Check("EXCLUDE-EMPTIES-THE-SCOPE-REFUSES: excluding everything in scope refuses with the count it removed, rather than returning a clean-looking sweep of nothing (Q3)",
+            !exAll.Success && exAll.Error is not null
+            && exAll.Error.Contains("removed every plugin", StringComparison.Ordinal)
+            && exAll.Error.Contains("nothing left to check", StringComparison.Ordinal),
+            exAll.Error ?? "<no refusal>");
+
+        Check("EXCLUDE-DESCRIPTION-NAMES-EVERY-GROUP: the caller-facing token list is held against SweepExclusion.Tokens, the one place they are enumerated — no wire-name guard reaches a tool parameter's prose (#386), so this parameter brings its own",
+            ExcludeDescriptionNamesTokens(out var descDetail), descDetail);
+
         // ---- a record scope can admit nothing from a base master the sweep opened. "Swept" has to mean examined.
         var modOnlyScope = ErrorCheck.Run(rb, null, 1000, null, new SweepScope(null, "HcCeModNpc", null, null));
         var modOnlyScopeText = Wire.RenderCheckErrors(modOnlyScope, 0);
@@ -1044,6 +1104,24 @@ public static class CheckErrorsProbe
             }
         detail = bad.Count == 0 ? "every section whole at every cap" : string.Join("; ", bad.Take(4));
         return bad.Count == 0;
+    }
+
+    /// <summary>The exclude= parameter's [Description] must name every token SweepExclusion accepts, and no word it
+    /// does not. A tool parameter's prose is a SECOND spelling of an accepted vocabulary, on a surface no existing
+    /// guard reads (#386) — so a token added to the list and not to the description would be undiscoverable, and one
+    /// named in the description and not accepted would be refused when a caller believed the docs.</summary>
+    static bool ExcludeDescriptionNamesTokens(out string detail)
+    {
+        var param = typeof(ReadTools).GetMethod(nameof(ReadTools.CheckErrorsTool))?
+            .GetParameters().FirstOrDefault(x => x.Name == "exclude");
+        if (param is null) { detail = "no exclude= parameter on CheckErrorsTool"; return false; }
+        var text = param.GetCustomAttributes(typeof(System.ComponentModel.DescriptionAttribute), false)
+                        .Cast<System.ComponentModel.DescriptionAttribute>().FirstOrDefault()?.Description;
+        if (text is null) { detail = "exclude= carries no [Description]"; return false; }
+        var missing = SweepExclusion.Tokens.Where(t => !text.Contains(t, StringComparison.Ordinal)).ToList();
+        detail = missing.Count == 0 ? $"names all {SweepExclusion.Tokens.Length} token(s)"
+                                    : "not named in the description: " + string.Join(", ", missing);
+        return missing.Count == 0;
     }
 
     /// <summary>The cap invariant, swept: for a range of max_chars values, NEITHER transport may return more than it

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -968,16 +968,15 @@ public static class CheckErrorsProbe
         Check("FLOOR-IGNORES-BODY-SIZE: at a cap no body fits under, the response is the same length whether its rows carry four characters each or four hundred — the irreducible part of a response is the header, the accounting and the boundary, and nothing that grows with the findings",
             floorBad.Count == 0, floorBad.Count == 0 ? "every lane's floor is content-independent" : string.Join("; ", floorBad));
 
-        // The emitter's guarantee, driven directly. Every call site now passes a cost for the units that can be
-        // large, so on the product's own fixtures the post-check never has to fire — which means removing it stays
-        // green everywhere. It is the backstop for a site that forgets, so it is exercised where a site HAS: a unit
-        // whose declared cost was smaller than what it wrote.
+        // The emitter's guarantee, driven directly, on the case the product's own fixtures cannot reach: a site
+        // that under-states its cost. The claim is that the damage is ONE unit — every later unit is refused, in
+        // every subject, including one never tried before, because the response's length only grows.
         var emitSb = new System.Text.StringBuilder();
         var emitter = new BoundedBody(null, 100, () => emitSb.Length);
         bool firstLanded = emitter.Emit(SweepSubject.DanglingEntries, 0, () => emitSb.Append(new string('x', 500)));
         bool secondRefused = !emitter.Emit(SweepSubject.PluginSections, 0, () => emitSb.Append("more"));
         bool closeRefused = !emitter.Close(SweepSubject.UnreadRows, 0, () => emitSb.Append("tail"));
-        Check("EMISSION-POST-CHECK-STOPS-AN-UNDERSTATED-UNIT: a unit that declared a cost smaller than what it wrote takes the body over exactly ONCE — every later unit is refused, in every subject, and so is a closing disclosure",
+        Check("EMISSION-AN-UNDERSTATED-COST-COSTS-ONE-UNIT: a unit that declared a cost smaller than what it wrote takes the body over exactly ONCE — every later unit is refused, in every subject, and so is a closing disclosure",
             firstLanded && secondRefused && closeRefused && emitSb.Length == 500,
             $"firstLanded={firstLanded} secondRefused={secondRefused} closeRefused={closeRefused} len={emitSb.Length}");
 

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -924,12 +924,15 @@ public static class CheckErrorsProbe
         // TEXT reserve was sized from. Escaped, each of these characters is six.
         var capWide = ErrorCheck.Run(rm, null, 1000) with
         {
-            DanglingBySource = new[]
-            {
-                new SweepCount(new string('\u00e9', 60) + ".esp", 900),
-                new SweepCount(new string('n', 62) + ".esp", 40),
-                new SweepCount("HcCeBulk.esp", 200),
-            },
+            // Twelve sources for a ten-row roster, so the sample the reserve is measured from actually DROPS
+            // two. Ten short non-ASCII names (61 chars plain, 366 escaped) against two long ASCII ones (204
+            // either way): ranked by the ESCAPED spelling the non-ASCII names win and the long ASCII pair falls
+            // out, which sizes the TEXT reserve off names a third the length of what the text render prints.
+            DanglingBySource = Enumerable.Range(0, 10)
+                .Select(i => new SweepCount(new string('\u00e9', 57) + i.ToString("000") + ".esp", 900 - i))
+                .Concat(Enumerable.Range(0, 2)
+                    .Select(i => new SweepCount(new string('n', 197) + i.ToString("000") + ".esp", 500 - i)))
+                .ToList(),
         };
         bool capWideOk = CapSweep(capWide, out var wideFail);
         // The histogram ROWS were unpinned for the same reason: the counts_only fixture's two axes are a few

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -1190,14 +1190,15 @@ public static class CheckErrorsProbe
         // check it never made. Both numbers are now asserted, against rows counted out of the document.
         var exDrop = Wire.RenderCheckErrors(withExcluded, 3000);
         int exNamed = withExcluded.ExcludedPlugins.Keys.Count(k => exDrop.Contains("  " + k + ":", StringComparison.Ordinal));
-        var exDropJson = JsonDocument.Parse(JsonWire.RenderCheckErrors(withExcluded, 3000)).RootElement
-                                     .GetProperty("accounting");
-        Check("EXCLUDED-ROWS-COUNTED-WHEN-DROPPED: when the cap leaves no room for the roster, the accounting states how many of how many were named — the count is the rows actually in the document, and json's own field agrees with it",
+        var exDropDoc = JsonDocument.Parse(JsonWire.RenderCheckErrors(withExcluded, 3000)).RootElement;
+        var exDropJson = exDropDoc.GetProperty("accounting");
+        int exJsonRows = exDropDoc.GetProperty("excluded_plugins").GetArrayLength();
+        Check("EXCLUDED-ROWS-COUNTED-WHEN-DROPPED: when the cap leaves no room for the roster, the accounting states how many of how many were named — in each transport the count is the rows actually in THAT document",
             exNamed < withExcluded.ExcludedPlugins.Count
             && exDrop.Contains($" {exNamed} of {withExcluded.ExcludedPlugins.Count} plugin(s) that could not be parsed are named above.", StringComparison.Ordinal)
-            && exDropJson.GetProperty("excluded_plugins_named").GetInt32() == withExcluded.ExcludedPlugins.Count
+            && exDropJson.GetProperty("excluded_plugins_named").GetInt32() == exJsonRows
             && exDropJson.GetProperty("excluded_plugins_total").GetInt32() == withExcluded.ExcludedPlugins.Count,
-            $"namedInText={exNamed} of {withExcluded.ExcludedPlugins.Count} jsonNamed={exDropJson.GetProperty("excluded_plugins_named").GetInt32()} line=[{AccountingLine(exDrop)}]");
+            $"textRows={exNamed} of {withExcluded.ExcludedPlugins.Count} jsonRows={exJsonRows} jsonNamed={exDropJson.GetProperty("excluded_plugins_named").GetInt32()} line=[{AccountingLine(exDrop)}]");
 
         // ---- the unread subject, which nothing pinned: _unreadTotal = 0 and deleting the clause that states it
         //      both stayed green. counts_only's reports list IS the honesty layer, so a cut there hides the boundary
@@ -1276,13 +1277,18 @@ public static class CheckErrorsProbe
             && scarredSections,
             $"scanError={scarredWhole.Contains("scan error:", StringComparison.Ordinal)} sections=[{scarredFail}]");
 
-        var countsForHisto = ErrorCheck.Run(rm, null, 1000, null, null, ErrorFindingClass.All, true);
-        var hCut = Wire.RenderCheckErrors(countsForHisto, 1500);      // stopped by the response
+        // Two hundred rows, the shape a real order produces — with thirteen the band where SOME rows fit and some
+        // do not is a few dozen characters wide, and a cap ladder can step straight over it.
+        var countsForHisto = HistogramSized(rm, 8);
+        // The budget-cut cap is SEARCHED FOR, not named: the histogram's head is charged to the budget now (it used
+        // to bypass it entirely), so which cap splits an axis is a fact about the fixture and moves with the header.
+        int hCap = PartialHistogramCap(countsForHisto);
+        var hCut = Wire.RenderCheckErrors(countsForHisto, hCap);      // stopped by the response
         var hRows = Wire.RenderCheckErrors(countsForHisto, 0, 3);     // stopped by the row limit
         Check("HISTOGRAM-REMEDY-NAMES-ITS-CAUSE: a histogram cut by the response offers max_chars=, one cut by the row limit offers limit= — the knob that stopped it, not the other one",
             hCut.Contains("more row(s) — raise max_chars= to see them", StringComparison.Ordinal)
             && hRows.Contains("more row(s) — raise limit= to see them", StringComparison.Ordinal),
-            $"budget-cut={hCut.Contains("raise max_chars=", StringComparison.Ordinal)} row-cut={hRows.Contains("raise limit=", StringComparison.Ordinal)}");
+            $"cap={hCap} budget-cut={hCut.Contains("raise max_chars=", StringComparison.Ordinal)} row-cut={hRows.Contains("raise limit=", StringComparison.Ordinal)}");
 
         // ---- a record scope can admit nothing from a base master the sweep opened. "Swept" has to mean examined.
         var modOnlyScope = ErrorCheck.Run(rb, null, 1000, null, new SweepScope(null, "HcCeModNpc", null, null));
@@ -1547,6 +1553,23 @@ public static class CheckErrorsProbe
             ExcludedPlugins = Enumerable.Range(0, 3)
                 .ToDictionary(i => $"HcCeBroken{i}.esp", i => new string('r', width)),
         };
+
+    /// <summary>The first max_chars at which a counts_only histogram axis renders SOME of its rows and not all of
+    /// them. Searched for the same reason the honesty tail's cap is: the head is charged to the budget now, so the
+    /// splitting cap is a property of the fixture rather than a number to hardcode and re-tune.</summary>
+    static int PartialHistogramCap(ErrorCheckResult r)
+    {
+        int last = 0;
+        for (int cap = 1500; cap <= 20000; cap += 20)
+        {
+            last = cap;
+            var text = Wire.RenderCheckErrors(r, cap);
+            if (text.Contains("more row(s) — raise max_chars= to see them", StringComparison.Ordinal)
+                && text.Contains(r.Histogram![0].Key, StringComparison.Ordinal))
+                return cap;
+        }
+        return last;
+    }
 
     /// <summary>The first max_chars at which the counts_only honesty tail lands SOME of its rows and not all of
     /// them — the shape the accounting's unread clause is about. Searched rather than hardcoded: the tail renders

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -918,6 +918,20 @@ public static class CheckErrorsProbe
                 .ToList(),
         };
         bool capTailsOk = CapSweep(capTails, out var tailsFail);
+        // A source plugin whose json-escaped name is much longer than its plain one. The worst case the reserve is
+        // measured from picks the LONGEST names, and one reserve is measured off a text render and one off a json
+        // one — ranking both by the escaped length let a name that is long in TEXT be pushed out of the sample the
+        // TEXT reserve was sized from. Escaped, each of these characters is six.
+        var capWide = ErrorCheck.Run(rm, null, 1000) with
+        {
+            DanglingBySource = new[]
+            {
+                new SweepCount(new string('\u00e9', 60) + ".esp", 900),
+                new SweepCount(new string('n', 62) + ".esp", 40),
+                new SweepCount("HcCeBulk.esp", 200),
+            },
+        };
+        bool capWideOk = CapSweep(capWide, out var wideFail);
         // The histogram ROWS were unpinned for the same reason: the counts_only fixture's two axes are a few
         // hundred chars, which fits inside the floor at every cap in the ladder, so unbounding them changed
         // nothing any arm could see. Two hundred rows of long keys is the shape the live order actually has —
@@ -931,8 +945,8 @@ public static class CheckErrorsProbe
         };
         bool capHistOk = CapSweep(capHist, out var histFail);
         Check("RESPONSE-NEVER-EXCEEDS-MAX-CHARS (#361): the accounting and the boundary are RESERVED before the body renders, so neither is appended past the cap — across a sweep of caps, in every lane, in both transports",
-            capListing && capFat && capCounts && capMasters && capTailsOk && capHistOk,
-            $"listing=[{capFail}] fat-head=[{fatFail}] counts_only=[{countsFail}] masters-only=[{mastersFail}] fat-tails=[{tailsFail}] fat-histograms=[{histFail}]");
+            capListing && capFat && capCounts && capMasters && capTailsOk && capHistOk && capWideOk,
+            $"listing=[{capFail}] fat-head=[{fatFail}] counts_only=[{countsFail}] masters-only=[{mastersFail}] fat-tails=[{tailsFail}] fat-histograms=[{histFail}] escaped-names=[{wideFail}]");
 
         // The surface the floor formulation deliberately cannot see: anything emitted UNCONDITIONALLY is inside the
         // floor CapSweep measures against. A histogram's title, its empty-case sentence and its "more rows" line are

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -945,6 +945,27 @@ public static class CheckErrorsProbe
             && !histFloor.Contains("more row(s)", StringComparison.Ordinal),
             $"floorLen={histFloor.Length} distinct={histFixture.Histogram?.Count}");
 
+        // The arm CapSweep's floor formulation needs standing beside it. A floor measured off the fixture under test
+        // is inflated by any write site that ignores the budget, and an inflated floor excuses the very overrun it
+        // was measuring — the first sabotage sweep proved it: unbounding both json histogram row loops changed
+        // nothing any arm could see, because at every cap the response WAS the (now enormous) floor.
+        //
+        // The pairs below differ ONLY in how many CHARACTERS their rows carry — same plugin counts, same distinct
+        // counts, same totals — so every number the accounting prints is identical and the two floors must be
+        // EXACTLY equal. Anything else means the response's irreducible part grew with content the budget was
+        // supposed to gate, which is an unbounded write site by definition. No slack, because none is owed.
+        var floorBad = new List<string>();
+        FloorIgnoresRowSize("counts_only histograms", floorBad,
+            HistogramSized(rm, 8), HistogramSized(rm, 400));
+        FloorIgnoresRowSize("counts_only honesty tail", floorBad,
+            UnreadSized(rm, 4), UnreadSized(rm, 400));
+        FloorIgnoresRowSize("listing sections", floorBad,
+            SectionsSized(ErrorCheck.Run(rm, null, 1000), 4), SectionsSized(ErrorCheck.Run(rm, null, 1000), 400));
+        FloorIgnoresRowSize("excluded roster", floorBad,
+            ExcludedSized(ErrorCheck.Run(rm, null, 1000), 4), ExcludedSized(ErrorCheck.Run(rm, null, 1000), 400));
+        Check("FLOOR-IGNORES-BODY-SIZE: at a cap no body fits under, the response is the same length whether its rows carry four characters each or four hundred — the irreducible part of a response is the header, the accounting and the boundary, and nothing that grows with the findings",
+            floorBad.Count == 0, floorBad.Count == 0 ? "every lane's floor is content-independent" : string.Join("; ", floorBad));
+
         Check("SECTION-IS-WHOLE-OR-ABSENT: across a sweep of caps, a section that starts also carries everything it has to say — the only things a cut may drop are a whole section or an entry, which are the two the accounting states",
             SectionsWhole(new[] { manyAmple, tight, ErrorCheck.Run(r, null, 1000) }, out var wholeFail), wholeFail);
 
@@ -1474,6 +1495,58 @@ public static class CheckErrorsProbe
         var lines = response.Split('\n');
         return lines.Length > 1 ? lines[0] + " | " + lines[1] : lines[0];
     }
+
+    /// <summary>Two results identical but for the SIZE of their rows must render to the same length at a cap no
+    /// body fits under. Both transports, and the difference is reported rather than a bare boolean, because the
+    /// number IS the leak: it is how many characters escaped the budget.</summary>
+    static void FloorIgnoresRowSize(string lane, List<string> bad, ErrorCheckResult thin, ErrorCheckResult fat)
+    {
+        int t = Wire.RenderCheckErrors(thin, 1).Length, f = Wire.RenderCheckErrors(fat, 1).Length;
+        if (t != f) bad.Add($"text {lane}: floor {t} -> {f} ({f - t} chars past the budget)");
+        int tj = JsonWire.RenderCheckErrors(thin, 1).Length, fj = JsonWire.RenderCheckErrors(fat, 1).Length;
+        if (tj != fj) bad.Add($"json {lane}: floor {tj} -> {fj} ({fj - tj} chars past the budget)");
+    }
+
+    /// <summary>A counts_only result whose two histogram axes carry 200 rows each, keyed at <paramref name="width"/>
+    /// characters. The COUNTS are fixed; only the characters move.</summary>
+    static ErrorCheckResult HistogramSized(LoadOrderResolver r, int width)
+    {
+        var rows = Enumerable.Range(0, 200)
+            .Select(i => new SweepCount(new string('k', width) + i.ToString("000"), 200 - i)).ToList();
+        return ErrorCheck.Run(r, null, 1000, null, null, ErrorFindingClass.All, true)
+               with { Histogram = rows, DanglingBySource = rows };
+    }
+
+    /// <summary>A counts_only result whose honesty layer carries six unreadable plugins, each with a scan error and
+    /// an unscannable sample of <paramref name="width"/> characters.</summary>
+    static ErrorCheckResult UnreadSized(LoadOrderResolver r, int width)
+        => ErrorCheck.Run(r, null, 1000, null, null, ErrorFindingClass.All, true)
+           with
+        {
+            Reports = Enumerable.Range(0, 6)
+                .Select(i => new PluginErrors($"HcCeUnread{i}.esp", Array.Empty<DanglingRef>(), Array.Empty<string>(),
+                                              2, new[] { new string('u', width) }, new string('x', width)))
+                .ToList(),
+        };
+
+    /// <summary>The listing lane's sections, with each section's FIXED part widened — a scan error and three
+    /// unscannable samples of <paramref name="width"/> characters, the shape that broke the json plugin head.</summary>
+    static ErrorCheckResult SectionsSized(ErrorCheckResult r, int width)
+        => r with
+        {
+            Reports = r.Reports.Select(x => new PluginErrors(
+                x.Plugin, x.Dangling, x.MissingMasters, 3,
+                Enumerable.Range(0, 3).Select(k => new string('s', width) + k).ToList(),
+                new string('e', width))).ToList(),
+        };
+
+    /// <summary>The excluded-plugin roster with three rows, each reason <paramref name="width"/> characters.</summary>
+    static ErrorCheckResult ExcludedSized(ErrorCheckResult r, int width)
+        => r with
+        {
+            ExcludedPlugins = Enumerable.Range(0, 3)
+                .ToDictionary(i => $"HcCeBroken{i}.esp", i => new string('r', width)),
+        };
 
     /// <summary>The first max_chars at which the counts_only honesty tail lands SOME of its rows and not all of
     /// them — the shape the accounting's unread clause is about. Searched rather than hardcoded: the tail renders

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -1496,6 +1496,28 @@ public static class CheckErrorsProbe
             && HistogramAxis(emptyTargetText, SourceAxis).Rows == 200,
             $"source={HistogramAxis(emptyTargetText, SourceAxis)}");
 
+        // "Nothing to tally" is an empty axis's WHOLE answer, so it is reserved like any other closing disclosure
+        // rather than emitted like a row. Charged to the budget it disappears at a tight cap, and a caller then
+        // cannot tell an axis that found nothing from an axis that was never computed — the Q3 distinction the
+        // empty-versus-absent split exists to make. Every cap in the band, not one sample at an unbounded cap.
+        var bothEmpty = countsForHisto with
+        {
+            Histogram = Array.Empty<SweepCount>(),
+            DanglingBySource = Array.Empty<SweepCount>(),
+        };
+        var emptyBad = new List<string>();
+        for (int cap = 200; cap <= 4000; cap += 20)
+        {
+            var t = Wire.RenderCheckErrors(bothEmpty, cap);
+            foreach (var axis in new[] { TargetAxis, SourceAxis })
+                if (!t.Contains(axis + " (the plugin the broken refs " + (axis == TargetAxis ? "point INTO" : "come FROM") + "): nothing to tally", StringComparison.Ordinal))
+                    emptyBad.Add($"text@{cap} {axis} says nothing (len {t.Length})");
+        }
+        Check("HISTOGRAM-EMPTY-AXIS-IS-NEVER-DROPPED: at every cap in the band, an axis with nothing to tally still SAYS so — its one sentence is its whole answer, and an answer a budget can refuse leaves 'found nothing' looking like 'never computed'",
+            emptyBad.Count == 0,
+            emptyBad.Count == 0 ? "both empty axes stated themselves at every cap"
+                                : string.Join("; ", emptyBad.Take(3)) + $" ({emptyBad.Count} total)");
+
         // The json twin of the same result. It never stated a cause at all, so the two transports disagreed about one
         // sweep: text named a knob and json wrote nothing. Both now read the SAME closing computation.
         var hRowsJson = JsonDocument.Parse(JsonWire.RenderCheckErrors(countsForHisto, 0, 3)).RootElement;

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -1282,6 +1282,33 @@ public static class CheckErrorsProbe
         Check("OVERRUN-NOTICE-STATES-THE-WHOLE-RESPONSE: the length the notice reports is the length the caller receives, notice included — a sentence about a length that leaves itself out is wrong by its own size",
             lenBad.Count == 0, lenBad.Count == 0 ? "every notice stated its response's true length" : string.Join("; ", lenBad));
 
+        // ---- the smallest overrun there is: ONE character, in the lane that cannot measure its document directly.
+        //      json decides whether to fire the notice from a COMPUTED length — the document so far plus what
+        //      closing the root still costs — and that closing cost was a hand-kept 2 where an indented writer
+        //      truly spends 3. A document of exactly cap+1 therefore compared as cap and said nothing, while the
+        //      length the notice STATES stayed right, because a second hand-kept number over-counted by the same
+        //      one and cancelled it. Both are now read off one measurement of the writer itself.
+        //      The cap here is a FIXTURE-KNOWN length: a result with no droppable body renders to ONE document
+        //      whatever the cap, so measuring that document and asking for one character less than it is a cap the
+        //      response is over by exactly one. The cap itself is printed inside the accounting, so its digit width
+        //      is part of that length — the arm holds both caps to the same width rather than assuming it.
+        var noBody = ErrorCheck.Run(rm, null, 1000) with
+        {
+            Reports = Array.Empty<PluginErrors>(),
+            ExcludedPlugins = new Dictionary<string, string>(),
+        };
+        const int RoomyCap = 4000;
+        var noBodyRoomy = JsonWire.RenderCheckErrors(noBody, RoomyCap);
+        int edgeCap = noBodyRoomy.Length - 1;
+        var oneOver = JsonWire.RenderCheckErrors(noBody, edgeCap);
+        int oneOverStated = StatedLength(oneOver.Replace("\\u0027", "'"));
+        Check("JSON-ONE-CHAR-OVERRUN-IS-DECLARED: a json document ONE character past its cap says so — the comparison that fires the notice is taken on the closed document, and a root-close cost kept by hand instead of measured made the smallest overrun the one nobody hears about",
+            noBodyRoomy.Length <= RoomyCap && edgeCap.ToString().Length == RoomyCap.ToString().Length
+            && !noBodyRoomy.Contains("max_chars_overrun", StringComparison.Ordinal)
+            && oneOver.Contains("max_chars_overrun", StringComparison.Ordinal)
+            && oneOverStated == oneOver.Length,
+            $"document={noBodyRoomy.Length} edgeCap={edgeCap} len={oneOver.Length} stated={oneOverStated}");
+
         // ---- the two honesty-layer row counts, both directions. They can each be a no-op and print
         //      "0 of 1 plugin(s) that could not be parsed are named above" over a response that named it.
         var withExcluded = ErrorCheck.Run(rm, null, 1000) with

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -2133,10 +2133,20 @@ public static class CheckErrorsProbe
             bad.Add($"{where} rendered {axis.Rows} of {distinct} and states {axis.Stated}");
     }
 
-    /// <summary>The caps this invariant is swept over. It used to step 3000 -> 8000, straight over the 4000-7000 band
-    /// the fat-head fixture's plugin object actually bites in: the arm's one real defect lived in a gap in its own
-    /// ladder. The band is now walked rather than jumped.</summary>
-    static readonly int[] CapLadder = { 120, 300, 700, 900, 1500, 3000, 4000, 4500, 5000, 5270, 6000, 7000, 8000, 40000 };
+    /// <summary>The caps this invariant is swept over: EVERY INTEGER from 1 to 12000, plus one cap far above
+    /// anything the fixtures need.
+    ///
+    /// <para>It used to be fourteen rungs, and it stepped 3000 -> 8000 straight over the 4000-7000 band the
+    /// fat-head fixture's plugin object actually bites in — the arm's one real defect lived in a gap in its own
+    /// ladder. Widening the rungs fixes the gap that was found; enumerating the caps retires the whole class,
+    /// because there are no gaps left to pick badly. It is not a thoroughness gesture: the defects this arm exists
+    /// to catch are BANDS a few hundred characters wide, and which band a fixture bites in moves whenever the
+    /// header does.</para>
+    ///
+    /// <para><b>What it costs, measured rather than assumed:</b> eight fixtures times twelve thousand caps times
+    /// two transports is a hundred and ninety-two thousand renders, and it takes the guard from 6.0 seconds to
+    /// 11.4 — which is why it is enumerated rather than sampled.</para></summary>
+    static readonly int[] CapLadder = Enumerable.Range(1, 12000).Append(40000).ToArray();
 
     /// <summary>The cap invariant, swept: for a range of max_chars values, NEITHER transport may return more than it
     /// was given — with ONE legitimate exception, recognised by a FIXTURE-KNOWN LENGTH rather than by a phrase the

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -255,10 +255,16 @@ public static class CheckErrorsProbe
 
         // ---- CAP: limit=1 over Bad's 2 dangling refs. ----
         var capped = ErrorCheck.Run(r, new[] { "HcCeBad.esp" }, 1);
-        Check("CAP: limit=1 returns 1 dangling ref but reports the TRUE total (2) and Capped",
-            capped.TotalDangling == 2 && capped.Capped
-            && capped.Reports.Count == 1 && capped.Reports[0].Dangling.Count == 1,
-            $"total={capped.TotalDangling} capped={capped.Capped} collected={(capped.Reports.Count > 0 ? capped.Reports[0].Dangling.Count : -1)}");
+        var cappedText = Wire.RenderCheckErrors(capped, 0);
+        // The budget's omission is claimed by the RESPONSE now, not by a flag on the result (ErrorCheckResult.Capped
+        // is superseded — see CheckAccounting). So the arm asserts what the caller is told, which is the thing that
+        // has to be true, and it names the budget the SWEEP was given rather than a render default.
+        Check("CAP: limit=1 returns 1 dangling ref, reports the TRUE total (2), and the response says the budget never listed the other",
+            capped.TotalDangling == 2
+            && capped.Reports.Count == 1 && capped.Reports[0].Dangling.Count == 1
+            && cappedText.Contains("1 of the 2 dangling ref(s) found by this sweep appear above", StringComparison.Ordinal)
+            && cappedText.Contains("1 were never listed: the listing budget (limit=1) ran out", StringComparison.Ordinal),
+            $"total={capped.TotalDangling} collected={(capped.Reports.Count > 0 ? capped.Reports[0].Dangling.Count : -1)} line=[{AccountingLine(cappedText)}]");
 
         // ---- #282: the record scope / class filter / counts_only knobs. ONE plugin was the narrowest scope the tool
         //      had, and its whole per-plugin body overflowed the tool-result cap with no way to ask a smaller question. ----
@@ -318,7 +324,10 @@ public static class CheckErrorsProbe
         var histo = countsOnly.Histogram;
         Check("COUNTS-ONLY: totals stay exact (2 dangling), NO per-plugin listing is built, and the histogram keys the refs by TARGET plugin",
             countsOnly.Success && countsOnly.TotalDangling == 2 && countsOnly.CountsOnly
-            && countsOnly.Reports.Count == 0 && !countsOnly.Capped
+            && countsOnly.Reports.Count == 0
+            // counts_only lists nothing BY DESIGN, so the response makes no listing claim at all — absent, never a
+            // zero, which would report a mode working correctly as a mode that dropped everything.
+            && !Wire.RenderCheckErrors(countsOnly, 0).Contains("found by this sweep appear above", StringComparison.Ordinal)
             && histo is not null && histo.Sum(h => h.Count) == 2
             && histo.Any(h => h.Key.Equals("HcCeGhost.esm", StringComparison.OrdinalIgnoreCase) && h.Count == 1)
             && histo.Any(h => h.Key.Equals("HcCeMaster.esm", StringComparison.OrdinalIgnoreCase) && h.Count == 1),
@@ -562,11 +571,12 @@ public static class CheckErrorsProbe
                 ? $"<no report for HcCeBaseMod.esp — it vanished from the sweep> reports=[{string.Join(",", tight.Reports.Select(p => p.Plugin))}] total={tight.TotalDangling}"
                 : $"listed={baseModRep.Dangling.Count} of {tight.TotalDangling} total");
 
-        Check("BASELINE-TOTALS-EXACT: the totals still count every dangling ref (5) and the sweep still reports Capped",
-            tight.TotalDangling == 5 && tight.Capped,
-            $"total={tight.TotalDangling} capped={tight.Capped} vanillaListed={(vanillaRep is null ? -1 : vanillaRep.Dangling.Count)}");
-
         var tightText = Wire.RenderCheckErrors(tight, 0);
+        Check("BASELINE-TOTALS-EXACT: the totals still count every dangling ref (5) and the response still says the budget ran out",
+            tight.TotalDangling == 5
+            && tightText.Contains("were never listed: the listing budget (limit=3) ran out", StringComparison.Ordinal),
+            $"total={tight.TotalDangling} vanillaListed={(vanillaRep is null ? -1 : vanillaRep.Dangling.Count)} line=[{AccountingLine(tightText)}]");
+
         var ample = ErrorCheck.Run(rb, null, 1000);
         var ampleText = Wire.RenderCheckErrors(ample, 0);
         var modOnly = ErrorCheck.Run(rb, new[] { "HcCeBaseMod.esp" }, 1000);
@@ -579,14 +589,13 @@ public static class CheckErrorsProbe
             tight.Reports.Count == 2 && tight.Reports[0].Plugin == "Skyrim.esm" && tight.Reports[1].Plugin == "HcCeBaseMod.esp",
             $"sections=[{string.Join(",", tight.Reports.Select(p => p.Plugin))}]");
 
-        Check("BASELINE-OMITTED-NAMED: the cap names WHICH plugin lost entries and how many — Skyrim.esm (2) — in the result AND in the rendered line (Q3)",
-            tight.ListingOmitted is { Count: 1 } om && om[0].Key == "Skyrim.esm" && om[0].Count == 2
-            && tightText.Contains("Skyrim.esm (2)", StringComparison.Ordinal)
-            && tightText.Contains("the listing budget (limit=) omitted 2 dangling ref(s)", StringComparison.Ordinal)
+        Check("BASELINE-OMITTED-NAMED: the response names WHICH plugin is missing entries and how many — Skyrim.esm (2) — in text AND in json (Q3)",
+            tightText.Contains("Missing here, by source plugin: Skyrim.esm (2)", StringComparison.Ordinal)
+            && JsonRoster(JsonWire.RenderCheckErrors(tight, 0)).SequenceEqual(new[] { "Skyrim.esm:2" })
             // the roster names every plugin here, so the truncation clause must be ABSENT — the other arm of the
             // conditional OMITTED-ROSTER-STATES-ITS-TRUNCATION holds in the true direction.
             && !tightText.Contains("the rest are not named here", StringComparison.Ordinal),
-            $"omitted=[{string.Join(",", (tight.ListingOmitted ?? new List<SweepCount>()).Select(c => $"{c.Key}:{c.Count}"))}]");
+            $"roster=[{string.Join(",", JsonRoster(JsonWire.RenderCheckErrors(tight, 0)))}] line=[{AccountingLine(tightText)}]");
 
         Check("BASELINE-SUMMARY: the split is stated (3 of 5, 2 from the rest) and names ONLY the base master this sweep actually opened — the four it never touched are not named (round-1 review: two reviewers, independently)",
             tight.BaselineDangling == 3 && tight.BaseMastersSwept is { Count: 1 } sw && sw[0] == "Skyrim.esm"
@@ -606,10 +615,12 @@ public static class CheckErrorsProbe
             && ampleText.Contains("baseline: 3 of 5", StringComparison.Ordinal),
             $"capped-has={tightText.Contains("BEFORE those", StringComparison.Ordinal)} ample-has={ampleText.Contains("the listing budget (limit=) is spent", StringComparison.Ordinal)}");
 
-        Check("BASELINE-AMPLE-BUDGET-UNCHANGED: with limit= ample, EVERY plugin's findings are listed in full and nothing is reported omitted (the phase order costs nothing when the budget is not scarce)",
-            !ample.Capped && ample.ListingOmitted is { Count: 0 }
-            && ample.Reports.Sum(p => p.Dangling.Count) == 5,
-            $"capped={ample.Capped} omitted={(ample.ListingOmitted is null ? "<null>" : ample.ListingOmitted.Count.ToString())} listed={ample.Reports.Sum(p => p.Dangling.Count)}");
+        Check("BASELINE-AMPLE-BUDGET-UNCHANGED: with limit= ample, EVERY plugin's findings are listed in full and the response says so positively — completeness is STATED, not left to the absence of a sentence (#361)",
+            ample.Reports.Sum(p => p.Dangling.Count) == 5
+            && ampleText.Contains("all 5 dangling ref(s) found by this sweep appear above", StringComparison.Ordinal)
+            && !ampleText.Contains("Missing here, by source plugin", StringComparison.Ordinal)
+            && !ampleText.Contains("Raise limit= to list more", StringComparison.Ordinal),
+            $"listed={ample.Reports.Sum(p => p.Dangling.Count)} line=[{AccountingLine(ampleText)}]");
 
         Check("SOURCE-HISTOGRAM: counts_only tallies dangling refs by SOURCE plugin (3 vanilla, 2 mod) beside the existing TARGET axis, and renders both",
             baseCounts.DanglingBySource is { Count: 2 } src
@@ -624,8 +635,9 @@ public static class CheckErrorsProbe
             $"source={(baseNoWalk.DanglingBySource is null ? "null" : "present")} target={(baseNoWalk.Histogram is null ? "null" : "present")}");
 
         Check("OMITTED-NULL-UNDER-COUNTS-ONLY: counts_only lists nothing BY DESIGN, so it reports no omissions rather than reporting the whole sweep as dropped",
-            baseCounts.ListingOmitted is null && !baseCounts.Capped,
-            $"omitted={(baseCounts.ListingOmitted is null ? "null" : "present")} capped={baseCounts.Capped}");
+            !baseCountsText.Contains("found by this sweep appear above", StringComparison.Ordinal)
+            && !baseCountsText.Contains("Missing here, by source plugin", StringComparison.Ordinal),
+            $"line=[{AccountingLine(baseCountsText)}]");
 
         // REACH (round-1 review, partially refused): this arm holds the set's CONTENTS — that it equals Mutagen's for
         // this release, matches case-insensitively, and excludes Creation Club / _ResourcePack. It does NOT hold
@@ -669,34 +681,38 @@ public static class CheckErrorsProbe
         var wholeText = Wire.RenderCheckErrors(whole, 0);
         Check("BASELINE-WHOLE-SET-DROPPED: a plugin that loses its ENTIRE set has no section, and the omissions list is the only place it appears — the sentence the render prints, produced",
             whole.Reports.All(p => p.Plugin != "Skyrim.esm")
-            && whole.ListingOmitted is { } wo && wo.Any(c => c.Key == "Skyrim.esm" && c.Count == 3)
+            && JsonRoster(JsonWire.RenderCheckErrors(whole, 0)).Contains("Skyrim.esm:3")
             && wholeText.Contains("Skyrim.esm (3)", StringComparison.Ordinal)
-            && wholeText.Contains("A plugin whose whole set the budget omitted, with nothing else to report, gets no section of its own", StringComparison.Ordinal),
-            $"sections=[{string.Join(",", whole.Reports.Select(p => p.Plugin))}] omitted=[{string.Join(",", (whole.ListingOmitted ?? new List<SweepCount>()).Select(c => $"{c.Key}:{c.Count}"))}]");
+            && wholeText.Contains("A plugin whose whole set is missing here, with nothing else to report, gets no section of its own", StringComparison.Ordinal),
+            $"sections=[{string.Join(",", whole.Reports.Select(p => p.Plugin))}] roster=[{string.Join(",", JsonRoster(JsonWire.RenderCheckErrors(whole, 0)))}]");
 
         // ---- a duplicated plugins= name is swept twice (pre-existing on main). The omissions table must not read the
         //      second sweep's section as the whole of what was listed and report the first sweep's findings as dropped
         //      by a budget that never ran out (round-1 review).
         var dup = ErrorCheck.Run(rb, new[] { "HcCeBaseMod.esp", "HcCeBaseMod.esp" }, 1000);
-        Check("OMITTED-NO-PHANTOM-ON-DUPLICATE-SCOPE: an uncapped sweep reports NOTHING omitted even when a plugin is named twice — a budget that never ran out cannot have dropped anything",
-            !dup.Capped && dup.ListingOmitted is { Count: 0 },
-            $"capped={dup.Capped} omitted=[{string.Join(",", (dup.ListingOmitted ?? new List<SweepCount>()).Select(c => $"{c.Key}:{c.Count}"))}]");
+        var dupText = Wire.RenderCheckErrors(dup, 0);
+        Check("OMITTED-NO-PHANTOM-ON-DUPLICATE-SCOPE: an uncapped sweep reports NOTHING missing even when a plugin is named twice — a response that listed everything cannot have dropped anything",
+            dupText.Contains("found by this sweep appear above", StringComparison.Ordinal)
+            && !dupText.Contains("Missing here, by source plugin", StringComparison.Ordinal)
+            && JsonRoster(JsonWire.RenderCheckErrors(dup, 0)).Length == 0,
+            $"line=[{AccountingLine(dupText)}]");
 
         // ---- json's omissions table must not be capped by limit=, the knob that caused the omissions: the tighter the
         //      budget, the more plugins lose entries and the fewer json would have named (round-1 review).
         var tiny = ErrorCheck.Run(rb, null, 1);
         var tinyJson = JsonWire.RenderCheckErrors(tiny, 0);
-        Check("OMITTED-JSON-NOT-LIMIT-CAPPED: at limit=1 the json still names BOTH plugins that lost entries — the omissions roster does not shrink as the budget does",
-            JsonDocument.Parse(tinyJson).RootElement.GetProperty("dangling_not_listed_by_source") is var t
-            && t.GetProperty("distinct").GetInt32() == 2 && t.GetProperty("rows").GetArrayLength() == 2,
-            tinyJson.Contains("dangling_not_listed_by_source", StringComparison.Ordinal) ? "see json" : "<field missing>");
+        Check("OMITTED-JSON-NOT-LIMIT-CAPPED: at limit=1 the json still names BOTH plugins missing entries — the roster does not shrink as the budget does (the tighter the budget, the MORE plugins lose entries)",
+            JsonRoster(tinyJson).Length == 2
+            && JsonDocument.Parse(tinyJson).RootElement.GetProperty("accounting")
+                           .GetProperty("dangling_missing_by_source_total").GetInt32() == 2,
+            $"roster=[{string.Join(",", JsonRoster(tinyJson))}]");
 
         var tightJson = JsonWire.RenderCheckErrors(tight, 0);
         var countsJson = JsonWire.RenderCheckErrors(baseCounts, 0);
         var noWalkBaseJson = JsonWire.RenderCheckErrors(baseNoWalk, 0);
         Check("BASELINE-JSON-PARITY: the json carries the same split, names the base set, flags scope, and carries both new tables; an unchecked class emits null (not 0)",
             JsonMatches(tightJson, "baseline_dangling", 3) && JsonMatches(tightJson, "non_baseline_dangling", 2)
-            && JsonHasHistogram(tightJson, "dangling_not_listed_by_source")
+            && JsonRoster(tightJson).Length > 0
             && JsonHasHistogram(countsJson, "dangling_by_source_plugin")
             && JsonNull(noWalkBaseJson, "baseline_dangling")
             && JsonDocument.Parse(tightJson).RootElement.GetProperty("base_masters_swept").GetArrayLength() == 1
@@ -728,6 +744,15 @@ public static class CheckErrorsProbe
                 m.BeginWrite.ToPath(mp).WithLoadOrder(new ISkyrimModGetter[] { skyManyOv }).Write();
                 manyPaths.Add(mp);
             }
+            // ONE plugin whose own findings outrun any sane cap. Twelve plugins of three refs cannot produce #361's
+            // shape: the cut has to land INSIDE a section, and with one section it lands inside the LAST one, which
+            // is the path where the old notice was never printed at all. On the live order this shape is ordinary —
+            // the largest single source carries 2591 dangling refs.
+            var bulk = new SkyrimMod(new ModKey("HcCeBulk", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            for (int k = 0; k < 200; k++) { var n = bulk.Npcs.AddNew(); n.EditorID = $"HcCeBulkNpc{k:000}"; n.Race.SetTo(baseDeadFk); }
+            string bulkPath = Path.Combine(manyDir, "HcCeBulk.esp");
+            bulk.BeginWrite.ToPath(bulkPath).WithLoadOrder(new ISkyrimModGetter[] { skyManyOv }).Write();
+            manyPaths.Add(bulkPath);
         }
         catch (Exception ex)
         {
@@ -740,15 +765,18 @@ public static class CheckErrorsProbe
         var manyText = Wire.RenderCheckErrors(many, 0);
         // Count names in the CAPPED LINE, not the whole render: every listed dangling entry also prints its source as
         // "000800:HcCeMany00.esp (Npc ...", so a whole-text match counts plugins the roster never named.
-        string cappedLine = manyText.Split('\n').FirstOrDefault(l => l.Contains("[the listing budget (limit=) omitted", StringComparison.Ordinal)) ?? "";
-        int namedInText = many.ListingOmitted!.Count(c => cappedLine.Contains(c.Key + " (", StringComparison.Ordinal));
-        Check("OMITTED-ROSTER-STATES-ITS-TRUNCATION: with more plugins losing entries than the line names, it says how many it did NOT name and never claims to be the only place they appear",
-            many.ListingOmitted is { Count: > 10 }
-            && namedInText == 10
-            && manyText.Contains("the 10 largest of " + many.ListingOmitted.Count, StringComparison.Ordinal)
+        string cappedLine = AccountingLine(manyText);
+        var manyRoster = JsonRoster(JsonWire.RenderCheckErrors(many, 0));
+        int manyRosterTotal = JsonDocument.Parse(JsonWire.RenderCheckErrors(many, 0)).RootElement
+                                          .GetProperty("accounting").GetProperty("dangling_missing_by_source_total").GetInt32();
+        int namedInText = manyRoster.Count(k => cappedLine.Contains(k.Split(':')[0] + " (", StringComparison.Ordinal));
+        Check("OMITTED-ROSTER-STATES-ITS-TRUNCATION: with more plugins missing entries than the line names, it says how many it did NOT name and never claims to be the only place they appear",
+            manyRosterTotal > 10
+            && manyRoster.Length == 10 && namedInText == 10
+            && manyText.Contains("the 10 largest of " + manyRosterTotal, StringComparison.Ordinal)
             && manyText.Contains("the rest are not named here", StringComparison.Ordinal)
             && !manyText.Contains("this list is the only place", StringComparison.Ordinal),
-            $"omitted={many.ListingOmitted?.Count} namedInText={namedInText} line=[{cappedLine}]");
+            $"rosterTotal={manyRosterTotal} named={namedInText} line=[{cappedLine}]");
 
         Check("OMITTED-REMEDY-DOES-NOT-PROMISE-SCOPING: the remedy qualifies scoping instead of asserting it reads a set in full — a plugin whose own set exceeds limit= would loop the caller back to this line",
             manyText.Contains("Raise limit= to list more", StringComparison.Ordinal)
@@ -782,10 +810,11 @@ public static class CheckErrorsProbe
         var cleanBase = ErrorCheck.Run(rc, null, 2);
         var cleanBaseText = Wire.RenderCheckErrors(cleanBase, 0);
         Check("BASELINE-PHASE-CLAUSE-NEEDS-BASELINE-FINDINGS: a capped sweep whose baseline came back CLEAN states the split but not the phase-order sentence — there were no baseline findings for it to be about",
-            cleanBase.Capped && cleanBase.BaselineDangling == 0 && cleanBase.BaseMastersSwept is { Count: 1 }
+            cleanBaseText.Contains("were never listed: the listing budget (limit=2) ran out", StringComparison.Ordinal)
+            && cleanBase.BaselineDangling == 0 && cleanBase.BaseMastersSwept is { Count: 1 }
             && cleanBaseText.Contains("baseline: 0 of 3", StringComparison.Ordinal)
             && !cleanBaseText.Contains("the listing budget (limit=) is spent", StringComparison.Ordinal),
-            $"capped={cleanBase.Capped} baseline={cleanBase.BaselineDangling}");
+            $"baseline={cleanBase.BaselineDangling} line=[{AccountingLine(cleanBaseText)}]");
         // ---- both axes empty: they must be tellable apart. Two identical untitled "nothing to tally" lines said
         //      neither which axis was which nor that a second one had been computed (round-1 review).
         var cleanCounts = ErrorCheck.Run(r, new[] { "HcCeClean.esp" }, 1000, null, null, ErrorFindingClass.All, countsOnly: true);
@@ -796,41 +825,75 @@ public static class CheckErrorsProbe
             cleanCountsText);
 
 
-        // ---- the render's cut is the RENDER's sentence: computed where the loop breaks, counting what it emitted, and
-        //      saying nothing about the listing budget. The two truncators are independent and never sum (advisor ruling).
+        // ---- the response's cut and the budget's are ONE accounting now: both are subtractions against the sweep's
+        //      own total, taken after emission stops, so "how many can I see" is a stated number rather than one the
+        //      caller derives from two sentences in different units (#361, and the class-stop that produced it).
         // an ample budget so every section exists, then a cap small enough that the RENDER is what drops them
         var manyAmple = ErrorCheck.Run(rm, null, 1000);
-        var truncText = Wire.RenderCheckErrors(manyAmple, 900);
+        // The cap must clear the RESERVE — the accounting and boundary are held back before the body renders, so a
+        // cap at or below the reserve renders an empty body and would let this arm "pass" over a response with
+        // nothing in it. 3000 leaves room for a partial listing over this fixture's 236 findings.
+        const int MultiCut = 3000;
+        var truncText = Wire.RenderCheckErrors(manyAmple, MultiCut);
         int renderedSections = truncText.Split("[ERROR] ").Length - 1;
-        Check("RENDER-CUT-COUNTS-ITS-OWN-OMISSION: the max_chars notice says how many plugin sections IT did not render, out of the total, and names the cut as the response being cut rather than the budget",
-            truncText.Contains("plugin section(s) were not rendered", StringComparison.Ordinal)
-            && truncText.Contains($"{manyAmple.Reports.Count - renderedSections} of {manyAmple.Reports.Count} plugin section(s)", StringComparison.Ordinal)
-            && truncText.Contains("separate from any limit= omission reported below", StringComparison.Ordinal)
-            // the units fold: the render counts ENTRIES it appended, in the same unit the budget line uses, so
-            // "how many findings can I actually see" is answered without subtracting two different measures
-            && truncText.Contains($"of the {manyAmple.Reports.Sum(x => x.Dangling.Count)} budget-listed dangling entries appear above", StringComparison.Ordinal)
-            && !truncText.Contains("may be partial", StringComparison.Ordinal),
-            truncText.Split('\n').FirstOrDefault(l => l.Contains("truncated at max_chars", StringComparison.Ordinal)) ?? "<no truncation notice>");
+        int visibleEntries = truncText.Split("-> ").Length - 1;
+        Check("RESPONSE-CUT-COUNTED-AT-THE-TOTAL: a response cut by max_chars states how many of the SWEEP's findings it carries, names max_chars as the cause, and counts the sections it rendered",
+            truncText.Contains($"{visibleEntries} of the {manyAmple.TotalDangling} dangling ref(s) found by this sweep appear above", StringComparison.Ordinal)
+            && truncText.Contains($"did not fit this response (max_chars={MultiCut})", StringComparison.Ordinal)
+            && truncText.Contains($"{renderedSections} of {manyAmple.Reports.Count} plugin section(s) were rendered", StringComparison.Ordinal)
+            // the budget was ample, so it dropped nothing and must not be named as a cause at all
+            && !truncText.Contains("the listing budget (limit=", StringComparison.Ordinal),
+            AccountingLine(truncText));
 
-        Check("RENDER-CUT-ENTRY-COUNT-IS-WHAT-IT-EMITTED: the entry figure equals the dangling lines actually in the response, not the sum of the sections it started — a section sum would overstate a partial last section",
-            truncText.Contains($"{truncText.Split("-> ").Length - 1} of the ", StringComparison.Ordinal),
-            $"lines={truncText.Split("-> ").Length - 1} notice={truncText.Split('\n').FirstOrDefault(l => l.Contains("budget-listed dangling entries", StringComparison.Ordinal))}");
+        Check("RESPONSE-CUT-ENTRY-COUNT-IS-WHAT-IT-EMITTED: the visible figure equals the dangling lines actually in the response, not the sum of the sections it started — a section sum would overstate a partial last section",
+            truncText.Contains($"[accounting: {visibleEntries} of the ", StringComparison.Ordinal)
+            && visibleEntries > 0 && visibleEntries < manyAmple.TotalDangling,
+            $"lines={visibleEntries} total={manyAmple.TotalDangling} line=[{AccountingLine(truncText)}]");
 
-        Check("RENDER-CUT-SILENT-WHEN-IT-DID-NOT-CUT: an untruncated response carries no such notice — the sentence exists only where the render actually dropped something",
-            !manyText.Contains("plugin section(s) were not rendered", StringComparison.Ordinal)
-            && !manyText.Contains("truncated at max_chars", StringComparison.Ordinal),
-            "untruncated render");
+        // #361's own lane: ONE report section, so the cut lands inside the LAST one. The outer loop then exhausts
+        // instead of breaking, which is exactly the path that used to leave the notice unprinted — measured on the
+        // live order at plain defaults as 644 entries present under a line claiming 1000 were listed.
+        const int OneCut = 5000;
+        var oneSection = ErrorCheck.Run(rm, new[] { "HcCeBulk.esp" }, 1000);
+        var oneText = Wire.RenderCheckErrors(oneSection, OneCut);
+        int oneVisible = oneText.Split("-> ").Length - 1;
+        Check("RESPONSE-CUT-INSIDE-THE-LAST-SECTION-IS-STATED (#361): with a single section, a cut inside it is still accounted — the claim is a subtraction at the total, so there is no exit for it to be missed at",
+            oneSection.Reports.Count == 1 && oneVisible < oneSection.TotalDangling
+            && oneText.Contains($"[accounting: {oneVisible} of the {oneSection.TotalDangling} dangling ref(s) found by this sweep appear above", StringComparison.Ordinal)
+            && oneText.Contains($"did not fit this response (max_chars={OneCut})", StringComparison.Ordinal),
+            $"sections={oneSection.Reports.Count} visible={oneVisible} of {oneSection.TotalDangling} line=[{AccountingLine(oneText)}]");
 
-        // json states its own cut in its own terms: rendered + truncated could not answer "how many were dropped"
-        // without a total to subtract from.
-        var truncJson = JsonDocument.Parse(JsonWire.RenderCheckErrors(manyAmple, 900)).RootElement;
-        Check("RENDER-CUT-JSON-DERIVABLE: plugins_with_findings - rendered gives the dropped section count exactly, beside truncated=true",
-            // TryGetProperty, not GetProperty: a missing field must fail this arm, not throw out of the guard
-            truncJson.GetProperty("truncated").GetBoolean()
-            && truncJson.TryGetProperty("plugins_with_findings", out var pwf)
-            && pwf.GetInt32() == manyAmple.Reports.Count
-            && pwf.GetInt32() - truncJson.GetProperty("rendered").GetInt32() > 0,
-            $"with_findings={(truncJson.TryGetProperty("plugins_with_findings", out var pwf2) ? pwf2.GetInt32().ToString() : "<absent>")} rendered={truncJson.GetProperty("rendered").GetInt32()}");
+        Check("RESPONSE-NEVER-EXCEEDS-MAX-CHARS (#361): the accounting and the boundary are RESERVED before the body renders, so neither is appended past the cap — across a sweep of caps, in both transports",
+            CapSweep(manyAmple, out var capFail), capFail);
+
+        Check("RESPONSE-CUT-COMPLETE-RESPONSE-SAYS-SO: an uncut, unbudgeted response states its completeness rather than staying silent — silence used to mean both 'complete' and #361",
+            manyText.Contains("dangling ref(s) found by this sweep appear above", StringComparison.Ordinal)
+            && !manyText.Contains("did not fit this response", StringComparison.Ordinal)
+            && !manyText.Contains("plugin section(s) were rendered", StringComparison.Ordinal),
+            AccountingLine(manyText));
+
+        // json states the same numbers, from the same computation — the twin cannot disagree because there is only
+        // one place either transport gets them.
+        var truncJson = JsonDocument.Parse(JsonWire.RenderCheckErrors(manyAmple, MultiCut)).RootElement;
+        var jAcct = truncJson.GetProperty("accounting");
+        Check("RESPONSE-CUT-JSON-NUMBERS-MATCH-THE-DOCUMENT: dangling_visible equals the entries actually in the json, and sections_rendered the plugin objects — a number that disagrees with its own document is the defect this replaces",
+            jAcct.GetProperty("dangling_visible").GetInt32()
+                == truncJson.GetProperty("plugins").EnumerateArray().Sum(pl => pl.GetProperty("dangling").GetArrayLength())
+            && jAcct.GetProperty("sections_rendered").GetInt32() == truncJson.GetProperty("plugins").GetArrayLength()
+            && jAcct.GetProperty("sections_with_findings").GetInt32() == manyAmple.Reports.Count
+            && jAcct.GetProperty("dangling_missing_by_response_cut").GetInt32() > 0
+            && jAcct.GetProperty("dangling_missing_by_budget").GetInt32() == 0,
+            $"visible={jAcct.GetProperty("dangling_visible").GetInt32()} inDoc={truncJson.GetProperty("plugins").EnumerateArray().Sum(pl => pl.GetProperty("dangling").GetArrayLength())} rendered={jAcct.GetProperty("sections_rendered").GetInt32()} objects={truncJson.GetProperty("plugins").GetArrayLength()}");
+
+        // #361's json lane: one plugin carrying more entries than the cap can hold. The budget used to be tested
+        // before each plugin OBJECT, so the whole array went out at once — 2.5x the cap on the live order, with
+        // truncated:false, which was true and useless.
+        var oneJson = JsonDocument.Parse(JsonWire.RenderCheckErrors(oneSection, OneCut)).RootElement;
+        Check("RESPONSE-CUT-JSON-PER-ENTRY (#361): one plugin's dangling array is cut at an ENTRY, so a single oversized plugin cannot carry the response past max_chars",
+            JsonWire.RenderCheckErrors(oneSection, OneCut).Length <= OneCut
+            && oneJson.GetProperty("plugins").EnumerateArray().Sum(pl => pl.GetProperty("dangling").GetArrayLength()) < oneSection.TotalDangling
+            && oneJson.GetProperty("truncated").GetBoolean(),
+            $"chars={JsonWire.RenderCheckErrors(oneSection, OneCut).Length} cap={OneCut} truncated={oneJson.GetProperty("truncated").GetBoolean()} overrun={oneJson.TryGetProperty("max_chars_overrun", out _)} entries={oneJson.GetProperty("plugins").EnumerateArray().Sum(pl => pl.GetProperty("dangling").GetArrayLength())} of {oneSection.TotalDangling}");
 
         // ---- a record scope can admit nothing from a base master the sweep opened. "Swept" has to mean examined.
         var modOnlyScope = ErrorCheck.Run(rb, null, 1000, null, new SweepScope(null, "HcCeModNpc", null, null));
@@ -851,10 +914,11 @@ public static class CheckErrorsProbe
         var baseOnly = ErrorCheck.Run(rb, new[] { "Skyrim.esm" }, 2);
         var baseOnlyText = Wire.RenderCheckErrors(baseOnly, 0);
         Check("BASELINE-PHASE-CLAUSE-NEEDS-A-NON-BASE-PLUGIN: a sweep scoped to base masters alone states the split but not the ordering sentence — there is no 'every other plugin' for the budget to reach first",
-            baseOnly.Capped && baseOnly.BaselineDangling > 0 && !baseOnly.NonBaseInScope
+            baseOnlyText.Contains("were never listed: the listing budget (limit=2) ran out", StringComparison.Ordinal)
+            && baseOnly.BaselineDangling > 0 && !baseOnly.NonBaseInScope
             && baseOnlyText.Contains("baseline: 3 of 3", StringComparison.Ordinal)
             && !baseOnlyText.Contains("the listing budget (limit=) is spent on every other plugin", StringComparison.Ordinal),
-            $"capped={baseOnly.Capped} baseline={baseOnly.BaselineDangling} nonBase={baseOnly.NonBaseInScope}");
+            $"baseline={baseOnly.BaselineDangling} nonBase={baseOnly.NonBaseInScope}");
 
         // The arm above cannot tell a correct gate from a subtraction that happens to agree: scoped to one name, the
         // scanned count and the swept-base count coincide. This fixture SEPARATES them — the same plugin named twice is
@@ -863,7 +927,8 @@ public static class CheckErrorsProbe
         var dupBase = ErrorCheck.Run(rb, new[] { "Skyrim.esm", "Skyrim.esm" }, 2);
         var dupBaseText = Wire.RenderCheckErrors(dupBase, 0);
         Check("BASELINE-PHASE-CLAUSE-NOT-A-SUBTRACTION: with the scanned count (2) and the swept-base count (1) deliberately apart, the ordering sentence still does not print — the gate reads a stated fact, not a difference between two counts of different things",
-            dupBase.Capped && dupBase.BaselineDangling > 0
+            dupBaseText.Contains("were never listed: the listing budget (limit=2) ran out", StringComparison.Ordinal)
+            && dupBase.BaselineDangling > 0
             && dupBase.PluginsScanned > (dupBase.BaseMastersSwept?.Count ?? 0)     // the old gate's test is TRUE here
             && !dupBase.NonBaseInScope                                             // and the fact says otherwise
             && !dupBaseText.Contains("the listing budget (limit=) is spent on every other plugin", StringComparison.Ordinal),
@@ -919,6 +984,45 @@ public static class CheckErrorsProbe
                 && (!expectTruncated || u.GetProperty("rendered").GetInt32() < expectTotal);
         }
         catch { return false; }
+    }
+
+    /// <summary>The accounting line out of a rendered response — the one line every omission claim now lives on.
+    /// Arms read it rather than the whole render because a listed dangling entry also prints its own source plugin,
+    /// so a whole-text match counts plugins the roster never named (the trap the line it replaces already paid for).
+    /// </summary>
+    static string AccountingLine(string text)
+        => text.Split('\n').FirstOrDefault(l => l.Contains("[accounting:", StringComparison.Ordinal)) ?? "";
+
+    /// <summary>The json roster as "plugin:count" keys, in the order it was written. The json twin of the text
+    /// line's roster, so an arm can hold the two transports against each other rather than trusting either.</summary>
+    static string[] JsonRoster(string json)
+    {
+        var acct = JsonDocument.Parse(json).RootElement.GetProperty("accounting");
+        return acct.GetProperty("dangling_missing_by_source").EnumerateArray()
+                   .Select(e => e.GetProperty("plugin").GetString() + ":" + e.GetProperty("count").GetInt32())
+                   .ToArray();
+    }
+
+    /// <summary>The cap invariant, swept: for a range of max_chars values, NEITHER transport may return more than it
+    /// was given — unless the response says it overran, which is the one declared arm (a cap smaller than the
+    /// accounting itself, which is never dropped). A single cap would pass by luck; the sweep is what makes the
+    /// invariant a claim rather than an anecdote.</summary>
+    static bool CapSweep(ErrorCheckResult r, out string detail)
+    {
+        var bad = new List<string>();
+        foreach (int cap in new[] { 120, 300, 700, 900, 1500, 3000, 8000, 40000 })
+        {
+            var text = Wire.RenderCheckErrors(r, cap);
+            var json = JsonWire.RenderCheckErrors(r, cap);
+            if (text.Length > cap && !text.Contains("raise it to at least", StringComparison.Ordinal))
+                bad.Add($"text@{cap}={text.Length} with no overrun notice");
+            if (json.Length > cap && !json.Contains("max_chars_overrun", StringComparison.Ordinal))
+                bad.Add($"json@{cap}={json.Length} with no overrun notice");
+            try { JsonDocument.Parse(json); }
+            catch (Exception ex) { bad.Add($"json@{cap} is not valid json: {ex.GetType().Name}"); }
+        }
+        detail = bad.Count == 0 ? "every cap honoured, or overrun declared" : string.Join("; ", bad);
+        return bad.Count == 0;
     }
 
     internal static bool JsonHasHistogram(string json, string prop)

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -778,10 +778,15 @@ public static class CheckErrorsProbe
             && !manyText.Contains("this list is the only place", StringComparison.Ordinal),
             $"rosterTotal={manyRosterTotal} named={namedInText} line=[{cappedLine}]");
 
-        Check("OMITTED-REMEDY-DOES-NOT-PROMISE-SCOPING: the remedy qualifies scoping instead of asserting it reads a set in full — a plugin whose own set exceeds limit= would loop the caller back to this line",
-            manyText.Contains("Raise limit= to list more", StringComparison.Ordinal)
-            && manyText.Contains("unless that set is itself larger than limit=", StringComparison.Ordinal),
-            cappedLine.Length == 0 ? "<no capped line>" : cappedLine);
+        // The remedy is assembled from the causes that FIRED. This sweep is capped by limit= and not by max_chars,
+        // so it must offer the budget knob and must NOT offer the response knob — a knob named beside a cause it did
+        // not move is a remedy the caller can follow and land in the same place.
+        Check("OMITTED-REMEDY-NAMES-ONLY-THE-CAUSE-THAT-FIRED: a budget-capped response offers limit= and not max_chars=, and its scoping clause names BOTH bounds rather than promising a full listing",
+            manyText.Contains("Raise limit= to list more.", StringComparison.Ordinal)
+            && !manyText.Contains("Raise max_chars= to fit more", StringComparison.Ordinal)
+            && manyText.Contains("depends on limit= and on max_chars=, which both still apply", StringComparison.Ordinal)
+            && !manyText.Contains("lists its set in full unless", StringComparison.Ordinal),
+            cappedLine.Length == 0 ? "<no accounting line>" : cappedLine);
 
         // ---- CLEAN-BASELINE fixture: a base master with NO dangling refs, on a sweep the budget still caps. The
         //      phase-order sentence talks about baseline findings crowding the list; with none found there is nothing
@@ -825,6 +830,16 @@ public static class CheckErrorsProbe
             cleanCountsText);
 
 
+        // The report SHAPE is synthesized rather than swept: no fixture plugin declares an absent master, and what
+        // is under test is the render's behaviour when a masters-only sweep has more sections than fit.
+        var mastersMany = ErrorCheck.Run(rm, null, 1000, null, null, ErrorFindingClass.MissingMasters) with
+        {
+            Reports = Enumerable.Range(0, 12).Select(i => new PluginErrors(
+                $"HcCeMasters{i:00}.esp", Array.Empty<DanglingRef>(),
+                new[] { "HcCeAbsentMaster.esm", "HcCeAlsoAbsent.esm" }, 0, Array.Empty<string>(), null)).ToList(),
+            TotalMissingMasters = 24,
+        };
+
         // ---- the response's cut and the budget's are ONE accounting now: both are subtractions against the sweep's
         //      own total, taken after emission stops, so "how many can I see" is a stated number rather than one the
         //      caller derives from two sentences in different units (#361, and the class-stop that produced it).
@@ -863,8 +878,27 @@ public static class CheckErrorsProbe
             && oneText.Contains($"did not fit this response (max_chars={OneCut})", StringComparison.Ordinal),
             $"sections={oneSection.Reports.Count} visible={oneVisible} of {oneSection.TotalDangling} line=[{AccountingLine(oneText)}]");
 
-        Check("RESPONSE-NEVER-EXCEEDS-MAX-CHARS (#361): the accounting and the boundary are RESERVED before the body renders, so neither is appended past the cap — across a sweep of caps, in both transports",
-            CapSweep(manyAmple, out var capFail), capFail);
+        // Every lane, not just the listing one. counts_only renders two histograms that took limit= as their only
+        // bound — measured at 27,944 chars against a max_chars of 5,000 — and a plugin whose FIXED part is fat
+        // (a scan error plus three unscannable-record exception messages) is the shape that broke the json lane's
+        // per-plugin test. Both are in the sweep, so the invariant is claimed over the whole surface.
+        var fatHead = ErrorCheck.Run(rm, null, 1000) with
+        {
+            Reports = ErrorCheck.Run(rm, null, 1000).Reports.Select((x, i) => i == 1
+                ? new PluginErrors(x.Plugin, x.Dangling, x.MissingMasters, 3,
+                                   Enumerable.Range(0, 3).Select(k => new string('s', 950) + k).ToList(),
+                                   new string('e', 900))
+                : x).ToList(),
+        };
+        // Evaluated eagerly, never short-circuited: a sweep that never runs cannot fail, and the detail below has
+        // to be able to say which lane broke.
+        bool capListing = CapSweep(manyAmple, out var capFail);
+        bool capFat = CapSweep(fatHead, out var fatFail);
+        bool capCounts = CapSweep(ErrorCheck.Run(rm, null, 1000, null, null, ErrorFindingClass.All, true), out var countsFail);
+        bool capMasters = CapSweep(mastersMany, out var mastersFail);
+        Check("RESPONSE-NEVER-EXCEEDS-MAX-CHARS (#361): the accounting and the boundary are RESERVED before the body renders, so neither is appended past the cap — across a sweep of caps, in every lane, in both transports",
+            capListing && capFat && capCounts && capMasters,
+            $"listing=[{capFail}] fat-head=[{fatFail}] counts_only=[{countsFail}] masters-only=[{mastersFail}]");
 
         Check("SECTION-IS-WHOLE-OR-ABSENT: across a sweep of caps, a section that starts also carries everything it has to say — the only things a cut may drop are a whole section or an entry, which are the two the accounting states",
             SectionsWhole(new[] { manyAmple, tight, ErrorCheck.Run(r, null, 1000) }, out var wholeFail), wholeFail);
@@ -901,7 +935,7 @@ public static class CheckErrorsProbe
         // ---- #344's exclusion axis. Applied to the SWEEP, so an excluded plugin costs no walk and no budget — the
         //      half of #344 the phase order could not reach. The BASELINE definition is untouched by it.
         var exBase = ErrorCheck.Run(rb, null, 1000, null, null, ErrorFindingClass.All, false,
-                                    new[] { "Skyrim.esm" });
+                                    Excl("Skyrim.esm"));
         var exBaseText = Wire.RenderCheckErrors(exBase, 0);
         Check("EXCLUDE-NAME: a named plugin is left out of the sweep entirely — its findings are gone from the TOTALS, not merely from the listing, and the response says the scope was narrowed",
             exBase.Success && exBase.TotalDangling == 2 && exBase.Reports.All(x => x.Plugin != "Skyrim.esm")
@@ -912,15 +946,19 @@ public static class CheckErrorsProbe
 
         var (baseTok, baseTokErr) = SweepExclusion.Resolve(new[] { SweepExclusion.BaseMastersToken }, Array.Empty<string>());
         Check("EXCLUDE-TOKEN-BASE-MASTERS: the group resolves to Mutagen's base-master set exactly — the same list the baseline split is defined by, never a second hand-kept copy",
-            baseTokErr is null && baseTok.SetEquals(ErrorCheck.BaseMasters),
-            $"err={baseTokErr} resolved=[{string.Join(",", baseTok)}]");
+            baseTokErr is null && baseTok is not null
+            && new HashSet<string>(baseTok.Names).SetEquals(ErrorCheck.BaseMasters)
+            // a GROUP contributes no typed names — nothing here is a claim that a specific plugin is in scope
+            && baseTok.TypedNames.Count == 0,
+            $"err={baseTokErr} resolved=[{string.Join(",", baseTok?.Names ?? Array.Empty<string>())}] typed={baseTok?.TypedNames.Count}");
 
         var (implTok, implTokErr) = SweepExclusion.Resolve(
             new[] { SweepExclusion.ImplicitToken }, new[] { "Skyrim.esm", "ccBGSSSE001-Fish.esm", "_ResourcePack.esl" });
         Check("EXCLUDE-TOKEN-IMPLICIT: the group resolves to what the ORDER force-loads — where Creation Club and _ResourcePack live — and it is a superset of the base masters rather than a rival definition of vanilla",
-            implTokErr is null && implTok.Contains("ccBGSSSE001-Fish.esm") && implTok.Contains("_ResourcePack.esl")
-            && implTok.Contains("Skyrim.esm"),
-            $"err={implTokErr} resolved=[{string.Join(",", implTok)}]");
+            implTokErr is null && implTok is not null
+            && implTok.Names.Contains("ccBGSSSE001-Fish.esm") && implTok.Names.Contains("_ResourcePack.esl")
+            && implTok.Names.Contains("Skyrim.esm") && implTok.TypedNames.Count == 0,
+            $"err={implTokErr} resolved=[{string.Join(",", implTok?.Names ?? Array.Empty<string>())}]");
 
         var (_, unknownErr) = SweepExclusion.Resolve(new[] { "vanilla" }, Array.Empty<string>());
         Check("EXCLUDE-UNKNOWN-GROUP-REFUSES: a value that is neither a filename nor a known group refuses BEFORE the sweep and names both what a filename looks like and every group there is",
@@ -936,10 +974,13 @@ public static class CheckErrorsProbe
         var (stemOk, stemOkErr) = SweepExclusion.Resolve(new[] { "Skyrim.esm" }, Array.Empty<string>());
         Check("EXCLUDE-EXTENSIONLESS-NEVER-FUZZY-MATCHES: 'Skyrim' is refused as an unknown group and never resolved to Skyrim.esm; 'Skyrim.esm' is taken as the name it is",
             stemErr is not null && stemErr.Contains("'Skyrim'", StringComparison.Ordinal)
-            && stemOkErr is null && stemOk.SetEquals(new[] { "Skyrim.esm" }),
-            $"stem=[{stemErr}] withExt=[{stemOkErr}] resolved=[{string.Join(",", stemOk)}]");
+            && stemOkErr is null && stemOk is not null
+            && new HashSet<string>(stemOk.Names).SetEquals(new[] { "Skyrim.esm" })
+            // and a NAME is typed, which is what makes it a claim the scope must satisfy
+            && stemOk.TypedNames.SequenceEqual(new[] { "Skyrim.esm" }),
+            $"stem=[{stemErr}] withExt=[{stemOkErr}] resolved=[{string.Join(",", stemOk?.Names ?? Array.Empty<string>())}]");
 
-        var exMiss = ErrorCheck.Run(rb, null, 1000, null, null, ErrorFindingClass.All, false, new[] { "HcCeNotHere.esp" });
+        var exMiss = ErrorCheck.Run(rb, null, 1000, null, null, ErrorFindingClass.All, false, Excl("HcCeNotHere.esp"));
         Check("EXCLUDE-NAME-NOT-IN-SCOPE-REFUSES: an exclusion matching nothing is a refusal, not a no-op — the silent reading returns exactly the findings the caller asked to leave out, with nothing to say the spelling missed",
             !exMiss.Success && exMiss.Error is not null
             && exMiss.Error.Contains("HcCeNotHere.esp", StringComparison.Ordinal)
@@ -948,15 +989,171 @@ public static class CheckErrorsProbe
             exMiss.Error ?? "<no refusal>");
 
         var exAll = ErrorCheck.Run(rb, null, 1000, null, null, ErrorFindingClass.All, false,
-                                   new[] { "Skyrim.esm", "HcCeBaseMod.esp" });
+                                   Excl("Skyrim.esm", "HcCeBaseMod.esp"));
         Check("EXCLUDE-EMPTIES-THE-SCOPE-REFUSES: excluding everything in scope refuses with the count it removed, rather than returning a clean-looking sweep of nothing (Q3)",
             !exAll.Success && exAll.Error is not null
             && exAll.Error.Contains("removed every plugin", StringComparison.Ordinal)
             && exAll.Error.Contains("nothing left to check", StringComparison.Ordinal),
             exAll.Error ?? "<no refusal>");
 
+        // The separation the refusal above depends on: a GROUP member that is not in scope is the ordinary case,
+        // and only a name the CALLER TYPED is a claim the scope has to satisfy. Expanded and validated as one list,
+        // any narrowed plugins= refused any group token, naming a plugin the caller never wrote.
+        var exGroupNarrow = ErrorCheck.Run(rb, new[] { "HcCeBaseMod.esp" }, 1000, null, null,
+                                           ErrorFindingClass.All, false, Excl("base_masters"));
+        Check("EXCLUDE-GROUP-MEMBER-NOT-IN-SCOPE-IS-NOT-A-REFUSAL: a group token over a narrowed scope drops whichever members are present and says nothing about the rest — only a TYPED name must be in scope",
+            exGroupNarrow.Success && exGroupNarrow.PluginsScanned == 1
+            && exGroupNarrow.Reports.Any(x => x.Plugin == "HcCeBaseMod.esp"),
+            $"success={exGroupNarrow.Success} err=[{exGroupNarrow.Error}] scanned={exGroupNarrow.PluginsScanned}");
+
+        // A group can legitimately match nothing here. That is not an error — but the response must still say the
+        // scope was narrowed, or exclude= leaves no trace and the caller cannot tell it was honoured.
+        var exGroupEmpty = ErrorCheck.Run(rb, new[] { "HcCeBaseMod.esp" }, 1000, null, null,
+                                          ErrorFindingClass.All, false, Excl("base_masters"));
+        Check("EXCLUDE-EMPTY-GROUP-STILL-NOTED: an exclusion that removes nothing from THIS scope is still reported as a narrowing — an exclude= that leaves no trace reads as one that was ignored",
+            exGroupEmpty.FilterNote is { } egn && egn.Contains("exclude= left out", StringComparison.Ordinal),
+            $"note=[{exGroupEmpty.FilterNote}]");
+
+        var (_, blankErr) = SweepExclusion.Resolve(new[] { "  " }, Array.Empty<string>());
+        Check("EXCLUDE-BLANK-VALUE-REFUSES: a blank entry refuses and names both shapes, rather than being skipped as though it were absent",
+            blankErr is not null && blankErr.Contains("blank value", StringComparison.Ordinal)
+            && SweepExclusion.Tokens.All(t => blankErr.Contains(t, StringComparison.Ordinal)),
+            blankErr ?? "<no refusal>");
+
+        Check("EXCLUDE-NAME-CASE-INSENSITIVE: a filename is recognised whatever its case, because every other plugin-name match in this sweep is case-insensitive",
+            SweepExclusion.IsPluginName("MyMod.ESP") && SweepExclusion.IsPluginName("MyMod.EsM")
+            && !SweepExclusion.IsPluginName("MyMod"),
+            $"ESP={SweepExclusion.IsPluginName("MyMod.ESP")} EsM={SweepExclusion.IsPluginName("MyMod.EsM")} bare={SweepExclusion.IsPluginName("MyMod")}");
+
         Check("EXCLUDE-DESCRIPTION-NAMES-EVERY-GROUP: the caller-facing token list is held against SweepExclusion.Tokens, the one place they are enumerated — no wire-name guard reaches a tool parameter's prose (#386), so this parameter brings its own",
             ExcludeDescriptionNamesTokens(out var descDetail), descDetail);
+
+        // ---- the accounting's central identity, on a fixture where BOTH causes fired. Every other cell is cut by
+        //      one truncator or the other; the live-order default shape is both at once, and it is the shape the
+        //      class exists for. Without this, the second cause clause could be dropped outright and stay green.
+        var bothCut = ErrorCheck.Run(rm, null, 100);
+        var bothText = Wire.RenderCheckErrors(bothCut, 4000);
+        var bothJson = JsonDocument.Parse(JsonWire.RenderCheckErrors(bothCut, 4000)).RootElement.GetProperty("accounting");
+        int bothVisible = bothText.Split("-> ").Length - 1;
+        Check("BOTH-CAUSES-SUM-TO-THE-WHOLE: with the budget AND the response both cutting, each cause is stated and the two sum EXACTLY to found minus visible — the identity the accounting is built on",
+            bothJson.GetProperty("dangling_missing_by_budget").GetInt32() > 0
+            && bothJson.GetProperty("dangling_missing_by_response_cut").GetInt32() > 0
+            && bothJson.GetProperty("dangling_missing_by_budget").GetInt32()
+               + bothJson.GetProperty("dangling_missing_by_response_cut").GetInt32()
+               == bothJson.GetProperty("dangling_found").GetInt32() - bothJson.GetProperty("dangling_visible").GetInt32()
+            && bothText.Contains("were never listed: the listing budget (limit=100) ran out", StringComparison.Ordinal)
+            && bothText.Contains("did not fit this response (max_chars=4000)", StringComparison.Ordinal)
+            && bothText.Contains($"[accounting: {bothVisible} of the {bothCut.TotalDangling} ", StringComparison.Ordinal),
+            $"budget={bothJson.GetProperty("dangling_missing_by_budget").GetInt32()} cut={bothJson.GetProperty("dangling_missing_by_response_cut").GetInt32()} found={bothCut.TotalDangling} visible={bothVisible}");
+
+        // ---- the roster's one advance over the split it replaces: a plugin whose entries the BUDGET listed and the
+        //      RESPONSE then dropped. Every other roster cell runs on a budget cut, so a roster that only ever
+        //      reported the budget's omissions would pass all of them.
+        var cutOnly = ErrorCheck.Run(rm, null, 1000);
+        var cutOnlyJson = JsonDocument.Parse(JsonWire.RenderCheckErrors(cutOnly, 3000)).RootElement;
+        Check("ROSTER-IS-RENDER-AWARE: on a sweep the budget never capped, the by-source roster still names the plugins THIS RESPONSE is missing entries for — under the superseded split those plugins appeared in no sentence at all",
+            cutOnlyJson.GetProperty("accounting").GetProperty("dangling_missing_by_budget").GetInt32() == 0
+            && cutOnlyJson.GetProperty("accounting").GetProperty("dangling_missing_by_response_cut").GetInt32() > 0
+            && JsonRoster(JsonWire.RenderCheckErrors(cutOnly, 3000)).Length > 0,
+            $"budget={cutOnlyJson.GetProperty("accounting").GetProperty("dangling_missing_by_budget").GetInt32()} roster=[{string.Join(",", JsonRoster(JsonWire.RenderCheckErrors(cutOnly, 3000)))}]");
+
+        // ---- #361's OTHER lane: findings= excluding 'dangling'. The sweep lists nothing, so the listing accounting
+        //      is absent by design — but the render still cuts SECTIONS, and that must still be stated. Gated on the
+        //      listing lane, this arm's shape was silent: the cheap "is any master missing anywhere" sweep returned
+        //      a truncated answer that read as whole.
+        var mastersManyText = Wire.RenderCheckErrors(mastersMany, 1200);
+        int mastersManySections = mastersManyText.Split("[ERROR] ").Length - 1;
+        Check("SECTIONS-CUT-STATED-WITH-NO-LISTING-LANE (#361): findings=[missing_masters] lists no dangling refs, so there is no listing accounting to make — and a response that dropped sections still says how many of how many it rendered",
+            mastersMany.Reports.Count > mastersManySections && mastersManySections > 0
+            && mastersManyText.Contains($"{mastersManySections} of {mastersMany.Reports.Count} plugin section(s) were rendered", StringComparison.Ordinal)
+            && mastersManyText.Contains("Raise max_chars= to fit more", StringComparison.Ordinal)
+            // and it makes NO listing claim, because nothing was listed
+            && !mastersManyText.Contains("found by this sweep appear above", StringComparison.Ordinal),
+            $"rendered={mastersManySections} of {mastersMany.Reports.Count} line=[{AccountingLine(mastersManyText)}]");
+
+        Check("SECTIONS-COMPLETE-MAKES-NO-CLAIM: the same lane, uncut, states nothing at all — a lane that lists nothing has no completeness to assert, and an accounting line there would be noise",
+            Wire.RenderCheckErrors(mastersMany, 0) is var mastersManyWhole
+            && !mastersManyWhole.Contains("[accounting:", StringComparison.Ordinal),
+            AccountingLine(Wire.RenderCheckErrors(mastersMany, 0)));
+
+        // ---- the overrun notice, in BOTH directions and followed to the letter.
+        Check("OVERRUN-NOTICE-ONLY-WHEN-OVER: a response inside its cap never claims to be longer than it — the notice is measured off the finished response, not predicted from the reserve",
+            Wire.RenderCheckErrors(manyAmple, 0) is var wholeResp
+            && !wholeResp.Contains("raise it to at least", StringComparison.Ordinal)
+            && Wire.RenderCheckErrors(manyAmple, 20000) is var roomy
+            && roomy.Length <= 20000 && !roomy.Contains("raise it to at least", StringComparison.Ordinal),
+            $"unbounded={Wire.RenderCheckErrors(manyAmple, 0).Length} at20k={Wire.RenderCheckErrors(manyAmple, 20000).Length}");
+
+        Check("OVERRUN-REMEDY-CLEARS-IT: raising max_chars to the number the notice names actually removes the notice — a remedy is a claim about a call that has not happened, so the arm makes the call",
+            RemedyClearsTheNotice(manyAmple, out var remedyFail), remedyFail);
+
+        // ---- the two honesty-layer row counts, both directions. They can each be a no-op and print
+        //      "0 of 1 plugin(s) that could not be parsed are named above" over a response that named it.
+        var withExcluded = ErrorCheck.Run(rm, null, 1000) with
+        {
+            ExcludedPlugins = new Dictionary<string, string> { ["HcCeBroken.esp"] = "header could not be parsed" },
+        };
+        Check("EXCLUDED-ROWS-COUNTED-WHEN-NAMED: a response that names every unparseable plugin makes NO claim about them — the clause exists only where rows were dropped",
+            Wire.RenderCheckErrors(withExcluded, 0) is var exWhole
+            && exWhole.Contains("HcCeBroken.esp", StringComparison.Ordinal)
+            && !exWhole.Contains("that could not be parsed are named above", StringComparison.Ordinal)
+            && JsonDocument.Parse(JsonWire.RenderCheckErrors(withExcluded, 0)).RootElement
+                 .GetProperty("accounting").GetProperty("excluded_plugins_named").GetInt32() == 1,
+            AccountingLine(Wire.RenderCheckErrors(withExcluded, 0)));
+
+        Check("EXCLUDED-ROWS-COUNTED-WHEN-DROPPED: when the cap leaves no room for the roster, the accounting says how many of how many were named — and json's own count agrees with the text",
+            Wire.RenderCheckErrors(withExcluded, 3000) is var exCut
+            && (exCut.Contains("0 of 1 plugin(s) that could not be parsed are named above", StringComparison.Ordinal)
+                || !exCut.Contains("HcCeBroken.esp", StringComparison.Ordinal) == false),
+            AccountingLine(Wire.RenderCheckErrors(withExcluded, 3000)));
+
+        // ---- json's §2.1 in-band fields, in both directions and in the lane that has them.
+        var jsonWhole = JsonDocument.Parse(JsonWire.RenderCheckErrors(ErrorCheck.Run(rm, null, 1000), 0)).RootElement;
+        Check("JSON-INBAND-FIELDS-BOTH-DIRECTIONS: capped and truncated are FALSE on a complete response and TRUE on a cut one, and plugins_with_findings/rendered agree with the document",
+            !jsonWhole.GetProperty("capped").GetBoolean() && !jsonWhole.GetProperty("truncated").GetBoolean()
+            && jsonWhole.GetProperty("rendered").GetInt32() == jsonWhole.GetProperty("plugins").GetArrayLength()
+            && JsonDocument.Parse(JsonWire.RenderCheckErrors(ErrorCheck.Run(rm, null, 100), 0)).RootElement
+                 .GetProperty("capped").GetBoolean(),
+            $"capped={jsonWhole.GetProperty("capped").GetBoolean()} truncated={jsonWhole.GetProperty("truncated").GetBoolean()}");
+
+        // counts_only has no listing, so the four listing fields are ABSENT rather than zero — written
+        // unconditionally they reported a 240-finding sweep as plugins_with_findings 0.
+        var countsJsonDoc = JsonDocument.Parse(JsonWire.RenderCheckErrors(baseCounts, 0)).RootElement;
+        Check("JSON-INBAND-FIELDS-ABSENT-UNDER-COUNTS-ONLY: the listing lane's four fields are not written where there is no listing — a field named for one lane's subject must be absent in the other, never 0",
+            !countsJsonDoc.TryGetProperty("plugins_with_findings", out _)
+            && !countsJsonDoc.TryGetProperty("rendered", out _)
+            && !countsJsonDoc.TryGetProperty("truncated", out _)
+            && !countsJsonDoc.TryGetProperty("capped", out _)
+            && countsJsonDoc.GetProperty("accounting").GetProperty("listing").GetBoolean() == false,
+            "counts_only json");
+
+        // ---- a section's OTHER findings ride the whole-or-absent rule too. No listing-lane fixture carried a scan
+        //      error or an unscannable record, so those two appends could be deleted outright and stay green.
+        var withScanError = ErrorCheck.Run(rm, null, 1000);
+        var scarred = withScanError with
+        {
+            Reports = withScanError.Reports.Select((x, i) => i == 0
+                ? new PluginErrors(x.Plugin, x.Dangling, x.MissingMasters, 4,
+                                   new[] { "0BCC84:HcCeMany00.esp — InvalidDataException: body could not be parsed" },
+                                   "record enumeration aborted partway: InvalidDataException: truncated group")
+                : x).ToList(),
+        };
+        var scarredWhole = Wire.RenderCheckErrors(scarred, 0);
+        bool scarredSections = SectionsWhole(new[] { scarred }, out var scarredFail);
+        Check("SECTION-CARRIES-ITS-OTHER-FINDINGS: a rendered section shows its scan error and its unscannable-record count, and both ride the whole-or-absent rule rather than being dropped a line at a time",
+            scarredWhole.Contains("scan error: record enumeration aborted partway", StringComparison.Ordinal)
+            && scarredWhole.Contains("4 record(s) could not be scanned", StringComparison.Ordinal)
+            && scarredWhole.Contains("body could not be parsed", StringComparison.Ordinal)
+            && scarredSections,
+            $"scanError={scarredWhole.Contains("scan error:", StringComparison.Ordinal)} sections=[{scarredFail}]");
+
+        var countsForHisto = ErrorCheck.Run(rm, null, 1000, null, null, ErrorFindingClass.All, true);
+        var hCut = Wire.RenderCheckErrors(countsForHisto, 1500);      // stopped by the response
+        var hRows = Wire.RenderCheckErrors(countsForHisto, 0, 3);     // stopped by the row limit
+        Check("HISTOGRAM-REMEDY-NAMES-ITS-CAUSE: a histogram cut by the response offers max_chars=, one cut by the row limit offers limit= — the knob that stopped it, not the other one",
+            hCut.Contains("more row(s) — raise max_chars= to see them", StringComparison.Ordinal)
+            && hRows.Contains("more row(s) — raise limit= to see them", StringComparison.Ordinal),
+            $"budget-cut={hCut.Contains("raise max_chars=", StringComparison.Ordinal)} row-cut={hRows.Contains("raise limit=", StringComparison.Ordinal)}");
 
         // ---- a record scope can admit nothing from a base master the sweep opened. "Swept" has to mean examined.
         var modOnlyScope = ErrorCheck.Run(rb, null, 1000, null, new SweepScope(null, "HcCeModNpc", null, null));
@@ -1106,10 +1303,15 @@ public static class CheckErrorsProbe
         return bad.Count == 0;
     }
 
-    /// <summary>The exclude= parameter's [Description] must name every token SweepExclusion accepts, and no word it
-    /// does not. A tool parameter's prose is a SECOND spelling of an accepted vocabulary, on a surface no existing
-    /// guard reads (#386) — so a token added to the list and not to the description would be undiscoverable, and one
-    /// named in the description and not accepted would be refused when a caller believed the docs.</summary>
+    /// <summary>The exclude= parameter's [Description] must name every token SweepExclusion accepts. A tool
+    /// parameter's prose is a SECOND spelling of an accepted vocabulary, on a surface no existing guard reads
+    /// (#386), so a token added to the set and not to the description would be undiscoverable.
+    ///
+    /// <para>The converse — a word in the description that is NOT an accepted token — is deliberately not checked:
+    /// the description is prose, and every ordinary word in it would have to be exempted. What protects that
+    /// direction is EXCLUDE-UNKNOWN-GROUP-REFUSES, which proves an unaccepted value refuses by name and lists the
+    /// real set, so a caller who believes a wrong word in the docs is told immediately rather than served
+    /// silently.</para></summary>
     static bool ExcludeDescriptionNamesTokens(out string detail)
     {
         var param = typeof(ReadTools).GetMethod(nameof(ReadTools.CheckErrorsTool))?
@@ -1122,6 +1324,37 @@ public static class CheckErrorsProbe
         detail = missing.Count == 0 ? $"names all {SweepExclusion.Tokens.Length} token(s)"
                                     : "not named in the description: " + string.Join(", ", missing);
         return missing.Count == 0;
+    }
+
+    /// <summary>Resolve an exclude= the way the service does, so an arm states the caller's spelling rather than
+    /// the expanded set.</summary>
+    static SweepExclusion.Resolved? Excl(params string[] values)
+    {
+        var (set, err) = SweepExclusion.Resolve(values, new[] { "Skyrim.esm" });
+        if (err is not null) throw new InvalidOperationException("fixture exclude= did not resolve: " + err);
+        return set;
+    }
+
+    /// <summary>Follow the overrun notice's own remedy: read the number it tells the caller to raise max_chars to,
+    /// re-render at exactly that, and see whether the notice is gone. A remedy is a claim about a call that has not
+    /// happened, so the only honest way to hold it is to make the call (CLAUDE.md §5 #11).</summary>
+    static bool RemedyClearsTheNotice(ErrorCheckResult r, out string detail)
+    {
+        var bad = new List<string>();
+        foreach (int cap in new[] { 120, 250, 400, 700, 1200, 2000, 3000 })
+        {
+            var text = Wire.RenderCheckErrors(r, cap);
+            int at = text.IndexOf("raise it to at least ", StringComparison.Ordinal);
+            if (at < 0) { if (text.Length > cap) bad.Add($"text@{cap} over by {text.Length - cap} with no notice"); continue; }
+            var digits = new string(text[(at + 21)..].TakeWhile(char.IsDigit).ToArray());
+            if (!int.TryParse(digits, out int raised)) { bad.Add($"text@{cap} notice names no number"); continue; }
+            var again = Wire.RenderCheckErrors(r, raised);
+            if (again.Contains("raise it to at least", StringComparison.Ordinal))
+                bad.Add($"text@{cap} said raise to {raised}; at {raised} the notice fired again (len {again.Length})");
+            if (again.Length > raised) bad.Add($"text@{cap}->{raised} still over by {again.Length - raised}");
+        }
+        detail = bad.Count == 0 ? "every overrun notice cleared at the number it named" : string.Join("; ", bad.Take(3));
+        return bad.Count == 0;
     }
 
     /// <summary>The cap invariant, swept: for a range of max_chars values, NEITHER transport may return more than it

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -866,6 +866,9 @@ public static class CheckErrorsProbe
         Check("RESPONSE-NEVER-EXCEEDS-MAX-CHARS (#361): the accounting and the boundary are RESERVED before the body renders, so neither is appended past the cap — across a sweep of caps, in both transports",
             CapSweep(manyAmple, out var capFail), capFail);
 
+        Check("SECTION-IS-WHOLE-OR-ABSENT: across a sweep of caps, a section that starts also carries everything it has to say — the only things a cut may drop are a whole section or an entry, which are the two the accounting states",
+            SectionsWhole(new[] { manyAmple, tight, ErrorCheck.Run(r, null, 1000) }, out var wholeFail), wholeFail);
+
         Check("RESPONSE-CUT-COMPLETE-RESPONSE-SAYS-SO: an uncut, unbudgeted response states its completeness rather than staying silent — silence used to mean both 'complete' and #361",
             manyText.Contains("dangling ref(s) found by this sweep appear above", StringComparison.Ordinal)
             && !manyText.Contains("did not fit this response", StringComparison.Ordinal)
@@ -1001,6 +1004,46 @@ public static class CheckErrorsProbe
         return acct.GetProperty("dangling_missing_by_source").EnumerateArray()
                    .Select(e => e.GetProperty("plugin").GetString() + ":" + e.GetProperty("count").GetInt32())
                    .ToArray();
+    }
+
+    /// <summary>The whole-or-absent rule, swept over caps. A section says more than its dangling entries — a scan
+    /// error, the missing masters it declares, how many records could not be read — and none of those is an entry,
+    /// so no accounting subject covers them one at a time. They are emitted with the section head or the section is
+    /// not started, and this holds the render to that: every head has its dangling header, every header has its
+    /// head, and the head count is what the accounting reports as rendered.
+    ///
+    /// <para>The tool's own parameter text promises master-table findings are "always listed in full". Under a
+    /// per-line drop that sentence was false at any cap tight enough to reach it.</para></summary>
+    static bool SectionsWhole(IReadOnlyList<ErrorCheckResult> results, out string detail)
+    {
+        var bad = new List<string>();
+        foreach (var r in results)
+            foreach (int cap in new[] { 400, 900, 1500, 2500, 4000, 9000, 30000 })
+            {
+                var text = Wire.RenderCheckErrors(r, cap);
+                int heads = text.Split("[ERROR] ").Length - 1;
+                int headers = text.Split("  dangling reference(s) (").Length - 1;
+                int withDangling = 0, rendered = 0;
+                foreach (var pl in r.Reports)
+                {
+                    if (!text.Contains("[ERROR] " + pl.Plugin + "\n", StringComparison.Ordinal)) continue;
+                    rendered++;
+                    if (pl.Dangling.Count > 0) withDangling++;
+                    // a section that declares missing masters must show them where it appears at all
+                    if (pl.MissingMasters.Count > 0
+                        && !text.Contains("  missing master(s): " + string.Join(", ", pl.MissingMasters), StringComparison.Ordinal))
+                        bad.Add($"@{cap} {pl.Plugin} rendered without its missing-master line");
+                }
+                if (headers != withDangling)
+                    bad.Add($"@{cap} {headers} dangling header(s) for {withDangling} rendered section(s) that have refs");
+                if (heads != rendered)
+                    bad.Add($"@{cap} {heads} head(s) but {rendered} section(s) matched by name");
+                var acctLine = AccountingLine(text);
+                if (rendered < r.Reports.Count && !acctLine.Contains($"{rendered} of {r.Reports.Count} plugin section(s) were rendered", StringComparison.Ordinal))
+                    bad.Add($"@{cap} rendered {rendered} of {r.Reports.Count} but the accounting does not say so");
+            }
+        detail = bad.Count == 0 ? "every section whole at every cap" : string.Join("; ", bad.Take(4));
+        return bad.Count == 0;
     }
 
     /// <summary>The cap invariant, swept: for a range of max_chars values, NEITHER transport may return more than it

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -1357,10 +1357,52 @@ public static class CheckErrorsProbe
         int hCap = PartialHistogramCap(countsForHisto);
         var hCut = Wire.RenderCheckErrors(countsForHisto, hCap);      // stopped by the response
         var hRows = Wire.RenderCheckErrors(countsForHisto, 0, 3);     // stopped by the row limit
+        // PER AXIS, both of them. Read as one substring test over the whole response, this arm was satisfied by
+        // whichever axis happened to be right: hRows.Contains("raise limit=") is true of the TARGET axis, so nothing
+        // ever looked at the SOURCE one — which at limit=3 rendered no rows at all, under a remedy naming max_chars=,
+        // at a cap 79,000 chars short of biting.
+        var rowsTarget = HistogramAxis(hRows, TargetAxis);
+        var rowsSource = HistogramAxis(hRows, SourceAxis);
+        var cutTarget = HistogramAxis(hCut, TargetAxis);
+        var cutSource = HistogramAxis(hCut, SourceAxis);
         Check("HISTOGRAM-REMEDY-NAMES-ITS-CAUSE: a histogram cut by the response offers max_chars=, one cut by the row limit offers limit= — the knob that stopped it, not the other one",
-            hCut.Contains("more row(s) — raise max_chars= to see them", StringComparison.Ordinal)
-            && hRows.Contains("more row(s) — raise limit= to see them", StringComparison.Ordinal),
-            $"cap={hCap} budget-cut={hCut.Contains("raise max_chars=", StringComparison.Ordinal)} row-cut={hRows.Contains("raise limit=", StringComparison.Ordinal)}");
+            cutTarget.Knob == "max_chars=" && rowsTarget.Knob == "limit=",
+            $"cap={hCap} budget-cut={cutTarget.Knob} row-cut={rowsTarget.Knob}");
+
+        Check("HISTOGRAM-AXES-CUT-INDEPENDENTLY: at limit=3 over two 200-row axes, EACH renders its three rows and states its own 197 against limit= — one axis's stop is not the other's, and a remedy is only offered by the axis it applies to",
+            rowsTarget.Rows == 3 && rowsTarget.Stated == 197 && rowsTarget.Knob == "limit="
+            && rowsSource.Rows == 3 && rowsSource.Stated == 197 && rowsSource.Knob == "limit=",
+            $"target={rowsTarget} source={rowsSource}");
+
+        // The other direction, or the arm above passes on a render that cuts nothing: with room and no row limit,
+        // both axes carry all 200 rows and neither states a cut.
+        var hWhole = Wire.RenderCheckErrors(countsForHisto, 0);
+        var wholeTarget = HistogramAxis(hWhole, TargetAxis);
+        var wholeSource = HistogramAxis(hWhole, SourceAxis);
+        Check("HISTOGRAM-AXES-WHOLE-WHEN-NOTHING-CUTS: with neither knob biting, each axis renders every one of its 200 rows and states no cut at all",
+            wholeTarget.Rows == 200 && wholeTarget.Stated == -1
+            && wholeSource.Rows == 200 && wholeSource.Stated == -1,
+            $"target={wholeTarget} source={wholeSource}");
+
+        // An EMPTY first axis must not take the second down with it: its empty-case line goes through the same
+        // emission path, and one shared subject meant a refusal there refused every row of the axis below.
+        var emptyTarget = countsForHisto with { Histogram = Array.Empty<SweepCount>() };
+        var emptyTargetText = Wire.RenderCheckErrors(emptyTarget, 0);
+        Check("HISTOGRAM-EMPTY-AXIS-DOES-NOT-SILENCE-THE-NEXT: when the TARGET axis has nothing to tally, the SOURCE axis still renders all 200 of its rows",
+            emptyTargetText.Contains("by TARGET plugin (the plugin the broken refs point INTO): nothing to tally", StringComparison.Ordinal)
+            && HistogramAxis(emptyTargetText, SourceAxis).Rows == 200,
+            $"source={HistogramAxis(emptyTargetText, SourceAxis)}");
+
+        // The json twin of the same result. It never stated a cause at all, so the two transports disagreed about one
+        // sweep: text named a knob and json wrote nothing. Both now read the SAME closing computation.
+        var hRowsJson = JsonDocument.Parse(JsonWire.RenderCheckErrors(countsForHisto, 0, 3)).RootElement;
+        var hWholeJson = JsonDocument.Parse(JsonWire.RenderCheckErrors(countsForHisto, 0)).RootElement;
+        Check("HISTOGRAM-JSON-STATES-THE-SAME-CUT: each json axis carries distinct/rendered and the knob that stopped it, matching its text twin row for row — a cut that reads as a remedy in one transport must not be silent in the other",
+            JsonAxis(hRowsJson, "dangling_by_target_plugin") == (200, 3, "limit")
+            && JsonAxis(hRowsJson, "dangling_by_source_plugin") == (200, 3, "limit")
+            && JsonAxis(hWholeJson, "dangling_by_target_plugin") == (200, 200, null)
+            && JsonAxis(hWholeJson, "dangling_by_source_plugin") == (200, 200, null),
+            $"cut target={JsonAxis(hRowsJson, "dangling_by_target_plugin")} source={JsonAxis(hRowsJson, "dangling_by_source_plugin")} whole target={JsonAxis(hWholeJson, "dangling_by_target_plugin")}");
 
         // ---- a record scope can admit nothing from a base master the sweep opened. "Swept" has to mean examined.
         var modOnlyScope = ErrorCheck.Run(rb, null, 1000, null, new SweepScope(null, "HcCeModNpc", null, null));
@@ -1702,6 +1744,46 @@ public static class CheckErrorsProbe
         if (at < 0) return -1;
         var digits = new string(note[(at + lead.Length)..].TakeWhile(char.IsDigit).ToArray());
         return int.TryParse(digits, out var n) ? n : -1;
+    }
+
+    /// <summary>The two counts_only axes, by the words that distinguish them in the render. Named here so an arm
+    /// cannot ask about "the histogram" and be answered by whichever of the two happens to fit.</summary>
+    const string TargetAxis = "TARGET plugin";
+    const string SourceAxis = "SOURCE plugin";
+
+    /// <summary>What ONE named histogram axis rendered: how many rows, the number its closing line states, and the
+    /// knob that line names. Per axis rather than over the whole response, because a substring test over both is
+    /// satisfied by either — which is how an axis that rendered nothing at all, under a remedy for a knob that
+    /// would not have moved it, sat green through two review rounds.
+    /// <para><c>Stated</c> is -1 and <c>Knob</c> "&lt;none&gt;" where the axis states no cut; <c>Rows</c> is -1 where
+    /// the axis is not in the response at all, which must never read the same as an axis that rendered zero.</para>
+    /// </summary>
+    static (int Rows, int Stated, string Knob) HistogramAxis(string text, string axis)
+    {
+        const string lead = "\ndangling ref(s) by ";
+        int at = text.IndexOf(lead + axis, StringComparison.Ordinal);
+        if (at < 0) return (-1, -1, "<absent>");
+        int end = text.IndexOf(lead, at + lead.Length, StringComparison.Ordinal);
+        var seg = end < 0 ? text[at..] : text[at..end];
+        var lines = seg.Split('\n');
+        int rows = lines.Count(l => l.StartsWith("  ", StringComparison.Ordinal)
+                                 && !l.StartsWith("  ...", StringComparison.Ordinal)
+                                 && l.Trim().Length > 0);
+        const string cutLead = "more row(s) — raise ";
+        int c = seg.IndexOf(cutLead, StringComparison.Ordinal);
+        if (c < 0) return (rows, -1, "<none>");
+        var stated = new string(seg[..c].Reverse().SkipWhile(ch => ch == ' ').TakeWhile(char.IsDigit).Reverse().ToArray());
+        var knob = new string(seg[(c + cutLead.Length)..].TakeWhile(ch => ch != ' ').ToArray());
+        return (rows, int.TryParse(stated, out var n) ? n : -1, knob);
+    }
+
+    /// <summary>The json twin of <see cref="HistogramAxis"/>: the axis object's own three facts. A missing object
+    /// answers (-1, -1, "&lt;absent&gt;") for the same reason.</summary>
+    static (int Distinct, int Rendered, string? CutBy) JsonAxis(JsonElement root, string name)
+    {
+        if (!root.TryGetProperty(name, out var h)) return (-1, -1, "<absent>");
+        var cut = h.TryGetProperty("cut_by", out var cb) && cb.ValueKind != JsonValueKind.Null ? cb.GetString() : null;
+        return (h.GetProperty("distinct").GetInt32(), h.GetProperty("rendered").GetInt32(), cut);
     }
 
     /// <summary>The size the empty-scope refusal claims for the scope it emptied, or -1 where it claims none. Read as

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -117,6 +117,15 @@ namespace HousecarlGenerator;
 ///   per-record link-walk fault isolation is the SAME try/catch idiom proven by effect-chain-guard + the cross_plugin_query
 ///   scan. The sweep surfaces both verbatim (ExcludedPlugins + the unscannable accounting), it does not re-implement them.
 ///
+/// THE ASSERTION RULE (pinned here after this guard shipped a tautology through two review rounds): AN INVARIANT
+///   ARM ASSERTS AGAINST A FIXTURE-KNOWN EXPECTED VALUE — NEVER AGAINST A PHRASE THE RENDER ITSELF EMITS. The cap
+///   invariant excused every overrun that contained "raise it to at least"; the render appends that notice to every
+///   response longer than its cap, so the arm could not fail and the two folds it was meant to pin were pinned by
+///   nothing. A number the fixture knows (a length, a count, a total the sweep computed) can be wrong and be caught;
+///   a substring the response composed about itself agrees with the response by construction. Where an arm must read
+///   the render's own words — following a remedy to the number it names, say — the words locate the value and the
+///   ASSERTION is still made against something measured independently.
+///
 /// Run: dotnet run --project src/housecarl-generator -- check-errors-guard
 /// </summary>
 public static class CheckErrorsProbe
@@ -1357,27 +1366,61 @@ public static class CheckErrorsProbe
         return bad.Count == 0;
     }
 
+    /// <summary>The caps this invariant is swept over. It used to step 3000 -> 8000, straight over the 4000-7000 band
+    /// the fat-head fixture's plugin object actually bites in: the arm's one real defect lived in a gap in its own
+    /// ladder. The band is now walked rather than jumped.</summary>
+    static readonly int[] CapLadder = { 120, 300, 700, 900, 1500, 3000, 4000, 4500, 5000, 5270, 6000, 7000, 8000, 40000 };
+
     /// <summary>The cap invariant, swept: for a range of max_chars values, NEITHER transport may return more than it
-    /// was given — unless the response says it overran, which is the one declared arm (a cap smaller than the
-    /// accounting itself, which is never dropped). A single cap would pass by luck; the sweep is what makes the
-    /// invariant a claim rather than an anecdote.</summary>
+    /// was given — with ONE legitimate exception, recognised by a FIXTURE-KNOWN LENGTH rather than by a phrase the
+    /// response emits about itself.
+    ///
+    /// <para><b>What this arm used to be, and why it could never fail.</b> It excused any overrun in a response
+    /// containing "raise it to at least". But <c>CheckAccounting.CapTooSmall</c> returns non-null for EVERY response
+    /// longer than its cap and both renders append the notice whenever it is non-null — so an over-cap response
+    /// always carries that phrase, the second conjunct was dead, and the flagship #361 cell was a tautology for two
+    /// whole review rounds. The json twin had the identical shape with <c>max_chars_overrun</c>.</para>
+    ///
+    /// <para><b>The FLOOR is the expected value.</b> The only response that may legitimately run over is the one with
+    /// no body in it at all — header, accounting and boundary, which are reserved and never dropped. That length is a
+    /// property of the FIXTURE: render it at a cap no body can fit under (1) and measure. Every response is then held
+    /// to <c>max(cap, floor + slack)</c>, so a single emitted body unit puts an over-cap response past the floor and
+    /// the arm goes red. The slack covers the one thing that moves the floor between caps — max_chars is printed
+    /// inside the accounting and again inside the overrun notice, so a wider cap widens the floor by its own digits.
+    /// It is bounded by digit width (<see cref="FloorSlack"/>), not by plausibility.</para>
+    ///
+    /// <para><b>What it does NOT bound, stated rather than implied:</b> anything the render emits UNCONDITIONALLY is
+    /// inside the floor it is measured against, so this arm cannot see it. HISTOGRAM-FRAMING-IS-BOUNDED is the arm
+    /// that holds that surface.</para></summary>
     static bool CapSweep(ErrorCheckResult r, out string detail)
     {
         var bad = new List<string>();
-        foreach (int cap in new[] { 120, 300, 700, 900, 1500, 3000, 8000, 40000 })
+        // The irreducible response, per transport, measured off the fixture once.
+        int textFloor = Wire.RenderCheckErrors(r, 1).Length;
+        int jsonFloor = JsonWire.RenderCheckErrors(r, 1).Length;
+        foreach (int cap in CapLadder)
         {
             var text = Wire.RenderCheckErrors(r, cap);
             var json = JsonWire.RenderCheckErrors(r, cap);
-            if (text.Length > cap && !text.Contains("raise it to at least", StringComparison.Ordinal))
-                bad.Add($"text@{cap}={text.Length} with no overrun notice");
-            if (json.Length > cap && !json.Contains("max_chars_overrun", StringComparison.Ordinal))
-                bad.Add($"json@{cap}={json.Length} with no overrun notice");
+            int textAllowed = Math.Max(cap, textFloor + FloorSlack(cap));
+            int jsonAllowed = Math.Max(cap, jsonFloor + FloorSlack(cap));
+            if (text.Length > textAllowed)
+                bad.Add($"text@{cap}={text.Length} over the allowed {textAllowed} (floor {textFloor})");
+            if (json.Length > jsonAllowed)
+                bad.Add($"json@{cap}={json.Length} over the allowed {jsonAllowed} (floor {jsonFloor})");
             try { JsonDocument.Parse(json); }
             catch (Exception ex) { bad.Add($"json@{cap} is not valid json: {ex.GetType().Name}"); }
         }
-        detail = bad.Count == 0 ? "every cap honoured, or overrun declared" : string.Join("; ", bad);
+        detail = bad.Count == 0 ? $"every cap honoured, or bounded by the floor (text {textFloor} / json {jsonFloor})"
+                                : string.Join("; ", bad);
         return bad.Count == 0;
     }
+
+    /// <summary>How much the floor may grow between the cap it was measured at and the cap under test. max_chars is
+    /// printed inside the accounting's by-cut clause and inside the overrun notice (which also prints the number to
+    /// raise to and the length reached) — four printed numbers, each bounded by the cap's own digit width. Four
+    /// digits of headroom per place, not a round number chosen for comfort.</summary>
+    static int FloorSlack(int cap) => 4 * cap.ToString().Length;
 
     internal static bool JsonHasHistogram(string json, string prop)
     {

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -1671,6 +1671,43 @@ public static class CheckErrorsProbe
             && twoAxesText.Contains("by SOURCE plugin", StringComparison.Ordinal),
             $"note occurrences={twoAxesText.Split("counts_only=true — totals above are exact", StringSplitOptions.None).Length - 1}");
 
+        // ---- a lane that cannot write an accounting line must not hold room for one.
+        // The plain counts_only lane declares no listing subject and has nothing unread or unparseable, so
+        // CheckAccounting.TextLine() is null for every value it could be handed. Reserved unconditionally, that
+        // lane still held the worst-case accounting out of max_chars — dead body budget in exactly the lane #392
+        // is about, where the room comes out of the histograms. Both directions, or the arm passes on a reserve
+        // that holds nothing anywhere.
+        var plainCounts = HistogramSized(rm, 3) with { Reports = Array.Empty<PluginErrors>(), ExcludedPlugins = new Dictionary<string, string>() };
+        var statingCounts = plainCounts with { Reports = UnreadSized(rm, 4).Reports };
+        int boundary = ReadSentences.SweepBoundary.Length + ReadSentences.SweepBoundaryLabel.Length;
+        var plainAcct = new CheckAccounting(plainCounts, 80000);
+        var statingAcct = new CheckAccounting(statingCounts, 80000);
+        int plainOver = plainAcct.TextReserve - boundary, statingOver = statingAcct.TextReserve - boundary;
+        Check("ACCOUNTING-RESERVE-IS-LANE-AWARE: a lane whose accounting line cannot be written reserves the boundary and nothing else, and a lane that CAN write one still reserves its worst case — a reserve is room for a specific sentence, and room held for a sentence this lane cannot write is a subtraction from the answer",
+            plainAcct.TextLine() is null && plainOver <= 32
+            && statingAcct.TextLine() is not null && statingOver >= 150,
+            $"plain: line={plainAcct.TextLine() ?? "(null)"} reserve-beyond-boundary={plainOver}; stating: reserve-beyond-boundary={statingOver}");
+
+        // …and what the caller gets for it: the room goes back to the rows. Same result, same cap, one unread
+        // plugin apart — the lane that has something to account for reserves more and renders fewer rows, and the
+        // plain lane must not be paying that price for a sentence it never writes.
+        var rowsBad = new List<string>();
+        int strictlyMore = 0, mostBy = 0;
+        for (int cap = 900; cap <= 2400; cap += 20)
+        {
+            int plainRows = HistogramAxis(Wire.RenderCheckErrors(plainCounts, cap), TargetAxis).Rows;
+            int statingRows = HistogramAxis(Wire.RenderCheckErrors(statingCounts, cap), TargetAxis).Rows;
+            // Never FEWER at any cap: the lane with nothing to account for cannot be the one paying for the
+            // accounting. Both at zero is a cap below either floor and says nothing either way, which is why the
+            // arm also needs the second half rather than the band being trimmed until it passes.
+            if (plainRows < statingRows) rowsBad.Add($"@{cap} plain={plainRows} FEWER than stating={statingRows}");
+            if (plainRows > statingRows) { strictlyMore++; mostBy = Math.Max(mostBy, plainRows - statingRows); }
+        }
+        Check("ACCOUNTING-RESERVE-DEAD-ROOM-GOES-TO-THE-ROWS: across the band, the lane with no accounting to write never renders FEWER histogram rows than the otherwise identical lane that has one, and at biting caps renders strictly more — the dead reserve was body budget, and this is where it went",
+            rowsBad.Count == 0 && strictlyMore > 0,
+            rowsBad.Count == 0 ? $"never fewer; strictly more at {strictlyMore} of 76 caps, by up to {mostBy} row(s)"
+                               : string.Join("; ", rowsBad.Take(3)) + $" ({rowsBad.Count} caps)");
+
         // ---- #344's exclude= pole, driven end to end through the TOOL surface over a synthetic MO2 instance.
         //      Every cell above calls the core directly, so nothing held the parameter's journey across two layers.
         failures += ExcludeWireChecks(Path.Combine(tmpDir, "wire"), Check);
@@ -2304,12 +2341,23 @@ public static class CheckErrorsProbe
     /// HISTOGRAM-FRAMING-IS-RESERVED-NOT-BUDGETED is the arm that holds that surface.</para>
     ///
     /// <para><b>What the reserved disclosures do to the floor, since the floor is what this arm allows.</b> Each
-    /// counts_only axis now holds back its own closing line, so a counts_only floor is roughly 120 characters per
-    /// axis — about 240 for check_errors' two — larger than it was, whether or not anything is cut. That is the
+    /// counts_only axis holds back its own closing line, and the noted axis its note as well. MEASURED on the
+    /// 200-row fixture: the closing lines are 145 and 144 characters, and the counts_only note another 77 — 366
+    /// for check_errors' two axes, whether or not anything is cut. (This paragraph said "roughly 120 per axis,
+    /// about 240 for the two" from an estimate; the numbers above are what the axes actually compose.) That is the
     /// stated price of #392's fix and it is real: it is body budget a caller does not get, and at caps near the
-    /// floor it is the difference between an axis that says what it dropped and one that vanishes. It does NOT
-    /// loosen this arm, because the floor is measured off the fixture rather than declared — a write site that
-    /// escapes the budget still inflates the floor, and FLOOR-IGNORES-BODY-SIZE is what catches that.</para>
+    /// floor it is the difference between an axis that says what it dropped and one that vanishes.</para>
+    ///
+    /// <para>The accounting's reserve is no longer part of that price in this lane. The plain counts_only lane —
+    /// no listing, nothing unread, nothing unparseable — cannot write an accounting line at all, and used to
+    /// reserve its worst case anyway. Measured on this guard's own fixture, as the chars reserved BEYOND the
+    /// boundary footer: <b>218 before, 32 after</b>. Those 186 were held out of every response in the one lane
+    /// where the room comes straight out of the histograms
+    /// (ACCOUNTING-RESERVE-IS-LANE-AWARE, ACCOUNTING-RESERVE-DEAD-ROOM-GOES-TO-THE-ROWS).</para>
+    ///
+    /// <para>None of it loosens this arm, because the floor is measured off the fixture rather than declared — a
+    /// write site that escapes the budget still inflates the floor, and FLOOR-IGNORES-BODY-SIZE is what catches
+    /// that.</para>
     /// </summary>
     static bool CapSweep(ErrorCheckResult r, out string detail)
     {

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -1515,6 +1515,30 @@ public static class CheckErrorsProbe
         Check("HISTOGRAM-AXIS-NEVER-DROPS-SILENTLY (#392): at every cap across the band, each axis is IN the response and states how many of its rows are missing — an axis may lose its rows to max_chars, never its statement that it had them",
             EveryAxisStatesItself(countsForHisto, 400, 8000, 20, out var axisFail), axisFail);
 
+        // The other half of making a disclosure part of the fixed part: the number the overrun notice branches on
+        // has to know about it. In the TEXT lane every unit is composed and measured before it is written, so no
+        // body unit can ever run past the budget — which makes "this response is longer than its cap" and "the cap
+        // could not hold the fixed part" the same statement there. Told a fixed-part size that leaves the reserved
+        // disclosures out, the caps in between get the other explanation — "the fixed part does fit, but one body
+        // unit was written before its size could be measured" — over a response that wrote no body unit at all.
+        //
+        // json is deliberately NOT swept here: its entries carry no measured cost by design, so a body overshoot is
+        // a real thing that happens in that lane and the same claim would be false about it.
+        var overrunCauseBad = new List<string>();
+        int overrunCaps = 0;
+        for (int cap = 200; cap <= 2000; cap += 20)
+        {
+            var t = Wire.RenderCheckErrors(countsForHisto, cap);
+            if (t.Length <= cap) continue;
+            overrunCaps++;
+            if (!t.Contains("does not fit in that many chars", StringComparison.Ordinal))
+                overrunCauseBad.Add($"text@{cap} len={t.Length} says [{OverrunNotice(t)}]");
+        }
+        Check("OVERRUN-IN-THE-TEXT-LANE-IS-ALWAYS-A-CAP-TOO-SMALL: every text response longer than its cap says the FIXED PART did not fit — the reserved closing disclosures are part of that fixed part, and this lane measures every body unit before writing it, so nothing else can put it over",
+            overrunCauseBad.Count == 0 && overrunCaps > 0,
+            overrunCauseBad.Count == 0 ? $"{overrunCaps} over-cap responses, every one naming the fixed part"
+                                       : string.Join("; ", overrunCauseBad.Take(3)) + $" ({overrunCauseBad.Count} of {overrunCaps} over-cap caps)");
+
         // ---- a record scope can admit nothing from a base master the sweep opened. "Swept" has to mean examined.
         var modOnlyScope = ErrorCheck.Run(rb, null, 1000, null, new SweepScope(null, "HcCeModNpc", null, null));
         var modOnlyScopeText = Wire.RenderCheckErrors(modOnlyScope, 0);

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -1098,11 +1098,25 @@ public static class CheckErrorsProbe
 
         var exAll = ErrorCheck.Run(rb, null, 1000, null, null, ErrorFindingClass.All, false,
                                    Excl("Skyrim.esm", "HcCeBaseMod.esp"));
+        // The NUMBER is asserted, not just the two phrases. Read only for its phrases this cell passed over whatever
+        // figure the refusal stated, which is the surface the off-order arm below found wrong.
         Check("EXCLUDE-EMPTIES-THE-SCOPE-REFUSES: excluding everything in scope refuses with the count it removed, rather than returning a clean-looking sweep of nothing (Q3)",
             !exAll.Success && exAll.Error is not null
             && exAll.Error.Contains("removed every plugin", StringComparison.Ordinal)
-            && exAll.Error.Contains("nothing left to check", StringComparison.Ordinal),
-            exAll.Error ?? "<no refusal>");
+            && exAll.Error.Contains("nothing left to check", StringComparison.Ordinal)
+            && ScopeInRefusal(exAll.Error) == 2,
+            $"stated={ScopeInRefusal(exAll.Error)} scope=2 err=[{exAll.Error}]");
+
+        // The same refusal over a scope that resolved ENTIRELY OFF-ORDER — plugins= naming a file on disk that is not
+        // in the active order, then excluded. The sweep's targets list is empty on that path BY DESIGN, so a number
+        // read off targets alone reports a scope that held one plugin as having held none.
+        var exOffOnly = ErrorCheck.Run(r, Array.Empty<string>(), 1000, new[] { ("HcCePatch.esp", patchPath) },
+                                       null, ErrorFindingClass.All, false, Excl("HcCePatch.esp"));
+        Check("EXCLUDE-EMPTIES-AN-OFF-ORDER-SCOPE-COUNTS-IT: when the excluded scope was entirely off-order, the refusal states the one plugin it held — a Q3 refusal must not report zero over a scope that had something in it",
+            !exOffOnly.Success && exOffOnly.Error is not null
+            && exOffOnly.Error.Contains("removed every plugin", StringComparison.Ordinal)
+            && ScopeInRefusal(exOffOnly.Error) == 1,
+            $"stated={ScopeInRefusal(exOffOnly.Error)} scope=1 err=[{exOffOnly.Error}]");
 
         // The separation the refusal above depends on: a GROUP member that is not in scope is the ordinary case,
         // and only a name the CALLER TYPED is a claim the scope has to satisfy. Expanded and validated as one list,
@@ -1687,6 +1701,19 @@ public static class CheckErrorsProbe
         int at = note.IndexOf(lead, StringComparison.Ordinal);
         if (at < 0) return -1;
         var digits = new string(note[(at + lead.Length)..].TakeWhile(char.IsDigit).ToArray());
+        return int.TryParse(digits, out var n) ? n : -1;
+    }
+
+    /// <summary>The size the empty-scope refusal claims for the scope it emptied, or -1 where it claims none. Read as
+    /// a NUMBER for the same reason <see cref="ExcludeLeftOut"/> is: the cell this strengthens matched the refusal's
+    /// two phrases and passed over whatever figure sat between them.</summary>
+    static int ScopeInRefusal(string? error)
+    {
+        const string tail = " in scope, all excluded)";
+        if (error is null) return -1;
+        int at = error.IndexOf(tail, StringComparison.Ordinal);
+        if (at < 0) return -1;
+        var digits = new string(error[..at].Reverse().TakeWhile(char.IsDigit).Reverse().ToArray());
         return int.TryParse(digits, out var n) ? n : -1;
     }
 

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -927,11 +927,12 @@ public static class CheckErrorsProbe
             // Twelve sources for a ten-row roster, so the sample the reserve is measured from actually DROPS
             // two. Ten short non-ASCII names (61 chars plain, 366 escaped) against two long ASCII ones (204
             // either way): ranked by the ESCAPED spelling the non-ASCII names win and the long ASCII pair falls
-            // out, which sizes the TEXT reserve off names a third the length of what the text render prints.
+            // out. The long pair carries the LARGEST counts, so the roster this response really prints is the one the
+            // worst case left out — which is what makes an under-sized text reserve show up as a response over its cap.
             DanglingBySource = Enumerable.Range(0, 10)
-                .Select(i => new SweepCount(new string('\u00e9', 57) + i.ToString("000") + ".esp", 900 - i))
+                .Select(i => new SweepCount(new string('\u00e9', 57) + i.ToString("000") + ".esp", 500 - i))
                 .Concat(Enumerable.Range(0, 2)
-                    .Select(i => new SweepCount(new string('n', 197) + i.ToString("000") + ".esp", 500 - i)))
+                    .Select(i => new SweepCount(new string('n', 197) + i.ToString("000") + ".esp", 900 - i)))
                 .ToList(),
         };
         bool capWideOk = CapSweep(capWide, out var wideFail);

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -1671,6 +1671,26 @@ public static class CheckErrorsProbe
             && twoAxesText.Contains("by SOURCE plugin", StringComparison.Ordinal),
             $"note occurrences={twoAxesText.Split("counts_only=true — totals above are exact", StringSplitOptions.None).Length - 1}");
 
+        // ---- the overrun sentence's enumeration, measured against the response it describes.
+        // "its header, the accounting above, the boundary" was the whole list for a branch after this lane gained a
+        // third member. Both directions, because the member is conditional: a counts_only overrun DOES carry the
+        // closing lines and the sentence names them; a listing-lane overrun carries none, and the phrase is written
+        // so that stays true rather than naming something that lane has not got.
+        // Measured off the RESPONSE, not recomposed: the head line and the cut line each axis actually wrote at a
+        // cap no row fits under, which is the case the sentence is explaining.
+        var enumText = Wire.RenderCheckErrors(countsForHisto, 1);
+        int closingChars = enumText.Split('\n')
+            .Where(l => l.Contains("more row(s)", StringComparison.Ordinal) || l.Contains(" distinct):", StringComparison.Ordinal))
+            .Sum(l => l.Length + 1);
+        int closingLines = enumText.Split('\n').Count(l => l.Contains("more row(s)", StringComparison.Ordinal));
+        var listingOverrun = Wire.RenderCheckErrors(SectionsSized(manyAmple, 1200), 1);
+        Check("OVERRUN-SENTENCE-ENUMERATES-WHAT-THE-RESPONSE-CARRIES: the sentence explaining an overrun lists the closing lines the response cannot drop, and they are a material share of what did not fit — while the lane that owes none still reads true, because the member is stated conditionally",
+            enumText.Contains("the closing line for anything it cut short", StringComparison.Ordinal)
+            && closingLines == 2 && closingChars >= 250 && closingChars < enumText.Length
+            && listingOverrun.Contains("the closing line for anything it cut short", StringComparison.Ordinal)
+            && !listingOverrun.Contains("more row(s)", StringComparison.Ordinal),
+            $"counts_only@1 len={enumText.Length} closingLines={closingLines} closingChars={closingChars}; listing@1 len={listingOverrun.Length} carries an axis close={listingOverrun.Contains("more row(s)", StringComparison.Ordinal)}");
+
         // ---- a lane that cannot write an accounting line must not hold room for one.
         // The plain counts_only lane declares no listing subject and has nothing unread or unparseable, so
         // CheckAccounting.TextLine() is null for every value it could be handed. Reserved unconditionally, that

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -905,9 +905,33 @@ public static class CheckErrorsProbe
         bool capFat = CapSweep(fatHead, out var fatFail);
         bool capCounts = CapSweep(ErrorCheck.Run(rm, null, 1000, null, null, ErrorFindingClass.All, true), out var countsFail);
         bool capMasters = CapSweep(mastersMany, out var mastersFail);
+        // The honesty tails are the lane whose budget argument was unpinned in both transports — int.MaxValue in
+        // place of the real budget stayed green, because no fixture in the battery had tails big enough to overrun.
+        // This one's six rows carry ~450 chars each, in both the [UNREAD] tail and the json `unread` roster.
+        var capTails = ErrorCheck.Run(rm, null, 1000, null, null, ErrorFindingClass.All, true) with
+        {
+            Reports = Enumerable.Range(0, 6)
+                .Select(i => new PluginErrors($"HcCeUnread{i}.esp", Array.Empty<DanglingRef>(), Array.Empty<string>(),
+                                              2, new[] { new string('u', 400) + i }, new string('x', 400)))
+                .ToList(),
+        };
+        bool capTailsOk = CapSweep(capTails, out var tailsFail);
         Check("RESPONSE-NEVER-EXCEEDS-MAX-CHARS (#361): the accounting and the boundary are RESERVED before the body renders, so neither is appended past the cap — across a sweep of caps, in every lane, in both transports",
-            capListing && capFat && capCounts && capMasters,
-            $"listing=[{capFail}] fat-head=[{fatFail}] counts_only=[{countsFail}] masters-only=[{mastersFail}]");
+            capListing && capFat && capCounts && capMasters && capTailsOk,
+            $"listing=[{capFail}] fat-head=[{fatFail}] counts_only=[{countsFail}] masters-only=[{mastersFail}] fat-tails=[{tailsFail}]");
+
+        // The surface the floor formulation deliberately cannot see: anything emitted UNCONDITIONALLY is inside the
+        // floor CapSweep measures against. A histogram's title, its empty-case sentence and its "more rows" line are
+        // exactly that — they bypassed the budget entirely. At a cap that admits no ROWS, a title is a section head
+        // with no section, which the whole-or-absent rule already forbids everywhere else.
+        var histFixture = ErrorCheck.Run(rm, null, 1000, null, null, ErrorFindingClass.All, true);
+        var histFloor = Wire.RenderCheckErrors(histFixture, 1);
+        Check("HISTOGRAM-FRAMING-IS-BOUNDED: at a cap that admits no histogram rows, the histogram's own title and framing lines are absent too — a title with nothing under it is a section head with no section, and it is charged to the budget like every other unit",
+            histFixture.Histogram is { Count: > 0 }
+            && !histFloor.Contains("dangling ref(s) by TARGET plugin", StringComparison.Ordinal)
+            && !histFloor.Contains("dangling ref(s) by SOURCE plugin", StringComparison.Ordinal)
+            && !histFloor.Contains("more row(s)", StringComparison.Ordinal),
+            $"floorLen={histFloor.Length} distinct={histFixture.Histogram?.Count}");
 
         Check("SECTION-IS-WHOLE-OR-ABSENT: across a sweep of caps, a section that starts also carries everything it has to say — the only things a cut may drop are a whole section or an entry, which are the two the accounting states",
             SectionsWhole(new[] { manyAmple, tight, ErrorCheck.Run(r, null, 1000) }, out var wholeFail), wholeFail);
@@ -1016,12 +1040,21 @@ public static class CheckErrorsProbe
             $"success={exGroupNarrow.Success} err=[{exGroupNarrow.Error}] scanned={exGroupNarrow.PluginsScanned}");
 
         // A group can legitimately match nothing here. That is not an error — but the response must still say the
-        // scope was narrowed, or exclude= leaves no trace and the caller cannot tell it was honoured.
-        var exGroupEmpty = ErrorCheck.Run(rb, new[] { "HcCeBaseMod.esp" }, 1000, null, null,
-                                          ErrorFindingClass.All, false, Excl("base_masters"));
-        Check("EXCLUDE-EMPTY-GROUP-STILL-NOTED: an exclusion that removes nothing from THIS scope is still reported as a narrowing — an exclude= that leaves no trace reads as one that was ignored",
-            exGroupEmpty.FilterNote is { } egn && egn.Contains("exclude= left out", StringComparison.Ordinal),
-            $"note=[{exGroupEmpty.FilterNote}]");
+        // scope was narrowed, or exclude= leaves no trace and the caller cannot tell it was honoured. The NUMBER it
+        // states is asserted, not the presence of the sentence: a substring match passes over any figure at all, and
+        // this one is the figure the class-C roster proved wrong (exclude.Names.Count * 99 stayed green).
+        Check("EXCLUDE-EMPTY-GROUP-STILL-NOTED: an exclusion that removes nothing from THIS scope is still reported as a narrowing, and the number it states is what the SCOPE lost — not the size of the group the token expanded to",
+            ExcludeLeftOut(exGroupNarrow.FilterNote) == 0,
+            $"note=[{exGroupNarrow.FilterNote}] stated={ExcludeLeftOut(exGroupNarrow.FilterNote)} scopeLoss=0 groupExpandsTo={ErrorCheck.BaseMasters.Count}");
+
+        // The other direction, which nothing exercised: a group token that actually REMOVES a plugin. The two group
+        // cells above were byte-identical calls, so no cell anywhere proved a token subtracts anything from a sweep.
+        var exGroupBites = ErrorCheck.Run(rb, null, 1000, null, null, ErrorFindingClass.All, false, Excl("base_masters"));
+        Check("EXCLUDE-GROUP-REMOVES-A-PLUGIN: over a scope that CONTAINS a group member, the token drops it from the sweep — the totals lose its findings, its section is gone, and the note states the one plugin the scope lost",
+            exGroupBites.Success && exGroupBites.PluginsScanned == 1
+            && exGroupBites.TotalDangling == 2 && exGroupBites.Reports.All(x => x.Plugin != "Skyrim.esm")
+            && ExcludeLeftOut(exGroupBites.FilterNote) == 1,
+            $"scanned={exGroupBites.PluginsScanned} total={exGroupBites.TotalDangling} sections=[{string.Join(",", exGroupBites.Reports.Select(x => x.Plugin))}] note=[{exGroupBites.FilterNote}]");
 
         var (_, blankErr) = SweepExclusion.Resolve(new[] { "  " }, Array.Empty<string>());
         Check("EXCLUDE-BLANK-VALUE-REFUSES: a blank entry refuses and names both shapes, rather than being skipped as though it were absent",
@@ -1033,6 +1066,15 @@ public static class CheckErrorsProbe
             SweepExclusion.IsPluginName("MyMod.ESP") && SweepExclusion.IsPluginName("MyMod.EsM")
             && !SweepExclusion.IsPluginName("MyMod"),
             $"ESP={SweepExclusion.IsPluginName("MyMod.ESP")} EsM={SweepExclusion.IsPluginName("MyMod.EsM")} bare={SweepExclusion.IsPluginName("MyMod")}");
+
+        // The helper above only says what a plugin NAME looks like. The two comparers that decide whether a typed
+        // name is in scope and whether a target is dropped are inside the sweep, and both could be Ordinal with every
+        // cell still green — so this one drives a mis-cased name all the way through and reads the TOTALS.
+        var exCase = ErrorCheck.Run(rb, null, 1000, null, null, ErrorFindingClass.All, false, Excl("sKyRiM.eSm"));
+        Check("EXCLUDE-NAME-CASE-INSENSITIVE-THROUGH-THE-SWEEP: a mis-cased filename is accepted as in-scope AND actually removes its plugin — the sweep loses that plugin's three findings, rather than the value being taken and then matching nothing",
+            exCase.Success && exCase.PluginsScanned == 1 && exCase.TotalDangling == 2
+            && exCase.Reports.All(x => x.Plugin != "Skyrim.esm") && ExcludeLeftOut(exCase.FilterNote) == 1,
+            $"success={exCase.Success} err=[{exCase.Error}] scanned={exCase.PluginsScanned} total={exCase.TotalDangling} note=[{exCase.FilterNote}]");
 
         Check("EXCLUDE-DESCRIPTION-NAMES-EVERY-GROUP: the caller-facing token list is held against SweepExclusion.Tokens, the one place they are enumerated — no wire-name guard reaches a tool parameter's prose (#386), so this parameter brings its own",
             ExcludeDescriptionNamesTokens(out var descDetail), descDetail);
@@ -1110,11 +1152,56 @@ public static class CheckErrorsProbe
                  .GetProperty("accounting").GetProperty("excluded_plugins_named").GetInt32() == 1,
             AccountingLine(Wire.RenderCheckErrors(withExcluded, 0)));
 
-        Check("EXCLUDED-ROWS-COUNTED-WHEN-DROPPED: when the cap leaves no room for the roster, the accounting says how many of how many were named — and json's own count agrees with the text",
-            Wire.RenderCheckErrors(withExcluded, 3000) is var exCut
-            && (exCut.Contains("0 of 1 plugin(s) that could not be parsed are named above", StringComparison.Ordinal)
-                || !exCut.Contains("HcCeBroken.esp", StringComparison.Ordinal) == false),
-            AccountingLine(Wire.RenderCheckErrors(withExcluded, 3000)));
+        // The cell this replaces carried a dead disjunct — `!x.Contains(name) == false`, i.e. "the name IS there",
+        // which is true of the uncut response — so it passed whatever the render did, and its label promised a json
+        // check it never made. Both numbers are now asserted, against rows counted out of the document.
+        var exDrop = Wire.RenderCheckErrors(withExcluded, 3000);
+        int exNamed = withExcluded.ExcludedPlugins.Keys.Count(k => exDrop.Contains("  " + k + ":", StringComparison.Ordinal));
+        var exDropJson = JsonDocument.Parse(JsonWire.RenderCheckErrors(withExcluded, 3000)).RootElement
+                                     .GetProperty("accounting");
+        Check("EXCLUDED-ROWS-COUNTED-WHEN-DROPPED: when the cap leaves no room for the roster, the accounting states how many of how many were named — the count is the rows actually in the document, and json's own field agrees with it",
+            exNamed < withExcluded.ExcludedPlugins.Count
+            && exDrop.Contains($" {exNamed} of {withExcluded.ExcludedPlugins.Count} plugin(s) that could not be parsed are named above.", StringComparison.Ordinal)
+            && exDropJson.GetProperty("excluded_plugins_named").GetInt32() == withExcluded.ExcludedPlugins.Count
+            && exDropJson.GetProperty("excluded_plugins_total").GetInt32() == withExcluded.ExcludedPlugins.Count,
+            $"namedInText={exNamed} of {withExcluded.ExcludedPlugins.Count} jsonNamed={exDropJson.GetProperty("excluded_plugins_named").GetInt32()} line=[{AccountingLine(exDrop)}]");
+
+        // ---- the unread subject, which nothing pinned: _unreadTotal = 0 and deleting the clause that states it
+        //      both stayed green. counts_only's reports list IS the honesty layer, so a cut there hides the boundary
+        //      of the answer rather than a finding inside it. Rows are made fat so a real cap drops some of them.
+        var unreadFat = ErrorCheck.Run(rm, null, 1000, null, null, ErrorFindingClass.All, true) with
+        {
+            Reports = Enumerable.Range(0, 6)
+                .Select(i => new PluginErrors($"HcCeUnread{i}.esp", Array.Empty<DanglingRef>(), Array.Empty<string>(),
+                                              2, new[] { new string('u', 400) + i }, new string('x', 400)))
+                .ToList(),
+        };
+        var unreadWhole = Wire.RenderCheckErrors(unreadFat, 0);
+        int unreadWholeRows = unreadWhole.Split("[UNREAD] ").Length - 1;
+        Check("UNREAD-ROWS-COUNTED-WHEN-NAMED: a counts_only response that names every plugin it could not read makes NO claim about them, and json still reports the total it was measured against",
+            unreadWholeRows == unreadFat.Reports.Count
+            && !unreadWhole.Contains("whose records could not be read are named above", StringComparison.Ordinal)
+            && JsonDocument.Parse(JsonWire.RenderCheckErrors(unreadFat, 0)).RootElement.GetProperty("accounting")
+                 .GetProperty("unread_plugins_total").GetInt32() == unreadFat.Reports.Count,
+            $"rows={unreadWholeRows} of {unreadFat.Reports.Count} line=[{AccountingLine(unreadWhole)}]");
+
+        // The cap is SEARCHED FOR rather than guessed: the honesty tail renders after two histograms, so which cap
+        // leaves room for some rows and not all of them is a fact about the fixture, not a number to hardcode and
+        // then re-tune whenever the header moves.
+        int unreadCap = PartialUnreadCap(unreadFat);
+        var unreadCut = Wire.RenderCheckErrors(unreadFat, unreadCap);
+        int unreadRows = unreadCut.Split("[UNREAD] ").Length - 1;
+        var unreadCutDoc = JsonDocument.Parse(JsonWire.RenderCheckErrors(unreadFat, unreadCap)).RootElement;
+        var unreadCutJson = unreadCutDoc.GetProperty("accounting");
+        // The json lane is its own render with its own encoding, so it cuts at its own row — its named-count is held
+        // against ITS OWN document, never against the text lane's. Each transport must agree with itself.
+        int unreadJsonRows = unreadCutDoc.GetProperty("unread").GetProperty("rows").GetArrayLength();
+        Check("UNREAD-ROWS-COUNTED-WHEN-DROPPED: when the cap drops rows off the honesty layer, the accounting states how many of how many were named — in each transport the count is the rows actually in THAT document",
+            unreadRows > 0 && unreadRows < unreadFat.Reports.Count
+            && unreadCut.Contains($" {unreadRows} of {unreadFat.Reports.Count} plugin(s) whose records could not be read are named above.", StringComparison.Ordinal)
+            && unreadCutJson.GetProperty("unread_plugins_named").GetInt32() == unreadJsonRows
+            && unreadCutJson.GetProperty("unread_plugins_total").GetInt32() == unreadFat.Reports.Count,
+            $"cap={unreadCap} textRows={unreadRows} of {unreadFat.Reports.Count} jsonRows={unreadJsonRows} jsonNamed={unreadCutJson.GetProperty("unread_plugins_named").GetInt32()} line=[{AccountingLine(unreadCut)}]");
 
         // ---- json's §2.1 in-band fields, in both directions and in the lane that has them.
         var jsonWhole = JsonDocument.Parse(JsonWire.RenderCheckErrors(ErrorCheck.Run(rm, null, 1000), 0)).RootElement;
@@ -1217,6 +1304,10 @@ public static class CheckErrorsProbe
             && twoAxesText.Contains("by SOURCE plugin", StringComparison.Ordinal),
             $"note occurrences={twoAxesText.Split("counts_only=true — totals above are exact", StringSplitOptions.None).Length - 1}");
 
+        // ---- #344's exclude= pole, driven end to end through the TOOL surface over a synthetic MO2 instance.
+        //      Every cell above calls the core directly, so nothing held the parameter's journey across two layers.
+        failures += ExcludeWireChecks(Path.Combine(tmpDir, "wire"), Check);
+
         Console.WriteLine();
         Console.WriteLine(failures == 0 ? "check-errors-guard: ALL PASS" : $"check-errors-guard: {failures} FAILURE(S)");
         return failures == 0 ? 0 : 1;
@@ -1261,6 +1352,146 @@ public static class CheckErrorsProbe
     /// </summary>
     static string AccountingLine(string text)
         => text.Split('\n').FirstOrDefault(l => l.Contains("[accounting:", StringComparison.Ordinal)) ?? "";
+
+    /// <summary>#344's <c>exclude=</c> pole, driven END TO END through the surface a caller actually reaches:
+    /// <see cref="ReadTools.CheckErrorsTool"/> -> <see cref="LoadOrderService.CheckErrors"/> -> <see cref="ErrorCheck.Run"/>,
+    /// over a SYNTHETIC MO2 instance in temp (the established synth-instance pattern — real ModOrganizer.ini, profile
+    /// and mod folders).
+    ///
+    /// <para><b>Why this exists.</b> Every other exclude= cell in this guard calls <c>ErrorCheck.Run</c> directly with
+    /// an already-resolved exclusion, so the parameter's journey across two layers was covered by nothing: passing
+    /// <c>null</c> in place of <c>exclude</c> at the tool call site, or in place of <c>excluded</c> at the service's
+    /// two <c>ErrorCheck.Run</c> calls, left the whole suite GREEN. The pole that closes #344 was disconnectable
+    /// end-to-end without a single cell noticing — a round-1 finding that survived into round 2 by silence.</para>
+    ///
+    /// <para>Every arm asserts the sweep's own TOTALS, which are fixture-known: this order carries five dangling refs,
+    /// three of them in the base master. An exclusion that does not reach the core returns five.</para></summary>
+    static int ExcludeWireChecks(string root, Action<string, bool, string?> Check)
+    {
+        string instance = Path.Combine(root, "instance");
+        string profiles = Path.Combine(instance, "profiles", "Default");
+        string mods = Path.Combine(instance, "mods");
+        string data = Path.Combine(root, "game", "Data");
+        Directory.CreateDirectory(profiles); Directory.CreateDirectory(mods); Directory.CreateDirectory(data);
+        File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(root, "game").Replace(@"\", @"\\") + ")\r\n");
+
+        // Skyrim.esm — a base master BY FILENAME, which is what Mutagen's Implicits set matches on, carrying three
+        // dangling refs of its own. HcCeWireMod.esp masters it and carries two more. Five in the order.
+        string baseModDir = Path.Combine(mods, "VanillaStub");
+        string wireModDir = Path.Combine(mods, "WireMod");
+        Directory.CreateDirectory(baseModDir); Directory.CreateDirectory(wireModDir);
+        var deadFk = FormKey.Factory("0E0E0E:Skyrim.esm");
+        var sky = new SkyrimMod(new ModKey("Skyrim", ModType.Master), SkyrimRelease.SkyrimSE);
+        for (int i = 0; i < 3; i++) { var n = sky.Npcs.AddNew(); n.EditorID = $"HcCeWireVanilla{i}"; n.Race.SetTo(deadFk); }
+        string skyPath = Path.Combine(baseModDir, "Skyrim.esm");
+        sky.BeginWrite.ToPath(skyPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        using (var skyOv = SkyrimMod.CreateFromBinaryOverlay(skyPath, SkyrimRelease.SkyrimSE))
+        {
+            var mod = new SkyrimMod(new ModKey("HcCeWireMod", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            for (int i = 0; i < 2; i++) { var n = mod.Npcs.AddNew(); n.EditorID = $"HcCeWireMod{i}"; n.Race.SetTo(deadFk); }
+            mod.BeginWrite.ToPath(Path.Combine(wireModDir, "HcCeWireMod.esp")).WithLoadOrder(new ISkyrimModGetter[] { skyOv }).Write();
+        }
+        // Skyrim.esm is in loadorder.txt and ABSENT from plugins.txt — which is exactly what makes it IMPLICIT
+        // (force-loaded). That is the fact LoadOrderService.ImplicitPluginNames() reads, and the `implicit` token's
+        // whole journey runs through it.
+        File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\nSkyrim.esm\r\nHcCeWireMod.esp\r\n");
+        File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*HcCeWireMod.esp\r\n");
+        File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+WireMod\r\n+VanillaStub\r\n");
+
+        var store = new UserConfigStore(Path.Combine(root, "houseCARL.user.json"));
+        using var svc = LoadOrderService.WithInstance(instance, 0, store);
+
+        int failures = 0;
+        void Arm(string label, bool ok, string? detail) { Check(label, ok, detail); if (!ok) failures++; }
+
+        // The control. Without it every arm below could pass on a sweep that found nothing at all.
+        var whole = ReadTools.CheckErrorsTool(svc);
+        Arm("EXCLUDE-WIRE-CONTROL: the synthetic instance sweeps both plugins through the tool surface and finds all five dangling refs — the baseline every exclusion below is measured against",
+            whole.Contains("scanned 2 plugins", StringComparison.Ordinal) && whole.Contains("5 dangling ref(s)", StringComparison.Ordinal),
+            First(whole));
+
+        // The pole itself, at the surface a caller reaches. A null at EITHER layer returns the control's numbers.
+        var byName = ReadTools.CheckErrorsTool(svc, exclude: new[] { "Skyrim.esm" });
+        Arm("EXCLUDE-WIRE-NAME-REACHES-THE-SWEEP (#344): exclude= given to the TOOL removes the plugin from the sweep the CORE runs — one plugin scanned, two dangling refs, the excluded plugin's three gone from the totals",
+            byName.Contains("scanned 1 plugin ", StringComparison.Ordinal) && byName.Contains("2 dangling ref(s)", StringComparison.Ordinal)
+            && !byName.Contains("[ERROR] Skyrim.esm", StringComparison.Ordinal),
+            First(byName));
+
+        var byGroup = ReadTools.CheckErrorsTool(svc, exclude: new[] { SweepExclusion.BaseMastersToken });
+        Arm("EXCLUDE-WIRE-BASE-MASTERS-REACHES-THE-SWEEP: the base_masters token survives the same journey and drops the base master — the group is expanded at the service and the expansion is what the core sweeps by",
+            byGroup.Contains("scanned 1 plugin ", StringComparison.Ordinal) && byGroup.Contains("2 dangling ref(s)", StringComparison.Ordinal),
+            First(byGroup));
+
+        // implicit is the one token whose members are read from the MO2 COMPOSITION, at the service layer. Nothing
+        // reached LoadOrderService.ImplicitPluginNames() before this arm.
+        var byImplicit = ReadTools.CheckErrorsTool(svc, exclude: new[] { SweepExclusion.ImplicitToken });
+        Arm("EXCLUDE-WIRE-IMPLICIT-READS-THE-COMPOSITION: the implicit token resolves from the profile's own plugins.txt/loadorder.txt split at the service layer and drops the force-loaded master from the core's sweep",
+            byImplicit.Contains("scanned 1 plugin ", StringComparison.Ordinal) && byImplicit.Contains("2 dangling ref(s)", StringComparison.Ordinal),
+            First(byImplicit));
+
+        // json is a second render over the same service call — the wire must carry there too, or one transport
+        // silently answers a different question.
+        var jsonExcl = ReadTools.CheckErrorsTool(svc, exclude: new[] { "Skyrim.esm" }, format: "json");
+        int jsonScanned = -1, jsonDangling = -1;
+        try
+        {
+            var d = JsonDocument.Parse(jsonExcl).RootElement;
+            jsonScanned = d.GetProperty("scanned_plugins").GetInt32();
+            jsonDangling = d.GetProperty("dangling").GetInt32();
+        }
+        catch { /* reported by the arm */ }
+        Arm("EXCLUDE-WIRE-JSON-AGREES: the json transport of the same excluded sweep reports the same narrowed totals — one exclusion, one sweep, two renders",
+            jsonScanned == 1 && jsonDangling == 2, $"scanned={jsonScanned} dangling={jsonDangling}");
+
+        // Q3 at the surface: a bad value refuses through the tool, not just in the resolver's unit test.
+        var refused = ReadTools.CheckErrorsTool(svc, exclude: new[] { "vanilla" });
+        Arm("EXCLUDE-WIRE-REFUSAL-REACHES-THE-CALLER: an unknown group refuses at the TOOL surface, naming the value and the real token set, rather than sweeping with the exclusion quietly dropped",
+            refused.Contains("'vanilla'", StringComparison.Ordinal)
+            && SweepExclusion.Tokens.All(t => refused.Contains(t, StringComparison.Ordinal))
+            && !refused.Contains("scanned 2 plugins", StringComparison.Ordinal),
+            First(refused));
+
+        return failures;
+    }
+
+    /// <summary>The first line of a tool response — enough to read a failure by, without printing a whole sweep.</summary>
+    static string First(string response)
+    {
+        var lines = response.Split('\n');
+        return lines.Length > 1 ? lines[0] + " | " + lines[1] : lines[0];
+    }
+
+    /// <summary>The first max_chars at which the counts_only honesty tail lands SOME of its rows and not all of
+    /// them — the shape the accounting's unread clause is about. Searched rather than hardcoded: the tail renders
+    /// after both histograms, so the cap that splits it is a property of the fixture and moves whenever the header
+    /// does. Returns the last cap tried when no split exists, so the arm fails with a readable number instead of
+    /// silently testing the wrong thing.</summary>
+    static int PartialUnreadCap(ErrorCheckResult r)
+    {
+        int last = 0;
+        for (int cap = 1500; cap <= 12000; cap += 100)
+        {
+            last = cap;
+            int rows = Wire.RenderCheckErrors(r, cap).Split("[UNREAD] ").Length - 1;
+            if (rows > 0 && rows < r.Reports.Count) return cap;
+        }
+        return last;
+    }
+
+    /// <summary>The number the <c>exclude=</c> narrowing note states, or -1 where it states none. Read as a NUMBER
+    /// so an arm can hold it against what the SCOPE actually lost: the cell this replaces matched the substring
+    /// "exclude= left out" and passed over any figure at all — <c>exclude.Names.Count * 99</c> stayed green.</summary>
+    static int ExcludeLeftOut(string? note)
+    {
+        const string lead = "exclude= left out ";
+        if (note is null) return -1;
+        int at = note.IndexOf(lead, StringComparison.Ordinal);
+        if (at < 0) return -1;
+        var digits = new string(note[(at + lead.Length)..].TakeWhile(char.IsDigit).ToArray());
+        return int.TryParse(digits, out var n) ? n : -1;
+    }
 
     /// <summary>The json roster as "plugin:count" keys, in the order it was written. The json twin of the text
     /// line's roster, so an arm can hold the two transports against each other rather than trusting either.</summary>

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -1048,6 +1048,22 @@ public static class CheckErrorsProbe
             refusedWhileHeld && landsOnceReleased && heldSb.Length == 61 && heldBody.ReservedTotal == 40,
             $"refusedWhileHeld={refusedWhileHeld} landsOnceReleased={landsOnceReleased} len={heldSb.Length} reserved={heldBody.ReservedTotal}");
 
+        // A subject that stopped STAYS stopped, even when room comes back. Releasing a sibling's reserve lowers
+        // what every test has to leave standing, so the budget on its own would let a stopped subject through
+        // again — the stop flag is the only thing that does not. It has its own arm because the product's loops
+        // break on the first refusal and never ask twice, which left the flag looking like a redundancy of
+        // monotonic length; with reserves in play it is no longer one.
+        var stopSb = new System.Text.StringBuilder();
+        var stopBody = new BoundedBody(null, 100, () => stopSb.Length);
+        stopBody.Reserve(SweepSubject.HistogramBySource, 60);
+        bool stoppedOnce = !stopBody.Emit(SweepSubject.HistogramByTarget, 50, () => stopSb.Append(new string('s', 50)));
+        stopBody.Release(SweepSubject.HistogramBySource);
+        bool stillStopped = !stopBody.Emit(SweepSubject.HistogramByTarget, 50, () => stopSb.Append(new string('s', 50)));
+        bool freshSubjectLands = stopBody.Emit(SweepSubject.UnreadRows, 50, () => stopSb.Append(new string('u', 50)));
+        Check("EMISSION-A-STOPPED-SUBJECT-STAYS-STOPPED: a subject the budget refused is not tried again when a released reserve makes room — and a subject that never stopped still emits at that same moment, so the arm cannot pass on an emitter that refuses everything",
+            stoppedOnce && stillStopped && freshSubjectLands && stopSb.Length == 50,
+            $"stoppedOnce={stoppedOnce} stillStopped={stillStopped} freshLands={freshSubjectLands} len={stopSb.Length}");
+
         Check("SECTION-IS-WHOLE-OR-ABSENT: across a sweep of caps, a section that starts also carries everything it has to say — the only things a cut may drop are a whole section or an entry, which are the two the accounting states",
             SectionsWhole(new[] { manyAmple, tight, ErrorCheck.Run(r, null, 1000) }, out var wholeFail), wholeFail);
 

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -905,14 +905,16 @@ public static class CheckErrorsProbe
         bool capFat = CapSweep(fatHead, out var fatFail);
         bool capCounts = CapSweep(ErrorCheck.Run(rm, null, 1000, null, null, ErrorFindingClass.All, true), out var countsFail);
         bool capMasters = CapSweep(mastersMany, out var mastersFail);
-        // The honesty tails are the lane whose budget argument was unpinned in both transports — int.MaxValue in
-        // place of the real budget stayed green, because no fixture in the battery had tails big enough to overrun.
-        // This one's six rows carry ~450 chars each, in both the [UNREAD] tail and the json `unread` roster.
+        // The honesty tails are the lane whose budget was unpinned in both transports — no fixture in the battery
+        // had tails big enough to overrun. Its rows carry a scan error plus an unscannable sample, both of them
+        // exception messages with no length of their own, so ONE row is sized past the json lane's whole reserve:
+        // at ~450 chars a row the json cost's removal was absorbed by the reserve and nothing went red, which said
+        // the cost was decorative when what it actually was, was untested.
         var capTails = ErrorCheck.Run(rm, null, 1000, null, null, ErrorFindingClass.All, true) with
         {
             Reports = Enumerable.Range(0, 6)
                 .Select(i => new PluginErrors($"HcCeUnread{i}.esp", Array.Empty<DanglingRef>(), Array.Empty<string>(),
-                                              2, new[] { new string('u', 400) + i }, new string('x', 400)))
+                                              2, new[] { new string('u', 2000) + i }, new string('x', 2000)))
                 .ToList(),
         };
         bool capTailsOk = CapSweep(capTails, out var tailsFail);
@@ -965,6 +967,29 @@ public static class CheckErrorsProbe
             ExcludedSized(ErrorCheck.Run(rm, null, 1000), 4), ExcludedSized(ErrorCheck.Run(rm, null, 1000), 400));
         Check("FLOOR-IGNORES-BODY-SIZE: at a cap no body fits under, the response is the same length whether its rows carry four characters each or four hundred — the irreducible part of a response is the header, the accounting and the boundary, and nothing that grows with the findings",
             floorBad.Count == 0, floorBad.Count == 0 ? "every lane's floor is content-independent" : string.Join("; ", floorBad));
+
+        // The emitter's guarantee, driven directly. Every call site now passes a cost for the units that can be
+        // large, so on the product's own fixtures the post-check never has to fire — which means removing it stays
+        // green everywhere. It is the backstop for a site that forgets, so it is exercised where a site HAS: a unit
+        // whose declared cost was smaller than what it wrote.
+        var emitSb = new System.Text.StringBuilder();
+        var emitter = new BoundedBody(null, 100, () => emitSb.Length);
+        bool firstLanded = emitter.Emit(SweepSubject.DanglingEntries, 0, () => emitSb.Append(new string('x', 500)));
+        bool secondRefused = !emitter.Emit(SweepSubject.PluginSections, 0, () => emitSb.Append("more"));
+        bool closeRefused = !emitter.Close(SweepSubject.UnreadRows, 0, () => emitSb.Append("tail"));
+        Check("EMISSION-POST-CHECK-STOPS-AN-UNDERSTATED-UNIT: a unit that declared a cost smaller than what it wrote takes the body over exactly ONCE — every later unit is refused, in every subject, and so is a closing disclosure",
+            firstLanded && secondRefused && closeRefused && emitSb.Length == 500,
+            $"firstLanded={firstLanded} secondRefused={secondRefused} closeRefused={closeRefused} len={emitSb.Length}");
+
+        // The other direction, or the arm above would pass on an emitter that refuses everything.
+        var okSb = new System.Text.StringBuilder();
+        var okEmitter = new BoundedBody(null, 100, () => okSb.Length);
+        bool a = okEmitter.Emit(SweepSubject.DanglingEntries, 10, () => okSb.Append(new string('y', 10)));
+        bool b = okEmitter.Emit(SweepSubject.PluginSections, 10, () => okSb.Append(new string('z', 10)));
+        bool c = okEmitter.Close(SweepSubject.UnreadRows, 4, () => okSb.Append("tail"));
+        Check("EMISSION-HONEST-COSTS-ALL-LAND: units that state their true cost and fit are all emitted, and the closing disclosure with them — the stop is a bound, not a refusal to write",
+            a && b && c && okSb.Length == 24,
+            $"a={a} b={b} c={c} len={okSb.Length}");
 
         Check("SECTION-IS-WHOLE-OR-ABSENT: across a sweep of caps, a section that starts also carries everything it has to say — the only things a cut may drop are a whole section or an entry, which are the two the accounting states",
             SectionsWhole(new[] { manyAmple, tight, ErrorCheck.Run(r, null, 1000) }, out var wholeFail), wholeFail);

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -960,17 +960,21 @@ public static class CheckErrorsProbe
             $"listing=[{capFail}] fat-head=[{fatFail}] counts_only=[{countsFail}] masters-only=[{mastersFail}] fat-tails=[{tailsFail}] fat-histograms=[{histFail}] escaped-names=[{wideFail}] fat-excluded=[{excludedFail}]");
 
         // The surface the floor formulation deliberately cannot see: anything emitted UNCONDITIONALLY is inside the
-        // floor CapSweep measures against. A histogram's title, its empty-case sentence and its "more rows" line are
-        // exactly that — they bypassed the budget entirely. At a cap that admits no ROWS, a title is a section head
-        // with no section, which the whole-or-absent rule already forbids everywhere else.
+        // floor CapSweep measures against. A histogram axis's own statement about itself is now exactly that, and
+        // deliberately so — it is reserved out of max_chars with the accounting and the boundary, not charged to
+        // the budget its rows are charged to (#392). This is the arm that holds the surface, and it holds BOTH
+        // halves: at a cap that admits no ROWS, each axis is still in the response and says its whole tally is
+        // missing, and not one row key is in the response. A title alone would be a section head with no section;
+        // a title with its cut line under it is the one thing max_chars may not take away.
         var histFixture = ErrorCheck.Run(rm, null, 1000, null, null, ErrorFindingClass.All, true);
         var histFloor = Wire.RenderCheckErrors(histFixture, 1);
-        Check("HISTOGRAM-FRAMING-IS-BOUNDED: at a cap that admits no histogram rows, the histogram's own title and framing lines are absent too — a title with nothing under it is a section head with no section, and it is charged to the budget like every other unit",
-            histFixture.Histogram is { Count: > 0 }
-            && !histFloor.Contains("dangling ref(s) by TARGET plugin", StringComparison.Ordinal)
-            && !histFloor.Contains("dangling ref(s) by SOURCE plugin", StringComparison.Ordinal)
-            && !histFloor.Contains("more row(s)", StringComparison.Ordinal),
-            $"floorLen={histFloor.Length} distinct={histFixture.Histogram?.Count}");
+        var floorTarget = HistogramAxis(histFloor, TargetAxis);
+        var floorSource = HistogramAxis(histFloor, SourceAxis);
+        Check("HISTOGRAM-FRAMING-IS-RESERVED-NOT-BUDGETED: at a cap that admits no histogram rows, EACH axis is still in the response and states its whole tally as cut by max_chars — the rows are bounded, the axis's statement about itself is not",
+            histFixture.Histogram is { Count: > 0 } && histFixture.DanglingBySource is { Count: > 0 }
+            && floorTarget.Rows == 0 && floorTarget.Stated == histFixture.Histogram!.Count && floorTarget.Knob == "max_chars="
+            && floorSource.Rows == 0 && floorSource.Stated == histFixture.DanglingBySource!.Count && floorSource.Knob == "max_chars=",
+            $"floorLen={histFloor.Length} target={floorTarget} (of {histFixture.Histogram?.Count}) source={floorSource} (of {histFixture.DanglingBySource?.Count})");
 
         // The arm CapSweep's floor formulation needs standing beside it. A floor measured off the fixture under test
         // is inflated by any write site that ignores the budget, and an inflated floor excuses the very overrun it
@@ -1000,20 +1004,49 @@ public static class CheckErrorsProbe
         var emitter = new BoundedBody(null, 100, () => emitSb.Length);
         bool firstLanded = emitter.Emit(SweepSubject.DanglingEntries, 0, () => emitSb.Append(new string('x', 500)));
         bool secondRefused = !emitter.Emit(SweepSubject.PluginSections, 0, () => emitSb.Append("more"));
-        bool closeRefused = !emitter.Close(SweepSubject.UnreadRows, 0, () => emitSb.Append("tail"));
-        Check("EMISSION-AN-UNDERSTATED-COST-COSTS-ONE-UNIT: a unit that declared a cost smaller than what it wrote takes the body over exactly ONCE — every later unit is refused, in every subject, and so is a closing disclosure",
-            firstLanded && secondRefused && closeRefused && emitSb.Length == 500,
-            $"firstLanded={firstLanded} secondRefused={secondRefused} closeRefused={closeRefused} len={emitSb.Length}");
+        Check("EMISSION-AN-UNDERSTATED-COST-COSTS-ONE-UNIT: a unit that declared a cost smaller than what it wrote takes the body over exactly ONCE — every later unit is refused, in every subject, including one never tried before",
+            firstLanded && secondRefused && emitSb.Length == 500,
+            $"firstLanded={firstLanded} secondRefused={secondRefused} len={emitSb.Length}");
+
+        // …and the ONE thing that still gets written in that state. A closing disclosure is not a unit: its room
+        // came out of max_chars before anything was emitted, so the budget the rows exhausted cannot also refuse
+        // the sentence reporting them. It used to be budget-gated, and a whole counts_only axis left the response
+        // with nothing saying it had ever existed (#392).
+        var closeSb = new System.Text.StringBuilder();
+        var closer = new BoundedBody(null, 100, () => closeSb.Length);
+        closer.Reserve(SweepSubject.UnreadRows, 4);
+        bool ranOver = closer.Emit(SweepSubject.DanglingEntries, 0, () => closeSb.Append(new string('x', 500)));
+        bool ownRowsRefused = !closer.Emit(SweepSubject.UnreadRows, 0, () => closeSb.Append("row"));
+        closer.Close(SweepSubject.UnreadRows, () => closeSb.Append("tail"));
+        Check("EMISSION-A-CLOSING-DISCLOSURE-IS-NEVER-REFUSED: with the body already past its budget and the subject's OWN rows refused, the subject still says what it dropped — a disclosure a budget can refuse is not a disclosure",
+            ranOver && ownRowsRefused && closeSb.Length == 504
+            && closeSb.ToString().EndsWith("tail", StringComparison.Ordinal),
+            $"ranOver={ranOver} ownRowsRefused={ownRowsRefused} len={closeSb.Length}");
 
         // The other direction, or the arm above would pass on an emitter that refuses everything.
         var okSb = new System.Text.StringBuilder();
         var okEmitter = new BoundedBody(null, 100, () => okSb.Length);
+        okEmitter.Reserve(SweepSubject.UnreadRows, 4);
         bool a = okEmitter.Emit(SweepSubject.DanglingEntries, 10, () => okSb.Append(new string('y', 10)));
         bool b = okEmitter.Emit(SweepSubject.PluginSections, 10, () => okSb.Append(new string('z', 10)));
-        bool c = okEmitter.Close(SweepSubject.UnreadRows, 4, () => okSb.Append("tail"));
+        okEmitter.Close(SweepSubject.UnreadRows, () => okSb.Append("tail"));
         Check("EMISSION-HONEST-COSTS-ALL-LAND: units that state their true cost and fit are all emitted, and the closing disclosure with them — the stop is a bound, not a refusal to write",
-            a && b && c && okSb.Length == 24,
-            $"a={a} b={b} c={c} len={okSb.Length}");
+            a && b && okSb.Length == 24,
+            $"a={a} b={b} len={okSb.Length}");
+
+        // A reserve has to BITE, or it is a promise with nothing behind it: while the room stands, a unit that
+        // would eat into it is refused — and once the subject it was held for turns out to have nothing to say,
+        // the same unit fits. Both directions, because a Reserve that held nothing and a Release that freed
+        // nothing would each leave every product arm green.
+        var heldSb = new System.Text.StringBuilder();
+        var heldBody = new BoundedBody(null, 100, () => heldSb.Length);
+        heldBody.Reserve(SweepSubject.HistogramBySource, 40);
+        bool refusedWhileHeld = !heldBody.Emit(SweepSubject.HistogramByTarget, 61, () => heldSb.Append(new string('h', 61)));
+        heldBody.Release(SweepSubject.HistogramBySource);
+        bool landsOnceReleased = heldBody.Emit(SweepSubject.UnreadRows, 61, () => heldSb.Append(new string('h', 61)));
+        Check("EMISSION-A-RESERVE-IS-ROOM-THE-ROWS-CANNOT-HAVE: a unit that would spend a standing closing-disclosure reserve is refused, and the identical unit lands once that reserve is released",
+            refusedWhileHeld && landsOnceReleased && heldSb.Length == 61 && heldBody.ReservedTotal == 40,
+            $"refusedWhileHeld={refusedWhileHeld} landsOnceReleased={landsOnceReleased} len={heldSb.Length} reserved={heldBody.ReservedTotal}");
 
         Check("SECTION-IS-WHOLE-OR-ABSENT: across a sweep of caps, a section that starts also carries everything it has to say — the only things a cut may drop are a whole section or an entry, which are the two the accounting states",
             SectionsWhole(new[] { manyAmple, tight, ErrorCheck.Run(r, null, 1000) }, out var wholeFail), wholeFail);
@@ -1431,9 +1464,13 @@ public static class CheckErrorsProbe
         var rowsSource = HistogramAxis(hRows, SourceAxis);
         var cutTarget = HistogramAxis(hCut, TargetAxis);
         var cutSource = HistogramAxis(hCut, SourceAxis);
-        Check("HISTOGRAM-REMEDY-NAMES-ITS-CAUSE: a histogram cut by the response offers max_chars=, one cut by the row limit offers limit= — the knob that stopped it, not the other one",
-            cutTarget.Knob == "max_chars=" && rowsTarget.Knob == "limit=",
-            $"cap={hCap} budget-cut={cutTarget.Knob} row-cut={rowsTarget.Knob}");
+        // PER AXIS means BOTH axes are read, and both are asserted. cutSource was computed here and never looked
+        // at — the same "one substring over the whole response" hole this arm was rewritten to close, left open one
+        // axis over. Asserting it is what would have gone red on #392 at authoring time.
+        Check("HISTOGRAM-REMEDY-NAMES-ITS-CAUSE: a histogram cut by the response offers max_chars=, one cut by the row limit offers limit= — the knob that stopped it, not the other one, on EACH axis",
+            cutTarget.Knob == "max_chars=" && cutSource.Knob == "max_chars="
+            && rowsTarget.Knob == "limit=" && rowsSource.Knob == "limit=",
+            $"cap={hCap} budget-cut target={cutTarget.Knob} source={cutSource.Knob} row-cut target={rowsTarget.Knob} source={rowsSource.Knob}");
 
         Check("HISTOGRAM-AXES-CUT-INDEPENDENTLY: at limit=3 over two 200-row axes, EACH renders its three rows and states its own 197 against limit= — one axis's stop is not the other's, and a remedy is only offered by the axis it applies to",
             rowsTarget.Rows == 3 && rowsTarget.Stated == 197 && rowsTarget.Knob == "limit="
@@ -1469,6 +1506,14 @@ public static class CheckErrorsProbe
             && JsonAxis(hWholeJson, "dangling_by_target_plugin") == (200, 200, null)
             && JsonAxis(hWholeJson, "dangling_by_source_plugin") == (200, 200, null),
             $"cut target={JsonAxis(hRowsJson, "dangling_by_target_plugin")} source={JsonAxis(hRowsJson, "dangling_by_source_plugin")} whole target={JsonAxis(hWholeJson, "dangling_by_target_plugin")}");
+
+        // #392, and the reason the whole revision exists. Every cap in the band three independent reviewers
+        // measured the drop in — on a 200-row fixture the by-SOURCE axis was silently absent at EVERY cap from
+        // 1000 upward — asked of BOTH transports, because the two disagreed exactly here: json's object framing
+        // was written unconditionally while the text lane emitted nothing at all, so one transport reported a cut
+        // the other was silent about.
+        Check("HISTOGRAM-AXIS-NEVER-DROPS-SILENTLY (#392): at every cap across the band, each axis is IN the response and states how many of its rows are missing — an axis may lose its rows to max_chars, never its statement that it had them",
+            EveryAxisStatesItself(countsForHisto, 400, 8000, 20, out var axisFail), axisFail);
 
         // ---- a record scope can admit nothing from a base master the sweep opened. "Swept" has to mean examined.
         var modOnlyScope = ErrorCheck.Run(rb, null, 1000, null, new SweepScope(null, "HcCeModNpc", null, null));
@@ -1977,6 +2022,55 @@ public static class CheckErrorsProbe
         return bad.Count == 0;
     }
 
+    /// <summary>Every histogram axis states itself at EVERY cap in a band. An axis may lose its ROWS to
+    /// <c>max_chars</c>; it may never lose the line saying so — that line is reserved out of <c>max_chars</c> with
+    /// the accounting and the boundary, so the pressure it exists to report cannot refuse it (#392).
+    ///
+    /// <para>Swept one cap at a time rather than over a ladder, because the defect this replaces was a BAND, not a
+    /// point: on a 200-row fixture the by-SOURCE axis was silently absent at every cap from 1000 upward, and a
+    /// ladder that happened to land outside it would have reported nothing.</para>
+    ///
+    /// <para>Both transports, because they disagreed exactly here — json's object framing was written
+    /// unconditionally while the text lane emitted nothing at all, so one transport declared a cut the other was
+    /// silent about. And what each axis STATES is held against the fixture's own distinct count and the rows the
+    /// response actually carries: an axis that is present and lying is not something this arm passes.</para>
+    /// </summary>
+    static bool EveryAxisStatesItself(ErrorCheckResult r, int from, int to, int step, out string detail)
+    {
+        var bad = new List<string>();
+        int targetDistinct = r.Histogram!.Count, sourceDistinct = r.DanglingBySource!.Count;
+        for (int cap = from; cap <= to; cap += step)
+        {
+            var text = Wire.RenderCheckErrors(r, cap);
+            AxisStatesItself(bad, $"text@{cap} TARGET", HistogramAxis(text, TargetAxis), targetDistinct);
+            AxisStatesItself(bad, $"text@{cap} SOURCE", HistogramAxis(text, SourceAxis), sourceDistinct);
+            var root = JsonDocument.Parse(JsonWire.RenderCheckErrors(r, cap)).RootElement;
+            var jt = JsonAxis(root, "dangling_by_target_plugin");
+            var js = JsonAxis(root, "dangling_by_source_plugin");
+            if (jt.Distinct != targetDistinct) bad.Add($"json@{cap} TARGET distinct={jt.Distinct} (fixture has {targetDistinct})");
+            if (js.Distinct != sourceDistinct) bad.Add($"json@{cap} SOURCE distinct={js.Distinct} (fixture has {sourceDistinct})");
+            if (jt.Rendered < jt.Distinct && jt.CutBy is null) bad.Add($"json@{cap} TARGET short by {jt.Distinct - jt.Rendered} and names no knob");
+            if (js.Rendered < js.Distinct && js.CutBy is null) bad.Add($"json@{cap} SOURCE short by {js.Distinct - js.Rendered} and names no knob");
+        }
+        detail = bad.Count == 0 ? $"every axis stated itself at all {1 + (to - from) / step} caps, both transports"
+                                : string.Join("; ", bad.Take(4)) + $" ({bad.Count} total)";
+        return bad.Count == 0;
+    }
+
+    /// <summary>One text axis, held to the two things it must never do: be absent from the response, and state a
+    /// number that is not the rows it left out.</summary>
+    static void AxisStatesItself(List<string> bad, string where, (int Rows, int Stated, string Knob) axis, int distinct)
+    {
+        if (axis.Rows < 0) { bad.Add($"{where} absent from the response entirely"); return; }
+        if (axis.Rows >= distinct)
+        {
+            if (axis.Stated != -1) bad.Add($"{where} rendered all {distinct} rows and still claims {axis.Stated} missing");
+            return;
+        }
+        if (axis.Stated != distinct - axis.Rows)
+            bad.Add($"{where} rendered {axis.Rows} of {distinct} and states {axis.Stated}");
+    }
+
     /// <summary>The caps this invariant is swept over. It used to step 3000 -> 8000, straight over the 4000-7000 band
     /// the fat-head fixture's plugin object actually bites in: the arm's one real defect lived in a gap in its own
     /// ladder. The band is now walked rather than jumped.</summary>
@@ -2001,8 +2095,17 @@ public static class CheckErrorsProbe
     /// It is bounded by digit width (<see cref="FloorSlack"/>), not by plausibility.</para>
     ///
     /// <para><b>What it does NOT bound, stated rather than implied:</b> anything the render emits UNCONDITIONALLY is
-    /// inside the floor it is measured against, so this arm cannot see it. HISTOGRAM-FRAMING-IS-BOUNDED is the arm
-    /// that holds that surface.</para></summary>
+    /// inside the floor it is measured against, so this arm cannot see it.
+    /// HISTOGRAM-FRAMING-IS-RESERVED-NOT-BUDGETED is the arm that holds that surface.</para>
+    ///
+    /// <para><b>What the reserved disclosures do to the floor, since the floor is what this arm allows.</b> Each
+    /// counts_only axis now holds back its own closing line, so a counts_only floor is roughly 120 characters per
+    /// axis — about 240 for check_errors' two — larger than it was, whether or not anything is cut. That is the
+    /// stated price of #392's fix and it is real: it is body budget a caller does not get, and at caps near the
+    /// floor it is the difference between an axis that says what it dropped and one that vanishes. It does NOT
+    /// loosen this arm, because the floor is measured off the fixture rather than declared — a write site that
+    /// escapes the budget still inflates the floor, and FLOOR-IGNORES-BODY-SIZE is what catches that.</para>
+    /// </summary>
     static bool CapSweep(ErrorCheckResult r, out string detail)
     {
         var bad = new List<string>();

--- a/src/housecarl-generator/CheckMeasureProbe.cs
+++ b/src/housecarl-generator/CheckMeasureProbe.cs
@@ -48,6 +48,11 @@ public static class CheckMeasureProbe
             foreach (int c in new[] { 2000, 1200 })
                 AxisCell($"F  counts_only axis-drop band, max_chars={c}", c,
                          () => ReadTools.CheckErrorsTool(svc, counts_only: true, max_chars: c));
+            // FOLLOW THE REMEDY, on live data. The guard follows it on fixtures; a remedy is a claim about a call
+            // that has not happened, and the caller making it is on a real order. Whatever number the 1200 cell's
+            // notice named, this is that call.
+            FollowRemedy(ReadTools.CheckErrorsTool(svc, counts_only: true, max_chars: 1200),
+                         n => ReadTools.CheckErrorsTool(svc, counts_only: true, max_chars: n));
             return 0;
         }
 
@@ -57,6 +62,23 @@ public static class CheckMeasureProbe
         Cell($"D  plugins=[{only}] text, defaults", () => ReadTools.CheckErrorsTool(svc, new[] { only }));
         Cell($"E  plugins=[{only}] json, defaults", () => ReadTools.CheckErrorsTool(svc, new[] { only }, format: "json"));
         return 0;
+    }
+
+    /// <summary>Read the number an overrun notice tells the caller to raise <c>max_chars</c> to, make that call, and
+    /// report what comes back — on the LIVE order rather than on a fixture. Two claims land here: the notice must be
+    /// gone (the remedy works), and the raised cap must not be materially larger than it needed to be, which the
+    /// re-rendered length is the evidence for.</summary>
+    static void FollowRemedy(string overrun, Func<int, string> render)
+    {
+        int at = overrun.IndexOf("raise it to at least ", StringComparison.Ordinal);
+        if (at < 0) { Console.WriteLine("## F  follow the remedy: the 1200 response named no number"); return; }
+        var digits = new string(overrun[(at + 21)..].TakeWhile(char.IsDigit).ToArray());
+        if (!int.TryParse(digits, out int raised)) { Console.WriteLine("## F  follow the remedy: unparseable number"); return; }
+        var again = render(raised);
+        Console.WriteLine($"## F  follow the remedy, max_chars={raised}");
+        Console.WriteLine($"   chars      : {again.Length}  (cap {raised}, unused {raised - again.Length})");
+        Console.WriteLine($"   notice gone: {!again.Contains("raise it to at least", StringComparison.Ordinal)}");
+        Console.WriteLine($"   inside cap : {again.Length <= raised}");
     }
 
     /// <summary>Report, for a counts_only response, whether EITHER axis is missing outright and whether the response
@@ -93,6 +115,14 @@ public static class CheckMeasureProbe
         bool notice = s.Contains("raise it to at least", StringComparison.Ordinal);
         Console.WriteLine($"   accounting line present : {acct}");
         Console.WriteLine($"   overrun notice present  : {notice}");
+        // WHICH overrun it named and what it told the caller to raise to. Both are decided by the fixed part the
+        // notice is handed, and on a counts_only response that emits no body unit the wrong branch is the one that
+        // says a body unit overshot. Printed rather than inferred, because "a notice fired" is not the claim.
+        if (notice)
+        {
+            int at = s.IndexOf(" This response is ", StringComparison.Ordinal);
+            Console.WriteLine($"   overrun notice says     : {(at < 0 ? "(not found)" : s[at..].Trim())}");
+        }
         // WHAT the accounting says matters as much as whether it exists: a line that discloses a different subject
         // entirely is not a disclosure of the axes, and the distinction is the whole question.
         if (acct)

--- a/src/housecarl-generator/CheckMeasureProbe.cs
+++ b/src/housecarl-generator/CheckMeasureProbe.cs
@@ -1,0 +1,90 @@
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// MANUAL / REAL-DATA measurement harness for PR 4's kickoff (`check-measure`): the two #361 lanes and the response
+/// accounting as they behave on the LIVE order, taken BEFORE any design work — the kickoff's binding empirical check.
+/// A synthetic fixture cannot stand in: every number here is a function of how big a real order's findings are against
+/// an 80k cap, and the #342s1 lesson is that a toy fixture was 15-20x off the order it stood for.
+///
+/// Drives the TOOL layer (<see cref="ReadTools.CheckErrorsTool"/>) — the same entry housecarl_check_errors calls, so
+/// what it measures is what a caller receives, render included. Read-only; needs --mo2 &lt;instance&gt;, SKIPs without.
+/// </summary>
+public static class CheckMeasureProbe
+{
+    public static int RunMeasure(string[] args)
+    {
+        string? mo2 = ArgVal(args, "--mo2");
+        if (mo2 is null) { Console.WriteLine("check-measure needs --mo2 <MO2 instance folder>"); return 2; }
+        string? only = ArgVal(args, "--plugin");
+
+        var store = new UserConfigStore(Path.Combine(Path.GetTempPath(), "hc-check-measure-" + Guid.NewGuid().ToString("N") + ".json"));
+        using var svc = LoadOrderService.WithInstance(mo2, 0, store);
+
+        int cap = Wire.DefaultMaxChars;
+        Console.WriteLine($"# check-measure — live order at {mo2}");
+        Console.WriteLine($"# default max_chars = {cap}, default limit = 1000\n");
+
+        if (only is null)
+        {
+            // Cell A — the whole-order text sweep at plain defaults: what a caller who types
+            // `housecarl_check_errors` with no arguments actually receives.
+            Cell("A  whole-order text, defaults", () => ReadTools.CheckErrorsTool(svc));
+            // Cell B — the same sweep as json: the twin lane, same defaults.
+            Cell("B  whole-order json, defaults", () => ReadTools.CheckErrorsTool(svc, format: "json"));
+            // Cell C — counts_only, which names the by-SOURCE tally the single-plugin cells below need.
+            Cell("C  counts_only text, defaults", () => ReadTools.CheckErrorsTool(svc, counts_only: true));
+            return 0;
+        }
+
+        // Cells D/E — ONE plugin in scope. This is the shape that reaches #361's silent path: with a single report
+        // section, a cut inside it ends the inner loop and the outer loop then EXHAUSTS rather than breaking, so the
+        // boundary-fired truncation notice never runs.
+        Cell($"D  plugins=[{only}] text, defaults", () => ReadTools.CheckErrorsTool(svc, new[] { only }));
+        Cell($"E  plugins=[{only}] json, defaults", () => ReadTools.CheckErrorsTool(svc, new[] { only }, format: "json"));
+        return 0;
+    }
+
+    /// <summary>Run one cell and report the facts that decide both #361 lanes: the response's true size against the
+    /// cap it was rendered under, whether a truncation notice is present, and the accounting lines it did emit.</summary>
+    static void Cell(string label, Func<string> call)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        string s = call();
+        sw.Stop();
+        int cap = Wire.DefaultMaxChars;
+        Console.WriteLine($"## {label}");
+        Console.WriteLine($"   chars      : {s.Length}  (cap {cap}{(s.Length > cap ? $" — OVER by {s.Length - cap}" : "")})");
+        Console.WriteLine($"   truncation notice present : {s.Contains("[truncated at max_chars=")}");
+        Console.WriteLine($"   json truncated flag       : {(s.Contains("\"truncated\"") ? s.Substring(s.IndexOf("\"truncated\"", StringComparison.Ordinal), Math.Min(24, s.Length - s.IndexOf("\"truncated\"", StringComparison.Ordinal))) : "n/a")}");
+        Console.WriteLine($"   budget line present       : {s.Contains("[the listing budget (limit=) omitted")}");
+        // The number no sentence in either format states: how many findings this RESPONSE actually carries. Counted
+        // off the rendered entries themselves, so it is what the caller can see rather than what a layer intended.
+        int shown = s.Contains("\"target\"") ? Count(s, "\"target\":") : Count(s, "[target not defined by any active plugin]");
+        Console.WriteLine($"   dangling entries VISIBLE in the response : {shown}");
+        Console.WriteLine($"   boundary footer present   : {s.Contains("boundary: checks FormLink resolution") || s.Contains("\"boundary\"")}");
+        Console.WriteLine($"   elapsed    : {sw.ElapsedMilliseconds} ms");
+        foreach (var line in s.Split('\n'))
+            if (line.StartsWith("scanned ", StringComparison.Ordinal) || line.StartsWith("baseline:", StringComparison.Ordinal)
+                || line.Contains("[the listing budget", StringComparison.Ordinal) || line.Contains("[truncated at max_chars=", StringComparison.Ordinal))
+                Console.WriteLine("   > " + Trim(line));
+        Console.WriteLine($"   last 220 chars: …{Trim(s[Math.Max(0, s.Length - 220)..])}");
+        Console.WriteLine();
+    }
+
+    static int Count(string hay, string needle)
+    {
+        int n = 0, i = 0;
+        while ((i = hay.IndexOf(needle, i, StringComparison.Ordinal)) >= 0) { n++; i += needle.Length; }
+        return n;
+    }
+
+    static string Trim(string s) => s.Replace("\r", "").Replace("\n", " ⏎ ");
+
+    static string? ArgVal(string[] a, string key)
+    {
+        int i = Array.IndexOf(a, key);
+        return i >= 0 && i + 1 < a.Length ? a[i + 1] : null;
+    }
+}

--- a/src/housecarl-generator/CheckMeasureProbe.cs
+++ b/src/housecarl-generator/CheckMeasureProbe.cs
@@ -35,6 +35,19 @@ public static class CheckMeasureProbe
             Cell("B  whole-order json, defaults", () => ReadTools.CheckErrorsTool(svc, format: "json"));
             // Cell C — counts_only, which names the by-SOURCE tally the single-plugin cells below need.
             Cell("C  counts_only text, defaults", () => ReadTools.CheckErrorsTool(svc, counts_only: true));
+            // Cell F -- the flagged residual, measured rather than reasoned about. A counts_only axis renders its
+            // rows through the bounded emitter and closes with a "... N more row(s)" line; if max_chars leaves room
+            // for neither, the axis is absent ENTIRELY, and in a counts_only lane with no unread and no excluded
+            // rows the accounting declares no subject, so TextLine() returns null and the response closes as
+            // complete. The question this cell answers is whether that band is reachable at PLAIN DEFAULTS on a
+            // real order, or only at caps far below what a caller ever passes.
+            // Plain defaults is the cell that decides it; the ladder below walks DOWN from there to find where the
+            // band actually starts, so the answer is "not at defaults, and here is how far below them it lives"
+            // rather than "not at defaults" alone.
+            AxisCell("F  counts_only axis-drop band, defaults", 0, () => ReadTools.CheckErrorsTool(svc, counts_only: true));
+            foreach (int c in new[] { 2000, 1200 })
+                AxisCell($"F  counts_only axis-drop band, max_chars={c}", c,
+                         () => ReadTools.CheckErrorsTool(svc, counts_only: true, max_chars: c));
             return 0;
         }
 
@@ -44,6 +57,61 @@ public static class CheckMeasureProbe
         Cell($"D  plugins=[{only}] text, defaults", () => ReadTools.CheckErrorsTool(svc, new[] { only }));
         Cell($"E  plugins=[{only}] json, defaults", () => ReadTools.CheckErrorsTool(svc, new[] { only }, format: "json"));
         return 0;
+    }
+
+    /// <summary>Report, for a counts_only response, whether EITHER axis is missing outright and whether the response
+    /// says anything about it. An axis that renders no rows AND states no cut AND leaves no accounting line is the
+    /// silent drop; an axis that states its cut, or a response that carries an accounting line, is not.</summary>
+    static void AxisCell(string label, int cap, Func<string> call)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        string s = call();
+        sw.Stop();
+        Console.WriteLine($"## {label}");
+        int effective = cap > 0 ? cap : Wire.DefaultMaxChars;
+        Console.WriteLine($"   chars      : {s.Length}  (cap {effective})");
+        foreach (var axis in new[] { "TARGET plugin", "SOURCE plugin" })
+        {
+            const string lead = "\ndangling ref(s) by ";
+            int at = s.IndexOf(lead + axis, StringComparison.Ordinal);
+            if (at < 0)
+            {
+                bool empty = s.Contains("by " + axis + " (the plugin the broken refs ", StringComparison.Ordinal);
+                Console.WriteLine($"   {axis,-14}: ABSENT from the response (empty-case line present: {empty})");
+                continue;
+            }
+            int end = s.IndexOf(lead, at + lead.Length, StringComparison.Ordinal);
+            var seg = end < 0 ? s[at..] : s[at..end];
+            int rows = seg.Split('\n').Count(l => l.StartsWith("  ", StringComparison.Ordinal)
+                                               && !l.StartsWith("  ...", StringComparison.Ordinal)
+                                               && l.Trim().Length > 0);
+            int cut = seg.IndexOf("more row(s) — raise ", StringComparison.Ordinal);
+            Console.WriteLine($"   {axis,-14}: rows={rows}  states a cut={cut >= 0}"
+                              + (cut >= 0 ? $" [{seg.Split('\n').First(l => l.Contains("more row(s)", StringComparison.Ordinal)).Trim()}]" : ""));
+        }
+        bool acct = s.Contains("[accounting:", StringComparison.Ordinal);
+        bool notice = s.Contains("raise it to at least", StringComparison.Ordinal);
+        Console.WriteLine($"   accounting line present : {acct}");
+        Console.WriteLine($"   overrun notice present  : {notice}");
+        // WHAT the accounting says matters as much as whether it exists: a line that discloses a different subject
+        // entirely is not a disclosure of the axes, and the distinction is the whole question.
+        if (acct)
+        {
+            int a = s.IndexOf("[accounting:", StringComparison.Ordinal);
+            int z = s.IndexOf("]", a, StringComparison.Ordinal);
+            Console.WriteLine($"   accounting says         : {s[a..(z < 0 ? s.Length : z + 1)]}");
+            Console.WriteLine($"   ...mentions a histogram : {s[a..(z < 0 ? s.Length : z + 1)].Contains("histogram", StringComparison.OrdinalIgnoreCase) || s[a..(z < 0 ? s.Length : z + 1)].Contains("row(s)", StringComparison.Ordinal)}");
+        }
+        // An ABSENT axis is silent about ITSELF by construction: its "... N more row(s)" line lives inside its own
+        // segment, so an axis that did not render has no way to have stated its cut. The accounting cannot cover it
+        // either — the histogram subjects are deliberately not declared accounting subjects. So the presence of an
+        // accounting line is NOT a disclosure of a dropped axis: at max_chars=2000 on the live order it reads
+        // "0 of 1 plugin(s) whose records could not be read are named above", about an entirely different subject,
+        // while the whole by-SOURCE axis is gone with nothing naming it.
+        bool absent = !s.Contains("by TARGET plugin", StringComparison.Ordinal)
+                   || !s.Contains("by SOURCE plugin", StringComparison.Ordinal);
+        Console.WriteLine($"   SILENT AXIS DROP        : {absent}   (an absent axis cannot state its own cut, and the accounting has no histogram subject)");
+        Console.WriteLine($"   elapsed    : {sw.ElapsedMilliseconds} ms");
     }
 
     /// <summary>Run one cell and report the facts that decide both #361 lanes: the response's true size against the

--- a/src/housecarl-generator/CheckMeasureProbe.cs
+++ b/src/housecarl-generator/CheckMeasureProbe.cs
@@ -56,9 +56,11 @@ public static class CheckMeasureProbe
         int cap = Wire.DefaultMaxChars;
         Console.WriteLine($"## {label}");
         Console.WriteLine($"   chars      : {s.Length}  (cap {cap}{(s.Length > cap ? $" — OVER by {s.Length - cap}" : "")})");
-        Console.WriteLine($"   truncation notice present : {s.Contains("[truncated at max_chars=")}");
+        Console.WriteLine($"   states what it is missing : {s.Contains("found by this sweep appear above") || s.Contains("\"dangling_missing\"")}");
+        Console.WriteLine($"   over its cap              : {s.Length > cap}{(s.Contains("raise it to at least") || s.Contains("max_chars_overrun") ? " (declared)" : "")}");
         Console.WriteLine($"   json truncated flag       : {(s.Contains("\"truncated\"") ? s.Substring(s.IndexOf("\"truncated\"", StringComparison.Ordinal), Math.Min(24, s.Length - s.IndexOf("\"truncated\"", StringComparison.Ordinal))) : "n/a")}");
-        Console.WriteLine($"   budget line present       : {s.Contains("[the listing budget (limit=) omitted")}");
+        foreach (var l in s.Split('\n'))
+            if (l.Contains("[accounting:", StringComparison.Ordinal)) Console.WriteLine("   accounting : " + Trim(l));
         // The number no sentence in either format states: how many findings this RESPONSE actually carries. Counted
         // off the rendered entries themselves, so it is what the caller can see rather than what a layer intended.
         int shown = s.Contains("\"target\"") ? Count(s, "\"target\":") : Count(s, "[target not defined by any active plugin]");
@@ -66,8 +68,7 @@ public static class CheckMeasureProbe
         Console.WriteLine($"   boundary footer present   : {s.Contains("boundary: checks FormLink resolution") || s.Contains("\"boundary\"")}");
         Console.WriteLine($"   elapsed    : {sw.ElapsedMilliseconds} ms");
         foreach (var line in s.Split('\n'))
-            if (line.StartsWith("scanned ", StringComparison.Ordinal) || line.StartsWith("baseline:", StringComparison.Ordinal)
-                || line.Contains("[the listing budget", StringComparison.Ordinal) || line.Contains("[truncated at max_chars=", StringComparison.Ordinal))
+            if (line.StartsWith("scanned ", StringComparison.Ordinal) || line.StartsWith("baseline:", StringComparison.Ordinal))
                 Console.WriteLine("   > " + Trim(line));
         Console.WriteLine($"   last 220 chars: …{Trim(s[Math.Max(0, s.Length - 220)..])}");
         Console.WriteLine();

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -272,6 +272,11 @@ if (args.Length > 0 && args[0] == "skse-config-audit-real") return SkseConfigAud
 if (args.Length > 0 && args[0] == "native-pairing-guard") return NativePairingProbe.RunGuard(args[1..]);
 if (args.Length > 0 && args[0] == "native-pairing-real") return NativePairingProbe.RunReal(args[1..]);
 
+// PR 4 kickoff (`check`'s response layer): MANUAL real-data measurement of the two #361 lanes and the response
+// accounting on the LIVE order, taken before any design work. Needs --mo2 <inst>; --plugin <Name.esp> selects the
+// single-section cells. SKIPs without --mo2.
+if (args.Length > 0 && args[0] == "check-measure") return CheckMeasureProbe.RunMeasure(args[1..]);
+
 // UNKNOWN MODE — refused, not silently taken as an output directory (2.0 tidy-up scar, W3 PR 3 housekeeping).
 // Every dispatch above matched nothing, and the corpus fallthrough below reads args[0] as the OUTPUT DIRECTORY. So a
 // mistyped probe name generated the whole corpus into a folder of that name and exited 0: two of them put 13.5 MB of

--- a/src/housecarl-generator/ScriptPropertyCheckProbe.cs
+++ b/src/housecarl-generator/ScriptPropertyCheckProbe.cs
@@ -476,23 +476,76 @@ public static class ScriptPropertyCheckProbe
                 .ToDictionary(i => $"HcSpBroken{i}.esp", i => new string('r', 300)),
         };
         var rosterWhole = Wire.RenderScriptCheck(excludedFat, 0);
-        // The cap is searched for, not named: which one admits the response but not the roster is a fact about the
-        // fixture. Counts_only, because the listing lane skips the roster entirely once its own record list is cut.
+        // The NONE-FIT cap, searched for rather than named: which one admits the response but not a single roster row
+        // is a fact about the fixture.
         var rosterCut = "";
         for (int cap = 200; cap <= 4000 && !rosterCut.Contains("did not fit max_chars", StringComparison.Ordinal); cap += 20)
             rosterCut = Wire.RenderScriptCheck(excludedFat, cap);
         Check("EXCLUDED-ROSTER-CUT-NAMES-ITS-SUBJECT: when max_chars leaves no room for the excluded-plugin roster, the marker says WHAT did not fit and how many plugins are unnamed — it no longer relies on a header line that can itself be dropped",
             rosterCut.Contains("the excluded-plugin list did not fit max_chars", StringComparison.Ordinal)
-            && rosterCut.Contains("3 plugin(s) the index could not parse are NOT named above", StringComparison.Ordinal)
-            && !rosterCut.Contains("HcSpBroken0.esp", StringComparison.Ordinal)
+            && RosterUnnamed(rosterCut) == 3
+            && RosterNamed(excludedFat, rosterCut) == 0
             // and the other direction: an ample cap names them and says nothing about a cut
             && rosterWhole.Contains("HcSpBroken0.esp", StringComparison.Ordinal)
             && !rosterWhole.Contains("did not fit max_chars", StringComparison.Ordinal),
-            $"cut=[{rosterCut.Split('\n').LastOrDefault(l => l.Contains("excluded-plugin list", StringComparison.Ordinal)) ?? "<no marker>"}] wholeNames={rosterWhole.Contains("HcSpBroken0.esp", StringComparison.Ordinal)}");
+            $"named={RosterNamed(excludedFat, rosterCut)} stated={RosterUnnamed(rosterCut)}");
+
+        // THE PARTIAL CUT, in both lanes that carry the marker. The search above stops at the FIRST cap that produces
+        // it, which is by construction the one where no row fits — so the case where the roster names some of its
+        // plugins and then says none of them were named was pinned by nothing. Every cap in the band is walked, and
+        // the marker's number is asserted against rows counted out of the response.
+        var partialBad = new List<string>();
+        RosterMarkerCountsItsRows("counts_only", excludedFat, partialBad);
+        // The listing lane's copy of the same marker. Its roster is only reached while the record list itself was NOT
+        // cut, so the fixture keeps the records and fattens the roster — the same shape, one call site over.
+        var listingFat = res with
+        {
+            ExcludedPlugins = Enumerable.Range(0, 3)
+                .ToDictionary(i => $"HcSpBroken{i}.esp", i => new string('r', 300)),
+        };
+        RosterMarkerCountsItsRows("listing", listingFat, partialBad);
+        Check("EXCLUDED-ROSTER-CUT-COUNTS-THE-ROWS-IT-DROPPED: at a cap that names SOME of the unparseable plugins and not the rest, the marker states how many are UNNAMED — the total, printed over a response that named one of them, is a sentence its own lines contradict",
+            partialBad.Count == 0,
+            partialBad.Count == 0 ? "both lanes state total minus the rows they emitted" : string.Join("; ", partialBad));
 
         Console.WriteLine();
         Console.WriteLine(failures == 0 ? "script-property-check-guard: ALL PASS" : $"script-property-check-guard: {failures} FAILURE(S)");
         return failures == 0 ? 0 : 1;
+    }
+
+    /// <summary>How many of the fixture's unparseable plugins this response actually NAMES, counted off its own lines
+    /// rather than inferred from a cap.</summary>
+    static int RosterNamed(ScriptCheckResult r, string text)
+        => r.ExcludedPlugins.Keys.Count(k => text.Contains("  " + k + ": ", StringComparison.Ordinal));
+
+    /// <summary>The number the roster-cut marker states, or -1 where it states none.</summary>
+    static int RosterUnnamed(string text)
+    {
+        const string lead = "did not fit max_chars — ";
+        int at = text.IndexOf(lead, StringComparison.Ordinal);
+        if (at < 0) return -1;
+        var digits = new string(text[(at + lead.Length)..].TakeWhile(char.IsDigit).ToArray());
+        return int.TryParse(digits, out var n) ? n : -1;
+    }
+
+    /// <summary>Walk the caps where the roster marker fires and hold its number against the rows the response
+    /// actually carries. EVERY cap in the band, not the first that produces a marker: the first is always the
+    /// none-fit case, and the defect lives at the caps above it. A band that never splits is reported as a gap in the
+    /// fixture rather than passed over — an arm that never saw a partial cut proves nothing about one.</summary>
+    static void RosterMarkerCountsItsRows(string lane, ScriptCheckResult r, List<string> bad)
+    {
+        bool sawPartial = false;
+        for (int cap = 200; cap <= 6000; cap += 20)
+        {
+            var text = Wire.RenderScriptCheck(r, cap);
+            int stated = RosterUnnamed(text);
+            if (stated < 0) continue;
+            int named = RosterNamed(r, text);
+            if (named > 0) sawPartial = true;
+            if (stated != r.ExcludedPlugins.Count - named)
+                bad.Add($"{lane}@{cap}: {named} named, marker says {stated} unnamed of {r.ExcludedPlugins.Count}");
+        }
+        if (!sawPartial) bad.Add($"{lane}: no cap in 200..6000 names SOME of the roster and cuts the rest");
     }
 
     // ---- fixture builders --------------------------------------------------------------------------

--- a/src/housecarl-generator/ScriptPropertyCheckProbe.cs
+++ b/src/housecarl-generator/ScriptPropertyCheckProbe.cs
@@ -466,6 +466,27 @@ public static class ScriptPropertyCheckProbe
             && !tinyCap.Contains("scope plugins=", StringComparison.Ordinal),
             $"tail=[{tinyCap.Split('\n').LastOrDefault(l => l.Contains("truncated", StringComparison.Ordinal))}]");
 
+        // #392's scope note, held here. This lane's single counts_only axis has the identical shape as
+        // check_errors' two — AppendHistogram is shared — and this lane keeps NO accounting at all, so the axis's
+        // own closing line is the only thing that can report a cut. Charged to the same budget as its rows, a cap
+        // that refused the rows refused the report of them and the axis left the response unmentioned. It is
+        // reserved out of max_chars now, and this walks every cap in the band rather than sampling one.
+        var axisBad = new List<string>();
+        int axisDistinct = counts.Histogram!.Count;
+        for (int cap = 200; cap <= 4000; cap += 20)
+        {
+            var t = Wire.RenderScriptCheck(counts, cap);
+            if (!t.Contains("unbound properties by NAME", StringComparison.Ordinal))
+            { axisBad.Add($"@{cap} axis absent from the response entirely"); continue; }
+            int shown = counts.Histogram!.Count(h => t.Contains("  " + h.Key + "\n", StringComparison.Ordinal));
+            int stated = HistogramStated(t);
+            if (shown >= axisDistinct) { if (stated != -1) axisBad.Add($"@{cap} rendered all {axisDistinct} and claims {stated}"); }
+            else if (stated != axisDistinct - shown) axisBad.Add($"@{cap} rendered {shown} of {axisDistinct} and states {stated}");
+        }
+        Check("HISTOGRAM-AXIS-NEVER-DROPS-SILENTLY (#392): at every cap across the band the counts_only axis is IN the response and states how many of its rows are missing — this lane keeps no accounting, so that line is the only thing that can say a cut happened",
+            axisBad.Count == 0,
+            axisBad.Count == 0 ? $"the axis stated itself at every cap (distinct {axisDistinct})" : string.Join("; ", axisBad.Take(4)) + $" ({axisBad.Count} total)");
+
         // The excluded-plugin roster's HEAD is charged to max_chars now (it used to be printed unconditionally), so
         // a tight cap can drop the whole roster — and the marker that says so used to be a bare
         // "... [truncated at max_chars]" that leant on a header line which may no longer be there. A marker has to
@@ -511,6 +532,18 @@ public static class ScriptPropertyCheckProbe
         Console.WriteLine();
         Console.WriteLine(failures == 0 ? "script-property-check-guard: ALL PASS" : $"script-property-check-guard: {failures} FAILURE(S)");
         return failures == 0 ? 0 : 1;
+    }
+
+    /// <summary>The number the histogram's closing line states, or -1 where the axis states no cut. Read as a
+    /// NUMBER, not as a substring: a response either says how many rows it dropped or it does not, and "contains a
+    /// remedy somewhere" is satisfied by any axis at all.</summary>
+    static int HistogramStated(string text)
+    {
+        const string lead = "more row(s) — raise ";
+        int at = text.IndexOf(lead, StringComparison.Ordinal);
+        if (at < 0) return -1;
+        var digits = new string(text[..at].Reverse().SkipWhile(c => c == ' ').TakeWhile(char.IsDigit).Reverse().ToArray());
+        return int.TryParse(digits, out var n) ? n : -1;
     }
 
     /// <summary>How many of the fixture's unparseable plugins this response actually NAMES, counted off its own lines

--- a/src/housecarl-generator/ScriptPropertyCheckProbe.cs
+++ b/src/housecarl-generator/ScriptPropertyCheckProbe.cs
@@ -466,6 +466,30 @@ public static class ScriptPropertyCheckProbe
             && !tinyCap.Contains("scope plugins=", StringComparison.Ordinal),
             $"tail=[{tinyCap.Split('\n').LastOrDefault(l => l.Contains("truncated", StringComparison.Ordinal))}]");
 
+        // The excluded-plugin roster's HEAD is charged to max_chars now (it used to be printed unconditionally), so
+        // a tight cap can drop the whole roster — and the marker that says so used to be a bare
+        // "... [truncated at max_chars]" that leant on a header line which may no longer be there. A marker has to
+        // name its own subject. Both directions: at an ample cap the roster is named and there is no marker.
+        var excludedFat = counts with
+        {
+            ExcludedPlugins = Enumerable.Range(0, 3)
+                .ToDictionary(i => $"HcSpBroken{i}.esp", i => new string('r', 300)),
+        };
+        var rosterWhole = Wire.RenderScriptCheck(excludedFat, 0);
+        // The cap is searched for, not named: which one admits the response but not the roster is a fact about the
+        // fixture. Counts_only, because the listing lane skips the roster entirely once its own record list is cut.
+        var rosterCut = "";
+        for (int cap = 200; cap <= 4000 && !rosterCut.Contains("did not fit max_chars", StringComparison.Ordinal); cap += 20)
+            rosterCut = Wire.RenderScriptCheck(excludedFat, cap);
+        Check("EXCLUDED-ROSTER-CUT-NAMES-ITS-SUBJECT: when max_chars leaves no room for the excluded-plugin roster, the marker says WHAT did not fit and how many plugins are unnamed — it no longer relies on a header line that can itself be dropped",
+            rosterCut.Contains("the excluded-plugin list did not fit max_chars", StringComparison.Ordinal)
+            && rosterCut.Contains("3 plugin(s) the index could not parse are NOT named above", StringComparison.Ordinal)
+            && !rosterCut.Contains("HcSpBroken0.esp", StringComparison.Ordinal)
+            // and the other direction: an ample cap names them and says nothing about a cut
+            && rosterWhole.Contains("HcSpBroken0.esp", StringComparison.Ordinal)
+            && !rosterWhole.Contains("did not fit max_chars", StringComparison.Ordinal),
+            $"cut=[{rosterCut.Split('\n').LastOrDefault(l => l.Contains("excluded-plugin list", StringComparison.Ordinal)) ?? "<no marker>"}] wholeNames={rosterWhole.Contains("HcSpBroken0.esp", StringComparison.Ordinal)}");
+
         Console.WriteLine();
         Console.WriteLine(failures == 0 ? "script-property-check-guard: ALL PASS" : $"script-property-check-guard: {failures} FAILURE(S)");
         return failures == 0 ? 0 : 1;

--- a/src/housecarl-mcp/CheckAccounting.cs
+++ b/src/housecarl-mcp/CheckAccounting.cs
@@ -18,6 +18,18 @@ namespace HousecarlMcp;
 /// layer rule survives as this class's internal discipline: the causes are still named separately, but they are
 /// decomposed out of one computation instead of raced by two.</para>
 ///
+/// <para><b>The DECLARED SUBJECT set, and the boolean it replaces.</b> The first cut of this class carried one
+/// <c>_listing</c> flag standing for two different lane facts — "did the dangling walk run" and "does this mode
+/// build a per-plugin listing" — and a section count read unconditionally off <c>Reports</c>, which means different
+/// things per lane. Six distinct wrong sentences came out of that in two review rounds, three of them created by
+/// the folds for the other three: a <c>findings=["missing_masters"]</c> json response that reported no sections at
+/// all, a <c>counts_only</c> response claiming "0 of 3 plugin section(s) were rendered" over a response that
+/// dropped nothing, an opener inside the gate and its closer outside it. So the accounting is now CONSTRUCTED with
+/// the subjects the lane actually has (<see cref="SweepSubject"/>), each carrying what the sweep FOUND and what the
+/// render EMITTED. Every sentence, every json field, the remedy and the reserve derive from that set. A lane
+/// without sections cannot claim about them, and a lane with them cannot fail to — by construction rather than by
+/// each clause remembering its own gate.</para>
+///
 /// <para><b>How #361 dies here rather than being patched.</b> Two invariants, neither of them a code path that has
 /// to remember to run:
 /// <list type="number">
@@ -30,86 +42,92 @@ namespace HousecarlMcp;
 /// invisible to the <c>truncated</c> flag the auto-spill trigger reads.</item>
 /// </list></para>
 ///
-/// <para><b>Deliberately findings-family-agnostic, and deliberately no further.</b> Its interface speaks in
-/// entries-emitted vs entries-found, which carries to any findings family without knowing what a family is. It
-/// takes no taxonomy parameter and holds no family enum: the merged <c>check</c> surface (SPEC §6.1) is a separate
-/// PR with its own design, and building its machinery here on speculation is what CLAUDE.md §8 names.</para>
+/// <para><b>Deliberately findings-family-agnostic, and deliberately no further.</b> Its subjects are lane facts —
+/// entries, sections, roster rows — which carry to any findings family without knowing what a family is. It takes
+/// no taxonomy parameter and holds no family enum: the merged <c>check</c> surface (SPEC §6.1) is a separate PR
+/// with its own design, and building its machinery here on speculation is what CLAUDE.md §8 names.</para>
 /// </summary>
 internal sealed class CheckAccounting
 {
-    // ---- what the SWEEP found (fixed before the render starts) --------------------------------------
+    // ---- the declared subjects: what this lane HAS, and how much of each the sweep found -------------
+    readonly Dictionary<SweepSubject, int> _found = new();
+    readonly Dictionary<SweepSubject, int> _emitted = new();
+
+    // ---- the dangling subject's own extras ----------------------------------------------------------
     readonly IReadOnlyList<SweepCount> _bySource;   // true dangling count per source plugin, never limit-capped
-    readonly int _found;                            // every dangling ref the sweep counted, in scope
+    readonly Dictionary<string, int> _bySourceEmitted = new(StringComparer.OrdinalIgnoreCase);
     readonly int _budgetListed;                     // the subset the listing budget admitted into the reports
-    readonly int _sectionsWithFindings;
-    readonly int _excludedTotal;
-    readonly int _unreadTotal;
-    readonly bool _listing;                         // is a per-plugin listing being built at all?
     readonly int _cap;
     readonly int _limit;
 
-    // ---- what the RENDER put in (filled as it emits) ------------------------------------------------
-    readonly Dictionary<string, int> _emitted = new(StringComparer.OrdinalIgnoreCase);
-    int _visible, _sections, _excluded, _unread;
-
-    /// <summary>Build the accounting for one response. Under <c>counts_only=true</c> the listing clauses are ABSENT
-    /// rather than zero: nothing is listed there BY DESIGN, and "the budget omitted everything" would report a mode
-    /// working correctly as a failure.</summary>
+    /// <summary>Build the accounting for one response, declaring the subjects this lane has.
+    ///
+    /// <para>Each declaration is a lane fact stated once, here, instead of a gate repeated at every clause:</para>
+    /// <list type="bullet">
+    /// <item><b>Dangling entries</b> — only where a per-plugin listing is built AND the walk that fills it ran.
+    /// Under <c>counts_only</c> nothing is listed BY DESIGN, and "the budget omitted everything" would report a
+    /// mode working correctly as a failure.</item>
+    /// <item><b>Plugin sections</b> — in EVERY listing lane, entries or not. With <c>findings=["missing_masters"]</c>
+    /// the sweep lists no dangling refs at all, and the section loop still cuts; gated on the listing flag those
+    /// responses said nothing in text and wrote no <c>rendered</c>/<c>truncated</c> in json.</item>
+    /// <item><b>Unread rows</b> — only under <c>counts_only</c>, where <c>Reports</c> carries the honesty layer
+    /// rather than findings. In the listing lane those same plugins ARE the sections, so the two subjects exist in
+    /// different lanes and can never double-count a row.</item>
+    /// <item><b>Excluded rows</b> — wherever the index actually excluded something.</item>
+    /// </list></summary>
     internal CheckAccounting(ErrorCheckResult r, int cap)
     {
         _cap = cap;
         _limit = r.Limit;
-        _listing = !r.CountsOnly && r.Classes.HasFlag(ErrorFindingClass.Dangling);
         _bySource = r.DanglingBySource ?? Array.Empty<SweepCount>();
-        _found = r.TotalDangling;
         _budgetListed = r.Reports.Sum(p => p.Dangling.Count);
-        _sectionsWithFindings = r.Reports.Count;
-        _excludedTotal = r.ExcludedPlugins.Count;
-        // counts_only's reports list carries the honesty layer only — plugins whose records could not be read. In
-        // the listing lane those same plugins carry findings and are counted as SECTIONS, so this subject exists
-        // exactly where the other one does not, and the two can never double-count the same row.
-        _unreadTotal = r.CountsOnly ? r.Reports.Count : 0;
+
+        if (!r.CountsOnly && r.Classes.HasFlag(ErrorFindingClass.Dangling)) Declare(SweepSubject.DanglingEntries, r.TotalDangling);
+        if (!r.CountsOnly) Declare(SweepSubject.PluginSections, r.Reports.Count);
+        if (r.CountsOnly) Declare(SweepSubject.UnreadRows, r.Reports.Count);
+        if (r.ExcludedPlugins.Count > 0) Declare(SweepSubject.ExcludedRows, r.ExcludedPlugins.Count);
     }
 
-    // ---- registration: the render tells the accounting what it emitted ------------------------------
+    void Declare(SweepSubject s, int found) { _found[s] = found; _emitted[s] = 0; }
 
-    /// <summary>One dangling entry just went into the response, sourced from <paramref name="plugin"/>. Called where
-    /// the line is APPENDED, never where a section is entered: a section total would claim entries for a section the
-    /// cut left half-written, which is the class of false number this construction exists to make unrepresentable.
-    /// </summary>
-    internal void Entry(string plugin)
+    internal bool Has(SweepSubject s) => _found.ContainsKey(s);
+    int Found(SweepSubject s) => _found.TryGetValue(s, out var n) ? n : 0;
+    int Emitted(SweepSubject s) => _emitted.TryGetValue(s, out var n) ? n : 0;
+
+    // ---- registration: the emission helper tells the accounting what it emitted ---------------------
+
+    /// <summary>One unit of <paramref name="s"/> just went into the response. Called from
+    /// <see cref="BoundedBody.Emit"/> where the unit LANDED, never where a section is entered: a section total would
+    /// claim entries for a section the cut left half-written, which is the class of false number this construction
+    /// exists to make unrepresentable.
+    ///
+    /// <para>A subject this lane did not declare is IGNORED rather than counted. That is what lets the histogram
+    /// rows share the one bounded-emission path without acquiring an accounting sentence of their own — the
+    /// histogram already discloses its own cut in both transports.</para></summary>
+    internal void Emitted(SweepSubject s, string? source = null)
     {
-        _visible++;
-        _emitted[plugin] = (_emitted.TryGetValue(plugin, out var had) ? had : 0) + 1;
+        if (!_found.ContainsKey(s)) return;
+        _emitted[s]++;
+        if (s == SweepSubject.DanglingEntries && source is not null)
+            _bySourceEmitted[source] = (_bySourceEmitted.TryGetValue(source, out var had) ? had : 0) + 1;
     }
 
-    internal void Section() => _sections++;
-
-    /// <summary>Rows the two honesty-layer rosters actually appended. Taken as a COUNT because those helpers are
-    /// shared with validate_scripts, whose response layer is not this PR's — they report what they emitted and each
-    /// caller states it in its own terms, so neither lane's prose leaks into the other's.</summary>
-    internal void ExcludedRows(int n) => _excluded += n;
-    internal void UnreadRows(int n) => _unread += n;
+    /// <summary>Rows a transport wrote WHOLE, outside the emission loop — json writes its excluded roster as one
+    /// array it either completes or does not start. Told explicitly rather than left at zero, which would claim
+    /// every row was dropped.</summary>
+    internal void EmittedAll(SweepSubject s) { if (_found.ContainsKey(s)) _emitted[s] = _found[s]; }
 
     // ---- derived ------------------------------------------------------------------------------------
 
     /// <summary>Refs the listing budget never admitted. A pure SWEEP fact, so it is readable before the body renders
     /// — which is what lets the baseline block's phase-order sentence consult it without waiting for emission.
     /// </summary>
-    internal int OmittedByBudget => _listing ? _found - _budgetListed : 0;
+    internal int OmittedByBudget => Has(SweepSubject.DanglingEntries) ? Found(SweepSubject.DanglingEntries) - _budgetListed : 0;
 
-    internal int Visible => _visible;
-    internal int Found => _found;
-    internal int Omitted => _listing ? _found - _visible : 0;
-
-    /// <summary>Refs the budget admitted and this response then could not fit. The other half of
-    /// <see cref="Omitted"/> BY CONSTRUCTION: both are subtractions off the same total, so the two causes sum to it
+    /// <summary>Refs the budget admitted and this response then could not fit. The other half of the dangling
+    /// subject's omission BY CONSTRUCTION: both are subtractions off the same total, so the two causes sum to it
     /// exactly rather than by two counters happening to agree.</summary>
-    internal int OmittedByCut => _listing ? _budgetListed - _visible : 0;
-
-    internal int SectionsRendered => _sections;
-    internal int SectionsWithFindings => _sectionsWithFindings;
-    internal bool Listing => _listing;
+    internal int OmittedByCut => Has(SweepSubject.DanglingEntries) ? _budgetListed - Emitted(SweepSubject.DanglingEntries) : 0;
 
     /// <summary>WHICH source plugins are missing entries from THIS response, largest first. Computed against what was
     /// emitted, so it covers both causes at once: under the two-layer split, a plugin whose entries the budget listed
@@ -118,11 +136,11 @@ internal sealed class CheckAccounting
     {
         get
         {
-            if (!_listing) return Array.Empty<SweepCount>();
+            if (!Has(SweepSubject.DanglingEntries)) return Array.Empty<SweepCount>();
             var acc = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             foreach (var row in _bySource)
             {
-                int shown = _emitted.TryGetValue(row.Key, out var c) ? c : 0;
+                int shown = _bySourceEmitted.TryGetValue(row.Key, out var c) ? c : 0;
                 if (row.Count > shown) acc[row.Key] = row.Count - shown;
             }
             return SweepFindings.Histogram(acc);
@@ -145,11 +163,13 @@ internal sealed class CheckAccounting
 
     /// <summary>Slack over the measured worst case, and the two lanes need very different amounts of it.
     ///
-    /// <para>The TEXT lane composes each line and tests <c>length + line.Length</c> before appending, so nothing it
-    /// writes can exceed the budget it was tested against. All it needs is the handful of newlines the accounting
-    /// and boundary are wrapped in. The JSON lane cannot do that — a <c>Utf8JsonWriter</c> has no way to measure an
-    /// object without writing it — so its test is taken before the write and the last entry lands over. That slack
-    /// has to cover one whole entry: two FormID strings, a type name and an EditorID.</para>
+    /// <para>The TEXT lane composes each unit and tests <c>length + cost</c> before appending, so nothing it writes
+    /// can exceed the budget it was tested against. All it needs is the handful of newlines the accounting and
+    /// boundary are wrapped in. The JSON lane cannot do that for every unit — a <c>Utf8JsonWriter</c> has no way to
+    /// measure an object without writing it — so its per-entry test is taken before the write and the last entry
+    /// lands over. That slack has to cover one whole entry: two FormID strings, a type name and an EditorID. It is
+    /// also what absorbs <see cref="BoundedBody"/>'s post-check, which stops the body the moment a unit crosses the
+    /// budget rather than pretending it cannot happen.</para>
     ///
     /// <para>One number for both cost the text lane a kilobyte of listing at every cap, which at small caps was the
     /// whole listing. A reserve slightly too large costs characters; one slightly too small is #361. The cap sweep
@@ -161,57 +181,81 @@ internal sealed class CheckAccounting
     /// what a real render can reach: the counts are the totals themselves, so their digit widths bound every real
     /// count; every optional clause is present; and the roster holds the LONGEST source names rather than the
     /// largest, because a partly-listed response can promote a long-named small source into the roster that a
-    /// fully-omitted one would have pushed out — "largest" is not a bound and "longest" is.</summary>
+    /// fully-omitted one would have pushed out — "largest" is not a bound and "longest" is.
+    ///
+    /// <para>Length is taken as the MAXIMUM of the plain and the json-escaped spelling. One reserve is measured off
+    /// a text render and one off a json one, and a name whose escaped form is longer than its plain form (any
+    /// non-ASCII plugin filename) ranks differently in the two — ordering both by the json length let a name that is
+    /// long in text be pushed out of the sample the TEXT reserve was sized from.</para></summary>
     Values Worst()
     {
-        var longest = _bySource.OrderByDescending(c => JsonEncodedText.Encode(c.Key).Value.Length)
-                               .Take(ReadSentences.SweepRosterRows)
-                               .Select(c => new SweepCount(c.Key, _found))
-                               .ToList();
+        int danglingFound = Found(SweepSubject.DanglingEntries);
+        // The roster is the dangling subject's, so a lane without that subject reserves nothing for it. The
+        // by-source tally is collected on EVERY sweep, so a worst case built off it unconditionally held ~700 chars
+        // back from a counts_only response for a roster that lane can never emit — at max_chars=1500 that was the
+        // whole histogram.
+        var longest = Has(SweepSubject.DanglingEntries)
+            ? _bySource.OrderByDescending(c => WidestSpelling(c.Key))
+                       .Take(ReadSentences.SweepRosterRows)
+                       .Select(c => new SweepCount(c.Key, danglingFound))
+                       .ToList()
+            : new List<SweepCount>();
         // Every slot at its widest, not at zero. The counts are digits in the rendered line, and a real response's
-        // Visible / Sections / Excluded / Unread are wider than 0 — so a worst case that passed 0 for them was
-        // bounded by the slack rather than by construction, which is not what its own summary claimed.
-        return new Values(Visible: _found, ByBudget: _found, ByCut: _found, Roster: longest,
-                          RosterTotal: Math.Max(_bySource.Count, longest.Count),
-                          Sections: _sectionsWithFindings, Excluded: _excludedTotal, Unread: _unreadTotal,
-                          Worst: true);
+        // emitted counts are wider than 0 — so a worst case that passed 0 for them was bounded by the slack rather
+        // than by construction, which is not what its own summary claimed.
+        var emitted = new Dictionary<SweepSubject, int>();
+        foreach (var kv in _found) emitted[kv.Key] = kv.Value;
+        emitted[SweepSubject.DanglingEntries] = danglingFound;
+        return new Values(Visible: danglingFound, ByBudget: danglingFound, ByCut: danglingFound, Roster: longest,
+                          RosterTotal: Math.Max(_bySource.Count, longest.Count), Emitted: emitted, Worst: true);
     }
 
-    /// <summary>What this response actually did.</summary>
-    Values Real() => new(_visible, OmittedByBudget, OmittedByCut, MissingBySource, MissingBySource.Count,
-                         _sections, _excluded, _unread, Worst: false);
+    static int WidestSpelling(string name) => Math.Max(name.Length, JsonEncodedText.Encode(name).Value.Length);
 
-    /// <summary>The numbers one rendering of the accounting states. A record rather than eight parameters so the
+    /// <summary>What this response actually did.</summary>
+    Values Real() => new(Emitted(SweepSubject.DanglingEntries), OmittedByBudget, OmittedByCut,
+                         MissingBySource, MissingBySource.Count, _emitted, Worst: false);
+
+    /// <summary>The numbers one rendering of the accounting states. A record rather than a parameter list so the
     /// real case and the worst case go through ONE composer per transport — a second formatter would be a second
     /// spelling, and a reserve computed off a spelling that has since drifted is a reserve that silently stops
     /// bounding anything.</summary>
     readonly record struct Values(int Visible, int ByBudget, int ByCut, IReadOnlyList<SweepCount> Roster,
-                                  int RosterTotal, int Sections, int Excluded, int Unread, bool Worst);
+                                  int RosterTotal, IReadOnlyDictionary<SweepSubject, int> Emitted, bool Worst);
+
+    /// <summary>Is this subject short in this rendering? ONE test, used by the clause that states it, by
+    /// <see cref="Missing"/>, and by the remedy — so the three cannot disagree about the same subject.</summary>
+    bool Short(Values v, SweepSubject s)
+        => Has(s) && (v.Worst || (v.Emitted.TryGetValue(s, out var e) ? e : 0) < Found(s));
+
+    int Shown(Values v, SweepSubject s) => v.Emitted.TryGetValue(s, out var e) ? e : 0;
 
     // ---- the text lane ------------------------------------------------------------------------------
 
     /// <summary>The accounting as the text transport states it, or null where there is nothing at all to account
-    /// for. Present on EVERY listing response, complete or not: silence used to mean both "this response carries
-    /// everything" and "#361", and those two must never read alike.</summary>
+    /// for. Present on EVERY response that has a listing subject, complete or not: silence used to mean both "this
+    /// response carries everything" and "#361", and those two must never read alike. A lane with no listing has no
+    /// completeness to assert, so it states an accounting only when something is actually short.</summary>
     internal string? TextLine()
     {
         var v = Real();
-        // A listing lane always states its accounting, complete or not. Any other lane states one only when
-        // something is actually short — there is no positive claim to make about a listing that never ran.
-        return _listing || Missing(v) ? Compose(v) : null;
+        return Has(SweepSubject.DanglingEntries) || Missing(v) ? Compose(v) : null;
     }
 
     string Compose(Values v)
     {
-        var sb = new StringBuilder();
-        int omitted = v.ByBudget + v.ByCut;
-        bool missing = Missing(v);
+        // The opener and the closer sit OUTSIDE every subject gate, because they are not about any subject. The
+        // opener used to be baked into the two listing leads, so a lane with no listing emitted a bare clause and
+        // an orphan "]" — the accounting's own framing had the shape it exists to forbid.
+        var sb = new StringBuilder(ReadSentences.SweepAccountingLead);
 
-        if (_listing)
+        if (Has(SweepSubject.DanglingEntries))
         {
+            int found = Found(SweepSubject.DanglingEntries);
+            int omitted = v.ByBudget + v.ByCut;
             sb.Append(omitted > 0 || v.Worst
-                ? string.Format(ReadSentences.SweepVisible, v.Visible, _found)
-                : string.Format(ReadSentences.SweepAllVisible, _found));
+                ? string.Format(ReadSentences.SweepVisible, v.Visible, found)
+                : string.Format(ReadSentences.SweepAllVisible, found));
 
             var causes = new List<string>();
             if (v.ByBudget > 0 || v.Worst) causes.Add(string.Format(ReadSentences.SweepOmittedByBudget, v.ByBudget, _limit));
@@ -219,20 +263,21 @@ internal sealed class CheckAccounting
             if (causes.Count > 0) sb.Append(string.Join(",", causes)).Append('.');
         }
 
-        // OUTSIDE the listing gate, deliberately. A section is dropped by the RENDER, and the render runs whether or
-        // not the dangling walk did: with findings=["missing_masters"] the sweep lists no dangling refs at all, so
-        // _listing is false — and the section loop still cuts. Gated on _listing this clause was absent there, which
-        // put #361's own shape (a cut that leaves no sentence) inside the fix for #361, in the lane the tool's own
+        // One clause per short subject, each computed from the subject it names. A section is dropped by the RENDER,
+        // and the render runs whether or not the dangling walk did — with findings=["missing_masters"] the sweep
+        // lists nothing and the section loop still cuts, which is #361's own shape in the lane the tool's own
         // description sells as the cheap "is any master missing anywhere" sweep.
-        if (v.Sections < _sectionsWithFindings || v.Worst)
-            sb.Append(string.Format(ReadSentences.SweepSections, v.Sections, _sectionsWithFindings));
-
+        if (Short(v, SweepSubject.PluginSections))
+            sb.Append(string.Format(ReadSentences.SweepSections, Shown(v, SweepSubject.PluginSections),
+                                    Found(SweepSubject.PluginSections)));
         // The two honesty-layer rosters. Their rows are what houseCARL could NOT read, so a silent cut there hides
         // the boundary of the answer rather than a finding inside it.
-        if (v.Excluded < _excludedTotal || v.Worst)
-            sb.Append(string.Format(ReadSentences.SweepExcludedCut, v.Excluded, _excludedTotal));
-        if (v.Unread < _unreadTotal || v.Worst)
-            sb.Append(string.Format(ReadSentences.SweepUnreadCut, v.Unread, _unreadTotal));
+        if (Short(v, SweepSubject.ExcludedRows))
+            sb.Append(string.Format(ReadSentences.SweepExcludedCut, Shown(v, SweepSubject.ExcludedRows),
+                                    Found(SweepSubject.ExcludedRows)));
+        if (Short(v, SweepSubject.UnreadRows))
+            sb.Append(string.Format(ReadSentences.SweepUnreadCut, Shown(v, SweepSubject.UnreadRows),
+                                    Found(SweepSubject.UnreadRows)));
 
         if (v.Roster.Count > 0)
         {
@@ -245,15 +290,16 @@ internal sealed class CheckAccounting
             if (v.RosterTotal > ReadSentences.SweepRosterRows || v.Worst)
                 sb.Append(string.Format(ReadSentences.SweepRosterCut, ReadSentences.SweepRosterRows, v.RosterTotal));
             sb.Append('.');
+            // The rule belongs to the roster — it explains what the roster is for, so it is stated where one exists.
+            sb.Append(ReadSentences.SweepNoSectionRule);
         }
 
-        // The rule belongs to the roster — it explains what the roster is for, so it is stated where one exists.
-        if (v.Roster.Count > 0) sb.Append(ReadSentences.SweepNoSectionRule);
-        if (missing)
+        if (Missing(v))
         {
             if (v.ByBudget > 0 || v.Worst) sb.Append(ReadSentences.SweepRemedyLimit);
-            if (v.ByCut > 0 || v.Sections < _sectionsWithFindings || v.Excluded < _excludedTotal
-                || v.Unread < _unreadTotal || v.Worst)
+            // max_chars is the knob for every subject except the listing budget's own share.
+            if (v.ByCut > 0 || v.Worst || Short(v, SweepSubject.PluginSections)
+                || Short(v, SweepSubject.ExcludedRows) || Short(v, SweepSubject.UnreadRows))
                 sb.Append(ReadSentences.SweepRemedyMaxChars);
             if (v.Roster.Count > 0) sb.Append(ReadSentences.SweepRemedyScope).Append(ReadSentences.SweepRemedyCountsOnly);
         }
@@ -261,12 +307,15 @@ internal sealed class CheckAccounting
         return sb.ToString();
     }
 
-    /// <summary>Is anything at all absent from this response? ONE test over EVERY subject, so the remedy and the
-    /// clauses above it cannot disagree. Dropped sections belong here: a sweep whose findings are all missing
-    /// masters omits no dangling ref, so without this term a response missing 34 of 41 sections closed as complete —
-    /// with no remedy, no roster, and a json twin that said truncated.</summary>
-    bool Missing(Values v) => v.Worst || v.ByBudget + v.ByCut > 0 || v.Sections < _sectionsWithFindings
-                              || v.Excluded < _excludedTotal || v.Unread < _unreadTotal;
+    /// <summary>Is anything at all absent from this response? ONE test over EVERY DECLARED subject, so the remedy and
+    /// the clauses above it cannot disagree, and a subject the lane does not have cannot make it true. Dropped
+    /// sections belong here: a sweep whose findings are all missing masters omits no dangling ref, so without this
+    /// term a response missing 34 of 41 sections closed as complete — with no remedy, no roster, and a json twin that
+    /// said truncated.</summary>
+    bool Missing(Values v)
+        => v.Worst || v.ByBudget + v.ByCut > 0
+           || Short(v, SweepSubject.PluginSections) || Short(v, SweepSubject.ExcludedRows)
+           || Short(v, SweepSubject.UnreadRows);
 
     // ---- the json lane ------------------------------------------------------------------------------
 
@@ -281,39 +330,44 @@ internal sealed class CheckAccounting
 
     void WriteJson(Utf8JsonWriter w, Values v)
     {
-        // capped is the listing budget's fact, truncated is this response's — both off the ONE computation, so a
-        // consumer no longer has to know which layer measured which.
-        //
-        // LISTING LANE ONLY, as on the base commit. Under counts_only there is no listing, and Reports carries the
-        // honesty roster instead — so _sectionsWithFindings is a count of UNREADABLE plugins and _sections is always
-        // 0. Written unconditionally, a counts_only sweep that found 240 dangling refs reported
-        // "plugins_with_findings": 0, and one with an unreadable plugin reported truncated:true beside its own
-        // "unread": {"truncated": false}. A field named for one lane's subject is absent in the other, never zero.
-        if (_listing)
+        // A field named for a subject is present exactly where that subject is, and absent otherwise — never a zero
+        // standing in for "this lane has no such thing". Written unconditionally, a counts_only sweep that found 240
+        // dangling refs reported "plugins_with_findings": 0; gated on the LISTING flag instead, a
+        // findings=["missing_masters"] sweep wrote no sections, no rendered and no truncated at all, so the json
+        // twin of a text response that stated its cut said nothing about it.
+        bool sections = Has(SweepSubject.PluginSections);
+        bool dangling = Has(SweepSubject.DanglingEntries);
+        if (dangling) w.WriteBoolean("capped", v.ByBudget > 0);
+        if (sections)
         {
-            w.WriteBoolean("capped", v.ByBudget > 0);
-            w.WriteNumber("plugins_with_findings", _sectionsWithFindings);
-            w.WriteNumber("rendered", v.Sections);
-            w.WriteBoolean("truncated", v.ByCut > 0 || v.Sections < _sectionsWithFindings);
+            w.WriteNumber("plugins_with_findings", Found(SweepSubject.PluginSections));
+            w.WriteNumber("rendered", Shown(v, SweepSubject.PluginSections));
+            // truncated is THIS RESPONSE's fact over every subject it has, which is what a consumer deciding
+            // whether to re-ask actually needs; capped above is the listing budget's separate one.
+            w.WriteBoolean("truncated", v.ByCut > 0 || Short(v, SweepSubject.PluginSections)
+                                        || Short(v, SweepSubject.ExcludedRows) || Short(v, SweepSubject.UnreadRows));
         }
         w.WriteStartObject("accounting");
-        w.WriteBoolean("listing", _listing);
-        if (_listing)
+        w.WriteBoolean("listing", dangling);
+        if (dangling)
         {
-            w.WriteNumber("dangling_found", _found);
+            w.WriteNumber("dangling_found", Found(SweepSubject.DanglingEntries));
             w.WriteNumber("dangling_visible", v.Visible);
             w.WriteNumber("dangling_missing", v.ByBudget + v.ByCut);
             w.WriteNumber("dangling_missing_by_budget", v.ByBudget);
             w.WriteNumber("dangling_missing_by_response_cut", v.ByCut);
             w.WriteNumber("limit", _limit);
-            w.WriteNumber("sections_with_findings", _sectionsWithFindings);
-            w.WriteNumber("sections_rendered", v.Sections);
+        }
+        if (sections)
+        {
+            w.WriteNumber("sections_with_findings", Found(SweepSubject.PluginSections));
+            w.WriteNumber("sections_rendered", Shown(v, SweepSubject.PluginSections));
         }
         w.WriteNumber("max_chars", _cap);
-        w.WriteNumber("excluded_plugins_total", _excludedTotal);
-        w.WriteNumber("excluded_plugins_named", v.Excluded);
-        w.WriteNumber("unread_plugins_total", _unreadTotal);
-        w.WriteNumber("unread_plugins_named", v.Unread);
+        w.WriteNumber("excluded_plugins_total", Found(SweepSubject.ExcludedRows));
+        w.WriteNumber("excluded_plugins_named", Shown(v, SweepSubject.ExcludedRows));
+        w.WriteNumber("unread_plugins_total", Found(SweepSubject.UnreadRows));
+        w.WriteNumber("unread_plugins_named", Shown(v, SweepSubject.UnreadRows));
         w.WriteStartArray("dangling_missing_by_source");
         for (int i = 0; i < v.Roster.Count && i < ReadSentences.SweepRosterRows; i++)
         {
@@ -352,18 +406,17 @@ internal sealed class CheckAccounting
         return (int)ms.Length;
     }
 
-    /// <summary>The measuring constructor: enough state for <see cref="WriteJson(Utf8JsonWriter, Values)"/> to write
-    /// the worst case at full width. It is never registered against and never rendered into a response.</summary>
+    /// <summary>The measuring constructor: every subject declared at full width, so
+    /// <see cref="WriteJson(Utf8JsonWriter, Values)"/> writes the worst case with no field missing. It is never
+    /// registered against and never rendered into a response.</summary>
     CheckAccounting(Values v)
     {
         _bySource = v.Roster;
-        _found = v.ByBudget;
         _cap = int.MaxValue;
         _limit = int.MaxValue;
-        _listing = true;
-        _sectionsWithFindings = v.RosterTotal;
-        _excludedTotal = v.RosterTotal;
-        _unreadTotal = v.RosterTotal;
+        _budgetListed = v.ByBudget;
+        foreach (SweepSubject s in Enum.GetValues<SweepSubject>())
+            if (s != SweepSubject.HistogramRows) Declare(s, Math.Max(v.ByBudget, v.RosterTotal));
     }
 
     // ---- the cap floor ------------------------------------------------------------------------------
@@ -381,10 +434,12 @@ internal sealed class CheckAccounting
     /// <para><paramref name="needed"/> is what it takes to carry this response's fixed part plus the accounting —
     /// the number a caller can set max_chars to and stop seeing this. It is not the current length: raising the cap
     /// widens the printed max_chars by a digit or two, which the slack below absorbs, and a probe follows the
-    /// remedy at a sweep of caps rather than trusting that reasoning.</para></summary>
+    /// remedy at a sweep of caps rather than trusting that reasoning. It is also never BELOW the cap the caller
+    /// already passed: a remedy telling them to lower max_chars is one they cannot act on, and the fixed part that
+    /// does not fit is by definition bigger than the budget it did not fit in.</para></summary>
     internal string? CapTooSmall(int contentLength, int needed) =>
         contentLength > _cap
-            ? string.Format(ReadSentences.SweepCapTooSmall, _cap, needed + RaiseSlack, contentLength)
+            ? string.Format(ReadSentences.SweepCapTooSmall, _cap, Math.Max(needed, contentLength) + RaiseSlack, contentLength)
             : null;
 
     /// <summary>Slack on the number the overrun notice tells a caller to raise to. Setting max_chars to exactly the

--- a/src/housecarl-mcp/CheckAccounting.cs
+++ b/src/housecarl-mcp/CheckAccounting.cs
@@ -151,14 +151,14 @@ internal sealed class CheckAccounting
 
     /// <summary>The chars held back from <c>max_chars</c> so the text accounting and the boundary footer are always
     /// affordable.</summary>
-    internal int TextReserve => _textReserve ??= Compose(Worst()).Length + ReadSentences.SweepBoundary.Length
+    internal int TextReserve => _textReserve ??= Compose(Worst(escaped: false)).Length + ReadSentences.SweepBoundary.Length
                                                  + ReadSentences.SweepBoundaryLabel.Length + TextGlue;
     int? _textReserve;
 
     /// <summary>The json lane's own reserve. Measured by SERIALIZING the worst case, not by estimating it off the
     /// text line: the two encodings differ in escaping and syntax, and a reserve that is an estimate is a reserve
     /// that is occasionally wrong in the direction that matters.</summary>
-    internal int JsonReserve => _jsonReserve ??= MeasureJson(Worst()) + JsonGlue;
+    internal int JsonReserve => _jsonReserve ??= MeasureJson(Worst(escaped: true)) + JsonGlue;
     int? _jsonReserve;
 
     /// <summary>Slack over the measured worst case, and the two lanes need very different amounts of it.
@@ -183,11 +183,12 @@ internal sealed class CheckAccounting
     /// largest, because a partly-listed response can promote a long-named small source into the roster that a
     /// fully-omitted one would have pushed out — "largest" is not a bound and "longest" is.
     ///
-    /// <para>Length is taken as the MAXIMUM of the plain and the json-escaped spelling. One reserve is measured off
-    /// a text render and one off a json one, and a name whose escaped form is longer than its plain form (any
-    /// non-ASCII plugin filename) ranks differently in the two — ordering both by the json length let a name that is
-    /// long in text be pushed out of the sample the TEXT reserve was sized from.</para></summary>
-    Values Worst()
+    /// <para>Length is measured in the LANE'S OWN encoding, which is why <paramref name="escaped"/> exists. Escaping
+    /// only ever adds characters, so a "longest by either spelling" rule is just the escaped one wearing a hat: it
+    /// ranks a short non-ASCII name above a much longer ASCII one, and a text reserve sized from that sample is
+    /// short by the difference. The two lanes disagree about which names are longest, so each asks its own
+    /// question.</para></summary>
+    Values Worst(bool escaped)
     {
         int danglingFound = Found(SweepSubject.DanglingEntries);
         // The roster is the dangling subject's, so a lane without that subject reserves nothing for it. The
@@ -195,7 +196,7 @@ internal sealed class CheckAccounting
         // back from a counts_only response for a roster that lane can never emit — at max_chars=1500 that was the
         // whole histogram.
         var longest = Has(SweepSubject.DanglingEntries)
-            ? _bySource.OrderByDescending(c => WidestSpelling(c.Key))
+            ? _bySource.OrderByDescending(c => escaped ? JsonEncodedText.Encode(c.Key).Value.Length : c.Key.Length)
                        .Take(ReadSentences.SweepRosterRows)
                        .Select(c => new SweepCount(c.Key, danglingFound))
                        .ToList()
@@ -209,8 +210,6 @@ internal sealed class CheckAccounting
         return new Values(Visible: danglingFound, ByBudget: danglingFound, ByCut: danglingFound, Roster: longest,
                           RosterTotal: Math.Max(_bySource.Count, longest.Count), Emitted: emitted, Worst: true);
     }
-
-    static int WidestSpelling(string name) => Math.Max(name.Length, JsonEncodedText.Encode(name).Value.Length);
 
     /// <summary>What this response actually did.</summary>
     Values Real() => new(Emitted(SweepSubject.DanglingEntries), OmittedByBudget, OmittedByCut,

--- a/src/housecarl-mcp/CheckAccounting.cs
+++ b/src/housecarl-mcp/CheckAccounting.cs
@@ -439,13 +439,34 @@ internal sealed class CheckAccounting
     /// <c>headerLength + reserve</c> it was a statement about the worst case the reserve is sized for, and it fired
     /// over a thousand times in a 200–6000 cap sweep on responses that were well inside their cap.</para>
     ///
+    /// <para><b>THE RULE THIS ARM IS BUILT ON: every quantity it reads is MEASURED, none derived.</b>
+    /// <paramref name="contentLength"/> is the finished response's own length; <paramref name="noticeLength"/> is
+    /// how much of that this notice is; <paramref name="needed"/> is that same length less what the emitter let
+    /// through, which <see cref="BoundedBody.FixedPart"/> measures at each unit as it lands. Not one of them is a
+    /// hand-kept running total or a worst case standing in for a real one.</para>
+    ///
+    /// <para>That is not a style preference. This branch fixed exactly this disease at the json writer's framing —
+    /// two constants kept by hand until <see cref="MeasureFraming"/> derived both from one measurement — and left
+    /// it alive one level up, where this arm's inputs were SUMMED from components captured at different moments: a
+    /// header measured before the histogram axes wrote their notes, a reserve total that still counted room
+    /// <see cref="BoundedBody.Release"/> had given back, and a lane's whole json entry slack. Each error was
+    /// invisible on its own, they did not cancel, and the first attempt to fix them by ADDING UP the write sites
+    /// instead missed json's empty <c>plugins</c> array. Subtracting the body is the form that cannot miss one.</para>
+    ///
     /// <para><paramref name="needed"/> is what it takes to carry this response's fixed part plus the accounting —
     /// the number a caller can set max_chars to and stop seeing this. It is not the current length: raising the cap
     /// widens the printed max_chars by a digit or two, which the slack below absorbs, and a probe follows the
     /// remedy at a sweep of caps rather than trusting that reasoning. It is also never BELOW the cap the caller
     /// already passed: a remedy telling them to lower max_chars is one they cannot act on, and the fixed part that
     /// does not fit is by definition bigger than the budget it did not fit in.</para></summary>
-    internal string? CapTooSmall(int contentLength, int needed)
+    /// <param name="contentLength">the WHOLE response, this notice included — it is part of what the caller
+    /// receives, so the cap test is asked of it.</param>
+    /// <param name="needed">this response's fixed part, every term measured (see the summary).</param>
+    /// <param name="noticeLength">how many of <paramref name="contentLength"/>'s chars are this notice. It
+    /// disappears the moment the response fits, so a remedy that counts it tells the caller to buy room for a
+    /// sentence they are paying to remove — measured at 234 chars over the true smallest fitting cap in the text
+    /// lane and 1,278 (85%) in json, the other half of that being the json slack the fixed part never needed.</param>
+    internal string? CapTooSmall(int contentLength, int needed, int noticeLength = 0)
     {
         if (contentLength <= _cap) return null;
         // WHICH overrun this is, from what the arm was already handed. A cap that cannot hold the fixed part is one
@@ -453,7 +474,8 @@ internal sealed class CheckAccounting
         // sentence told that caller their header and accounting did not fit in a cap holding them with room to
         // spare. needed IS the fixed part's size, so no state is added to tell them apart.
         var sentence = needed > _cap ? ReadSentences.SweepCapTooSmall : ReadSentences.SweepCapOvershot;
-        return string.Format(sentence, _cap, Math.Max(needed, contentLength) + RaiseSlack, contentLength);
+        int raiseTo = Math.Max(needed, contentLength - noticeLength) + RaiseSlack;
+        return string.Format(sentence, _cap, raiseTo, contentLength);
     }
 
     /// <summary>Slack on the number the overrun notice tells a caller to raise to. Setting max_chars to exactly the

--- a/src/housecarl-mcp/CheckAccounting.cs
+++ b/src/housecarl-mcp/CheckAccounting.cs
@@ -415,7 +415,7 @@ internal sealed class CheckAccounting
         _limit = int.MaxValue;
         _budgetListed = v.ByBudget;
         foreach (SweepSubject s in Enum.GetValues<SweepSubject>())
-            if (s != SweepSubject.HistogramRows) Declare(s, Math.Max(v.ByBudget, v.RosterTotal));
+            if (!s.IsHistogram()) Declare(s, Math.Max(v.ByBudget, v.RosterTotal));
     }
 
     // ---- the cap floor ------------------------------------------------------------------------------

--- a/src/housecarl-mcp/CheckAccounting.cs
+++ b/src/housecarl-mcp/CheckAccounting.cs
@@ -112,11 +112,6 @@ internal sealed class CheckAccounting
             _bySourceEmitted[source] = (_bySourceEmitted.TryGetValue(source, out var had) ? had : 0) + 1;
     }
 
-    /// <summary>Rows a transport wrote WHOLE, outside the emission loop — json writes its excluded roster as one
-    /// array it either completes or does not start. Told explicitly rather than left at zero, which would claim
-    /// every row was dropped.</summary>
-    internal void EmittedAll(SweepSubject s) { if (_found.ContainsKey(s)) _emitted[s] = _found[s]; }
-
     // ---- derived ------------------------------------------------------------------------------------
 
     /// <summary>Refs the listing budget never admitted. A pure SWEEP fact, so it is readable before the body renders
@@ -187,7 +182,15 @@ internal sealed class CheckAccounting
     /// only ever adds characters, so a "longest by either spelling" rule is just the escaped one wearing a hat: it
     /// ranks a short non-ASCII name above a much longer ASCII one, and a text reserve sized from that sample is
     /// short by the difference. The two lanes disagree about which names are longest, so each asks its own
-    /// question.</para></summary>
+    /// question.</para>
+    ///
+    /// <para><b>Which lane an arm can see this in, said rather than left to be discovered.</b> The TEXT half is
+    /// pinned: ranked by the escaped spelling instead, the escaped-names fixture overruns the text cap by 300-plus
+    /// characters at eight caps in the sweep. The JSON half is not — sabotaged to rank by the plain spelling, every
+    /// arm in both guards stays green, because the json reserve carries a kilobyte of slack sized for one whole
+    /// entry and it absorbs the difference at every cap a fixture can reach. Asking each lane its own question is
+    /// kept anyway: a reserve that happens to be covered by slack meant for something else is not a reserve, and
+    /// that posture is what produced four unbounded write sites in a row.</para></summary>
     Values Worst(bool escaped)
     {
         int danglingFound = Found(SweepSubject.DanglingEntries);

--- a/src/housecarl-mcp/CheckAccounting.cs
+++ b/src/housecarl-mcp/CheckAccounting.cs
@@ -145,10 +145,28 @@ internal sealed class CheckAccounting
     // ---- the reserve --------------------------------------------------------------------------------
 
     /// <summary>The chars held back from <c>max_chars</c> so the text accounting and the boundary footer are always
-    /// affordable.</summary>
-    internal int TextReserve => _textReserve ??= Compose(Worst(escaped: false)).Length + ReadSentences.SweepBoundary.Length
-                                                 + ReadSentences.SweepBoundaryLabel.Length + TextGlue;
+    /// affordable. Two terms, and only the boundary's is unconditional: the boundary is written on every response,
+    /// the accounting line only where this lane can write one.
+    ///
+    /// <para><b>Reserved per LANE, off the same predicate the line itself uses.</b> <see cref="TextLine"/> returns
+    /// null unless the lane declared the dangling subject or something it declared is short, so in the plain
+    /// <c>counts_only</c> lane — no listing, nothing unparseable, nothing unread — no value of anything can make it
+    /// non-null. Reserved unconditionally, that lane held ~154 chars of worst-case accounting plus its wrap for a
+    /// sentence it is structurally unable to write: dead body budget in exactly the lane #392 is about, where every
+    /// held char is a histogram row the caller does not see. Measured on a 74/180-row fixture at
+    /// <c>max_chars=1200</c>, the response came back 315 chars under its own cap with both axes at zero rows.</para></summary>
+    internal int TextReserve => _textReserve ??= (CanStateAccounting ? Compose(Worst(escaped: false)).Length + TextWrap : 0)
+                                                 + ReadSentences.SweepBoundary.Length
+                                                 + ReadSentences.SweepBoundaryLabel.Length + TextWrap;
     int? _textReserve;
+
+    /// <summary>Can this lane write an accounting line at ALL? Literally <see cref="TextLine"/>'s own test, asked
+    /// of the WORST case instead of the real one — so it is true wherever any rendering of this lane could produce
+    /// a line, and false only where none could. Written as the same expression rather than as a second list of
+    /// subjects, because the two disagreeing is the whole defect: a reserve is room for a specific sentence, and
+    /// room held for a sentence this lane cannot write is not a reserve, it is a subtraction from the
+    /// answer.</summary>
+    bool CanStateAccounting => Has(SweepSubject.DanglingEntries) || Missing(Worst(escaped: false));
 
     /// <summary>The json lane's own reserve. Measured by SERIALIZING the worst case, not by estimating it off the
     /// text line: the two encodings differ in escaping and syntax, and a reserve that is an estimate is a reserve
@@ -168,8 +186,13 @@ internal sealed class CheckAccounting
     ///
     /// <para>One number for both cost the text lane a kilobyte of listing at every cap, which at small caps was the
     /// whole listing. A reserve slightly too large costs characters; one slightly too small is #361. The cap sweep
-    /// in check-errors-guard is what holds both honest — not either number's plausibility.</para></summary>
-    const int TextGlue = 64;
+    /// in check-errors-guard is what holds both honest — not either number's plausibility.</para>
+    ///
+    /// <para><see cref="TextWrap"/> is the text lane's glue charged PER WRAPPED BLOCK rather than once for both,
+    /// because the two blocks are not both always written. Each is two newlines in the render; 32 is headroom, and
+    /// twice 32 is the 64 this was before the split, so a lane writing both reserves exactly what it always
+    /// did.</para></summary>
+    const int TextWrap = 32;
     const int JsonGlue = 1024;
 
     /// <summary>The values that make the longest line this sweep could produce. Every substitution is at or above
@@ -226,9 +249,15 @@ internal sealed class CheckAccounting
                                   int RosterTotal, IReadOnlyDictionary<SweepSubject, int> Emitted, bool Worst);
 
     /// <summary>Is this subject short in this rendering? ONE test, used by the clause that states it, by
-    /// <see cref="Missing"/>, and by the remedy — so the three cannot disagree about the same subject.</summary>
+    /// <see cref="Missing"/>, and by the remedy — so the three cannot disagree about the same subject.
+    ///
+    /// <para><c>Found(s) &gt; 0</c> is not a shortcut for the real case, where it is already implied — nothing can
+    /// be emitted short of zero. It is what makes the WORST case honest: a lane declares
+    /// <see cref="SweepSubject.UnreadRows"/> on every <c>counts_only</c> sweep, empty or not, and with
+    /// <c>v.Worst</c> alone a declared-but-empty subject reserved room for a clause no rendering of it can
+    /// write.</para></summary>
     bool Short(Values v, SweepSubject s)
-        => Has(s) && (v.Worst || (v.Emitted.TryGetValue(s, out var e) ? e : 0) < Found(s));
+        => Has(s) && Found(s) > 0 && (v.Worst || (v.Emitted.TryGetValue(s, out var e) ? e : 0) < Found(s));
 
     int Shown(Values v, SweepSubject s) => v.Emitted.TryGetValue(s, out var e) ? e : 0;
 
@@ -314,8 +343,13 @@ internal sealed class CheckAccounting
     /// sections belong here: a sweep whose findings are all missing masters omits no dangling ref, so without this
     /// term a response missing 34 of 41 sections closed as complete — with no remedy, no roster, and a json twin that
     /// said truncated.</summary>
+    /// <para>It does NOT take <c>v.Worst</c> as an answer on its own. The worst case is every DECLARED subject at
+    /// its widest, not every subject declared: read as "assume something is missing", it wrote the remedy clauses
+    /// into a reserve for a lane where nothing can be. The worst case still dominates the real one term by term —
+    /// its counts are the totals and <see cref="Short"/> is true of every subject that can ever be short — so the
+    /// reserve stays an upper bound while dropping what no rendering could reach.</para></summary>
     bool Missing(Values v)
-        => v.Worst || v.ByBudget + v.ByCut > 0
+        => v.ByBudget + v.ByCut > 0
            || Short(v, SweepSubject.PluginSections) || Short(v, SweepSubject.ExcludedRows)
            || Short(v, SweepSubject.UnreadRows);
 

--- a/src/housecarl-mcp/CheckAccounting.cs
+++ b/src/housecarl-mcp/CheckAccounting.cs
@@ -420,11 +420,17 @@ internal sealed class CheckAccounting
 
     // ---- the cap floor ------------------------------------------------------------------------------
 
-    /// <summary>The overrun notice, or null. Non-null exactly where the caller's <c>max_chars</c> cannot hold the
-    /// response's HEADER plus the accounting — the one arm where the response is longer than it was asked to be:
-    /// dropping the accounting would restore exactly the silence #361 is, and refusing would turn a call that
-    /// answers today into one that does not, so the accounting ships and the overrun is named with the number that
-    /// fixes it.
+    /// <summary>The overrun notice, or null. Non-null on every response longer than the cap it was given, and it
+    /// names WHICH of the two overruns happened: a <c>max_chars</c> too small to hold the response's fixed part
+    /// (<see cref="ReadSentences.SweepCapTooSmall"/>), or a body unit that ran past what the budget had left after
+    /// that fixed part fit (<see cref="ReadSentences.SweepCapOvershot"/>). Both are arms where the response is
+    /// longer than it was asked to be: dropping the accounting would restore exactly the silence #361 is, and
+    /// refusing would turn a call that answers today into one that does not, so the accounting ships and the overrun
+    /// is named with the number that fixes it.
+    ///
+    /// <para>ONE sentence for both was tried and rejected: the fixed-part explanation is FALSE of the second, and
+    /// there is nothing true of both that is also a cause. The discriminator adds no state —
+    /// <paramref name="needed"/> is the fixed part's own size, which the caller of this method already has.</para>
     ///
     /// <para>It is asked of the FINISHED response's length, and answers only about that. Predicted from
     /// <c>headerLength + reserve</c> it was a statement about the worst case the reserve is sized for, and it fired
@@ -436,10 +442,16 @@ internal sealed class CheckAccounting
     /// remedy at a sweep of caps rather than trusting that reasoning. It is also never BELOW the cap the caller
     /// already passed: a remedy telling them to lower max_chars is one they cannot act on, and the fixed part that
     /// does not fit is by definition bigger than the budget it did not fit in.</para></summary>
-    internal string? CapTooSmall(int contentLength, int needed) =>
-        contentLength > _cap
-            ? string.Format(ReadSentences.SweepCapTooSmall, _cap, Math.Max(needed, contentLength) + RaiseSlack, contentLength)
-            : null;
+    internal string? CapTooSmall(int contentLength, int needed)
+    {
+        if (contentLength <= _cap) return null;
+        // WHICH overrun this is, from what the arm was already handed. A cap that cannot hold the fixed part is one
+        // story; a body unit that ran past the budget after the fixed part fit is a different one, and the first
+        // sentence told that caller their header and accounting did not fit in a cap holding them with room to
+        // spare. needed IS the fixed part's size, so no state is added to tell them apart.
+        var sentence = needed > _cap ? ReadSentences.SweepCapTooSmall : ReadSentences.SweepCapOvershot;
+        return string.Format(sentence, _cap, Math.Max(needed, contentLength) + RaiseSlack, contentLength);
+    }
 
     /// <summary>Slack on the number the overrun notice tells a caller to raise to. Setting max_chars to exactly the
     /// length measured under the OLD cap gets the notice back with the number one higher, because max_chars is

--- a/src/housecarl-mcp/CheckAccounting.cs
+++ b/src/housecarl-mcp/CheckAccounting.cs
@@ -133,24 +133,29 @@ internal sealed class CheckAccounting
 
     /// <summary>The chars held back from <c>max_chars</c> so the text accounting and the boundary footer are always
     /// affordable.</summary>
-    internal int TextReserve => _textReserve ??= Compose(Worst()).Length + ReadSentences.SweepBoundary.Length + ReadSentences.SweepBoundaryLabel.Length + Glue;
+    internal int TextReserve => _textReserve ??= Compose(Worst()).Length + ReadSentences.SweepBoundary.Length
+                                                 + ReadSentences.SweepBoundaryLabel.Length + TextGlue;
     int? _textReserve;
 
     /// <summary>The json lane's own reserve. Measured by SERIALIZING the worst case, not by estimating it off the
     /// text line: the two encodings differ in escaping and syntax, and a reserve that is an estimate is a reserve
     /// that is occasionally wrong in the direction that matters.</summary>
-    internal int JsonReserve => _jsonReserve ??= MeasureJson(Worst()) + Glue;
+    internal int JsonReserve => _jsonReserve ??= MeasureJson(Worst()) + JsonGlue;
     int? _jsonReserve;
 
-    /// <summary>Slack over the measured worst case, and it is load-bearing rather than cosmetic. A body's budget
-    /// test is taken BEFORE a line or entry is written, because neither transport can measure one without writing
-    /// it — so the last one always lands slightly over the budget it was tested against, and the reserve absorbs
-    /// exactly that. One dangling entry is two FormID strings, a type name and an EditorID; a kilobyte covers one
-    /// comfortably, plus the brackets that close the document and the newlines the text lane wraps its line in.
+    /// <summary>Slack over the measured worst case, and the two lanes need very different amounts of it.
     ///
-    /// <para>A reserve slightly too large costs a few characters of listing. One slightly too small is #361. The cap
-    /// sweep in check-errors-guard is what holds this honest — not the number's plausibility.</para></summary>
-    const int Glue = 1024;
+    /// <para>The TEXT lane composes each line and tests <c>length + line.Length</c> before appending, so nothing it
+    /// writes can exceed the budget it was tested against. All it needs is the handful of newlines the accounting
+    /// and boundary are wrapped in. The JSON lane cannot do that — a <c>Utf8JsonWriter</c> has no way to measure an
+    /// object without writing it — so its test is taken before the write and the last entry lands over. That slack
+    /// has to cover one whole entry: two FormID strings, a type name and an EditorID.</para>
+    ///
+    /// <para>One number for both cost the text lane a kilobyte of listing at every cap, which at small caps was the
+    /// whole listing. A reserve slightly too large costs characters; one slightly too small is #361. The cap sweep
+    /// in check-errors-guard is what holds both honest — not either number's plausibility.</para></summary>
+    const int TextGlue = 64;
+    const int JsonGlue = 1024;
 
     /// <summary>The values that make the longest line this sweep could produce. Every substitution is at or above
     /// what a real render can reach: the counts are the totals themselves, so their digit widths bound every real
@@ -163,9 +168,13 @@ internal sealed class CheckAccounting
                                .Take(ReadSentences.SweepRosterRows)
                                .Select(c => new SweepCount(c.Key, _found))
                                .ToList();
-        return new Values(Visible: 0, ByBudget: _found, ByCut: _found, Roster: longest,
+        // Every slot at its widest, not at zero. The counts are digits in the rendered line, and a real response's
+        // Visible / Sections / Excluded / Unread are wider than 0 — so a worst case that passed 0 for them was
+        // bounded by the slack rather than by construction, which is not what its own summary claimed.
+        return new Values(Visible: _found, ByBudget: _found, ByCut: _found, Roster: longest,
                           RosterTotal: Math.Max(_bySource.Count, longest.Count),
-                          Sections: 0, Excluded: 0, Unread: 0, Worst: true);
+                          Sections: _sectionsWithFindings, Excluded: _excludedTotal, Unread: _unreadTotal,
+                          Worst: true);
     }
 
     /// <summary>What this response actually did.</summary>
@@ -186,8 +195,10 @@ internal sealed class CheckAccounting
     /// everything" and "#361", and those two must never read alike.</summary>
     internal string? TextLine()
     {
-        if (!_listing && _excluded >= _excludedTotal && _unread >= _unreadTotal) return null;
-        return Compose(Real());
+        var v = Real();
+        // A listing lane always states its accounting, complete or not. Any other lane states one only when
+        // something is actually short — there is no positive claim to make about a listing that never ran.
+        return _listing || Missing(v) ? Compose(v) : null;
     }
 
     string Compose(Values v)
@@ -206,12 +217,15 @@ internal sealed class CheckAccounting
             if (v.ByBudget > 0 || v.Worst) causes.Add(string.Format(ReadSentences.SweepOmittedByBudget, v.ByBudget, _limit));
             if (v.ByCut > 0 || v.Worst) causes.Add(string.Format(ReadSentences.SweepOmittedByCut, v.ByCut, _cap));
             if (causes.Count > 0) sb.Append(string.Join(",", causes)).Append('.');
-
-            // Stated whenever a section did not make it: the entry count cannot answer "is a whole plugin missing",
-            // and a plugin with no section at all is exactly what the roster below exists to recover.
-            if (v.Sections < _sectionsWithFindings || v.Worst)
-                sb.Append(string.Format(ReadSentences.SweepSections, v.Sections, _sectionsWithFindings));
         }
+
+        // OUTSIDE the listing gate, deliberately. A section is dropped by the RENDER, and the render runs whether or
+        // not the dangling walk did: with findings=["missing_masters"] the sweep lists no dangling refs at all, so
+        // _listing is false — and the section loop still cuts. Gated on _listing this clause was absent there, which
+        // put #361's own shape (a cut that leaves no sentence) inside the fix for #361, in the lane the tool's own
+        // description sells as the cheap "is any master missing anywhere" sweep.
+        if (v.Sections < _sectionsWithFindings || v.Worst)
+            sb.Append(string.Format(ReadSentences.SweepSections, v.Sections, _sectionsWithFindings));
 
         // The two honesty-layer rosters. Their rows are what houseCARL could NOT read, so a silent cut there hides
         // the boundary of the answer rather than a finding inside it.
@@ -233,14 +247,26 @@ internal sealed class CheckAccounting
             sb.Append('.');
         }
 
-        if (missing && _listing) sb.Append(ReadSentences.SweepNoSectionRule);
-        sb.Append(missing ? ReadSentences.SweepRemedy : ReadSentences.SweepComplete);
+        // The rule belongs to the roster — it explains what the roster is for, so it is stated where one exists.
+        if (v.Roster.Count > 0) sb.Append(ReadSentences.SweepNoSectionRule);
+        if (missing)
+        {
+            if (v.ByBudget > 0 || v.Worst) sb.Append(ReadSentences.SweepRemedyLimit);
+            if (v.ByCut > 0 || v.Sections < _sectionsWithFindings || v.Excluded < _excludedTotal
+                || v.Unread < _unreadTotal || v.Worst)
+                sb.Append(ReadSentences.SweepRemedyMaxChars);
+            if (v.Roster.Count > 0) sb.Append(ReadSentences.SweepRemedyScope).Append(ReadSentences.SweepRemedyCountsOnly);
+        }
+        sb.Append(ReadSentences.SweepClose);
         return sb.ToString();
     }
 
-    /// <summary>Is anything at all absent from this response? One test, so the remedy and the roster rule can never
-    /// disagree about whether there is something to remedy.</summary>
-    bool Missing(Values v) => v.Worst || v.ByBudget + v.ByCut > 0 || v.Excluded < _excludedTotal || v.Unread < _unreadTotal;
+    /// <summary>Is anything at all absent from this response? ONE test over EVERY subject, so the remedy and the
+    /// clauses above it cannot disagree. Dropped sections belong here: a sweep whose findings are all missing
+    /// masters omits no dangling ref, so without this term a response missing 34 of 41 sections closed as complete —
+    /// with no remedy, no roster, and a json twin that said truncated.</summary>
+    bool Missing(Values v) => v.Worst || v.ByBudget + v.ByCut > 0 || v.Sections < _sectionsWithFindings
+                              || v.Excluded < _excludedTotal || v.Unread < _unreadTotal;
 
     // ---- the json lane ------------------------------------------------------------------------------
 
@@ -257,10 +283,19 @@ internal sealed class CheckAccounting
     {
         // capped is the listing budget's fact, truncated is this response's — both off the ONE computation, so a
         // consumer no longer has to know which layer measured which.
-        w.WriteBoolean("capped", v.ByBudget > 0);
-        w.WriteNumber("plugins_with_findings", _sectionsWithFindings);
-        w.WriteNumber("rendered", v.Sections);
-        w.WriteBoolean("truncated", v.ByCut > 0 || v.Sections < _sectionsWithFindings);
+        //
+        // LISTING LANE ONLY, as on the base commit. Under counts_only there is no listing, and Reports carries the
+        // honesty roster instead — so _sectionsWithFindings is a count of UNREADABLE plugins and _sections is always
+        // 0. Written unconditionally, a counts_only sweep that found 240 dangling refs reported
+        // "plugins_with_findings": 0, and one with an unreadable plugin reported truncated:true beside its own
+        // "unread": {"truncated": false}. A field named for one lane's subject is absent in the other, never zero.
+        if (_listing)
+        {
+            w.WriteBoolean("capped", v.ByBudget > 0);
+            w.WriteNumber("plugins_with_findings", _sectionsWithFindings);
+            w.WriteNumber("rendered", v.Sections);
+            w.WriteBoolean("truncated", v.ByCut > 0 || v.Sections < _sectionsWithFindings);
+        }
         w.WriteStartObject("accounting");
         w.WriteBoolean("listing", _listing);
         if (_listing)
@@ -339,13 +374,24 @@ internal sealed class CheckAccounting
     /// answers today into one that does not, so the accounting ships and the overrun is named with the number that
     /// fixes it.
     ///
-    /// <para><paramref name="headerLength"/> is the response's length where the BODY BEGINS, not where it ends.
-    /// Measured at the end it is the body's own length, which at any cut is about the whole budget — so the notice
-    /// fired on every truncated response and added its own unbudgeted couple of hundred chars, which is how the
-    /// first cut of this class overran a 5000-char cap by 106. The condition is about the fixed part of the
-    /// response, so it is asked before the variable part exists.</para></summary>
-    internal string? CapTooSmall(int headerLength, int reserve) =>
-        headerLength + reserve > _cap ? string.Format(ReadSentences.SweepCapTooSmall, _cap, headerLength + reserve) : null;
+    /// <para>It is asked of the FINISHED response's length, and answers only about that. Predicted from
+    /// <c>headerLength + reserve</c> it was a statement about the worst case the reserve is sized for, and it fired
+    /// over a thousand times in a 200–6000 cap sweep on responses that were well inside their cap.</para>
+    ///
+    /// <para><paramref name="needed"/> is what it takes to carry this response's fixed part plus the accounting —
+    /// the number a caller can set max_chars to and stop seeing this. It is not the current length: raising the cap
+    /// widens the printed max_chars by a digit or two, which the slack below absorbs, and a probe follows the
+    /// remedy at a sweep of caps rather than trusting that reasoning.</para></summary>
+    internal string? CapTooSmall(int contentLength, int needed) =>
+        contentLength > _cap
+            ? string.Format(ReadSentences.SweepCapTooSmall, _cap, needed + RaiseSlack, contentLength)
+            : null;
+
+    /// <summary>Slack on the number the overrun notice tells a caller to raise to. Setting max_chars to exactly the
+    /// length measured under the OLD cap gets the notice back with the number one higher, because max_chars is
+    /// printed inside the accounting and gained a digit — measured, at every 3→4 and 4→5 digit crossing. Two digits
+    /// of headroom per place it is printed clears it, and the follow-the-remedy arm is what holds that.</summary>
+    const int RaiseSlack = 8;
 
     /// <summary>The chars the body may occupy. Never negative — a cap too small for the accounting yields a body
     /// budget of zero and the notice above, not a negative bound that every emission test passes.</summary>

--- a/src/housecarl-mcp/CheckAccounting.cs
+++ b/src/housecarl-mcp/CheckAccounting.cs
@@ -1,0 +1,353 @@
+using System.Text;
+using System.Text.Json;
+using HousecarlCore;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// ONE ACCOUNTING for the integrity sweep's response, consumed by BOTH transports (#337's one-source-per-sentence,
+/// applied to the numbers underneath the prose rather than only to the prose).
+///
+/// <para><b>What it replaces, and why the replacement is structural.</b> The response used to describe its own
+/// omissions from TWO independent counters in two different units: core's listing budget (<c>limit=</c>, counted
+/// while the sweep ran) and the render's own cut (<c>max_chars</c>, counted at a break point). Neither could see
+/// the other, so neither could answer the question a caller actually has — how many of these findings can I see —
+/// and on the live ARR order at plain defaults the two together said "3996 not listed" and "554 of the 1000
+/// budget-listed appear above" while the answer was 554 of 4996. Every omission claim here is a SUBTRACTION against
+/// the sweep's own totals, taken after emission stops, so there is one number and one source for it. The 2026-08-18
+/// layer rule survives as this class's internal discipline: the causes are still named separately, but they are
+/// decomposed out of one computation instead of raced by two.</para>
+///
+/// <para><b>How #361 dies here rather than being patched.</b> Two invariants, neither of them a code path that has
+/// to remember to run:
+/// <list type="number">
+/// <item>Being missing is MEASURED AT THE TOTAL, never reported at an exit. There is no flag set where a loop
+/// breaks, so there is no "the cut landed somewhere that never set the flag" — the silent last-section cut, in both
+/// transports, is unrepresentable rather than fixed.</item>
+/// <item>The accounting and the boundary footer are RESERVED out of the caller's <c>max_chars</c> before the body
+/// renders, never appended past it. This is <see cref="ReadSentences.ClauseReserve"/>'s construction, which #342's
+/// review arrived at over the same overshoot one tool over: a 2000-char batch returning ~3100, with the overrun
+/// invisible to the <c>truncated</c> flag the auto-spill trigger reads.</item>
+/// </list></para>
+///
+/// <para><b>Deliberately findings-family-agnostic, and deliberately no further.</b> Its interface speaks in
+/// entries-emitted vs entries-found, which carries to any findings family without knowing what a family is. It
+/// takes no taxonomy parameter and holds no family enum: the merged <c>check</c> surface (SPEC §6.1) is a separate
+/// PR with its own design, and building its machinery here on speculation is what CLAUDE.md §8 names.</para>
+/// </summary>
+internal sealed class CheckAccounting
+{
+    // ---- what the SWEEP found (fixed before the render starts) --------------------------------------
+    readonly IReadOnlyList<SweepCount> _bySource;   // true dangling count per source plugin, never limit-capped
+    readonly int _found;                            // every dangling ref the sweep counted, in scope
+    readonly int _budgetListed;                     // the subset the listing budget admitted into the reports
+    readonly int _sectionsWithFindings;
+    readonly int _excludedTotal;
+    readonly int _unreadTotal;
+    readonly bool _listing;                         // is a per-plugin listing being built at all?
+    readonly int _cap;
+    readonly int _limit;
+
+    // ---- what the RENDER put in (filled as it emits) ------------------------------------------------
+    readonly Dictionary<string, int> _emitted = new(StringComparer.OrdinalIgnoreCase);
+    int _visible, _sections, _excluded, _unread;
+
+    /// <summary>Build the accounting for one response. Under <c>counts_only=true</c> the listing clauses are ABSENT
+    /// rather than zero: nothing is listed there BY DESIGN, and "the budget omitted everything" would report a mode
+    /// working correctly as a failure.</summary>
+    internal CheckAccounting(ErrorCheckResult r, int cap)
+    {
+        _cap = cap;
+        _limit = r.Limit;
+        _listing = !r.CountsOnly && r.Classes.HasFlag(ErrorFindingClass.Dangling);
+        _bySource = r.DanglingBySource ?? Array.Empty<SweepCount>();
+        _found = r.TotalDangling;
+        _budgetListed = r.Reports.Sum(p => p.Dangling.Count);
+        _sectionsWithFindings = r.Reports.Count;
+        _excludedTotal = r.ExcludedPlugins.Count;
+        // counts_only's reports list carries the honesty layer only — plugins whose records could not be read. In
+        // the listing lane those same plugins carry findings and are counted as SECTIONS, so this subject exists
+        // exactly where the other one does not, and the two can never double-count the same row.
+        _unreadTotal = r.CountsOnly ? r.Reports.Count : 0;
+    }
+
+    // ---- registration: the render tells the accounting what it emitted ------------------------------
+
+    /// <summary>One dangling entry just went into the response, sourced from <paramref name="plugin"/>. Called where
+    /// the line is APPENDED, never where a section is entered: a section total would claim entries for a section the
+    /// cut left half-written, which is the class of false number this construction exists to make unrepresentable.
+    /// </summary>
+    internal void Entry(string plugin)
+    {
+        _visible++;
+        _emitted[plugin] = (_emitted.TryGetValue(plugin, out var had) ? had : 0) + 1;
+    }
+
+    internal void Section() => _sections++;
+
+    /// <summary>Rows the two honesty-layer rosters actually appended. Taken as a COUNT because those helpers are
+    /// shared with validate_scripts, whose response layer is not this PR's — they report what they emitted and each
+    /// caller states it in its own terms, so neither lane's prose leaks into the other's.</summary>
+    internal void ExcludedRows(int n) => _excluded += n;
+    internal void UnreadRows(int n) => _unread += n;
+
+    // ---- derived ------------------------------------------------------------------------------------
+
+    /// <summary>Refs the listing budget never admitted. A pure SWEEP fact, so it is readable before the body renders
+    /// — which is what lets the baseline block's phase-order sentence consult it without waiting for emission.
+    /// </summary>
+    internal int OmittedByBudget => _listing ? _found - _budgetListed : 0;
+
+    internal int Visible => _visible;
+    internal int Found => _found;
+    internal int Omitted => _listing ? _found - _visible : 0;
+
+    /// <summary>Refs the budget admitted and this response then could not fit. The other half of
+    /// <see cref="Omitted"/> BY CONSTRUCTION: both are subtractions off the same total, so the two causes sum to it
+    /// exactly rather than by two counters happening to agree.</summary>
+    internal int OmittedByCut => _listing ? _budgetListed - _visible : 0;
+
+    internal int SectionsRendered => _sections;
+    internal int SectionsWithFindings => _sectionsWithFindings;
+    internal bool Listing => _listing;
+
+    /// <summary>WHICH source plugins are missing entries from THIS response, largest first. Computed against what was
+    /// emitted, so it covers both causes at once: under the two-layer split, a plugin whose entries the budget listed
+    /// and the cut then dropped appeared in neither sentence.</summary>
+    internal IReadOnlyList<SweepCount> MissingBySource
+    {
+        get
+        {
+            if (!_listing) return Array.Empty<SweepCount>();
+            var acc = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            foreach (var row in _bySource)
+            {
+                int shown = _emitted.TryGetValue(row.Key, out var c) ? c : 0;
+                if (row.Count > shown) acc[row.Key] = row.Count - shown;
+            }
+            return SweepFindings.Histogram(acc);
+        }
+    }
+
+    // ---- the reserve --------------------------------------------------------------------------------
+
+    /// <summary>The chars held back from <c>max_chars</c> so the text accounting and the boundary footer are always
+    /// affordable.</summary>
+    internal int TextReserve => _textReserve ??= Compose(Worst()).Length + ReadSentences.SweepBoundary.Length + ReadSentences.SweepBoundaryLabel.Length + Glue;
+    int? _textReserve;
+
+    /// <summary>The json lane's own reserve. Measured by SERIALIZING the worst case, not by estimating it off the
+    /// text line: the two encodings differ in escaping and syntax, and a reserve that is an estimate is a reserve
+    /// that is occasionally wrong in the direction that matters.</summary>
+    internal int JsonReserve => _jsonReserve ??= MeasureJson(Worst()) + Glue;
+    int? _jsonReserve;
+
+    /// <summary>Slack over the measured worst case, and it is load-bearing rather than cosmetic. A body's budget
+    /// test is taken BEFORE a line or entry is written, because neither transport can measure one without writing
+    /// it — so the last one always lands slightly over the budget it was tested against, and the reserve absorbs
+    /// exactly that. One dangling entry is two FormID strings, a type name and an EditorID; a kilobyte covers one
+    /// comfortably, plus the brackets that close the document and the newlines the text lane wraps its line in.
+    ///
+    /// <para>A reserve slightly too large costs a few characters of listing. One slightly too small is #361. The cap
+    /// sweep in check-errors-guard is what holds this honest — not the number's plausibility.</para></summary>
+    const int Glue = 1024;
+
+    /// <summary>The values that make the longest line this sweep could produce. Every substitution is at or above
+    /// what a real render can reach: the counts are the totals themselves, so their digit widths bound every real
+    /// count; every optional clause is present; and the roster holds the LONGEST source names rather than the
+    /// largest, because a partly-listed response can promote a long-named small source into the roster that a
+    /// fully-omitted one would have pushed out — "largest" is not a bound and "longest" is.</summary>
+    Values Worst()
+    {
+        var longest = _bySource.OrderByDescending(c => JsonEncodedText.Encode(c.Key).Value.Length)
+                               .Take(ReadSentences.SweepRosterRows)
+                               .Select(c => new SweepCount(c.Key, _found))
+                               .ToList();
+        return new Values(Visible: 0, ByBudget: _found, ByCut: _found, Roster: longest,
+                          RosterTotal: Math.Max(_bySource.Count, longest.Count),
+                          Sections: 0, Excluded: 0, Unread: 0, Worst: true);
+    }
+
+    /// <summary>What this response actually did.</summary>
+    Values Real() => new(_visible, OmittedByBudget, OmittedByCut, MissingBySource, MissingBySource.Count,
+                         _sections, _excluded, _unread, Worst: false);
+
+    /// <summary>The numbers one rendering of the accounting states. A record rather than eight parameters so the
+    /// real case and the worst case go through ONE composer per transport — a second formatter would be a second
+    /// spelling, and a reserve computed off a spelling that has since drifted is a reserve that silently stops
+    /// bounding anything.</summary>
+    readonly record struct Values(int Visible, int ByBudget, int ByCut, IReadOnlyList<SweepCount> Roster,
+                                  int RosterTotal, int Sections, int Excluded, int Unread, bool Worst);
+
+    // ---- the text lane ------------------------------------------------------------------------------
+
+    /// <summary>The accounting as the text transport states it, or null where there is nothing at all to account
+    /// for. Present on EVERY listing response, complete or not: silence used to mean both "this response carries
+    /// everything" and "#361", and those two must never read alike.</summary>
+    internal string? TextLine()
+    {
+        if (!_listing && _excluded >= _excludedTotal && _unread >= _unreadTotal) return null;
+        return Compose(Real());
+    }
+
+    string Compose(Values v)
+    {
+        var sb = new StringBuilder();
+        int omitted = v.ByBudget + v.ByCut;
+        bool missing = Missing(v);
+
+        if (_listing)
+        {
+            sb.Append(omitted > 0 || v.Worst
+                ? string.Format(ReadSentences.SweepVisible, v.Visible, _found)
+                : string.Format(ReadSentences.SweepAllVisible, _found));
+
+            var causes = new List<string>();
+            if (v.ByBudget > 0 || v.Worst) causes.Add(string.Format(ReadSentences.SweepOmittedByBudget, v.ByBudget, _limit));
+            if (v.ByCut > 0 || v.Worst) causes.Add(string.Format(ReadSentences.SweepOmittedByCut, v.ByCut, _cap));
+            if (causes.Count > 0) sb.Append(string.Join(",", causes)).Append('.');
+
+            // Stated whenever a section did not make it: the entry count cannot answer "is a whole plugin missing",
+            // and a plugin with no section at all is exactly what the roster below exists to recover.
+            if (v.Sections < _sectionsWithFindings || v.Worst)
+                sb.Append(string.Format(ReadSentences.SweepSections, v.Sections, _sectionsWithFindings));
+        }
+
+        // The two honesty-layer rosters. Their rows are what houseCARL could NOT read, so a silent cut there hides
+        // the boundary of the answer rather than a finding inside it.
+        if (v.Excluded < _excludedTotal || v.Worst)
+            sb.Append(string.Format(ReadSentences.SweepExcludedCut, v.Excluded, _excludedTotal));
+        if (v.Unread < _unreadTotal || v.Worst)
+            sb.Append(string.Format(ReadSentences.SweepUnreadCut, v.Unread, _unreadTotal));
+
+        if (v.Roster.Count > 0)
+        {
+            sb.Append(ReadSentences.SweepRosterLead);
+            for (int i = 0; i < v.Roster.Count && i < ReadSentences.SweepRosterRows; i++)
+            {
+                if (i > 0) sb.Append(", ");
+                sb.Append(v.Roster[i].Key).Append(" (").Append(v.Roster[i].Count).Append(')');
+            }
+            if (v.RosterTotal > ReadSentences.SweepRosterRows || v.Worst)
+                sb.Append(string.Format(ReadSentences.SweepRosterCut, ReadSentences.SweepRosterRows, v.RosterTotal));
+            sb.Append('.');
+        }
+
+        if (missing && _listing) sb.Append(ReadSentences.SweepNoSectionRule);
+        sb.Append(missing ? ReadSentences.SweepRemedy : ReadSentences.SweepComplete);
+        return sb.ToString();
+    }
+
+    /// <summary>Is anything at all absent from this response? One test, so the remedy and the roster rule can never
+    /// disagree about whether there is something to remedy.</summary>
+    bool Missing(Values v) => v.Worst || v.ByBudget + v.ByCut > 0 || v.Excluded < _excludedTotal || v.Unread < _unreadTotal;
+
+    // ---- the json lane ------------------------------------------------------------------------------
+
+    /// <summary>The accounting as json states it — the same numbers, in the transport's own terms rather than as a
+    /// prose sentence a machine consumer would have to parse.
+    ///
+    /// <para>It writes §2.1's four required in-band fields too, flat, rather than leaving them at the call site. Not
+    /// tidiness: <see cref="JsonReserve"/> measures this method, so a field written anywhere else is a field outside
+    /// the reserve — which is how the first cut of this class under-reserved and let a 5000-char cap return 5673.
+    /// Everything the close emits is written here, and therefore measured.</para></summary>
+    internal void WriteJson(Utf8JsonWriter w) => WriteJson(w, Real());
+
+    void WriteJson(Utf8JsonWriter w, Values v)
+    {
+        // capped is the listing budget's fact, truncated is this response's — both off the ONE computation, so a
+        // consumer no longer has to know which layer measured which.
+        w.WriteBoolean("capped", v.ByBudget > 0);
+        w.WriteNumber("plugins_with_findings", _sectionsWithFindings);
+        w.WriteNumber("rendered", v.Sections);
+        w.WriteBoolean("truncated", v.ByCut > 0 || v.Sections < _sectionsWithFindings);
+        w.WriteStartObject("accounting");
+        w.WriteBoolean("listing", _listing);
+        if (_listing)
+        {
+            w.WriteNumber("dangling_found", _found);
+            w.WriteNumber("dangling_visible", v.Visible);
+            w.WriteNumber("dangling_missing", v.ByBudget + v.ByCut);
+            w.WriteNumber("dangling_missing_by_budget", v.ByBudget);
+            w.WriteNumber("dangling_missing_by_response_cut", v.ByCut);
+            w.WriteNumber("limit", _limit);
+            w.WriteNumber("sections_with_findings", _sectionsWithFindings);
+            w.WriteNumber("sections_rendered", v.Sections);
+        }
+        w.WriteNumber("max_chars", _cap);
+        w.WriteNumber("excluded_plugins_total", _excludedTotal);
+        w.WriteNumber("excluded_plugins_named", v.Excluded);
+        w.WriteNumber("unread_plugins_total", _unreadTotal);
+        w.WriteNumber("unread_plugins_named", v.Unread);
+        w.WriteStartArray("dangling_missing_by_source");
+        for (int i = 0; i < v.Roster.Count && i < ReadSentences.SweepRosterRows; i++)
+        {
+            w.WriteStartObject();
+            w.WriteString("plugin", v.Roster[i].Key);
+            w.WriteNumber("count", v.Roster[i].Count);
+            w.WriteEndObject();
+        }
+        w.WriteEndArray();
+        // The roster's own bound, disclosed rather than implied — the same rule the text line follows, so a machine
+        // consumer and a reading one learn the same thing about how complete the roster is.
+        w.WriteNumber("dangling_missing_by_source_total", v.RosterTotal);
+        w.WriteEndObject();
+    }
+
+    /// <summary>Serialize one accounting into a scratch buffer and measure it. Used for the worst case only — the
+    /// real one is written straight into the response.
+    ///
+    /// <para>Under the RESPONSE's writer options, not the default ones. Measuring unindented what is then written
+    /// indented is a reserve that is wrong by the whole indentation, and it was: the first cut of this measured with
+    /// a bare writer and a 5000-char cap returned 5673.</para></summary>
+    static int MeasureJson(Values v)
+    {
+        // A standalone writer needs an enclosing object for a named property, and the wrapper's own two braces are
+        // covered by Glue.
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, JsonWire.WriterOptions))
+        {
+            w.WriteStartObject();
+            new CheckAccounting(v).WriteJson(w, v);
+            // The boundary rides the measurement rather than being added as a raw char count: json escapes the
+            // apostrophes in it, so its encoded length is not its string length.
+            w.WriteString("boundary", ReadSentences.SweepBoundary);
+            w.WriteEndObject();
+        }
+        return (int)ms.Length;
+    }
+
+    /// <summary>The measuring constructor: enough state for <see cref="WriteJson(Utf8JsonWriter, Values)"/> to write
+    /// the worst case at full width. It is never registered against and never rendered into a response.</summary>
+    CheckAccounting(Values v)
+    {
+        _bySource = v.Roster;
+        _found = v.ByBudget;
+        _cap = int.MaxValue;
+        _limit = int.MaxValue;
+        _listing = true;
+        _sectionsWithFindings = v.RosterTotal;
+        _excludedTotal = v.RosterTotal;
+        _unreadTotal = v.RosterTotal;
+    }
+
+    // ---- the cap floor ------------------------------------------------------------------------------
+
+    /// <summary>The overrun notice, or null. Non-null exactly where the caller's <c>max_chars</c> cannot hold the
+    /// response's HEADER plus the accounting — the one arm where the response is longer than it was asked to be:
+    /// dropping the accounting would restore exactly the silence #361 is, and refusing would turn a call that
+    /// answers today into one that does not, so the accounting ships and the overrun is named with the number that
+    /// fixes it.
+    ///
+    /// <para><paramref name="headerLength"/> is the response's length where the BODY BEGINS, not where it ends.
+    /// Measured at the end it is the body's own length, which at any cut is about the whole budget — so the notice
+    /// fired on every truncated response and added its own unbudgeted couple of hundred chars, which is how the
+    /// first cut of this class overran a 5000-char cap by 106. The condition is about the fixed part of the
+    /// response, so it is asked before the variable part exists.</para></summary>
+    internal string? CapTooSmall(int headerLength, int reserve) =>
+        headerLength + reserve > _cap ? string.Format(ReadSentences.SweepCapTooSmall, _cap, headerLength + reserve) : null;
+
+    /// <summary>The chars the body may occupy. Never negative — a cap too small for the accounting yields a body
+    /// budget of zero and the notice above, not a negative bound that every emission test passes.</summary>
+    internal int BodyBudget(int reserve) => Math.Max(0, _cap - reserve);
+}

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1262,7 +1262,6 @@ static class JsonWire
             WriteStringArray(w, "classes_checked", ClassNames(r.Classes));
             WriteNullable(w, "filter_note", r.FilterNote);
             WriteStringArray(w, "off_order_scanned", r.OffOrderScanned ?? Array.Empty<string>());
-            WriteExcluded(w, r.ExcludedPlugins);
             w.WriteBoolean("counts_only", r.CountsOnly);
 
             // #344 — the baseline split as DATA (the text render's baseline line). base_masters names the set that was
@@ -1284,12 +1283,17 @@ static class JsonWire
             WriteStringArray(w, "base_masters", HousecarlCore.ErrorCheck.BaseMasters);
             // Where the BODY begins — see CheckAccounting.CapTooSmall for why it is asked here and not at the end.
             int headerLength = Size(w, ms);
+            // EVERYTHING BELOW THIS LINE GOES THROUGH `body`, including the excluded roster, which used to be
+            // written up in the header where no budget could reach it — 1,188 chars past the budget on three
+            // 400-character parse reasons, while the TEXT lane bounded the same roster. The fourth instance of one
+            // class, which is why the bound now lives in one helper rather than at each write site.
+            var body = new BoundedBody(acct, budget, () => Size(w, ms));
 
             if (r.CountsOnly)
             {
-                WriteHistogram(w, "dangling_by_target_plugin", r.Histogram, histogramLimit, ms, budget);
-                WriteHistogram(w, "dangling_by_source_plugin", r.DanglingBySource, histogramLimit, ms, budget);   // #344 — the new axis
-                acct.UnreadRows(WriteUnreadPlugins(w, r.Reports, ms, budget));
+                WriteHistogram(w, "dangling_by_target_plugin", r.Histogram, histogramLimit, body);
+                WriteHistogram(w, "dangling_by_source_plugin", r.DanglingBySource, histogramLimit, body);   // #344 — the new axis
+                WriteUnreadPlugins(w, r.Reports, body);
             }
             else
             {
@@ -1303,42 +1307,50 @@ static class JsonWire
                     // chars against a 5,270 cap, silently. The text lane composes its fixed part and measures it;
                     // this is the same rule, and a Utf8JsonWriter can only be measured by writing, so it is written
                     // once into a scratch buffer at the same nesting depth.
-                    if (Size(w, ms) + PluginHeadCost(p) >= budget) break;
-                    w.WriteStartObject();
-                    w.WriteString("plugin", p.Plugin);
-                    WriteNullable(w, "scan_error", p.ScanError);
-                    WriteStringArray(w, "missing_masters", p.MissingMasters);
-                    // The unscannable fields sit before the dangling array so that once the ENTRY loop breaks
-                    // mid-plugin, all that follows is three fixed closing brackets.
-                    w.WriteNumber("unscannable_records", p.UnscannableRecords);
-                    WriteStringArray(w, "unscannable_samples", p.UnscannableSamples);
-                    w.WriteStartArray("dangling");
+                    // The plugin object's fixed part carries a scan-error string and up to three unscannable-record
+                    // exception messages, all unbounded, so it is one of the two units whose cost is MEASURED rather
+                    // than left to the post-check: a two-report fixture whose second plugin carried three ~950-char
+                    // samples returned 7,296 chars against a 5,270 cap, silently.
+                    bool opened = body.Emit(SweepSubject.PluginSections, PluginHeadCost(p), () =>
+                    {
+                        w.WriteStartObject();
+                        w.WriteString("plugin", p.Plugin);
+                        WriteNullable(w, "scan_error", p.ScanError);
+                        WriteStringArray(w, "missing_masters", p.MissingMasters);
+                        // The unscannable fields sit before the dangling array so that once the ENTRY loop breaks
+                        // mid-plugin, all that follows is three fixed closing brackets.
+                        w.WriteNumber("unscannable_records", p.UnscannableRecords);
+                        WriteStringArray(w, "unscannable_samples", p.UnscannableSamples);
+                        w.WriteStartArray("dangling");
+                    });
+                    if (!opened) break;
                     foreach (var d in p.Dangling)
                     {
                         // Per ENTRY: one plugin's array can be thousands of rows, and a check taken only at the
-                        // plugin boundary lets all of them out at once (#361, measured at 2.5x the cap).
-                        if (Size(w, ms) >= budget) break;
-                        w.WriteStartObject();
-                        w.WriteString("source", d.Source.ToString());
-                        w.WriteString("source_type", d.SourceType);
-                        WriteNullable(w, "source_editorid", d.SourceEditorId);
-                        w.WriteString("target", d.Target.ToString());
-                        w.WriteEndObject();
-                        acct.Entry(p.Plugin);
+                        // plugin boundary lets all of them out at once (#361, measured at 2.5x the cap). An entry
+                        // is small and uniform, so it carries no measured cost — the emitter's post-check is what
+                        // stops the loop, and JsonGlue is the reserve sized to absorb the one entry that crosses.
+                        if (!body.Emit(SweepSubject.DanglingEntries, 0, () =>
+                        {
+                            w.WriteStartObject();
+                            w.WriteString("source", d.Source.ToString());
+                            w.WriteString("source_type", d.SourceType);
+                            WriteNullable(w, "source_editorid", d.SourceEditorId);
+                            w.WriteString("target", d.Target.ToString());
+                            w.WriteEndObject();
+                        }, p.Plugin)) break;
                     }
+                    // The section's own closing brackets are what PluginHeadCost already paid for. Counted where its
+                    // content landed, exactly as the text lane counts it: its ENTRIES are accounted separately, so a
+                    // section whose entry loop stopped on the budget is a rendered section carrying fewer entries,
+                    // not a partly-rendered one.
                     w.WriteEndArray();
                     w.WriteEndObject();
-                    // Counted where the section's own content landed, exactly as the text lane counts it: its
-                    // ENTRIES are accounted separately, so a section whose entry loop stopped on the budget is a
-                    // rendered section carrying fewer entries, not a partly-rendered one.
-                    acct.Section();
                 }
                 w.WriteEndArray();
             }
 
-            // This transport writes the excluded roster WHOLE, above, so nothing of it is ever missing here — told
-            // to the accounting explicitly rather than left at zero, which would claim every row was dropped.
-            acct.ExcludedRows(r.ExcludedPlugins.Count);
+            WriteExcluded(w, r.ExcludedPlugins, body);
 
             // §2.1's required in-band accounting rides the accounting's own writer — everything the close emits is
             // written in one place, which is the same place JsonReserve measures.
@@ -1527,12 +1539,15 @@ static class JsonWire
 
     /// <summary>A counts_only histogram: <c>{distinct, rows:[{key,count}], rendered}</c>. Absent when the mode was not
     /// requested; PRESENT with an empty <c>rows</c> when the sweep genuinely found nothing — the two must not look alike.</summary>
-    /// <param name="budget">the bytes this render may occupy; unbounded by default, which is what validate_scripts
-    /// still passes. `distinct` vs `rendered` already discloses a short list, so the bound needs no new field.</param>
+    /// <param name="body">the ONE bounded emission path, or null for validate_scripts, which passes no budget —
+    /// its response layer is not this branch's. `distinct` vs `rendered` already discloses a short list, so the
+    /// bound needs no new field.</param>
     static void WriteHistogram(Utf8JsonWriter w, string name, IReadOnlyList<SweepCount>? rows, int rowLimit,
-                               MemoryStream? ms = null, int budget = int.MaxValue)
+                               BoundedBody? body = null)
     {
         if (rows is null) return;
+        // The object's own three fixed members do not grow with the findings, so they are part of the fixed part;
+        // the ROWS are what the budget gates, and `rendered` is written from what the gate let through.
         w.WriteStartObject(name);
         w.WriteNumber("distinct", rows.Count);
         w.WriteStartArray("rows");
@@ -1540,8 +1555,13 @@ static class JsonWire
         foreach (var row in rows)
         {
             if (shown >= rowLimit) break;
-            if (ms is not null && Size(w, ms) >= budget) break;
-            w.WriteStartObject(); w.WriteString("key", row.Key); w.WriteNumber("count", row.Count); w.WriteEndObject();
+            var r = row;
+            if (body is not null
+                && !body.Emit(SweepSubject.HistogramRows, 0,
+                              () => { w.WriteStartObject(); w.WriteString("key", r.Key); w.WriteNumber("count", r.Count); w.WriteEndObject(); }))
+                break;
+            if (body is null)
+            { w.WriteStartObject(); w.WriteString("key", row.Key); w.WriteNumber("count", row.Count); w.WriteEndObject(); }
             shown++;
         }
         w.WriteEndArray();
@@ -1554,35 +1574,71 @@ static class JsonWire
     /// <para>Wrapped in <c>{total, rows, rendered, truncated}</c> rather than a bare array: a budget cut used to drop
     /// trailing rows with NO flag, so a consumer iterating the array believed it had the complete set of what went
     /// unchecked — and the text render said "truncated" for the same result (PR #288 review, finding 4).</para></summary>
-    static int WriteUnreadPlugins(Utf8JsonWriter w, IReadOnlyList<PluginErrors> reports, MemoryStream ms, int budget)
+    static void WriteUnreadPlugins(Utf8JsonWriter w, IReadOnlyList<PluginErrors> reports, BoundedBody body)
     {
         w.WriteStartObject("unread");
         w.WriteNumber("total", reports.Count);
         w.WriteStartArray("rows");
-        int rendered = 0; bool truncated = false;
+        int rendered = 0;
         foreach (var p in reports)
         {
-            if (Size(w, ms) >= budget) { truncated = true; break; }
+            // The EXACT sibling of the plugin head, and it was missed by that fix: the row carries a scan error and
+            // its unscannable samples, all unbounded, and the budget was tested before writing it — 9,823 chars
+            // against an 8,000 cap while the text twin returned 4,788. So it is the second unit whose cost is
+            // measured rather than left to the post-check.
+            var row = p;
+            if (!body.Emit(SweepSubject.UnreadRows, UnreadRowCost(p), () =>
+            {
+                w.WriteStartObject();
+                w.WriteString("plugin", row.Plugin);
+                WriteNullable(w, "scan_error", row.ScanError);
+                w.WriteNumber("unscannable_records", row.UnscannableRecords);
+                WriteStringArray(w, "unscannable_samples", row.UnscannableSamples);
+                w.WriteEndObject();
+            })) break;
+            rendered++;
+        }
+        w.WriteEndArray();
+        w.WriteNumber("rendered", rendered);
+        w.WriteBoolean("truncated", rendered < reports.Count);
+        w.WriteEndObject();
+    }
+
+    /// <summary>What one unread row costs, encoded exactly as the response will encode it — the same construction as
+    /// <see cref="PluginHeadCost"/>, at this row's own nesting depth.</summary>
+    static int UnreadRowCost(PluginErrors p)
+    {
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            w.WriteStartObject("unread");
+            w.WriteStartArray("rows");
             w.WriteStartObject();
             w.WriteString("plugin", p.Plugin);
             WriteNullable(w, "scan_error", p.ScanError);
             w.WriteNumber("unscannable_records", p.UnscannableRecords);
             WriteStringArray(w, "unscannable_samples", p.UnscannableSamples);
             w.WriteEndObject();
-            rendered++;
+            w.WriteEndArray();
+            w.WriteEndObject();
+            w.WriteEndObject();
         }
-        w.WriteEndArray();
-        w.WriteNumber("rendered", rendered);
-        w.WriteBoolean("truncated", truncated);
-        w.WriteEndObject();
-        return rendered;
+        return (int)ms.Length;
     }
 
-    static void WriteExcluded(Utf8JsonWriter w, IReadOnlyDictionary<string, string> excluded)
+    /// <summary>The excluded-plugin roster. <paramref name="body"/> is the bounded emission path; null is
+    /// validate_scripts, which passes no budget here — its response layer is not this branch's.</summary>
+    static void WriteExcluded(Utf8JsonWriter w, IReadOnlyDictionary<string, string> excluded, BoundedBody? body = null)
     {
         w.WriteStartArray("excluded_plugins");
         foreach (var kv in excluded)
-        { w.WriteStartObject(); w.WriteString("plugin", kv.Key); w.WriteString("reason", kv.Value); w.WriteEndObject(); }
+        {
+            var row = kv;
+            void Write() { w.WriteStartObject(); w.WriteString("plugin", row.Key); w.WriteString("reason", row.Value); w.WriteEndObject(); }
+            if (body is null) { Write(); continue; }
+            if (!body.Emit(SweepSubject.ExcludedRows, 0, Write)) break;
+        }
         w.WriteEndArray();
     }
 

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1287,8 +1287,8 @@ static class JsonWire
 
             if (r.CountsOnly)
             {
-                WriteHistogram(w, "dangling_by_target_plugin", r.Histogram, histogramLimit);
-                WriteHistogram(w, "dangling_by_source_plugin", r.DanglingBySource, histogramLimit);   // #344 — the new axis
+                WriteHistogram(w, "dangling_by_target_plugin", r.Histogram, histogramLimit, ms, budget);
+                WriteHistogram(w, "dangling_by_source_plugin", r.DanglingBySource, histogramLimit, ms, budget);   // #344 — the new axis
                 acct.UnreadRows(WriteUnreadPlugins(w, r.Reports, ms, budget));
             }
             else
@@ -1296,16 +1296,20 @@ static class JsonWire
                 w.WriteStartArray("plugins");
                 foreach (var p in r.Reports)
                 {
-                    if (Size(w, ms) >= budget) break;
+                    // A SECTION IS WHOLE OR ABSENT HERE TOO, and the cost is MEASURED rather than assumed small. The
+                    // plugin object's fixed part carries a scan-error string and up to three unscannable-record
+                    // exception messages, all unbounded — tested with a bare `Size(w, ms) >= budget` before writing
+                    // it, a two-report fixture whose second plugin carried three ~950-char samples returned 7,296
+                    // chars against a 5,270 cap, silently. The text lane composes its fixed part and measures it;
+                    // this is the same rule, and a Utf8JsonWriter can only be measured by writing, so it is written
+                    // once into a scratch buffer at the same nesting depth.
+                    if (Size(w, ms) + PluginHeadCost(p) >= budget) break;
                     w.WriteStartObject();
                     w.WriteString("plugin", p.Plugin);
                     WriteNullable(w, "scan_error", p.ScanError);
                     WriteStringArray(w, "missing_masters", p.MissingMasters);
-                    // The unscannable fields are written BEFORE the dangling array, not after it. Field order carries
-                    // no meaning to a consumer, and putting them here is what bounds the tail: once the entry loop
-                    // breaks mid-plugin, all that follows is three fixed closing brackets. Written after the array,
-                    // their length rode outside the budget — and unscannable_samples carries up to three exception
-                    // messages, so "outside the budget" was unbounded, not merely untidy.
+                    // The unscannable fields sit before the dangling array so that once the ENTRY loop breaks
+                    // mid-plugin, all that follows is three fixed closing brackets.
                     w.WriteNumber("unscannable_records", p.UnscannableRecords);
                     WriteStringArray(w, "unscannable_samples", p.UnscannableSamples);
                     w.WriteStartArray("dangling");
@@ -1324,8 +1328,9 @@ static class JsonWire
                     }
                     w.WriteEndArray();
                     w.WriteEndObject();
-                    // Counted where the object CLOSED, so a section is "rendered" only once all of it is in the
-                    // document — the twin of the text lane counting an entry where its line landed.
+                    // Counted where the section's own content landed, exactly as the text lane counts it: its
+                    // ENTRIES are accounted separately, so a section whose entry loop stopped on the budget is a
+                    // rendered section carrying fewer entries, not a partly-rendered one.
                     acct.Section();
                 }
                 w.WriteEndArray();
@@ -1339,10 +1344,37 @@ static class JsonWire
             // written in one place, which is the same place JsonReserve measures.
             acct.WriteJson(w);
             w.WriteString("boundary", ReadSentences.SweepBoundary);
-            if (acct.CapTooSmall(headerLength, reserve) is { } notice) w.WriteString("max_chars_overrun", notice);
+            // Measured, like the text lane: Size() is the document so far, plus the one brace still to close.
+            if (acct.CapTooSmall(Size(w, ms) + 1, headerLength + reserve) is { } notice)
+                w.WriteString("max_chars_overrun", notice);
             w.WriteEndObject();
         }
         return Finish(ms);
+    }
+
+    /// <summary>What a plugin object's FIXED part costs, encoded exactly as the response will encode it — same
+    /// writer options, same nesting depth, so escaping and indentation are counted rather than estimated. Over-counts
+    /// by the scratch wrapper's own braces, which is the safe direction for a budget test.</summary>
+    static int PluginHeadCost(PluginErrors p)
+    {
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            w.WriteStartArray("plugins");
+            w.WriteStartObject();
+            w.WriteString("plugin", p.Plugin);
+            WriteNullable(w, "scan_error", p.ScanError);
+            WriteStringArray(w, "missing_masters", p.MissingMasters);
+            w.WriteNumber("unscannable_records", p.UnscannableRecords);
+            WriteStringArray(w, "unscannable_samples", p.UnscannableSamples);
+            w.WriteStartArray("dangling");
+            w.WriteEndArray();
+            w.WriteEndObject();
+            w.WriteEndArray();
+            w.WriteEndObject();
+        }
+        return (int)ms.Length;
     }
 
     /// <summary>The document's size so far, without flushing: committed bytes plus what the writer still holds. A
@@ -1495,7 +1527,10 @@ static class JsonWire
 
     /// <summary>A counts_only histogram: <c>{distinct, rows:[{key,count}], rendered}</c>. Absent when the mode was not
     /// requested; PRESENT with an empty <c>rows</c> when the sweep genuinely found nothing — the two must not look alike.</summary>
-    static void WriteHistogram(Utf8JsonWriter w, string name, IReadOnlyList<SweepCount>? rows, int rowLimit)
+    /// <param name="budget">the bytes this render may occupy; unbounded by default, which is what validate_scripts
+    /// still passes. `distinct` vs `rendered` already discloses a short list, so the bound needs no new field.</param>
+    static void WriteHistogram(Utf8JsonWriter w, string name, IReadOnlyList<SweepCount>? rows, int rowLimit,
+                               MemoryStream? ms = null, int budget = int.MaxValue)
     {
         if (rows is null) return;
         w.WriteStartObject(name);
@@ -1505,6 +1540,7 @@ static class JsonWire
         foreach (var row in rows)
         {
             if (shown >= rowLimit) break;
+            if (ms is not null && Size(w, ms) >= budget) break;
             w.WriteStartObject(); w.WriteString("key", row.Key); w.WriteNumber("count", row.Count); w.WriteEndObject();
             shown++;
         }

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1291,8 +1291,11 @@ static class JsonWire
 
             if (r.CountsOnly)
             {
-                WriteHistogram(w, "dangling_by_target_plugin", SweepSubject.HistogramByTarget, r.Histogram, histogramLimit, body);
-                WriteHistogram(w, "dangling_by_source_plugin", SweepSubject.HistogramBySource, r.DanglingBySource, histogramLimit, body);   // #344 — the new axis
+                // Both axes handed over together, so both frames are reserved before either writes — the json twin
+                // of the text lane's two-pass reserve, for the same reason (#392).
+                WriteHistograms(w, body, histogramLimit,
+                    ("dangling_by_target_plugin", SweepSubject.HistogramByTarget, r.Histogram),
+                    ("dangling_by_source_plugin", SweepSubject.HistogramBySource, r.DanglingBySource));   // #344 — the new axis
                 WriteUnreadPlugins(w, r.Reports, body);
             }
             else
@@ -1360,12 +1363,16 @@ static class JsonWire
             // like the text lane, the notice is part of the document whose length it states, so its own encoded cost
             // is counted in and the composition is run to a fixed point.
             int closed = Size(w, ms) + Framing.RootClose;
-            if (acct.CapTooSmall(closed, headerLength + reserve) is { } notice)
+            // The response's FIXED PART: the header, plus everything reserved out of max_chars before the body
+            // rendered — the accounting, the boundary, and every axis's own frame. It is what the notice branches
+            // on, so a reserve missing from it would explain a cap too small for the fixed part as a body overshoot.
+            int fixedPart = reserve + body.ReservedTotal;
+            if (acct.CapTooSmall(closed, headerLength + fixedPart) is { } notice)
             {
                 int cost = OverrunNoticeCost(notice);
-                var settled = acct.CapTooSmall(closed + cost, headerLength + reserve)!;
+                var settled = acct.CapTooSmall(closed + cost, headerLength + fixedPart)!;
                 if (OverrunNoticeCost(settled) != cost)
-                    settled = acct.CapTooSmall(closed + OverrunNoticeCost(settled), headerLength + reserve)!;
+                    settled = acct.CapTooSmall(closed + OverrunNoticeCost(settled), headerLength + fixedPart)!;
                 w.WriteString("max_chars_overrun", settled);
             }
             w.WriteEndObject();
@@ -1600,6 +1607,46 @@ static class JsonWire
     }
 
     // ---- shared sweep writers (#282) ---------------------------------------------------------------
+    /// <summary>Reserve every axis's OBJECT FRAME out of the body budget, then write the axes. The frame — the
+    /// <c>distinct</c>/<c>rendered</c>/<c>cut_by</c> members around the rows — is this transport's whole disclosure
+    /// that the axis exists and how much of it is here, so it is written unconditionally and the room for it comes
+    /// out of <c>max_chars</c> first, exactly as the text lane reserves its closing line (#392).
+    ///
+    /// <para>The reserve covers the frame's LEADING members as well as its trailing ones, and the leading ones are
+    /// already written by the time this axis's own rows are tested — so an axis over-reserves against itself by
+    /// that much. Over-reserving costs characters; under-reserving is the thing this exists to stop, so the
+    /// simpler arithmetic is taken in the safe direction deliberately.</para></summary>
+    static void WriteHistograms(Utf8JsonWriter w, BoundedBody? body, int rowLimit,
+                                params (string Name, SweepSubject Subject, IReadOnlyList<SweepCount>? Rows)[] axes)
+    {
+        if (body is not null)
+            foreach (var a in axes)
+                if (a.Rows is not null) body.Reserve(a.Subject, HistogramFrameCost(a.Name, a.Rows.Count));
+        foreach (var a in axes) WriteHistogram(w, a.Name, a.Subject, a.Rows, rowLimit, body);
+    }
+
+    /// <summary>What ONE axis object costs with no rows in it, encoded exactly as the response will encode it — the
+    /// same construction as <see cref="PluginHeadCost"/>, at this object's own nesting depth, with every member at
+    /// its widest: <c>rendered</c> can print as many digits as <c>distinct</c>, and <c>cut_by</c> carries the longer
+    /// of the two knob names.</summary>
+    static int HistogramFrameCost(string name, int distinct)
+    {
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            w.WriteStartObject(name);
+            w.WriteNumber("distinct", distinct);
+            w.WriteStartArray("rows");
+            w.WriteEndArray();
+            w.WriteNumber("rendered", distinct);
+            w.WriteString("cut_by", "max_chars");
+            w.WriteEndObject();
+            w.WriteEndObject();
+        }
+        return (int)ms.Length;
+    }
+
     /// <summary>A counts_only histogram: <c>{distinct, rows:[{key,count}], rendered, cut_by}</c>. Absent when the mode
     /// was not requested; PRESENT with an empty <c>rows</c> when the sweep genuinely found nothing — the two must not
     /// look alike.</summary>
@@ -1610,7 +1657,7 @@ static class JsonWire
     static void WriteHistogram(Utf8JsonWriter w, string name, SweepSubject subject, IReadOnlyList<SweepCount>? rows,
                                int rowLimit, BoundedBody? body = null)
     {
-        if (rows is null) return;
+        if (rows is null) { body?.Release(subject); return; }
         // The object's own fixed members do not grow with the findings, so they are part of the fixed part; the ROWS
         // are what the budget gates, and `rendered` is written from what the gate let through.
         w.WriteStartObject(name);
@@ -1639,6 +1686,9 @@ static class JsonWire
         if (HistogramCut.For(rows.Count, shown, cutByBudget) is { } cut) w.WriteString("cut_by", cut.Knob);
         else w.WriteNull("cut_by");
         w.WriteEndObject();
+        // The frame is written, so the room held for it is spent — and holding it any longer would charge the
+        // unread and excluded rows below for a disclosure that is already on the document.
+        body?.Release(subject);
     }
 
     /// <summary>Under counts_only, check_errors' reports carry the honesty layer only — plugins whose records could not

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1359,7 +1359,7 @@ static class JsonWire
             // Measured, like the text lane: Size() is the document so far, plus what closing it still costs — and
             // like the text lane, the notice is part of the document whose length it states, so its own encoded cost
             // is counted in and the composition is run to a fixed point.
-            int closed = Size(w, ms) + RootClose;
+            int closed = Size(w, ms) + Framing.RootClose;
             if (acct.CapTooSmall(closed, headerLength + reserve) is { } notice)
             {
                 int cost = OverrunNoticeCost(notice);
@@ -1398,13 +1398,51 @@ static class JsonWire
         return (int)ms.Length;
     }
 
-    /// <summary>What closing the root object still costs an INDENTED writer: a newline and the brace. It was
-    /// counted as one char, and the notice then stated a length one short of the document the caller received.
-    /// </summary>
-    const int RootClose = 2;
+    /// <summary>What THIS writer's own framing costs, measured against the writer rather than kept by hand: opening
+    /// the root object, closing it, and the separator a property pays for not being the first one inside it.
+    ///
+    /// <para><b>Why one measurement rather than a number per site.</b> These were two hand-kept constants —
+    /// <c>RootClose = 2</c> here, and a <c>- 2</c> for "the scratch wrapper's own braces" inside
+    /// <see cref="OverrunNoticeCost"/> — and both were wrong by one, in opposite directions. An indented writer
+    /// closes the root with a newline and a brace, and the newline this platform's writer emits is a CR/LF pair, so
+    /// that close costs three characters and not two. The scratch wrapper therefore costs one more than it was
+    /// credited with, and the notice, written into an object that already has properties, also pays for a separator
+    /// the scratch document never wrote. The two
+    /// errors CANCELLED in the length the notice states, so the arm holding that number stayed green while the
+    /// comparison that decides whether a notice fires at all stayed one character short — a document of exactly
+    /// <c>cap + 1</c> read as <c>cap</c> and said nothing about it. Derived from one measurement, the two cannot
+    /// drift apart again: either both are right, or the same measurement is wrong for both.</para></summary>
+    static readonly WriterFraming Framing = MeasureFraming();
+
+    /// <summary>The three costs <see cref="MeasureFraming"/> reads off the writer, in bytes of the encoded
+    /// document.</summary>
+    readonly record struct WriterFraming(int Open, int RootClose, int Separator);
+
+    /// <summary>Write two BYTE-IDENTICAL properties into a root object and take the deltas: what the first cost
+    /// above the bare <c>{</c> is one property, what the second cost above the first is that same property PLUS the
+    /// separator, and what the finished document holds above the still-open one is the root close.</summary>
+    static WriterFraming MeasureFraming()
+    {
+        using var ms = new MemoryStream();
+        int opened, first, second;
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            opened = Size(w, ms);
+            w.WriteString("f", "");
+            first = Size(w, ms);
+            w.WriteString("f", "");
+            second = Size(w, ms);
+            w.WriteEndObject();
+        }
+        return new WriterFraming(Open: opened, RootClose: (int)ms.Length - second,
+                                 Separator: (second - first) - (first - opened));
+    }
 
     /// <summary>What the overrun notice costs the document, encoded as the response will encode it — json escapes
-    /// what a raw char count would miss, and the notice's own length is part of the length it reports.</summary>
+    /// what a raw char count would miss, and the notice's own length is part of the length it reports. The scratch
+    /// document is a root object of its own, so what the REAL document pays is the scratch less the wrapper it
+    /// already has, plus the separator the notice owes for following the properties written before it.</summary>
     static int OverrunNoticeCost(string notice)
     {
         using var ms = new MemoryStream();
@@ -1414,7 +1452,7 @@ static class JsonWire
             w.WriteString("max_chars_overrun", notice);
             w.WriteEndObject();
         }
-        return (int)ms.Length - 2;   // the scratch wrapper's own braces
+        return (int)ms.Length - (Framing.Open + Framing.RootClose) + Framing.Separator;
     }
 
     /// <summary>The document's size so far, without flushing: committed bytes plus what the writer still holds. A

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1031,8 +1031,6 @@ static class JsonWire
         return Finish(ms);
     }
 
-    /// <summary>The P5 scoped-vs-winner fields note, shared verbatim by the json and dense renders (D2 — one wording,
-    /// two renders that can't drift).</summary>
     /// <summary>The P5 scoped-vs-winner field-source note, as one of a 4-way matrix over (winner_fields=, where_source=).
     /// <paramref name="whereWinner"/> (#233) is true when the MATCH decided on the live winner (where_source=winner) —
     /// then the note must NOT claim the match was selected on the scoped body (the D2 no-drift rule). Shared by the

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1356,9 +1356,18 @@ static class JsonWire
             // written in one place, which is the same place JsonReserve measures.
             acct.WriteJson(w);
             w.WriteString("boundary", ReadSentences.SweepBoundary);
-            // Measured, like the text lane: Size() is the document so far, plus the one brace still to close.
-            if (acct.CapTooSmall(Size(w, ms) + 1, headerLength + reserve) is { } notice)
-                w.WriteString("max_chars_overrun", notice);
+            // Measured, like the text lane: Size() is the document so far, plus what closing it still costs — and
+            // like the text lane, the notice is part of the document whose length it states, so its own encoded cost
+            // is counted in and the composition is run to a fixed point.
+            int closed = Size(w, ms) + RootClose;
+            if (acct.CapTooSmall(closed, headerLength + reserve) is { } notice)
+            {
+                int cost = OverrunNoticeCost(notice);
+                var settled = acct.CapTooSmall(closed + cost, headerLength + reserve)!;
+                if (OverrunNoticeCost(settled) != cost)
+                    settled = acct.CapTooSmall(closed + OverrunNoticeCost(settled), headerLength + reserve)!;
+                w.WriteString("max_chars_overrun", settled);
+            }
             w.WriteEndObject();
         }
         return Finish(ms);
@@ -1387,6 +1396,25 @@ static class JsonWire
             w.WriteEndObject();
         }
         return (int)ms.Length;
+    }
+
+    /// <summary>What closing the root object still costs an INDENTED writer: a newline and the brace. It was
+    /// counted as one char, and the notice then stated a length one short of the document the caller received.
+    /// </summary>
+    const int RootClose = 2;
+
+    /// <summary>What the overrun notice costs the document, encoded as the response will encode it — json escapes
+    /// what a raw char count would miss, and the notice's own length is part of the length it reports.</summary>
+    static int OverrunNoticeCost(string notice)
+    {
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            w.WriteString("max_chars_overrun", notice);
+            w.WriteEndObject();
+        }
+        return (int)ms.Length - 2;   // the scratch wrapper's own braces
     }
 
     /// <summary>The document's size so far, without flushing: committed bytes plus what the writer still holds. A
@@ -1534,9 +1562,6 @@ static class JsonWire
     }
 
     // ---- shared sweep writers (#282) ---------------------------------------------------------------
-    /// <summary>Row cap for the budget-omissions table — independent of limit=, which is what caused the omissions.</summary>
-    const int OmittedSourceRows = 200;
-
     /// <summary>A counts_only histogram: <c>{distinct, rows:[{key,count}], rendered}</c>. Absent when the mode was not
     /// requested; PRESENT with an empty <c>rows</c> when the sweep genuinely found nothing — the two must not look alike.</summary>
     /// <param name="body">the ONE bounded emission path, or null for validate_scripts, which passes no budget —

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1615,7 +1615,16 @@ static class JsonWire
     /// <para>The reserve covers the frame's LEADING members as well as its trailing ones, and the leading ones are
     /// already written by the time this axis's own rows are tested — so an axis over-reserves against itself by
     /// that much. Over-reserving costs characters; under-reserving is the thing this exists to stop, so the
-    /// simpler arithmetic is taken in the safe direction deliberately.</para></summary>
+    /// simpler arithmetic is taken in the safe direction deliberately.</para>
+    ///
+    /// <para><b>No arm can see this reserve today, and that is said here rather than left to be discovered.</b>
+    /// Sabotaged to reserve nothing, every arm in both guards stays green: the two frames together are about 180
+    /// bytes and <see cref="CheckAccounting"/>'s json slack is 1024, so the room sized for one whole entry absorbs
+    /// them at every cap a fixture can reach. It is kept anyway, because "bounded by a slack sized for something
+    /// else" is exactly the posture that produced four unbounded write sites in a row — the frame is written
+    /// unconditionally, so its room is reserved by construction rather than borrowed. The guarantee it belongs to
+    /// is pinned in the TEXT lane (HISTOGRAM-AXIS-NEVER-DROPS-SILENTLY,
+    /// OVERRUN-IN-THE-TEXT-LANE-IS-ALWAYS-A-CAP-TOO-SMALL); no arm claims to pin it here.</para></summary>
     static void WriteHistograms(Utf8JsonWriter w, BoundedBody? body, int rowLimit,
                                 params (string Name, SweepSubject Subject, IReadOnlyList<SweepCount>? Rows)[] axes)
     {

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1291,8 +1291,8 @@ static class JsonWire
 
             if (r.CountsOnly)
             {
-                WriteHistogram(w, "dangling_by_target_plugin", r.Histogram, histogramLimit, body);
-                WriteHistogram(w, "dangling_by_source_plugin", r.DanglingBySource, histogramLimit, body);   // #344 — the new axis
+                WriteHistogram(w, "dangling_by_target_plugin", SweepSubject.HistogramByTarget, r.Histogram, histogramLimit, body);
+                WriteHistogram(w, "dangling_by_source_plugin", SweepSubject.HistogramBySource, r.DanglingBySource, histogramLimit, body);   // #344 — the new axis
                 WriteUnreadPlugins(w, r.Reports, body);
             }
             else
@@ -1480,7 +1480,7 @@ static class JsonWire
 
             if (r.CountsOnly)
             {
-                WriteHistogram(w, "unbound_by_property", r.Histogram, histogramLimit);
+                WriteHistogram(w, "unbound_by_property", SweepSubject.HistogramByProperty, r.Histogram, histogramLimit);
                 // Wrapped + budget-flagged for the same reason check_errors' `unread` is (#288 review finding 4): a
                 // silently short honesty list reads as a complete one.
                 var scanErrors = r.Reports.Where(x => x.ScanError is not null).ToList();
@@ -1562,35 +1562,44 @@ static class JsonWire
     }
 
     // ---- shared sweep writers (#282) ---------------------------------------------------------------
-    /// <summary>A counts_only histogram: <c>{distinct, rows:[{key,count}], rendered}</c>. Absent when the mode was not
-    /// requested; PRESENT with an empty <c>rows</c> when the sweep genuinely found nothing — the two must not look alike.</summary>
+    /// <summary>A counts_only histogram: <c>{distinct, rows:[{key,count}], rendered, cut_by}</c>. Absent when the mode
+    /// was not requested; PRESENT with an empty <c>rows</c> when the sweep genuinely found nothing — the two must not
+    /// look alike.</summary>
     /// <param name="body">the ONE bounded emission path, or null for validate_scripts, which passes no budget —
-    /// its response layer is not this branch's. `distinct` vs `rendered` already discloses a short list, so the
-    /// bound needs no new field.</param>
-    static void WriteHistogram(Utf8JsonWriter w, string name, IReadOnlyList<SweepCount>? rows, int rowLimit,
-                               BoundedBody? body = null)
+    /// its response layer is not this branch's.</param>
+    /// <param name="subject">this axis's OWN emission subject. Two axes sharing one meant the first to stop stopped
+    /// the second (see <see cref="SweepSubject.HistogramBySource"/>).</param>
+    static void WriteHistogram(Utf8JsonWriter w, string name, SweepSubject subject, IReadOnlyList<SweepCount>? rows,
+                               int rowLimit, BoundedBody? body = null)
     {
         if (rows is null) return;
-        // The object's own three fixed members do not grow with the findings, so they are part of the fixed part;
-        // the ROWS are what the budget gates, and `rendered` is written from what the gate let through.
+        // The object's own fixed members do not grow with the findings, so they are part of the fixed part; the ROWS
+        // are what the budget gates, and `rendered` is written from what the gate let through.
         w.WriteStartObject(name);
         w.WriteNumber("distinct", rows.Count);
         w.WriteStartArray("rows");
         int shown = 0;
+        bool cutByBudget = false;
         foreach (var row in rows)
         {
             if (shown >= rowLimit) break;
             var r = row;
             if (body is not null
-                && !body.Emit(SweepSubject.HistogramRows, 0,
+                && !body.Emit(subject, 0,
                               () => { w.WriteStartObject(); w.WriteString("key", r.Key); w.WriteNumber("count", r.Count); w.WriteEndObject(); }))
-                break;
+            { cutByBudget = true; break; }
             if (body is null)
             { w.WriteStartObject(); w.WriteString("key", row.Key); w.WriteNumber("count", row.Count); w.WriteEndObject(); }
             shown++;
         }
         w.WriteEndArray();
         w.WriteNumber("rendered", shown);
+        // WHICH knob stopped it, from the SAME computation the text lane renders as a sentence. distinct vs rendered
+        // says an axis is short; it cannot say which parameter a consumer would have to change, and this lane said
+        // nothing at all while the text twin named a knob — one sweep, two transports, two different answers.
+        // Null where the axis is whole, so "complete" is read rather than inferred from two numbers.
+        if (HistogramCut.For(rows.Count, shown, cutByBudget) is { } cut) w.WriteString("cut_by", cut.Knob);
+        else w.WriteNull("cut_by");
         w.WriteEndObject();
     }
 

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1281,9 +1281,7 @@ static class JsonWire
             // is written even when the walk did not run, because it is true either way.
             WriteStringArray(w, "base_masters_swept", r.BaseMastersSwept ?? Array.Empty<string>());
             WriteStringArray(w, "base_masters", HousecarlCore.ErrorCheck.BaseMasters);
-            // Where the BODY begins — see CheckAccounting.CapTooSmall for why it is asked here and not at the end.
-            int headerLength = Size(w, ms);
-            // EVERYTHING BELOW THIS LINE GOES THROUGH `body`, including the excluded roster, which used to be
+            // EVERYTHING A CAP CAN REFUSE GOES THROUGH `body`, including the excluded roster, which used to be
             // written up in the header where no budget could reach it — 1,188 chars past the budget on three
             // 400-character parse reasons, while the TEXT lane bounded the same roster. The fourth instance of one
             // class, which is why the bound now lives in one helper rather than at each write site.
@@ -1363,16 +1361,17 @@ static class JsonWire
             // like the text lane, the notice is part of the document whose length it states, so its own encoded cost
             // is counted in and the composition is run to a fixed point.
             int closed = Size(w, ms) + Framing.RootClose;
-            // The response's FIXED PART: the header, plus everything reserved out of max_chars before the body
-            // rendered — the accounting, the boundary, and every axis's own frame. It is what the notice branches
-            // on, so a reserve missing from it would explain a cap too small for the fixed part as a body overshoot.
-            int fixedPart = reserve + body.ReservedTotal;
-            if (acct.CapTooSmall(closed, headerLength + fixedPart) is { } notice)
+            // The response's FIXED PART, by SUBTRACTION (CheckAccounting.CapTooSmall states the rule): the document
+            // just measured, less what the entries and rows put in it. Handed the RESERVE instead it carried this
+            // lane's whole JsonGlue — a kilobyte sized to absorb one entry, inside a number describing a fixed part
+            // that never spends it — and the raise-to it feeds came out 85% above the smallest cap that fits.
+            int needed = body.FixedPart(closed);
+            if (acct.CapTooSmall(closed, needed) is { } notice)
             {
                 int cost = OverrunNoticeCost(notice);
-                var settled = acct.CapTooSmall(closed + cost, headerLength + fixedPart)!;
+                var settled = acct.CapTooSmall(closed + cost, needed, cost)!;
                 if (OverrunNoticeCost(settled) != cost)
-                    settled = acct.CapTooSmall(closed + OverrunNoticeCost(settled), headerLength + fixedPart)!;
+                    settled = acct.CapTooSmall(closed + OverrunNoticeCost(settled), needed, OverrunNoticeCost(settled))!;
                 w.WriteString("max_chars_overrun", settled);
             }
             w.WriteEndObject();
@@ -1668,10 +1667,15 @@ static class JsonWire
     {
         if (rows is null) { body?.Release(subject); return; }
         // The object's own fixed members do not grow with the findings, so they are part of the fixed part; the ROWS
-        // are what the budget gates, and `rendered` is written from what the gate let through.
-        w.WriteStartObject(name);
-        w.WriteNumber("distinct", rows.Count);
-        w.WriteStartArray("rows");
+        // are what the budget gates, and `rendered` is written from what the gate let through. The frame goes
+        // through the body so what it costs is MEASURED into the response's fixed part rather than inferred from
+        // the reserve that held room for it — the same rule the text lane's notes now follow.
+        Unconditional(body, subject, () =>
+        {
+            w.WriteStartObject(name);
+            w.WriteNumber("distinct", rows.Count);
+            w.WriteStartArray("rows");
+        });
         int shown = 0;
         bool cutByBudget = false;
         foreach (var row in rows)
@@ -1686,18 +1690,32 @@ static class JsonWire
             { w.WriteStartObject(); w.WriteString("key", row.Key); w.WriteNumber("count", row.Count); w.WriteEndObject(); }
             shown++;
         }
-        w.WriteEndArray();
-        w.WriteNumber("rendered", shown);
-        // WHICH knob stopped it, from the SAME computation the text lane renders as a sentence. distinct vs rendered
-        // says an axis is short; it cannot say which parameter a consumer would have to change, and this lane said
-        // nothing at all while the text twin named a knob — one sweep, two transports, two different answers.
-        // Null where the axis is whole, so "complete" is read rather than inferred from two numbers.
-        if (HistogramCut.For(rows.Count, shown, cutByBudget) is { } cut) w.WriteString("cut_by", cut.Knob);
-        else w.WriteNull("cut_by");
-        w.WriteEndObject();
-        // The frame is written, so the room held for it is spent — and holding it any longer would charge the
-        // unread and excluded rows below for a disclosure that is already on the document.
+        int rendered = shown;
+        Unconditional(body, subject, () =>
+        {
+            w.WriteEndArray();
+            w.WriteNumber("rendered", rendered);
+            // WHICH knob stopped it, from the SAME computation the text lane renders as a sentence. distinct vs
+            // rendered says an axis is short; it cannot say which parameter a consumer would have to change, and
+            // this lane said nothing at all while the text twin named a knob — one sweep, two transports, two
+            // different answers. Null where the axis is whole, so "complete" is read rather than inferred from two
+            // numbers.
+            if (HistogramCut.For(rows.Count, rendered, cutByBudget) is { } cut) w.WriteString("cut_by", cut.Knob);
+            else w.WriteNull("cut_by");
+            w.WriteEndObject();
+        });
+        // The frame is written and charged, so whatever room is still held for it goes back — holding it any longer
+        // would charge the unread and excluded rows below for a disclosure already on the document.
         body?.Release(subject);
+    }
+
+    /// <summary>Write part of an axis object's own FRAME: unconditional, never refused, and measured into the
+    /// response's fixed part when there is a body to measure it with. validate_scripts passes none — its response
+    /// layer is not this branch's — and then this is a plain write.</summary>
+    static void Unconditional(BoundedBody? body, SweepSubject subject, Action commit)
+    {
+        if (body is null) commit();
+        else body.Fixed(subject, commit);
     }
 
     /// <summary>Under counts_only, check_errors' reports carry the honesty layer only — plugins whose records could not

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1671,9 +1671,33 @@ static class JsonWire
             var row = kv;
             void Write() { w.WriteStartObject(); w.WriteString("plugin", row.Key); w.WriteString("reason", row.Value); w.WriteEndObject(); }
             if (body is null) { Write(); continue; }
-            if (!body.Emit(SweepSubject.ExcludedRows, 0, Write)) break;
+            // The THIRD unit whose cost is measured rather than left to the post-check, and for the same reason as
+            // the other two: `reason` is a Mutagen parse-failure message with no length of its own. Passed 0, the
+            // post-check let one whole row land over budget and JsonGlue absorbed it only while the row was smaller
+            // than that — 5,456 chars against a 5,000 cap on three 1,200-char reasons, while the TEXT twin, which
+            // has always measured its own unit.Length here, was inside the same cap with room to spare.
+            if (!body.Emit(SweepSubject.ExcludedRows, ExcludedRowCost(row), Write)) break;
         }
         w.WriteEndArray();
+    }
+
+    /// <summary>What one excluded-roster row costs, encoded exactly as the response will encode it — the same
+    /// construction as <see cref="PluginHeadCost"/> and <see cref="UnreadRowCost"/>, at this row's own depth.</summary>
+    static int ExcludedRowCost(KeyValuePair<string, string> row)
+    {
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            w.WriteStartArray("excluded_plugins");
+            w.WriteStartObject();
+            w.WriteString("plugin", row.Key);
+            w.WriteString("reason", row.Value);
+            w.WriteEndObject();
+            w.WriteEndArray();
+            w.WriteEndObject();
+        }
+        return (int)ms.Length;
     }
 
     static List<string> ClassNames(ErrorFindingClass c)

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -23,6 +23,11 @@ static class JsonWire
 {
     static readonly JsonWriterOptions Opts = new() { Indented = true };
 
+    /// <summary>The options every json response is written under, exposed so <see cref="CheckAccounting"/> measures
+    /// its reserve against the SAME encoding it will be written in. Measuring unindented what is written indented
+    /// under-reserves by the whole indentation.</summary>
+    internal static JsonWriterOptions WriterOptions => Opts;
+
     static string Finish(MemoryStream ms) => Encoding.UTF8.GetString(ms.ToArray());
 
     static void WriteNullable(Utf8JsonWriter w, string name, string? v)
@@ -1213,24 +1218,31 @@ static class JsonWire
     }
 
     // ---- housecarl_check_errors (#282) --------------------------------------------------------------
-    /// <summary>The integrity sweep as JSON: <c>{scanned_plugins, dangling, baseline_dangling, non_baseline_dangling,
-    /// base_masters_swept, base_masters, missing_masters, unscannable, classes, filter_note, off_order_scanned,
-    /// excluded_plugins, dangling_by_source_plugin, capped, dangling_not_listed_by_source, plugins:[…],
-    /// plugins_with_findings, rendered, truncated, boundary}</c>, or the <c>counts_only</c> shape with
-    /// <c>histogram</c> in place of <c>plugins</c>.
-    /// An error CLASS the caller excluded is
-    /// emitted as <c>null</c>, NOT as 0 — the json counterpart of the text render's "NOT CHECKED", so a skipped check
-    /// cannot be parsed as a clean one (Q3). Budget-aware: drops trailing rows and flags <c>truncated</c>, always
-    /// leaving valid JSON.
-    /// <para>The field list above is a HAND-KEPT second spelling of the wire names, outside <c>wire-names-guard</c>'s
-    /// reach — it drifted once already (it named <c>base_masters_in_scope</c>, which no writer emits). If it drifts a
-    /// second time, delete it rather than correct it again and let the writer below be the only authority (#358's
-    /// roster lesson).</para></summary>
+    /// <summary>The integrity sweep as json, carrying the SAME accounting the text render states in prose — one
+    /// <see cref="CheckAccounting"/> computes both, so the two transports cannot disagree about what this response
+    /// is missing (#337).
+    ///
+    /// <para>An error CLASS the caller excluded is emitted as <c>null</c>, NOT as 0 — the json counterpart of the
+    /// text render's "NOT CHECKED", so a skipped check cannot be parsed as a clean one (Q3).</para>
+    ///
+    /// <para><b>The budget is tested per ENTRY, not per plugin</b> (#361). It used to be tested before each plugin
+    /// OBJECT, so one plugin's whole dangling array went out in a single piece: measured on the live ARR order, a
+    /// single-plugin sweep of a 2591-ref plugin returned 202,425 chars against an 80,000 cap and reported
+    /// <c>truncated: false</c> — true, and useless, because <c>max_chars</c> had not been applied at all. Testing at
+    /// the entry makes the overshoot unrepresentable rather than smaller.</para>
+    ///
+    /// <para>The field list this summary used to carry has been deleted rather than corrected a second time: it was
+    /// a HAND-KEPT second spelling of the wire names, outside <c>wire-names-guard</c>'s reach, and it had already
+    /// drifted once (it named <c>base_masters_in_scope</c>, which no writer emits). The writer below is the only
+    /// authority — #358's roster lesson, taken at the second drift as that comment itself asked.</para></summary>
     public static string RenderCheckErrors(ErrorCheckResult r, int maxChars, int histogramLimit = 1000)
     {
         int cap = Cap(maxChars);
         bool didDangling = r.Classes.HasFlag(ErrorFindingClass.Dangling);
         bool didMasters = r.Classes.HasFlag(ErrorFindingClass.MissingMasters);
+        var acct = new CheckAccounting(r, cap);
+        int reserve = acct.JsonReserve;
+        int budget = acct.BodyBudget(reserve);
         using var ms = new MemoryStream();
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
@@ -1270,65 +1282,73 @@ static class JsonWire
             // is written even when the walk did not run, because it is true either way.
             WriteStringArray(w, "base_masters_swept", r.BaseMastersSwept ?? Array.Empty<string>());
             WriteStringArray(w, "base_masters", HousecarlCore.ErrorCheck.BaseMasters);
+            // Where the BODY begins — see CheckAccounting.CapTooSmall for why it is asked here and not at the end.
+            int headerLength = Size(w, ms);
 
             if (r.CountsOnly)
             {
                 WriteHistogram(w, "dangling_by_target_plugin", r.Histogram, histogramLimit);
                 WriteHistogram(w, "dangling_by_source_plugin", r.DanglingBySource, histogramLimit);   // #344 — the new axis
-                WriteUnreadPlugins(w, r.Reports, ms, cap);
+                acct.UnreadRows(WriteUnreadPlugins(w, r.Reports, ms, budget));
             }
             else
             {
-                w.WriteBoolean("capped", r.Capped);
-                // #344 — WHICH plugins lost entries to the budget. Absent (not empty) when nothing was listed at all,
-                // matching the histograms' null-means-not-computed rule; empty rows mean nothing was dropped.
-                // NOT histogramLimit: that is limit=, the very knob whose smallness caused the omissions — the tighter
-                // the budget, the more plugins lose entries and the fewer of them json would have named (round-1
-                // review). Its own cap, with distinct/rendered disclosing any truncation.
-                WriteHistogram(w, "dangling_not_listed_by_source", r.ListingOmitted, OmittedSourceRows);
                 w.WriteStartArray("plugins");
-                int rendered = 0; bool truncated = false;
                 foreach (var p in r.Reports)
                 {
-                    w.Flush();
-                    if (ms.Length >= cap) { truncated = true; break; }
+                    if (Size(w, ms) >= budget) break;
                     w.WriteStartObject();
                     w.WriteString("plugin", p.Plugin);
                     WriteNullable(w, "scan_error", p.ScanError);
                     WriteStringArray(w, "missing_masters", p.MissingMasters);
+                    // The unscannable fields are written BEFORE the dangling array, not after it. Field order carries
+                    // no meaning to a consumer, and putting them here is what bounds the tail: once the entry loop
+                    // breaks mid-plugin, all that follows is three fixed closing brackets. Written after the array,
+                    // their length rode outside the budget — and unscannable_samples carries up to three exception
+                    // messages, so "outside the budget" was unbounded, not merely untidy.
+                    w.WriteNumber("unscannable_records", p.UnscannableRecords);
+                    WriteStringArray(w, "unscannable_samples", p.UnscannableSamples);
                     w.WriteStartArray("dangling");
                     foreach (var d in p.Dangling)
                     {
+                        // Per ENTRY: one plugin's array can be thousands of rows, and a check taken only at the
+                        // plugin boundary lets all of them out at once (#361, measured at 2.5x the cap).
+                        if (Size(w, ms) >= budget) break;
                         w.WriteStartObject();
                         w.WriteString("source", d.Source.ToString());
                         w.WriteString("source_type", d.SourceType);
                         WriteNullable(w, "source_editorid", d.SourceEditorId);
                         w.WriteString("target", d.Target.ToString());
                         w.WriteEndObject();
+                        acct.Entry(p.Plugin);
                     }
                     w.WriteEndArray();
-                    w.WriteNumber("unscannable_records", p.UnscannableRecords);
-                    WriteStringArray(w, "unscannable_samples", p.UnscannableSamples);
                     w.WriteEndObject();
-                    rendered++;
+                    // Counted where the object CLOSED, so a section is "rendered" only once all of it is in the
+                    // document — the twin of the text lane counting an entry where its line landed.
+                    acct.Section();
                 }
                 w.WriteEndArray();
-                // The same layer rule as the text render: this writer performed this omission, so it states it in its
-                // own terms. rendered + truncated alone did not let a consumer derive HOW MANY sections were dropped —
-                // there was no total to subtract from — so the total rides along and the arithmetic is exact.
-                w.WriteNumber("plugins_with_findings", r.Reports.Count);
-                w.WriteNumber("rendered", rendered);
-                w.WriteBoolean("truncated", truncated);
             }
 
-            w.WriteString("boundary",
-                "checks FormLink resolution, missing masters, and parse failures. Does NOT verify navmesh/terrain spatial " +
-                "integrity (CRC/grid), flag required-but-null fields, list unused-master cleanup, or link-check an owned " +
-                "item's ownership 'variable' word; a null FormLink is a legal optional.");
+            // This transport writes the excluded roster WHOLE, above, so nothing of it is ever missing here — told
+            // to the accounting explicitly rather than left at zero, which would claim every row was dropped.
+            acct.ExcludedRows(r.ExcludedPlugins.Count);
+
+            // §2.1's required in-band accounting rides the accounting's own writer — everything the close emits is
+            // written in one place, which is the same place JsonReserve measures.
+            acct.WriteJson(w);
+            w.WriteString("boundary", ReadSentences.SweepBoundary);
+            if (acct.CapTooSmall(headerLength, reserve) is { } notice) w.WriteString("max_chars_overrun", notice);
             w.WriteEndObject();
         }
         return Finish(ms);
     }
+
+    /// <summary>The document's size so far, without flushing: committed bytes plus what the writer still holds. A
+    /// flush per entry would be the obvious spelling and the wrong one — this is the same number, and it is what
+    /// makes a per-entry budget test affordable.</summary>
+    static int Size(Utf8JsonWriter w, MemoryStream ms) => (int)(ms.Length + w.BytesPending);
 
     /// <summary>check_errors' stamp + coverage as data (PR #305 re-review) — the sweep twin of
     /// <see cref="WriteEpochWithCoverage"/>: <c>epoch_covers_all_inputs</c> is false exactly when off-order files
@@ -1498,7 +1518,7 @@ static class JsonWire
     /// <para>Wrapped in <c>{total, rows, rendered, truncated}</c> rather than a bare array: a budget cut used to drop
     /// trailing rows with NO flag, so a consumer iterating the array believed it had the complete set of what went
     /// unchecked — and the text render said "truncated" for the same result (PR #288 review, finding 4).</para></summary>
-    static void WriteUnreadPlugins(Utf8JsonWriter w, IReadOnlyList<PluginErrors> reports, MemoryStream ms, int cap)
+    static int WriteUnreadPlugins(Utf8JsonWriter w, IReadOnlyList<PluginErrors> reports, MemoryStream ms, int budget)
     {
         w.WriteStartObject("unread");
         w.WriteNumber("total", reports.Count);
@@ -1506,8 +1526,7 @@ static class JsonWire
         int rendered = 0; bool truncated = false;
         foreach (var p in reports)
         {
-            w.Flush();
-            if (ms.Length >= cap) { truncated = true; break; }
+            if (Size(w, ms) >= budget) { truncated = true; break; }
             w.WriteStartObject();
             w.WriteString("plugin", p.Plugin);
             WriteNullable(w, "scan_error", p.ScanError);
@@ -1520,6 +1539,7 @@ static class JsonWire
         w.WriteNumber("rendered", rendered);
         w.WriteBoolean("truncated", truncated);
         w.WriteEndObject();
+        return rendered;
     }
 
     static void WriteExcluded(Utf8JsonWriter w, IReadOnlyDictionary<string, string> excluded)

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1619,10 +1619,14 @@ static class JsonWire
     /// <para><b>No arm can see this reserve today, and that is said here rather than left to be discovered.</b>
     /// Sabotaged to reserve nothing, every arm in both guards stays green: the two frames together are about 180
     /// bytes and <see cref="CheckAccounting"/>'s json slack is 1024, so the room sized for one whole entry absorbs
-    /// them at every cap a fixture can reach. It is kept anyway, because "bounded by a slack sized for something
-    /// else" is exactly the posture that produced four unbounded write sites in a row — the frame is written
-    /// unconditionally, so its room is reserved by construction rather than borrowed. The guarantee it belongs to
-    /// is pinned in the TEXT lane (HISTOGRAM-AXIS-NEVER-DROPS-SILENTLY,
+    /// them at every cap a fixture can reach. The same is true of routing the frame's writes through
+    /// <see cref="BoundedBody.Fixed"/> rather than writing them straight to the writer — sabotaged back, every arm
+    /// stays green, because the fixed part the overrun notice branches on is SUBTRACTED from the finished document
+    /// and the frame is inside it either way. Both are kept, because "bounded by a slack sized for something else"
+    /// is exactly the posture that produced four unbounded write sites in a row — the frame is written
+    /// unconditionally, so its room is reserved by construction rather than borrowed, and charged against that room
+    /// as it lands rather than held until after the rows it should no longer be blocking. The guarantee it belongs
+    /// to is pinned in the TEXT lane (HISTOGRAM-AXIS-NEVER-DROPS-SILENTLY,
     /// OVERRUN-IN-THE-TEXT-LANE-IS-ALWAYS-A-CAP-TOO-SMALL); no arm claims to pin it here.</para></summary>
     static void WriteHistograms(Utf8JsonWriter w, BoundedBody? body, int rowLimit,
                                 params (string Name, SweepSubject Subject, IReadOnlyList<SweepCount>? Rows)[] axes)

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -7181,10 +7181,6 @@ public sealed class LoadOrderService : IDisposable
         return report.IsEmpty ? outcome : outcome with { CellShell = report };
     }
 
-    /// <summary>Map a wire field-op to a core <see cref="WriteRequest"/> for CREATE: RecordType is the create type (not
-    /// derived), and a create op carries NO formid (it sets a field on the new record, whose id is auto-allocated) — a
-    /// stray formid is refused loud (Q3) rather than silently ignored. Builds the composition <see cref="StructSpec"/> the
-    /// same way <see cref="MapEdit"/> does (so a created Spell's Effects / LeveledItem's Entries compose identically).</summary>
     /// <summary>The CALLING tool's vocabulary for a create op, threaded down so a refusal never names a spelling the
     /// caller cannot see (PR #311 review 6 [low]; the same rule as <c>origins</c>, <c>sourceParam</c>,
     /// <c>offerModParam</c> and <c>InPlaceAgainHint</c>). <paramref name="Element"/> is the ops-list member word;
@@ -7196,6 +7192,10 @@ public sealed class LoadOrderService : IDisposable
         public static readonly CreateOpNaming Legacy = new("op", "CopyFrom / from_plugin");
     }
 
+    /// <summary>Map a wire field-op to a core <see cref="WriteRequest"/> for CREATE: RecordType is the create type (not
+    /// derived), and a create op carries NO formid (it sets a field on the new record, whose id is auto-allocated) — a
+    /// stray formid is refused loud (Q3) rather than silently ignored. Builds the composition <see cref="StructSpec"/> the
+    /// same way <see cref="MapEdit"/> does (so a created Spell's Effects / LeveledItem's Entries compose identically).</summary>
     WriteRequest? MapCreateEdit(BulkOp op, int index, string recordType, CreateOpNaming naming, out string? error)
     {
         error = null;

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4580,7 +4580,10 @@ public sealed class LoadOrderService : IDisposable
         // loads that plugins.txt does not list — so it is read HERE, where that composition lives, and the core
         // sweep receives plain filenames. Resolved before anything is swept: a bad value refuses having done no
         // work (Q3).
-        var (excluded, excludeErr) = SweepExclusion.Resolve(exclude, ImplicitPluginNamesOrEmpty());
+        var (implicitNames, implicitErr) = ImplicitPluginNames();
+        if (implicitErr is not null && exclude is { Count: > 0 })
+            return ErrorCheckResult.Fail(implicitErr);
+        var (excluded, excludeErr) = SweepExclusion.Resolve(exclude, implicitNames);
         if (excludeErr is not null) return ErrorCheckResult.Fail(excludeErr);
 
         if (plugins is { Count: > 0 })
@@ -4618,15 +4621,25 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>The force-loaded plugin names (in the order, absent from plugins.txt) for
-    /// <see cref="SweepExclusion.ImplicitToken"/>, or empty when the composition cannot be read — a sweep must not
-    /// fail because an exclusion group could not be widened, and an exclusion that then matches nothing refuses in
-    /// the core with the name it could not find, which is the honest report either way.</summary>
-    IReadOnlyList<string> ImplicitPluginNamesOrEmpty()
+    /// <see cref="SweepExclusion.ImplicitToken"/>, or a REASON it could not be read.
+    ///
+    /// <para>It used to swallow the failure and return an empty list. That is the shape houseCARL fails on: a probe
+    /// that cannot see turns into an absence, and the absence is then acted on. Here the group expanded to nothing,
+    /// nothing was excluded, and the response carried no note that exclude= had even been passed — while the
+    /// parameter's own text promised a value that matches nothing is refused. A read that did not happen is not a
+    /// set that is empty, and the caller who asked for the group is the one who is told.</para></summary>
+    (IReadOnlyList<string> Names, string? Error) ImplicitPluginNames()
     {
         string profileDir;
         lock (_gate) { EnsurePathsDerived(); profileDir = _profileDir; }
-        try { return Mo2LoadOrder.ReadComposition(profileDir).ImplicitPluginNames; }
-        catch { return Array.Empty<string>(); }
+        try { return (Mo2LoadOrder.ReadComposition(profileDir).ImplicitPluginNames, null); }
+        catch (Exception ex)
+        {
+            return (Array.Empty<string>(),
+                $"exclude= could not be resolved: the MO2 profile's plugin list at '{profileDir}' could not be read " +
+                $"({ex.GetType().Name}: {ex.Message}). The '{SweepExclusion.ImplicitToken}' group is defined by which " +
+                "plugins that file does NOT list, so it cannot be widened without it. Nothing was swept.");
+        }
     }
 
     /// <summary>Parse the two sweep tools' shared record-scope params (#282) into a <see cref="SweepScope"/>: FormID

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4563,7 +4563,7 @@ public sealed class LoadOrderService : IDisposable
     public ErrorCheckResult CheckErrors(IReadOnlyList<string>? plugins, int limit,
                                         IReadOnlyList<string>? formids = null, string? editoridContains = null,
                                         string? type = null, IReadOnlyList<string>? findings = null,
-                                        bool countsOnly = false)
+                                        bool countsOnly = false, IReadOnlyList<string>? exclude = null)
     {
         var (recordScope, scopeErr) = BuildSweepScope(formids, editoridContains, type);
         if (scopeErr is not null) return ErrorCheckResult.Fail(scopeErr);
@@ -4575,6 +4575,13 @@ public sealed class LoadOrderService : IDisposable
         // and capture an adjacent build, making a refusal stamp N while the sweep stamped N+1.
         var resolver = Resolver;
         var viewAll = resolver.Capture();
+
+        // #344's exclude= axis. The `implicit` group is a fact about the MO2 composition — the plugins the order
+        // loads that plugins.txt does not list — so it is read HERE, where that composition lives, and the core
+        // sweep receives plain filenames. Resolved before anything is swept: a bad value refuses having done no
+        // work (Q3).
+        var (excluded, excludeErr) = SweepExclusion.Resolve(exclude, ImplicitPluginNamesOrEmpty());
+        if (excludeErr is not null) return ErrorCheckResult.Fail(excludeErr);
 
         if (plugins is { Count: > 0 })
         {
@@ -4605,9 +4612,21 @@ public sealed class LoadOrderService : IDisposable
                 offOrder.Add((n, loc.Path!));
             }
             return ErrorCheck.Run(resolver, viewAll, active, limit, offOrder.Count > 0 ? offOrder : null,
-                                  recordScope, classes, countsOnly);
+                                  recordScope, classes, countsOnly, excluded);
         }
-        return ErrorCheck.Run(resolver, viewAll, plugins, limit, null, recordScope, classes, countsOnly);
+        return ErrorCheck.Run(resolver, viewAll, plugins, limit, null, recordScope, classes, countsOnly, excluded);
+    }
+
+    /// <summary>The force-loaded plugin names (in the order, absent from plugins.txt) for
+    /// <see cref="SweepExclusion.ImplicitToken"/>, or empty when the composition cannot be read — a sweep must not
+    /// fail because an exclusion group could not be widened, and an exclusion that then matches nothing refuses in
+    /// the core with the name it could not find, which is the honest report either way.</summary>
+    IReadOnlyList<string> ImplicitPluginNamesOrEmpty()
+    {
+        string profileDir;
+        lock (_gate) { EnsurePathsDerived(); profileDir = _profileDir; }
+        try { return Mo2LoadOrder.ReadComposition(profileDir).ImplicitPluginNames; }
+        catch { return Array.Empty<string>(); }
     }
 
     /// <summary>Parse the two sweep tools' shared record-scope params (#282) into a <see cref="SweepScope"/>: FormID

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4580,9 +4580,13 @@ public sealed class LoadOrderService : IDisposable
         // loads that plugins.txt does not list — so it is read HERE, where that composition lives, and the core
         // sweep receives plain filenames. Resolved before anything is swept: a bad value refuses having done no
         // work (Q3).
-        var (implicitNames, implicitErr) = ImplicitPluginNames();
-        if (implicitErr is not null && exclude is { Count: > 0 })
-            return ErrorCheckResult.Fail(implicitErr);
+        // The composition read only defines the `implicit` GROUP, so only a caller who wrote that token is affected
+        // by its failure. Gated on "an exclusion was passed at all", exclude=["CoolMod.esp"] over an unreadable
+        // profile was refused with a message about a group the caller never named — and a refusal a caller cannot
+        // act on is the shape this gate exists to avoid, not one to spread.
+        bool wantsImplicit = exclude?.Any(v => (v ?? "").Trim().Equals(SweepExclusion.ImplicitToken, StringComparison.OrdinalIgnoreCase)) == true;
+        var (implicitNames, implicitErr) = wantsImplicit ? ImplicitPluginNames() : (Array.Empty<string>(), null);
+        if (implicitErr is not null) return ErrorCheckResult.Fail(implicitErr);
         var (excluded, excludeErr) = SweepExclusion.Resolve(exclude, implicitNames);
         if (excludeErr is not null) return ErrorCheckResult.Fail(excludeErr);
 

--- a/src/housecarl-mcp/ReadSentences.cs
+++ b/src/housecarl-mcp/ReadSentences.cs
@@ -305,7 +305,12 @@ internal static class ReadSentences
     /// were comfortably shorter: 1032 caps out of a 200–6000 sweep in the default text lane alone, and every cap
     /// from 800 up in the missing-masters lane, where the reserve is held for a line that lane never emitted. A
     /// sentence about a length is asked of the length.</para></summary>
-    [MustState("max_chars=", "raise it to at least")]
+    /// <summary>Pinned on the COMPLETED sentence as well as on the lead, because sharing the lead is a
+    /// construction and a construction can be undone: sabotaged to spell its own opener with a shortened list,
+    /// this sentence passed everything. The phrases are the enumeration's members, so a sentence that stops
+    /// carrying one fails by name whether it dropped the member or dropped the lead.</summary>
+    [MustState("max_chars=", "raise it to at least", "its header", "the accounting above",
+               "the closing line for anything it cut short", "the boundary")]
     internal const string SweepCapTooSmall =
         SweepFixedPartLead + "does not fit in that many chars, so raise it to at least {1}.";
 
@@ -321,7 +326,8 @@ internal static class ReadSentences
     ///
     /// <para>Both spellings end in the same remedy clause, because the remedy is the same and two spellings of it is
     /// how the cap sweep stops finding the number it follows.</para></summary>
-    [MustState("max_chars=", "raise it to at least")]
+    [MustState("max_chars=", "raise it to at least", "its header", "the accounting above",
+               "the closing line for anything it cut short", "the boundary")]
     internal const string SweepCapOvershot =
         SweepFixedPartLead + "does fit, but one body unit was written before its size could be measured and ran " +
         "past what was left, so raise it to at least {1}.";

--- a/src/housecarl-mcp/ReadSentences.cs
+++ b/src/housecarl-mcp/ReadSentences.cs
@@ -187,9 +187,16 @@ internal static class ReadSentences
     /// silence: "no accounting line" used to mean both "complete" and "the cut landed somewhere that never got to
     /// print one" (#361), and a reader could not tell those apart. Now the line is unconditional over the listing
     /// lane, so its absence means the lane did not run, never that the response is whole.</summary>
+    /// <summary>The accounting's own framing. It used to be baked into the two listing leads below, so a lane with
+    /// no listing emitted its clauses with no opener and then the closer on its own — the accounting's framing had
+    /// exactly the shape it exists to forbid. It is not about any subject, so it is stated outside every subject
+    /// gate.</summary>
+    [NoClaims("a label; the claims it introduces are the accounting's own clauses")]
+    internal const string SweepAccountingLead = "[accounting:";
+
     [MustState("appear above", "found by this sweep")]
     internal const string SweepAllVisible =
-        "[accounting: all {0} dangling ref(s) found by this sweep appear above.";
+        " all {0} dangling ref(s) found by this sweep appear above.";
 
     /// <summary>The lead, on a response that is missing findings. ONE number for the question a caller actually
     /// has - how many of these can I see - measured on the live order at plain defaults, where the two sentences
@@ -197,7 +204,7 @@ internal static class ReadSentences
     /// to work out that 554 of 4996 was the answer.</summary>
     [MustState("appear above", "found by this sweep")]
     internal const string SweepVisible =
-        "[accounting: {0} of the {1} dangling ref(s) found by this sweep appear above.";
+        " {0} of the {1} dangling ref(s) found by this sweep appear above.";
 
     /// <summary>The listing budget's share of what is missing. A cause clause is stated only when its own count is
     /// non-zero - a response cut by max_chars alone must not report the budget dropping 0, which reads as the
@@ -288,8 +295,9 @@ internal static class ReadSentences
     /// sentence about a length is asked of the length.</para></summary>
     [MustState("max_chars=", "raise it to at least")]
     internal const string SweepCapTooSmall =
-        " This response is {2} chars, longer than the max_chars={0} it was given: that budget cannot carry the " +
-        "accounting above, which is never dropped - raise it to at least {1}.";
+        " This response is {2} chars, longer than the max_chars={0} it was given: what it must carry whatever the " +
+        "budget - its header, the accounting above, the boundary - does not fit in that many chars, so raise it to " +
+        "at least {1}.";
 
     /// <summary>The sweep's honest scope boundary, stated to BOTH transports from here. It was two hand-copied
     /// twins — the text render's and the json writer's — and they had already drifted: the text one qualified the

--- a/src/housecarl-mcp/ReadSentences.cs
+++ b/src/housecarl-mcp/ReadSentences.cs
@@ -175,6 +175,123 @@ internal static class ReadSentences
         + (collection ? MergeCollectionFraming.Length + ClauseFieldsMaxChars + ClauseGlue : 0)
         + (singular ? SingleResolvedFraming.Length + ClauseFieldsMaxChars + ClauseGlue : 0);
 
+    // ---- the sweep response's omission accounting (#344 / #361) -------------------------------------
+    //
+    // These framings are the PROSE half of CheckAccounting; the arithmetic is there, in one place, and every
+    // number below arrives already computed from what the render EMITTED. They live in this class rather than
+    // beside that logic for the same reason ReadSentences exists at all: a sentence born as a render literal is
+    // a sentence that gets copied into the other transport and then drifts. Here they are inside the content net
+    // that walks this class's consts, so emptying one fails a guard instead of a review round.
+
+    /// <summary>The lead, on a response that carries every finding the sweep found. Stated rather than implied by
+    /// silence: "no accounting line" used to mean both "complete" and "the cut landed somewhere that never got to
+    /// print one" (#361), and a reader could not tell those apart. Now the line is unconditional over the listing
+    /// lane, so its absence means the lane did not run, never that the response is whole.</summary>
+    [MustState("appear above", "found by this sweep")]
+    internal const string SweepAllVisible =
+        "[accounting: all {0} dangling ref(s) found by this sweep appear above.";
+
+    /// <summary>The lead, on a response that is missing findings. ONE number for the question a caller actually
+    /// has - how many of these can I see - measured on the live order at plain defaults, where the two sentences
+    /// this replaces said "3996 not listed" and "554 of the 1000 budget-listed appear above" and left the reader
+    /// to work out that 554 of 4996 was the answer.</summary>
+    [MustState("appear above", "found by this sweep")]
+    internal const string SweepVisible =
+        "[accounting: {0} of the {1} dangling ref(s) found by this sweep appear above.";
+
+    /// <summary>The listing budget's share of what is missing. A cause clause is stated only when its own count is
+    /// non-zero - a response cut by max_chars alone must not report the budget dropping 0, which reads as the
+    /// budget being involved when it was not.</summary>
+    [MustState("limit=")]
+    internal const string SweepOmittedByBudget = " {0} were never listed: the listing budget (limit={1}) ran out";
+
+    /// <summary>The response cut's share. Its subject is THIS RESPONSE, and it names max_chars because that is the
+    /// knob that moves it - the layer rule kept as the accounting's internal discipline: one computation, but each
+    /// cause named by the layer that caused it.</summary>
+    [MustState("max_chars=")]
+    internal const string SweepOmittedByCut = " {0} did not fit this response (max_chars={1})";
+
+    /// <summary>How many plugin sections reached the response. Answers what the entry count cannot: a plugin whose
+    /// whole set is missing has no section to read the loss off, so the section count is what tells a reader the
+    /// listing is a window rather than the whole order.</summary>
+    [MustState("plugin section(s)")]
+    internal const string SweepSections = " {0} of {1} plugin section(s) were rendered.";
+
+    /// <summary>The excluded-plugin roster's own cut. Its rows are the plugins houseCARL could not parse at all,
+    /// so losing them silently hides the honesty layer rather than a finding.</summary>
+    [MustState("could not be parsed")]
+    internal const string SweepExcludedCut = " {0} of {1} plugin(s) that could not be parsed are named above.";
+
+    /// <summary>The counts_only lane's unread rows, same rule as the excluded roster.</summary>
+    [MustState("could not be read")]
+    internal const string SweepUnreadCut = " {0} of {1} plugin(s) whose records could not be read are named above.";
+
+    /// <summary>The by-source roster: WHICH plugins are missing entries, and how many each. Under the render-aware
+    /// accounting this is the RESPONSE's roster, not the budget's - a plugin whose entries the budget listed and
+    /// the cut then dropped belongs here, and under the two-layer split it appeared in neither sentence.</summary>
+    [NoClaims("a label introducing the roster rows; every claim it carries is in the rows and the clauses around it")]
+    internal const string SweepRosterLead = " Missing here, by source plugin: ";
+
+    /// <summary>The roster's own truncation. A roster that silently stops rebuilds the hole this accounting closes,
+    /// one level down (#344 round-1 review), so the count it did not name is stated rather than implied.</summary>
+    [MustState("not named here")]
+    internal const string SweepRosterCut = " (the {0} largest of {1}; the rest are not named here)";
+
+    /// <summary>A RULE about the listing, not a claim about this response's contents - so it is unconditional
+    /// (#339: prefer deleting the conditional to moving its test). It is what lets a reader trust the roster: a
+    /// plugin can be absent from the sections entirely and still be findable there.</summary>
+    [MustState("no section of its own")]
+    internal const string SweepNoSectionRule =
+        " A plugin whose whole set is missing here, with nothing else to report, gets no section of its own.";
+
+    /// <summary>The remedy. Each knob is named beside the cause it moves, because a caller cut by max_chars who
+    /// raises limit= gets the identical response back. The scoping clause carries its own bound: on the live order
+    /// the largest single source runs to 2591 refs against a default limit of 1000, so an unqualified "scope to it"
+    /// would loop the caller back to this same line (#344 round-1 review, measured).</summary>
+    [MustState("limit=", "max_chars=", "counts_only=true")]
+    internal const string SweepRemedy =
+        " Raise limit= to list more, max_chars= to fit more; scoping plugins= to one of these re-spends the whole " +
+        "budget on that plugin, which lists its set in full unless that set is itself larger than limit=. " +
+        "counts_only=true returns the by-source tally for every plugin, capped only in how many ROWS it prints.]";
+
+    /// <summary>The closer on a complete response - no remedy, because there is nothing to remedy.</summary>
+    [NoClaims("the bracket closing a line whose every claim is stated before it")]
+    internal const string SweepComplete = "]";
+
+    /// <summary>The one arm where the response is allowed to exceed max_chars, and it says so. A cap smaller than
+    /// the accounting itself leaves no honest response: dropping the accounting restores exactly the silence #361
+    /// IS, and refusing turns a call that answers today into one that does not. So the accounting ships, the
+    /// overrun is NAMED with the number that fixes it, and the invariant a probe can pin becomes "never over
+    /// max_chars, or over it and saying so" rather than a promise with an undocumented hole.</summary>
+    [MustState("max_chars=", "raise it to at least")]
+    internal const string SweepCapTooSmall =
+        " This response is longer than the max_chars={0} it was given: that budget is smaller than the accounting " +
+        "above, which is never dropped, so nothing was listed - raise it to at least {1}.";
+
+    /// <summary>The sweep's honest scope boundary, stated to BOTH transports from here. It was two hand-copied
+    /// twins — the text render's and the json writer's — and they had already drifted: the text one qualified the
+    /// ownership word with "(a rank/global Mutagen can't type on an override)" and the json one did not. The fuller
+    /// reading is the one kept, per the response-layer plan's rule that a twin disagreement resolves to one reading
+    /// and the choice is named in the PR body.
+    ///
+    /// <para>The label is separate because only one transport wants it: text prints "boundary: " ahead of the claim,
+    /// json carries the same claim as the value of a key already called <c>boundary</c>, and repeating the word
+    /// inside the value is how a twin starts.</para></summary>
+    [MustState("Does NOT verify navmesh/terrain", "required-but-null", "unused-master cleanup", "legal optional")]
+    internal const string SweepBoundary =
+        "checks FormLink resolution, missing masters, and parse failures. Does NOT verify navmesh/terrain spatial " +
+        "integrity (CRC/grid), flag required-but-null fields, list unused-master cleanup, or link-check an owned " +
+        "item's ownership 'variable' word (a rank/global Mutagen can't type on an override); a null FormLink is a " +
+        "legal optional.";
+
+    /// <summary>The text transport's label for the claim above.</summary>
+    [NoClaims("a label; the claim it introduces is SweepBoundary")]
+    internal const string SweepBoundaryLabel = "boundary: ";
+
+    /// <summary>How many source plugins the roster names before it says how many it did not. Ten is enough to act
+    /// on; the count of the rest is what keeps the roster from becoming its own silent cut.</summary>
+    internal const int SweepRosterRows = 10;
+
     /// <summary>How many declaring plugins a COLLECTION field names before it summarises the rest. Three names is
     /// enough to go look at; the rest are a count, because this rides EVERY annotated field of every row.</summary>
     internal const int DeclarerNameCap = 3;

--- a/src/housecarl-mcp/ReadSentences.cs
+++ b/src/housecarl-mcp/ReadSentences.cs
@@ -299,6 +299,24 @@ internal static class ReadSentences
         "budget - its header, the accounting above, the boundary - does not fit in that many chars, so raise it to " +
         "at least {1}.";
 
+    /// <summary>The OTHER way a response ends up over its cap, and the reason there are two sentences rather than one
+    /// with a cause that is only sometimes true. A body unit whose size cannot be known before it is written — a json
+    /// entry, whose cost the emitter deliberately leaves at zero — can land past what the budget had left. The fixed
+    /// part FITS in that case: the notice above would tell the caller their header and accounting do not fit in a cap
+    /// that holds them with room to spare, and send them chasing a cap that is not the problem.
+    ///
+    /// <para>Which sentence applies is not new state: the overrun arm is already handed what the fixed part needs, so
+    /// <c>needed &gt; max_chars</c> IS the discriminator. Measured on a json entry carrying a 4,000-character EditorID:
+    /// 7,008 chars against a 4,000 cap, over a fixture whose irreducible response is 2,618.</para>
+    ///
+    /// <para>Both spellings end in the same remedy clause, because the remedy is the same and two spellings of it is
+    /// how the cap sweep stops finding the number it follows.</para></summary>
+    [MustState("max_chars=", "raise it to at least")]
+    internal const string SweepCapOvershot =
+        " This response is {2} chars, longer than the max_chars={0} it was given: what it must carry whatever the " +
+        "budget - its header, the accounting above, the boundary - does fit, but one body unit was written before " +
+        "its size could be measured and ran past what was left, so raise it to at least {1}.";
+
     /// <summary>The sweep's honest scope boundary, stated to BOTH transports from here. It was two hand-copied
     /// twins — the text render's and the json writer's — and they had already drifted: the text one qualified the
     /// ownership word with "(a rank/global Mutagen can't type on an override)" and the json one did not. The fuller

--- a/src/housecarl-mcp/ReadSentences.cs
+++ b/src/housecarl-mcp/ReadSentences.cs
@@ -237,36 +237,59 @@ internal static class ReadSentences
     [MustState("not named here")]
     internal const string SweepRosterCut = " (the {0} largest of {1}; the rest are not named here)";
 
-    /// <summary>A RULE about the listing, not a claim about this response's contents - so it is unconditional
-    /// (#339: prefer deleting the conditional to moving its test). It is what lets a reader trust the roster: a
-    /// plugin can be absent from the sections entirely and still be findable there.</summary>
+    /// <summary>A RULE about the listing rather than a claim about this response's contents. It is stated wherever
+    /// a roster is, which is the only place it means anything — it exists to tell a reader that the roster above is
+    /// where a plugin with no section of its own can still be found.</summary>
     [MustState("no section of its own")]
     internal const string SweepNoSectionRule =
         " A plugin whose whole set is missing here, with nothing else to report, gets no section of its own.";
 
-    /// <summary>The remedy. Each knob is named beside the cause it moves, because a caller cut by max_chars who
-    /// raises limit= gets the identical response back. The scoping clause carries its own bound: on the live order
-    /// the largest single source runs to 2591 refs against a default limit of 1000, so an unqualified "scope to it"
-    /// would loop the caller back to this same line (#344 round-1 review, measured).</summary>
-    [MustState("limit=", "max_chars=", "counts_only=true")]
-    internal const string SweepRemedy =
-        " Raise limit= to list more, max_chars= to fit more; scoping plugins= to one of these re-spends the whole " +
-        "budget on that plugin, which lists its set in full unless that set is itself larger than limit=. " +
-        "counts_only=true returns the by-source tally for every plugin, capped only in how many ROWS it prints.]";
+    // THE REMEDY IS ASSEMBLED FROM THE CAUSES THAT ACTUALLY FIRED. One fixed sentence naming every knob was
+    // measured wrong twice over: it opened with "Raise limit= to list more" on responses where the budget had
+    // dropped nothing, and it promised scoping "lists its set in full unless that set is itself larger than limit="
+    // on responses whose cause was max_chars — driven on a real scope, that promise returned 16 of 40. A knob named
+    // beside a cause it did not move is a remedy the caller can follow and land in the same place.
 
-    /// <summary>The closer on a complete response - no remedy, because there is nothing to remedy.</summary>
-    [NoClaims("the bracket closing a line whose every claim is stated before it")]
-    internal const string SweepComplete = "]";
+    /// <summary>Offered only where the listing budget actually dropped something.</summary>
+    [MustState("limit=")]
+    internal const string SweepRemedyLimit = " Raise limit= to list more.";
+
+    /// <summary>Offered only where THIS RESPONSE could not fit what the budget admitted.</summary>
+    [MustState("max_chars=")]
+    internal const string SweepRemedyMaxChars = " Raise max_chars= to fit more of what was found.";
+
+    /// <summary>The scoping clause, and it names BOTH bounds rather than one. Re-spending the budget on one plugin
+    /// says nothing about whether the response can carry the result: on the live order the largest single source
+    /// runs to 2591 refs against a default limit of 1000, and a scoped sweep of it still met max_chars.</summary>
+    [MustState("plugins=", "limit=", "max_chars=")]
+    internal const string SweepRemedyScope =
+        " Scoping plugins= to one of these re-spends the whole listing budget on that plugin; whether you then see " +
+        "its set in full depends on limit= and on max_chars=, which both still apply.";
+
+    /// <summary>Offered wherever a by-source roster exists, since that is the tally it points at.</summary>
+    [MustState("counts_only=true")]
+    internal const string SweepRemedyCountsOnly =
+        " counts_only=true returns the by-source tally for every plugin, capped only in how many ROWS it prints.";
+
+    /// <summary>The bracket that closes the line, remedies or not.</summary>
+    [NoClaims("punctuation closing the accounting line")]
+    internal const string SweepClose = "]";
 
     /// <summary>The one arm where the response is allowed to exceed max_chars, and it says so. A cap smaller than
     /// the accounting itself leaves no honest response: dropping the accounting restores exactly the silence #361
-    /// IS, and refusing turns a call that answers today into one that does not. So the accounting ships, the
-    /// overrun is NAMED with the number that fixes it, and the invariant a probe can pin becomes "never over
-    /// max_chars, or over it and saying so" rather than a promise with an undocumented hole.</summary>
+    /// IS, and refusing turns a call that answers today into one that does not. So the accounting ships and the
+    /// overrun is NAMED with the number that clears it.
+    ///
+    /// <para><b>It is MEASURED, never predicted.</b> The first cut of this fired on
+    /// <c>headerLength + reserve &gt; max_chars</c> — a statement about the worst case the reserve is sized for, not
+    /// about this response. It printed "this response is longer than the max_chars you gave it" over responses that
+    /// were comfortably shorter: 1032 caps out of a 200–6000 sweep in the default text lane alone, and every cap
+    /// from 800 up in the missing-masters lane, where the reserve is held for a line that lane never emitted. A
+    /// sentence about a length is asked of the length.</para></summary>
     [MustState("max_chars=", "raise it to at least")]
     internal const string SweepCapTooSmall =
-        " This response is longer than the max_chars={0} it was given: that budget is smaller than the accounting " +
-        "above, which is never dropped, so nothing was listed - raise it to at least {1}.";
+        " This response is {2} chars, longer than the max_chars={0} it was given: that budget cannot carry the " +
+        "accounting above, which is never dropped - raise it to at least {1}.";
 
     /// <summary>The sweep's honest scope boundary, stated to BOTH transports from here. It was two hand-copied
     /// twins — the text render's and the json writer's — and they had already drifted: the text one qualified the

--- a/src/housecarl-mcp/ReadSentences.cs
+++ b/src/housecarl-mcp/ReadSentences.cs
@@ -183,10 +183,6 @@ internal static class ReadSentences
     // a sentence that gets copied into the other transport and then drifts. Here they are inside the content net
     // that walks this class's consts, so emptying one fails a guard instead of a review round.
 
-    /// <summary>The lead, on a response that carries every finding the sweep found. Stated rather than implied by
-    /// silence: "no accounting line" used to mean both "complete" and "the cut landed somewhere that never got to
-    /// print one" (#361), and a reader could not tell those apart. Now the line is unconditional over the listing
-    /// lane, so its absence means the lane did not run, never that the response is whole.</summary>
     /// <summary>The accounting's own framing. It used to be baked into the two listing leads below, so a lane with
     /// no listing emitted its clauses with no opener and then the closer on its own — the accounting's framing had
     /// exactly the shape it exists to forbid. It is not about any subject, so it is stated outside every subject
@@ -282,6 +278,22 @@ internal static class ReadSentences
     [NoClaims("punctuation closing the accounting line")]
     internal const string SweepClose = "]";
 
+    /// <summary>The lead both overrun sentences share, and the ENUMERATION of what a response carries whatever the
+    /// budget says. One constant because the two sentences differ only in what happened next — spelled twice, the
+    /// list drifted: it said "its header, the accounting above, the boundary" for a whole branch after this lane
+    /// gained a third member, each cut axis's own closing disclosure, reserved out of <c>max_chars</c> before the
+    /// body renders. On a two-200-row-axis counts_only overrun those disclosures are ~289 chars of what did not
+    /// fit, and the sentence explaining the overrun named everything except them — leaving a reader to blame a
+    /// short header and a boundary they can measure.
+    ///
+    /// <para>The third member is stated CONDITIONALLY ("for anything it cut short") because the listing lane has
+    /// no histogram axes and owes no closing line — an unconditional member would be a list naming something that
+    /// lane does not carry, which is the same class of wrong the addition fixes.</para></summary>
+    [MustState("its header", "the accounting above", "cut short", "the boundary")]
+    internal const string SweepFixedPartLead =
+        " This response is {2} chars, longer than the max_chars={0} it was given: what it must carry whatever the " +
+        "budget — its header, the accounting above, the closing line for anything it cut short, the boundary — ";
+
     /// <summary>The one arm where the response is allowed to exceed max_chars, and it says so. A cap smaller than
     /// the accounting itself leaves no honest response: dropping the accounting restores exactly the silence #361
     /// IS, and refusing turns a call that answers today into one that does not. So the accounting ships and the
@@ -295,9 +307,7 @@ internal static class ReadSentences
     /// sentence about a length is asked of the length.</para></summary>
     [MustState("max_chars=", "raise it to at least")]
     internal const string SweepCapTooSmall =
-        " This response is {2} chars, longer than the max_chars={0} it was given: what it must carry whatever the " +
-        "budget - its header, the accounting above, the boundary - does not fit in that many chars, so raise it to " +
-        "at least {1}.";
+        SweepFixedPartLead + "does not fit in that many chars, so raise it to at least {1}.";
 
     /// <summary>The OTHER way a response ends up over its cap, and the reason there are two sentences rather than one
     /// with a cause that is only sometimes true. A body unit whose size cannot be known before it is written — a json
@@ -313,9 +323,8 @@ internal static class ReadSentences
     /// how the cap sweep stops finding the number it follows.</para></summary>
     [MustState("max_chars=", "raise it to at least")]
     internal const string SweepCapOvershot =
-        " This response is {2} chars, longer than the max_chars={0} it was given: what it must carry whatever the " +
-        "budget - its header, the accounting above, the boundary - does fit, but one body unit was written before " +
-        "its size could be measured and ran past what was left, so raise it to at least {1}.";
+        SweepFixedPartLead + "does fit, but one body unit was written before its size could be measured and ran " +
+        "past what was left, so raise it to at least {1}.";
 
     /// <summary>The sweep's honest scope boundary, stated to BOTH transports from here. It was two hand-copied
     /// twins — the text render's and the json writer's — and they had already drifted: the text one qualified the

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -488,6 +488,8 @@ public static class ReadTools
          "the COUNTS too — they are always the counts for the scope actually swept, and the response says so. BASELINE: the " +
          "base-game masters carry permanent vanilla dangling refs no load order can fix, so the response splits them out of the " +
          "total and spends limit= on every other plugin FIRST — vanilla can no longer crowd mod findings out of the listing. " +
+         "exclude= drops named plugins or whole groups (base_masters / implicit) out of the sweep when you want them gone " +
+         "entirely rather than merely accounted for. " +
          "Results cap at limit= and max_chars (both overruns explicit); a capped listing NAMES which source plugins lost entries.")]
     public static string CheckErrorsTool(
         LoadOrderService svc,
@@ -499,6 +501,14 @@ public static class ReadTools
             string[]? formids = null,
         [Description("Optional. Sweep only records whose EditorID contains this substring (case-insensitive). A record with no EditorID never matches.")]
             string? editorid_contains = null,
+        [Description("Optional. Plugins to leave OUT of the sweep entirely — they cost no record walk and no limit= " +
+             "budget. Each value is either a plugin filename WITH its extension ('CoolMod.esp') or one of two group " +
+             "names: base_masters (the five the game ships with) or implicit (every plugin the order force-loads " +
+             "because plugins.txt does not list it — this is where Creation Club plugins and _ResourcePack.esl are, " +
+             "and it INCLUDES the base masters). A value that is neither, or a name nothing in scope matches, is " +
+             "refused before the sweep runs rather than quietly excluding nothing. This does not change what counts " +
+             "as the vanilla BASELINE the response splits out — that is always Mutagen's own base-master set.")]
+            string[]? exclude = null,
         [Description("Optional. Which error classes to look for: 'dangling' and/or 'missing_masters' (default both). Excluding 'dangling' SKIPS the per-record link walk entirely — that is how you ask 'is any master missing anywhere in my order' without paying for a full sweep. An excluded class renders as 'not checked', never as 0. Unscannable records and scan errors are ALWAYS reported and cannot be filtered out (a suppressed 'could not read' would read as clean).")]
             string[]? findings = null,
         [Description("Optional. true = return ONLY the header totals plus two histograms, with no per-plugin listing: dangling-by-TARGET-plugin (which plugin the broken refs point INTO — the one absent dependency behind a wall of findings) and dangling-by-SOURCE-plugin (which plugin they come FROM — how much of the total is vanilla baseline and how much your mods introduced). The cheap before/after-a-fix comparison; totals stay exact (never limit-capped) and limit= caps the histogram ROWS instead.")]
@@ -514,7 +524,7 @@ public static class ReadTools
         bool json = Wire.WantsJson(format, out var fmtErr);
         if (fmtErr is not null) return fmtErr;
         int lim = limit <= 0 ? 1000 : limit;
-        var result = svc.CheckErrors(plugins, lim, formids, editorid_contains, type, findings, counts_only);
+        var result = svc.CheckErrors(plugins, lim, formids, editorid_contains, type, findings, counts_only, exclude);
         return json ? JsonWire.RenderCheckErrors(result, max_chars, lim)
                     : Wire.RenderCheckErrors(result, max_chars, lim);
     });

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -1176,12 +1176,10 @@ static class Wire
             sb.Append("swept OFF-ORDER (on disk, not in the active load order): ").Append(string.Join(", ", off))
               .Append("   [the file's own records; links resolved against the active order + the file's own definitions]\n");
         AppendBaselineSplit(sb, r, acct);   // #344 — how much of the dangling total is vanilla baseline
-        // Where the BODY begins. The overrun arm is a question about the fixed part of the response, so it is asked
-        // here rather than at the end, where the answer would be the body's own length.
-        int headerLength = sb.Length;
-        // EVERYTHING BELOW THIS LINE GOES THROUGH `body`. The header above is the response's fixed part and the
-        // accounting plus boundary are reserved out of max_chars before it renders — those two are the only things
-        // a response may never drop, which is why they are not emitted through a helper that can refuse.
+        // EVERYTHING A CAP CAN REFUSE GOES THROUGH `body`. What the header above, the axes' own lines, the reserved
+        // closing disclosures, the accounting and the boundary come to is therefore whatever the finished response
+        // is MINUS what `body` let through — which is how the overrun notice is told the fixed part's size
+        // (BoundedBody.FixedPart), rather than by a header length captured here and summed with a reserve.
         var body = new BoundedBody(acct, budget, () => sb.Length);
 
         if (r.CountsOnly)
@@ -1198,7 +1196,7 @@ static class Wire
                                   "dangling ref(s) by SOURCE plugin (the plugin the broken refs come FROM)"));
             AppendScanErrorTail(sb, body, r.Reports);
             AppendExcludedPlugins(sb, body, r.ExcludedPlugins);   // #288 review finding 5: the NAMES, not just the header count
-            return Close(sb, acct, reserve + body.ReservedTotal, headerLength);
+            return Close(sb, acct, body);
         }
 
         if (r.Reports.Count == 0 && r.ExcludedPlugins.Count == 0)
@@ -1242,7 +1240,7 @@ static class Wire
         }
 
         AppendExcludedPlugins(sb, body, r.ExcludedPlugins);
-        return Close(sb, acct, reserve + body.ReservedTotal, headerLength);
+        return Close(sb, acct, body);
     }
 
     /// <summary>Close the response: the accounting for what it emitted, then the boundary. Both live inside the
@@ -1250,11 +1248,11 @@ static class Wire
     /// overrun. The single exception — a <c>max_chars</c> smaller than the accounting itself — is stated in-band
     /// rather than taken silently (#361: appending past the cap without saying so is half of what that issue is).
     /// </summary>
-    /// <param name="reserved">everything held out of <c>max_chars</c> before the body rendered: the accounting, the
-    /// boundary, and every subject's closing disclosure. With the header it IS the response's fixed part, which is
-    /// the quantity the overrun notice branches on — a disclosure reserved but left out of this number would get a
-    /// cap too small for the fixed part explained as a body unit overshooting.</param>
-    static string Close(StringBuilder sb, CheckAccounting acct, int reserved, int headerLength)
+    /// <param name="body">the bounded body, for what the BODY wrote
+    /// (<see cref="BoundedBody.FixedPart"/> subtracts it). The rest of the finished response is its fixed part —
+    /// the quantity the overrun notice branches on. Given a fixed part that leaves out an unconditional line, a cap
+    /// too small for that line gets explained as a body unit overshooting.</param>
+    static string Close(StringBuilder sb, CheckAccounting acct, BoundedBody body)
     {
         if (acct.TextLine() is { } line) sb.Append('\n').Append(line).Append('\n');
         sb.Append('\n').Append(ReadSentences.SweepBoundaryLabel).Append(ReadSentences.SweepBoundary).Append('\n');
@@ -1263,10 +1261,11 @@ static class Wire
         // own length: 1,109 stated on a response of 1,281. Composing it changes only the width of one printed
         // number, so a second pass settles it and a third is only ever needed when that width moved.
         var response = sb.ToString().TrimEnd('\n');
-        if (acct.CapTooSmall(response.Length, headerLength + reserved) is not { } notice) return response;
-        var settled = acct.CapTooSmall(response.Length + notice.Length, headerLength + reserved)!;
+        int needed = body.FixedPart(response.Length);
+        if (acct.CapTooSmall(response.Length, needed) is not { } notice) return response;
+        var settled = acct.CapTooSmall(response.Length + notice.Length, needed, notice.Length)!;
         if (settled.Length != notice.Length)
-            settled = acct.CapTooSmall(response.Length + settled.Length, headerLength + reserved)!;
+            settled = acct.CapTooSmall(response.Length + settled.Length, needed, settled.Length)!;
         return response + settled;
     }
 
@@ -1324,13 +1323,13 @@ static class Wire
     /// exists so the two sweep headers stay textually identical (one shape, no drift).</summary>
     static string EpochOffOrderQualifier(ScriptCheckResult r) => "";
 
-    /// <summary>Reserve EVERY axis's closing disclosure, then render them all. The two passes are the point: an axis
-    /// that reserved its own room only when its turn came would find a sibling had already spent the budget, which
-    /// is the silence the reserve exists to remove. Reserving is therefore not something each axis does for itself.
-    /// </summary>
+    /// <summary>Reserve EVERY axis's FIXED PART — its unconditional lines and its closing disclosure — then render
+    /// them all. The two passes are the point: an axis that reserved its own room only when its turn came would
+    /// find a sibling had already spent the budget, which is the silence the reserve exists to remove. Reserving is
+    /// therefore not something each axis does for itself.</summary>
     static void AppendHistograms(StringBuilder sb, BoundedBody body, int rowLimit, params HistogramAxis[] axes)
     {
-        foreach (var a in axes) body.Reserve(a.Subject, a.TextDisclosure);
+        foreach (var a in axes) body.Reserve(a.Subject, a.TextFixed);
         foreach (var a in axes) AppendHistogram(sb, body, rowLimit, a);
     }
 
@@ -1346,11 +1345,13 @@ static class Wire
     {
         // The note and the not-computed line are fixed text that does not grow with the findings, and the second is
         // this axis's whole answer — a "the walk was not run" that a budget could drop would be the silence the
-        // sentence exists to break. They are part of the response's fixed part, deliberately.
-        if (axis.Note is not null) sb.Append('\n').Append(axis.Note).Append('\n');
+        // sentence exists to break. They are part of the response's fixed part, deliberately — and they go through
+        // `body` so that fixed part is MEASURED. Appended straight to the builder they were invisible to the
+        // overrun notice, which then explained a cap too small for them as a body unit overshooting (#391 review).
+        if (axis.NoteLine.Length > 0) body.Fixed(axis.Subject, () => sb.Append(axis.NoteLine));
         if (axis.Rows is not { } rows)
         {
-            if (axis.NotComputed is not null) sb.Append(axis.NotComputed).Append('\n');
+            if (axis.NotComputedLine.Length > 0) body.Fixed(axis.Subject, () => sb.Append(axis.NotComputedLine));
             body.Release(axis.Subject);
             return;
         }

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -1183,13 +1183,15 @@ static class Wire
         {
             AppendHistogram(sb, r.Histogram, histogramLimit, "dangling ref(s) by TARGET plugin (the plugin the broken refs point INTO)",
                             "counts_only=true — totals above are exact; no per-plugin listing was built.",
-                            notComputed: "no dangling histogram, by target or by source — the link walk was not run (findings= excluded 'dangling').");
+                            notComputed: "no dangling histogram, by target or by source — the link walk was not run (findings= excluded 'dangling').",
+                            budget: budget);
             // #344 — the SOURCE axis: which plugin the broken refs come FROM. The target axis names the absent
             // dependency behind a wall of findings; only this one answers "how much of this is vanilla, and how much
             // did the mods introduce". No note and no not-computed line of its own — both would repeat what the
             // target histogram directly above has just said.
             AppendHistogram(sb, r.DanglingBySource, histogramLimit,
-                            "dangling ref(s) by SOURCE plugin (the plugin the broken refs come FROM)", note: null);
+                            "dangling ref(s) by SOURCE plugin (the plugin the broken refs come FROM)", note: null,
+                            budget: budget);
             acct.UnreadRows(AppendScanErrorTail(sb, r.Reports, budget));
             acct.ExcludedRows(AppendExcludedPlugins(sb, r.ExcludedPlugins, budget).Appended);   // #288 review finding 5: the NAMES, not just the header count
             return Close(sb, acct, reserve, headerLength);
@@ -1249,8 +1251,9 @@ static class Wire
     {
         if (acct.TextLine() is { } line) sb.Append('\n').Append(line).Append('\n');
         sb.Append('\n').Append(ReadSentences.SweepBoundaryLabel).Append(ReadSentences.SweepBoundary).Append('\n');
-        if (acct.CapTooSmall(headerLength, reserve) is { } notice) sb.Append(notice).Append('\n');
-        return sb.ToString().TrimEnd('\n');
+        // The overrun question is asked of the FINISHED response, so the string is built first and measured.
+        var response = sb.ToString().TrimEnd('\n');
+        return acct.CapTooSmall(response.Length, headerLength + reserve) is { } notice ? response + notice : response;
     }
 
     /// <summary>#344 — the baseline split: how much of the dangling total came from the base-game masters, and how
@@ -1310,8 +1313,12 @@ static class Wire
     /// <summary>Render a <c>counts_only=</c> histogram, capped at <paramref name="rowLimit"/> with the true distinct-key
     /// count always stated. A null histogram means the mode was not requested; an EMPTY one means the sweep genuinely
     /// found nothing, and the two read differently (Q3).</summary>
+    /// <param name="budget">the chars this render may occupy. Defaults to unbounded, which is what validate_scripts
+    /// still passes — its response layer is not this branch's. check_errors passes the real budget: measured on a
+    /// 400-row-per-axis sweep, an unbounded counts_only response returned 27,944 chars against a max_chars of 5,000,
+    /// which is the one lane the cap invariant did not reach.</param>
     static void AppendHistogram(StringBuilder sb, IReadOnlyList<SweepCount>? rows, int rowLimit, string title, string? note,
-                                string? notComputed = null)
+                                string? notComputed = null, int budget = int.MaxValue)
     {
         if (note is not null) sb.Append('\n').Append(note).Append('\n');
         if (rows is null) { if (notComputed is not null) sb.Append(notComputed).Append('\n'); return; }
@@ -1320,14 +1327,20 @@ static class Wire
         if (rows.Count == 0) { sb.Append("\n").Append(title).Append(": nothing to tally — no findings in the swept scope.\n"); return; }
         sb.Append('\n').Append(title).Append(" (").Append(rows.Count).Append(" distinct):\n");
         int shown = 0;
+        bool cutByBudget = false;
         foreach (var row in rows)
         {
             if (shown >= rowLimit) break;
-            sb.Append("  ").Append(row.Count.ToString().PadLeft(6)).Append("  ").Append(row.Key).Append('\n');
+            var line = "  " + row.Count.ToString().PadLeft(6) + "  " + row.Key + "\n";
+            if (sb.Length + line.Length > budget) { cutByBudget = true; break; }
+            sb.Append(line);
             shown++;
         }
+        // The remedy names the knob that STOPPED it. "raise limit=" on rows the response had no room for is a knob
+        // that moves nothing — the same defect the accounting's own remedy was measured for.
         if (shown < rows.Count)
-            sb.Append("  ... [").Append(rows.Count - shown).Append(" more row(s) — raise limit= to see them]\n");
+            sb.Append("  ... [").Append(rows.Count - shown).Append(" more row(s) — raise ")
+              .Append(cutByBudget ? "max_chars=" : "limit=").Append(" to see them]\n");
     }
 
     /// <summary>The named, reasoned list of plugins the index build could not parse. Shared by the listing and

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -1186,14 +1186,15 @@ static class Wire
 
         if (r.CountsOnly)
         {
-            AppendHistogram(sb, body, r.Histogram, histogramLimit, "dangling ref(s) by TARGET plugin (the plugin the broken refs point INTO)",
+            AppendHistogram(sb, body, SweepSubject.HistogramByTarget, r.Histogram, histogramLimit,
+                            "dangling ref(s) by TARGET plugin (the plugin the broken refs point INTO)",
                             "counts_only=true — totals above are exact; no per-plugin listing was built.",
                             notComputed: "no dangling histogram, by target or by source — the link walk was not run (findings= excluded 'dangling').");
             // #344 — the SOURCE axis: which plugin the broken refs come FROM. The target axis names the absent
             // dependency behind a wall of findings; only this one answers "how much of this is vanilla, and how much
             // did the mods introduce". No note and no not-computed line of its own — both would repeat what the
             // target histogram directly above has just said.
-            AppendHistogram(sb, body, r.DanglingBySource, histogramLimit,
+            AppendHistogram(sb, body, SweepSubject.HistogramBySource, r.DanglingBySource, histogramLimit,
                             "dangling ref(s) by SOURCE plugin (the plugin the broken refs come FROM)", note: null);
             AppendScanErrorTail(sb, body, r.Reports);
             AppendExcludedPlugins(sb, body, r.ExcludedPlugins);   // #288 review finding 5: the NAMES, not just the header count
@@ -1326,7 +1327,11 @@ static class Wire
     /// the empty-case sentence and the "more rows" line used to bypass the budget entirely (~650 chars past a tight
     /// cap), and a title with no rows under it is a section head with no section — the whole-or-absent rule this
     /// render follows everywhere else. So the title rides the FIRST ROW as one unit.</param>
-    static void AppendHistogram(StringBuilder sb, BoundedBody body, IReadOnlyList<SweepCount>? rows, int rowLimit,
+    /// <param name="subject">this axis's OWN emission subject, never one shared with a sibling axis. A subject is
+    /// what <see cref="BoundedBody"/> stops, and the close below stops it: shared, the first axis to close refused
+    /// every row of the next one (see <see cref="SweepSubject.HistogramBySource"/>).</param>
+    static void AppendHistogram(StringBuilder sb, BoundedBody body, SweepSubject subject,
+                                IReadOnlyList<SweepCount>? rows, int rowLimit,
                                 string title, string? note, string? notComputed = null)
     {
         // The note and the not-computed line are fixed text that does not grow with the findings, and the second is
@@ -1339,43 +1344,40 @@ static class Wire
         if (rows.Count == 0)
         {
             var empty = "\n" + title + ": nothing to tally — no findings in the swept scope.\n";
-            body.Emit(SweepSubject.HistogramRows, empty.Length, () => sb.Append(empty));
+            body.Emit(subject, empty.Length, () => sb.Append(empty));
             return;
         }
         // The "more rows" line is HELD BACK rather than emitted on hope: rows shown without the count of the rows
-        // that were not is the silent cut one level down. Its widest spelling is bounded by the row count's digits.
+        // that were not is the silent cut one level down. Its widest spelling is bounded by the row count's digits,
+        // and by the longer of the two knob names — which is max_chars.
         var head = "\n" + title + " (" + rows.Count + " distinct):\n";
         int shown = 0;
         bool cutByBudget = false;
-        var moreReserve = MoreRowsLine(rows.Count, byBudget: true).Length;
+        var moreReserve = new HistogramCut(rows.Count, ByBudget: true).Line.Length;
         foreach (var row in rows)
         {
             if (shown >= rowLimit) break;
             var line = "  " + row.Count.ToString().PadLeft(6) + "  " + row.Key + "\n";
             var unit = shown == 0 ? head + line : line;
-            if (!body.Emit(SweepSubject.HistogramRows, unit.Length + moreReserve, () => sb.Append(unit)))
+            if (!body.Emit(subject, unit.Length + moreReserve, () => sb.Append(unit)))
             { cutByBudget = true; break; }
             shown++;
         }
-        // The remedy names the knob that STOPPED it. "raise limit=" on rows the response had no room for is a knob
-        // that moves nothing — the same defect the accounting's own remedy was measured for.
+        // The closing disclosure, from ONE computation the json lane reads too. The remedy names the knob that
+        // STOPPED THIS AXIS: "raise limit=" on rows the response had no room for is a knob that moves nothing, and so
+        // is "raise max_chars=" on rows the row budget refused. An axis that rendered every row it had says nothing.
         //
         // An axis the budget admitted NO rows of still says so, head and count together as one unit: an axis that
         // exists and renders nothing at all is the same silent cut, one level down.
+        if (HistogramCut.For(rows.Count, shown, cutByBudget) is not { } cut) return;
         if (shown == 0)
         {
-            var only = head + MoreRowsLine(rows.Count, cutByBudget);
-            body.Close(SweepSubject.HistogramRows, only.Length, () => sb.Append(only));
+            var only = head + cut.Line;
+            body.Close(subject, only.Length, () => sb.Append(only));
         }
-        else if (shown < rows.Count)
-            body.Close(SweepSubject.HistogramRows, 0, () => sb.Append(MoreRowsLine(rows.Count - shown, cutByBudget)));
+        else
+            body.Close(subject, 0, () => sb.Append(cut.Line));
     }
-
-    /// <summary>The histogram's own disclosure of its cut, in one spelling — it is composed twice, once to measure
-    /// the room to hold back for it and once to write it, and two spellings of one sentence is how a reserve stops
-    /// covering what it reserves for.</summary>
-    static string MoreRowsLine(int remaining, bool byBudget)
-        => "  ... [" + remaining + " more row(s) — raise " + (byBudget ? "max_chars=" : "limit=") + " to see them]\n";
 
     /// <summary>The named, reasoned list of plugins the index build could not parse. Shared by the listing and
     /// <c>counts_only=</c> paths — counts_only used to return before it, leaving the header's bare count with no way to
@@ -1454,7 +1456,8 @@ static class Wire
             // validate_scripts' response layer is not this branch's, so it keeps no accounting — but it goes through
             // the same bounded emission path, because a second appending path is a second place to forget the bound.
             var scriptBody = new BoundedBody(null, cap, () => sb.Length);
-            AppendHistogram(sb, scriptBody, r.Histogram, histogramLimit, "unbound properties by NAME",
+            AppendHistogram(sb, scriptBody, SweepSubject.HistogramByProperty, r.Histogram, histogramLimit,
+                            "unbound properties by NAME",
                             "counts_only=true — totals above are exact; no per-record listing was built.",
                             notComputed: "no unbound histogram — findings= excluded both unbound classes, so nothing was tallied.");
             foreach (var rec in r.Reports)   // the honesty layer: plugins whose record enumeration faulted

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -1178,22 +1178,24 @@ static class Wire
         // Where the BODY begins. The overrun arm is a question about the fixed part of the response, so it is asked
         // here rather than at the end, where the answer would be the body's own length.
         int headerLength = sb.Length;
+        // EVERYTHING BELOW THIS LINE GOES THROUGH `body`. The header above is the response's fixed part and the
+        // accounting plus boundary are reserved out of max_chars before it renders — those two are the only things
+        // a response may never drop, which is why they are not emitted through a helper that can refuse.
+        var body = new BoundedBody(acct, budget, () => sb.Length);
 
         if (r.CountsOnly)
         {
-            AppendHistogram(sb, r.Histogram, histogramLimit, "dangling ref(s) by TARGET plugin (the plugin the broken refs point INTO)",
+            AppendHistogram(sb, body, r.Histogram, histogramLimit, "dangling ref(s) by TARGET plugin (the plugin the broken refs point INTO)",
                             "counts_only=true — totals above are exact; no per-plugin listing was built.",
-                            notComputed: "no dangling histogram, by target or by source — the link walk was not run (findings= excluded 'dangling').",
-                            budget: budget);
+                            notComputed: "no dangling histogram, by target or by source — the link walk was not run (findings= excluded 'dangling').");
             // #344 — the SOURCE axis: which plugin the broken refs come FROM. The target axis names the absent
             // dependency behind a wall of findings; only this one answers "how much of this is vanilla, and how much
             // did the mods introduce". No note and no not-computed line of its own — both would repeat what the
             // target histogram directly above has just said.
-            AppendHistogram(sb, r.DanglingBySource, histogramLimit,
-                            "dangling ref(s) by SOURCE plugin (the plugin the broken refs come FROM)", note: null,
-                            budget: budget);
-            acct.UnreadRows(AppendScanErrorTail(sb, r.Reports, budget));
-            acct.ExcludedRows(AppendExcludedPlugins(sb, r.ExcludedPlugins, budget).Appended);   // #288 review finding 5: the NAMES, not just the header count
+            AppendHistogram(sb, body, r.DanglingBySource, histogramLimit,
+                            "dangling ref(s) by SOURCE plugin (the plugin the broken refs come FROM)", note: null);
+            AppendScanErrorTail(sb, body, r.Reports);
+            AppendExcludedPlugins(sb, body, r.ExcludedPlugins);   // #288 review finding 5: the NAMES, not just the header count
             return Close(sb, acct, reserve, headerLength);
         }
 
@@ -1223,22 +1225,21 @@ static class Wire
             }
             if (p.Dangling.Count > 0)
                 fixedPart.Append("  dangling reference(s) (").Append(p.Dangling.Count).Append("):\n");
-            if (sb.Length + fixedPart.Length > budget) break;
-            sb.Append(fixedPart);
-            acct.Section();
+            var section = fixedPart.ToString();
+            if (!body.Emit(SweepSubject.PluginSections, section.Length, () => sb.Append(section))) break;
 
             foreach (var d in p.Dangling)
             {
                 var line = "    " + d.Source + " (" + d.SourceType
                          + (string.IsNullOrEmpty(d.SourceEditorId) ? "" : " '" + d.SourceEditorId + "'")
                          + ") -> " + d.Target + "   [target not defined by any active plugin]\n";
-                if (sb.Length + line.Length > budget) break;
-                sb.Append(line);
-                acct.Entry(p.Plugin);   // registered where the line LANDED — the accounting counts the response
+                // Registered where the line LANDS — the accounting counts the response, and the by-source roster is
+                // tallied off the same registration, so the count and the roster cannot disagree.
+                if (!body.Emit(SweepSubject.DanglingEntries, line.Length, () => sb.Append(line), p.Plugin)) break;
             }
         }
 
-        acct.ExcludedRows(AppendExcludedPlugins(sb, r.ExcludedPlugins, budget).Appended);
+        AppendExcludedPlugins(sb, body, r.ExcludedPlugins);
         return Close(sb, acct, reserve, headerLength);
     }
 
@@ -1313,62 +1314,83 @@ static class Wire
     /// <summary>Render a <c>counts_only=</c> histogram, capped at <paramref name="rowLimit"/> with the true distinct-key
     /// count always stated. A null histogram means the mode was not requested; an EMPTY one means the sweep genuinely
     /// found nothing, and the two read differently (Q3).</summary>
-    /// <param name="budget">the chars this render may occupy. Defaults to unbounded, which is what validate_scripts
-    /// still passes — its response layer is not this branch's. check_errors passes the real budget: measured on a
-    /// 400-row-per-axis sweep, an unbounded counts_only response returned 27,944 chars against a max_chars of 5,000,
-    /// which is the one lane the cap invariant did not reach.</param>
-    static void AppendHistogram(StringBuilder sb, IReadOnlyList<SweepCount>? rows, int rowLimit, string title, string? note,
-                                string? notComputed = null, int budget = int.MaxValue)
+    /// <param name="body">the ONE bounded emission path. Its framing goes through it as well as its rows: the title,
+    /// the empty-case sentence and the "more rows" line used to bypass the budget entirely (~650 chars past a tight
+    /// cap), and a title with no rows under it is a section head with no section — the whole-or-absent rule this
+    /// render follows everywhere else. So the title rides the FIRST ROW as one unit.</param>
+    static void AppendHistogram(StringBuilder sb, BoundedBody body, IReadOnlyList<SweepCount>? rows, int rowLimit,
+                                string title, string? note, string? notComputed = null)
     {
+        // The note and the not-computed line are fixed text that does not grow with the findings, and the second is
+        // this axis's whole answer — a "the walk was not run" that a budget could drop would be the silence the
+        // sentence exists to break. They are part of the response's fixed part, deliberately.
         if (note is not null) sb.Append('\n').Append(note).Append('\n');
         if (rows is null) { if (notComputed is not null) sb.Append(notComputed).Append('\n'); return; }
         // The title rides the empty case too: two axes that both came back empty rendered as two identical untitled
         // sentences, with no way to tell which was which — or that a second axis existed at all (round-1 review).
-        if (rows.Count == 0) { sb.Append("\n").Append(title).Append(": nothing to tally — no findings in the swept scope.\n"); return; }
-        sb.Append('\n').Append(title).Append(" (").Append(rows.Count).Append(" distinct):\n");
+        if (rows.Count == 0)
+        {
+            var empty = "\n" + title + ": nothing to tally — no findings in the swept scope.\n";
+            body.Emit(SweepSubject.HistogramRows, empty.Length, () => sb.Append(empty));
+            return;
+        }
+        // The "more rows" line is HELD BACK rather than emitted on hope: rows shown without the count of the rows
+        // that were not is the silent cut one level down. Its widest spelling is bounded by the row count's digits.
+        var head = "\n" + title + " (" + rows.Count + " distinct):\n";
         int shown = 0;
         bool cutByBudget = false;
+        var moreReserve = MoreRowsLine(rows.Count, byBudget: true).Length;
         foreach (var row in rows)
         {
             if (shown >= rowLimit) break;
             var line = "  " + row.Count.ToString().PadLeft(6) + "  " + row.Key + "\n";
-            if (sb.Length + line.Length > budget) { cutByBudget = true; break; }
-            sb.Append(line);
+            var unit = shown == 0 ? head + line : line;
+            if (!body.Emit(SweepSubject.HistogramRows, unit.Length + moreReserve, () => sb.Append(unit)))
+            { cutByBudget = true; break; }
             shown++;
         }
         // The remedy names the knob that STOPPED it. "raise limit=" on rows the response had no room for is a knob
         // that moves nothing — the same defect the accounting's own remedy was measured for.
-        if (shown < rows.Count)
-            sb.Append("  ... [").Append(rows.Count - shown).Append(" more row(s) — raise ")
-              .Append(cutByBudget ? "max_chars=" : "limit=").Append(" to see them]\n");
+        //
+        // An axis the budget admitted NO rows of still says so, head and count together as one unit: an axis that
+        // exists and renders nothing at all is the same silent cut, one level down.
+        if (shown == 0)
+        {
+            var only = head + MoreRowsLine(rows.Count, cutByBudget);
+            body.Close(SweepSubject.HistogramRows, only.Length, () => sb.Append(only));
+        }
+        else if (shown < rows.Count)
+            body.Close(SweepSubject.HistogramRows, 0, () => sb.Append(MoreRowsLine(rows.Count - shown, cutByBudget)));
     }
+
+    /// <summary>The histogram's own disclosure of its cut, in one spelling — it is composed twice, once to measure
+    /// the room to hold back for it and once to write it, and two spellings of one sentence is how a reserve stops
+    /// covering what it reserves for.</summary>
+    static string MoreRowsLine(int remaining, bool byBudget)
+        => "  ... [" + remaining + " more row(s) — raise " + (byBudget ? "max_chars=" : "limit=") + " to see them]\n";
 
     /// <summary>The named, reasoned list of plugins the index build could not parse. Shared by the listing and
     /// <c>counts_only=</c> paths — counts_only used to return before it, leaving the header's bare count with no way to
     /// learn WHICH plugin went unchecked without re-running (PR #288 review, finding 5).</summary>
-    static (int Appended, bool Stopped) AppendExcludedPlugins(StringBuilder sb, IReadOnlyDictionary<string, string> excluded,
-                                                             int budget)
+    static void AppendExcludedPlugins(StringBuilder sb, BoundedBody body, IReadOnlyDictionary<string, string> excluded)
     {
-        if (excluded.Count == 0) return (0, false);
-        var head = "\nexcluded plugins (could not be parsed — NOT checked):\n";
-        if (sb.Length + head.Length > budget) return (0, true);
-        sb.Append(head);
-        int n = 0;
+        if (excluded.Count == 0) return;
+        // The head rides the first ROW, so the list is whole or absent: a head with nothing under it says a roster
+        // exists and then names none of it.
+        const string head = "\nexcluded plugins (could not be parsed — NOT checked):\n";
+        bool first = true;
         foreach (var kv in excluded)
         {
-            var line = "  " + kv.Key + ": " + kv.Value + "\n";
-            if (sb.Length + line.Length > budget) return (n, true);
-            sb.Append(line);
-            n++;
+            var unit = (first ? head : "") + "  " + kv.Key + ": " + kv.Value + "\n";
+            if (!body.Emit(SweepSubject.ExcludedRows, unit.Length, () => sb.Append(unit))) return;
+            first = false;
         }
-        return (n, false);
     }
 
     /// <summary>Under <c>counts_only=</c> the reports list carries the honesty layer only (records/plugins houseCARL
     /// could not read). Emit it verbatim so a counts-only answer still names what it could not check (Q3).</summary>
-    static int AppendScanErrorTail(StringBuilder sb, IReadOnlyList<PluginErrors> reports, int budget)
+    static void AppendScanErrorTail(StringBuilder sb, BoundedBody body, IReadOnlyList<PluginErrors> reports)
     {
-        int n = 0;
         foreach (var p in reports)
         {
             var line = new StringBuilder("\n[UNREAD] ").Append(p.Plugin).Append(": ");
@@ -1379,11 +1401,9 @@ static class Wire
                 if (p.UnscannableSamples.Count > 0) line.Append(": ").Append(string.Join("; ", p.UnscannableSamples));
             }
             line.Append('\n');
-            if (sb.Length + line.Length > budget) break;
-            sb.Append(line);
-            n++;
+            var row = line.ToString();
+            if (!body.Emit(SweepSubject.UnreadRows, row.Length, () => sb.Append(row))) return;
         }
-        return n;
     }
 
     // ---- housecarl_validate_scripts -----------------------------------------------------------------
@@ -1419,7 +1439,10 @@ static class Wire
 
         if (r.CountsOnly)
         {
-            AppendHistogram(sb, r.Histogram, histogramLimit, "unbound properties by NAME",
+            // validate_scripts' response layer is not this branch's, so it keeps no accounting — but it goes through
+            // the same bounded emission path, because a second appending path is a second place to forget the bound.
+            var scriptBody = new BoundedBody(null, cap, () => sb.Length);
+            AppendHistogram(sb, scriptBody, r.Histogram, histogramLimit, "unbound properties by NAME",
                             "counts_only=true — totals above are exact; no per-record listing was built.",
                             notComputed: "no unbound histogram — findings= excluded both unbound classes, so nothing was tallied.");
             foreach (var rec in r.Reports)   // the honesty layer: plugins whose record enumeration faulted
@@ -1429,7 +1452,8 @@ static class Wire
             }
             // The helper reports rather than annotates (it is shared with check_errors, whose accounting states the
             // same fact in its own terms), so this lane keeps its own marker at its own call site.
-            if (AppendExcludedPlugins(sb, r.ExcludedPlugins, cap).Stopped) sb.Append("  ... [truncated at max_chars]\n");
+            AppendExcludedPlugins(sb, scriptBody, r.ExcludedPlugins);
+            if (scriptBody.Stopped(SweepSubject.ExcludedRows)) sb.Append(ExcludedRosterCut(r.ExcludedPlugins.Count));
             AppendScriptCheckBoundary(sb);
             return sb.ToString().TrimEnd('\n');
         }
@@ -1483,8 +1507,12 @@ static class Wire
             sb.Append("\n[finding list capped at limit; true totals = ").Append(UnboundTotalText(r, didObject, didScalar))
               .Append(" + ").Append(NullTotalText(r, didNull)).Append(" — raise limit= to see all]\n");
 
-        if (!truncated && AppendExcludedPlugins(sb, r.ExcludedPlugins, cap).Stopped)
-            sb.Append("  ... [truncated at max_chars]\n");
+        var listBody = new BoundedBody(null, cap, () => sb.Length);
+        if (!truncated)
+        {
+            AppendExcludedPlugins(sb, listBody, r.ExcludedPlugins);
+            if (listBody.Stopped(SweepSubject.ExcludedRows)) sb.Append(ExcludedRosterCut(r.ExcludedPlugins.Count));
+        }
 
         AppendScriptCheckBoundary(sb);
         return sb.ToString().TrimEnd('\n');
@@ -1510,6 +1538,14 @@ static class Wire
     /// from records-with-scripts and unverifiable, which it does not narrow — that asymmetry is the whole point.</summary>
     static string PropLabel(ScriptCheckResult r)
         => r.PropertyContains is null ? "" : $" matching '{r.PropertyContains}'";
+
+    /// <summary>What validate_scripts says when max_chars leaves no room for the excluded-plugin roster. It used to
+    /// be a bare "... [truncated at max_chars]" appended under a header line that was always printed — and once the
+    /// roster's HEAD became droppable too, that marker could stand alone with nothing above it saying what had been
+    /// truncated. A marker that names its own subject does not depend on a line that may not be there.</summary>
+    static string ExcludedRosterCut(int total)
+        => $"\n... [the excluded-plugin list did not fit max_chars — {total} plugin(s) the index could not parse are "
+         + "NOT named above; raise max_chars= to see them]\n";
 
     static void AppendScriptCheckBoundary(StringBuilder sb)
         => sb.Append("\nboundary: checks Auto (CK-editable) properties across the extends chain — not code-driven full ")

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -1190,45 +1190,44 @@ static class Wire
 
         foreach (var p in r.Reports)
         {
-            // Composed then measured, never appended then regretted: the section header decides whether this section
-            // starts at all, and a section that does not start is counted as not rendered rather than half-written.
-            var head = "\n[ERROR] " + p.Plugin + "\n";
-            if (sb.Length + head.Length > budget) break;
-            sb.Append(head);
-            acct.Section();
+            // A SECTION IS EMITTED WHOLE, OR NOT AT ALL — except for its dangling entries, which are the one thing
+            // the accounting can account for one at a time. Everything else a section says (the scan error, the
+            // missing masters, the unscannable-record count) is a finding in its own right, and a per-line "append
+            // if it fits" dropped those silently: they are not entries, so no accounting subject covered them, and
+            // the tool's own parameter text promises master-table findings are "always listed in full". Composing
+            // the fixed part first makes the only droppable units the two the accounting already states — a whole
+            // section, or an entry.
+            var fixedPart = new StringBuilder("\n[ERROR] ").Append(p.Plugin).Append('\n');
             if (p.ScanError is not null)
-                Fit(sb, "  scan error: " + p.ScanError + "\n", budget);
+                fixedPart.Append("  scan error: ").Append(p.ScanError).Append('\n');
             if (p.MissingMasters.Count > 0)
-                Fit(sb, "  missing master(s): " + string.Join(", ", p.MissingMasters)
-                        + "   [declared as a dependency but not present in the active order — install/enable it, or this plugin's refs into it dangle]\n", budget);
-            if (p.Dangling.Count > 0)
-            {
-                Fit(sb, "  dangling reference(s) (" + p.Dangling.Count + "):\n", budget);
-                foreach (var d in p.Dangling)
-                {
-                    var line = "    " + d.Source + " (" + d.SourceType
-                             + (string.IsNullOrEmpty(d.SourceEditorId) ? "" : " '" + d.SourceEditorId + "'")
-                             + ") -> " + d.Target + "   [target not defined by any active plugin]\n";
-                    if (sb.Length + line.Length > budget) break;
-                    sb.Append(line);
-                    acct.Entry(p.Plugin);   // registered where the line LANDED — the accounting counts the response
-                }
-            }
+                fixedPart.Append("  missing master(s): ").Append(string.Join(", ", p.MissingMasters))
+                         .Append("   [declared as a dependency but not present in the active order — install/enable it, or this plugin's refs into it dangle]\n");
             if (p.UnscannableRecords > 0)
-                Fit(sb, "  " + p.UnscannableRecords + " record(s) could not be scanned (Mutagen could not parse their content)"
-                        + (p.UnscannableSamples.Count > 0 ? ": " + string.Join("; ", p.UnscannableSamples) : "") + "\n", budget);
+            {
+                fixedPart.Append("  ").Append(p.UnscannableRecords).Append(" record(s) could not be scanned (Mutagen could not parse their content)");
+                if (p.UnscannableSamples.Count > 0) fixedPart.Append(": ").Append(string.Join("; ", p.UnscannableSamples));
+                fixedPart.Append('\n');
+            }
+            if (p.Dangling.Count > 0)
+                fixedPart.Append("  dangling reference(s) (").Append(p.Dangling.Count).Append("):\n");
+            if (sb.Length + fixedPart.Length > budget) break;
+            sb.Append(fixedPart);
+            acct.Section();
+
+            foreach (var d in p.Dangling)
+            {
+                var line = "    " + d.Source + " (" + d.SourceType
+                         + (string.IsNullOrEmpty(d.SourceEditorId) ? "" : " '" + d.SourceEditorId + "'")
+                         + ") -> " + d.Target + "   [target not defined by any active plugin]\n";
+                if (sb.Length + line.Length > budget) break;
+                sb.Append(line);
+                acct.Entry(p.Plugin);   // registered where the line LANDED — the accounting counts the response
+            }
         }
 
         acct.ExcludedRows(AppendExcludedPlugins(sb, r.ExcludedPlugins, budget).Appended);
         return Close(sb, acct, reserve, headerLength);
-    }
-
-    /// <summary>Append <paramref name="line"/> only if it fits the body budget. A line that does not fit is DROPPED,
-    /// not clipped: half a finding is a finding a caller cannot act on, and what was dropped is accounted for below
-    /// either way.</summary>
-    static void Fit(StringBuilder sb, string line, int budget)
-    {
-        if (sb.Length + line.Length <= budget) sb.Append(line);
     }
 
     /// <summary>Close the response: the accounting for what it emitted, then the boundary. Both live inside the

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -1186,19 +1186,19 @@ static class Wire
 
         if (r.CountsOnly)
         {
-            AppendHistogram(sb, body, SweepSubject.HistogramByTarget, r.Histogram, histogramLimit,
-                            "dangling ref(s) by TARGET plugin (the plugin the broken refs point INTO)",
-                            "counts_only=true — totals above are exact; no per-plugin listing was built.",
-                            notComputed: "no dangling histogram, by target or by source — the link walk was not run (findings= excluded 'dangling').");
-            // #344 — the SOURCE axis: which plugin the broken refs come FROM. The target axis names the absent
-            // dependency behind a wall of findings; only this one answers "how much of this is vanilla, and how much
-            // did the mods introduce". No note and no not-computed line of its own — both would repeat what the
-            // target histogram directly above has just said.
-            AppendHistogram(sb, body, SweepSubject.HistogramBySource, r.DanglingBySource, histogramLimit,
-                            "dangling ref(s) by SOURCE plugin (the plugin the broken refs come FROM)", note: null);
+            // Both axes are handed over TOGETHER so both are reserved before either renders. #344's SOURCE axis —
+            // which plugin the broken refs come FROM — carries no note and no not-computed line of its own: both
+            // would repeat what the TARGET axis directly above has just said.
+            AppendHistograms(sb, body, histogramLimit,
+                new HistogramAxis(SweepSubject.HistogramByTarget, r.Histogram,
+                                  "dangling ref(s) by TARGET plugin (the plugin the broken refs point INTO)",
+                                  "counts_only=true — totals above are exact; no per-plugin listing was built.",
+                                  "no dangling histogram, by target or by source — the link walk was not run (findings= excluded 'dangling')."),
+                new HistogramAxis(SweepSubject.HistogramBySource, r.DanglingBySource,
+                                  "dangling ref(s) by SOURCE plugin (the plugin the broken refs come FROM)"));
             AppendScanErrorTail(sb, body, r.Reports);
             AppendExcludedPlugins(sb, body, r.ExcludedPlugins);   // #288 review finding 5: the NAMES, not just the header count
-            return Close(sb, acct, reserve, headerLength);
+            return Close(sb, acct, reserve + body.ReservedTotal, headerLength);
         }
 
         if (r.Reports.Count == 0 && r.ExcludedPlugins.Count == 0)
@@ -1242,7 +1242,7 @@ static class Wire
         }
 
         AppendExcludedPlugins(sb, body, r.ExcludedPlugins);
-        return Close(sb, acct, reserve, headerLength);
+        return Close(sb, acct, reserve + body.ReservedTotal, headerLength);
     }
 
     /// <summary>Close the response: the accounting for what it emitted, then the boundary. Both live inside the
@@ -1250,7 +1250,11 @@ static class Wire
     /// overrun. The single exception — a <c>max_chars</c> smaller than the accounting itself — is stated in-band
     /// rather than taken silently (#361: appending past the cap without saying so is half of what that issue is).
     /// </summary>
-    static string Close(StringBuilder sb, CheckAccounting acct, int reserve, int headerLength)
+    /// <param name="reserved">everything held out of <c>max_chars</c> before the body rendered: the accounting, the
+    /// boundary, and every subject's closing disclosure. With the header it IS the response's fixed part, which is
+    /// the quantity the overrun notice branches on — a disclosure reserved but left out of this number would get a
+    /// cap too small for the fixed part explained as a body unit overshooting.</param>
+    static string Close(StringBuilder sb, CheckAccounting acct, int reserved, int headerLength)
     {
         if (acct.TextLine() is { } line) sb.Append('\n').Append(line).Append('\n');
         sb.Append('\n').Append(ReadSentences.SweepBoundaryLabel).Append(ReadSentences.SweepBoundary).Append('\n');
@@ -1259,10 +1263,10 @@ static class Wire
         // own length: 1,109 stated on a response of 1,281. Composing it changes only the width of one printed
         // number, so a second pass settles it and a third is only ever needed when that width moved.
         var response = sb.ToString().TrimEnd('\n');
-        if (acct.CapTooSmall(response.Length, headerLength + reserve) is not { } notice) return response;
-        var settled = acct.CapTooSmall(response.Length + notice.Length, headerLength + reserve)!;
+        if (acct.CapTooSmall(response.Length, headerLength + reserved) is not { } notice) return response;
+        var settled = acct.CapTooSmall(response.Length + notice.Length, headerLength + reserved)!;
         if (settled.Length != notice.Length)
-            settled = acct.CapTooSmall(response.Length + settled.Length, headerLength + reserve)!;
+            settled = acct.CapTooSmall(response.Length + settled.Length, headerLength + reserved)!;
         return response + settled;
     }
 
@@ -1320,63 +1324,65 @@ static class Wire
     /// exists so the two sweep headers stay textually identical (one shape, no drift).</summary>
     static string EpochOffOrderQualifier(ScriptCheckResult r) => "";
 
-    /// <summary>Render a <c>counts_only=</c> histogram, capped at <paramref name="rowLimit"/> with the true distinct-key
-    /// count always stated. A null histogram means the mode was not requested; an EMPTY one means the sweep genuinely
-    /// found nothing, and the two read differently (Q3).</summary>
-    /// <param name="body">the ONE bounded emission path. Its framing goes through it as well as its rows: the title,
-    /// the empty-case sentence and the "more rows" line used to bypass the budget entirely (~650 chars past a tight
-    /// cap), and a title with no rows under it is a section head with no section — the whole-or-absent rule this
-    /// render follows everywhere else. So the title rides the FIRST ROW as one unit.</param>
-    /// <param name="subject">this axis's OWN emission subject, never one shared with a sibling axis. A subject is
-    /// what <see cref="BoundedBody"/> stops, and the close below stops it: shared, the first axis to close refused
-    /// every row of the next one (see <see cref="SweepSubject.HistogramBySource"/>).</param>
-    static void AppendHistogram(StringBuilder sb, BoundedBody body, SweepSubject subject,
-                                IReadOnlyList<SweepCount>? rows, int rowLimit,
-                                string title, string? note, string? notComputed = null)
+    /// <summary>Reserve EVERY axis's closing disclosure, then render them all. The two passes are the point: an axis
+    /// that reserved its own room only when its turn came would find a sibling had already spent the budget, which
+    /// is the silence the reserve exists to remove. Reserving is therefore not something each axis does for itself.
+    /// </summary>
+    static void AppendHistograms(StringBuilder sb, BoundedBody body, int rowLimit, params HistogramAxis[] axes)
+    {
+        foreach (var a in axes) body.Reserve(a.Subject, a.TextDisclosure);
+        foreach (var a in axes) AppendHistogram(sb, body, rowLimit, a);
+    }
+
+    /// <summary>Render ONE <c>counts_only=</c> histogram axis, capped at <paramref name="rowLimit"/> with the true
+    /// distinct-key count always stated. A null histogram means the mode was not requested; an EMPTY one means the
+    /// sweep genuinely found nothing, and the two read differently (Q3).</summary>
+    /// <param name="body">the ONE bounded emission path. The axis's ROWS go through it and can be refused; the
+    /// axis's own statement about itself cannot — that room was reserved out of <c>max_chars</c> before the body
+    /// rendered, and <see cref="BoundedBody.Close"/> spends it without asking. Charging the statement to the same
+    /// budget as the rows is what let a whole axis disappear with nothing saying so (#392): the pressure that cut
+    /// the rows cut the sentence reporting the cut.</param>
+    static void AppendHistogram(StringBuilder sb, BoundedBody body, int rowLimit, HistogramAxis axis)
     {
         // The note and the not-computed line are fixed text that does not grow with the findings, and the second is
         // this axis's whole answer — a "the walk was not run" that a budget could drop would be the silence the
         // sentence exists to break. They are part of the response's fixed part, deliberately.
-        if (note is not null) sb.Append('\n').Append(note).Append('\n');
-        if (rows is null) { if (notComputed is not null) sb.Append(notComputed).Append('\n'); return; }
-        // The title rides the empty case too: two axes that both came back empty rendered as two identical untitled
-        // sentences, with no way to tell which was which — or that a second axis existed at all (round-1 review).
-        if (rows.Count == 0)
+        if (axis.Note is not null) sb.Append('\n').Append(axis.Note).Append('\n');
+        if (axis.Rows is not { } rows)
         {
-            var empty = "\n" + title + ": nothing to tally — no findings in the swept scope.\n";
-            body.Emit(subject, empty.Length, () => sb.Append(empty));
+            if (axis.NotComputed is not null) sb.Append(axis.NotComputed).Append('\n');
+            body.Release(axis.Subject);
             return;
         }
-        // The "more rows" line is HELD BACK rather than emitted on hope: rows shown without the count of the rows
-        // that were not is the silent cut one level down. Its widest spelling is bounded by the row count's digits,
-        // and by the longer of the two knob names — which is max_chars.
-        var head = "\n" + title + " (" + rows.Count + " distinct):\n";
+        // The title rides the empty case too: two axes that both came back empty rendered as two identical untitled
+        // sentences, with no way to tell which was which — or that a second axis existed at all (round-1 review).
+        // "Nothing to tally" is this axis's entire answer, so it closes with it rather than emitting it: an answer a
+        // tight cap can refuse leaves the caller unable to tell "no findings" from "this axis was never computed".
+        if (rows.Count == 0) { body.Close(axis.Subject, () => sb.Append(axis.EmptyLine)); return; }
+        var head = axis.Head;
         int shown = 0;
         bool cutByBudget = false;
-        var moreReserve = new HistogramCut(rows.Count, ByBudget: true).Line.Length;
         foreach (var row in rows)
         {
             if (shown >= rowLimit) break;
             var line = "  " + row.Count.ToString().PadLeft(6) + "  " + row.Key + "\n";
             var unit = shown == 0 ? head + line : line;
-            if (!body.Emit(subject, unit.Length + moreReserve, () => sb.Append(unit)))
-            { cutByBudget = true; break; }
+            // The row pays for itself only. What the closing line costs is already held back, against this axis's
+            // own tests as much as its siblings' — a subject may spend the budget on its rows, never on its own
+            // disclosure.
+            if (!body.Emit(axis.Subject, unit.Length, () => sb.Append(unit))) { cutByBudget = true; break; }
             shown++;
         }
         // The closing disclosure, from ONE computation the json lane reads too. The remedy names the knob that
         // STOPPED THIS AXIS: "raise limit=" on rows the response had no room for is a knob that moves nothing, and so
-        // is "raise max_chars=" on rows the row budget refused. An axis that rendered every row it had says nothing.
+        // is "raise max_chars=" on rows the row budget refused. An axis that rendered every row it had says nothing,
+        // and gives its reserved room back for the subjects rendering after it.
         //
-        // An axis the budget admitted NO rows of still says so, head and count together as one unit: an axis that
-        // exists and renders nothing at all is the same silent cut, one level down.
-        if (HistogramCut.For(rows.Count, shown, cutByBudget) is not { } cut) return;
-        if (shown == 0)
-        {
-            var only = head + cut.Line;
-            body.Close(subject, only.Length, () => sb.Append(only));
-        }
-        else
-            body.Close(subject, 0, () => sb.Append(cut.Line));
+        // An axis the budget admitted NO rows of still says so, head and count together: an axis that exists and
+        // renders nothing at all is the same silent cut, one level down.
+        if (HistogramCut.For(rows.Count, shown, cutByBudget) is not { } cut) { body.Release(axis.Subject); return; }
+        if (shown == 0) body.Close(axis.Subject, () => sb.Append(head).Append(cut.Line));
+        else body.Close(axis.Subject, () => sb.Append(cut.Line));
     }
 
     /// <summary>The named, reasoned list of plugins the index build could not parse. Shared by the listing and
@@ -1456,10 +1462,13 @@ static class Wire
             // validate_scripts' response layer is not this branch's, so it keeps no accounting — but it goes through
             // the same bounded emission path, because a second appending path is a second place to forget the bound.
             var scriptBody = new BoundedBody(null, cap, () => sb.Length);
-            AppendHistogram(sb, scriptBody, SweepSubject.HistogramByProperty, r.Histogram, histogramLimit,
-                            "unbound properties by NAME",
-                            "counts_only=true — totals above are exact; no per-record listing was built.",
-                            notComputed: "no unbound histogram — findings= excluded both unbound classes, so nothing was tallied.");
+            // This lane's axis has the identical shape and the identical exposure, and it keeps no accounting at
+            // all — so the reserved closing disclosure is the ONLY thing standing between a tight cap and an axis
+            // that vanishes without a word (#392's scope note).
+            AppendHistograms(sb, scriptBody, histogramLimit,
+                new HistogramAxis(SweepSubject.HistogramByProperty, r.Histogram, "unbound properties by NAME",
+                                  "counts_only=true — totals above are exact; no per-record listing was built.",
+                                  "no unbound histogram — findings= excluded both unbound classes, so nothing was tallied."));
             foreach (var rec in r.Reports)   // the honesty layer: plugins whose record enumeration faulted
             {
                 if (sb.Length >= cap) { sb.Append("\n... [truncated at max_chars]\n"); break; }

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -505,8 +505,9 @@ public static class ReadTools
              "budget. Each value is either a plugin filename WITH its extension ('CoolMod.esp') or one of two group " +
              "names: base_masters (the five the game ships with) or implicit (every plugin the order force-loads " +
              "because plugins.txt does not list it — this is where Creation Club plugins and _ResourcePack.esl are, " +
-             "and it INCLUDES the base masters). A value that is neither, or a name nothing in scope matches, is " +
-             "refused before the sweep runs rather than quietly excluding nothing. This does not change what counts " +
+             "and it INCLUDES the base masters). A value that is neither is refused before the sweep runs, and so is " +
+             "a FILENAME YOU NAMED that nothing in scope matches — a group member that is not in this order is the " +
+             "ordinary case and is simply dropped. This does not change what counts " +
              "as the vanilla BASELINE the response splits out — that is always Mutagen's own base-master set.")]
             string[]? exclude = null,
         [Description("Optional. Which error classes to look for: 'dangling' and/or 'missing_masters' (default both). Excluding 'dangling' SKIPS the per-record link walk entirely — that is how you ask 'is any master missing anywhere in my order' without paying for a full sweep. An excluded class renders as 'not checked', never as 0. Unscannable records and scan errors are ALWAYS reported and cannot be filtered out (a suppressed 'could not read' would read as clean).")]
@@ -1252,9 +1253,16 @@ static class Wire
     {
         if (acct.TextLine() is { } line) sb.Append('\n').Append(line).Append('\n');
         sb.Append('\n').Append(ReadSentences.SweepBoundaryLabel).Append(ReadSentences.SweepBoundary).Append('\n');
-        // The overrun question is asked of the FINISHED response, so the string is built first and measured.
+        // The overrun question is asked of the FINISHED response, so the string is built first and measured — and
+        // the notice is PART of the response it reports the length of. Measured without itself it understated by its
+        // own length: 1,109 stated on a response of 1,281. Composing it changes only the width of one printed
+        // number, so a second pass settles it and a third is only ever needed when that width moved.
         var response = sb.ToString().TrimEnd('\n');
-        return acct.CapTooSmall(response.Length, headerLength + reserve) is { } notice ? response + notice : response;
+        if (acct.CapTooSmall(response.Length, headerLength + reserve) is not { } notice) return response;
+        var settled = acct.CapTooSmall(response.Length + notice.Length, headerLength + reserve)!;
+        if (settled.Length != notice.Length)
+            settled = acct.CapTooSmall(response.Length + settled.Length, headerLength + reserve)!;
+        return response + settled;
     }
 
     /// <summary>#344 — the baseline split: how much of the dangling total came from the base-game masters, and how

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -1143,6 +1143,12 @@ static class Wire
         int cap = Cap(maxChars);
         bool didDangling = r.Classes.HasFlag(ErrorFindingClass.Dangling);
         bool didMasters = r.Classes.HasFlag(ErrorFindingClass.MissingMasters);
+        // ONE accounting for this response, and the body renders inside what it leaves (#361). Everything below
+        // emits through `acct`, and every omission claim is computed from those registrations after emission stops
+        // — there is no truncation flag to miss, and no path that appends the tail past the cap.
+        var acct = new CheckAccounting(r, cap);
+        int reserve = acct.TextReserve;
+        int budget = acct.BodyBudget(reserve);
         var sb = new StringBuilder();
 
         sb.Append("check_errors — load-order integrity sweep\n");
@@ -1158,7 +1164,10 @@ static class Wire
         if (r.OffOrderScanned is { Count: > 0 } off)
             sb.Append("swept OFF-ORDER (on disk, not in the active load order): ").Append(string.Join(", ", off))
               .Append("   [the file's own records; links resolved against the active order + the file's own definitions]\n");
-        AppendBaselineSplit(sb, r);   // #344 — how much of the dangling total is vanilla baseline
+        AppendBaselineSplit(sb, r, acct);   // #344 — how much of the dangling total is vanilla baseline
+        // Where the BODY begins. The overrun arm is a question about the fixed part of the response, so it is asked
+        // here rather than at the end, where the answer would be the body's own length.
+        int headerLength = sb.Length;
 
         if (r.CountsOnly)
         {
@@ -1171,75 +1180,67 @@ static class Wire
             // target histogram directly above has just said.
             AppendHistogram(sb, r.DanglingBySource, histogramLimit,
                             "dangling ref(s) by SOURCE plugin (the plugin the broken refs come FROM)", note: null);
-            AppendScanErrorTail(sb, r.Reports, cap);
-            AppendExcludedPlugins(sb, r.ExcludedPlugins, cap);   // #288 review finding 5: the NAMES, not just the header count
-            AppendCheckErrorsBoundary(sb);
-            return sb.ToString().TrimEnd('\n');
+            acct.UnreadRows(AppendScanErrorTail(sb, r.Reports, budget));
+            acct.ExcludedRows(AppendExcludedPlugins(sb, r.ExcludedPlugins, budget).Appended);   // #288 review finding 5: the NAMES, not just the header count
+            return Close(sb, acct, reserve, headerLength);
         }
 
         if (r.Reports.Count == 0 && r.ExcludedPlugins.Count == 0)
             sb.Append("\nNo errors found in the scanned scope.\n");
 
-        bool truncated = false;
-        int sections = 0;
-        int entries = 0;    // dangling entries actually appended, in the unit the budget line uses
         foreach (var p in r.Reports)
         {
-            if (sb.Length >= cap)
-            {
-                // AN OMISSION SENTENCE IS COMPUTED BY THE LAYER THAT PERFORMED THE OMISSION, AND CLAIMS ONLY THAT
-                // LAYER'S OMISSION. This is the render's cut, so it is counted here, where the loop already knows
-                // what it emitted — and it says nothing about the listing budget, whose own omissions the capped
-                // line below reports in its own terms. The two truncators are independent and do not sum: crossing
-                // that seam is what made rounds 1 and 2 a single class (advisor ruling, 2026-08-18).
-                // The entry count is stated in the BUDGET LINE'S unit, so a reader can answer "how many findings can
-                // I actually see" without subtracting two figures that count different things; it replaces a "may be
-                // partial" hedge that existed only because the loop was counting sections (Aaron's PR #360 review).
-                // REACH: this notice fires where the section loop breaks — at a section BOUNDARY. A cut landing
-                // inside the LAST section ends the inner loop instead, leaving truncated unset and this sentence
-                // unprinted; that path is #361, pre-existing and untouched here.
-                sb.Append("\n... [truncated at max_chars=").Append(cap).Append(": ")
-                  .Append(r.Reports.Count - sections).Append(" of ").Append(r.Reports.Count)
-                  .Append(" plugin section(s) were not rendered; ").Append(entries).Append(" of the ")
-                  .Append(r.Reports.Sum(x => x.Dangling.Count))
-                  .Append(" budget-listed dangling entries appear above. ")
-                  .Append("This is the response being cut, separate from any limit= omission reported below. ")
-                  .Append(SweepNarrowHint).Append("]\n");
-                truncated = true;
-                break;
-            }
-            sb.Append("\n[ERROR] ").Append(p.Plugin).Append('\n');
-            sections++;
+            // Composed then measured, never appended then regretted: the section header decides whether this section
+            // starts at all, and a section that does not start is counted as not rendered rather than half-written.
+            var head = "\n[ERROR] " + p.Plugin + "\n";
+            if (sb.Length + head.Length > budget) break;
+            sb.Append(head);
+            acct.Section();
             if (p.ScanError is not null)
-                sb.Append("  scan error: ").Append(p.ScanError).Append('\n');
+                Fit(sb, "  scan error: " + p.ScanError + "\n", budget);
             if (p.MissingMasters.Count > 0)
-                sb.Append("  missing master(s): ").Append(string.Join(", ", p.MissingMasters))
-                  .Append("   [declared as a dependency but not present in the active order — install/enable it, or this plugin's refs into it dangle]\n");
+                Fit(sb, "  missing master(s): " + string.Join(", ", p.MissingMasters)
+                        + "   [declared as a dependency but not present in the active order — install/enable it, or this plugin's refs into it dangle]\n", budget);
             if (p.Dangling.Count > 0)
             {
-                sb.Append("  dangling reference(s) (").Append(p.Dangling.Count).Append("):\n");
+                Fit(sb, "  dangling reference(s) (" + p.Dangling.Count + "):\n", budget);
                 foreach (var d in p.Dangling)
                 {
-                    if (sb.Length >= cap) break;
-                    entries++;   // counted where one is actually appended: a section total would lie about a partial section
-                    sb.Append("    ").Append(d.Source).Append(" (").Append(d.SourceType);
-                    if (!string.IsNullOrEmpty(d.SourceEditorId)) sb.Append(" '").Append(d.SourceEditorId).Append('\'');
-                    sb.Append(") -> ").Append(d.Target).Append("   [target not defined by any active plugin]\n");
+                    var line = "    " + d.Source + " (" + d.SourceType
+                             + (string.IsNullOrEmpty(d.SourceEditorId) ? "" : " '" + d.SourceEditorId + "'")
+                             + ") -> " + d.Target + "   [target not defined by any active plugin]\n";
+                    if (sb.Length + line.Length > budget) break;
+                    sb.Append(line);
+                    acct.Entry(p.Plugin);   // registered where the line LANDED — the accounting counts the response
                 }
             }
             if (p.UnscannableRecords > 0)
-            {
-                sb.Append("  ").Append(p.UnscannableRecords).Append(" record(s) could not be scanned (Mutagen could not parse their content)");
-                if (p.UnscannableSamples.Count > 0) sb.Append(": ").Append(string.Join("; ", p.UnscannableSamples));
-                sb.Append('\n');
-            }
+                Fit(sb, "  " + p.UnscannableRecords + " record(s) could not be scanned (Mutagen could not parse their content)"
+                        + (p.UnscannableSamples.Count > 0 ? ": " + string.Join("; ", p.UnscannableSamples) : "") + "\n", budget);
         }
 
-        if (r.Capped) AppendCappedLine(sb, r);   // #344 — Q3: a cap that does not say WHICH plugins lost entries is the silent half of the defect
+        acct.ExcludedRows(AppendExcludedPlugins(sb, r.ExcludedPlugins, budget).Appended);
+        return Close(sb, acct, reserve, headerLength);
+    }
 
-        if (!truncated) AppendExcludedPlugins(sb, r.ExcludedPlugins, cap);
+    /// <summary>Append <paramref name="line"/> only if it fits the body budget. A line that does not fit is DROPPED,
+    /// not clipped: half a finding is a finding a caller cannot act on, and what was dropped is accounted for below
+    /// either way.</summary>
+    static void Fit(StringBuilder sb, string line, int budget)
+    {
+        if (sb.Length + line.Length <= budget) sb.Append(line);
+    }
 
-        AppendCheckErrorsBoundary(sb);
+    /// <summary>Close the response: the accounting for what it emitted, then the boundary. Both live inside the
+    /// reserve taken before the body rendered, so this is the ONE place either can be appended and it cannot
+    /// overrun. The single exception — a <c>max_chars</c> smaller than the accounting itself — is stated in-band
+    /// rather than taken silently (#361: appending past the cap without saying so is half of what that issue is).
+    /// </summary>
+    static string Close(StringBuilder sb, CheckAccounting acct, int reserve, int headerLength)
+    {
+        if (acct.TextLine() is { } line) sb.Append('\n').Append(line).Append('\n');
+        sb.Append('\n').Append(ReadSentences.SweepBoundaryLabel).Append(ReadSentences.SweepBoundary).Append('\n');
+        if (acct.CapTooSmall(headerLength, reserve) is { } notice) sb.Append(notice).Append('\n');
         return sb.ToString().TrimEnd('\n');
     }
 
@@ -1257,7 +1258,7 @@ static class Wire
     /// (<see cref="ErrorCheckResult.BaseMastersSwept"/>) rather than the whole definition: "0 of 12 are vanilla" over
     /// a scope that never included vanilla is a true sentence that teaches something false — and so is a "3 of 3"
     /// naming five plugins when the sweep opened one (round-1 review, found independently by two reviewers).</para></summary>
-    static void AppendBaselineSplit(StringBuilder sb, ErrorCheckResult r)
+    static void AppendBaselineSplit(StringBuilder sb, ErrorCheckResult r, CheckAccounting acct)
     {
         if (!r.Classes.HasFlag(ErrorFindingClass.Dangling) || r.BaseMastersSwept is not { Count: > 0 } swept) return;
         sb.Append("baseline: ").Append(r.BaselineDangling).Append(" of ").Append(r.TotalDangling)
@@ -1273,67 +1274,10 @@ static class Wire
         // in the sweep from the resolved targets — comparing PluginsScanned against the swept-base count subtracts two
         // numbers that measure different things and prints this sentence over a base-only scope whenever they diverge
         // (Aaron's PR #360 review: a record scope that filters a base master out, or a repeated plugins= name).
-        if (r.Capped && r.BaselineDangling > 0 && r.NonBaseInScope)
+        if (acct.OmittedByBudget > 0 && r.BaselineDangling > 0 && r.NonBaseInScope)
             sb.Append("  the listing budget (limit=) is spent on every other plugin BEFORE those, so baseline findings ")
               .Append("cannot crowd the rest out of the list; the sections below stay in load order.").Append('\n');
     }
-
-    /// <summary>How many omitted-by-plugin rows the capped line names before it says how many it did NOT name. The
-    /// unnamed count is stated, never implied: on a large order dozens of plugins lose entries, and a roster that
-    /// truncates while claiming to be the only place those plugins appear rebuilds the very hole this fix closes,
-    /// one level down (round-1 review).</summary>
-    const int OmittedPluginsShown = 10;
-
-    /// <summary>#344 — the capped line, whose every subject is the LISTING BUDGET's: an omission sentence is computed
-    /// by the layer that performed the omission and claims only that layer's omission (advisor ruling, 2026-08-18).
-    /// The render's own cut is reported at the truncation notice, in the render's terms. It used to state the true total and stop, which said that entries were dropped
-    /// but never WHICH plugin lost them; a plugin that lost its whole set, and had nothing else to report, has no
-    /// section above at all, so the report gave a reader no way to find it. Q3: what a cap dropped is part of the
-    /// answer, not an omission the caller is expected to infer.</summary>
-    static void AppendCappedLine(StringBuilder sb, ErrorCheckResult r)
-    {
-        // A capped sweep always dropped at least one ref (capped is set only where the budget hit 0 with a finding
-        // in hand), so the count is stated flat rather than behind a test that cannot fail.
-        int notListed = r.ListingOmitted?.Sum(c => c.Count) ?? 0;
-        sb.Append('\n').Append("[the listing budget (limit=) omitted ").Append(notListed)
-          .Append(" dangling ref(s); true total = ").Append(r.TotalDangling);
-        if (r.ListingOmitted is { Count: > 0 } omitted)
-        {
-            sb.Append(", across ").Append(omitted.Count).Append(" source plugin(s). Largest sources");
-            if (omitted.Count > OmittedPluginsShown)
-                sb.Append(" (the ").Append(OmittedPluginsShown).Append(" largest of ").Append(omitted.Count)
-                  .Append("; the rest are not named here)");
-            sb.Append(": ");
-            int shown = 0;
-            foreach (var row in omitted)
-            {
-                if (shown >= OmittedPluginsShown) break;
-                if (shown > 0) sb.Append(", ");
-                sb.Append(row.Key).Append(" (").Append(row.Count).Append(')');
-                shown++;
-            }
-            // A RULE about the budget, not a claim about this response's contents. The conditional it replaces tested
-            // r.Reports — sweep state — to describe what the reader can see, which is the seam the layer rule closes;
-            // the honest fix was to delete the conditional rather than to move its test (#339 precedent).
-            sb.Append(". A plugin whose whole set the budget omitted, with nothing else to report, gets no section of ")
-              .Append("its own.");
-        }
-        else sb.Append('.');
-        // The remedy is a claim about a call that has not happened. Raising limit= always works; scoping re-spends
-        // the WHOLE budget on the named plugin, which is enough unless that plugin's own set is larger than limit=
-        // — on a real order the biggest single source ran to 2591 refs against a default of 1000, so an unqualified
-        // "scope to it" would loop the caller back to this same line (round-1 review, measured).
-        // Every subject in this line is the BUDGET's. What the response itself dropped is the render's fact, stated at
-        // the truncation notice above in its own terms; the two are independent and are never added together.
-        sb.Append(" Raise limit= to list more; scoping plugins= to one of these re-spends the whole budget on that ")
-          .Append("plugin, which lists its set in full unless that set is itself larger than limit=. counts_only=true ")
-          .Append("returns the by-source tally for every plugin, capped only in how many ROWS it prints.]").Append('\n');
-    }
-
-    static void AppendCheckErrorsBoundary(StringBuilder sb)
-        => sb.Append("\nboundary: checks FormLink resolution, missing masters, and parse failures. Does NOT verify navmesh/terrain ")
-             .Append("spatial integrity (CRC/grid), flag required-but-null fields, list unused-master cleanup, or link-check an owned ")
-             .Append("item's ownership 'variable' word (a rank/global Mutagen can't type on an override); a null FormLink is a legal optional.\n");
 
     // ---- shared sweep-render pieces (#282) ----------------------------------------------------------
     /// <summary>The truncation/overflow hint the two sweep tools share. The old wording told the caller to "scope
@@ -1380,33 +1324,44 @@ static class Wire
     /// <summary>The named, reasoned list of plugins the index build could not parse. Shared by the listing and
     /// <c>counts_only=</c> paths — counts_only used to return before it, leaving the header's bare count with no way to
     /// learn WHICH plugin went unchecked without re-running (PR #288 review, finding 5).</summary>
-    static void AppendExcludedPlugins(StringBuilder sb, IReadOnlyDictionary<string, string> excluded, int cap)
+    static (int Appended, bool Stopped) AppendExcludedPlugins(StringBuilder sb, IReadOnlyDictionary<string, string> excluded,
+                                                             int budget)
     {
-        if (excluded.Count == 0) return;
-        sb.Append("\nexcluded plugins (could not be parsed — NOT checked):\n");
+        if (excluded.Count == 0) return (0, false);
+        var head = "\nexcluded plugins (could not be parsed — NOT checked):\n";
+        if (sb.Length + head.Length > budget) return (0, true);
+        sb.Append(head);
+        int n = 0;
         foreach (var kv in excluded)
         {
-            if (sb.Length >= cap) { sb.Append("  ... [truncated at max_chars]\n"); break; }
-            sb.Append("  ").Append(kv.Key).Append(": ").Append(kv.Value).Append('\n');
+            var line = "  " + kv.Key + ": " + kv.Value + "\n";
+            if (sb.Length + line.Length > budget) return (n, true);
+            sb.Append(line);
+            n++;
         }
+        return (n, false);
     }
 
     /// <summary>Under <c>counts_only=</c> the reports list carries the honesty layer only (records/plugins houseCARL
     /// could not read). Emit it verbatim so a counts-only answer still names what it could not check (Q3).</summary>
-    static void AppendScanErrorTail(StringBuilder sb, IReadOnlyList<PluginErrors> reports, int cap)
+    static int AppendScanErrorTail(StringBuilder sb, IReadOnlyList<PluginErrors> reports, int budget)
     {
+        int n = 0;
         foreach (var p in reports)
         {
-            if (sb.Length >= cap) { sb.Append("\n... [truncated at max_chars]\n"); break; }
-            sb.Append("\n[UNREAD] ").Append(p.Plugin).Append(": ");
-            if (p.ScanError is not null) sb.Append(p.ScanError).Append(' ');
+            var line = new StringBuilder("\n[UNREAD] ").Append(p.Plugin).Append(": ");
+            if (p.ScanError is not null) line.Append(p.ScanError).Append(' ');
             if (p.UnscannableRecords > 0)
             {
-                sb.Append(p.UnscannableRecords).Append(" record(s) could not be scanned");
-                if (p.UnscannableSamples.Count > 0) sb.Append(": ").Append(string.Join("; ", p.UnscannableSamples));
+                line.Append(p.UnscannableRecords).Append(" record(s) could not be scanned");
+                if (p.UnscannableSamples.Count > 0) line.Append(": ").Append(string.Join("; ", p.UnscannableSamples));
             }
-            sb.Append('\n');
+            line.Append('\n');
+            if (sb.Length + line.Length > budget) break;
+            sb.Append(line);
+            n++;
         }
+        return n;
     }
 
     // ---- housecarl_validate_scripts -----------------------------------------------------------------
@@ -1450,7 +1405,9 @@ static class Wire
                 if (sb.Length >= cap) { sb.Append("\n... [truncated at max_chars]\n"); break; }
                 if (rec.ScanError is not null) sb.Append("\n[SCAN ERROR] ").Append(rec.Plugin).Append(": ").Append(rec.ScanError).Append('\n');
             }
-            AppendExcludedPlugins(sb, r.ExcludedPlugins, cap);   // #288 review finding 5
+            // The helper reports rather than annotates (it is shared with check_errors, whose accounting states the
+            // same fact in its own terms), so this lane keeps its own marker at its own call site.
+            if (AppendExcludedPlugins(sb, r.ExcludedPlugins, cap).Stopped) sb.Append("  ... [truncated at max_chars]\n");
             AppendScriptCheckBoundary(sb);
             return sb.ToString().TrimEnd('\n');
         }
@@ -1504,7 +1461,8 @@ static class Wire
             sb.Append("\n[finding list capped at limit; true totals = ").Append(UnboundTotalText(r, didObject, didScalar))
               .Append(" + ").Append(NullTotalText(r, didNull)).Append(" — raise limit= to see all]\n");
 
-        if (!truncated) AppendExcludedPlugins(sb, r.ExcludedPlugins, cap);
+        if (!truncated && AppendExcludedPlugins(sb, r.ExcludedPlugins, cap).Stopped)
+            sb.Append("  ... [truncated at max_chars]\n");
 
         AppendScriptCheckBoundary(sb);
         return sb.ToString().TrimEnd('\n');

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -1379,20 +1379,24 @@ static class Wire
 
     /// <summary>The named, reasoned list of plugins the index build could not parse. Shared by the listing and
     /// <c>counts_only=</c> paths — counts_only used to return before it, leaving the header's bare count with no way to
-    /// learn WHICH plugin went unchecked without re-running (PR #288 review, finding 5).</summary>
-    static void AppendExcludedPlugins(StringBuilder sb, BoundedBody body, IReadOnlyDictionary<string, string> excluded)
+    /// learn WHICH plugin went unchecked without re-running (PR #288 review, finding 5).
+    /// <para>Returns HOW MANY rows it emitted. The roster is cut one row at a time, so "how many are unnamed" is a
+    /// subtraction at the append site and nowhere else: handed the TOTAL instead, the callers that state it said all
+    /// three plugins were unnamed on a response that had just named one of them.</para></summary>
+    static int AppendExcludedPlugins(StringBuilder sb, BoundedBody body, IReadOnlyDictionary<string, string> excluded)
     {
-        if (excluded.Count == 0) return;
+        if (excluded.Count == 0) return 0;
         // The head rides the first ROW, so the list is whole or absent: a head with nothing under it says a roster
         // exists and then names none of it.
         const string head = "\nexcluded plugins (could not be parsed — NOT checked):\n";
-        bool first = true;
+        int emitted = 0;
         foreach (var kv in excluded)
         {
-            var unit = (first ? head : "") + "  " + kv.Key + ": " + kv.Value + "\n";
-            if (!body.Emit(SweepSubject.ExcludedRows, unit.Length, () => sb.Append(unit))) return;
-            first = false;
+            var unit = (emitted == 0 ? head : "") + "  " + kv.Key + ": " + kv.Value + "\n";
+            if (!body.Emit(SweepSubject.ExcludedRows, unit.Length, () => sb.Append(unit))) return emitted;
+            emitted++;
         }
+        return emitted;
     }
 
     /// <summary>Under <c>counts_only=</c> the reports list carries the honesty layer only (records/plugins houseCARL
@@ -1460,8 +1464,9 @@ static class Wire
             }
             // The helper reports rather than annotates (it is shared with check_errors, whose accounting states the
             // same fact in its own terms), so this lane keeps its own marker at its own call site.
-            AppendExcludedPlugins(sb, scriptBody, r.ExcludedPlugins);
-            if (scriptBody.Stopped(SweepSubject.ExcludedRows)) sb.Append(ExcludedRosterCut(r.ExcludedPlugins.Count));
+            int namedExcluded = AppendExcludedPlugins(sb, scriptBody, r.ExcludedPlugins);
+            if (scriptBody.Stopped(SweepSubject.ExcludedRows))
+                sb.Append(ExcludedRosterCut(r.ExcludedPlugins.Count - namedExcluded));
             AppendScriptCheckBoundary(sb);
             return sb.ToString().TrimEnd('\n');
         }
@@ -1518,8 +1523,9 @@ static class Wire
         var listBody = new BoundedBody(null, cap, () => sb.Length);
         if (!truncated)
         {
-            AppendExcludedPlugins(sb, listBody, r.ExcludedPlugins);
-            if (listBody.Stopped(SweepSubject.ExcludedRows)) sb.Append(ExcludedRosterCut(r.ExcludedPlugins.Count));
+            int namedExcluded = AppendExcludedPlugins(sb, listBody, r.ExcludedPlugins);
+            if (listBody.Stopped(SweepSubject.ExcludedRows))
+                sb.Append(ExcludedRosterCut(r.ExcludedPlugins.Count - namedExcluded));
         }
 
         AppendScriptCheckBoundary(sb);
@@ -1550,9 +1556,12 @@ static class Wire
     /// <summary>What validate_scripts says when max_chars leaves no room for the excluded-plugin roster. It used to
     /// be a bare "... [truncated at max_chars]" appended under a header line that was always printed — and once the
     /// roster's HEAD became droppable too, that marker could stand alone with nothing above it saying what had been
-    /// truncated. A marker that names its own subject does not depend on a line that may not be there.</summary>
-    static string ExcludedRosterCut(int total)
-        => $"\n... [the excluded-plugin list did not fit max_chars — {total} plugin(s) the index could not parse are "
+    /// truncated. A marker that names its own subject does not depend on a line that may not be there.
+    /// <para><paramref name="unnamed"/> is the total LESS the rows the render actually emitted, counted at the append
+    /// site. Handed the total, the marker claimed every plugin was unnamed on a roster that had named some of them
+    /// — measured at max_chars=840 over three plugins, one of which is printed on the line directly above it.</para></summary>
+    static string ExcludedRosterCut(int unnamed)
+        => $"\n... [the excluded-plugin list did not fit max_chars — {unnamed} plugin(s) the index could not parse are "
          + "NOT named above; raise max_chars= to see them]\n";
 
     static void AppendScriptCheckBoundary(StringBuilder sb)

--- a/src/housecarl-mcp/SweepEmission.cs
+++ b/src/housecarl-mcp/SweepEmission.cs
@@ -116,6 +116,16 @@ internal readonly record struct HistogramAxis(SweepSubject Subject, IReadOnlyLis
     /// second axis existed at all.</summary>
     internal string EmptyLine => "\n" + Title + ": nothing to tally — no findings in the swept scope.\n";
 
+    /// <summary>The axis's note, spelled ONCE. It is written whatever the budget says, so the room for it is held
+    /// back with the closing disclosure rather than taken out of the body's — and the render and the reserve read
+    /// this one string, for the same reason <see cref="HistogramCut.Line"/> has one spelling.</summary>
+    internal string NoteLine => Note is null ? "" : "\n" + Note + "\n";
+
+    /// <summary>What this axis says INSTEAD of a tally when the mode was not requested. Also unconditional, and so
+    /// also reserved: "the walk was not run" is the axis's whole answer, and an answer a budget can drop leaves the
+    /// caller unable to tell it from a tally that came back empty (Q3).</summary>
+    internal string NotComputedLine => Rows is null && NotComputed is not null ? NotComputed + "\n" : "";
+
     /// <summary>The axis's IRREDUCIBLE DISCLOSURE, in text-lane characters: the widest thing
     /// <see cref="BoundedBody.Close"/> can be asked to write for it, which is its head plus a cut line naming
     /// every row — the case where the budget admitted no rows at all. An axis that renders some of its rows
@@ -125,6 +135,17 @@ internal readonly record struct HistogramAxis(SweepSubject Subject, IReadOnlyLis
         => Rows is null ? 0
          : Rows.Count == 0 ? EmptyLine.Length
          : Head.Length + new HistogramCut(Rows.Count, ByBudget: true).Line.Length;
+
+    /// <summary>Everything this axis puts in the response's FIXED PART, in text-lane characters: its unconditional
+    /// lines plus its closing disclosure. ONE reserve for the lot, because they are one thing — what this axis
+    /// writes whatever the budget says.
+    ///
+    /// <para>The notes used to sit outside every reserve. They are appended straight to the builder after the
+    /// header has been measured, so the overrun notice was told a fixed part up to ~184 chars smaller than the one
+    /// the response actually carried; in the band between the two it explained a cap too small for the fixed part
+    /// as a body unit overshooting, over a <c>counts_only</c> response that emitted no body unit at all — 96 caps
+    /// of a 100–6000 sweep on the null-axes lane.</para></summary>
+    internal int TextFixed => NoteLine.Length + NotComputedLine.Length + TextDisclosure;
 }
 
 /// <summary>
@@ -166,10 +187,13 @@ internal readonly record struct HistogramAxis(SweepSubject Subject, IReadOnlyLis
 /// that cannot be fixtured honestly is the signal to delete it, not a testing gap to work around (CLAUDE.md §5 #11,
 /// PR #339's precedent).</para>
 ///
-/// <para>The FIXED PART is outside this helper entirely: the header, every reserved closing disclosure, the
-/// accounting and the boundary. Those are the things a response is never allowed to drop, which is exactly why
-/// none of them is emitted through a helper that can refuse. What a cap too small for the fixed part gets is an
-/// overrun that SAYS SO (<see cref="CheckAccounting.CapTooSmall"/>), never a shorter response with less in it.</para>
+/// <para>The FIXED PART is outside the emission gate entirely: the header, every axis's unconditional lines, every
+/// reserved closing disclosure, the accounting and the boundary. Those are the things a response is never allowed
+/// to drop, which is exactly why none of them goes through <see cref="Emit"/>. What a cap too small for the fixed
+/// part gets is an overrun that SAYS SO (<see cref="CheckAccounting.CapTooSmall"/>), never a shorter response with
+/// less in it. The unconditional writes still come through this class — <see cref="Fixed"/> and
+/// <see cref="Close"/> — so that <see cref="FixedBeyondHeader"/> is MEASURED at the write rather than assembled
+/// from what each site remembered to declare.</para>
 /// </summary>
 internal sealed class BoundedBody
 {
@@ -201,34 +225,62 @@ internal sealed class BoundedBody
     {
         if (_stopped.Contains(subject)) return false;
         if (_length() + cost + Held > _budget) { _stopped.Add(subject); return false; }
+        int before = _length();
         commit();
+        BodyTotal += _length() - before;
         _acct?.Emitted(subject, source);
         return true;
     }
 
-    /// <summary>Hold back the room one subject's CLOSING DISCLOSURE will need, BEFORE any unit is emitted. Every
-    /// emission test then has to leave that room standing, so by the time the subject closes, what it writes is
-    /// already paid for.
+    /// <summary>What the BODY actually appended, measured at each unit as it landed — the declared cost is a budget
+    /// test, never this number. It is the only quantity that separates a response's body from its fixed part, which
+    /// is why it is taken here rather than reconstructed from the counts the accounting keeps.</summary>
+    internal int BodyTotal { get; private set; }
+
+    /// <summary>Hold back the room one subject writes WHATEVER THE BUDGET SAYS — its unconditional lines and its
+    /// closing disclosure — BEFORE any unit is emitted. Every emission test then has to leave that room standing,
+    /// so by the time the subject writes, what it writes is already paid for.
     ///
-    /// <para>Reserving is what makes the disclosure unrefusable, and it has to happen before the FIRST unit of ANY
+    /// <para>Reserving is what makes those writes unrefusable, and it has to happen before the FIRST unit of ANY
     /// subject: an axis that reserved its own room after a sibling had already spent the budget would be the exact
     /// silence this exists to remove.</para></summary>
-    internal void Reserve(SweepSubject subject, int cost)
-    {
-        _held[subject] = cost;
-        ReservedTotal += cost;
-    }
+    internal void Reserve(SweepSubject subject, int cost) => _held[subject] = cost;
 
-    /// <summary>Everything ever reserved here, spent or not. It is the part of the response's fixed part that the
-    /// header does not carry, so the overrun notice needs it to tell a cap too small for the fixed part from a body
-    /// unit that ran past what was left after the fixed part fit.</summary>
-    internal int ReservedTotal { get; private set; }
+    /// <summary>This response's FIXED PART: every char it carries whatever the budget says — the header, each
+    /// axis's unconditional lines, each closing disclosure, the accounting and the boundary.
+    ///
+    /// <para><b>It is SUBTRACTED, not assembled.</b> Everything a cap can refuse goes through <see cref="Emit"/>
+    /// and is measured there (<see cref="BodyTotal"/>); the fixed part is therefore the finished response minus
+    /// that, plus room still held that no unit was allowed to touch. Nothing here enumerates the unconditional
+    /// write sites, which is the point — the number this feeds is what the overrun notice branches on, and every
+    /// version of it that was ASSEMBLED came out wrong in a way nothing could see. Summed from a header measured
+    /// before the axes wrote their notes, a reserve total that still counted room <see cref="Release"/> had given
+    /// back, and a lane's whole json slack, it understated the text lane's fixed part by up to ~184 chars and
+    /// overstated the json raise-to by 85%. Assembled from the write sites instead, it still missed json's empty
+    /// <c>plugins</c> array — a site nobody thinks of as a write.</para>
+    ///
+    /// <para>The one thing it deliberately excludes is the overrun notice, which is why the caller passes the
+    /// length it measured: the notice is gone the moment the response fits, so a fixed part counting it would tell
+    /// a caller to buy room for a sentence they are paying to remove.</para></summary>
+    /// <param name="contentLength">the finished response as the transport measured it, WITHOUT the notice.</param>
+    internal int FixedPart(int contentLength) => contentLength - BodyTotal + Held;
 
     /// <summary>Room reserved and not yet spent. Held against every emission test, including tests of the subject
-    /// that reserved it — a subject may spend the budget on its rows, never on its own disclosure.</summary>
+    /// that reserved it — a subject may spend the budget on its rows, never on what it writes regardless.</summary>
     int Held
     {
         get { int n = 0; foreach (var v in _held.Values) n += v; return n; }
+    }
+
+    /// <summary>Write part of a subject's reserved, UNCONDITIONAL text now — an axis's note, a json axis object's
+    /// own frame. It is not a unit, so it is not registered and it cannot be refused; what it appends is measured
+    /// and charged against the room already held for this subject, so a write and the room held for it are not
+    /// held against the body twice over.</summary>
+    internal void Fixed(SweepSubject subject, Action commit)
+    {
+        int before = _length();
+        commit();
+        if (_held.TryGetValue(subject, out var held)) _held[subject] = Math.Max(0, held - (_length() - before));
     }
 
     /// <summary>Write a subject's own CLOSING DISCLOSURE — the line that says how much of it did not fit. It is not
@@ -247,10 +299,11 @@ internal sealed class BoundedBody
         _stopped.Add(subject);   // nothing follows a subject's closing disclosure
     }
 
-    /// <summary>Give a subject's reserved room back UNSPENT — for the subject that turned out to have nothing to
-    /// disclose, because it rendered everything it had. Without this the room stays held against every later
-    /// subject's emission test, and the subjects after a complete histogram would pay for a sentence nobody
-    /// wrote.</summary>
+    /// <summary>Give a subject's remaining reserved room back UNSPENT — for the subject that turned out to have
+    /// nothing left to say, because it rendered everything it had. Without this the room stays held against every
+    /// later subject's emission test, and the subjects after a complete histogram would pay for a sentence nobody
+    /// wrote. What the subject DID write is already in the response, and <see cref="FixedPart"/> measures it there;
+    /// what is given back here is room, and room nobody wrote is not part of anything's fixed part.</summary>
     internal void Release(SweepSubject subject) => _held.Remove(subject);
 
     /// <summary>Did this subject stop short? For the one caller that states the fact in its own words rather than

--- a/src/housecarl-mcp/SweepEmission.cs
+++ b/src/housecarl-mcp/SweepEmission.cs
@@ -25,12 +25,60 @@ internal enum SweepSubject
     /// <summary>Rows of the <c>counts_only</c> honesty layer: the plugins whose records could not be read.</summary>
     UnreadRows,
 
-    /// <summary>Histogram rows under <c>counts_only</c>. Deliberately NOT a declared accounting subject: the
-    /// histogram already discloses its own cut in both transports (a "... N more row(s)" line in text, the
-    /// <c>distinct</c> vs <c>rendered</c> pair in json), and a second statement of one fact is how a twin starts.
-    /// It is a subject HERE so that the framing lines and the rows go through the same bound as everything else.
-    /// </summary>
-    HistogramRows,
+    /// <summary>Rows of the <c>counts_only</c> dangling histogram, by TARGET plugin — the plugin the broken refs
+    /// point INTO.</summary>
+    HistogramByTarget,
+
+    /// <summary>Rows of the <c>counts_only</c> dangling histogram, by SOURCE plugin — the plugin the broken refs
+    /// come FROM (#344's axis).
+    ///
+    /// <para><b>Its own subject, and that is the point.</b> Both axes shared one for a while, and a subject is what
+    /// <see cref="BoundedBody"/> stops: when the TARGET axis closed on <c>limit=</c> it marked the shared subject
+    /// stopped, and every row of the axis below was then refused — at <c>limit=3</c> over two 200-row axes, the
+    /// SOURCE axis rendered no rows at all, at a cap 79,000 chars short of biting, under a remedy naming
+    /// <c>max_chars=</c>, a knob that would have moved nothing. One subject standing for two lane facts is the
+    /// <c>_listing</c> boolean <see cref="CheckAccounting"/> was built to retire, one level down.</para></summary>
+    HistogramBySource,
+
+    /// <summary>Rows of validate_scripts' <c>counts_only</c> histogram, by property NAME.</summary>
+    HistogramByProperty,
+}
+
+/// <summary>
+/// Which subjects are histogram axes. Deliberately NOT declared accounting subjects: an axis discloses its own cut
+/// in both transports (<see cref="HistogramCut"/>), and a second statement of one fact is how a twin starts. They are
+/// subjects at all so that an axis's framing lines and its rows go through the same bound as everything else.
+/// </summary>
+internal static class SweepSubjects
+{
+    internal static bool IsHistogram(this SweepSubject s)
+        => s is SweepSubject.HistogramByTarget or SweepSubject.HistogramBySource or SweepSubject.HistogramByProperty;
+}
+
+/// <summary>
+/// ONE histogram axis's closing fact: how many of its rows this response does not carry, and WHICH knob moves them.
+///
+/// <para>Computed once, from the emitting loop's own three facts, and consumed by BOTH transports — the text lane
+/// renders <see cref="Line"/>, the json lane writes the same two facts as fields. They used to reach it separately:
+/// text composed a sentence and json wrote nothing at all, so one cut read as a stated remedy in one transport and as
+/// a bare <c>rendered &lt; distinct</c> in the other, with no way to tell which knob had done it.</para>
+///
+/// <para>The knob is the one that STOPPED the axis. "raise limit=" over rows the response had no room for names
+/// something that moves nothing, and so does "raise max_chars=" over rows the row budget refused.</para>
+/// </summary>
+internal readonly record struct HistogramCut(int Remaining, bool ByBudget)
+{
+    /// <summary>This axis's cut, or null where it rendered every row it had.</summary>
+    internal static HistogramCut? For(int distinct, int shown, bool byBudget)
+        => shown >= distinct ? null : new HistogramCut(distinct - shown, byBudget);
+
+    /// <summary>The knob a caller raises to see these rows, spelled as the parameter is.</summary>
+    internal string Knob => ByBudget ? "max_chars" : "limit";
+
+    /// <summary>The text lane's spelling, in ONE place: it is composed twice, once to measure the room to hold back
+    /// for it and once to write it, and two spellings of one sentence is how a reserve stops covering what it
+    /// reserves for.</summary>
+    internal string Line => "  ... [" + Remaining + " more row(s) — raise " + Knob + "= to see them]\n";
 }
 
 /// <summary>

--- a/src/housecarl-mcp/SweepEmission.cs
+++ b/src/housecarl-mcp/SweepEmission.cs
@@ -37,7 +37,17 @@ internal enum SweepSubject
     /// stopped, and every row of the axis below was then refused — at <c>limit=3</c> over two 200-row axes, the
     /// SOURCE axis rendered no rows at all, at a cap 79,000 chars short of biting, under a remedy naming
     /// <c>max_chars=</c>, a knob that would have moved nothing. One subject standing for two lane facts is the
-    /// <c>_listing</c> boolean <see cref="CheckAccounting"/> was built to retire, one level down.</para></summary>
+    /// <c>_listing</c> boolean <see cref="CheckAccounting"/> was built to retire, one level down.</para>
+    ///
+    /// <para><b>Observable in the TEXT lane only, and said here rather than left to be assumed.</b> What made the
+    /// shared subject bite is <see cref="BoundedBody.Close"/>, which stops a subject after a row budget cut the axis
+    /// short. The json lane writes no closing line, so nothing there stops a subject except the budget itself —
+    /// and because the response's length only grows, a budget that refuses the first axis refuses the second anyway.
+    /// Sabotaged to share, the json lane stayed green at every arm: the split is unobservable there TODAY. It is
+    /// threaded through both transports regardless, because the alternative is a hard-coded coupling that comes back
+    /// the moment json gains any per-axis close, and because a parameter has to carry some value — the honest one
+    /// costs nothing. No arm claims to pin it in json; HISTOGRAM-AXES-CUT-INDEPENDENTLY pins the text lane, and
+    /// HISTOGRAM-JSON-STATES-THE-SAME-CUT pins what json does say about a cut.</para></summary>
     HistogramBySource,
 
     /// <summary>Rows of validate_scripts' <c>counts_only</c> histogram, by property NAME.</summary>

--- a/src/housecarl-mcp/SweepEmission.cs
+++ b/src/housecarl-mcp/SweepEmission.cs
@@ -140,11 +140,22 @@ internal readonly record struct HistogramAxis(SweepSubject Subject, IReadOnlyLis
     /// lines plus its closing disclosure. ONE reserve for the lot, because they are one thing — what this axis
     /// writes whatever the budget says.
     ///
-    /// <para>The notes used to sit outside every reserve. They are appended straight to the builder after the
-    /// header has been measured, so the overrun notice was told a fixed part up to ~184 chars smaller than the one
-    /// the response actually carried; in the band between the two it explained a cap too small for the fixed part
-    /// as a body unit overshooting, over a <c>counts_only</c> response that emitted no body unit at all — 96 caps
-    /// of a 100–6000 sweep on the null-axes lane.</para></summary>
+    /// <para>The notes used to sit outside every reserve, appended straight to the builder after the header had
+    /// been measured. That is what made the overrun notice's fixed part up to ~184 chars smaller than the one the
+    /// response carried, and in the band between the two it explained a cap too small for the fixed part as a body
+    /// unit overshooting — over a <c>counts_only</c> response that emitted no body unit at all, at 96 caps of a
+    /// 100–6000 sweep on the null-axes lane.</para>
+    ///
+    /// <para><b>What fixed THAT is the subtraction (<see cref="BoundedBody.FixedPart"/>), not this — and no arm
+    /// pins this, which is said here rather than left to be discovered.</b> Sabotaged to reserve only the closing
+    /// disclosure and write the notes straight to the builder, every arm in both guards stays green. It cannot
+    /// bite while the only noted axis is the FIRST one: its note is written before any axis has spent anything, so
+    /// holding the room and writing it early are the same thing. It is reserved anyway, because that equality is a
+    /// property of today's axis ORDER rather than of the design — a second axis carrying a note would write it
+    /// after the first axis had emptied the budget, and land past the cap. The mechanism itself is pinned at the
+    /// unit level (EMISSION-THE-FIXED-PART-IS-WHAT-THE-BODY-DID-NOT-WRITE, and EMISSION-A-RESERVE-IS-ROOM-THE-ROWS-
+    /// CANNOT-HAVE goes red when <see cref="BoundedBody.Reserve"/> holds nothing); what no fixture reaches is a
+    /// response where this term changes the answer.</para></summary>
     internal int TextFixed => NoteLine.Length + NotComputedLine.Length + TextDisclosure;
 }
 

--- a/src/housecarl-mcp/SweepEmission.cs
+++ b/src/housecarl-mcp/SweepEmission.cs
@@ -43,13 +43,19 @@ internal enum SweepSubject
 /// even measured at). Four instances of one class. Every body write now goes through <see cref="Emit"/>, and the
 /// bound is enforced by this class rather than promised by the caller.</para>
 ///
-/// <para><b>The cost is a hint; the post-check is the guarantee.</b> A caller passes a <paramref name="cost"/> only
-/// where one unit can be LARGE — a plugin object carrying three exception messages, an unread row carrying a scan
-/// error — because there the pre-test is what keeps the response inside its cap rather than one unit over it.
-/// Everywhere else the cost is zero and the pre-test degenerates to "is there room at all". What makes a silent
-/// overrun unrepresentable is the check AFTER the write: a unit that took the response past its budget stops the
-/// body, in every subject, and the accounting states what was cut. A site that under-states its cost can make the
-/// response one unit long — never silently long, and never long without saying so.</para>
+/// <para><b>Why a site that under-states its cost still cannot run away.</b> A caller passes a cost only where one
+/// unit can be LARGE — a plugin object carrying three exception messages, an unread row carrying a scan error —
+/// because there the test before the write is what keeps the response inside its cap rather than one unit over it.
+/// Everywhere else the cost is zero and the test degenerates to "is there room at all". That is enough on its own,
+/// because the response's length only ever GROWS: the first unit whose declared cost was too small takes it past
+/// the budget, and from that moment every test — in every subject, whether or not that subject has been tried —
+/// is a comparison against a length already over. So the damage of a forgotten cost is ONE unit, and it is never
+/// silent, because the accounting is a subtraction taken after emission and states what was left out either way.</para>
+///
+/// <para>An explicit "the response has gone over, stop everything" flag was written here first and then deleted:
+/// monotonic length already makes it true, so the flag could be removed with every arm still green. A conditional
+/// that cannot be fixtured honestly is the signal to delete it, not a testing gap to work around (CLAUDE.md §5 #11,
+/// PR #339's precedent).</para>
 ///
 /// <para>The header and the accounting are outside this: the header is the response's fixed part and the accounting
 /// plus boundary are RESERVED out of <c>max_chars</c> before the body renders. Those are the two things a response
@@ -61,7 +67,6 @@ internal sealed class BoundedBody
     readonly Func<int> _length;
     readonly CheckAccounting? _acct;
     readonly HashSet<SweepSubject> _stopped = new();
-    bool _over;
 
     /// <param name="acct">the accounting to register emissions with, or null for a lane that keeps no accounting
     /// (validate_scripts, whose response layer is not this branch's — it still gets the same bound).</param>
@@ -78,18 +83,15 @@ internal sealed class BoundedBody
     /// the caller's loop breaks and the accounting already knows, because the count it will report is the count of
     /// units that came back true.</summary>
     /// <param name="cost">an UPPER BOUND on what <paramref name="commit"/> will append, or 0 where the site has no
-    /// cheap way to measure one. See the class summary: the guarantee is the post-check, not this number.</param>
+    /// cheap way to measure one — see the class summary for why a zero here bounds the damage at one unit.</param>
     /// <param name="source">for <see cref="SweepSubject.DanglingEntries"/>, the plugin the entry came FROM — the
     /// by-source roster is tallied off the same registration as the count, so the two cannot disagree.</param>
     internal bool Emit(SweepSubject subject, int cost, Action commit, string? source = null)
     {
-        if (_over || _stopped.Contains(subject)) return false;
+        if (_stopped.Contains(subject)) return false;
         if (_length() + cost > _budget) { _stopped.Add(subject); return false; }
         commit();
         _acct?.Emitted(subject, source);
-        // The guarantee. A unit whose cost was understated has just taken the response past its budget: nothing
-        // more goes in, in any subject, and the accounting's subtractions report every one of them as missing.
-        if (_length() > _budget) _over = true;
         return true;
     }
 
@@ -103,14 +105,13 @@ internal sealed class BoundedBody
     /// the accounting states.</para></summary>
     internal bool Close(SweepSubject subject, int cost, Action commit)
     {
-        if (_over || _length() + cost > _budget) return false;
+        if (_length() + cost > _budget) return false;
         commit();
         _stopped.Add(subject);   // nothing follows a subject's closing disclosure
-        if (_length() > _budget) _over = true;
         return true;
     }
 
     /// <summary>Did this subject stop short? For the one caller that states the fact in its own words rather than
     /// through the accounting (validate_scripts).</summary>
-    internal bool Stopped(SweepSubject subject) => _over || _stopped.Contains(subject);
+    internal bool Stopped(SweepSubject subject) => _stopped.Contains(subject);
 }

--- a/src/housecarl-mcp/SweepEmission.cs
+++ b/src/housecarl-mcp/SweepEmission.cs
@@ -1,3 +1,5 @@
+using HousecarlCore;
+
 namespace HousecarlMcp;
 
 /// <summary>
@@ -92,6 +94,40 @@ internal readonly record struct HistogramCut(int Remaining, bool ByBudget)
 }
 
 /// <summary>
+/// ONE counts_only histogram axis, as both the RESERVE and the RENDER need it.
+///
+/// <para>They read the same object for the same reason the cut line has one spelling: a reserve is a promise about
+/// a specific sentence, and room measured off a different title or a different row count is not a reserve for the
+/// sentence that gets written. Handing the two a single value makes them the same sentence by construction rather
+/// than by two call sites agreeing.</para>
+/// </summary>
+/// <param name="Rows">the axis's tally, or null where the mode was not requested — an ABSENT axis and an EMPTY one
+/// are different answers and must not render alike (Q3).</param>
+/// <param name="NotComputed">what to say instead when <paramref name="Rows"/> is null: the axis's whole answer, and
+/// fixed text that does not grow with the findings.</param>
+internal readonly record struct HistogramAxis(SweepSubject Subject, IReadOnlyList<SweepCount>? Rows, string Title,
+                                              string? Note = null, string? NotComputed = null)
+{
+    /// <summary>The axis's section head. Ridden by its first row, so a title never stands over nothing.</summary>
+    internal string Head => "\n" + Title + " (" + (Rows?.Count ?? 0) + " distinct):\n";
+
+    /// <summary>What an axis with nothing to tally says. Two axes that both came back empty rendered as two
+    /// identical untitled sentences before the title rode this too, with no way to tell which was which — or that a
+    /// second axis existed at all.</summary>
+    internal string EmptyLine => "\n" + Title + ": nothing to tally — no findings in the swept scope.\n";
+
+    /// <summary>The axis's IRREDUCIBLE DISCLOSURE, in text-lane characters: the widest thing
+    /// <see cref="BoundedBody.Close"/> can be asked to write for it, which is its head plus a cut line naming
+    /// every row — the case where the budget admitted no rows at all. An axis that renders some of its rows
+    /// discloses in less than this, and an axis that renders all of them gives the room back
+    /// (<see cref="BoundedBody.Release"/>).</summary>
+    internal int TextDisclosure
+        => Rows is null ? 0
+         : Rows.Count == 0 ? EmptyLine.Length
+         : Head.Length + new HistogramCut(Rows.Count, ByBudget: true).Line.Length;
+}
+
+/// <summary>
 /// THE ONE PLACE either sweep transport appends anything the caller's <c>max_chars</c> can refuse.
 ///
 /// <para><b>Why one helper rather than a test per write site.</b> Boundedness used to be asserted at each site, so
@@ -107,17 +143,33 @@ internal readonly record struct HistogramCut(int Remaining, bool ByBudget)
 /// Everywhere else the cost is zero and the test degenerates to "is there room at all". That is enough on its own,
 /// because the response's length only ever GROWS: the first unit whose declared cost was too small takes it past
 /// the budget, and from that moment every test — in every subject, whether or not that subject has been tried —
-/// is a comparison against a length already over. So the damage of a forgotten cost is ONE unit, and it is never
-/// silent, because the accounting is a subtraction taken after emission and states what was left out either way.</para>
+/// is a comparison against a length already over. So the damage of a forgotten cost is ONE unit.</para>
+///
+/// <para><b>Why that damage is never SILENT, stated as it actually holds.</b> A response has exactly two ways of
+/// telling a caller what it left out, and the guarantee is that neither of them is emitted through this helper:
+/// <list type="bullet">
+/// <item>the ACCOUNTING — a subtraction against the sweep's own totals, taken after emission stops, computed from
+/// the subjects the lane DECLARED (<see cref="CheckAccounting"/>) and written inside a reserve; and</item>
+/// <item>a subject's OWN CLOSING DISCLOSURE — the line that says how much of that subject did not fit, written by
+/// <see cref="Close"/> out of room <see cref="Reserve"/> held back before the body rendered.</item>
+/// </list>
+/// This paragraph used to name only the first, and read it as covering everything: "the accounting states what was
+/// left out either way". It does not. The histogram axes are deliberately NOT declared accounting subjects (see
+/// <see cref="SweepSubjects"/>), so for them the first route does not exist — and the second was budget-gated like
+/// a row, which means the pressure that cut the rows also cut the line reporting the cut. A whole
+/// <c>counts_only</c> axis therefore left the response with nothing anywhere saying so, at every cap in a wide band
+/// (#392). A disclosure that the budget can refuse is not a disclosure, so it is now part of the response's fixed
+/// part like the header and the accounting: reserved first, written unconditionally.</para>
 ///
 /// <para>An explicit "the response has gone over, stop everything" flag was written here first and then deleted:
 /// monotonic length already makes it true, so the flag could be removed with every arm still green. A conditional
 /// that cannot be fixtured honestly is the signal to delete it, not a testing gap to work around (CLAUDE.md §5 #11,
 /// PR #339's precedent).</para>
 ///
-/// <para>The header and the accounting are outside this: the header is the response's fixed part and the accounting
-/// plus boundary are RESERVED out of <c>max_chars</c> before the body renders. Those are the two things a response
-/// is never allowed to drop, which is exactly why they are not emitted through a helper that can refuse.</para>
+/// <para>The FIXED PART is outside this helper entirely: the header, every reserved closing disclosure, the
+/// accounting and the boundary. Those are the things a response is never allowed to drop, which is exactly why
+/// none of them is emitted through a helper that can refuse. What a cap too small for the fixed part gets is an
+/// overrun that SAYS SO (<see cref="CheckAccounting.CapTooSmall"/>), never a shorter response with less in it.</para>
 /// </summary>
 internal sealed class BoundedBody
 {
@@ -125,6 +177,7 @@ internal sealed class BoundedBody
     readonly Func<int> _length;
     readonly CheckAccounting? _acct;
     readonly HashSet<SweepSubject> _stopped = new();
+    readonly Dictionary<SweepSubject, int> _held = new();
 
     /// <param name="acct">the accounting to register emissions with, or null for a lane that keeps no accounting
     /// (validate_scripts, whose response layer is not this branch's — it still gets the same bound).</param>
@@ -147,27 +200,58 @@ internal sealed class BoundedBody
     internal bool Emit(SweepSubject subject, int cost, Action commit, string? source = null)
     {
         if (_stopped.Contains(subject)) return false;
-        if (_length() + cost > _budget) { _stopped.Add(subject); return false; }
+        if (_length() + cost + Held > _budget) { _stopped.Add(subject); return false; }
         commit();
         _acct?.Emitted(subject, source);
         return true;
     }
 
-    /// <summary>Emit a subject's own CLOSING DISCLOSURE — the line that says how much of it did not fit. It is not
-    /// a unit, so it is not registered and it is not refused because the subject stopped: a subject that stopped is
-    /// exactly when this has to be said. The budget still applies, and the room for it is what the caller held back
-    /// while emitting the units.
+    /// <summary>Hold back the room one subject's CLOSING DISCLOSURE will need, BEFORE any unit is emitted. Every
+    /// emission test then has to leave that room standing, so by the time the subject closes, what it writes is
+    /// already paid for.
     ///
-    /// <para>Without this it was refused by its own subject's stop flag, and a histogram cut by max_chars rendered
-    /// its rows and then said nothing about the ones it had dropped — the silent cut, one level down from the one
-    /// the accounting states.</para></summary>
-    internal bool Close(SweepSubject subject, int cost, Action commit)
+    /// <para>Reserving is what makes the disclosure unrefusable, and it has to happen before the FIRST unit of ANY
+    /// subject: an axis that reserved its own room after a sibling had already spent the budget would be the exact
+    /// silence this exists to remove.</para></summary>
+    internal void Reserve(SweepSubject subject, int cost)
     {
-        if (_length() + cost > _budget) return false;
+        _held[subject] = cost;
+        ReservedTotal += cost;
+    }
+
+    /// <summary>Everything ever reserved here, spent or not. It is the part of the response's fixed part that the
+    /// header does not carry, so the overrun notice needs it to tell a cap too small for the fixed part from a body
+    /// unit that ran past what was left after the fixed part fit.</summary>
+    internal int ReservedTotal { get; private set; }
+
+    /// <summary>Room reserved and not yet spent. Held against every emission test, including tests of the subject
+    /// that reserved it — a subject may spend the budget on its rows, never on its own disclosure.</summary>
+    int Held
+    {
+        get { int n = 0; foreach (var v in _held.Values) n += v; return n; }
+    }
+
+    /// <summary>Write a subject's own CLOSING DISCLOSURE — the line that says how much of it did not fit. It is not
+    /// a unit, so it is not registered, and it is <b>NEVER REFUSED</b>: not because the subject stopped (a subject
+    /// that stopped is exactly when this has to be said), and not on the budget either. The room came out of
+    /// <see cref="Reserve"/> before the body rendered, which is what makes writing it unconditionally safe rather
+    /// than merely hopeful.
+    ///
+    /// <para>It used to take a budget, and a subject whose rows the budget refused had its disclosure refused by
+    /// the same pressure — the whole axis then left the response with nothing saying it had ever existed. A
+    /// disclosure a budget can refuse is not a disclosure (#392).</para></summary>
+    internal void Close(SweepSubject subject, Action commit)
+    {
+        _held.Remove(subject);   // spent here, and only here
         commit();
         _stopped.Add(subject);   // nothing follows a subject's closing disclosure
-        return true;
     }
+
+    /// <summary>Give a subject's reserved room back UNSPENT — for the subject that turned out to have nothing to
+    /// disclose, because it rendered everything it had. Without this the room stays held against every later
+    /// subject's emission test, and the subjects after a complete histogram would pay for a sentence nobody
+    /// wrote.</summary>
+    internal void Release(SweepSubject subject) => _held.Remove(subject);
 
     /// <summary>Did this subject stop short? For the one caller that states the fact in its own words rather than
     /// through the accounting (validate_scripts).</summary>

--- a/src/housecarl-mcp/SweepEmission.cs
+++ b/src/housecarl-mcp/SweepEmission.cs
@@ -1,0 +1,116 @@
+namespace HousecarlMcp;
+
+/// <summary>
+/// The countable things a sweep response can carry. A lane DECLARES the subjects it has
+/// (<see cref="CheckAccounting"/>), and every sentence about what is missing is computed from a declared subject
+/// — so a lane without sections cannot claim about sections, and a lane with them cannot fail to.
+///
+/// <para>These are LANE FACTS, not a findings taxonomy: "how many plugin sections did this response render" is a
+/// question about the render, and it stays the same question whatever classes of finding the sections carry. The
+/// merged <c>check</c> surface's families are a separate design (SPEC §6.1) and no enum here anticipates them.</para>
+/// </summary>
+internal enum SweepSubject
+{
+    /// <summary>Dangling references listed one line at a time. The only subject the listing budget (<c>limit=</c>)
+    /// can also drop, which is why it is the only one whose omission is decomposed into two causes.</summary>
+    DanglingEntries,
+
+    /// <summary>Per-plugin report sections. Present in every LISTING lane, including one where <c>findings=</c>
+    /// excluded 'dangling' and there are no entries at all — the render still cuts sections there.</summary>
+    PluginSections,
+
+    /// <summary>Rows of the excluded-plugin roster: the plugins the index could not parse.</summary>
+    ExcludedRows,
+
+    /// <summary>Rows of the <c>counts_only</c> honesty layer: the plugins whose records could not be read.</summary>
+    UnreadRows,
+
+    /// <summary>Histogram rows under <c>counts_only</c>. Deliberately NOT a declared accounting subject: the
+    /// histogram already discloses its own cut in both transports (a "... N more row(s)" line in text, the
+    /// <c>distinct</c> vs <c>rendered</c> pair in json), and a second statement of one fact is how a twin starts.
+    /// It is a subject HERE so that the framing lines and the rows go through the same bound as everything else.
+    /// </summary>
+    HistogramRows,
+}
+
+/// <summary>
+/// THE ONE PLACE either sweep transport appends anything the caller's <c>max_chars</c> can refuse.
+///
+/// <para><b>Why one helper rather than a test per write site.</b> Boundedness used to be asserted at each site, so
+/// the unbounded ones were found one at a time and each fix bred a sibling: the json plugin head (7,296 chars
+/// against a 5,270 cap), then its exact twin the <c>counts_only</c> unread roster (9,823 against 8,000), then the
+/// histogram framing lines, then the json excluded roster (1,188 chars past, written above the point the header is
+/// even measured at). Four instances of one class. Every body write now goes through <see cref="Emit"/>, and the
+/// bound is enforced by this class rather than promised by the caller.</para>
+///
+/// <para><b>The cost is a hint; the post-check is the guarantee.</b> A caller passes a <paramref name="cost"/> only
+/// where one unit can be LARGE — a plugin object carrying three exception messages, an unread row carrying a scan
+/// error — because there the pre-test is what keeps the response inside its cap rather than one unit over it.
+/// Everywhere else the cost is zero and the pre-test degenerates to "is there room at all". What makes a silent
+/// overrun unrepresentable is the check AFTER the write: a unit that took the response past its budget stops the
+/// body, in every subject, and the accounting states what was cut. A site that under-states its cost can make the
+/// response one unit long — never silently long, and never long without saying so.</para>
+///
+/// <para>The header and the accounting are outside this: the header is the response's fixed part and the accounting
+/// plus boundary are RESERVED out of <c>max_chars</c> before the body renders. Those are the two things a response
+/// is never allowed to drop, which is exactly why they are not emitted through a helper that can refuse.</para>
+/// </summary>
+internal sealed class BoundedBody
+{
+    readonly int _budget;
+    readonly Func<int> _length;
+    readonly CheckAccounting? _acct;
+    readonly HashSet<SweepSubject> _stopped = new();
+    bool _over;
+
+    /// <param name="acct">the accounting to register emissions with, or null for a lane that keeps no accounting
+    /// (validate_scripts, whose response layer is not this branch's — it still gets the same bound).</param>
+    /// <param name="budget">the chars the BODY may occupy: the caller's max_chars less the accounting's reserve.</param>
+    /// <param name="length">what the response has emitted so far, in the transport's own unit.</param>
+    internal BoundedBody(CheckAccounting? acct, int budget, Func<int> length)
+    {
+        _acct = acct;
+        _budget = budget;
+        _length = length;
+    }
+
+    /// <summary>Emit one unit of <paramref name="subject"/>, or refuse. Returns false when the unit did not fit —
+    /// the caller's loop breaks and the accounting already knows, because the count it will report is the count of
+    /// units that came back true.</summary>
+    /// <param name="cost">an UPPER BOUND on what <paramref name="commit"/> will append, or 0 where the site has no
+    /// cheap way to measure one. See the class summary: the guarantee is the post-check, not this number.</param>
+    /// <param name="source">for <see cref="SweepSubject.DanglingEntries"/>, the plugin the entry came FROM — the
+    /// by-source roster is tallied off the same registration as the count, so the two cannot disagree.</param>
+    internal bool Emit(SweepSubject subject, int cost, Action commit, string? source = null)
+    {
+        if (_over || _stopped.Contains(subject)) return false;
+        if (_length() + cost > _budget) { _stopped.Add(subject); return false; }
+        commit();
+        _acct?.Emitted(subject, source);
+        // The guarantee. A unit whose cost was understated has just taken the response past its budget: nothing
+        // more goes in, in any subject, and the accounting's subtractions report every one of them as missing.
+        if (_length() > _budget) _over = true;
+        return true;
+    }
+
+    /// <summary>Emit a subject's own CLOSING DISCLOSURE — the line that says how much of it did not fit. It is not
+    /// a unit, so it is not registered and it is not refused because the subject stopped: a subject that stopped is
+    /// exactly when this has to be said. The budget still applies, and the room for it is what the caller held back
+    /// while emitting the units.
+    ///
+    /// <para>Without this it was refused by its own subject's stop flag, and a histogram cut by max_chars rendered
+    /// its rows and then said nothing about the ones it had dropped — the silent cut, one level down from the one
+    /// the accounting states.</para></summary>
+    internal bool Close(SweepSubject subject, int cost, Action commit)
+    {
+        if (_over || _length() + cost > _budget) return false;
+        commit();
+        _stopped.Add(subject);   // nothing follows a subject's closing disclosure
+        if (_length() > _budget) _over = true;
+        return true;
+    }
+
+    /// <summary>Did this subject stop short? For the one caller that states the fact in its own words rather than
+    /// through the accounting (validate_scripts).</summary>
+    internal bool Stopped(SweepSubject subject) => _over || _stopped.Contains(subject);
+}


### PR DESCRIPTION
## `check_errors`: the response says what it is missing, stays inside `max_chars`, and `exclude=` lands

Fixes #361. Fixes #344. Fixes #392.

### The second review's fold, in one paragraph

The response-accounting layer this branch builds computed omission claims instead of guessing them, and cured a
matched pair of hand-kept constants at the json writer by MEASURING the framing. Aaron's second review found the
same disease alive one level up: the overrun discriminator's inputs were SUMMED from components captured at
different moments — a header measured before the histogram axes wrote their notes, a reserve total that still
counted room `Release` had given back, and a lane's whole json entry slack. The rule that came out of it is pinned
where the discriminator lives: **every quantity it reads is MEASURED, none derived.** The fixed part is now the
finished response minus what the emitter let through, so nothing enumerates the unconditional write sites and none
can be forgotten. Measured consequences: a 96-cap band that shipped the wrong overrun explanation is 0 caps; the
"raise `max_chars=` to at least N" number went from 234 chars over the true smallest fitting cap in text and 1,278
(85%) in json to 8 and 7; and a `counts_only` lane that cannot write an accounting line stopped reserving 186
characters for one. Full record, with both sabotage sweeps and the live re-measurement, in
[the fold comment](https://github.com/Avick3110/houseCARL/pull/391#issuecomment-5368934947).

### Scope, and what this is NOT

This is **4a** of RUN_ORDER row 4's 2026-08-20 split: the `check_errors` response layer, the `exclude=`
pole, and #361. **It does not complete W3.** W3 completes at **4b**, the `check` merge per SPEC §6.1
(`check_errors` + `validate_scripts`, the dialogue classes 1–7 fold, the `findings=` taxonomy,
zero-capability-loss verification), which is its own kickoff and inherits this accounting. Row 4's other
rider, **#302** (insert-at-index), is untouched here and stays its own small PR.

Settled decisions this branch was built under, unchanged: render-aware omission accounting from one shared
source for both formats; the vanilla BASELINE stays Mutagen's `BaseMasters` exactly; `exclude=` is the
caller's own scope subtraction and does not redefine the baseline; **no three-family machinery** — that is
4b's design input, and nothing here anticipates it.

### What changed

**One accounting, built from the subjects a lane has.** Omission claims are subtractions against the
sweep's own totals, taken after emission stops, so there is one number and one source for it. The lane
declares which subjects it has — dangling entries, plugin sections, excluded rows, unread rows — and every
sentence, json field, remedy and reserve derives from that set. A lane without sections cannot claim about
sections; a lane with them cannot fail to.

**One bounded write path.** Every body write goes through `BoundedBody.Emit`. The header is the response's
fixed part and the accounting plus boundary are reserved out of `max_chars` before the body renders; those
two are the only things a response may never drop, which is why they are not emitted through a helper that
can refuse.

**`exclude=`** (#344's second stage) takes plugin filenames or the group tokens `base_masters` /
`implicit`, applied at the SWEEP so an excluded plugin costs no walk and no `limit=` budget.

### The review rounds, the stop, and why the greens were not evidence

**Round 1** (pre-fold, previous session) — folded findings across three areas: the text sections clause
gated on the listing flag, a `Missing()` that ignored dropped sections, `counts_only` json emitting listing
fields, the json plugin-object head unbounded before its budget test, `counts_only` histograms bounded by
`limit=` only, and an `exclude=` end-to-end gap that was **neither fixed nor declared dropped**.

**Round 2** — returned the same three failure classes. §5 #11's class-stop fired. The advisor ruled: stop,
fold nothing, hand the fold to a fresh session, and **repair the verification before folding anything**.
Three of round 2's six class-A instances had been created by round 1's own folds.

**Why `ci-all` green on this branch was not evidence.** The flagship cell —
`RESPONSE-NEVER-EXCEEDS-MAX-CHARS (#361)` — excused any overrun in a response containing "raise it to at
least". `CheckAccounting.CapTooSmall` returns non-null for **every** response longer than its cap, and both
renders append that notice whenever it is non-null, so an over-cap response always carried the phrase and
the second conjunct was dead. The json twin had the identical shape with `max_chars_overrun`. The cell was
a tautology for the whole of two review rounds, and the two round-1 folds it was meant to pin — the json
plugin-head cost and the honesty-tail budgets — were pinned by nothing. **Two sabotage sweeps had run
during the build phase, both all-RED, and neither said anything about the arm that mattered.**

**No round 3.** This is a directed completion under the advisor's ruling, not a fourth pass of the loop.

### The harness repair, done first

- The cap invariant now asserts a **fixture-known length**: each response is held to `max(cap, floor +
  slack)`, where the floor is the fixture's own irreducible response (rendered at a cap no body fits under)
  and the slack is the cap's digit width times the places `max_chars` is printed. The ladder stepped
  3000 → 8000, straight over the band the fat-head fixture bites in; it now walks 4000–7000.
- `FLOOR-IGNORES-BODY-SIZE` stands beside it, because a floor measured off the fixture under test is
  inflated by any unbounded write site — and an inflated floor excuses the overrun it was measuring. Four
  pairs of results differ only in how many characters their rows carry; every printed number is identical,
  so the two floors must be exactly equal. **No slack, because none is owed.**
- The assertion rule is pinned in the guard's header: *an invariant arm asserts against a fixture-known
  expected value — never against a phrase the render itself emits.*
- `exclude=` gained an end-to-end wire block: tool → service → core over a synthetic MO2 instance, by name,
  by both group tokens, in both transports, on a refusal, and on a composition read that fails.
- Class-C cells repaired: a substring match that passed over any figure, a dead disjunct
  (`!x.Contains(n) == false`, true of the uncut response) under a label promising a json check it never
  made, two byte-identical group calls so nothing proved a token removes anything, a case-insensitivity
  cell that only tested the name-shape helper, an unpinned `unread` subject, unpinned honesty-tail budgets.

### What the repaired harness then found

Three cells went RED against the product before any fix, and the first sabotage sweep found a fourth:

| defect | measured |
|---|---|
| histogram title / empty-case / "more rows" framing bypassed the budget | present at a cap that admits no rows |
| `exclude=` note reported the expanded group size, not the scope loss | "left out 5 plugin(s)" over a sweep that removed none |
| **json excluded roster written with no bound at all**, above the point the header is measured | 1,188 chars past on three 400-char reasons; the text lane bounded the same roster |
| json histogram rows unbounded changed nothing any arm could see | the counts_only fixture's axes fit inside the floor at every cap |

### Sabotage sweeps

Both from a committed state, each carrying a **known-RED canary** (the round-2 reviewer's json plugin-head
reproduction).

- **Sweep 1** (repaired harness, pre-fold): canary RED, 10 of 11 cells RED. The one GREEN — unbounding both
  json histogram row loops — was a real fixture gap and was closed.
- **Sweep 2** (folded product, 18 cells over both guards): canary RED, **18 of 18 RED, no green cells.**
  Two intermediate greens were each acted on rather than accepted:
  - Removing the emitter's stop-everything flag stayed green **including against an arm written for it** —
    because monotonic length already made it true. **The conditional was deleted, not tested around**
    (§5 #11; PR #339's precedent).
  - The "widest of the plain and escaped spelling" roster ranking stayed green when reverted — because
    escaping only ever adds characters, so that rule produces the identical order and the fix was a no-op.
    Each reserve now ranks in its own lane's encoding, and the fixture carries twelve sources for a ten-row
    roster with the long ASCII names at the largest counts. Reverting it now overruns the text cap by
    300+ chars at eight caps.

### Triage and refusals

This was a directed fold of the handoff's rosters, not a review round: every instance was re-verified at
source before folding, and most were reproduced by measurement. Nothing was refused as non-reproducing.
**Two items were refused as stated and refined instead**, with grounds:

1. *"The `exclude=` parameter description still says a name nothing in scope matches is refused."* Half
   wrong: a **typed filename** that matches nothing IS refused, and correctly. What over-claimed was the
   sentence's silence about group members, which are dropped rather than refused. The wording now separates
   the two rather than removing the claim.
2. *"The changelog attributes '530 of 4996' to the old render; 530/537 is the new one."* The number was
   wrong in the other direction too: the sentence's subject is the OLD render, whose visible count was 554,
   so the honest fix is "554 of 4996". The new render's own figure is **538**, measured, not 537.

One item is fixed but named as reasoned-from-source rather than measured: nothing in the fixture set proves
the live order carries a non-ASCII plugin filename. The arm is synthetic and says so.

### Live-order measurements

MO2 instance `E:\Skyrim Modding\ARR 2.0`, 3800 plugins, 4996 dangling refs, plain defaults
(`limit=1000`, `max_chars=80000`), driven through the tool layer by `check-measure`.

| cell | `main` @ `fab249f` | this branch |
|---|---|---|
| A whole-order text | 81,678 (**+1,678 over cap**), 554 visible | 79,600, "538 of the 4996", 67 of 137 sections stated |
| B whole-order json | 80,894 (**+894**), 304 visible | 78,885, 307 visible |
| C counts_only text | 10,530 | 10,530 |
| D one plugin, text | 80,984 (**+984**), **no notice at all**, 644 visible under a line implying 1000 | 79,800, "633 of the 2591" |
| E one plugin, json | **202,425 (+122,425)**, `truncated: false` | 79,112, `truncated: true` |

C is back to `main`'s figure: the counts_only lane was reserving ~700 chars for a roster it never renders.

### Verification

`ci-all` **124/124**. `check-errors-guard` **126 arms**, all pass. `script-property-check-guard` **38 arms**,
all pass. (Counts after the directed revision below; they were 119 and 37 after the fold of the four inline
review findings, and 113 / 36 before it.)

### The post-fold review round, and why one was run after a directed fold

One bounded round, run at Aaron's direction as an explicit exception to §5 #11's "no new rounds after directed folds".
**The ground:** rounds 1 and 2 reviewed *pre-fold* code through a harness whose flagship cell was a tautology
(`RESPONSE-NEVER-EXCEEDS-MAX-CHARS` excused any overrun containing "raise it to at least"), so their greens were
void as evidence. The merge-state code had never been seen fresh through a working harness. This round is that
first look, not a fourth pass of the loop.

Three fresh reviewers, each in its own worktree (`isolation: "worktree"`), over the full diff vs `main` @ `fab249f`,
seeded with the settled-decisions list and nothing else — no mention of the four inline findings, of the earlier
rounds, or of where the conductor thought the risk sat. Lenses: **correctness**, **harness + output bounds**
(sabotage-driven), **caller contract**.

**Outcome at the time: STOP and escalate under §4. Nothing was folded.** The escalation was ruled on and its
revision taken; what follows below is the completion of it, and every row of this table is dispositioned there.

**Outcome: STOP and escalate under §4. Nothing was folded.** Two findings land in the classes that make another
fold the wrong instrument, and they are the two the round was most needed for:

| sev | finding | who found it |
|---|---|---|
| HIGH | a whole `counts_only` histogram axis drops from the text lane with nothing saying so, while the json twin reports the cut | **all three, independently, on three different fixtures** |
| HIGH | `HISTOGRAM-REMEDY-NAMES-ITS-CAUSE` computes `cutSource` and never asserts it — asserting it would have gone red on the HIGH above at authoring time | harness |
| MEDIUM | `JsonWire.RootClose = 2` is one short (indented `Utf8JsonWriter` writes `\r\n}` here, measured cost **3**), so a json document of exactly `cap + 1` reads as `cap` and no notice fires | correctness |
| MEDIUM | `SweepRemedyCountsOnly` offers `counts_only=true` as the remedy for a roster, and at the same `max_chars` that mode prints no by-source tally at all | contract |
| MEDIUM | json's `dangling_not_listed_by_source` (top-level, 200 rows) is gone, replaced by `accounting.dangling_missing_by_source` (10 rows), with no changelog line | contract |
| LOW ×5 | `validate_scripts` json roster still unbounded while the changelog names the tool not the format; json roster reports `0 of 3` inside its cap; plain-only reserve ranking (the json half of that conditional) stays green under sabotage; `Emit`'s `_stopped` short-circuit is unobservable; `EmittedAll` unreferenced with a stale doc | contract, harness, correctness |

**The `RootClose` pair is why the harness verdict matters.** `OverrunNoticeCost` subtracts 2 where the wrapper truly
costs 3, over-counting by the same 1. The two errors cancel in the *stated* length, so
`OVERRUN-NOTICE-STATES-THE-WHOLE-RESPONSE` stays green while the *trigger* comparison stays one short — two arms
held green by a matched pair of off-by-ones, both of them arms this session strengthened.

**What the round confirmed sound.** The harness reviewer replaced `CapLadder` with **every integer from 1 to 12000**
across all eight fixtures in both transports and found **no overrun** — the three measured-cost sites
(`PluginHeadCost`, `UnreadRowCost`, `ExcludedRowCost`) are all load-bearing, each going red under sabotage. Its
inventory ran **20 sabotages, 15 red**; the five greens are reported above or are cases where green is the correct
answer. The contract reviewer followed `"raise it to at least N"` mechanically across 4 fixtures × 9 caps × both
transports: every notice cleared on the first raise. The two overrun sentences discriminate correctly. The
`exclude=` arithmetic, both its refusals, the two-cause decomposition, the baseline gate and the per-lane field
presence all held.

**Triage and refusal rate.** Every finding was verified at source before being recorded, and the two cheapest to
falsify were re-measured independently by the conductor: `RootClose`'s true cost (3, by direct measurement) and the
unasserted `cutSource` (read at `CheckErrorsProbe.cs:1406-1409`). **Nothing was refused as non-reproducing** — 0 of
11. Stating why, since a 100% acceptance rate is normally the triage-health alarm: three reviewers with disjoint
lenses converged on one HIGH from three separate fixtures, the rest were verified line by line, and — the part that
defuses the alarm — **nothing was folded**, so no unverified finding could reach the code. The refusal rate is a
guard against bad folds, and there were no folds. One reviewer declined to report `validate_scripts`' pre-existing
unbounded boundary tail as out of this branch's charter, which is the discipline working.

### The directed revision - the escalation's Y-prime, taken

The §4 escalation's proposed revision was ruled on and **taken**, and this is the completion of it. No review
rounds: a directed fold under a ruling, per §5 #11's "no new rounds after directed folds".

**Y-prime, as shipped.** A subject's closing disclosure joins the response's fixed part. `BoundedBody.Reserve`
holds each subject's closing line out of `max_chars` before anything is emitted; every emission test has to leave
that room standing; `Close` spends it and **cannot refuse**; `Release` gives it back when the subject rendered
everything it had. Both transports and `validate_scripts`' twin — the text lane reserves an axis's head plus its
widest cut line, the json lane reserves the axis object's frame, both measured off one `HistogramAxis` value so a
reserve and the sentence it reserves for cannot be different sentences. The reserve joins `headerLength` in what
`CapTooSmall` is told the fixed part costs, so a cap too small for the disclosures gets the fixed-part
explanation rather than the body-overshoot one.

`BoundedBody`'s safety argument said "the accounting is a subtraction taken after emission and states what was
left out either way". That was the false step — the histogram axes are not declared accounting subjects, so for
them that route does not exist. The docstring now names **both** disclosure routes, says which one the histogram
axes have, and says why a budget-gated one is not a disclosure at all.

**#392 is closed by this branch** (`Fixes #392` above): it was a regression this branch introduced, and this
revision is what closes it.

**The matched constants.** `JsonWire.RootClose = 2` and `OverrunNoticeCost`'s `- 2` were two hand-kept numbers
compensating each other: an indented writer closes the root in 3 characters, and the notice also owes a separator
the scratch document never wrote. The stated length stayed right while the comparison that decides whether a
notice fires at all stayed one short, so a json document of exactly `cap + 1` read as `cap` and said nothing.
Both now come off ONE measurement of the writer (`MeasureFraming` writes two byte-identical properties into a
root object and takes the deltas), so they cannot drift apart again. `JSON-ONE-CHAR-OVERRUN-IS-DECLARED` is the
arm: its cap is a fixture-known length — a result with no droppable body renders to one document at any cap, so
that document's length minus one is a cap it is over by exactly one character. RED before the fix, GREEN after,
and RED again under sabotage of either half of the shared derivation.

**`cutSource` is asserted.** `HISTOGRAM-REMEDY-NAMES-ITS-CAUSE` computed it and never looked at it — the same
"one substring over the whole response" hole the arm was rewritten to close, left open one axis over. Both axes
are now asserted, in both directions.

### The json shape change: intended, and no longer silent

`dangling_not_listed_by_source` (top-level, 200 rows) is gone; the roster is
`accounting.dangling_missing_by_source` (10 rows) with `accounting.dangling_missing_by_source_total` beside it.
**The rename was intended** — one shared source for every omission claim is this branch's chartered decision, and
a roster written from a second source could disagree with the counts next to it. **The 200 -> 10 reduction was
not separately decided; it fell out of reusing the text line's roster cap** — and it is kept, because the same
charter forces it. Measured:

| roster rows reserved | json fixed part | text fixed part |
|---|---|---|
| 10 | 2,812 | 2,004 |
| 200 | **20,864** | **9,361** |

Measured on a listing sweep whose findings come from 200 source plugins. The accounting is reserved out of
`max_chars` before the body renders, so a 200-row roster is 18,052 characters held back from **every** response
whether or not anything was dropped — 23% of the default cap, and more than a small cap has in total. On `main`
that roster was unreserved and could overrun the cap, which is half of what #361 is. It now rides in
`plugin/CHANGELOG.md` with the measurement and with what to do instead (`..._total` for the count, `plugins=` for
the rest).

### The five LOWs - fixed or dropped, stated either way

| # | LOW | disposition |
|---|---|---|
| 1 | `validate_scripts` json roster unbounded while the changelog names the tool | **Fixed** — the entry now names the TEXT render and says json makes no such claim. Bounding json's copy is that lane's response layer, outside this branch. |
| 2 | json roster reports `0 of 3` inside its cap | **Dropped**, with the measurement rather than an opinion: three unparseable plugins at `max_chars=8000` returns 6,803 chars and names none of them. The room is the gap between the worst-case accounting reserve and the accounting actually written, and the reserve is taken before the body renders, when the real numbers do not exist yet. Closing it means reordering the response so the roster precedes the entries, or reserving a roster with no bound on its size — design changes outside a directed revision. The response is honest about the state it is in: 0 of 3 named, and it names the knob. |
| 3 | the json half of the per-lane reserve ranking stays green under sabotage | **Fixed (documented)**, verified both directions this session: ranking both lanes by the ESCAPED spelling overruns the text cap at eight caps by 300+ chars; ranking both by the PLAIN spelling leaves every arm in both guards green. The docstring now says which half is pinned, which is not, and why the unpinned one is kept. |
| 4 | `Emit`'s `_stopped` short-circuit is unobservable | **Fixed** — it is no longer a redundancy of monotonic length: releasing a sibling's reserve lowers what every test must leave standing, so the budget alone would let a stopped subject back in. `EMISSION-A-STOPPED-SUBJECT-STAYS-STOPPED` drives it directly and goes RED when the flag is removed. |
| 5 | `EmittedAll` unreferenced with a stale doc | **Fixed** — deleted. Its doc described a json path that no longer exists. |

Nothing was filed: per CLAUDE.md §2 a low found reviewing our own branch is fixed on the branch or dropped.

### The sabotage sweep over the revision

Eight cells, scripted, each from a **committed** state, carrying the round-2 reviewer's json plugin-head
reproduction as the **known-RED canary** (cell 0). Every restore ran through `HOUSECARL_ALLOW_DIRTY_RESTORE`
naming each file it discarded, after reading the hook's own deny message, and each restore was verified by
grepping for a string the fold had introduced.

| cell | verdict |
|---|---|
| CANARY - json plugin head cost forced to 0 | **RED** |
| `Close` budget-gated again (the pre-revision behaviour) | **RED**, 4 arms, including both `HISTOGRAM-AXIS-NEVER-DROPS-SILENTLY` |
| `Reserve` holds nothing | **RED** |
| `Release` frees nothing | **RED** |
| text lane: the disclosure reserve left out of the fixed part | GREEN -> acted on -> **RED** |
| json lane: axis frames not reserved | **GREEN, kept and reported** |
| the empty axis's line back through the refusable path | GREEN -> acted on -> **RED** |
| the `shown == 0` close writes the cut line without its head | **RED**, 4 arms |

Two further RED-checks outside the sweep: removing the stopped-subject short-circuit (LOW 4's arm), and both
directions of the per-lane reserve ranking (LOW 3).

**The three greens, each acted on rather than accepted:**

- *The disclosure reserve left out of the fixed part* was a real defect nothing could see: the caps between
  "header plus accounting fits" and "header plus accounting plus disclosures fits" were told the fixed part fit
  and a body unit overshot, on a response that wrote no body unit at all. New arm
  `OVERRUN-IN-THE-TEXT-LANE-IS-ALWAYS-A-CAP-TOO-SMALL` — in the text lane every unit is measured before it is
  written, so a body overshoot is impossible there and "longer than its cap" and "the cap could not hold the
  fixed part" are the same statement. json is deliberately not swept by it: its entries carry no measured cost
  by design, so the claim would be false about that lane. The cell is RED after the arm.
- *The empty axis's "nothing to tally"* is that axis's whole answer; losing it leaves "found nothing" looking
  like "never computed". New arm `HISTOGRAM-EMPTY-AXIS-IS-NEVER-DROPPED`, every cap from 200 to 4000. RED after.
- *The json axis frames* have **no honest fixture**: the two frames are about 180 bytes and the json slack is
  1024, so the room sized for one whole entry absorbs them at every cap a fixture can reach. Kept anyway —
  bounding a write site by slack sized for something else is the posture that produced four unbounded write
  sites in a row — and the docstring now states that no arm pins it in that lane and names the text-lane arms
  that pin the guarantee it belongs to. **This cell stays green and is reported as green.**

### Re-measured after the revision

**Live order**, `E:\Skyrim Modding\ARR 2.0`, 3800 plugins, 4996 dangling refs, plain defaults, driven through the
tool layer by `check-measure`. Every cell **identical to this PR's baseline table**. The floor did not shift cell
C: an axis that renders whole releases its reserve, so the ~120 chars per axis is room its own rows compete with
while it renders, not a flat tax on the response.

| cell | PR baseline | after the revision |
|---|---|---|
| A whole-order text | 79,600, "538 of the 4996", 67 of 137 sections | **79,600, "538 of the 4996"** |
| B whole-order json | 78,885, 307 visible | **78,885, 307 visible** |
| C counts_only text | 10,530 | **10,530** |
| D one plugin, text | 79,800, "633 of the 2591" | **79,800, "633 of the 2591"** |
| E one plugin, json | 79,112, `truncated: true` | **79,112, `truncated: true`** |

**Cell F - #392 on the live order, which is the whole point of the revision:**

| `max_chars` | before | after |
|---|---|---|
| 80000 (plain default) | 74 + 180 rows, both axes whole | unchanged |
| 2000 | by-SOURCE axis **ABSENT, unnamed** | present, `... [180 more row(s) - raise max_chars= to see them]` |
| 1200 | **both axes ABSENT, unnamed** | both present, both state their cut, and the response says its fixed part does not fit |

**The 1-12000 integer cap sweep, in both transports, is now the permanent ladder.** The harness reviewer ran it
once as a one-off; it is cheap enough to keep, so the fourteen-rung ladder is gone. Eight fixtures x 12,000 caps
x 2 transports = 192,000 renders, **no overrun anywhere, in either transport**. Cost, measured inside `ci-all`:
this guard goes from under 1.4s (it was not in the slowest eight) to 6.1s, and the whole run from 0.73 to 0.83 of
a minute. That retires the ladder-gap class structurally — the arm's one real defect lived in a gap in its own
rungs — rather than by picking better rungs. The sweep was proven to have RUN rather than merely reported green:
instrumented to print its ladder length, it reported 12,000 caps on each of the eight fixtures.

### A caller-visible change outside `check_errors`

`validate_scripts` shares the excluded-plugin roster helper, so that roster is now charged to `max_chars`
and a tight cap can drop it whole. Its marker names its own subject — which list did not fit and how many
plugins are therefore unnamed — instead of a bare "truncated at max_chars" under a heading that may itself
be gone. `plugin/CHANGELOG.md` carries it.


🤖 Generated with [Claude Code](https://claude.com/claude-code)





