### PR TITLE
The whole verb vocabulary reaches a [Description] from one const, not three hand-typed copies

### DIFF
--- a/src/housecarl-core/WriteVerbs.cs
+++ b/src/housecarl-core/WriteVerbs.cs
@@ -85,10 +85,14 @@ public readonly record struct VerbUse(string Verb, VerbInput Input, bool NeedsKe
 /// </summary>
 public static class WriteVerbs
 {
-    /// <summary>Every verb the write surface accepts, in the order the shipped tool descriptions list them. The one
-    /// home in CODE for the NAMES; <see cref="On"/> is the one home for which of them apply where. The prose home is
-    /// the tool-surface SPEC, which CLAUDE.md points readers at — these are two homes for two audiences, not two
-    /// authorities on one fact.</summary>
+    /// <summary>Every verb the write surface accepts, in the order the shipped tool descriptions list them. The home
+    /// for the names as a collection code can ITERATE, and the one of the two in-code statements whose membership is
+    /// actually pinned: <c>remedy-verbs-guard</c>'s SITE-UNKNOWN-VERB holds this against a vocabulary written
+    /// independently inside that probe. <see cref="AllRecital"/> states the same names a second time, as the
+    /// caller-facing literal an attribute can concatenate, and carries no such pin — see its summary for what that
+    /// does and does not establish. <see cref="On"/> is the one home for which of them apply where. The prose home
+    /// for the set as DOCUMENTATION is the tool-surface SPEC, which CLAUDE.md points readers at — two audiences,
+    /// not two authorities on one fact.</summary>
     public static readonly IReadOnlyList<string> All =
         new[] { "Set", "Add", "Remove", "SetAtIndex", "InsertAtIndex", "ReplaceAll", "Merge", "CopyFrom" };
 
@@ -109,7 +113,18 @@ public static class WriteVerbs
     /// anything stop a future description from hand-typing the whole set instead of concatenating this — a site
     /// that did would be the #302 edit-every-site regression back again, silently. The three sites named above are
     /// a statement about the code as it stands, not a property anything enforces. Making both of those checkable
-    /// is #386's job; this const is the single home the check would be written against.</para></summary>
+    /// is #386's job; this const is the single home the check would be written against.
+    ///
+    /// <para><b>One hazard this const CREATES, until #386's guard exists.</b> <c>BulkOp.verb</c> appends
+    /// <c>" (deep-copy the field at field_path from from_plugin's version — see from_plugin)"</c> straight onto
+    /// this recital, so that gloss describes whichever verb is LAST here — <c>CopyFrom</c> today, by position and
+    /// nothing else. Appending a ninth verb — the very edit this const exists to make sufficient — silently moves
+    /// the gloss onto the new verb and strips it off <c>CopyFrom</c>, shipping a false claim in
+    /// <c>housecarl_bulk_apply</c>'s schema; reordering does the same. The other two sites are position-independent
+    /// (one appends after a full stop, one reads <c>"op is " + AllRecital + ". "</c>). Until a guard pins the tail
+    /// token to the verb the trailing gloss describes, the protection is the vocabulary gate before W6: changing
+    /// this set is a reviewed act, not a drive-by. Recorded rather than fixed because the fix moves caller-facing
+    /// text, and this const's whole warrant is that it changed none.</para></summary>
     public const string AllRecital = "Set (default) | Add | Remove | SetAtIndex | InsertAtIndex | ReplaceAll | Merge | CopyFrom";
 
     /// <summary>The verbs that work on <paramref name="shape"/>, each with the slot it consumes and the phrase a

--- a/src/housecarl-core/WriteVerbs.cs
+++ b/src/housecarl-core/WriteVerbs.cs
@@ -93,9 +93,9 @@ public static class WriteVerbs
         new[] { "Set", "Add", "Remove", "SetAtIndex", "InsertAtIndex", "ReplaceAll", "Merge", "CopyFrom" };
 
     /// <summary>The same vocabulary as the CALLER-FACING recital a <c>[Description]</c> prints — the pipe-joined
-    /// form, with the defaulting verb marked. Every tool description that names the WHOLE verb set concatenates
-    /// this instead of typing the names out (<c>ApplyTools</c>'s <c>op=</c>, the <c>ApplyOp.op</c> and
-    /// <c>BulkOp.verb</c> shape declarations).
+    /// form, with the defaulting verb marked. Three shipped descriptions concatenate it today rather than typing
+    /// the names out: <c>ApplyTools</c>'s <c>op=</c> method prose, the <c>ApplyOp.op</c> shape declaration, and
+    /// the <c>BulkOp.verb</c> one.
     ///
     /// <para><b>Why a second member, rather than reading <see cref="All"/> there.</b> An attribute argument must be
     /// a compile-time constant, and <see cref="All"/> is a collection built at runtime — so a description literally
@@ -104,10 +104,12 @@ public static class WriteVerbs
     /// when it added <c>InsertAtIndex</c>, and the one PR #339 retired everywhere it could reach. This is that
     /// pattern applied to the description surface (#386).</para>
     ///
-    /// <para>Two members are still two statements of one fact, so they are HELD TOGETHER rather than trusted:
-    /// <c>description-vocab-guard</c>'s INV4 asserts this recital names exactly <see cref="All"/>, and asserts both
-    /// against a vocabulary written independently inside the guard — the second spelling that lets the check fail,
-    /// since comparing either of these to the other alone would pass just as happily on two matching mistakes.</para></summary>
+    /// <para><b>What this does NOT establish.</b> Two members are two statements of one fact, and nothing here
+    /// holds them together: no build step asserts that this recital names exactly <see cref="All"/>. Nor does
+    /// anything stop a future description from hand-typing the whole set instead of concatenating this — a site
+    /// that did would be the #302 edit-every-site regression back again, silently. The three sites named above are
+    /// a statement about the code as it stands, not a property anything enforces. Making both of those checkable
+    /// is #386's job; this const is the single home the check would be written against.</para></summary>
     public const string AllRecital = "Set (default) | Add | Remove | SetAtIndex | InsertAtIndex | ReplaceAll | Merge | CopyFrom";
 
     /// <summary>The verbs that work on <paramref name="shape"/>, each with the slot it consumes and the phrase a

--- a/src/housecarl-core/WriteVerbs.cs
+++ b/src/housecarl-core/WriteVerbs.cs
@@ -85,13 +85,30 @@ public readonly record struct VerbUse(string Verb, VerbInput Input, bool NeedsKe
 /// </summary>
 public static class WriteVerbs
 {
-    /// <summary>Every verb the write surface accepts, in the order the shipped tool descriptions list them
-    /// (checked: <c>ApplyTools</c>'s <c>op</c> reads "Set | Add | Remove | SetAtIndex | InsertAtIndex | ReplaceAll
-    /// | Merge | CopyFrom"). The one home in CODE for the NAMES; <see cref="On"/> is the one home for which of them
-    /// apply where. The prose home is the tool-surface SPEC, which CLAUDE.md points readers at — these are two
-    /// homes for two audiences, not two authorities on one fact.</summary>
+    /// <summary>Every verb the write surface accepts, in the order the shipped tool descriptions list them. The one
+    /// home in CODE for the NAMES; <see cref="On"/> is the one home for which of them apply where. The prose home is
+    /// the tool-surface SPEC, which CLAUDE.md points readers at — these are two homes for two audiences, not two
+    /// authorities on one fact.</summary>
     public static readonly IReadOnlyList<string> All =
         new[] { "Set", "Add", "Remove", "SetAtIndex", "InsertAtIndex", "ReplaceAll", "Merge", "CopyFrom" };
+
+    /// <summary>The same vocabulary as the CALLER-FACING recital a <c>[Description]</c> prints — the pipe-joined
+    /// form, with the defaulting verb marked. Every tool description that names the WHOLE verb set concatenates
+    /// this instead of typing the names out (<c>ApplyTools</c>'s <c>op=</c>, the <c>ApplyOp.op</c> and
+    /// <c>BulkOp.verb</c> shape declarations).
+    ///
+    /// <para><b>Why a second member, rather than reading <see cref="All"/> there.</b> An attribute argument must be
+    /// a compile-time constant, and <see cref="All"/> is a collection built at runtime — so a description literally
+    /// cannot read it. The choice is therefore between one <c>const</c> the descriptions share and one hand-typed
+    /// copy per description — and the hand-typed arrangement is the one #302 had to go round and edit site by site
+    /// when it added <c>InsertAtIndex</c>, and the one PR #339 retired everywhere it could reach. This is that
+    /// pattern applied to the description surface (#386).</para>
+    ///
+    /// <para>Two members are still two statements of one fact, so they are HELD TOGETHER rather than trusted:
+    /// <c>description-vocab-guard</c>'s INV4 asserts this recital names exactly <see cref="All"/>, and asserts both
+    /// against a vocabulary written independently inside the guard — the second spelling that lets the check fail,
+    /// since comparing either of these to the other alone would pass just as happily on two matching mistakes.</para></summary>
+    public const string AllRecital = "Set (default) | Add | Remove | SetAtIndex | InsertAtIndex | ReplaceAll | Merge | CopyFrom";
 
     /// <summary>The verbs that work on <paramref name="shape"/>, each with the slot it consumes and the phrase a
     /// remedy prints for it. Indexed by shape — the two facts in <see cref="CollectionShape"/> are the whole input,

--- a/src/housecarl-core/WriteVerbs.cs
+++ b/src/housecarl-core/WriteVerbs.cs
@@ -113,7 +113,7 @@ public static class WriteVerbs
     /// anything stop a future description from hand-typing the whole set instead of concatenating this — a site
     /// that did would be the #302 edit-every-site regression back again, silently. The three sites named above are
     /// a statement about the code as it stands, not a property anything enforces. Making both of those checkable
-    /// is #386's job; this const is the single home the check would be written against.
+    /// is #386's job; this const is the single home the check would be written against.</para>
     ///
     /// <para><b>One hazard this const CREATES, until #386's guard exists.</b> <c>BulkOp.verb</c> appends
     /// <c>" (deep-copy the field at field_path from from_plugin's version — see from_plugin)"</c> straight onto

--- a/src/housecarl-mcp/ApplyTools.cs
+++ b/src/housecarl-mcp/ApplyTools.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using ModelContextProtocol.Server;
+using HousecarlCore;
 
 namespace HousecarlMcp;
 
@@ -47,7 +48,7 @@ public static class ApplyTools
          "dotted ('BasicStats.Damage', 'Name', 'Keywords'); step INTO a list/dict element MID-path with brackets " +
          "('Effects[0].Data.Magnitude'), but at the LEAF use op + key instead of brackets. value is coerced to the " +
          "field's real type — a number, an enum name ('OneHanded'), or a FormID for a reference.\n" +
-         "op is Set (default) | Add | Remove | SetAtIndex | InsertAtIndex | ReplaceAll | Merge | CopyFrom. " +
+         "op is " + WriteVerbs.AllRecital + ". " +
          "InsertAtIndex inserts a NEW element AT key= and shifts the rest right (key = the list's length appends); use it to grow a POSITION-CONTIGUOUS run in place, e.g. adding an arm to an existing CTDA OR-group, where Add would land the row at the end as a separate AND-group. On a [Flags] enum (SPEL " +
          "Flags, NPC Configuration.Flags, WEAP Data.Flags...) Add SETS a bit and Remove CLEARS one, leaving the " +
          "OTHER bits untouched — the way to flip one flag WITHOUT a Set silently dropping every bit you didn't " +
@@ -350,7 +351,7 @@ public sealed record ApplyOp
     [JsonPropertyName("field_path"), Description("Dotted field path, e.g. 'BasicStats.Damage' or 'Entries'. Step into a list/dict element mid-path with brackets ('Effects[0].Data.Magnitude'); at the LEAF use op + key, not brackets.")]
     public string? FieldPath { get; init; }
 
-    [JsonPropertyName("op"), Description("Set (default) | Add | Remove | SetAtIndex | InsertAtIndex | ReplaceAll | Merge | CopyFrom. SetAtIndex OVERWRITES the element at key=; InsertAtIndex inserts a new one AT key= and shifts the rest right (key = the list's length appends). On a [Flags] enum, Add sets one bit and Remove clears one, leaving the others untouched.")]
+    [JsonPropertyName("op"), Description(WriteVerbs.AllRecital + ". SetAtIndex OVERWRITES the element at key=; InsertAtIndex inserts a new one AT key= and shifts the rest right (key = the list's length appends). On a [Flags] enum, Add sets one bit and Remove clears one, leaving the others untouched.")]
     public string? Op { get; init; }
 
     [JsonPropertyName("value"), Description("The value, coerced to the field's type. Omit for Remove / ReplaceAll / Merge / compose / CopyFrom.")]

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -1576,7 +1576,7 @@ public sealed record BulkOp
     [JsonPropertyName("field_path"), Description("Dotted field path, e.g. 'BasicStats.Damage' or 'Entries'. Step into a list/dict element mid-path with brackets, e.g. 'Effects[0].Data.Magnitude'; at the LEAF use verb + key, not brackets.")]
     public string? FieldPath { get; init; }
 
-    [JsonPropertyName("verb"), Description("Set (default) | Add | Remove | SetAtIndex | InsertAtIndex | ReplaceAll | Merge | CopyFrom (deep-copy the field at field_path from from_plugin's version — see from_plugin). SetAtIndex OVERWRITES the element at key=; InsertAtIndex inserts a new one AT key= and shifts the rest right (key = the list's length appends).")]
+    [JsonPropertyName("verb"), Description(WriteVerbs.AllRecital + " (deep-copy the field at field_path from from_plugin's version — see from_plugin). SetAtIndex OVERWRITES the element at key=; InsertAtIndex inserts a new one AT key= and shifts the rest right (key = the list's length appends).")]
     public string Verb { get; init; } = "Set";
 
     [JsonPropertyName("value"), Description("The value (coerced to the field's type). Omit for Remove / ReplaceAll / Merge / compose.")]


### PR DESCRIPTION
`Refs #386` — **closes nothing.** #386's substance is the vocabulary guard over caller-facing prose; that half is still in design after a §4 class-stop. This PR banks the finished half: the verb-set const, plus the docstring work that stopped it over-claiming.

## What this is

Three tool descriptions recited the whole write-verb set by hand. `WriteVerbs.AllRecital` is the const form of that vocabulary, and the three sites now concatenate it.

An attribute argument must be a compile-time constant and `WriteVerbs.All` is a runtime collection, so a description literally cannot read it. The choice was one shared `const` or one hand-typed copy per description — and the hand-typed arrangement is the one #302 had to go round and edit site by site when it added `InsertAtIndex`.

| Site | Was |
|---|---|
| `ApplyTools.cs:51` (`housecarl_apply`'s method prose) | the eight names, typed out |
| `ApplyTools.cs:354` (`ApplyOp.op`) | the eight names, typed out |
| `WriteTools.cs:1579` (`BulkOp.verb`) | the eight names, typed out |

## The caller-facing text is byte-identical — five independent measurements

`AllRecital` carries `"(default)"` inside its value, which is what made the three conversions byte-identical drop-ins rather than rewording shipped descriptions for the const's convenience.

| # | Who | Method |
|---|---|---|
| 1 | build session | `identity.py` — substitute the const's value back into the branch source, diff whole files against `git show d9b95de:` |
| 2 | first review session | the same proof, re-run independently |
| 3 | this review session | `r2_description_parity.py` — **design-distinct**: never diffs files; extracts every `[Description(...)]` argument on both sides, evaluates it with its own literal evaluator, compares multisets. 26 in `ApplyTools.cs`, 107 in `WriteTools.cs`, identical. Carries a canary (perturb the resolved recital by one character, and the run must FAIL) |
| 4 | this session, on **this** branch after fold 1 | same, `--wt` pointed at this worktree, with a negative control proving `--wt` was honoured |
| 5 | this session, after fold 2 | same again, canary + negative control |

Reviewers added a sixth by decoding the compiled custom-attribute blobs out of `housecarl-mcp.dll` and matching the verbatim `d9b95de` literals, with their own known-red canary.

Every proof's reference side is `d9b95de`'s own literals. The const is never compared to itself — the pin rule (`RemedyVerbsGuardProbe`'s SITE-UNKNOWN-VERB is the standing precedent).

**CHANGELOG: no `## Unreleased` line.** CLAUDE.md §5 #10 scopes the requirement to a user-facing change. There is none — the description text is byte-identical and the rest is XML docs. Four sessions reached this call independently.

**Suite:** Release build clean; `ci-all` **129/129 ALL PASS** — exactly `main`'s 130 minus the vocabulary guard, which confirms the guard is absent from this branch and nothing else moved.

## Two directed folds, both the same discipline

A claim nothing enforces is removed or narrowed to what *is* enforced — never softened.

**Fold 1 (`a5af24d`)** removed two claims from `AllRecital`'s summary:

- *"Every tool description that names the WHOLE verb set concatenates this"* — nothing establishes it; a future description can hand-type all eight names and nothing says so. Measured: exactly three sites concatenate it. Replaced with that census, as a fact about the code rather than a universal.
- A paragraph crediting `description-vocab-guard`'s INV4 with holding `AllRecital` and `All` together. **The split created this one** — that guard is not on this branch (file absent, 0 references in `CiAll`). Removed rather than reworded.

What replaced both is a **"What this does NOT establish"** paragraph naming the gaps.

**Fold 2 (`2d1295f`)** — see the round report below for how this one was found.

- `All`'s summary said it was *"The one home in CODE for the NAMES"*. Adding `AllRecital` made that false in the same file, twenty lines apart. Narrowed to what is enforced, measured not assumed: `remedy-verbs-guard`'s SITE-UNKNOWN-VERB holds `All` against a vocabulary written independently inside that probe, and **nothing in the generator source reads `AllRecital` at all**. So `All` is the iterable home and the pinned one; `AllRecital` is the caller-facing one and is unpinned.
- Recorded the one hazard the const **creates** (below).

## The hazard this const creates — recorded, deferred, deposited

`BulkOp.verb` appends `" (deep-copy the field at field_path from from_plugin's version — see from_plugin)"` straight onto the recital, so that gloss describes whichever verb is **last** — `CopyFrom` today, by position and nothing else. Appending a ninth verb — *the very edit this const exists to make sufficient* — silently moves the gloss onto the new verb and strips it off `CopyFrom`, shipping a false claim in `housecarl_bulk_apply`'s schema. Reordering does the same. The other two sites are position-independent.

**Not fixed here, deliberately:** the clean fix moves caller-facing text, and this const's whole warrant is that it moves none. It is written into the does-NOT-establish paragraph, and deposited on #386 as an acceptance item — a guard reading the recital surface can pin *the tail token is the verb the trailing gloss describes*, which turns a positional accident into a checked fact. Interim protection is the vocabulary gate before W6: changing this set is a reviewed act, not a drive-by. That is a process guarantee, not a mechanical one, which is what #386 exists to retire.

## Round history

This branch is the B half of a split ruled after #386's guard hit a §4 class-stop. Its diff has now had attention in four passes.

- **Guard-branch rounds (3 reviewers).** All three independently found that the guard's source lexer cannot see a string literal inside an interpolation hole — reproduced on live shipped prose, including `compact_plugin`'s own caller-facing refusal. Same failure class as the design before it, so it was class-stopped under §4 rather than folded. Those rounds also re-verified this commit's byte-identity and found nothing wrong with it.
- **This branch's round (2 fresh reviewers, own worktrees, seeded with only the settled decisions concerning this diff).** Three MEDIUMs. Two survived triage:
  - `All`'s "one home" sentence — **folded** (fold 2).
  - the gloss coupling — **deferred with ground**, deposited on #386.
  - **Refused: "PR #339 is a false citation."** The reviewer read #339's title (*place_asset: a Data-relative source…*), found nothing about verb recitals, and named #427 instead. Refused on measurement: #339's **diff** adds ten shared sentence consts — `PlaceSourceWillNotGuess`, `PlaceSourceNoSubstitute`, `PlaceSourcePoleSpelling`, `PlaceBothSlotsPoleConstraint` and others — which is the single-home-for-a-sentence pattern #386's own promotion comment means by "PR #339's const-concat pattern". The docstring's claim is explicitly scoped: *"the one PR #339 retired everywhere **it could reach**"*. The reviewer judged from the title, not the diff. Its secondary point is factually correct but does not falsify the sentence: `f1ad632` (#302's work) and `3e81094` (which created `WriteVerbs.cs`) are both in #427, so those shipped together — the docstring never claims otherwise.
  - Lows: the added `using HousecarlCore;` in `ApplyTools.cs:6` is redundant against the csproj's global using, but **`WriteTools.cs:6` already carries the same using on `main`**, so this matches its sibling rather than breaking a convention — left as-is. A pre-existing off-by-one in `WriteVerbs.cs:62` ("a seventh name"; `InsertAtIndex` was the eighth — measured at `f1ad632^`) is outside this diff and filed as #429 per CLAUDE.md §2.
- **No round after the directed folds** — §11.

## For your review

**Fold 2's origin is the live argument for the A-half guard.** A directed fold, whose entire brief was to remove a claim nothing enforces, itself falsified an adjacent sentence in exactly that class — twenty lines away, in the same file, in the same commit's blast radius — and the new paragraph it wrote said so without anyone noticing. It took fresh eyes on a 35-line diff to catch, after three rounds had already been over this code. The author is the worst triager of their own fold; that is what #386's guard exists to stop needing to be true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
