### PR TITLE
The read surface's refusal grammar: one shape, and a guard that keeps it

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -15,12 +15,26 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 - **A read tool asked for json now refuses in json.** Reads that take `format="json"` previously answered
   some refusals with a plain sentence instead of a json document, so a caller parsing the response had to
-  handle two shapes depending on which rule it broke. Every refusal those tools can reach on a json call is
-  now one document — `ok:false` plus the `error` sentence, and the build stamp where the refusal consulted
-  one. A row that failed inside a call that succeeded is not a refusal and keeps its own `error` field, with
-  no `ok`: that is how a served answer is told from a refused one. Text output is unchanged. The refusals
-  still outside this shape are the ones whose own render says so: the tools with no json format, the
-  `format='dense'` refusals, and an unreadable `format=` itself, which cannot know the shape you wanted.
+  handle two shapes depending on which rule it broke. Those refusals are now one document — `ok:false` plus
+  the `error` sentence, and the build stamp where the refusal consulted one. A row that failed inside a call
+  that succeeded is not a refusal and keeps its own `error` field, with no `ok`: that is how a served answer
+  is told from a refused one. The refusals still outside this shape are the ones whose own render says so:
+  the tools with no json format, the `format='dense'` refusals, and an unreadable `format=` itself, which
+  cannot know the shape you wanted. Which refusals are in and which are out is enforced by
+  `refusal-completeness-guard`, which derives the covered surface rather than working from a list.
+
+- **`housecarl_records` with `counts_only=true` renames one json field: `ok` is now `resolved`.** The census
+  reported `{count, ok, errors}` with `ok` holding the number of inputs that resolved — the same key the
+  refusal shape above uses to mean "this call was refused", in a different type. A caller reading the
+  response as a refusal check saw `"ok": 0` on a served census where nothing resolved. The field pairs with
+  `errors` beside it now. The `ok:false` refusal discriminant is unchanged, and the text render still says
+  `ok=`. **If you parse the json census, update the field name.**
+
+- **Two read tools refuse an unreadable `format=` before anything else.** `housecarl_batch_record_detail`
+  and `housecarl_resolve` checked for an empty `formids=` first, which meant that one refusal could not be
+  a json document however you asked for it. The transport is settled first now. If a call breaks both rules
+  at once — an unreadable `format=` *and* an empty `formids=` — you are told about the `format=` where you
+  used to be told about the `formids=`. Apart from that ordering, text output is unchanged.
 
 - **houseCARL no longer edits a localized plugin in place, and now tells you where that plugin's text
   actually lives.** A localized plugin keeps its text in separate `.STRINGS`/`.DLSTRINGS`/`.ILSTRINGS`

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -18,10 +18,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
   handle two shapes depending on which rule it broke. Those refusals are now one document — `ok:false` plus
   the `error` sentence, and the build stamp where the refusal consulted one. A row that failed inside a call
   that succeeded is not a refusal and keeps its own `error` field, with no `ok`: that is how a served answer
-  is told from a refused one. The refusals still outside this shape are the ones whose own render says so:
-  the tools with no json format, the `format='dense'` refusals, and an unreadable `format=` itself, which
-  cannot know the shape you wanted. Which refusals are in and which are out is enforced by
-  `refusal-completeness-guard`, which derives the covered surface rather than working from a list.
+  is told from a refused one. The refusals still outside this shape are the tools with no json format, the
+  `format='dense'` refusals, and an unreadable `format=` itself, which cannot know the shape you wanted —
+  plus an internal failure or an unconfigured instance, which are not refusals of your call. Which refusals
+  are in and which are out is enforced by `refusal-completeness-guard`, which derives the covered surface
+  rather than working from a list.
 
 - **`housecarl_records` with `counts_only=true` renames one json field: `ok` is now `resolved`.** The census
   reported `{count, ok, errors}` with `ok` holding the number of inputs that resolved — the same key the

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,15 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **A read tool asked for json now refuses in json.** Reads that take `format="json"` previously answered
+  some refusals with a plain sentence instead of a json document, so a caller parsing the response had to
+  handle two shapes depending on which rule it broke. Every refusal those tools can reach on a json call is
+  now one document — `ok:false` plus the `error` sentence, and the build stamp where the refusal consulted
+  one. A row that failed inside a call that succeeded is not a refusal and keeps its own `error` field, with
+  no `ok`: that is how a served answer is told from a refused one. Text output is unchanged. The refusals
+  still outside this shape are the ones whose own render says so: the tools with no json format, the
+  `format='dense'` refusals, and an unreadable `format=` itself, which cannot know the shape you wanted.
+
 - **houseCARL no longer edits a localized plugin in place, and now tells you where that plugin's text
   actually lives.** A localized plugin keeps its text in separate `.STRINGS`/`.DLSTRINGS`/`.ILSTRINGS`
   files and carries only indices into them. houseCARL previously committed such a plugin without the

--- a/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
@@ -282,8 +282,16 @@ public static class BulkPrimitivesWave2Probe
             // conflict_tree + json is REFUSED loud (a text-only diff view — never silently dropped, Q3).
             var ctJson = ReadTools.ReadRecord(svc, w1Fk.ToString(), plugin: null, fields: null, depth: 1,
                 conflict_tree: true, resolve_names: false, format: "json", max_chars: 0);
+            // The refusal is a json DOCUMENT now, not prose: a json caller gets the refusal grammar
+            // ({ok:false, error}) like every other reachable refusal on this surface (#403). This pin used to
+            // assert the bare "error: …" spelling — the behaviour the refusal grammar deliberately replaced.
+            var ctDoc = ParseOrNull(ctJson);
             Check("conflict_tree=true + format=json is REFUSED loud (text-only diff, not silently dropped — Q3)",
-                  ctJson.StartsWith("error:", StringComparison.OrdinalIgnoreCase) && ctJson.Contains("conflict_tree", StringComparison.OrdinalIgnoreCase));
+                  ctDoc is not null
+                  && ctDoc.RootElement.TryGetProperty("ok", out var ctOk) && ctOk.ValueKind == JsonValueKind.False
+                  && ctDoc.RootElement.TryGetProperty("error", out var ctErr)
+                  && ctErr.GetString()!.Contains("conflict_tree", StringComparison.OrdinalIgnoreCase));
+            ctDoc?.Dispose();
 
             // batch json: {count, records, rendered, truncated}; records carry the same record objects.
             var batchJson = ReadTools.BatchRecordDetail(svc, new[] { w1Fk.ToString(), "not-a-formid" }, fields: new[] { "Name" }, depth: 1,

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -210,6 +210,18 @@ public static class CiAll
         // a reader that stops early turns red instead of quietly shrinking the net. Self-contained (no corpus, no
         // MO2 instance); it reads source files, so it must run from the repo root.
         ("description-vocab-guard", DescriptionVocabularyGuardProbe.RunGuard),
+        // The read surface's refusal grammar is COMPLETE, and stays complete (#403). The grammar shipped as 81
+        // explicit Wire.Refuse sites whose population was found by a regex over two hand-named files; the pre-PR
+        // review found it short by fourteen, and proved by mutation that reverting all fourteen ReadTools sites
+        // to prose left this whole suite green. So: the population DERIVES itself (every Guard.Tool body that
+        // consults the format machinery — a new json-capable tool enrols itself, and housecarl_check stops being
+        // outside the net), the enumeration PARSES rather than pattern-matching (the construct that defeated the
+        // sweep was a ternary spanning three lines, which is exactly what a line-oriented pattern cannot see),
+        // and the bare refusals that remain each cite the settled decision that rules them correct. Carries its
+        // own known-RED fixture — the pre-fix ternary — because a checker whose known-red case comes back green
+        // is a broken checker. Self-contained (no corpus, no MO2 instance); reads source, so it must run from the
+        // repo root.
+        ("refusal-completeness-guard", RefusalCompletenessGuardProbe.RunGuard),
         ("nullarm-guard", NullArmGuardProbe.RunGuard),
         ("formlink-null-guard", FormLinkNullProbe.RunGuard),
         ("formlink-remove-guard", FormLinkRemoveProbe.RunGuard),

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -873,6 +873,24 @@ internal static class RecordsGuardProbe
                   "…and carries NO ok — a served census must not answer to the refusal discriminant");
             Check(censusResolved, "…the resolved count is `resolved`, beside `errors`, saying what it counts");
 
+            // Settled #4 keeps a three-way epoch split — stamped / explicit null / omitted — and a POST-capture
+            // refusal is stamped with the build it consulted (PR #305). The off-order refusals hold that stamp in
+            // the PoleInfo they were handed, and used to render `epoch: null`: a refusal that DID consult a build
+            // saying it consulted none. Only the sites holding a stamp changed; a refusal with none still says so.
+            var offRefusal = RecordsTools.Records(svc, types: new[] { "WEAP" }, source: Je($"\"{oldName}\""),
+                                                  conflicts_only: true, format: "json");
+            bool offIsRefusal = false, offStamped = false;
+            try
+            {
+                var od = Je(offRefusal);
+                offIsRefusal = od.TryGetProperty("ok", out var ook) && ook.ValueKind == JsonValueKind.False;
+                offStamped = od.TryGetProperty("epoch", out var oep)
+                             && oep.ValueKind == JsonValueKind.String && oep.GetString()!.Length > 0;
+            }
+            catch { }
+            Check(offIsRefusal, "an off-order scan refusal reaches a json caller as a refusal document");
+            Check(offStamped, "…carrying the build it consulted, not epoch:null (settled #4's post-capture bucket)");
+
             Console.WriteLine();
             Console.WriteLine(_fail == 0
                 ? "[records-guard] PASS — the 2.0 read surface's core contract holds."

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -803,8 +803,7 @@ internal static class RecordsGuardProbe
                          && errProp.ValueKind == JsonValueKind.String
                          && errProp.GetString()!.Length > 0,
                   "…carrying the sentence in an error string");
-            Check(parsed && rj.GetProperty("error").GetString()!.StartsWith("notaform", StringComparison.Ordinal) == false
-                         && rj.GetProperty("error").GetString()!.Contains("is not a form"),
+            Check(parsed && rj.GetProperty("error").GetString()!.Contains("is not a form"),
                   "…and the sentence is the one the caller needs (names the rule it broke)");
             Check(parsed && !rj.GetProperty("error").GetString()!.StartsWith("error: ", StringComparison.Ordinal),
                   "…without the text lane's 'error: ' prefix — the property name already says what it is");

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -851,6 +851,28 @@ internal static class RecordsGuardProbe
             Check(rowDoc && !anyRowOk,
                   "…and no ROW carries ok either — the discriminant is document-level only");
 
+            // The counts_only CENSUS is a served document too, and it used to carry `"ok": <int>` — the resolved
+            // row COUNT under the discriminant's own key (#403 round 1). Three unresolvable inputs rendered
+            // `"ok": 0`, which a consumer branching on the discriminant reads as a refusal and a consumer typing
+            // it as a boolean cannot parse at all. The count is `resolved` now, beside `errors`.
+            var censusJson = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]), "FFFFF1:HcRecBase.esp" },
+                                                  counts_only: true, format: "json");
+            bool censusDoc = false, censusHasOk = true, censusResolved = false, censusCounted = false;
+            try
+            {
+                var cd = Je(censusJson);
+                censusDoc = cd.TryGetProperty("count", out _);
+                censusHasOk = cd.TryGetProperty("ok", out _);
+                censusResolved = cd.TryGetProperty("resolved", out var rv) && rv.ValueKind == JsonValueKind.Number;
+                censusCounted = cd.TryGetProperty("errors", out var errv) && errv.GetInt32() > 0;
+            }
+            catch { }
+            Check(censusDoc, "a counts_only census RENDERS as a served document");
+            Check(censusCounted, "…with the unresolvable input really counted as an error (the fixture bites)");
+            Check(censusDoc && !censusHasOk,
+                  "…and carries NO ok — a served census must not answer to the refusal discriminant");
+            Check(censusResolved, "…the resolved count is `resolved`, beside `errors`, saying what it counts");
+
             Console.WriteLine();
             Console.WriteLine(_fail == 0
                 ? "[records-guard] PASS — the 2.0 read surface's core contract holds."

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -827,17 +827,29 @@ internal static class RecordsGuardProbe
             // A per-ROW failure is NOT a refusal: the call was answered and rendered a row that failed.
             var rowJson = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]), "FFFFF1:HcRecBase.esp" },
                                                format: "json");
-            bool rowDoc = false, rowHasOk = true;
+            bool rowDoc = false, rowHasOk = true, anyRowOk = true, sawFailedRow = false;
             try
             {
                 var rd = Je(rowJson);
-                rowDoc = rd.TryGetProperty("records", out _);
+                rowDoc = rd.TryGetProperty("records", out var recs);
                 rowHasOk = rd.TryGetProperty("ok", out _);
+                if (rowDoc)
+                {
+                    anyRowOk = false;
+                    foreach (var row in recs.EnumerateArray())
+                    {
+                        if (row.TryGetProperty("ok", out _)) anyRowOk = true;
+                        if (row.TryGetProperty("error", out _)) sawFailedRow = true;
+                    }
+                }
             }
             catch { }
             Check(rowDoc, "a batch with one unresolvable row still RENDERS (the call succeeded)");
