### PR TITLE
docs: the #429 verb count and four malformed docstrings (#432 + three more of its class)

### DIFF
--- a/src/housecarl-core/PapyrusDecompiler.cs
+++ b/src/housecarl-core/PapyrusDecompiler.cs
@@ -1103,7 +1103,7 @@ public sealed class PapyrusDecompiler
     }
 
     // ------------------------------------------------------------------ shared helpers
-    /// <summary>Compiler expression temps only: ::temp<N> and the ::NoneVar discard slot. Other
+    /// <summary>Compiler expression temps only: <c>::temp&lt;N&gt;</c> and the ::NoneVar discard slot. Other
     /// ::-prefixed names (CK fragment ::mangled_* locals, ::X_var auto-prop backing) are real storage.</summary>
     static bool IsTemp(string name)
         => name.Equals("::NoneVar", StringComparison.OrdinalIgnoreCase)

--- a/src/housecarl-core/WriteVerbs.cs
+++ b/src/housecarl-core/WriteVerbs.cs
@@ -59,8 +59,8 @@ public readonly record struct VerbUse(string Verb, VerbInput Input, bool NeedsKe
 /// produced it, and they drifted: a dict caller reached a message offering <c>InsertAtIndex</c> (measured on
 /// <c>Package.Data</c> — following the offer returns "InsertAtIndex is only valid on list"); the Set-on-list remedy
 /// named two of the five list verbs; the leaf-bracket remedy offered both cardinalities' verbs at once and left the
-/// caller to work out which half was theirs. Adding <c>InsertAtIndex</c> (#302) made the drift visible by adding a
-/// seventh name to keep in sync, but it did not cause it — a hand-maintained copy of a set rots whether or not the
+/// caller to work out which half was theirs. Adding <c>InsertAtIndex</c> (#302) made the drift visible by adding an
+/// eighth name to keep in sync, but it did not cause it — a hand-maintained copy of a set rots whether or not the
 /// set is growing. Two consecutive pre-PR review rounds returned instances of it, which is the CLAUDE.md §11
 /// class-stop: the fix is the generator, not another round of copies.</para>
 ///

--- a/src/housecarl-mcp/CheckAccounting.cs
+++ b/src/housecarl-mcp/CheckAccounting.cs
@@ -551,7 +551,7 @@ internal sealed class CheckAccounting
     /// the clauses above it cannot disagree, and a subject the lane does not have cannot make it true. Dropped
     /// sections belong here: a sweep whose findings are all missing masters omits no dangling ref, so without this
     /// term a response missing 34 of 41 sections closed as complete — with no remedy, no roster, and a json twin that
-    /// said truncated.</summary>
+    /// said truncated.
     /// <para>It does NOT take <c>v.Worst</c> as an answer on its own. The worst case is every DECLARED subject at
     /// its widest, not every subject declared: read as "assume something is missing", it wrote the remedy clauses
     /// into a reserve for a lane where nothing can be. The worst case still dominates the real one term by term —

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -634,7 +634,7 @@ static class NifWire
         return bits.Count == 0 ? "none" : string.Join(",", bits);
     }
 
-    /// <summary>Append "<label><a, b, c>" as one line, cut with an explicit notice if it would blow the cap (Q3).</summary>
+    /// <summary>Append "&lt;label&gt;&lt;a, b, c&gt;" as one line, cut with an explicit notice if it would blow the cap (Q3).</summary>
     static void AppendClampedList(StringBuilder sb, string label, IEnumerable<string> items, int cap)
     {
         sb.Append(label);

--- a/src/housecarl-mcp/ReadSentences.cs
+++ b/src/housecarl-mcp/ReadSentences.cs
@@ -576,7 +576,7 @@ internal static class ReadSentences
     ///
     /// <para>Unstated, a caller who wrote <c>plugins=["MyMod.esp"] findings=["errors","dialogue"]</c> would read the
     /// dialogue section as scoped to their plugin when it is scoped to their seeds — the two answers differ and
-    /// nothing in the response would say which one they were reading.</para></summary>
+    /// nothing in the response would say which one they were reading.</para>
     /// <para>What it says about HOW MANY is two sentences, not one, and that is the point: "it validated exactly
     /// the N seed(s) given in seeds=" was printed from the number NAMED, so a call whose <c>limit=</c> stopped it
     /// short claimed a completeness the accounting in the same section immediately contradicted (round-1


### PR DESCRIPTION
## What

Two commits, docs-only — every changed line is a `///` comment (verified mechanically: the non-docstring-filtered diff is empty).

1. **Fixes #429** — WriteVerbs.cs's drift narrative said adding `InsertAtIndex` added "a seventh name"; seven verbs existed before it, so it was the eighth.
2. **Fixes #432** — PapyrusDecompiler.cs's `::temp<N>` opened an XML tag that never closed, so the compiler discarded the docstring (CS1570). Verifying the fix with `-p:GenerateDocumentationFile=true` surfaced **three more instances of the same class**, previously masked because earlier checks read only the head of the warning list: a doubled `</summary>` in CheckAccounting.cs:554 and ReadSentences.cs:579, and literal angle brackets in NifTools.cs:637. All fixed the same way — escape or rebalance, no prose changed in meaning.

## Verification

- Full `housecarl-mcp` Release build with doc generation: **zero CS1570**, no errors.
- Filtered diff over `src`: nothing but `///` lines → no caller-facing text moves, no `## Unreleased` CHANGELOG line (not a user-facing change).

## Reviewer notes

- Docs-only PR → no pre-PR review rounds per CLAUDE.md §5 #11 scope.
- Routing per the advisor rec (Aaron-go 2026-08-26): deliberately unmilestoned — neither issue gates 2.0.
- Committed by the advisor session on Aaron's direct instruction ("then your last to do is the docs only PR") — logged as a one-off under the lane's no-commit rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)