+            Check(sawFailedRow, "…the unresolvable row really is carried as a failed row (the fixture bites)");
             Check(rowDoc && !rowHasOk,
-                  "…and carries no ok — a failed row must never read as a refused call");
+                  "…the DOCUMENT carries no ok — a failed row must never read as a refused call");
+            Check(rowDoc && !anyRowOk,
+                  "…and no ROW carries ok either — the discriminant is document-level only");
 
             Console.WriteLine();
             Console.WriteLine(_fail == 0

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -777,6 +777,68 @@ internal static class RecordsGuardProbe
             Check(stale.StartsWith("error:") && stale.Contains(epoch0!) && stale.Contains("epoch"),
                   "…after the order changes, re-entry REFUSES naming both epochs (never mixes two worlds)");
 
+            // ============================================================================================
+            //  6 — REFUSAL GRAMMAR: a json caller gets a json refusal, every time (#403)
+            // ============================================================================================
+            // Content pins, deliberately NOT wiring pins: the shape is spelled out here — "ok", false,
+            // "error", and the text lane's "error: " prefix written as its own literal — so emptying or
+            // renaming the render-side construction fails this arm instead of moving with it.
+            Console.WriteLine();
+            Console.WriteLine("--- 6: refusal grammar — one shape per transport ---");
+
+            // A plain parameter refusal: the form name is not a form. Before this lane it came back as bare
+            // prose on BOTH transports; the json caller had to parse an error string out of English.
+            var badForm = new RecordsTools.RecordsProject { form = "notaform" };
+            var refJson = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, project: badForm, format: "json");
+            var refText = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, project: badForm);
+
+            JsonElement rj = default;
+            bool parsed = false;
+            try { rj = Je(refJson); parsed = true; } catch { /* not json at all — the bug this arm exists for */ }
+            Check(parsed, "a json-mode parameter refusal is a JSON DOCUMENT, not prose");
+            Check(parsed && rj.TryGetProperty("ok", out var okProp)
+                         && okProp.ValueKind == JsonValueKind.False,
+                  "…and declares itself refused with ok:false");
+            Check(parsed && rj.TryGetProperty("error", out var errProp)
+                         && errProp.ValueKind == JsonValueKind.String
+                         && errProp.GetString()!.Length > 0,
+                  "…carrying the sentence in an error string");
+            Check(parsed && rj.GetProperty("error").GetString()!.StartsWith("notaform", StringComparison.Ordinal) == false
+                         && rj.GetProperty("error").GetString()!.Contains("is not a form"),
+                  "…and the sentence is the one the caller needs (names the rule it broke)");
+            Check(parsed && !rj.GetProperty("error").GetString()!.StartsWith("error: ", StringComparison.Ordinal),
+                  "…without the text lane's 'error: ' prefix — the property name already says what it is");
+
+            // The text twin is unchanged prose, and states the SAME sentence.
+            Check(refText.StartsWith("error: ", StringComparison.Ordinal),
+                  "the text twin is still prose opening 'error: '");
+            Check(parsed && refText.StartsWith("error: ", StringComparison.Ordinal)
+                         && refText["error: ".Length..].Trim() == rj.GetProperty("error").GetString()!.Trim(),
+                  "…and both transports state ONE sentence, not two spellings of it");
+
+            // A refusal raised inside a helper with no transport in scope (ParsePole) takes its shape at the
+            // call site — the population this lane had to trace rather than assume.
+            var poleJson = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) },
+                                                source: Je("\"previous_provider\""), format: "json");
+            bool poleOk = false;
+            try { poleOk = Je(poleJson).GetProperty("ok").ValueKind == JsonValueKind.False; } catch { }
+            Check(poleOk, "a refusal raised in a no-transport helper still reaches the caller as json");
+
+            // A per-ROW failure is NOT a refusal: the call was answered and rendered a row that failed.
+            var rowJson = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]), "FFFFF1:HcRecBase.esp" },
+                                               format: "json");
+            bool rowDoc = false, rowHasOk = true;
+            try
+            {
+                var rd = Je(rowJson);
+                rowDoc = rd.TryGetProperty("records", out _);
+                rowHasOk = rd.TryGetProperty("ok", out _);
+            }
+            catch { }
+            Check(rowDoc, "a batch with one unresolvable row still RENDERS (the call succeeded)");
+            Check(rowDoc && !rowHasOk,
+                  "…and carries no ok — a failed row must never read as a refused call");
+
             Console.WriteLine();
             Console.WriteLine(_fail == 0
                 ? "[records-guard] PASS — the 2.0 read surface's core contract holds."

--- a/src/housecarl-generator/RefusalCompletenessGuardProbe.cs
+++ b/src/housecarl-generator/RefusalCompletenessGuardProbe.cs
@@ -264,17 +264,30 @@ public static class RefusalCompletenessGuardProbe
         var seen = new HashSet<int>();
         foreach (var scope in scopes)
         {
-            // Names bound by an `out var X` ARGUMENT — the shape of a refusal produced inside a helper and handed
-            // straight back. Deliberately NOT every SingleVariableDesignation: `is { } prompt` binds the same way
-            // and the MO2-not-configured prompt it binds is trained guidance addressed to the model, not a
-            // refusal sentence — it is returned bare by the whole tool surface, write tools included, and is a
-            // separate surface-wide question rather than part of this grammar.
+            // Names bound to a string a HELPER produced — the shape of a refusal handed straight back, which is
+            // how twelve of the fourteen escaped. Two bindings carry it, and both must be in the net: an
+            // `out var X` argument (Wire.WantsJson, ExpandListInput's tuple) and an `is { } X` pattern
+            // (Artifacts.ValidateToFile). An earlier draft took only the first, and the ValidateToFile sites —
+            // the fold's own fix — went invisible; the mutation sweep's cell for them came back with nothing
+            // flagged, which is how the gap was found.
+            //
+            // One binding is excluded, structurally and by name rather than by file: a designation bound from
+            // ConfigPromptOrNull(). What that returns is trained guidance addressed to the model when no MO2
+            // instance is configured — not a refusal sentence, returned bare by the whole tool surface including
+            // the write tools, and a separate surface-wide question rather than part of this grammar.
             var outNames = new HashSet<string>(StringComparer.Ordinal);
             foreach (var arg in scope.DescendantNodes().OfType<ArgumentSyntax>())
             {
                 if (!arg.RefKindKeyword.IsKind(SyntaxKind.OutKeyword)) continue;
                 if (arg.Expression is DeclarationExpressionSyntax { Designation: SingleVariableDesignationSyntax sv })
                     outNames.Add(sv.Identifier.Text);
+            }
+            foreach (var pat in scope.DescendantNodes().OfType<IsPatternExpressionSyntax>())
+            {
+                if (pat.Pattern is not RecursivePatternSyntax { Designation: SingleVariableDesignationSyntax pv })
+                    continue;
+                if (pat.Expression.ToString().Contains("ConfigPromptOrNull", StringComparison.Ordinal)) continue;
+                outNames.Add(pv.Identifier.Text);
             }
 
             foreach (var ret in scope.DescendantNodes().OfType<ReturnStatementSyntax>())

--- a/src/housecarl-generator/RefusalCompletenessGuardProbe.cs
+++ b/src/housecarl-generator/RefusalCompletenessGuardProbe.cs
@@ -108,6 +108,38 @@ public static class RefusalCompletenessGuardProbe
         }
         """;
 
+    /// <summary>THE SECOND KNOWN-RED FIXTURE — <c>ReadTools.cs:101</c> under Aaron's gate-review mutation: the
+    /// refusal <c>Artifacts.ExpandListInput</c> hands back through a tuple, returned bare. This shape defeated the
+    /// net until the deconstruction designation joined it, and the miss was invisible to every other cell in the
+    /// sweep because <c>is { } verr</c> — the shape one line below it in the same file — WAS in the net. The
+    /// enumerator must flag this; eight live sites carry it.</summary>
+    const string HelperTupleFixture = """
+        static class Fixture
+        {
+            static string Body()
+            {
+                bool json = Wire.WantsJson(format, out var ferr);
+                var (toks, demand, echoSrc, xerr) = Artifacts.ExpandListInput(formids, "formids");
+                if (xerr is not null) return xerr;
+                return Ok();
+            }
+        }
+        """;
+
+    /// <summary>Its counter-fixture: the same tuple, wrapped. Silence here is an arm too.</summary>
+    const string WrappedTupleFixture = """
+        static class Fixture
+        {
+            static string Body()
+            {
+                bool json = Wire.WantsJson(format, out var ferr);
+                var (toks, demand, echoSrc, xerr) = Artifacts.ExpandListInput(formids, "formids");
+                if (xerr is not null) return Wire.Refuse(json, xerr);
+                return Ok();
+            }
+        }
+        """;
+
     public static int RunGuard(string[] args)
     {
         _pass = _fail = 0;
@@ -125,6 +157,15 @@ public static class RefusalCompletenessGuardProbe
         Check(greenHits.Count == 0,
               $"…and the wrapped form of the same shape is NOT flagged (found {greenHits.Count}, expected 0) — "
               + "an enumerator that flags everything proves nothing");
+
+        var tupleRed = Enumerate("<fixture>", HelperTupleFixture, out var tupleErrors);
+        Check(tupleErrors.Count == 0, $"the tuple-deconstruction fixture parses ({string.Join("; ", tupleErrors)})");
+        Check(tupleRed.Count == 1,
+              $"KNOWN-RED FIXTURE: a refusal handed back through a deconstructed tuple is FLAGGED "
+              + $"(found {tupleRed.Count}, expected 1) — the binding is a designation, not an out argument");
+        var tupleGreen = Enumerate("<fixture>", WrappedTupleFixture, out _);
+        Check(tupleGreen.Count == 0,
+              $"…and the wrapped form of the same tuple is NOT flagged (found {tupleGreen.Count}, expected 0)");
 
         // ---- 2. the population, derived from the artifact ----------------------------------------------
         Console.WriteLine();
@@ -278,11 +319,13 @@ public static class RefusalCompletenessGuardProbe
         foreach (var scope in scopes)
         {
             // Names bound to a string a HELPER produced — the shape of a refusal handed straight back, which is
-            // how twelve of the fourteen escaped. Two bindings carry it, and both must be in the net: an
-            // `out var X` argument (Wire.WantsJson, ExpandListInput's tuple) and an `is { } X` pattern
-            // (Artifacts.ValidateToFile). An earlier draft took only the first, and the ValidateToFile sites —
-            // the fold's own fix — went invisible; the mutation sweep's cell for them came back with nothing
-            // flagged, which is how the gap was found.
+            // how twelve of the fourteen escaped. THREE bindings carry it on this surface, and each is its own
+            // syntax: an `out var X` argument (Wire.WantsJson), a tuple deconstruction `var (…, X) = Helper(…)`
+            // (Artifacts.ExpandListInput), and an `is { } X` recursive pattern (Artifacts.ValidateToFile). Each
+            // one was missing from a draft of this net and each miss was found the same way — by a mutation cell
+            // that reverted the site and came back with nothing flagged. ExpandListInput's tuple is NOT an out
+            // argument: its left side is a DeclarationExpressionSyntax carrying a ParenthesizedVariableDesignation,
+            // so the `out var` walk below cannot see it and an earlier comment here said otherwise.
             //
             // One binding is excluded, structurally and by name rather than by file: a designation bound from
             // ConfigPromptOrNull(). What that returns is trained guidance addressed to the model when no MO2
@@ -294,6 +337,14 @@ public static class RefusalCompletenessGuardProbe
                 if (!arg.RefKindKeyword.IsKind(SyntaxKind.OutKeyword)) continue;
                 if (arg.Expression is DeclarationExpressionSyntax { Designation: SingleVariableDesignationSyntax sv })
                     outNames.Add(sv.Identifier.Text);
+            }
+            foreach (var decl in scope.DescendantNodes().OfType<DeclarationExpressionSyntax>())
+            {
+                if (decl.Designation is not ParenthesizedVariableDesignationSyntax pd) continue;
+                if (decl.Parent is AssignmentExpressionSyntax asg
+                    && asg.Right.ToString().Contains("ConfigPromptOrNull", StringComparison.Ordinal)) continue;
+                foreach (var v in pd.DescendantNodesAndSelf().OfType<SingleVariableDesignationSyntax>())
+                    outNames.Add(v.Identifier.Text);
             }
             foreach (var pat in scope.DescendantNodes().OfType<IsPatternExpressionSyntax>())
             {

--- a/src/housecarl-generator/RefusalCompletenessGuardProbe.cs
+++ b/src/housecarl-generator/RefusalCompletenessGuardProbe.cs
@@ -57,20 +57,27 @@ public static class RefusalCompletenessGuardProbe
     /// — a surface that renders refusals correctly through its own helper is not a hole.</para></summary>
     static readonly string[] ApprovedRenderers = { "Wire.Refuse", "JsonWire.Render", "Wire.Render", "Refuse" };
 
-    /// <summary>The refusals that stay bare inside a format-consuming tool body, each with the settled decision
-    /// that rules it correct. Keyed <c>file:sentence-fragment</c> rather than by line, so ordinary edits above a
-    /// site do not rot the list while a CHANGE to the site still trips it.</summary>
-    static readonly (string File, string Fragment, string Decision, string Why)[] Allow =
+    /// <summary>The refusals that stay bare inside a policed scope, each with the settled decision that rules it
+    /// correct. Keyed <c>file:kind:fragment</c> rather than by line, so ordinary edits above a site do not rot the
+    /// list while a CHANGE to the site still trips it.
+    ///
+    /// <para>An entry is TYPED, and matched only against its own kind. A <see cref="HitKind.Binding"/> entry names
+    /// an identifier and must equal it exactly; a <see cref="HitKind.Literal"/> entry names message text and
+    /// matches a substring of it. Untyped substring matching let the binding entry <c>ferr</c> rule a future
+    /// refusal SENTENCE correct for containing those four letters — "…the record was transferred…" would have
+    /// dropped out of <c>unexplained</c> silently. Nothing on the tree hit it, which is exactly why it needed
+    /// closing: the allowlist is the guard's only escape hatch, and a hole in it is silent by construction.</para></summary>
+    static readonly (string File, HitKind Kind, string Fragment, string Decision, string Why)[] Allow =
     {
         // The format= parse refusal itself. Surface-wide ("*") on purpose: the population derives past the read
         // lane into the write tools, and the rule does not change there — a call whose format VALUE did not parse
         // has not told anyone which shape it wanted, so there is no known render to answer in. ApplyTools states
         // exactly that in its own comment at the site.
-        ("*", "ferr",   "#7", "the format= parse refusal cannot know the shape the caller wanted"),
-        ("*", "fmtErr", "#7", "the format= parse refusal cannot know the shape the caller wanted"),
+        ("*", HitKind.Binding, "ferr",   "#7", "the format= parse refusal cannot know the shape the caller wanted"),
+        ("*", HitKind.Binding, "fmtErr", "#7", "the format= parse refusal cannot know the shape the caller wanted"),
         // dense is a textual transport, so its two refusals are text by definition rather than by omission.
-        ("RecordsTools.cs", "format='dense' is the scan lane's columnar form",     "#7", "dense is a textual transport"),
-        ("RecordsTools.cs", "format='dense' is the in-order scan's columnar form", "#7", "dense is a textual transport"),
+        ("RecordsTools.cs", HitKind.Literal, "format='dense' is the scan lane's columnar form",     "#7", "dense is a textual transport"),
+        ("RecordsTools.cs", HitKind.Literal, "format='dense' is the in-order scan's columnar form", "#7", "dense is a textual transport"),
     };
 
     /// <summary>THE KNOWN-RED FIXTURE — <c>RecordsTools.cs:223</c> as it stood BEFORE the fold: a return whose
@@ -168,6 +175,22 @@ public static class RefusalCompletenessGuardProbe
         }
         """;
 
+    /// <summary>THE ALLOWLIST-KIND FIXTURE — Aaron's latent-hole example, made a test. Two hits from one policed
+    /// helper: the binding <c>ferr</c>, which the surface-wide entry rules correct, and a refusal SENTENCE that
+    /// happens to contain those same four letters inside "transferred", which it must NOT. Under untyped substring
+    /// matching the second was ruled correct and left <c>unexplained</c> silently.</summary>
+    const string AllowlistKindFixture = """
+        static class Fixture
+        {
+            static string Body(bool json)
+            {
+                bool j = Wire.WantsJson(format, out var ferr);
+                if (ferr is not null) return ferr;
+                return $"error: the record was transferred from a plugin outside the order.";
+            }
+        }
+        """;
+
     public static int RunGuard(string[] args)
     {
         _pass = _fail = 0;
@@ -223,6 +246,17 @@ public static class RefusalCompletenessGuardProbe
         // ---- 3. the residue: every flagged site must cite a ruling -------------------------------------
         Console.WriteLine();
         Console.WriteLine("--- 3: every bare refusal in the population cites a settled decision ---");
+
+        var kinds = Enumerate("<fixture>", AllowlistKindFixture, out var kindErrors, populationOnly: true);
+        Check(kindErrors.Count == 0, $"the allowlist-kind fixture parses ({string.Join("; ", kindErrors)})");
+        var binding = kinds.FirstOrDefault(h => h.Kind == HitKind.Binding);
+        var literal = kinds.FirstOrDefault(h => h.Kind == HitKind.Literal);
+        Check(kinds.Count == 2 && binding.Sentence == "ferr" && literal.Sentence?.Contains("transferred", StringComparison.Ordinal) == true,
+              $"the allowlist-kind fixture yields one binding hit and one literal hit (found {kinds.Count})");
+        Check(Match(binding) is not null, "a binding entry rules the identifier it names (`ferr`)");
+        Check(Match(literal) is null,
+              "…and does NOT rule a refusal SENTENCE containing the same letters — \"the record was transferred\" "
+              + "stays unexplained (an entry only matches its own kind)");
         var flagged = new List<Hit>();
         foreach (var file in Directory.EnumerateFiles(srcDir, "*.cs"))
         {
@@ -240,7 +274,7 @@ public static class RefusalCompletenessGuardProbe
         // A stale allowlist is a silent hole: it says a site is fine when the site is gone or has changed shape.
         var unused = Allow.Where(a => !flagged.Any(h => Matches(h, a))).ToList();
         foreach (var a in unused)
-            Console.WriteLine($"    STALE ALLOWLIST ENTRY  {a.File} :: '{a.Fragment}' ({a.Decision}) matches nothing");
+            Console.WriteLine($"    STALE ALLOWLIST ENTRY  {a.File} :: {a.Kind} '{a.Fragment}' ({a.Decision}) matches nothing");
         Check(unused.Count == 0,
               $"every allowlist entry still names a live site (found {unused.Count} stale)");
 
@@ -275,7 +309,13 @@ public static class RefusalCompletenessGuardProbe
 
     // ================= the enumeration =================
 
-    internal readonly record struct Hit(string File, int Line, string Sentence);
+    /// <summary>What a hit's <c>Sentence</c> IS. The two kinds are different vocabularies — an identifier the
+    /// body returned, and a message a caller reads — and an allowlist entry that matched across them is a hole:
+    /// Aaron's gate review named the shape, a refusal LITERAL containing the substring "ferr" (e.g. "…the record
+    /// was transferred…") silently ruled correct by the binding entry meant for `out var ferr`.</summary>
+    internal enum HitKind { Literal, Binding }
+
+    internal readonly record struct Hit(string File, int Line, string Sentence, HitKind Kind);
 
     /// <summary>Every <c>Guard.Tool</c> body that consults the format machinery — the surface this guard polices,
     /// derived rather than named. Returns the FILES those bodies live in; <paramref name="bodies"/> counts them.</summary>
@@ -422,13 +462,14 @@ public static class RefusalCompletenessGuardProbe
                 if (IsWrapped(expr)) continue;
 
                 string? sentence = RefusalLiteral(expr);
+                var kind = HitKind.Literal;
                 if (sentence is null && expr is IdentifierNameSyntax id && outNames.Contains(id.Identifier.Text))
-                    sentence = id.Identifier.Text;
+                    (sentence, kind) = (id.Identifier.Text, HitKind.Binding);
                 if (sentence is null) continue;
                 if (TransportAlreadyLeft(ret)) continue;
 
                 int line = ret.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
-                if (seen.Add(line)) hits.Add(new Hit(file, line, sentence));
+                if (seen.Add(line)) hits.Add(new Hit(file, line, sentence, kind));
             }
         }
         return hits;
@@ -544,16 +585,23 @@ public static class RefusalCompletenessGuardProbe
 
     // ================= allowlist matching =================
 
-    static (string File, string Fragment, string Decision, string Why)? Match(Hit h)
+    static (string File, HitKind Kind, string Fragment, string Decision, string Why)? Match(Hit h)
     {
         foreach (var a in Allow)
             if (Matches(h, a)) return a;
         return null;
     }
 
-    static bool Matches(Hit h, (string File, string Fragment, string Decision, string Why) a)
-        => (a.File == "*" || string.Equals(h.File, a.File, StringComparison.OrdinalIgnoreCase))
-           && h.Sentence.Contains(a.Fragment, StringComparison.Ordinal);
+    /// <summary>An entry rules a hit only when it is the SAME KIND of thing. A binding entry names an identifier,
+    /// so it must equal it — a substring there would let <c>ferr</c> rule <c>transferErr</c>. A literal entry names
+    /// message text, where a substring is the point: the entry quotes the stable clause, not the whole sentence.</summary>
+    static bool Matches(Hit h, (string File, HitKind Kind, string Fragment, string Decision, string Why) a)
+        => h.Sentence is not null
+           && (a.File == "*" || string.Equals(h.File, a.File, StringComparison.OrdinalIgnoreCase))
+           && h.Kind == a.Kind
+           && (a.Kind == HitKind.Binding
+                   ? string.Equals(h.Sentence, a.Fragment, StringComparison.Ordinal)
+                   : h.Sentence.Contains(a.Fragment, StringComparison.Ordinal));
 
     static string Trim(string s) => s.Length <= 110 ? s : s[..110] + "…";
 

--- a/src/housecarl-generator/RefusalCompletenessGuardProbe.cs
+++ b/src/housecarl-generator/RefusalCompletenessGuardProbe.cs
@@ -1,0 +1,382 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REFUSAL-COMPLETENESS GUARD (#403) — the read surface's refusal grammar is complete, and STAYS complete.
+///
+/// <para><b>Why it exists.</b> The refusal grammar shipped as 81 explicit <c>Wire.Refuse</c> call sites, and the
+/// set of sites needing one was found by running a regex over two hand-named files. Round 1 of the pre-PR review
+/// found that population short by fourteen — twelve refusals produced inside a helper and returned verbatim, a
+/// ternary whose two arms were both bare (the regex wants <c>return "error:</c> on ONE line; that line reads
+/// <c>return comparisonForm</c>), and a whole json-capable read tool that was never in the file set. Reviewer 3
+/// then proved by mutation that reverting ALL fourteen <c>ReadTools</c> call sites to prose left the entire
+/// 131-probe suite green. So the grammar had neither completeness by construction nor a guard that noticed its
+/// absence — CLAUDE.md §3's hand-wired-coverage failure mode, restated on the response layer.</para>
+///
+/// <para><b>Two binding properties, both load-bearing.</b></para>
+/// <list type="number">
+///   <item><b>It PARSES.</b> Roslyn walks return statements; there is no regex anywhere in the enumeration. The
+///   thing that defeated the sweep was a construct spanning lines, which is precisely what a line-oriented
+///   pattern cannot see and what a syntax tree sees for free. <see cref="PreFixTernaryFixture"/> preserves that
+///   exact pre-fix ternary as a permanent known-RED fixture: <c>INV-FIXTURE-RED</c> asserts the enumerator flags
+///   it. <b>If that fixture ever passes, the guard is broken, not the tree</b> — a checker whose known-red case
+///   comes back green is a broken checker, never a clean surface (§11).</item>
+///   <item><b>The population is DERIVED, never listed.</b> <see cref="DerivePopulation"/> finds every
+///   <c>Guard.Tool</c> body that consults the format machinery (<c>Wire.WantsJson</c> /
+///   <c>Wire.CrossQueryFormat</c>) and takes THAT as the surface under guard. A new json-capable read tool
+///   enrols itself; a hand-named file set is what let <c>housecarl_check</c> sit outside the trace with a bare
+///   refusal and its own comment stating the rule it was breaking.</item>
+/// </list>
+///
+/// <para><b>The allowlist is small BECAUSE the population is derived.</b> Of the 26 refusal returns that stay
+/// bare on the tree, only the ones actually inside a format-consuming tool body are the guard's business; the
+/// text-lane renderers and <c>ParsePole</c>'s own returns are not in a tool body at all, and their call sites —
+/// which ARE in one — are covered like any other site. Every entry below cites the settled decision that makes
+/// it correct, so an exception cannot be added without naming the ruling that permits it.</para>
+///
+/// <para>Self-contained: reads source files, no corpus and no MO2 instance, so it must run from the repo root.
+/// Run: <c>dotnet run --project src/housecarl-generator -- refusal-completeness-guard</c></para>
+/// </summary>
+public static class RefusalCompletenessGuardProbe
+{
+    static int _pass, _fail;
+    static readonly CSharpParseOptions Options = new(LanguageVersion.Preview);
+
+    /// <summary>Renderers that give a returned refusal its shape. A return wrapped in one of these has answered
+    /// the transport question; anything else carrying a refusal sentence has not.
+    ///
+    /// <para><c>Refuse</c> is listed unqualified as well as <c>Wire.Refuse</c>: the WRITE tools reach the same
+    /// verb through a local helper of that name, and the shape a refusal gets does not depend on how the call
+    /// spells its receiver. Matching the verb rather than the receiver is what lets the population stay derived
+    /// — a surface that renders refusals correctly through its own helper is not a hole.</para></summary>
+    static readonly string[] ApprovedRenderers = { "Wire.Refuse", "JsonWire.Render", "Wire.Render", "Refuse" };
+
+    /// <summary>The refusals that stay bare inside a format-consuming tool body, each with the settled decision
+    /// that rules it correct. Keyed <c>file:sentence-fragment</c> rather than by line, so ordinary edits above a
+    /// site do not rot the list while a CHANGE to the site still trips it.</summary>
+    static readonly (string File, string Fragment, string Decision, string Why)[] Allow =
+    {
+        // The format= parse refusal itself. Surface-wide ("*") on purpose: the population derives past the read
+        // lane into the write tools, and the rule does not change there — a call whose format VALUE did not parse
+        // has not told anyone which shape it wanted, so there is no known render to answer in. ApplyTools states
+        // exactly that in its own comment at the site.
+        ("*", "ferr",   "#7", "the format= parse refusal cannot know the shape the caller wanted"),
+        ("*", "fmtErr", "#7", "the format= parse refusal cannot know the shape the caller wanted"),
+        // dense is a textual transport, so its two refusals are text by definition rather than by omission.
+        ("RecordsTools.cs", "format='dense' is the scan lane's columnar form",     "#7", "dense is a textual transport"),
+        ("RecordsTools.cs", "format='dense' is the in-order scan's columnar form", "#7", "dense is a textual transport"),
+    };
+
+    /// <summary>THE KNOWN-RED FIXTURE — <c>RecordsTools.cs:223</c> as it stood BEFORE the fold: a return whose
+    /// two ternary arms are both bare refusal sentences, with a wrapped statement on either side. The sweep that
+    /// missed it needed the literal on the same line as the <c>return</c>. The enumerator must flag this; the
+    /// arm that says so is the guard's own proof that it can still see what a regex could not.</summary>
+    const string PreFixTernaryFixture = """
+        static class Fixture
+        {
+            static string Body()
+            {
+                bool json = Wire.WantsJson(format, out var ferr);
+                if (a) return Wire.Refuse(json, $"error: wrapped above.");
+                if (form is not ("fields" or "everything"))
+                    return comparisonForm
+                        ? $"error: project.depth belongs to the 'fields'/'everything' forms."
+                        : $"error: project.depth expands field contents.";
+                if (b) return Wire.Refuse(json, $"error: wrapped below.");
+                return Ok();
+            }
+        }
+        """;
+
+    /// <summary>The counter-fixture: the SAME shape, correctly wrapped. An enumerator that flags everything would
+    /// also flag this, and would be useless while looking vigilant — so its silence here is an arm too.</summary>
+    const string PostFixTernaryFixture = """
+        static class Fixture
+        {
+            static string Body()
+            {
+                bool json = Wire.WantsJson(format, out var ferr);
+                if (form is not ("fields" or "everything"))
+                    return Wire.Refuse(json, comparisonForm
+                        ? $"error: project.depth belongs to the 'fields'/'everything' forms."
+                        : $"error: project.depth expands field contents.");
+                return Ok();
+            }
+        }
+        """;
+
+    public static int RunGuard(string[] args)
+    {
+        _pass = _fail = 0;
+        Console.WriteLine("=== refusal-completeness-guard: the read surface's refusal grammar, by construction ===");
+        Console.WriteLine();
+
+        // ---- 1. the enumerator itself, against fixtures whose verdict is known by hand ------------------
+        Console.WriteLine("--- 1: the enumerator can see what the sweep could not ---");
+        var redHits = Enumerate("<fixture>", PreFixTernaryFixture, out var fixErrors);
+        Check(fixErrors.Count == 0, $"the known-RED fixture parses ({string.Join("; ", fixErrors)})");
+        Check(redHits.Count == 1,
+              $"KNOWN-RED FIXTURE: the pre-fix ternary is FLAGGED (found {redHits.Count}, expected 1) — if this "
+              + "passes, the enumerator is broken, not the tree");
+        var greenHits = Enumerate("<fixture>", PostFixTernaryFixture, out _);
+        Check(greenHits.Count == 0,
+              $"…and the wrapped form of the same shape is NOT flagged (found {greenHits.Count}, expected 0) — "
+              + "an enumerator that flags everything proves nothing");
+
+        // ---- 2. the population, derived from the artifact ----------------------------------------------
+        Console.WriteLine();
+        Console.WriteLine("--- 2: the population derives itself ---");
+        var srcDir = Path.Combine(Directory.GetCurrentDirectory(), "src", "housecarl-mcp");
+        if (!Directory.Exists(srcDir))
+        {
+            Check(false, $"there is no '{srcDir}' to scan — this guard reads source, so the CWD must be the repo root");
+            return Done();
+        }
+
+        var population = DerivePopulation(srcDir, out var parseErrors, out var bodies);
+        Check(parseErrors.Count == 0,
+              $"every scanned file PARSES — a file that does not parse has untrustworthy returns ({string.Join("; ", parseErrors)})");
+        Check(population.Count > 0, "the derived population is non-empty (Guard.Tool bodies consulting the format machinery)");
+        Console.WriteLine($"    population: {bodies} tool body/bodies across {population.Count} file(s) — "
+                        + string.Join(", ", population.OrderBy(f => f)));
+
+        // ---- 3. the residue: every flagged site must cite a ruling -------------------------------------
+        Console.WriteLine();
+        Console.WriteLine("--- 3: every bare refusal in the population cites a settled decision ---");
+        var flagged = new List<Hit>();
+        foreach (var file in Directory.EnumerateFiles(srcDir, "*.cs"))
+        {
+            var text = File.ReadAllText(file);
+            foreach (var h in Enumerate(Path.GetFileName(file), text, out _, populationOnly: true))
+                flagged.Add(h);
+        }
+
+        var unexplained = flagged.Where(h => Match(h) is null).ToList();
+        foreach (var h in unexplained)
+            Console.WriteLine($"    UNEXPLAINED  {h.File}:{h.Line}  {Trim(h.Sentence)}");
+        Check(unexplained.Count == 0,
+              $"no bare whole-call refusal in the population is without a ruling (found {unexplained.Count})");
+
+        // A stale allowlist is a silent hole: it says a site is fine when the site is gone or has changed shape.
+        var unused = Allow.Where(a => !flagged.Any(h => Matches(h, a))).ToList();
+        foreach (var a in unused)
+            Console.WriteLine($"    STALE ALLOWLIST ENTRY  {a.File} :: '{a.Fragment}' ({a.Decision}) matches nothing");
+        Check(unused.Count == 0,
+              $"every allowlist entry still names a live site (found {unused.Count} stale)");
+
+        Console.WriteLine();
+        Console.WriteLine($"    {flagged.Count} bare refusal return(s) in the population, all ruled: "
+                        + string.Join(", ", Allow.Select(a => a.Decision).Distinct()));
+        return Done();
+    }
+
+    static int Done()
+    {
+        Console.WriteLine();
+        Console.WriteLine(_fail == 0
+            ? "[refusal-completeness-guard] PASS — every reachable refusal in the derived population is shaped or ruled."
+            : "[refusal-completeness-guard] FAIL — see the lines above.");
+        Console.WriteLine($"=== refusal-completeness-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
+        return _fail == 0 ? 0 : 1;
+    }
+
+    // ================= the enumeration =================
+
+    internal readonly record struct Hit(string File, int Line, string Sentence);
+
+    /// <summary>Every <c>Guard.Tool</c> body that consults the format machinery — the surface this guard polices,
+    /// derived rather than named. Returns the FILES those bodies live in; <paramref name="bodies"/> counts them.</summary>
+    static HashSet<string> DerivePopulation(string srcDir, out List<string> parseErrors, out int bodies)
+    {
+        parseErrors = new List<string>();
+        bodies = 0;
+        var files = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var path in Directory.EnumerateFiles(srcDir, "*.cs"))
+        {
+            var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(path), Options);
+            foreach (var d in tree.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error))
+                parseErrors.Add($"{Path.GetFileName(path)} {d.Id} line {d.Location.GetLineSpan().StartLinePosition.Line + 1}");
+            foreach (var body in ToolBodies(tree.GetRoot()))
+            {
+                bodies++;
+                files.Add(Path.GetFileName(path));
+                _ = body;
+            }
+        }
+        return files;
+    }
+
+    /// <summary>A <c>Guard.Tool(...)</c> invocation's body lambda, when that body consults the format machinery.
+    /// This is the definition of "on the json-capable read surface" — a tool that never asks about the transport
+    /// has no transport to honour, which is why <c>housecarl_effect_chain</c> is correctly absent without an
+    /// allowlist entry, and why a NEW json-capable tool enrols itself the day it is written.</summary>
+    static IEnumerable<SyntaxNode> ToolBodies(SyntaxNode root)
+    {
+        foreach (var inv in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            if (inv.Expression is not MemberAccessExpressionSyntax ma) continue;
+            if (ma.Name.Identifier.Text != "Tool" || ma.Expression.ToString() != "Guard") continue;
+            foreach (var arg in inv.ArgumentList.Arguments)
+            {
+                var e = arg.Expression;
+                if (e is not (ParenthesizedLambdaExpressionSyntax or SimpleLambdaExpressionSyntax
+                              or AnonymousMethodExpressionSyntax)) continue;
+                if (ConsultsFormat(e)) yield return e;
+            }
+        }
+    }
+
+    static bool ConsultsFormat(SyntaxNode body)
+        => body.DescendantNodes().OfType<InvocationExpressionSyntax>()
+               .Any(i => i.Expression is MemberAccessExpressionSyntax m
+                      && m.Expression.ToString() == "Wire"
+                      && m.Name.Identifier.Text is "WantsJson" or "CrossQueryFormat");
+
+    /// <summary>Every return in <paramref name="src"/> that hands a caller an UNSHAPED refusal.
+    ///
+    /// <para>Two shapes count, and both are structural — no pattern is matched against source text.
+    /// (a) the returned expression carries a string literal whose value opens with the refusal prefix, at ANY
+    /// depth, so a ternary arm, a concatenation and an interpolation are all seen; (b) the returned expression is
+    /// a bare identifier introduced by an <c>out var</c> or a deconstruction in the same body — the shape of a
+    /// refusal produced inside a helper and handed straight back, which is how twelve of the fourteen escaped.
+    /// Either way, a return already wrapped in an approved renderer is not a hit.</para>
+    ///
+    /// <para><paramref name="populationOnly"/> restricts the walk to derived tool bodies; the fixtures run with it
+    /// off, since a fixture is a body in its own right.</para></summary>
+    internal static List<Hit> Enumerate(string file, string src, out List<string> parseErrors,
+                                        bool populationOnly = false)
+    {
+        var tree = CSharpSyntaxTree.ParseText(src, Options);
+        parseErrors = tree.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => $"{d.Id} line {d.Location.GetLineSpan().StartLinePosition.Line + 1}")
+            .ToList();
+
+        var root = tree.GetRoot();
+        var scopes = populationOnly
+            ? ToolBodies(root).ToList()
+            : new List<SyntaxNode> { root };
+
+        var hits = new List<Hit>();
+        var seen = new HashSet<int>();
+        foreach (var scope in scopes)
+        {
+            // Names bound by an `out var X` ARGUMENT — the shape of a refusal produced inside a helper and handed
+            // straight back. Deliberately NOT every SingleVariableDesignation: `is { } prompt` binds the same way
+            // and the MO2-not-configured prompt it binds is trained guidance addressed to the model, not a
+            // refusal sentence — it is returned bare by the whole tool surface, write tools included, and is a
+            // separate surface-wide question rather than part of this grammar.
+            var outNames = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var arg in scope.DescendantNodes().OfType<ArgumentSyntax>())
+            {
+                if (!arg.RefKindKeyword.IsKind(SyntaxKind.OutKeyword)) continue;
+                if (arg.Expression is DeclarationExpressionSyntax { Designation: SingleVariableDesignationSyntax sv })
+                    outNames.Add(sv.Identifier.Text);
+            }
+
+            foreach (var ret in scope.DescendantNodes().OfType<ReturnStatementSyntax>())
+            {
+                var expr = ret.Expression;
+                if (expr is null) continue;
+                if (IsWrapped(expr)) continue;
+
+                string? sentence = RefusalLiteral(expr);
+                if (sentence is null && expr is IdentifierNameSyntax id && outNames.Contains(id.Identifier.Text))
+                    sentence = id.Identifier.Text;
+                if (sentence is null) continue;
+                if (TransportAlreadyLeft(ret)) continue;
+
+                int line = ret.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+                if (seen.Add(line)) hits.Add(new Hit(file, line, sentence));
+            }
+        }
+        return hits;
+    }
+
+    /// <summary>Has the json transport already returned before this statement?
+    ///
+    /// <para>The text-lane twin shape: <c>if (json) return JsonWire.RenderX(o); … if (!o.Success) return
+    /// "error: " + o.Error;</c>. The second return is prose on purpose and is UNREACHABLE on a json call, because
+    /// the json arm left several lines above it. Recognising that structurally is what keeps the allowlist honest
+    /// — every one of these would otherwise need a hand-written exception saying "the transport already left",
+    /// and a guard whose exceptions restate a structural fact is a guard that has stopped deriving.</para>
+    ///
+    /// <para>Deliberately narrow: only an <c>if (json) return …;</c> with no else, appearing EARLIER in an
+    /// enclosing block. A conditional that merely mentions <c>json</c> does not count.</para></summary>
+    static bool TransportAlreadyLeft(ReturnStatementSyntax ret)
+    {
+        SyntaxNode? node = ret;
+        while (node is not null)
+        {
+            if (node.Parent is BlockSyntax block)
+            {
+                foreach (var st in block.Statements)
+                {
+                    if (st == node) break;               // only statements BEFORE this one count
+                    if (st is not IfStatementSyntax ifs || ifs.Else is not null) continue;
+                    if (ifs.Condition is not IdentifierNameSyntax cond || cond.Identifier.Text != "json") continue;
+                    var inner = ifs.Statement is BlockSyntax b
+                        ? b.Statements.LastOrDefault()
+                        : ifs.Statement;
+                    if (inner is ReturnStatementSyntax) return true;
+                }
+            }
+            node = node.Parent;
+        }
+        return false;
+    }
+
+    /// <summary>Is this return already shaped? True when an approved renderer is the OUTERMOST call, or wraps the
+    /// literal-bearing part of a conditional (<c>json ? JsonWire.X : Wire.X</c> is shaped on both arms).</summary>
+    static bool IsWrapped(ExpressionSyntax expr)
+    {
+        foreach (var inv in expr.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>())
+        {
+            var name = inv.Expression.ToString();
+            if (ApprovedRenderers.Any(r => name.StartsWith(r, StringComparison.Ordinal))) return true;
+        }
+        return false;
+    }
+
+    /// <summary>The first refusal sentence carried anywhere inside the expression, or null. Uses the compiler's
+    /// own decoding, so an escape or an interpolation hole cannot hide the prefix.</summary>
+    static string? RefusalLiteral(ExpressionSyntax expr)
+    {
+        foreach (var node in expr.DescendantNodesAndSelf())
+        {
+            string? v = node switch
+            {
+                LiteralExpressionSyntax lit when lit.IsKind(SyntaxKind.StringLiteralExpression)
+                    => lit.Token.ValueText,
+                InterpolatedStringTextSyntax txt => txt.TextToken.ValueText,
+                _ => null,
+            };
+            if (v is not null && v.StartsWith("error: ", StringComparison.Ordinal)) return v;
+        }
+        return null;
+    }
+
+    // ================= allowlist matching =================
+
+    static (string File, string Fragment, string Decision, string Why)? Match(Hit h)
+    {
+        foreach (var a in Allow)
+            if (Matches(h, a)) return a;
+        return null;
+    }
+
+    static bool Matches(Hit h, (string File, string Fragment, string Decision, string Why) a)
+        => (a.File == "*" || string.Equals(h.File, a.File, StringComparison.OrdinalIgnoreCase))
+           && h.Sentence.Contains(a.Fragment, StringComparison.Ordinal);
+
+    static string Trim(string s) => s.Length <= 110 ? s : s[..110] + "…";
+
+    static void Check(bool ok, string label)
+    {
+        Console.WriteLine($"  {(ok ? "PASS" : "FAIL")}  {label}");
+        if (ok) _pass++; else _fail++;
+    }
+}

--- a/src/housecarl-generator/RefusalCompletenessGuardProbe.cs
+++ b/src/housecarl-generator/RefusalCompletenessGuardProbe.cs
@@ -167,6 +167,19 @@ public static class RefusalCompletenessGuardProbe
         Check(unused.Count == 0,
               $"every allowlist entry still names a live site (found {unused.Count} stale)");
 
+        // ---- 4. the discriminant means ONE thing, structurally -----------------------------------------
+        Console.WriteLine();
+        Console.WriteLine("--- 4: `ok` is the discriminant and nothing else ---");
+        var okWrites = OkKeyWrites(Path.Combine(srcDir, "JsonWire.cs"));
+        var strays = okWrites.Where(w => !w.Legal).ToList();
+        foreach (var w in strays)
+            Console.WriteLine($"    STRAY `ok`  JsonWire.cs:{w.Line}  writes ok as `{Trim(w.Value)}` in {w.Method}()");
+        Check(strays.Count == 0,
+              $"every `ok` key is either the refusal discriminant (literal false) or a write outcome (o.Success) "
+              + $"— a SERVED read document that writes `ok` is the #403 round-1 collision (found {strays.Count})");
+        Console.WriteLine($"    {okWrites.Count} `ok` write(s): "
+                        + string.Join(", ", okWrites.GroupBy(w => w.Value).Select(g => $"{g.Count()}x {g.Key}")));
+
         Console.WriteLine();
         Console.WriteLine($"    {flagged.Count} bare refusal return(s) in the population, all ruled: "
                         + string.Join(", ", Allow.Select(a => a.Decision).Distinct()));
@@ -373,6 +386,51 @@ public static class RefusalCompletenessGuardProbe
             if (v is not null && v.StartsWith("error: ", StringComparison.Ordinal)) return v;
         }
         return null;
+    }
+
+    // ================= the discriminant =================
+
+    internal readonly record struct OkWrite(int Line, string Method, string Value, bool Legal);
+
+    /// <summary>Every write of an <c>ok</c> PROPERTY in the json renderer, with what it writes and whether that
+    /// is a legal meaning.
+    ///
+    /// <para>Exactly two meanings are legal, and they are told apart by the ARGUMENT, structurally:</para>
+    /// <list type="bullet">
+    ///   <item>a literal <c>false</c> — the refusal discriminant, written in one place
+    ///   (<c>WriteRefusal</c>);</item>
+    ///   <item><c>o.Success</c> — the WRITE surface's outcome flag, which carries both verdicts by long-standing
+    ///   contract and is not this lane's business.</item>
+    /// </list>
+    ///
+    /// <para>Anything else writing that key is the #403 round-1 collision: <c>RenderCounts</c> wrote
+    /// <c>WriteNumber("ok", ok)</c> — a resolved-row COUNT — onto a served census, so a consumer branching on the
+    /// discriminant read an answered call as a refused one, and a typed consumer could not parse it. Held here as
+    /// a structural fact rather than a runtime sample, because the collision was invisible to every runtime arm on
+    /// the surface: the document it appeared on was never one the refusal probes rendered.</para></summary>
+    static List<OkWrite> OkKeyWrites(string jsonWirePath)
+    {
+        var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(jsonWirePath), Options);
+        var outp = new List<OkWrite>();
+        foreach (var inv in tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            if (inv.Expression is not MemberAccessExpressionSyntax ma) continue;
+            if (!ma.Name.Identifier.Text.StartsWith("Write", StringComparison.Ordinal)) continue;
+            var args = inv.ArgumentList.Arguments;
+            if (args.Count < 2) continue;
+            if (args[0].Expression is not LiteralExpressionSyntax key
+                || !key.IsKind(SyntaxKind.StringLiteralExpression)
+                || key.Token.ValueText != "ok") continue;
+
+            var value = args[1].Expression.ToString();
+            bool legal = value == "false"                                  // the discriminant
+                      || value.EndsWith(".Success", StringComparison.Ordinal);  // a write outcome
+            var method = inv.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault()?.Identifier.Text
+                         ?? "<file scope>";
+            outp.Add(new OkWrite(inv.GetLocation().GetLineSpan().StartLinePosition.Line + 1,
+                                 method, value, legal));
+        }
+        return outp;
     }
 
     // ================= allowlist matching =================

--- a/src/housecarl-generator/RefusalCompletenessGuardProbe.cs
+++ b/src/housecarl-generator/RefusalCompletenessGuardProbe.cs
@@ -24,18 +24,21 @@ namespace HousecarlGenerator;
 ///   exact pre-fix ternary as a permanent known-RED fixture: <c>INV-FIXTURE-RED</c> asserts the enumerator flags
 ///   it. <b>If that fixture ever passes, the guard is broken, not the tree</b> — a checker whose known-red case
 ///   comes back green is a broken checker, never a clean surface (§11).</item>
-///   <item><b>The population is DERIVED, never listed.</b> <see cref="DerivePopulation"/> finds every
-///   <c>Guard.Tool</c> body that consults the format machinery (<c>Wire.WantsJson</c> /
-///   <c>Wire.CrossQueryFormat</c>) and takes THAT as the surface under guard. A new json-capable read tool
-///   enrols itself; a hand-named file set is what let <c>housecarl_check</c> sit outside the trace with a bare
-///   refusal and its own comment stating the rule it was breaking.</item>
+///   <item><b>The population is DERIVED, never listed.</b> <see cref="DerivePopulation"/> takes every scope in
+///   which the transport is DECIDED — a <c>Guard.Tool</c> body consulting <c>Wire.WantsJson</c> /
+///   <c>Wire.CrossQueryFormat</c> — or HANDED over — a method or local function declaring a <c>bool json</c> or
+///   a <c>QueryFormat</c> parameter. A new json-capable read tool enrols itself, and so does a new helper given
+///   the transport; a hand-named file set is what let <c>housecarl_check</c> sit outside the trace with a bare
+///   refusal and its own comment stating the rule it was breaking, and the tool-body-only draft of this net is
+///   what let <c>RenderListAggregate</c> revert to prose while the guard stayed green.</item>
 /// </list>
 ///
-/// <para><b>The allowlist is small BECAUSE the population is derived.</b> Of the 26 refusal returns that stay
-/// bare on the tree, only the ones actually inside a format-consuming tool body are the guard's business; the
-/// text-lane renderers and <c>ParsePole</c>'s own returns are not in a tool body at all, and their call sites —
-/// which ARE in one — are covered like any other site. Every entry below cites the settled decision that makes
-/// it correct, so an exception cannot be added without naming the ruling that permits it.</para>
+/// <para><b>The allowlist is small BECAUSE the population is derived.</b> Of the refusal returns that stay bare
+/// on the tree, only the ones in a policed scope are the guard's business, and a text-lane return inside one is
+/// excluded STRUCTURALLY rather than by hand when the json arm returned above it (<see cref="TransportAlreadyLeft"/>).
+/// <c>ParsePole</c>'s own returns are in no policed scope at all — no transport is decided in it or handed to it —
+/// and its call sites, which ARE policed, are covered like any other site. Every entry below cites the settled
+/// decision that makes it correct, so an exception cannot be added without naming the ruling that permits it.</para>
 ///
 /// <para>Self-contained: reads source files, no corpus and no MO2 instance, so it must run from the repo root.
 /// Run: <c>dotnet run --project src/housecarl-generator -- refusal-completeness-guard</c></para>
@@ -140,6 +143,31 @@ public static class RefusalCompletenessGuardProbe
         }
         """;
 
+    /// <summary>THE POPULATION FIXTURE — three helpers, none of them a <c>Guard.Tool</c> body, enumerated with
+    /// the population filter ON. Two were HANDED the transport (a <c>bool json</c>, a <c>QueryFormat</c>) and
+    /// must be policed; the third has none in scope and must not be, because its shape is decided at its call
+    /// sites (<c>ParsePole</c>'s posture, settled #8). This is the arm that proves the derivation itself rather
+    /// than asserting it — the <c>QueryFormat</c> half has no live site today, so nothing else would.</summary>
+    const string TransportHelperFixture = """
+        static class Fixture
+        {
+            static string Render(string groupBy, bool json)
+            {
+                return $"error: project.group_by='{groupBy}' is not a count key.";
+            }
+
+            static string Scan(QueryFormat fmt)
+            {
+                return $"error: the scan lane refused.";
+            }
+
+            static string NoTransport(string pole)
+            {
+                return $"error: a helper with no transport in scope decides nothing here.";
+            }
+        }
+        """;
+
     public static int RunGuard(string[] args)
     {
         _pass = _fail = 0;
@@ -177,11 +205,19 @@ public static class RefusalCompletenessGuardProbe
             return Done();
         }
 
+        var handed = Enumerate("<fixture>", TransportHelperFixture, out var handedErrors, populationOnly: true);
+        Check(handedErrors.Count == 0, $"the transport-helper fixture parses ({string.Join("; ", handedErrors)})");
+        Check(handed.Count == 2,
+              $"a helper HANDED the transport is in the population — both spellings (found {handed.Count}, "
+              + "expected 2: the `bool json` helper and the `QueryFormat` one)");
+        Check(handed.All(h => !h.Sentence.Contains("decides nothing here", StringComparison.Ordinal)),
+              "…and a helper with NO transport in scope is not (settled #8 — its shape is decided at its call sites)");
+
         var population = DerivePopulation(srcDir, out var parseErrors, out var bodies);
         Check(parseErrors.Count == 0,
               $"every scanned file PARSES — a file that does not parse has untrustworthy returns ({string.Join("; ", parseErrors)})");
-        Check(population.Count > 0, "the derived population is non-empty (Guard.Tool bodies consulting the format machinery)");
-        Console.WriteLine($"    population: {bodies} tool body/bodies across {population.Count} file(s) — "
+        Check(population.Count > 0, "the derived population is non-empty (bodies that decide the transport, and helpers handed it)");
+        Console.WriteLine($"    population: {bodies} policed scope(s) across {population.Count} file(s) — "
                         + string.Join(", ", population.OrderBy(f => f)));
 
         // ---- 3. the residue: every flagged site must cite a ruling -------------------------------------
@@ -263,10 +299,20 @@ public static class RefusalCompletenessGuardProbe
         return files;
     }
 
-    /// <summary>A <c>Guard.Tool(...)</c> invocation's body lambda, when that body consults the format machinery.
-    /// This is the definition of "on the json-capable read surface" — a tool that never asks about the transport
-    /// has no transport to honour, which is why <c>housecarl_effect_chain</c> is correctly absent without an
-    /// allowlist entry, and why a NEW json-capable tool enrols itself the day it is written.</summary>
+    /// <summary>Every scope on the json-capable surface, derived from the artifact in two ways — a scope is
+    /// policed when the transport is DECIDED in it or HANDED to it.
+    ///
+    /// <para>(a) A <c>Guard.Tool(...)</c> body lambda that consults the format machinery. A tool that never asks
+    /// about the transport has no transport to honour, which is why <c>housecarl_effect_chain</c> is correctly
+    /// absent without an allowlist entry, and why a NEW json-capable tool enrols itself the day it is written.</para>
+    ///
+    /// <para>(b) Any method or local function DECLARING a transport parameter — a <c>bool json</c>, or a
+    /// <c>QueryFormat</c>. Aaron's gate review found (a) alone insufficient: a helper handed the transport
+    /// produces its refusal AND returns it inside itself, so no tool-body return ever carries the sentence and
+    /// the site sat outside the net entirely (<c>RecordsTools.RenderListAggregate</c>, reverted to prose, left
+    /// the guard green). Deriving on the parameter closes it without naming a file — a helper that was given the
+    /// transport was given the obligation with it. <c>ParsePole</c> stays correctly outside both: it has no
+    /// transport in scope, so its shape is decided at its call sites, which ARE in a tool body.</para></summary>
     static IEnumerable<SyntaxNode> ToolBodies(SyntaxNode root)
     {
         foreach (var inv in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
@@ -281,7 +327,19 @@ public static class RefusalCompletenessGuardProbe
                 if (ConsultsFormat(e)) yield return e;
             }
         }
+        foreach (var m in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
+            if (CarriesTransport(m.ParameterList)) yield return m;
+        foreach (var f in root.DescendantNodes().OfType<LocalFunctionStatementSyntax>())
+            if (CarriesTransport(f.ParameterList)) yield return f;
     }
+
+    /// <summary>Does this signature take the transport as an argument? <c>bool json</c> by name and type — the
+    /// spelling the whole read surface uses — or a <c>QueryFormat</c> of any name, which carries the three-way
+    /// text/json/dense answer and so is unambiguous on its type alone.</summary>
+    static bool CarriesTransport(ParameterListSyntax? ps)
+        => ps is not null && ps.Parameters.Any(p =>
+               (p.Type?.ToString() is "bool" or "bool?" && p.Identifier.Text == "json")
+               || p.Type?.ToString() is "QueryFormat" or "Wire.QueryFormat");
 
     static bool ConsultsFormat(SyntaxNode body)
         => body.DescendantNodes().OfType<InvocationExpressionSyntax>()

--- a/src/housecarl-generator/RefusalCompletenessGuardProbe.cs
+++ b/src/housecarl-generator/RefusalCompletenessGuardProbe.cs
@@ -281,6 +281,9 @@ public static class RefusalCompletenessGuardProbe
             {
                 var expr = ret.Expression;
                 if (expr is null) continue;
+                // `return (xerr);` is `return xerr;` with noise. Unwrap before asking what shape it is, so a
+                // refusal cannot escape the net behind a pair of brackets.
+                while (expr is ParenthesizedExpressionSyntax paren) expr = paren.Expression;
                 if (IsWrapped(expr)) continue;
 
                 string? sentence = RefusalLiteral(expr);

--- a/src/housecarl-mcp/CheckTools.cs
+++ b/src/housecarl-mcp/CheckTools.cs
@@ -151,7 +151,7 @@ public static class CheckTools
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         bool json = Wire.WantsJson(format, out var fmtErr);
         if (fmtErr is not null) return fmtErr;
-        if (!SweepFamilySelection.TryParse(findings, out var selection, out var famErr)) return "error: " + famErr;
+        if (!SweepFamilySelection.TryParse(findings, out var selection, out var famErr)) return Wire.Refuse(json, "error: " + famErr);
         int lim = limit <= 0 ? 1000 : limit;
 
         // WHAT EVERY FAMILY AGREES IS MALFORMED, CHECKED BEFORE ANY OF THEM IS DISPATCHED. These parameters were

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -35,6 +35,29 @@ static class JsonWire
         if (v is null) w.WriteNull(name); else w.WriteString(name, v);
     }
 
+    /// <summary>The ONE way a json DOCUMENT declares itself a refusal: <c>ok:false</c> followed by the message.
+    /// Every whole-call refusal on the read surface writes its discriminant through here, so the shape cannot be
+    /// stated one way in one renderer and another way in the next (#403 — the discriminant was absent entirely
+    /// while <see cref="RenderError"/>'s own summary claimed json consumers saw one refusal grammar).
+    ///
+    /// <para><b>Document-level only.</b> A per-ROW <c>error</c> field — a malformed FormID in a batch, a seed that
+    /// did not resolve — is NOT a refusal: the call succeeded and rendered a row that failed. Those sites keep a
+    /// bare <c>error</c> and must never gain <c>ok</c>, or a consumer branching on the discriminant would read a
+    /// served document as a refused one.</para>
+    ///
+    /// <para><b>Epoch is the caller's, deliberately.</b> Some refusals stamp the build they consulted
+    /// (<c>epoch:"…"</c>), some state it as null, and the pre-capture validation refusals omit it entirely because
+    /// they consulted no build (PR #305). That three-way split is a live contract, so this helper writes the
+    /// discriminant and the message and leaves epoch to the site.</para></summary>
+    internal static void WriteRefusal(Utf8JsonWriter w, string? error)
+    {
+        w.WriteBoolean("ok", false);
+        // `error` is nullable at one caller (read_plugin_file's error mode reads a DTO field that is typed
+        // optional), and that site wrote a json null before this helper existed. Preserved rather than tightened:
+        // changing what a refusal document says is not this lane's change.
+        WriteNullable(w, "error", error);
+    }
+
     // ---- housecarl_resolve (P3) ---------------------------------------------------------------------
     /// <summary>Render the bulk name-resolution result as JSON: <c>{count, resolved:[…], rendered, truncated}</c> —
     /// one <c>{formid,type,editorid,name,winner}</c> row per resolvable input, or <c>{formid,error}</c> for a
@@ -122,7 +145,7 @@ static class JsonWire
             // Refusals carry the bare stamp only — coverage is an assertion about RESOLVED inputs, and a refusal's
             // poles were never resolved (emitting true there claimed full coverage on e.g. an off-order-path
             // refusal; PR #305 third round, finding 2). Text refusals carry no qualifier either — D2 restored.
-            if (o.Error is not null) { w.WriteString("error", o.Error); WriteNullable(w, "epoch", o.Epoch); }
+            if (o.Error is not null) { WriteRefusal(w, o.Error); WriteNullable(w, "epoch", o.Epoch); }
             else
             {
                 WriteEpochWithCoverage(w, o);   // §2.1.1: the INDEX build + whether it covers every input
@@ -179,17 +202,27 @@ static class JsonWire
 
     static int Cap(int maxChars) => maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
 
-    /// <summary>A bare whole-call refusal document: <c>{error, epoch?}</c> — for tool-layer refusals that have no
-    /// outcome object to render (e.g. the §2.1.1 artifact epoch-mismatch handed back beside the batch), matching
+    /// <summary>A whole-call refusal document: <c>{ok:false, error, epoch}</c> — for tool-layer refusals that have
+    /// no outcome object to render (e.g. the §2.1.1 artifact epoch-mismatch handed back beside the batch), matching
     /// the outcome-borne refusal shape so json consumers see ONE refusal grammar. The stamp rides when the refusal
-    /// consulted a build (the PR #305 contract).</summary>
+    /// consulted a build (the PR #305 contract).
+    ///
+    /// <para><b>The discriminant is written through <see cref="WriteRefusal"/>, not here.</b> This summary used to
+    /// claim the one-grammar match while the document carried no <c>ok</c> at all, so a consumer branching on it
+    /// found the property absent on exactly the refusals this method serves (#403). The claim is now true by
+    /// construction: every whole-call refusal on the surface goes through that one writer.</para>
+    ///
+    /// <para><b><c>ok</c> marks refusals only.</b> A served read document carries no <c>ok</c> — absence means the
+    /// call was answered. Deliberate asymmetry with the write surface, which writes the flag on both outcomes:
+    /// stamping <c>ok:true</c> across every read render is a change to documents that are not refusals, and this
+    /// lane's contract is the refusal grammar.</para></summary>
     internal static string RenderError(string error, string? epoch)
     {
         using var ms = new MemoryStream();
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
             w.WriteStartObject();
-            w.WriteString("error", error);
+            WriteRefusal(w, error);
             WriteNullable(w, "epoch", epoch);
             w.WriteEndObject();
         }
@@ -349,7 +382,7 @@ static class JsonWire
             if (o.Error is not null)
             {
                 // A stamped refusal carries its stamp on the wire too (PR #305 review) — same contract as text.
-                w.WriteStartObject(); w.WriteString("error", o.Error); WriteNullable(w, "epoch", o.Epoch); w.WriteEndObject();
+                w.WriteStartObject(); WriteRefusal(w, o.Error); WriteNullable(w, "epoch", o.Epoch); w.WriteEndObject();
             }
             else WriteReadRecord(w, o, ms, cap, epoch: o.Epoch,
                                  childFields: new SortedSet<string>(StringComparer.Ordinal), stateChildNote: true);
@@ -959,7 +992,7 @@ static class JsonWire
             WriteEnvelope(w, envelope);
             // Post-capture refusals are stamped (PR #305 contract — e.g. the artifact epoch-mismatch refusal);
             // pre-capture validation refusals carry null and render bare, same as the text twin.
-            if (q.Error is not null) { w.WriteString("error", q.Error); if (q.Epoch is not null) w.WriteString("epoch", q.Epoch); }
+            if (q.Error is not null) { WriteRefusal(w, q.Error); if (q.Epoch is not null) w.WriteString("epoch", q.Epoch); }
             else if (q.Groups is not null)                                   // group_by= → count table
             {
                 WriteNullable(w, "group_by", q.GroupBy);
@@ -1074,7 +1107,7 @@ static class JsonWire
             w.WriteStartObject();
             WriteEnvelope(w, envelope);
             // Post-capture refusals are stamped (PR #305 contract); pre-capture validation refusals stay bare.
-            if (q.Error is not null) { w.WriteString("error", q.Error); if (q.Epoch is not null) w.WriteString("epoch", q.Epoch); }
+            if (q.Error is not null) { WriteRefusal(w, q.Error); if (q.Epoch is not null) w.WriteString("epoch", q.Epoch); }
             else
             {
                 bool detail = fields is { Count: > 0 };
@@ -1247,7 +1280,7 @@ static class JsonWire
             // bytes never reach the stream and the refusal rendered as an EMPTY STRING — a latent, pre-existing Q3
             // break on every json-mode sweep refusal, surfaced by the epoch guard's refusal-render arm (PR #305).
             // Bare stamp only: coverage is an assertion about SWEPT inputs, and a refusal swept none (finding 2).
-            if (r.Error is not null) { w.WriteString("error", r.Error); WriteNullable(w, "epoch", r.Epoch); w.WriteEndObject(); w.Flush(); return Finish(ms); }
+            if (r.Error is not null) { WriteRefusal(w, r.Error); WriteNullable(w, "epoch", r.Epoch); w.WriteEndObject(); w.Flush(); return Finish(ms); }
 
             WriteErrorsHead(w, r);
             // EVERYTHING A CAP CAN REFUSE GOES THROUGH `body`, including the excluded roster, which used to be
@@ -1632,7 +1665,7 @@ static class JsonWire
             using (var ew = new Utf8JsonWriter(ems, Opts))
             {
                 ew.WriteStartObject();
-                ew.WriteString("error", o.Error);
+                WriteRefusal(ew, o.Error);
                 WriteNullable(ew, "epoch", o.Epoch);
                 ew.WriteEndObject();
                 ew.Flush();
@@ -1805,7 +1838,7 @@ static class JsonWire
         {
             w.WriteStartObject();
             // w.Flush() before Finish — same latent empty-refusal bug as RenderCheckErrors' early return (see there).
-            if (r.Error is not null) { w.WriteString("error", r.Error); WriteNullable(w, "epoch", r.Epoch); w.WriteEndObject(); w.Flush(); return Finish(ms); }
+            if (r.Error is not null) { WriteRefusal(w, r.Error); WriteNullable(w, "epoch", r.Epoch); w.WriteEndObject(); w.Flush(); return Finish(ms); }
 
             WriteScriptsHead(w, r);
             var body = new BoundedBody(acct, budget, () => Size(w, ms));
@@ -2221,10 +2254,10 @@ static class JsonWire
         {
             w.WriteStartObject();
             WriteEnvelope(w, envelope);
-            if (o.Mode == "error") { w.WriteString("error", o.Error); }
+            if (o.Mode == "error") { WriteRefusal(w, o.Error); }
             else if (o.Mode == "ambiguous")
             {
-                w.WriteString("error", $"'{Path.GetFileName(o.Requested)}' is provided by {o.Ambiguous.Count} locations — specify which with mod= (or pass an absolute path).");
+                WriteRefusal(w, $"'{Path.GetFileName(o.Requested)}' is provided by {o.Ambiguous.Count} locations — specify which with mod= (or pass an absolute path).");
                 w.WriteStartArray("ambiguous");
                 foreach (var h in o.Ambiguous) { w.WriteStartObject(); w.WriteString("where", h.Where); w.WriteString("path", h.Path); w.WriteEndObject(); }
                 w.WriteEndArray();

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -452,7 +452,18 @@ static class JsonWire
 
     // ---- housecarl_records (W2 PR 1) ----------------------------------------------------------------
 
-    /// <summary>records counts_only on the list lane: the census document, no rows.</summary>
+    /// <summary>records counts_only on the list lane: the census document, no rows.
+    ///
+    /// <para><b>The resolved count is <c>resolved</c>, not <c>ok</c> (#403 round 1).</b> This document is a
+    /// SERVED answer, and it used to carry <c>"ok": &lt;int&gt;</c> — the same key the refusal grammar uses as its
+    /// discriminant, in a different type. A consumer told that <c>ok:false</c> means refused and that absence
+    /// means answered read a fully served census of three unresolvable inputs (<c>"ok": 0</c>) as a refusal, and
+    /// a consumer typing <c>ok</c> as a boolean failed to parse the document at all. <c>resolved</c> pairs with
+    /// <c>errors</c> beside it and says what the number counts. The <c>ok:false</c> discriminant is entrenched on
+    /// the write surface and keeps its meaning; it is this key that was the collision.</para>
+    ///
+    /// <para>The TEXT twin keeps <c>ok=</c>: prose has no discriminant to collide with, and the text lane's
+    /// output is deliberately unchanged by this branch.</para></summary>
     public static string RenderCounts(IReadOnlyList<KeyValuePair<string, string>> envelope, int count, int ok, int errors, string? epoch)
     {
         using var ms = new MemoryStream();
@@ -461,7 +472,7 @@ static class JsonWire
             w.WriteStartObject();
             WriteEnvelope(w, envelope);
             w.WriteNumber("count", count);
-            w.WriteNumber("ok", ok);
+            w.WriteNumber("resolved", ok);
             w.WriteNumber("errors", errors);
             WriteNullable(w, "epoch", epoch);
             w.WriteEndObject();

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -98,14 +98,14 @@ public static class ReadTools
         // plain file's tokens, or a §2.1.1 artifact's identity column + its epoch demand (checked in the batch's
         // own capture: scan once, project forever, never against a build the artifact didn't come from).
         var (toks, demand, echoSrc, xerr) = Artifacts.ExpandListInput(formids, "formids");
-        if (xerr is not null) return xerr;
+        if (xerr is not null) return Wire.Refuse(json, xerr);
         formids = toks!;
 
         var toFile = to_file?.Trim();
         bool wantFile = !string.IsNullOrEmpty(toFile);
         if (wantFile)
         {
-            if (Artifacts.ValidateToFile(toFile!) is { } verr) return verr;
+            if (Artifacts.ValidateToFile(toFile!) is { } verr) return Wire.Refuse(json, verr);
             if (conflict_tree) return Wire.Refuse(json, "error: to_file= writes the result as JSONL rows, and conflict_tree=true is a text-only diff view with no row form — drop one of the two.");
         }
 
@@ -279,7 +279,7 @@ public static class ReadTools
         if (references is { Length: > 0 })
         {
             var (toks, demand, echoSrc, xerr) = Artifacts.ExpandListInput(references, "references");
-            if (xerr is not null) return xerr;
+            if (xerr is not null) return Wire.Refuse(json, xerr);
             references = toks!; refDemand = demand; refEcho = echoSrc;
         }
         IReadOnlyList<FormKey>? refFks = null;
@@ -300,7 +300,7 @@ public static class ReadTools
         bool wantFile = !string.IsNullOrEmpty(toFile);
         if (wantFile)
         {
-            if (Artifacts.ValidateToFile(toFile!) is { } verr) return verr;
+            if (Artifacts.ValidateToFile(toFile!) is { } verr) return Wire.Refuse(json, verr);
             if (conflict_tree) return Wire.Refuse(json, "error: to_file= writes the result as JSONL rows, and conflict_tree=true is a text-only diff view with no row form — drop one of the two.");
             if (offset > 0) return Wire.Refuse(json, "error: to_file= captures the COMPLETE result (the artifact is never a window), so offset= has nothing to page — drop offset=.");
         }
@@ -404,12 +404,12 @@ public static class ReadTools
 
         // formids= under the @file convention — see batch_record_detail's twin.
         var (toks, demand, echoSrc, xerr) = Artifacts.ExpandListInput(formids, "formids");
-        if (xerr is not null) return xerr;
+        if (xerr is not null) return Wire.Refuse(json, xerr);
         formids = toks!;
 
         var toFile = to_file?.Trim();
         bool wantFile = !string.IsNullOrEmpty(toFile);
-        if (wantFile && Artifacts.ValidateToFile(toFile!) is { } verr) return verr;
+        if (wantFile && Artifacts.ValidateToFile(toFile!) is { } verr) return Wire.Refuse(json, verr);
 
         var rows = svc.ResolveRefs(formids, demand, out var epoch, out var artifactRefusal);
         if (artifactRefusal is not null)

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -46,10 +46,10 @@ public static class ReadTools
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         bool json = Wire.WantsJson(format, out var ferr);
         if (ferr is not null) return ferr;
-        if (json && conflict_tree) return "error: conflict_tree=true is a text-only diff view and is not carried in json mode — use format=text for the conflict tree, or drop conflict_tree for the json field data.";
+        if (json && conflict_tree) return Wire.Refuse(json, "error: conflict_tree=true is a text-only diff view and is not carried in json mode — use format=text for the conflict tree, or drop conflict_tree for the json field data.");
         FormKey fk;
         try { fk = FormKey.Factory(formid.Trim()); }
-        catch (Exception ex) { return $"error: bad FormID '{formid}': {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '0F1AC1:Skyrim.esm'."; }
+        catch (Exception ex) { return Wire.Refuse(json, $"error: bad FormID '{formid}': {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '0F1AC1:Skyrim.esm'."); }
 
         var outcome = svc.ResolveRead(fk, plugin?.Trim(), fields, conflict_tree, depth <= 0 ? 1 : depth, resolve_names);
         return json ? JsonWire.RenderRecord(outcome, max_chars) : Wire.RenderRecord(svc, outcome, fields, conflict_tree, max_chars);
@@ -87,10 +87,12 @@ public static class ReadTools
             string? to_file = null) => Guard.Tool("housecarl_batch_record_detail", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        if (formids is null || formids.Length == 0) return "error: formids is empty. Pass one or more 'XXXXXX:Plugin.esp' FormIDs.";
+        // Transport BEFORE the first refusal: the empty-formids check used to fire above this line, so a json
+        // caller got that one refusal as bare prose while every later refusal in the same body honoured json.
         bool json = Wire.WantsJson(format, out var ferr);
         if (ferr is not null) return ferr;
-        if (json && conflict_tree) return "error: conflict_tree=true is a text-only diff view and is not carried in json mode — use format=text for the conflict tree, or drop conflict_tree for the json field data.";
+        if (formids is null || formids.Length == 0) return Wire.Refuse(json, "error: formids is empty. Pass one or more 'XXXXXX:Plugin.esp' FormIDs.");
+        if (json && conflict_tree) return Wire.Refuse(json, "error: conflict_tree=true is a text-only diff view and is not carried in json mode — use format=text for the conflict tree, or drop conflict_tree for the json field data.");
 
         // formids= under the @file convention (§5.1): a single "@<path>" element stands for the whole list — a
         // plain file's tokens, or a §2.1.1 artifact's identity column + its epoch demand (checked in the batch's
@@ -104,7 +106,7 @@ public static class ReadTools
         if (wantFile)
         {
             if (Artifacts.ValidateToFile(toFile!) is { } verr) return verr;
-            if (conflict_tree) return "error: to_file= writes the result as JSONL rows, and conflict_tree=true is a text-only diff view with no row form — drop one of the two.";
+            if (conflict_tree) return Wire.Refuse(json, "error: to_file= writes the result as JSONL rows, and conflict_tree=true is a text-only diff view with no row form — drop one of the two.");
         }
 
         var outcomes = svc.ResolveBatch(formids, fields, conflict_tree, depth <= 0 ? 1 : depth, resolve_names, plugin?.Trim(),
@@ -257,16 +259,19 @@ public static class ReadTools
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         var fmt = Wire.CrossQueryFormat(format, out var ferr);
         if (ferr is not null) return ferr;
-        if (fmt is not Wire.QueryFormat.Text && conflict_tree) return $"error: conflict_tree=true is a text-only diff view and is not carried in {(fmt is Wire.QueryFormat.Json ? "json" : "dense")} mode — use format=text for the conflict tree, or drop conflict_tree for the field data.";
+        // This tool carries the three-value format; `dense` is a textual transport, so only the json arm gets the
+        // refusal document. Named once here so the refusals below read the same as every other tool body's.
+        bool json = fmt is Wire.QueryFormat.Json;
+        if (fmt is not Wire.QueryFormat.Text && conflict_tree) return Wire.Refuse(json, $"error: conflict_tree=true is a text-only diff view and is not carried in {(fmt is Wire.QueryFormat.Json ? "json" : "dense")} mode — use format=text for the conflict tree, or drop conflict_tree for the field data.");
         if (group_by is not null && ((fields is { Length: > 0 }) || conflict_tree))
-            return "error: group_by aggregates matches into a count table and cannot be combined with fields= or conflict_tree=true (those expand each match to full detail — pick one). Drop fields=/conflict_tree, or drop group_by.";
+            return Wire.Refuse(json, "error: group_by aggregates matches into a count table and cannot be combined with fields= or conflict_tree=true (those expand each match to full detail — pick one). Drop fields=/conflict_tree, or drop group_by.");
         if (depth <= 0) depth = 1;
         if (depth > 1 && group_by is not null)
-            return "error: depth= expands per-match field contents, and group_by= renders a count table with no field values — depth= never applies there. Drop depth= (or drop group_by= and pass fields= for per-match detail).";
+            return Wire.Refuse(json, "error: depth= expands per-match field contents, and group_by= renders a count table with no field values — depth= never applies there. Drop depth= (or drop group_by= and pass fields= for per-match detail).");
         if (depth > 1 && fields is not { Length: > 0 } && !conflict_tree)
-            return "error: depth= expands the list/dict contents of fields= paths, and no fields= was passed — summary lines have nothing to expand. Pass fields= (e.g. fields=['Effects'], depth=4) or conflict_tree=true (the whole-record dump), or drop depth=.";
+            return Wire.Refuse(json, "error: depth= expands the list/dict contents of fields= paths, and no fields= was passed — summary lines have nothing to expand. Pass fields= (e.g. fields=['Effects'], depth=4) or conflict_tree=true (the whole-record dump), or drop depth=.");
         if (depth > 1 && fmt is Wire.QueryFormat.Dense)
-            return "error: depth>1 is not carried in format='dense' — dense rows are positional (one cell per requested fields= path), and depth expansion emits extra sub-paths that would break the column alignment. Use format=text or format=json for depth expansion, or drop depth= for the dense summary cells.";
+            return Wire.Refuse(json, "error: depth>1 is not carried in format='dense' — dense rows are positional (one cell per requested fields= path), and depth expansion emits extra sub-paths that would break the column alignment. Use format=text or format=json for depth expansion, or drop depth= for the dense summary cells.");
         // references= may itself be an @file / @artifact list (the §5.1 @file convention) — expanded BEFORE the
         // FormKey parse; an artifact target contributes its epoch demand, checked inside the scan's own capture.
         HousecarlCore.ArtifactDemand? refDemand = null;
@@ -285,7 +290,7 @@ public static class ReadTools
             {
                 if (string.IsNullOrWhiteSpace(r)) continue;
                 try { list.Add(FormKey.Factory(r.Trim())); }
-                catch (Exception ex) { return $"error: bad references FormID '{r}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }
+                catch (Exception ex) { return Wire.Refuse(json, $"error: bad references FormID '{r}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
             }
             if (list.Count > 0) refFks = list.Distinct().ToList();   // preserve input order, drop dupes
         }
@@ -296,8 +301,8 @@ public static class ReadTools
         if (wantFile)
         {
             if (Artifacts.ValidateToFile(toFile!) is { } verr) return verr;
-            if (conflict_tree) return "error: to_file= writes the result as JSONL rows, and conflict_tree=true is a text-only diff view with no row form — drop one of the two.";
-            if (offset > 0) return "error: to_file= captures the COMPLETE result (the artifact is never a window), so offset= has nothing to page — drop offset=.";
+            if (conflict_tree) return Wire.Refuse(json, "error: to_file= writes the result as JSONL rows, and conflict_tree=true is a text-only diff view with no row form — drop one of the two.");
+            if (offset > 0) return Wire.Refuse(json, "error: to_file= captures the COMPLETE result (the artifact is never a window), so offset= has nothing to page — drop offset=.");
         }
 
         var outcome = svc.CrossQuery(type, refFks, editorid_contains, conflicts_only, plugins, where,
@@ -392,9 +397,10 @@ public static class ReadTools
             string? to_file = null) => Guard.Tool("housecarl_resolve", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        if (formids is null || formids.Length == 0) return "error: formids is empty. Pass one or more 'XXXXXX:Plugin.esp' FormIDs.";
+        // Transport BEFORE the first refusal — see the same hoist in BatchRecordDetail.
         bool json = Wire.WantsJson(format, out var ferr);
         if (ferr is not null) return ferr;
+        if (formids is null || formids.Length == 0) return Wire.Refuse(json, "error: formids is empty. Pass one or more 'XXXXXX:Plugin.esp' FormIDs.");
 
         // formids= under the @file convention — see batch_record_detail's twin.
         var (toks, demand, echoSrc, xerr) = Artifacts.ExpandListInput(formids, "formids");
@@ -668,6 +674,36 @@ static class Wire
         if (f.Equals("json", StringComparison.OrdinalIgnoreCase)) return true;
         error = $"error: format='{format}' is not recognized — use 'text' (the default) or 'json'.";
         return false;
+    }
+
+    /// <summary>The read surface's refusal literal prefix. The text lane states a refusal as <c>"error: …"</c>;
+    /// the json lane carries the same sentence in an <c>error</c> property WITHOUT the prefix (the property name
+    /// already says what it is). One definition so the two lanes cannot disagree about where the sentence starts.</summary>
+    internal const string RefusalPrefix = "error: ";
+
+    /// <summary>THE ONE REFUSAL RENDER PATH for the read surface. A tool body states its refusal once, in the text
+    /// spelling, and this decides the shape the caller actually asked for.
+    ///
+    /// <para><b>Why it exists.</b> A read tool decides its transport early and then refuses in prose regardless —
+    /// <c>housecarl_records</c> settles <c>json</c> at the top of its body and 60-odd later refusals returned a bare
+    /// string anyway. <see cref="Guard"/> hands a body's return value straight back, so nothing downstream converted
+    /// it: a caller who asked for json got a non-json body for a third of the surface's refusals. The discriminant
+    /// (#403) was the smaller half of that; this is the half that decides whether a refusal is json at all.</para>
+    ///
+    /// <para><b>Text is byte-identical to what it was.</b> The message passed here is the sentence as authored, so
+    /// the text lane returns it unchanged — this call site is not a wording change. The json lane strips
+    /// <see cref="RefusalPrefix"/> and renders <c>{ok:false, error, epoch}</c> through
+    /// <see cref="JsonWire.RenderError"/>, matching the shape the already-wrapped sites emit.</para>
+    ///
+    /// <para><b>Not for per-row failures.</b> A row that failed inside a call that succeeded is not a refusal; it
+    /// keeps its per-row <c>error</c> field. This path is whole-call only.</para></summary>
+    internal static string Refuse(bool json, string message, string? epoch = null)
+    {
+        if (!json) return message;
+        var bare = message.StartsWith(RefusalPrefix, StringComparison.Ordinal)
+            ? message[RefusalPrefix.Length..]
+            : message;
+        return JsonWire.RenderError(bare, epoch);
     }
 
     /// <summary>The cross_plugin_query format vocabulary — the one tool with a third format (<c>dense</c>, the #223

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -987,9 +987,9 @@ public static class RecordsTools
                     // considered; the named source= decides whose VERSION the body forms read. Identity-fact
                     // forms have nothing for the pole to change — accepting-and-ignoring it is the sin.
                     if (form is "summary" or "aggregate")
-                        return Wire.Refuse(json, $"error: a plugins= scope with a named source= reads the POLE's version of each scoped match — and the '{form}' form's rows are identity facts the pole doesn't change. Drop source=, or use form='fields'/'everything' (the pole's bodies) or 'delta'/'tree' (comparisons).");
+                        return Wire.Refuse(json, $"error: a plugins= scope with a named source= reads the POLE's version of each scoped match — and the '{form}' form's rows are identity facts the pole doesn't change. Drop source=, or use form='fields'/'everything' (the pole's bodies) or 'delta'/'tree' (comparisons).", probeEpoch);
                     if (winnerFields)
-                        return Wire.Refuse(json, "error: fields_source='winner' and a named source= under a plugins= scope are TWO display poles on one call — the pole's version is what this composition reads. Drop fields_source= (or drop source= and keep fields_source='winner').");
+                        return Wire.Refuse(json, "error: fields_source='winner' and a named source= under a plugins= scope are TWO display poles on one call — the pole's version is what this composition reads. Drop fields_source= (or drop source= and keep fields_source='winner').", probeEpoch);
                     scopePlusPole = true;
                     // The scope statement is the truthful arm only for the forms that READ the pole's bodies;
                     // delta's pipeline states its subject itself (R3-2). A scoped TREE reads every provider,
@@ -1276,25 +1276,25 @@ public static class RecordsTools
             envelope.Add(new("epoch_covers_source", "false"));
             headerLine += "\n(the off-order file's content is OUTSIDE the epoch fingerprint — an edit to it changes answers without changing the epoch)";
             if (conflicts_only)
-                return Wire.Refuse(json, "error: conflicts_only= has no meaning on an out-of-load-order file — it is not in the conflict frame. Drop it, or read the winner (source=\"winner\").");
+                return Wire.Refuse(json, "error: conflicts_only= has no meaning on an out-of-load-order file — it is not in the conflict frame. Drop it, or read the winner (source=\"winner\").", pole.Epoch);
             if (form == "info_order")
-                return Wire.Refuse(json, "error: the info_order form merges the ACTIVE order's touching plugins — an out-of-load-order file is not in that frame. Read the winner's merge (drop source=), or enumerate the file's DIAL records with form='summary'.");
+                return Wire.Refuse(json, "error: the info_order form merges the ACTIVE order's touching plugins — an out-of-load-order file is not in that frame. Read the winner's merge (drop source=), or enumerate the file's DIAL records with form='summary'.", pole.Epoch);
             if (walk is not null)
-                return Wire.Refuse(json, "error: the walk expands the ACTIVE order's winner link graph — an out-of-load-order file's records are not in that graph. Enumerate the file with form='summary', then walk specific records via formids= (dropping source=).");
+                return Wire.Refuse(json, "error: the walk expands the ACTIVE order's winner link graph — an out-of-load-order file's records are not in that graph. Enumerate the file with form='summary', then walk specific records via formids= (dropping source=).", pole.Epoch);
             if (dense) return "error: format='dense' is the in-order scan's columnar form — an off-order file scan renders text or json.";
             if (versusSpec?.Kind == LoadOrderService.PoleKind.Overlay)
                 return Wire.Refuse(json, "error: an overlay pole on a SCAN would replay the SkyPatcher INI layer over every match — a per-record replay at scan scale " +
                        "(a scan comparison compares EVERY match, so it is not a bound). Name the records via formids= — the list lane reads and " +
-                       "compares their post-state bodies — or read the whole layer via housecarl_skypatcher_layer.");
+                       "compares their post-state bodies — or read the whole layer via housecarl_skypatcher_layer.", pole.Epoch);
             if (where_source is not null)
             {
                 // Full-vocabulary validation, mirroring the in-order engine (review F9): an unknown spelling must
                 // refuse by name, never be accepted-and-ignored.
                 var ws = where_source.Trim().ToLowerInvariant();
                 if (ws == "winner")
-                    return Wire.Refuse(json, "error: where_source=winner matches on the live load-order winner — but this scan streams an out-of-load-order FILE's bodies, many of which have no winner. Match the winner by scanning the winner (drop source=), or drop where_source=.");
+                    return Wire.Refuse(json, "error: where_source=winner matches on the live load-order winner — but this scan streams an out-of-load-order FILE's bodies, many of which have no winner. Match the winner by scanning the winner (drop source=), or drop where_source=.", pole.Epoch);
                 if (ws is not ("scoped" or "scanned"))
-                    return Wire.Refuse(json, $"error: where_source='{where_source}' is not a known source — over an out-of-load-order file the match reads the FILE's own bodies ('scoped', the default); drop where_source=, or use 'winner' on an in-order scan.");
+                    return Wire.Refuse(json, $"error: where_source='{where_source}' is not a known source — over an out-of-load-order file the match reads the FILE's own bodies ('scoped', the default); drop where_source=, or use 'winner' on an in-order scan.", pole.Epoch);
             }
 
             // The completed off-order lane (W2 PR 2): the same filter grammar as the in-order scan, run by the

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -220,9 +220,9 @@ public static class RecordsTools
             // forms while `depth: 2` refused — the rule must not depend on the value), and 0/negative is refused
             // rather than silently becoming 1.
             if (form is not ("fields" or "everything"))
-                return comparisonForm
+                return Wire.Refuse(json, comparisonForm
                     ? $"error: project.depth belongs to the 'fields'/'everything' forms — the '{form}' comparison always deep-reads BOTH sides at the diff engine's fixed depth so line sets correspond (narrow with project.fields instead)."
-                    : $"error: project.depth expands field contents and belongs to the 'fields'/'everything' forms (got form='{form}').";
+                    : $"error: project.depth expands field contents and belongs to the 'fields'/'everything' forms (got form='{form}').");
             if (dv < 1)
                 return Wire.Refuse(json, $"error: project.depth={dv} — depth must be >= 1 (1 shows a container as a collapsed summary; higher opens it).");
         }
@@ -378,7 +378,7 @@ public static class RecordsTools
         bool wantFile = !string.IsNullOrEmpty(toFile);
         if (wantFile)
         {
-            if (Artifacts.ValidateToFile(toFile!) is { } verr) return verr;
+            if (Artifacts.ValidateToFile(toFile!) is { } verr) return Wire.Refuse(json, verr);
             if (offset > 0) return Wire.Refuse(json, "error: to_file= captures the COMPLETE result (the artifact is never a window), so offset= has nothing to page — drop offset=.");
             if (form == "aggregate") return Wire.Refuse(json, "error: to_file= writes row artifacts, and the aggregate form is a count table with no record rows — drop one of the two.");
             if (counts_only) return Wire.Refuse(json, "error: counts_only= returns the census with no rows, and to_file= writes the rows — the two contradict; drop one (review: this pair used to return the census and silently write nothing).");
@@ -439,7 +439,7 @@ public static class RecordsTools
             if (dense) return "error: format='dense' is the scan lane's columnar form — a formids= read renders text or json.";
 
             var (toks, demand, echoSrc, xerr) = Artifacts.ExpandListInput(formids!, "formids");
-            if (xerr is not null) return xerr;
+            if (xerr is not null) return Wire.Refuse(json, xerr);
             var ids = toks!;
 
             List<KeyValuePair<string, string>> Echo()
@@ -954,7 +954,7 @@ public static class RecordsTools
             if (hasFormids)
             {
                 var (ftoks, fdemand, fecho, fxerr) = Artifacts.ExpandListInput(formids!, "formids");
-                if (fxerr is not null) return fxerr;
+                if (fxerr is not null) return Wire.Refuse(json, fxerr);
                 fidDemand = fdemand; fidEcho = fecho;
                 var fkList = new List<FormKey>();
                 foreach (var t in ftoks!)
@@ -1009,7 +1009,7 @@ public static class RecordsTools
             if (refs is { Length: > 0 })
             {
                 var (toks, demand, echoSrc, xerr) = Artifacts.ExpandListInput(refs, "references");
-                if (xerr is not null) return xerr;
+                if (xerr is not null) return Wire.Refuse(json, xerr);
                 refs = toks!; refDemand = demand; refEcho = echoSrc;
             }
             IReadOnlyList<FormKey>? refFks = null;
@@ -1304,7 +1304,7 @@ public static class RecordsTools
             if (refs is { Length: > 0 })
             {
                 var (toks, demand, echoSrc2, xerr) = Artifacts.ExpandListInput(refs, "references");
-                if (xerr is not null) return xerr;
+                if (xerr is not null) return Wire.Refuse(json, xerr);
                 refs = toks!; refDemand = demand; refEcho = echoSrc2;
             }
             IReadOnlyList<FormKey>? refFks = null;
@@ -1324,7 +1324,7 @@ public static class RecordsTools
             if (formids is { Length: > 0 })
             {
                 var (ftoks, fdemand, fecho, fxerr) = Artifacts.ExpandListInput(formids!, "formids");
-                if (fxerr is not null) return fxerr;
+                if (fxerr is not null) return Wire.Refuse(json, fxerr);
                 fidDemand = fdemand; fidEcho = fecho;
                 var fkList = new List<FormKey>();
                 foreach (var t in ftoks!)

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -205,15 +205,15 @@ public static class RecordsTools
         {
             case "identity" or "summary" or "fields" or "everything" or "aggregate" or "delta" or "tree" or "info_order" or "chain": break;
             default:
-                return $"error: project.form='{project?.form}' is not a form — use identity | summary | fields | everything | aggregate | delta | tree | chain | info_order.";
+                return Wire.Refuse(json, $"error: project.form='{project?.form}' is not a form — use identity | summary | fields | everything | aggregate | delta | tree | chain | info_order.");
         }
         bool comparisonForm = form is "delta" or "tree";
         // Sub-parameters exist only inside their forms (SPEC §2.2) — a stray one is refused by name, so the caller
         // learns the form-scoping rule instead of getting a silently-ignored knob.
         if (project?.fields is { Length: > 0 } && form != "fields" && !comparisonForm)
-            return $"error: project.fields belongs to the 'fields'/'delta'/'tree' forms (got form='{form}'). Set project.form, or drop fields.";
+            return Wire.Refuse(json, $"error: project.fields belongs to the 'fields'/'delta'/'tree' forms (got form='{form}'). Set project.form, or drop fields.");
         if (form == "fields" && project?.fields is not { Length: > 0 })
-            return "error: the 'fields' form names its field paths — pass project.fields=[\"<path>\", …] (or use form='everything' for the full body).";
+            return Wire.Refuse(json, "error: the 'fields' form names its field paths — pass project.fields=[\"<path>\", …] (or use form='everything' for the full body).");
         if (project?.depth is { } dv)
         {
             // ANY explicit depth is form-scoped (review round 3: `depth: 1` was accepted-and-dropped on other
@@ -224,41 +224,42 @@ public static class RecordsTools
                     ? $"error: project.depth belongs to the 'fields'/'everything' forms — the '{form}' comparison always deep-reads BOTH sides at the diff engine's fixed depth so line sets correspond (narrow with project.fields instead)."
                     : $"error: project.depth expands field contents and belongs to the 'fields'/'everything' forms (got form='{form}').";
             if (dv < 1)
-                return $"error: project.depth={dv} — depth must be >= 1 (1 shows a container as a collapsed summary; higher opens it).";
+                return Wire.Refuse(json, $"error: project.depth={dv} — depth must be >= 1 (1 shows a container as a collapsed summary; higher opens it).");
         }
         if (project?.group_by is not null && form != "aggregate")
-            return $"error: project.group_by belongs to the 'aggregate' form only (got form='{form}'). Set project.form='aggregate', or drop group_by.";
+            return Wire.Refuse(json, $"error: project.group_by belongs to the 'aggregate' form only (got form='{form}'). Set project.form='aggregate', or drop group_by.");
         if (form == "aggregate")
         {
             // Validated HERE, before any read runs (review round 3: the list lane validated it only inside the
             // render, after the batch had already been paid for).
             var gbv = project?.group_by?.Trim().ToLowerInvariant();
             if (string.IsNullOrEmpty(gbv))
-                return "error: the 'aggregate' form names its count key — pass project.group_by='winner' | 'type' | 'defined_in'.";
+                return Wire.Refuse(json, "error: the 'aggregate' form names its count key — pass project.group_by='winner' | 'type' | 'defined_in'.");
             if (gbv is not ("winner" or "type" or "defined_in"))
-                return $"error: project.group_by='{project!.group_by}' is not a count key — use 'winner', 'type', or 'defined_in'.";
+                return Wire.Refuse(json, $"error: project.group_by='{project!.group_by}' is not a count key — use 'winner', 'type', or 'defined_in'.");
         }
         if (project is { resolve_names: true } && form is not ("fields" or "everything"))
-            return $"error: project.resolve_names annotates field values and belongs to the 'fields'/'everything' forms (got form='{form}').";
+            return Wire.Refuse(json, $"error: project.resolve_names annotates field values and belongs to the 'fields'/'everything' forms (got form='{form}').");
         int depth = project?.depth is { } d && d > 0 ? d : 1;
         var projFields = form is "fields" or "delta" or "tree" ? project?.fields : null;
         bool resolveNames = project?.resolve_names ?? false;
 
         // ---- SOURCE: the §4.2 pole grammar (source = the SUBJECT; versus = the comparison REFERENCE) ----
-        if (ParsePole(source, "source", subjectRole: true, out var srcSpec) is { } sperr) return sperr;
+        // ParsePole is a helper with no transport in scope, so its five refusals take the shape here.
+        if (ParsePole(source, "source", subjectRole: true, out var srcSpec) is { } sperr) return Wire.Refuse(json, sperr);
         srcSpec ??= LoadOrderService.PoleSpec.Winner;
-        if (ParsePole(versus, "versus", subjectRole: false, out var versusSpec) is { } vperr) return vperr;
+        if (ParsePole(versus, "versus", subjectRole: false, out var versusSpec) is { } vperr) return Wire.Refuse(json, vperr);
 
         // versus= belongs to the comparison forms; the delta form REQUIRES it (§4.1 — a delta has two poles).
         if (versusSpec is not null && !comparisonForm)
-            return $"error: versus= is the comparison REFERENCE pole and belongs to the 'delta'/'tree' forms (got form='{form}') — set project.form='delta' (subject vs reference) or 'tree' (every provider vs reference), or drop versus=.";
+            return Wire.Refuse(json, $"error: versus= is the comparison REFERENCE pole and belongs to the 'delta'/'tree' forms (got form='{form}') — set project.form='delta' (subject vs reference) or 'tree' (every provider vs reference), or drop versus=.");
         if (form == "delta" && versusSpec is null)
-            return "error: the 'delta' form compares the subject (source=, default the winner) against a REFERENCE — pass versus= (\"winner\" | a plugin filename | \"previous_provider\" | {\"overlay\": …}).";
+            return Wire.Refuse(json, "error: the 'delta' form compares the subject (source=, default the winner) against a REFERENCE — pass versus= (\"winner\" | a plugin filename | \"previous_provider\" | {\"overlay\": …}).");
         if (form == "tree")
         {
             versusSpec ??= LoadOrderService.PoleSpec.Winner;
             if (versusSpec.Kind == LoadOrderService.PoleKind.PreviousProvider)
-                return "error: versus='previous_provider' is subject-relative and pairs with the 'delta' form (one subject, one reference below it) — a tree diffs EVERY provider against ONE reference pole. Use form='delta', or a named/winner versus= on the tree.";
+                return Wire.Refuse(json, "error: versus='previous_provider' is subject-relative and pairs with the 'delta' form (one subject, one reference below it) — a tree diffs EVERY provider against ONE reference pole. Use form='delta', or a named/winner versus= on the tree.");
         }
         // ---- walk= (the §3 traversal construct) ---------------------------------------------------------
         string walkDirection = "forward";
@@ -268,47 +269,47 @@ public static class RecordsTools
         {
             var dir = walk.direction?.Trim().ToLowerInvariant();
             if (dir is not (null or "" or "forward" or "reverse"))
-                return $"error: walk.direction='{walk.direction}' — use 'forward' (what the seeds point at) or 'reverse' (what points at them; depth 1).";
+                return Wire.Refuse(json, $"error: walk.direction='{walk.direction}' — use 'forward' (what the seeds point at) or 'reverse' (what points at them; depth 1).");
             if (!string.IsNullOrEmpty(dir)) walkDirection = dir!;
             if (walk.depth is { } wd)
             {
-                if (wd < 1) return $"error: walk.depth={wd} — depth must be >= 1 (hops from the seed).";
+                if (wd < 1) return Wire.Refuse(json, $"error: walk.depth={wd} — depth must be >= 1 (hops from the seed).");
                 walkDepth = wd;
             }
             if (walk.max_nodes is { } wn)
             {
-                if (wn < 1) return $"error: walk.max_nodes={wn} — the node budget must be >= 1.";
+                if (wn < 1) return Wire.Refuse(json, $"error: walk.max_nodes={wn} — the node budget must be >= 1.");
                 walkMaxNodes = wn;
             }
             foreach (var x in walk.exclusions ?? Array.Empty<RecordsWalkExclusion>())
             {
                 if (string.IsNullOrWhiteSpace(x.match))
-                    return "error: a walk.exclusions entry needs match= — the record type name a read reports (e.g. 'Race').";
+                    return Wire.Refuse(json, "error: a walk.exclusions entry needs match= — the record type name a read reports (e.g. 'Race').");
                 var sev = x.severity?.Trim().ToLowerInvariant();
                 if (sev is not ("stop" or "refuse"))
-                    return $"error: walk.exclusions '{x.match}': severity='{x.severity}' — use 'stop' (prune, record the boundary) or 'refuse' (the whole walk fails loud).";
+                    return Wire.Refuse(json, $"error: walk.exclusions '{x.match}': severity='{x.severity}' — use 'stop' (prune, record the boundary) or 'refuse' (the whole walk fails loud).");
                 walkExclusions.Add((x.match!.Trim(), sev == "refuse"));
             }
             if (walkDirection == "reverse")
             {
                 if (walk.depth is > 1)
-                    return "error: walk.direction='reverse' with depth>1 is a TRANSITIVE reverse lookup — no index exists for it today, so it is refused rather than run as an unbounded scan-of-scans (the reverse-reference index is the known future capability that lifts this). Depth-1 reverse: references= with a bounding types=/plugins=, or MGEF seeds under form='chain' for the typed carrier lane.";
+                    return Wire.Refuse(json, "error: walk.direction='reverse' with depth>1 is a TRANSITIVE reverse lookup — no index exists for it today, so it is refused rather than run as an unbounded scan-of-scans (the reverse-reference index is the known future capability that lifts this). Depth-1 reverse: references= with a bounding types=/plugins=, or MGEF seeds under form='chain' for the typed carrier lane.");
                 if (walk.seed_paths is { Length: > 0 } || walk.exclusions is { Length: > 0 } || walk.follow is not null)
-                    return "error: walk.seed_paths/follow/exclusions shape a FORWARD expansion — a reverse walk scans TOWARD the seeds. Drop them.";
+                    return Wire.Refuse(json, "error: walk.seed_paths/follow/exclusions shape a FORWARD expansion — a reverse walk scans TOWARD the seeds. Drop them.");
                 if (form != "chain")
-                    return "error: the reverse walk's general spelling on this surface IS references= (the same construct, depth 1, bounded by types=/plugins=) — walk.direction='reverse' serves form='chain' with MGEF seeds (per-carrier magnitude/area/duration).";
+                    return Wire.Refuse(json, "error: the reverse walk's general spelling on this surface IS references= (the same construct, depth 1, bounded by types=/plugins=) — walk.direction='reverse' serves form='chain' with MGEF seeds (per-carrier magnitude/area/duration).");
             }
             if (references is { Length: > 0 })
-                return "error: walk= and references= are the same construct (references= IS the reverse walk at depth 1) — use one spelling per call.";
+                return Wire.Refuse(json, "error: walk= and references= are the same construct (references= IS the reverse walk at depth 1) — use one spelling per call.");
             if (dense)
-                return "error: format='dense' renders positional columnar cells 1:1 with requested field paths, and a walk's outputs (chains; reached-set reads) have no fixed column set — use format='text' or 'json'.";
+                return Wire.Refuse(json, "error: format='dense' renders positional columnar cells 1:1 with requested field paths, and a walk's outputs (chains; reached-set reads) have no fixed column set — use format='text' or 'json'.");
             if (comparisonForm || form is "info_order" or "identity")
-                return $"error: walk= derives a selection (the reached set), and the '{form}' form does not consume one — use form='chain' for the walk's own paths, or summary/fields/everything/aggregate over the reached set. To compare reached records, walk with to_file= and re-enter the artifact via formids=[\"@<file>\"] with form='{form}'.";
+                return Wire.Refuse(json, $"error: walk= derives a selection (the reached set), and the '{form}' form does not consume one — use form='chain' for the walk's own paths, or summary/fields/everything/aggregate over the reached set. To compare reached records, walk with to_file= and re-enter the artifact via formids=[\"@<file>\"] with form='{form}'.");
             if (where is { Length: > 0 })
-                return "error: walk= composed with where= (filtering the reached set by predicate) — walk with to_file=, then re-enter the artifact on a bounded scan via where=[\"formid in @<file>\", …]; the reached set becomes the scan's identity list.";
+                return Wire.Refuse(json, "error: walk= composed with where= (filtering the reached set by predicate) — walk with to_file=, then re-enter the artifact on a bounded scan via where=[\"formid in @<file>\", …]; the reached set becomes the scan's identity list.");
         }
         if (form == "chain" && walk is null)
-            return "error: the 'chain' form renders a walk's paths — pass walk= (e.g. walk={\"follow\": \"Template\"} over NPC seeds; reverse MGEF carriers: walk={\"direction\": \"reverse\"} with MGEF formids=).";
+            return Wire.Refuse(json, "error: the 'chain' form renders a walk's paths — pass walk= (e.g. walk={\"follow\": \"Template\"} over NPC seeds; reverse MGEF carriers: walk={\"direction\": \"reverse\"} with MGEF formids=).");
 
         // The existing single-pole lanes below drive off the named-pole fields; the richer specs dispatch to the
         // comparison/overlay lanes before reaching them.
@@ -326,13 +327,13 @@ public static class RecordsTools
             var fs = fields_source.Trim().ToLowerInvariant();
             if (fs == "winner") winnerFields = true;
             else if (fs is not ("scoped" or "scanned"))
-                return $"error: fields_source='{fields_source}' — use 'winner' (display the live winner's values) or omit it (display the matched body). A NAMED display pole is the scope-vs-pole composition: plugins= selects, source= names whose version the body forms read.";
+                return Wire.Refuse(json, $"error: fields_source='{fields_source}' — use 'winner' (display the live winner's values) or omit it (display the matched body). A NAMED display pole is the scope-vs-pole composition: plugins= selects, source= names whose version the body forms read.");
             if (winnerFields && comparisonForm)
-                return $"error: fields_source='winner' retargets what a matched row DISPLAYS, and the '{form}' form's display IS its two poles (source=/versus=) — name the version you want as a pole instead.";
+                return Wire.Refuse(json, $"error: fields_source='winner' retargets what a matched row DISPLAYS, and the '{form}' form's display IS its two poles (source=/versus=) — name the version you want as a pole instead.");
             if (winnerFields && form is "chain" or "info_order")
-                return $"error: fields_source='winner' retargets FIELD display, and the '{form}' form renders no field values — drop it.";
+                return Wire.Refuse(json, $"error: fields_source='winner' retargets FIELD display, and the '{form}' form renders no field values — drop it.");
             if (winnerFields && walk is not null)
-                return "error: fields_source='winner' — a walk's reading forms display the source= pole's version of the reached set: name the version via source= instead.";
+                return Wire.Refuse(json, "error: fields_source='winner' — a walk's reading forms display the source= pole's version of the reached set: name the version via source= instead.");
         }
 
         // ---- lane decision ------------------------------------------------------------------------------
@@ -340,50 +341,50 @@ public static class RecordsTools
         bool hasScan = types is { Length: > 0 } || plugins?.names is { Length: > 0 } || conflicts_only
                        || where is { Length: > 0 } || references is { Length: > 0 };
         if (!hasFormids && !hasScan)
-            return "error: select something — formids= (a record list), or a scan scope: types=, plugins=, conflicts_only=true, where=, references=.";
+            return Wire.Refuse(json, "error: select something — formids= (a record list), or a scan scope: types=, plugins=, conflicts_only=true, where=, references=.");
         // formids= composes with the scan terms (the W2 formids×scan composition): the identity set intersects
         // the scan's selection — or IS the universe when it is the only bound. The reverse MGEF walk keeps its
         // own lane (formids are the seeds; types= narrows the typed carrier scan).
         bool reverseWalk = walk is not null && walkDirection == "reverse";
         if (reverseWalk && (plugins?.names is { Length: > 0 } || conflicts_only || where is { Length: > 0 }))
-            return "error: the reverse MGEF walk takes formids= (the effects) and optionally types= (narrowing the carrier types) — the general bounded reverse over other scan terms is the references= spelling.";
+            return Wire.Refuse(json, "error: the reverse MGEF walk takes formids= (the effects) and optionally types= (narrowing the carrier types) — the general bounded reverse over other scan terms is the references= spelling.");
         if (reverseWalk && !hasFormids)
-            return "error: the reverse walk needs its seeds — pass formids= (the MGEF(s) whose carriers to trace).";
+            return Wire.Refuse(json, "error: the reverse walk needs its seeds — pass formids= (the MGEF(s) whose carriers to trace).");
         // dense is DEFINED as positional columnar cells 1:1 with the requested field paths (the tool description's
         // own rule) — the forms with no fixed column set refuse by name rather than quietly switching transport
         // (re-review: everything fell back to text, aggregate to the json table, neither saying so).
         if (dense && form == "everything")
-            return "error: format='dense' renders positional columnar cells 1:1 with requested field paths, and the 'everything' form has no fixed column set — use format='text' or 'json', or name the paths via form='fields'.";
+            return Wire.Refuse(json, "error: format='dense' renders positional columnar cells 1:1 with requested field paths, and the 'everything' form has no fixed column set — use format='text' or 'json', or name the paths via form='fields'.");
         if (dense && form == "aggregate")
-            return "error: format='dense' is the per-row columnar transport, and the 'aggregate' form is a count table — its json render IS the compact form; use format='json'.";
+            return Wire.Refuse(json, "error: format='dense' is the per-row columnar transport, and the 'aggregate' form is a count table — its json render IS the compact form; use format='json'.");
         if (dense && comparisonForm)
-            return $"error: format='dense' renders positional columnar cells 1:1 with requested field paths, and the '{form}' form's rows are variable-length delta lists with no fixed column set — use format='text' or 'json'.";
+            return Wire.Refuse(json, $"error: format='dense' renders positional columnar cells 1:1 with requested field paths, and the '{form}' form's rows are variable-length delta lists with no fixed column set — use format='text' or 'json'.");
         if (dense && form == "info_order")
-            return "error: format='dense' renders positional columnar cells 1:1 with requested field paths, and the 'info_order' form is an ordered sequence render with no fixed column set — use format='text' or 'json'.";
+            return Wire.Refuse(json, "error: format='dense' renders positional columnar cells 1:1 with requested field paths, and the 'info_order' form is an ordered sequence render with no fixed column set — use format='text' or 'json'.");
         if (form == "info_order" && srcSpec.Kind != LoadOrderService.PoleKind.Winner)
-            return "error: the info_order form merges EVERY plugin touching each topic — that merge is the answer, so a source= pole has no seat here (each line already names the plugin that placed it). Drop source=.";
+            return Wire.Refuse(json, "error: the info_order form merges EVERY plugin touching each topic — that merge is the answer, so a source= pole has no seat here (each line already names the plugin that placed it). Drop source=.");
         // fields_source= is the SCAN lane's display pole (it retargets what a matched row DISPLAYS); the list
         // lane's read IS its display, so the request would be silently meaningless there — refuse by name
         // (re-review: it was accepted and dropped). The GENERAL display pole is the composition itself:
         // plugins= (scope) x source= (whose version) reads any pole's bodies; fields_source='winner' remains
         // the winner shorthand on a scoped scan.
         if (winnerFields && formids is { Length: > 0 } && !hasScan)
-            return "error: fields_source= is the scan lane's display pole — on a formids= read the version you want IS the source: name it via source= (source=\"winner\" is the default).";
+            return Wire.Refuse(json, "error: fields_source= is the scan lane's display pole — on a formids= read the version you want IS the source: name it via source= (source=\"winner\" is the default).");
 
-        if (offset < 0) return $"error: offset={offset} — offset must be >= 0.";
+        if (offset < 0) return Wire.Refuse(json, $"error: offset={offset} — offset must be >= 0.");
         if (offset > 0 && form == "aggregate")
-            return "error: the aggregate form counts ALL selected records (a count table has no row window), so offset= has nothing to page — drop offset=, or drop the aggregate form for per-record rows.";
+            return Wire.Refuse(json, "error: the aggregate form counts ALL selected records (a count table has no row window), so offset= has nothing to page — drop offset=, or drop the aggregate form for per-record rows.");
         var toFile = to_file?.Trim();
         bool wantFile = !string.IsNullOrEmpty(toFile);
         if (wantFile)
         {
             if (Artifacts.ValidateToFile(toFile!) is { } verr) return verr;
-            if (offset > 0) return "error: to_file= captures the COMPLETE result (the artifact is never a window), so offset= has nothing to page — drop offset=.";
-            if (form == "aggregate") return "error: to_file= writes row artifacts, and the aggregate form is a count table with no record rows — drop one of the two.";
-            if (counts_only) return "error: counts_only= returns the census with no rows, and to_file= writes the rows — the two contradict; drop one (review: this pair used to return the census and silently write nothing).";
+            if (offset > 0) return Wire.Refuse(json, "error: to_file= captures the COMPLETE result (the artifact is never a window), so offset= has nothing to page — drop offset=.");
+            if (form == "aggregate") return Wire.Refuse(json, "error: to_file= writes row artifacts, and the aggregate form is a count table with no record rows — drop one of the two.");
+            if (counts_only) return Wire.Refuse(json, "error: counts_only= returns the census with no rows, and to_file= writes the rows — the two contradict; drop one (review: this pair used to return the census and silently write nothing).");
         }
         if (where_source is not null && where is not { Length: > 0 })
-            return "error: where_source= retargets the where= predicates and needs where= — add predicates, or drop where_source=.";
+            return Wire.Refuse(json, "error: where_source= retargets the where= predicates and needs where= — add predicates, or drop where_source=.");
 
         // ---- the response envelope (form + resolved source arm) -----------------------------------------
         // Text renders get it as a header line; json renders carry the same pairs as top-level fields.
@@ -475,8 +476,8 @@ public static class RecordsTools
             if (form == "identity")
             {
                 if (srcName is not null || srcOverlay)
-                    return "error: the identity form is the load-order labeling frame (type/editorid/name/WINNER per FormID) — " +
-                           "it does not take a source= pole. Use form='summary' or 'fields' for a named version's view.";
+                    return Wire.Refuse(json, "error: the identity form is the load-order labeling frame (type/editorid/name/WINNER per FormID) — " +
+                           "it does not take a source= pole. Use form='summary' or 'fields' for a named version's view.");
                 var rows = svc.ResolveRefs(ids, demand, out var epoch, out var refusal);
                 if (refusal is not null)
                     return json ? JsonWire.RenderError(refusal, epoch) : "error: " + refusal + $"\nepoch={epoch}";
@@ -778,7 +779,7 @@ public static class RecordsTools
             else   // tree
             {
                 if (srcSpec.Kind != LoadOrderService.PoleKind.Winner)
-                    return "error: the tree form has no subject — every provider of each record is on the bench, and the pole each is diffed against is versus=. Drop source= (or use form='delta' for a subject-vs-reference comparison).";
+                    return Wire.Refuse(json, "error: the tree form has no subject — every provider of each record is on the bench, and the pole each is diffed against is versus=. Drop source= (or use form='delta' for a subject-vs-reference comparison).");
                 var rows = svc.TreeBatch(ids, versusSpec!, projFields, demand,
                                          out var rArm, out var covers, out var refusal, out var epoch);
                 if (refusal is not null)
@@ -919,12 +920,12 @@ public static class RecordsTools
         string ScanLane()
         {
             if (form == "identity")
-                return "error: the identity form labels a formids= list; a scan's summary rows already carry each match's identity — use form='summary' (the default).";
+                return Wire.Refuse(json, "error: the identity form labels a formids= list; a scan's summary rows already carry each match's identity — use form='summary' (the default).");
 
             if (srcOverlay || versusSpec?.Kind == LoadOrderService.PoleKind.Overlay)
-                return "error: an overlay pole on a SCAN would replay the SkyPatcher INI layer over every match — a per-record replay at scan scale " +
+                return Wire.Refuse(json, "error: an overlay pole on a SCAN would replay the SkyPatcher INI layer over every match — a per-record replay at scan scale " +
                        "(a scan comparison compares EVERY match, so it is not a bound). Name the records via formids= — the list lane reads and " +
-                       "compares their post-state bodies — or read the whole layer via housecarl_skypatcher_layer.";
+                       "compares their post-state bodies — or read the whole layer via housecarl_skypatcher_layer.");
             bool hasBodyFilter = where is { Length: > 0 } || references is { Length: > 0 };
             bool hasTypes = types is { Length: > 0 };
             bool hasScope = plugins?.names is { Length: > 0 };
@@ -939,11 +940,11 @@ public static class RecordsTools
             // off-order or scoped selection universe (re-review R3-1/R3-2).
             bool pipelineArms = form == "delta" || form == "info_order" || walk is not null;
             if (hasBodyFilter && !hasTypes && !hasScope && !hasFormids)
-                return "error: where=/references= is a body scan and must be combined with types=, plugins=, or a formids= set to bound the work " +
+                return Wire.Refuse(json, "error: where=/references= is a body scan and must be combined with types=, plugins=, or a formids= set to bound the work " +
                        "(conflicts_only= alone is not enough — an unbounded body scan over the whole order is refused; the " +
-                       "reverse-reference index that would lift this is a known future capability).";
+                       "reverse-reference index that would lift this is a known future capability).");
             if (plugins is { defined_in: true } && !hasScope)
-                return "error: plugins.defined_in=true keeps records DEFINED in the scoped plugins, so plugins.names must name that scope.";
+                return Wire.Refuse(json, "error: plugins.defined_in=true keeps records DEFINED in the scoped plugins, so plugins.names must name that scope.");
 
             // formids×scan (W2 composition): the identity set intersects the scan — expanded here (@file /
             // artifact demand honored inside the scan's own capture), parsed once, handed to the engine as the
@@ -960,9 +961,9 @@ public static class RecordsTools
                 {
                     if (string.IsNullOrWhiteSpace(t)) continue;
                     try { fkList.Add(FormKey.Factory(t.Trim())); }
-                    catch (Exception ex) { return $"error: bad formids entry '{t}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }
+                    catch (Exception ex) { return Wire.Refuse(json, $"error: bad formids entry '{t}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
                 }
-                if (fkList.Count == 0) return "error: formids= expanded to an empty list — nothing to intersect the scan with.";
+                if (fkList.Count == 0) return Wire.Refuse(json, "error: formids= expanded to an empty list — nothing to intersect the scan with.");
                 formidSet = fkList;
             }
 
@@ -975,7 +976,7 @@ public static class RecordsTools
                 // an arm statement about a different world). The off-order lane reads the file directly and
                 // consults no further build.
                 var probe = svc.ProbeSourceArm(srcName, srcMod, out var probeErr);
-                if (probeErr is not null) return "error: " + probeErr;
+                if (probeErr is not null) return Wire.Refuse(json, "error: " + probeErr);
                 srcName = probe!.Plugin;   // a PATH pole resolves back to its plugin name — every consumer below uses the resolved name (round-3 F4)
                 probeEpoch = probe.Epoch;
                 if (!probe.InOrder)
@@ -986,9 +987,9 @@ public static class RecordsTools
                     // considered; the named source= decides whose VERSION the body forms read. Identity-fact
                     // forms have nothing for the pole to change — accepting-and-ignoring it is the sin.
                     if (form is "summary" or "aggregate")
-                        return $"error: a plugins= scope with a named source= reads the POLE's version of each scoped match — and the '{form}' form's rows are identity facts the pole doesn't change. Drop source=, or use form='fields'/'everything' (the pole's bodies) or 'delta'/'tree' (comparisons).";
+                        return Wire.Refuse(json, $"error: a plugins= scope with a named source= reads the POLE's version of each scoped match — and the '{form}' form's rows are identity facts the pole doesn't change. Drop source=, or use form='fields'/'everything' (the pole's bodies) or 'delta'/'tree' (comparisons).");
                     if (winnerFields)
-                        return "error: fields_source='winner' and a named source= under a plugins= scope are TWO display poles on one call — the pole's version is what this composition reads. Drop fields_source= (or drop source= and keep fields_source='winner').";
+                        return Wire.Refuse(json, "error: fields_source='winner' and a named source= under a plugins= scope are TWO display poles on one call — the pole's version is what this composition reads. Drop fields_source= (or drop source= and keep fields_source='winner').");
                     scopePlusPole = true;
                     // The scope statement is the truthful arm only for the forms that READ the pole's bodies;
                     // delta's pipeline states its subject itself (R3-2). A scoped TREE reads every provider,
@@ -1019,7 +1020,7 @@ public static class RecordsTools
                 {
                     if (string.IsNullOrWhiteSpace(r)) continue;
                     try { list.Add(FormKey.Factory(r.Trim())); }
-                    catch (Exception ex) { return $"error: bad references FormID '{r}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }
+                    catch (Exception ex) { return Wire.Refuse(json, $"error: bad references FormID '{r}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
                 }
                 if (list.Count > 0) refFks = list.Distinct().ToList();
             }
@@ -1275,25 +1276,25 @@ public static class RecordsTools
             envelope.Add(new("epoch_covers_source", "false"));
             headerLine += "\n(the off-order file's content is OUTSIDE the epoch fingerprint — an edit to it changes answers without changing the epoch)";
             if (conflicts_only)
-                return "error: conflicts_only= has no meaning on an out-of-load-order file — it is not in the conflict frame. Drop it, or read the winner (source=\"winner\").";
+                return Wire.Refuse(json, "error: conflicts_only= has no meaning on an out-of-load-order file — it is not in the conflict frame. Drop it, or read the winner (source=\"winner\").");
             if (form == "info_order")
-                return "error: the info_order form merges the ACTIVE order's touching plugins — an out-of-load-order file is not in that frame. Read the winner's merge (drop source=), or enumerate the file's DIAL records with form='summary'.";
+                return Wire.Refuse(json, "error: the info_order form merges the ACTIVE order's touching plugins — an out-of-load-order file is not in that frame. Read the winner's merge (drop source=), or enumerate the file's DIAL records with form='summary'.");
             if (walk is not null)
-                return "error: the walk expands the ACTIVE order's winner link graph — an out-of-load-order file's records are not in that graph. Enumerate the file with form='summary', then walk specific records via formids= (dropping source=).";
+                return Wire.Refuse(json, "error: the walk expands the ACTIVE order's winner link graph — an out-of-load-order file's records are not in that graph. Enumerate the file with form='summary', then walk specific records via formids= (dropping source=).");
             if (dense) return "error: format='dense' is the in-order scan's columnar form — an off-order file scan renders text or json.";
             if (versusSpec?.Kind == LoadOrderService.PoleKind.Overlay)
-                return "error: an overlay pole on a SCAN would replay the SkyPatcher INI layer over every match — a per-record replay at scan scale " +
+                return Wire.Refuse(json, "error: an overlay pole on a SCAN would replay the SkyPatcher INI layer over every match — a per-record replay at scan scale " +
                        "(a scan comparison compares EVERY match, so it is not a bound). Name the records via formids= — the list lane reads and " +
-                       "compares their post-state bodies — or read the whole layer via housecarl_skypatcher_layer.";
+                       "compares their post-state bodies — or read the whole layer via housecarl_skypatcher_layer.");
             if (where_source is not null)
             {
                 // Full-vocabulary validation, mirroring the in-order engine (review F9): an unknown spelling must
                 // refuse by name, never be accepted-and-ignored.
                 var ws = where_source.Trim().ToLowerInvariant();
                 if (ws == "winner")
-                    return "error: where_source=winner matches on the live load-order winner — but this scan streams an out-of-load-order FILE's bodies, many of which have no winner. Match the winner by scanning the winner (drop source=), or drop where_source=.";
+                    return Wire.Refuse(json, "error: where_source=winner matches on the live load-order winner — but this scan streams an out-of-load-order FILE's bodies, many of which have no winner. Match the winner by scanning the winner (drop source=), or drop where_source=.");
                 if (ws is not ("scoped" or "scanned"))
-                    return $"error: where_source='{where_source}' is not a known source — over an out-of-load-order file the match reads the FILE's own bodies ('scoped', the default); drop where_source=, or use 'winner' on an in-order scan.";
+                    return Wire.Refuse(json, $"error: where_source='{where_source}' is not a known source — over an out-of-load-order file the match reads the FILE's own bodies ('scoped', the default); drop where_source=, or use 'winner' on an in-order scan.");
             }
 
             // The completed off-order lane (W2 PR 2): the same filter grammar as the in-order scan, run by the
@@ -1314,7 +1315,7 @@ public static class RecordsTools
                 {
                     if (string.IsNullOrWhiteSpace(r)) continue;
                     try { list.Add(FormKey.Factory(r.Trim())); }
-                    catch (Exception ex) { return $"error: bad references FormID '{r}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }
+                    catch (Exception ex) { return Wire.Refuse(json, $"error: bad references FormID '{r}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
                 }
                 if (list.Count > 0) refFks = list.Distinct().ToList();
             }
@@ -1330,9 +1331,9 @@ public static class RecordsTools
                 {
                     if (string.IsNullOrWhiteSpace(t)) continue;
                     try { fkList.Add(FormKey.Factory(t.Trim())); }
-                    catch (Exception ex) { return $"error: bad formids entry '{t}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }
+                    catch (Exception ex) { return Wire.Refuse(json, $"error: bad formids entry '{t}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
                 }
-                if (fkList.Count == 0) return "error: formids= expanded to an empty list — nothing to intersect the scan with.";
+                if (fkList.Count == 0) return Wire.Refuse(json, "error: formids= expanded to an empty list — nothing to intersect the scan with.");
                 formidSet = fkList;
             }
             var offGroupBy = form == "aggregate" ? project!.group_by!.Trim().ToLowerInvariant() : null;
@@ -1871,7 +1872,7 @@ public static class RecordsTools
     {
         var gb = groupBy.Trim().ToLowerInvariant();
         if (gb is not ("winner" or "type" or "defined_in"))
-            return $"error: project.group_by='{groupBy}' is not a count key — use 'winner', 'type', or 'defined_in'.";
+            return Wire.Refuse(json, $"error: project.group_by='{groupBy}' is not a count key — use 'winner', 'type', or 'defined_in'.");
         var groups = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         int errors = 0;
         foreach (var o in outcomes)


### PR DESCRIPTION
Fixes #403

A read tool asked for `format="json"` answered some refusals with a plain sentence instead of a json document, so a caller parsing the response handled two shapes depending on which rule it broke. This routes those refusals through one render path, gives the json lane the `ok:false` discriminant #403 asked for, and — after the review found the first attempt's coverage was hand-wired — adds a guard that derives the covered surface instead of trusting a sweep.

## What changed

- **`Wire.Refuse` is the one render path.** A tool body states its refusal once, in the text spelling; the path decides the shape. Refusal **text is byte-identical by construction** — `Refuse` returns the message unchanged when `json` is false.
- **`JsonWire.WriteRefusal` is the one discriminant writer.** 10 document-root refusals; `RenderError`'s summary claimed a shape the document did not carry (#403).
- **Two refusal-ordering fixes.** `batch_record_detail` and `resolve` refused an empty `formids=` *above* the line deciding the transport, so that one refusal could not honour json however it was rendered.
- **The served census stops answering to the discriminant** — `counts_only=true` wrote `"ok": <int>` (a resolved-row count) on a served document. Renamed `resolved`.
- **Eight post-capture refusals carry the build they consulted** instead of asserting `epoch: null`.
- **`refusal-completeness-guard`** — new, and the reason this branch is worth more than its diff.

Per-row `error` fields never gain `ok` (12 sites, untouched): a row that failed inside a call that succeeded is not a refusal.

## Review rounds

**One round, three fresh reviewers** (`isolation: "worktree"`, seeded with the branch's settled-decisions list and nothing else), then a **§11 class stop** and a directed fold wave. Round 2 was deliberately not run — reasoning below.

| Reviewer | Lens | Findings |
|---|---|---|
| 1 | runtime behaviour | 1 high, 2 medium, 1 low |
| 2 | contract completeness | 2 high, 1 medium, 2 low |
| 3 | does the pinning bite | 2 high, 2 medium |

**All three found the same class, by three different methods, without seeing each other's work:** a whole-call refusal escaping the one render path because the covered population was enumerated by a regex over two hand-named files.

### What the round found

- **The branch was not green.** `ci-all` was 130/131. `BulkPrimitivesWave2Probe.cs:285` pinned `conflict_tree=true, format=json` as `StartsWith("error:")` — the exact refusal this branch converts to a document. "Branch-green" had been measured on three guards, not the suite.
- **14 refusals outside every settled exception.** Twelve helper-returned (`ExpandListInput` / `ValidateToFile` hand back an `"error: …"` string that the body returned verbatim — `RecordsTools.cs:381` had a bare one three lines above three wrapped ones); one ternary at `RecordsTools.cs:223` whose two arms were both bare, between wrapped statements on either side; and `housecarl_check`, a json-capable read tool never in the traced file set, whose own comment seven lines below the bare return already stated the rule it was breaking.
- **Nothing would have caught a regression.** Reviewer 3 proved by mutation that reverting **all 14** `ReadTools` `Wire.Refuse` sites to prose left the whole 131-probe suite green. The grammar was pinned at 2 of 68 sites in `RecordsTools` and 0 of 14 in `ReadTools`.
- **The discriminant collided with an existing key**, on a document no refusal probe rendered.

### Triage: what was refused or narrowed

Refusal rate was low, so here is where triage bit rather than obeyed:

- **The `epoch` finding was narrowed.** Reviewer 1 called `Wire.Refuse`'s unused `epoch` parameter a defect at all 81 sites; reviewer 3 dropped the same observation as chartered shape (settled #2). Both were partly right: the `epoch: null` *shape* is chartered, but passing null where a stamp is **in hand** is a site-level miss under settled #4. Fixed at the 8 sites holding one; `RecordsTools.cs:979` deliberately left alone, because `ProbeSourceArm` returns null there and settled #4's third bucket is correct.
- **`Guard.Named` prose refused as a fix.** Reviewer 2 raised it and correctly declined to file it, citing settled #5. Agreed — claim-scope, not a defect.
- **The dead conjunct: reviewer 3 over reviewer 1.** `StartsWith("notaform") == false` can never be false, but the `Contains` half does the stated work. Dead weight, not a defect — deleted as fix-or-drop.
- **Settled decision #10 was never tested.** No reviewer proposed remedy unification or remedy-text changes, so nothing was refused on that front. Remedy work stays #439's own PR.

### Why one round, not three

§11 forbids folding a third instance of a recurring class and sends it to Aaron instead. The class recurred three times *inside* round 1, via three independent methods — a stronger signal than two sequential rounds, not a weaker one. Round 2 would either find instance #4 (unfoldable by rule) or find nothing (which would not remove the 14 sites). Neither changes the decision, and #323's precedent — ten rounds, ~4M tokens, four of five highs self-inflicted by the folds — argues against grinding to satisfy the letter of the rule.

Escalated under §4 framing **(b)**: the goal stands, the assumption that per-site explicit calls achieve it was false as executed. **Aaron ruled**: framing (b) accepted, option (i) now with (ii) filed as the direction (#440), and the `ok` collision ruled a rename. The advisor verified the collision and the `CheckTools` site at source and endorsed the round-2 skip on the record. What follows is that directed fold wave — no new rounds after it, per §11.

## The guard

Two properties, both load-bearing:

- **The population derives itself.** Every `Guard.Tool` body that consults the format machinery — 15 bodies across 8 files, found by walking the tree. A new json-capable tool enrols itself the day it is written; a hand-named file set is what let `housecarl_check` sit outside the net. Deriving also reaches past the read lane into the write tools, which is why the `format=` parse exception is written surface-wide rather than per file.
- **The enumeration parses.** Roslyn walks return statements; no regex anywhere. What defeated the sweep was a ternary spanning three lines — exactly what a line-oriented pattern cannot see. That construct is preserved verbatim as a **permanent known-RED fixture** the enumerator must flag, with the wrapped form of the same shape as its counter-fixture. If the fixture ever passes, the guard is broken, not the tree.

Three shapes are excluded structurally rather than by hand, because an exception that restates a structural fact is a guard that has stopped deriving: the MO2 config prompt (trained guidance, not a refusal), the write tools' own local `Refuse` helper (same verb, different receiver), and a text-lane twin whose json arm returned above it. What stays bare cites the settled decision that permits it, and a stale entry is its own failure.

A fourth arm makes the discriminant unambiguous by construction: every `ok` property write in the json renderer must be the literal `false` (the discriminant, written in one place) or an outcome's `.Success` (the write surface's contract). Anything else is the census collision returning.

## Aaron's gate review — four directed folds

His independent review found four, all folded (no new rounds — §11 forbids reopening the loop after directed folds). Each fold is one commit with its own RED-check from a committed state, and each mutation he supplied is now a permanent cell or fixture.

| Sev | Finding | What landed |
|---|---|---|
| high | The binding net missed the **tuple deconstruction**. `var (…, xerr) = Artifacts.ExpandListInput(…)` is a `DeclarationExpressionSyntax` carrying a `ParenthesizedVariableDesignationSyntax` — neither an `out var` argument nor an `is { }` pattern. 8 live sites; reverting any of them left the guard green. | The designation joins the net; the shape joins the permanent fixture set with its wrapped counter-fixture. The comment above the walk called ExpandListInput's tuple an out argument — it now names all three bindings for what they are. |
| high | The derived population **stopped at `Guard.Tool` lambdas**, so a helper *handed* the transport sat outside it — it produces and returns its refusal internally, so no tool-body return ever carries the sentence. `RecordsTools.RenderListAggregate` reverted to prose, guard green. | A scope is policed when the transport is **decided in it or handed to it**: a method or local function declaring `bool json` or `QueryFormat` joins the population. Still derived — no file named. Three live scopes join; **nothing new is flagged, so no allowlist entry was needed** — the escalation condition the finding set out did not fire. A fixture proves the derivation both ways, including the `QueryFormat` half, which has no live parameter today and would otherwise be unproven. |
| low | Allowlist matching was an **unanchored substring across two kinds** of `Hit.Sentence` — an identifier for a binding hit, a whole message for a literal one. A future refusal sentence containing `ferr` ("…the record was transferred…") would have been ruled correct silently. | Hits and entries are typed. A binding entry must **equal** the identifier; a literal entry matches message text; no cross-kind match. The example is the fixture: one policed helper yielding both hits, the binding ruled, the sentence left unexplained. |
| low | The CHANGELOG sentence read as a **closed list**, and two prose paths were missing from it. | Both verified at source first — `Guard.Named` (`Guard.cs:40`) on any unhandled exception, and `svc.ConfigPromptOrNull()`'s MO2 setup prompt, returned first by every tool body. The claim now names them as *not refusals of your call*. The `Guard.Named` triage stays refused as claim-scope; this narrows the claim to match it, it does not reopen it. |

**What the two highs say about the guard, stated plainly.** Its shape net is an **enumerated list of syntactic shapes** with a known-RED fixture per shape — a literal at any depth, an `out var` binding, an `is { }` binding, and now a tuple designation — over an enumerated list of policed scopes, tool bodies plus transport-carrying signatures. That is much stronger than the regex it replaced and still weaker than a property: every blind spot found so far has been a shape or a scope missing from those lists, and each was found by someone mutating the tree rather than by the guard noticing. **#440 is the by-construction close** — a typed refusal rendered per-transport at the `Guard.Tool` boundary, where the enumeration stops being load-bearing. A fourth blind-spot instance after this merges promotes it.

## Verification

- **`ci-all`: 132/132 ALL PASS** (the suite grew by this guard). Branch-green means the suite now, not three guards.
- **Byte-identity, mechanically** (`dev-scratch/literal_identity.py`, rewritten and re-run over `2fd7b6e..HEAD`): every C# string literal extracted from both sides by a scanner rather than a line regex — comments skipped, regular / verbatim / interpolated / raw forms all recognised — and refusal-bearing ones compared as multisets across the whole of `src/housecarl-mcp`: **267 base / 268 head, zero changed sentences**. The single addition is the new `RefusalPrefix` constant, `"error: "`. Canary-tested: perturbing one head-side sentence by one character reports it. **Its scope is refusal text only**, so it is blind to served-schema changes by design and reports those separately — `resolved: 1→2` (the rename) and `error: 25→15` (the `WriteString("error", …)` sites collapsing into the one writer). The counts differ from the figures quoted before Aaron's review because that extractor scoped itself to the changed files; the deltas agree, and this one states its scope.
- **Mutation check, from a committed state, canary intact** (`dev-scratch/completeness_sweep.sh`), re-run in full after Aaron's folds:

| Cell | Verdict |
|---|---|
| canary — the `:223` ternary back to bare arms | FAIL (expected), 1 unexplained |
| tuple-deconstruction — `ReadTools.cs:101` → `return xerr;` | FAIL, 1 |
| transport-helper — `RenderListAggregate` → the bare form | FAIL, 1 |
| one `ReadTools` site → prose | FAIL, 1 |
| helper-returned `verr` revert | FAIL, 1 |
| `CheckTools` `famErr` revert | FAIL, 1 |
| ALL `ReadTools` sites → prose (20 bypassed) | FAIL, 14 |
| ALL `RecordsTools` sites → prose (74 bypassed) | FAIL, 66 |
| allowlist kind check removed | FAIL |
| control — an unrelated comment edit | PASS |

**The earlier table overclaimed the `ALL ReadTools` cell**, and Aaron's finding 1 is what exposed it: that cell reverted only the literal-bearing sites, so the binding arm of the net was never exercised by it and the tuple hole survived a sweep that read as exhaustive. The cell now rewrites **every** `Wire.Refuse(` in the file — all 20 — through a bypass helper whose name is not an approved renderer. 14 of the 20 come back unexplained; the other 6 pass an *identifier* (`xerr` x3, `verr` x3), so under the bypass the return is still an invocation and the guard has nothing to flag. Those 6 are the sites the dedicated `tuple-deconstruction` and `helper-returned-verr` cells cover, by reverting the return to the genuinely bare form. Stated here rather than left implicit: a mass cell is not a substitute for the per-shape cells.

The `transport-helper` cell was itself broken on first run — anchored on the refusal sentence, it hit the *identical* sentence at `RecordsTools.cs:239` inside a tool body and reddened for the wrong reason. Re-anchored on the enclosing `gb` check, and only then did it confirm the finding.

- **Both step-4 arms RED-checked both directions**; reverting the rename reddens the structural arm (naming `RenderCounts()` at file:line) and the runtime arm independently.

Two defects were found by the verification machinery rather than by reading: the guard's first draft took only `out var` bindings, so `ValidateToFile`'s `is { } verr` sites — the fold's own fix — were invisible, and the mutation cell for them flagged nothing. And `return (xerr);` slipped the net until parentheses were unwrapped.

## Trace corrections

- #403 recorded **~39** `RenderError` call sites. The real count is **54** repo-wide, **44** on the read surface; ~39 is `RecordsTools.cs` alone.
- The build session's stage-1 report said **27** bare-text refusals were json-reachable. The true figure was **84**, from a regex that missed single-line `if (…) return "error: …";`.
- **"161 sites traced, zero untraced" was scoped to two files**, not to the read surface — `disposition.py`'s `FILES` list. That scoping is what left `housecarl_check` out. The disposition artifact on disk is the *post-fix* re-measurement (73 sites), not the 161-site pre-fix table; its five residual "defect" rows are `ParsePole`'s, correctly handled at its two call sites, because the classifier is call-site-blind.

The completeness claim is no longer carried by a count. It is carried by a guard that derives its own population, and #440 records the change that would make it true by construction rather than merely checked.

## Not in this PR

Remedy-grammar work is **#439**'s own follow-up PR, verified disjoint (0 overlapping lines) and deliberately not folded here. Its failing arm stays at `dev-scratch/ARM7_remedy_repro.patch`, uncommitted. The non-refusal duplicated-sentence tail is **#438**. The MO2 config prompt is returned bare by the whole tool surface including the write tools — a separate surface-wide question, excluded from the guard by name with that reason stated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

