### PR TITLE
Remedy sentences name the calling tool's own levers (scoped claim)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,14 +13,19 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
-- **A truncated `housecarl_records` response now names the parameters your call actually has.** When a read
-  hit `max_chars`, the notice told you to narrow with `fields=` and lower `depth=`; on that tool those are
-  spelled `project.fields=` and `project.depth=`, so following the advice as written got you a refusal. A
-  collapsed container cell said `pass depth=2 to expand` for the same reason. Both transports were affected
-  and both are fixed. The scan notice also offered `conflict_tree`, which `housecarl_records` has no
-  parameter for at all — it now names the field selector alone. The 1.x read tools' notices are unchanged;
-  they were already naming their own parameters. Check it by starving a read: `max_chars=220` on a
-  `project.form="fields"` call, and read the notice back.
+- **`housecarl_records` truncation and expansion notices now name the parameters your call actually has.**
+  When a read hit `max_chars`, the notice told you to narrow with `fields=` and lower `depth=`; on that tool
+  those are spelled `project.fields=` and `project.depth=`, so following the advice as written got you a
+  refusal. A collapsed container cell said `pass depth=2 to expand` for the same reason — including under
+  `source=` and the SkyPatcher post view, which were a separate read path. The scoped-vs-winner note told
+  you to pass `winner_fields=true`; that parameter was renamed on this tool and is `fields_source="winner"`.
+  All of it applies on `format="text"`, `"json"` and `"dense"`, and to the rows written to a `to_file=`
+  artifact. The scan notice also offered `conflict_tree`, which `housecarl_records` has no parameter for at
+  all — it now names the field selector alone. One further spelling was inconsistent with itself: the
+  selector appeared as both `project.fields` and `project.fields=` depending on which renderer composed the
+  sentence, and is now always `project.fields=`. The 1.x read tools' notices are unchanged; they were
+  already naming their own parameters. Check it by starving a read — a few `formids=` with
+  `project={"form":"fields","fields":[…]}` and `max_chars=220` — and reading the notice back.
 
 - **A read tool asked for json now refuses in json.** Reads that take `format="json"` previously answered
   some refusals with a plain sentence instead of a json document, so a caller parsing the response had to

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,15 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **A truncated `housecarl_records` response now names the parameters your call actually has.** When a read
+  hit `max_chars`, the notice told you to narrow with `fields=` and lower `depth=`; on that tool those are
+  spelled `project.fields=` and `project.depth=`, so following the advice as written got you a refusal. A
+  collapsed container cell said `pass depth=2 to expand` for the same reason. Both transports were affected
+  and both are fixed. The scan notice also offered `conflict_tree`, which `housecarl_records` has no
+  parameter for at all — it now names the field selector alone. The 1.x read tools' notices are unchanged;
+  they were already naming their own parameters. Check it by starving a read: `max_chars=220` on a
+  `project.form="fields"` call, and read the notice back.
+
 - **A read tool asked for json now refuses in json.** Reads that take `format="json"` previously answered
   some refusals with a plain sentence instead of a json document, so a caller parsing the response had to
   handle two shapes depending on which rule it broke. Those refusals are now one document — `ok:false` plus

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -21,14 +21,21 @@ saying it sets an expectation their install may contradict. Say what is known, a
   scoped-vs-winner note told you to pass `winner_fields=true`; that parameter was renamed on this tool and
   is `fields_source="winner"`. A scan's cut told you to drop `conflict_tree`, which this tool has no
   parameter for in any spelling, and then to drop `project.fields=`, which the `fields` form refuses to run
-  without — it now points at dropping `project=` for summary rows, which works. The selector itself was
+  without — it now points at dropping `project=` for summary rows, which works, and it says so only when
+  the call passed a `project=` block to drop: a scan that passed none is already reading the summary rows
+  that clause points at, and is told to lower `limit=` or raise `max_chars` instead. A cut over records read
+  in a batch told you to `request fewer formids` whether or not you had passed any; where the rows came from
+  a scan it names `limit=` now, which is what windows that response. The selector itself was
   spelled two ways depending on which renderer composed the sentence, and is now always `project.fields=`.
 
-  **What this covers:** the `fields`, `tree` and `delta` forms, the collapsed-container hint on every
-  `source=` lane, and the scoped-vs-winner note — on `format="text"` and `"json"`, with the container hint
-  additionally covered on `"dense"` and in `to_file=` artifact rows. **What it does not:** the
-  `everything` form still names `project.fields=`, which that form refuses, and a walk or chain response
-  still says `raise limit=` for a bound that `walk.max_nodes` controls. Both are filed and unfixed here.
+  **What this covers:** the `fields`, `tree` and `delta` forms and the `summary` form's scan cut, the
+  collapsed-container hint on every `source=` lane, and the scoped-vs-winner note — on `format="text"` and
+  `"json"`, with the container hint additionally covered on `"dense"` and in `to_file=` artifact rows. The
+  cut's own selection and slim-down clauses are covered on `"text"` alone, because that is the only format
+  that writes them: `"json"` and `"dense"` report a cut as data rather than as a sentence. **What it does
+  not:** the `everything` form still names `project.fields=`, which that form refuses, and a walk or chain
+  response still says `raise limit=` for a bound that `walk.max_nodes` controls. Both are filed and unfixed
+  here.
 
   The 1.x read tools' notices are unchanged; they were already naming their own parameters. Check it by
   starving a read — a few `formids=` with `project={"form":"fields","fields":[…]}` and `max_chars=220` —

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,19 +13,26 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
-- **`housecarl_records` truncation and expansion notices now name the parameters your call actually has.**
-  When a read hit `max_chars`, the notice told you to narrow with `fields=` and lower `depth=`; on that tool
-  those are spelled `project.fields=` and `project.depth=`, so following the advice as written got you a
-  refusal. A collapsed container cell said `pass depth=2 to expand` for the same reason — including under
-  `source=` and the SkyPatcher post view, which were a separate read path. The scoped-vs-winner note told
-  you to pass `winner_fields=true`; that parameter was renamed on this tool and is `fields_source="winner"`.
-  All of it applies on `format="text"`, `"json"` and `"dense"`, and to the rows written to a `to_file=`
-  artifact. The scan notice also offered `conflict_tree`, which `housecarl_records` has no parameter for at
-  all — it now names the field selector alone. One further spelling was inconsistent with itself: the
-  selector appeared as both `project.fields` and `project.fields=` depending on which renderer composed the
-  sentence, and is now always `project.fields=`. The 1.x read tools' notices are unchanged; they were
-  already naming their own parameters. Check it by starving a read — a few `formids=` with
-  `project={"form":"fields","fields":[…]}` and `max_chars=220` — and reading the notice back.
+- **`housecarl_records` truncation and expansion notices name that tool's own parameters — on the forms and
+  lanes listed here.** When a read hit `max_chars`, the notice told you to narrow with `fields=` and lower
+  `depth=`; on that tool those are spelled `project.fields=` and `project.depth=`, so following the advice
+  as written got you a refusal. A collapsed container cell said `pass depth=2 to expand` for the same
+  reason, including under `source=` and the SkyPatcher post view, which read through a separate path. The
+  scoped-vs-winner note told you to pass `winner_fields=true`; that parameter was renamed on this tool and
+  is `fields_source="winner"`. A scan's cut told you to drop `conflict_tree`, which this tool has no
+  parameter for in any spelling, and then to drop `project.fields=`, which the `fields` form refuses to run
+  without — it now points at dropping `project=` for summary rows, which works. The selector itself was
+  spelled two ways depending on which renderer composed the sentence, and is now always `project.fields=`.
+
+  **What this covers:** the `fields`, `tree` and `delta` forms, the collapsed-container hint on every
+  `source=` lane, and the scoped-vs-winner note — on `format="text"` and `"json"`, with the container hint
+  additionally covered on `"dense"` and in `to_file=` artifact rows. **What it does not:** the
+  `everything` form still names `project.fields=`, which that form refuses, and a walk or chain response
+  still says `raise limit=` for a bound that `walk.max_nodes` controls. Both are filed and unfixed here.
+
+  The 1.x read tools' notices are unchanged; they were already naming their own parameters. Check it by
+  starving a read — a few `formids=` with `project={"form":"fields","fields":[…]}` and `max_chars=220` —
+  and reading the notice back.
 
 - **A read tool asked for json now refuses in json.** Reads that take `format="json"` previously answered
   some refusals with a plain sentence instead of a json document, so a caller parsing the response had to

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -902,20 +902,27 @@ internal static class RecordsGuardProbe
             var tinyJson = RecordsTools.Records(
                 svc, formids: weapons.Select(Fid).ToArray(), format: "json", max_chars: 220,
                 project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage", "EditorID", "Name" } });
-            var notes = new List<string>();
-            void Harvest(JsonElement e)
+            // Every note-bearing key anywhere in the document — a remedy is wrong wherever it sits, and a
+            // harvester that only reads the top level would miss the per-row ones, which is where they are.
+            static List<string> HarvestNotes(string json)
             {
-                if (e.ValueKind == JsonValueKind.Object)
-                    foreach (var p in e.EnumerateObject())
-                    {
-                        if (p.Name is "note" or "truncation_note" && p.Value.ValueKind == JsonValueKind.String)
-                            notes.Add(p.Value.GetString()!);
-                        Harvest(p.Value);
-                    }
-                else if (e.ValueKind == JsonValueKind.Array)
-                    foreach (var it in e.EnumerateArray()) Harvest(it);
+                var found = new List<string>();
+                void Walk(JsonElement e)
+                {
+                    if (e.ValueKind == JsonValueKind.Object)
+                        foreach (var p in e.EnumerateObject())
+                        {
+                            if (p.Name is "note" or "truncation_note" or "error" && p.Value.ValueKind == JsonValueKind.String)
+                                found.Add(p.Value.GetString()!);
+                            Walk(p.Value);
+                        }
+                    else if (e.ValueKind == JsonValueKind.Array)
+                        foreach (var it in e.EnumerateArray()) Walk(it);
+                }
+                try { Walk(JsonDocument.Parse(json).RootElement); } catch { }
+                return found;
             }
-            try { Harvest(Je(tinyJson)); } catch { }
+            var notes = HarvestNotes(tinyJson);
 
             Check(notes.Count > 0, "a max_chars-starved fields read emits a truncation notice at all");
             // The claim: no notice this TOOL emits may advertise the OTHER generation's selector. Spelled
@@ -941,6 +948,35 @@ internal static class RecordsGuardProbe
             Check(textTruncated, "the text lane truncates the same starved read");
             Check(textTruncated && !textWrongLever,
                   "…and its notice names project.fields= too — one vocabulary per caller, both lanes");
+
+            // MEASURED SURFACE — a remedy predicts what a LATER call produces, so the sentences are read,
+            // not reasoned about. This prints every lever-naming sentence a housecarl_records caller can be
+            // handed across the site families, both lanes, on every run. The assertions above pin the two
+            // that regressed; this block is the evidence for the rest, and the place a NEW wrong lever shows
+            // up before anyone writes an arm for it.
+            var lever = new System.Text.RegularExpressions.Regex(
+                @"\bfields=|\bdepth=|\boffset=|\blimit=|\bmax_chars=|conflict_tree|\bto_file=|\bform=");
+            void Measure(string label, string resp)
+            {
+                var hits = resp.StartsWith("{", StringComparison.Ordinal)
+                    ? HarvestNotes(resp)
+                    : resp.Split('\n').Where(l => l.Contains('[') || l.Contains("error:")).ToList();
+                foreach (var h in hits.Where(h => lever.IsMatch(h)).Distinct())
+                    Console.WriteLine($"        [{label}] {h.Trim()}");
+            }
+            string[] wf = weapons.Select(Fid).ToArray();
+            var containerFields = new RecordsTools.RecordsProject { form = "fields", fields = new[] { "Effects" } };
+            foreach (var (label, resp) in new (string, string)[]
+            {
+                ("fields/json", tinyJson), ("fields/text", tinyText),
+                ("container/text", RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) }, project: containerFields)),
+                ("container/json", RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) }, format: "json", project: containerFields)),
+                ("tree/text",  RecordsTools.Records(svc, formids: wf, max_chars: 300, project: new RecordsTools.RecordsProject { form = "tree" })),
+                ("tree/json",  RecordsTools.Records(svc, formids: wf, max_chars: 300, format: "json", project: new RecordsTools.RecordsProject { form = "tree" })),
+                ("scan/text",  RecordsTools.Records(svc, types: new[] { "WEAP" }, max_chars: 300, project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage" } })),
+                ("scan/json",  RecordsTools.Records(svc, types: new[] { "WEAP" }, max_chars: 300, format: "json", project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage" } })),
+            })
+                Measure(label, resp);
 
             Console.WriteLine();
             Console.WriteLine(_fail == 0

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -890,6 +890,58 @@ internal static class RecordsGuardProbe
             Check(offIsRefusal, "an off-order scan refusal reaches a json caller as a refusal document");
             Check(offStamped, "…carrying the build it consulted, not epoch:null (settled #4's post-capture bucket)");
 
+            // ============================================================================================
+            //  7 — REMEDY GRAMMAR: a truncation notice names levers THIS tool actually has
+            // ============================================================================================
+            // A remedy predicts what a later call produces. housecarl_records spells its field selector
+            // project.fields=; the 1.x read tools spell it fields=. The json body renderers are shared by
+            // both generations, so a remedy composed inside one can name the other's vocabulary.
+            Console.WriteLine();
+            Console.WriteLine("--- 7: remedy notices name this tool's own levers ---");
+
+            var tinyJson = RecordsTools.Records(
+                svc, formids: weapons.Select(Fid).ToArray(), format: "json", max_chars: 220,
+                project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage", "EditorID", "Name" } });
+            var notes = new List<string>();
+            void Harvest(JsonElement e)
+            {
+                if (e.ValueKind == JsonValueKind.Object)
+                    foreach (var p in e.EnumerateObject())
+                    {
+                        if (p.Name is "note" or "truncation_note" && p.Value.ValueKind == JsonValueKind.String)
+                            notes.Add(p.Value.GetString()!);
+                        Harvest(p.Value);
+                    }
+                else if (e.ValueKind == JsonValueKind.Array)
+                    foreach (var it in e.EnumerateArray()) Harvest(it);
+            }
+            try { Harvest(Je(tinyJson)); } catch { }
+
+            Check(notes.Count > 0, "a max_chars-starved fields read emits a truncation notice at all");
+            // The claim: no notice this TOOL emits may advertise the OTHER generation's selector. Spelled
+            // out here rather than compared against the render's own constant.
+            var wrongLever = notes.Where(n => System.Text.RegularExpressions.Regex.IsMatch(n, @"(?<!project\.)\bfields=")).ToList();
+            foreach (var n in wrongLever) Console.WriteLine("        offending notice: " + n);
+            Check(notes.Count > 0 && wrongLever.Count == 0,
+                  "…and no notice tells a housecarl_records caller to narrow with 'fields=' (it has project.fields=)");
+
+            // The same question on the text lane — the two lanes compose their notices separately, so a
+            // vocabulary fix on one proves nothing about the other (D2).
+            var tinyText = RecordsTools.Records(
+                svc, formids: weapons.Select(Fid).ToArray(), max_chars: 220,
+                project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage", "EditorID", "Name" } });
+            bool textTruncated = tinyText.Contains("truncated") || tinyText.Contains("max_chars=");
+            // Report the whole LINE each hit sits on, not a character window around it: the window
+            // prints the middle of a field render and says nothing about what actually matched.
+            var textHits = tinyText.Split('\n')
+                .Where(l => System.Text.RegularExpressions.Regex.IsMatch(l, @"(?<!project\.)\bfields="))
+                .ToList();
+            bool textWrongLever = textHits.Count > 0;
+            foreach (var l in textHits) Console.WriteLine("        offending line: " + l.Trim());
+            Check(textTruncated, "the text lane truncates the same starved read");
+            Check(textTruncated && !textWrongLever,
+                  "…and its notice names project.fields= too — one vocabulary per caller, both lanes");
+
             Console.WriteLine();
             Console.WriteLine(_fail == 0
                 ? "[records-guard] PASS — the 2.0 read surface's core contract holds."

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -1084,6 +1084,34 @@ internal static class RecordsGuardProbe
             Check(!slimmed.StartsWith("error:") && slimmed.Contains("form=summary"),
                   "…and dropping project= as the scan notice says yields summary rows, not a refusal");
 
+            // The batch notice's SELECTION clause is a function of the selection LANE, not of the tool: the same
+            // Wire.RenderBatch serves the formids= lane and two scan-derived body lanes, and "request fewer formids"
+            // is inert on a call that named no formids. Both directions are asserted, because a fix that swapped the
+            // clause unconditionally would satisfy one arm and break the other. The wrong-lever patterns above cannot
+            // see this one — 'formids' is a lever housecarl_records genuinely HAS, so only the lane makes it wrong.
+            static string? BatchCut(string resp) =>
+                resp.Split('\n').FirstOrDefault(l => l.Contains("... [truncated: rendered") && l.Contains(" records before hitting"));
+            var scanBatch = RecordsTools.Records(svc, types: new[] { "WEAP" }, max_chars: 400,
+                                                 project: new RecordsTools.RecordsProject { form = "everything" });
+            var scanCut = BatchCut(scanBatch);
+            Check(scanCut is not null && scanCut.Contains("lower limit=") && !scanCut.Contains("formids"),
+                  "…a SCAN-selected batch's truncation notice names limit=, not a formids list the caller never wrote");
+            var fidBatch = RecordsTools.Records(svc, formids: wf, max_chars: 400,
+                                                project: new RecordsTools.RecordsProject { form = "everything" });
+            var fidCut = BatchCut(fidBatch);
+            Check(fidCut is not null && fidCut.Contains("request fewer formids") && !fidCut.Contains("lower limit="),
+                  "…and the formids= lane still says 'request fewer formids', which is true only there");
+            // The OFF-ORDER scan is the second scan-derived body lane and the in-order arm above cannot reach it:
+            // with only that one, reverting this lane's call site left the guard green. The off-order file holds a
+            // single weapon override by fixture design (several checks above depend on that count), so this batch
+            // has one row and the notice is driven by starving the cap rather than by a second row — the sentence
+            // it composes is the same one, which is what the arm reads.
+            var offBatch = RecordsTools.Records(svc, types: new[] { "WEAP" }, source: Je($"\"{oldName}\""), max_chars: 12,
+                                                project: new RecordsTools.RecordsProject { form = "everything" });
+            var offCut = BatchCut(offBatch);
+            Check(offCut is not null && offCut.Contains("lower limit=") && !offCut.Contains("formids"),
+                  "…and the OFF-ORDER scan's batch notice names limit= too (its own lane, its own arm)");
+
             Console.WriteLine();
             Console.WriteLine(_fail == 0
                 ? "[records-guard] PASS — the 2.0 read surface's core contract holds."

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -1048,6 +1048,10 @@ internal static class RecordsGuardProbe
                 // LeverNames.Records left the guard green while six sentences reverted to the pre-fix form
                 // (round 2). The lookahead is the whole point — bare 'project.fields' in a remedy is the defect.
                 (@"\bproject\.fields(?!=)", "narrow with 'project.fields' without the '=' (the pre-fix spelling)"),
+                // Actionability, not spelling. "drop project.fields=" names a lever records genuinely HAS, so no
+                // name-based pattern above can catch it — and the 'fields' form refuses without its paths, so the
+                // call it predicts is rejected. Having the lever is not the test; the next call working is.
+                (@"drop project\.fields",  "drop 'project.fields' (the 'fields' form refuses without its paths)"),
             };
             // Per-PROBE, before the per-lane assertions: a lane aggregates several site families, so a family that
             // stops emitting (fixture rot, a container that no longer collapses) leaves the lane count healthy and
@@ -1072,6 +1076,13 @@ internal static class RecordsGuardProbe
                           $"…no {lane} sentence tells a housecarl_records caller to {claim}");
                 }
             }
+
+            // The scan remedy's predicted call, actually MADE. Every assertion above reads a sentence; this one
+            // follows it. The notice says to drop project= for slimmer rows, so drop it and require what the
+            // sentence promised: a summary render, not a refusal.
+            var slimmed = RecordsTools.Records(svc, types: new[] { "WEAP" }, max_chars: 300);
+            Check(!slimmed.StartsWith("error:") && slimmed.Contains("form=summary"),
+                  "…and dropping project= as the scan notice says yields summary rows, not a refusal");
 
             Console.WriteLine();
             Console.WriteLine(_fail == 0

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -923,60 +923,72 @@ internal static class RecordsGuardProbe
                 return found;
             }
             var notes = HarvestNotes(tinyJson);
-
             Check(notes.Count > 0, "a max_chars-starved fields read emits a truncation notice at all");
-            // The claim: no notice this TOOL emits may advertise the OTHER generation's selector. Spelled
-            // out here rather than compared against the render's own constant.
-            var wrongLever = notes.Where(n => System.Text.RegularExpressions.Regex.IsMatch(n, @"(?<!project\.)\bfields=")).ToList();
-            foreach (var n in wrongLever) Console.WriteLine("        offending notice: " + n);
-            Check(notes.Count > 0 && wrongLever.Count == 0,
-                  "…and no notice tells a housecarl_records caller to narrow with 'fields=' (it has project.fields=)");
 
-            // The same question on the text lane — the two lanes compose their notices separately, so a
-            // vocabulary fix on one proves nothing about the other (D2).
+            // The same starved read on the text lane. The two lanes compose their notices separately, so a
+            // vocabulary fix on one proves nothing about the other (D2) — hence a per-lane count below.
             var tinyText = RecordsTools.Records(
                 svc, formids: weapons.Select(Fid).ToArray(), max_chars: 220,
                 project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage", "EditorID", "Name" } });
-            bool textTruncated = tinyText.Contains("truncated") || tinyText.Contains("max_chars=");
-            // Report the whole LINE each hit sits on, not a character window around it: the window
-            // prints the middle of a field render and says nothing about what actually matched.
-            var textHits = tinyText.Split('\n')
-                .Where(l => System.Text.RegularExpressions.Regex.IsMatch(l, @"(?<!project\.)\bfields="))
-                .ToList();
-            bool textWrongLever = textHits.Count > 0;
-            foreach (var l in textHits) Console.WriteLine("        offending line: " + l.Trim());
-            Check(textTruncated, "the text lane truncates the same starved read");
-            Check(textTruncated && !textWrongLever,
-                  "…and its notice names project.fields= too — one vocabulary per caller, both lanes");
 
-            // MEASURED SURFACE — a remedy predicts what a LATER call produces, so the sentences are read,
-            // not reasoned about. This prints every lever-naming sentence a housecarl_records caller can be
-            // handed across the site families, both lanes, on every run. The assertions above pin the two
-            // that regressed; this block is the evidence for the rest, and the place a NEW wrong lever shows
-            // up before anyone writes an arm for it.
-            var lever = new System.Text.RegularExpressions.Regex(
-                @"\bfields=|\bdepth=|\boffset=|\blimit=|\bmax_chars=|conflict_tree|\bto_file=|\bform=");
-            void Measure(string label, string resp)
-            {
-                var hits = resp.StartsWith("{", StringComparison.Ordinal)
-                    ? HarvestNotes(resp)
-                    : resp.Split('\n').Where(l => l.Contains('[') || l.Contains("error:")).ToList();
-                foreach (var h in hits.Where(h => lever.IsMatch(h)).Distinct())
-                    Console.WriteLine($"        [{label}] {h.Trim()}");
-            }
+            // The remedy surface is wider than one starved read: a collapsed container cell names the
+            // expansion knob, a scan's cut names the slimming levers, a tree row names the selector. Drive
+            // one call per site family per lane and assert over ALL of them, so the claim is "no sentence
+            // this tool emits names a lever it lacks" rather than "not this one sentence".
             string[] wf = weapons.Select(Fid).ToArray();
             var containerFields = new RecordsTools.RecordsProject { form = "fields", fields = new[] { "Effects" } };
-            foreach (var (label, resp) in new (string, string)[]
+            var scanFields = new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage" } };
+            var probes = new (string Label, string Resp)[]
             {
                 ("fields/json", tinyJson), ("fields/text", tinyText),
                 ("container/text", RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) }, project: containerFields)),
                 ("container/json", RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) }, format: "json", project: containerFields)),
                 ("tree/text",  RecordsTools.Records(svc, formids: wf, max_chars: 300, project: new RecordsTools.RecordsProject { form = "tree" })),
                 ("tree/json",  RecordsTools.Records(svc, formids: wf, max_chars: 300, format: "json", project: new RecordsTools.RecordsProject { form = "tree" })),
-                ("scan/text",  RecordsTools.Records(svc, types: new[] { "WEAP" }, max_chars: 300, project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage" } })),
-                ("scan/json",  RecordsTools.Records(svc, types: new[] { "WEAP" }, max_chars: 300, format: "json", project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage" } })),
-            })
-                Measure(label, resp);
+                ("scan/text",  RecordsTools.Records(svc, types: new[] { "WEAP" }, max_chars: 300, project: scanFields)),
+                ("scan/json",  RecordsTools.Records(svc, types: new[] { "WEAP" }, max_chars: 300, format: "json", project: scanFields)),
+            };
+
+            // Harvest with NO lever filter. A filter is where a wrong lever hides: the pre-fix tree notice
+            // said "narrow with project.fields" with no '=', and a regex keyed on '=' did not see it at all.
+            // json → every note/error string in the document; text → every line carrying remedy vocabulary.
+            var remedyLine = new System.Text.RegularExpressions.Regex(
+                @"max_chars|narrow|expand|raise |lower |drop |page with|request fewer|continue with");
+            var sentences = new List<(string Lane, string Label, string Text)>();
+            foreach (var (label, resp) in probes)
+            {
+                bool jsonLane = label.EndsWith("/json", StringComparison.Ordinal);
+                var hits = jsonLane
+                    ? HarvestNotes(resp)
+                    : resp.Split('\n').Where(l => remedyLine.IsMatch(l)).ToList();
+                foreach (var h in hits.Select(h => h.Trim()).Distinct())
+                {
+                    sentences.Add((jsonLane ? "json" : "text", label, h));
+                    Console.WriteLine($"        [{label}] {h}");
+                }
+            }
+
+            // Every lever housecarl_records spells differently, or does not have at all. Each is asserted
+            // PER LANE: a lane that emitted nothing is a broken fixture, not a pass.
+            var wrongLevers = new (string Pattern, string Claim)[]
+            {
+                (@"(?<!project\.)\bfields=", "narrow with 'fields=' (it has project.fields=)"),
+                (@"(?<!project\.)\bdepth=",  "lower or pass 'depth=' (it has project.depth=)"),
+                (@"\bconflict_tree\b",       "drop 'conflict_tree' (it has no such parameter — the tree is a project FORM)"),
+            };
+            foreach (var lane in new[] { "json", "text" })
+            {
+                var laneSentences = sentences.Where(s => s.Lane == lane).ToList();
+                Check(laneSentences.Count > 0, $"the {lane} lane emits remedy sentences at all (the fixture bites)");
+                foreach (var (pattern, claim) in wrongLevers)
+                {
+                    var bad = laneSentences
+                        .Where(s => System.Text.RegularExpressions.Regex.IsMatch(s.Text, pattern)).ToList();
+                    foreach (var b in bad) Console.WriteLine($"        OFFENDING [{b.Label}] {b.Text}");
+                    Check(laneSentences.Count > 0 && bad.Count == 0,
+                          $"…no {lane} sentence tells a housecarl_records caller to {claim}");
+                }
+            }
 
             Console.WriteLine();
             Console.WriteLine(_fail == 0

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -90,7 +90,18 @@ internal static class RecordsGuardProbe
             var spellB = master.Spells.AddNew(); spellB.EditorID = "HcRecSpellB";
             { var e = new Effect(); e.BaseEffect.SetTo(mgefB.FormKey); e.Data = new EffectData { Magnitude = 7 }; spellB.Effects.Add(e); }
 
+            // A record whose deep read cannot COMPLETE: ReadEngine's expansion budget is 2000 lines, so a form
+            // list one element past it truncates, and FieldsDiff surfaces that as Complete=false. That is the only
+            // way to reach the delta form's "TRUNCATED at the cap … Narrow with project.fields=" sentence, which
+            // no other fixture record can drive (its other route, nesting past ConflictDiffDepth=16, is not
+            // buildable here). The override below is a pure copy, so the comparison has zero deltas AND is
+            // incomplete — the exact pair that branch requires.
+            var bigList = master.FormLists.AddNew(); bigList.EditorID = "HcRecBigList";
+            for (int i = 0; i < ReadEngine.MaxExpandNodes + 1; i++)
+                bigList.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(weapons[i % weapons.Count]));
+
             var ovMod = new SkyrimMod(ovKey, SkyrimRelease.SkyrimSE);
+            WriteEngine.GenericGetOrAddAsOverride(ovMod, bigList);   // identical copy — no field changed
             ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(ovMod, master.Weapons.First(w => w.FormKey == weapons[0])))
                 .BasicStats = new WeaponBasicStats { Damage = 99, Weight = 1 };
             // A DELETED override (PR #307 review fold): header/resolution-only where-terms must still see it.
@@ -983,6 +994,13 @@ internal static class RecordsGuardProbe
                 ("delta/text", "text", RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, source: Je($"\"{ovName}\""),
                                                             versus: Je("\"previous_provider\""), max_chars: 320,
                                                             project: new RecordsTools.RecordsProject { form = "delta" })),
+                // The delta form's OTHER truncation sentence — zero deltas but an incomplete deep read, so the row
+                // must not read as a clean 'identical'. It opens its remedy with a capital ("Narrow with …"), which
+                // is why it was invisible to a case-sensitive harvest; the big form list is the fixture that drives
+                // it. Its sentence is a records sentence like any other and is asserted with the rest.
+                ("deltaIdentical/text", "text", RecordsTools.Records(svc, formids: new[] { Fid(bigList.FormKey) }, source: Je($"\"{ovName}\""),
+                                                                     versus: Je("\"previous_provider\""),
+                                                                     project: new RecordsTools.RecordsProject { form = "delta" })),
                 // No delta/json probe: measured, the json delta row signals a cut STRUCTURALLY — deltas_rendered
                 // plus deltas_truncated:true (JsonWire.WriteDeltaRow) — and composes no lever-naming sentence at
                 // all, so that lane has nothing this arm can be wrong about. The delta clause of the claim is
@@ -1013,8 +1031,14 @@ internal static class RecordsGuardProbe
             // 'pass ' is in this alternation because leaving it out was a blind spot of exactly the kind the
             // no-lever-filter rule exists to stop: the text P5 note reads "… — pass winner_fields=true for
             // load-order truth" and matched none of the other words, so the text lane harvested it as nothing.
+            // IgnoreCase because without it this is also a filter on CAPITALISATION, which is not a property of
+            // whether a sentence is a remedy. A remedy that opens a sentence — "… Narrow with project.fields= to
+            // compare in full.", "… Drop source=." — carries a capital and matched none of these alternatives, so
+            // the text lane discarded it before `sentences` was built and every per-lane assertion below ran over
+            // a set that could not contain it. Found at the gate review on PR #450.
             var remedyLine = new System.Text.RegularExpressions.Regex(
-                @"max_chars|narrow|expand|raise |lower |drop |pass |page with|request fewer|continue with");
+                @"max_chars|narrow|expand|raise |lower |drop |pass |page with|request fewer|continue with",
+                System.Text.RegularExpressions.RegexOptions.IgnoreCase);
             var sentences = new List<(string Lane, string Label, string Text)>();
             foreach (var (label, lane, resp) in probes)
             {

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -1108,6 +1108,29 @@ internal static class RecordsGuardProbe
             Check(!slimmed.StartsWith("error:") && slimmed.Contains("form=summary"),
                   "…and dropping project= as the scan notice says yields summary rows, not a refusal");
 
+            // The two artifact ROW writers compose a field-truncation note of their own, and production writes rows
+            // uncapped (the file is the answer), so that note is dormant — but it is composed from a vocabulary the
+            // row writer is handed, and a records artifact handed nothing would say "narrow with fields=". Dormant
+            // is not proof: the writers take a rowCap so the seam can be DRIVEN here, which is the only way to read
+            // the sentence rather than reason about it. Both writers, because they are separate seams.
+            var artOutcomes = svc.ResolveBatch(new[] { Fid(spellA.FormKey) }, new[] { "Effects" }, false, 2,
+                                               containerHint: LeverNames.Records.ContainerHint);
+            var noQuery = Array.Empty<KeyValuePair<string, string>>();
+            var capBatch = Path.Combine(root, "cap-batch.jsonl");
+            Artifacts.WriteBatch(artOutcomes, capBatch, "to_file", noQuery, LeverNames.Records, rowCap: 40);
+            var batchNote = HarvestArtifact(capBatch).FirstOrDefault(s => s.Contains("[truncated at max_chars:"));
+            Check(batchNote is not null && batchNote.Contains("project.fields=") && batchNote.Contains("project.depth=")
+                  && !System.Text.RegularExpressions.Regex.IsMatch(batchNote, @"(?<!project\.)\b(fields|depth)="),
+                  "…a batch artifact ROW's truncation note speaks the caller's vocabulary, not 1.x's");
+            var capQuery = svc.CrossQuery(new[] { "SPEL" }, null, null, false, null, null, 500);
+            var capCross = Path.Combine(root, "cap-cross.jsonl");
+            Artifacts.WriteCrossQuery(svc, capQuery, new[] { "Effects" }, false, false, 2, capCross, "to_file", noQuery,
+                                      LeverNames.Records, rowCap: 40);
+            var crossNote = HarvestArtifact(capCross).FirstOrDefault(s => s.Contains("[truncated at max_chars:"));
+            Check(crossNote is not null && crossNote.Contains("project.fields=") && crossNote.Contains("project.depth=")
+                  && !System.Text.RegularExpressions.Regex.IsMatch(crossNote, @"(?<!project\.)\b(fields|depth)="),
+                  "…and a cross-query artifact ROW's does too (its own writer, its own seam)");
+
             // The scan notice's SLIM-DOWN clause is only true for a call that passed something to slim with. Both
             // directions, because a fix that dropped the clause everywhere would satisfy the first arm and lose a
             // remedy that is genuinely actionable on the second. No wrong-lever pattern can see this either —

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -904,6 +904,12 @@ internal static class RecordsGuardProbe
                 project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage", "EditorID", "Name" } });
             // Every note-bearing key anywhere in the document — a remedy is wrong wherever it sits, and a
             // harvester that only reads the top level would miss the per-row ones, which is where they are.
+            //
+            // Round 1: the object-property-only version of this walk was itself a blind spot. WriteNotes emits an
+            // ARRAY of bare strings under "notes" (the predicate, scan, where_source and P5 scoped-vs-winner
+            // notes), so an entire note family was invisible to every assertion below — which is how a sentence
+            // naming winner_fields= to a housecarl_records caller sat green. String ELEMENTS of a notes array are
+            // harvested too now.
             static List<string> HarvestNotes(string json)
             {
                 var found = new List<string>();
@@ -914,12 +920,43 @@ internal static class RecordsGuardProbe
                         {
                             if (p.Name is "note" or "truncation_note" or "error" && p.Value.ValueKind == JsonValueKind.String)
                                 found.Add(p.Value.GetString()!);
+                            if (p.Name is "notes" or "layer_notes" && p.Value.ValueKind == JsonValueKind.Array)
+                                foreach (var it in p.Value.EnumerateArray())
+                                    if (it.ValueKind == JsonValueKind.String) found.Add(it.GetString()!);
                             Walk(p.Value);
                         }
                     else if (e.ValueKind == JsonValueKind.Array)
                         foreach (var it in e.EnumerateArray()) Walk(it);
                 }
                 try { Walk(JsonDocument.Parse(json).RootElement); } catch { }
+                return found;
+            }
+            // An artifact is JSONL — one json document per line, line 1 the manifest. Spilled rows are read by the
+            // same caller as the inline render, so they are part of this surface; round 1 proved they were never
+            // read back (dropping the carrier from the spill writer left the guard green).
+            // format=dense carries its container hint inside the POSITIONAL CELLS, not under a note key, so the
+            // note-key walk above harvests nothing from it (measured: container/dense and scan/dense came back
+            // empty while the sentence was plainly in the response). Every string in the document, then —
+            // deliberately over-approximate, because an over-harvest costs a triage row and an under-harvest
+            // hides a wrong lever, which is the whole lesson of this arm.
+            static List<string> HarvestAllStrings(string json)
+            {
+                var found = new List<string>();
+                void Walk(JsonElement e)
+                {
+                    if (e.ValueKind == JsonValueKind.String) found.Add(e.GetString()!);
+                    else if (e.ValueKind == JsonValueKind.Object) foreach (var p in e.EnumerateObject()) Walk(p.Value);
+                    else if (e.ValueKind == JsonValueKind.Array) foreach (var it in e.EnumerateArray()) Walk(it);
+                }
+                try { Walk(JsonDocument.Parse(json).RootElement); } catch { }
+                return found;
+            }
+            static List<string> HarvestArtifact(string path)
+            {
+                var found = new List<string>();
+                if (!File.Exists(path)) return found;
+                foreach (var line in File.ReadAllLines(path))
+                    if (!string.IsNullOrWhiteSpace(line)) found.AddRange(HarvestNotes(line));
                 return found;
             }
             var notes = HarvestNotes(tinyJson);
@@ -938,32 +975,64 @@ internal static class RecordsGuardProbe
             string[] wf = weapons.Select(Fid).ToArray();
             var containerFields = new RecordsTools.RecordsProject { form = "fields", fields = new[] { "Effects" } };
             var scanFields = new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage" } };
-            var probes = new (string Label, string Resp)[]
+            var ovlPost = Je("{\"overlay\": \"skypatcher\", \"state\": \"post\"}");
+            // The SOURCE lanes. Round 1: these read through ResolveBatchFromPole / OverlayPostBatch, which had no
+            // containerHint parameter at all, so every probe above (all winner-source) could not reach them and
+            // they kept emitting the 1.x knob. A source= probe per lane is what makes that lane assertable.
+            var poleScope = Je($"\"{masterName}\"");
+            // The spilled ARTIFACT rows, read back off disk. Two writers reach an artifact — an explicit to_file
+            // and the ceiling auto-spill — and both pass the carrier; this drives the explicit one and reads the
+            // file, so dropping the carrier from the writer is a RED cell instead of a silent green.
+            var artProbe = Path.Combine(root, "remedy-rows.jsonl");
+            var artResp = RecordsTools.Records(svc, types: new[] { "SPEL" }, to_file: artProbe, project: containerFields);
+            var probes = new (string Label, string Lane, string Resp)[]
             {
-                ("fields/json", tinyJson), ("fields/text", tinyText),
-                ("container/text", RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) }, project: containerFields)),
-                ("container/json", RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) }, format: "json", project: containerFields)),
-                ("tree/text",  RecordsTools.Records(svc, formids: wf, max_chars: 300, project: new RecordsTools.RecordsProject { form = "tree" })),
-                ("tree/json",  RecordsTools.Records(svc, formids: wf, max_chars: 300, format: "json", project: new RecordsTools.RecordsProject { form = "tree" })),
-                ("scan/text",  RecordsTools.Records(svc, types: new[] { "WEAP" }, max_chars: 300, project: scanFields)),
-                ("scan/json",  RecordsTools.Records(svc, types: new[] { "WEAP" }, max_chars: 300, format: "json", project: scanFields)),
+                ("fields/json", "json", tinyJson), ("fields/text", "text", tinyText),
+                ("container/text", "text", RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) }, project: containerFields)),
+                ("container/json", "json", RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) }, format: "json", project: containerFields)),
+                ("tree/text",  "text", RecordsTools.Records(svc, formids: wf, max_chars: 300, project: new RecordsTools.RecordsProject { form = "tree" })),
+                ("tree/json",  "json", RecordsTools.Records(svc, formids: wf, max_chars: 300, format: "json", project: new RecordsTools.RecordsProject { form = "tree" })),
+                ("scan/text",  "text", RecordsTools.Records(svc, types: new[] { "WEAP" }, max_chars: 300, project: scanFields)),
+                ("scan/json",  "json", RecordsTools.Records(svc, types: new[] { "WEAP" }, max_chars: 300, format: "json", project: scanFields)),
+                // format=dense is a THIRD transport on this tool, threaded and — until round 1 — wholly unasserted.
+                ("container/dense", "dense", RecordsTools.Records(svc, types: new[] { "SPEL" }, format: "dense", project: containerFields)),
+                ("scan/dense",      "dense", RecordsTools.Records(svc, types: new[] { "WEAP" }, format: "dense", max_chars: 300, project: scanFields)),
+                // source= poles: the plugin pole (active arm) and the SkyPatcher overlay post pole.
+                ("pole/text", "text", RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) }, source: poleScope, project: containerFields)),
+                ("pole/json", "json", RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) }, source: poleScope, format: "json", project: containerFields)),
+                ("overlay/text", "text", RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) }, source: ovlPost, project: containerFields)),
+                ("overlay/json", "json", RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) }, source: ovlPost, format: "json", project: containerFields)),
+                // A plugins=-scoped fields scan, which is what emits the P5 scoped-vs-winner note on all three
+                // transports. It fires on every such scan, not only starved ones.
+                ("scoped/text",  "text",  RecordsTools.Records(svc, plugins: new RecordsTools.RecordsScope { names = new[] { masterName } }, types: new[] { "WEAP" }, project: scanFields)),
+                ("scoped/json",  "json",  RecordsTools.Records(svc, plugins: new RecordsTools.RecordsScope { names = new[] { masterName } }, types: new[] { "WEAP" }, format: "json", project: scanFields)),
+                ("scoped/dense", "dense", RecordsTools.Records(svc, plugins: new RecordsTools.RecordsScope { names = new[] { masterName } }, types: new[] { "WEAP" }, format: "dense", project: scanFields)),
+                ("spill/artifact", "artifact", artResp),
             };
 
             // Harvest with NO lever filter. A filter is where a wrong lever hides: the pre-fix tree notice
             // said "narrow with project.fields" with no '=', and a regex keyed on '=' did not see it at all.
             // json → every note/error string in the document; text → every line carrying remedy vocabulary.
+            // 'pass ' is in this alternation because leaving it out was a blind spot of exactly the kind the
+            // no-lever-filter rule exists to stop: the text P5 note reads "… — pass winner_fields=true for
+            // load-order truth" and matched none of the other words, so the text lane harvested it as nothing.
             var remedyLine = new System.Text.RegularExpressions.Regex(
-                @"max_chars|narrow|expand|raise |lower |drop |page with|request fewer|continue with");
+                @"max_chars|narrow|expand|raise |lower |drop |pass |page with|request fewer|continue with");
             var sentences = new List<(string Lane, string Label, string Text)>();
-            foreach (var (label, resp) in probes)
+            foreach (var (label, lane, resp) in probes)
             {
-                bool jsonLane = label.EndsWith("/json", StringComparison.Ordinal);
-                var hits = jsonLane
-                    ? HarvestNotes(resp)
-                    : resp.Split('\n').Where(l => remedyLine.IsMatch(l)).ToList();
+                // text is scraped line-wise; json and dense are documents; the artifact lane is read off DISK,
+                // because the response there is a manifest and the rows the caller reads are in the file.
+                var hits = lane switch
+                {
+                    "artifact" => HarvestArtifact(artProbe),
+                    "text"     => resp.Split('\n').Where(l => remedyLine.IsMatch(l)).ToList(),
+                    "dense"    => HarvestAllStrings(resp),
+                    _          => HarvestNotes(resp),
+                };
                 foreach (var h in hits.Select(h => h.Trim()).Distinct())
                 {
-                    sentences.Add((jsonLane ? "json" : "text", label, h));
+                    sentences.Add((lane, label, h));
                     Console.WriteLine($"        [{label}] {h}");
                 }
             }
@@ -975,8 +1044,17 @@ internal static class RecordsGuardProbe
                 (@"(?<!project\.)\bfields=", "narrow with 'fields=' (it has project.fields=)"),
                 (@"(?<!project\.)\bdepth=",  "lower or pass 'depth=' (it has project.depth=)"),
                 (@"\bconflict_tree\b",       "drop 'conflict_tree' (it has no such parameter — the tree is a project FORM)"),
+                // Not a differently-SCOPED spelling but a rename: housecarl_records refuses winner_fields by alias
+                // and points at fields_source="winner". The P5 note named it on all three transports (round 1).
+                (@"\bwinner_fields\b",       "pass 'winner_fields=true' (it has fields_source=\"winner\")"),
             };
-            foreach (var lane in new[] { "json", "text" })
+            // Per-PROBE, before the per-lane assertions: a lane aggregates several site families, so a family that
+            // stops emitting (fixture rot, a container that no longer collapses) leaves the lane count healthy and
+            // its own absence silent. Every probe in the list above is expected to carry at least one sentence.
+            foreach (var (label, _, _) in probes)
+                Check(sentences.Any(s => s.Label == label), $"probe '{label}' emits a sentence at all (this family bites)");
+
+            foreach (var lane in new[] { "json", "text", "dense", "artifact" })
             {
                 var laneSentences = sentences.Where(s => s.Lane == lane).ToList();
                 Check(laneSentences.Count > 0, $"the {lane} lane emits remedy sentences at all (the fixture bites)");

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -902,43 +902,20 @@ internal static class RecordsGuardProbe
             var tinyJson = RecordsTools.Records(
                 svc, formids: weapons.Select(Fid).ToArray(), format: "json", max_chars: 220,
                 project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage", "EditorID", "Name" } });
-            // Every note-bearing key anywhere in the document — a remedy is wrong wherever it sits, and a
-            // harvester that only reads the top level would miss the per-row ones, which is where they are.
+            // EVERY string in the response, with no key allowlist at all.
             //
-            // Round 1: the object-property-only version of this walk was itself a blind spot. WriteNotes emits an
-            // ARRAY of bare strings under "notes" (the predicate, scan, where_source and P5 scoped-vs-winner
-            // notes), so an entire note family was invisible to every assertion below — which is how a sentence
-            // naming winner_fields= to a housecarl_records caller sat green. String ELEMENTS of a notes array are
-            // harvested too now.
-            static List<string> HarvestNotes(string json)
-            {
-                var found = new List<string>();
-                void Walk(JsonElement e)
-                {
-                    if (e.ValueKind == JsonValueKind.Object)
-                        foreach (var p in e.EnumerateObject())
-                        {
-                            if (p.Name is "note" or "truncation_note" or "error" && p.Value.ValueKind == JsonValueKind.String)
-                                found.Add(p.Value.GetString()!);
-                            if (p.Name is "notes" or "layer_notes" && p.Value.ValueKind == JsonValueKind.Array)
-                                foreach (var it in p.Value.EnumerateArray())
-                                    if (it.ValueKind == JsonValueKind.String) found.Add(it.GetString()!);
-                            Walk(p.Value);
-                        }
-                    else if (e.ValueKind == JsonValueKind.Array)
-                        foreach (var it in e.EnumerateArray()) Walk(it);
-                }
-                try { Walk(JsonDocument.Parse(json).RootElement); } catch { }
-                return found;
-            }
-            // An artifact is JSONL — one json document per line, line 1 the manifest. Spilled rows are read by the
-            // same caller as the inline render, so they are part of this surface; round 1 proved they were never
-            // read back (dropping the carrier from the spill writer left the guard green).
-            // format=dense carries its container hint inside the POSITIONAL CELLS, not under a note key, so the
-            // note-key walk above harvests nothing from it (measured: container/dense and scan/dense came back
-            // empty while the sentence was plainly in the response). Every string in the document, then —
-            // deliberately over-approximate, because an over-harvest costs a triage row and an under-harvest
-            // hides a wrong lever, which is the whole lesson of this arm.
+            // The allowlist retired here was the arm-that-cannot-fail class in its purest form. It began as
+            // note/truncation_note/error object properties; round 1 found it blind to WriteNotes' ARRAY of bare
+            // strings (the predicate, scan, where_source and P5 notes), which is how a sentence naming
+            // winner_fields= to a housecarl_records caller sat green. Widening the allowlist was the wrong repair:
+            // round 2 then found that "truncation_note" occurs NOWHERE in the product source — the codebase
+            // spelling is truncated_note — so one of the three keys had never matched anything, and scan_note
+            // (reachable from records' effect_chain form) was never listed. A guard keyed on names it does not
+            // verify exist cannot fail for the reason it claims to pass.
+            //
+            // So the harvest names nothing. It is deliberately over-approximate: an over-harvest costs a triage
+            // row, an under-harvest hides a wrong lever. The shape filter that survives is on the LITERAL
+            // (a multi-word sentence vs a bare key), never on which lever a sentence names.
             static List<string> HarvestAllStrings(string json)
             {
                 var found = new List<string>();
@@ -956,10 +933,10 @@ internal static class RecordsGuardProbe
                 var found = new List<string>();
                 if (!File.Exists(path)) return found;
                 foreach (var line in File.ReadAllLines(path))
-                    if (!string.IsNullOrWhiteSpace(line)) found.AddRange(HarvestNotes(line));
+                    if (!string.IsNullOrWhiteSpace(line)) found.AddRange(HarvestAllStrings(line));
                 return found;
             }
-            var notes = HarvestNotes(tinyJson);
+            var notes = HarvestAllStrings(tinyJson);
             Check(notes.Count > 0, "a max_chars-starved fields read emits a truncation notice at all");
 
             // The same starved read on the text lane. The two lanes compose their notices separately, so a
@@ -996,7 +973,20 @@ internal static class RecordsGuardProbe
                 ("scan/json",  "json", RecordsTools.Records(svc, types: new[] { "WEAP" }, max_chars: 300, format: "json", project: scanFields)),
                 // format=dense is a THIRD transport on this tool, threaded and — until round 1 — wholly unasserted.
                 ("container/dense", "dense", RecordsTools.Records(svc, types: new[] { "SPEL" }, format: "dense", project: containerFields)),
-                ("scan/dense",      "dense", RecordsTools.Records(svc, types: new[] { "WEAP" }, format: "dense", max_chars: 300, project: scanFields)),
+                // No scan/dense probe: a starved dense scan auto-spills instead of composing a truncation
+                // notice, so it carries no remedy to assert over. Its bite check used to pass on column-name
+                // noise from the all-strings harvest, which is the arm-that-cannot-fail shape. The dense
+                // container hint is the clause the scoped claim actually makes, and container/dense holds it;
+                // the spilled rows are covered by the artifact lane.
+                // The delta form is inside the scoped claim and was unprobed: reverting its four hand-spelled
+                // sites to the 1.x vocabulary left the guard green (round 2).
+                ("delta/text", "text", RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, source: Je($"\"{ovName}\""),
+                                                            versus: Je("\"previous_provider\""), max_chars: 320,
+                                                            project: new RecordsTools.RecordsProject { form = "delta" })),
+                // No delta/json probe: measured, the json delta row signals a cut STRUCTURALLY — deltas_rendered
+                // plus deltas_truncated:true (JsonWire.WriteDeltaRow) — and composes no lever-naming sentence at
+                // all, so that lane has nothing this arm can be wrong about. The delta clause of the claim is
+                // therefore stated for text only, rather than asserted over a lane that emits no remedy.
                 // source= poles: the plugin pole (active arm) and the SkyPatcher overlay post pole.
                 ("pole/text", "text", RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) }, source: poleScope, project: containerFields)),
                 ("pole/json", "json", RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) }, source: poleScope, format: "json", project: containerFields)),
@@ -1034,8 +1024,7 @@ internal static class RecordsGuardProbe
                 {
                     "artifact" => HarvestArtifact(artProbe),
                     "text"     => resp.Split('\n').Where(l => remedyLine.IsMatch(l)).ToList(),
-                    "dense"    => HarvestAllStrings(resp),
-                    _          => HarvestNotes(resp),
+                    _          => HarvestAllStrings(resp),
                 };
                 foreach (var h in hits.Select(h => h.Trim()).Distinct())
                 {
@@ -1054,12 +1043,21 @@ internal static class RecordsGuardProbe
                 // Not a differently-SCOPED spelling but a rename: housecarl_records refuses winner_fields by alias
                 // and points at fields_source="winner". The P5 note named it on all three transports (round 1).
                 (@"\bwinner_fields\b",       "pass 'winner_fields=true' (it has fields_source=\"winner\")"),
+                // The '=' itself. The harvest was unfiltered from the start, but every pattern here was keyed on
+                // '=' or a bare word, so nothing held the selector's own spelling: dropping the '=' from
+                // LeverNames.Records left the guard green while six sentences reverted to the pre-fix form
+                // (round 2). The lookahead is the whole point — bare 'project.fields' in a remedy is the defect.
+                (@"\bproject\.fields(?!=)", "narrow with 'project.fields' without the '=' (the pre-fix spelling)"),
             };
             // Per-PROBE, before the per-lane assertions: a lane aggregates several site families, so a family that
             // stops emitting (fixture rot, a container that no longer collapses) leaves the lane count healthy and
             // its own absence silent. Every probe in the list above is expected to carry at least one sentence.
+            // The hit must be REMEDY-SHAPED, not merely a string. The all-strings harvest returns column names
+            // and spill paths on the dense lane, so "any hit" let a probe that composes no remedy report that it
+            // bites — the arm-that-cannot-fail shape again, one level up.
             foreach (var (label, _, _) in probes)
-                Check(sentences.Any(s => s.Label == label), $"probe '{label}' emits a sentence at all (this family bites)");
+                Check(sentences.Any(s => s.Label == label && remedyLine.IsMatch(s.Text)),
+                      $"probe '{label}' emits a remedy sentence at all (this family bites)");
 
             foreach (var lane in new[] { "json", "text", "dense", "artifact" })
             {

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -1002,6 +1002,13 @@ internal static class RecordsGuardProbe
                 ("pole/json", "json", RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) }, source: poleScope, format: "json", project: containerFields)),
                 ("overlay/text", "text", RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) }, source: ovlPost, project: containerFields)),
                 ("overlay/json", "json", RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) }, source: ovlPost, format: "json", project: containerFields)),
+                // The OFF-ORDER file pole is a second arm of source= with its own read, and the active-pole probes
+                // above cannot reach it. Measured, not assumed: with only those, sabotaging the off-order arm's
+                // hint left this guard green. BasicStats is the collapsed container on a weapon.
+                ("poleOff/text", "text", RecordsTools.Records(svc, formids: new[] { Fid(weapons[1]) }, source: Je($"\"{oldName}\""),
+                                                              project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats" } })),
+                ("poleOff/json", "json", RecordsTools.Records(svc, formids: new[] { Fid(weapons[1]) }, source: Je($"\"{oldName}\""), format: "json",
+                                                              project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats" } })),
                 // A plugins=-scoped fields scan, which is what emits the P5 scoped-vs-winner note on all three
                 // transports. It fires on every such scan, not only starved ones.
                 ("scoped/text",  "text",  RecordsTools.Records(svc, plugins: new RecordsTools.RecordsScope { names = new[] { masterName } }, types: new[] { "WEAP" }, project: scanFields)),

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -1108,6 +1108,22 @@ internal static class RecordsGuardProbe
             Check(!slimmed.StartsWith("error:") && slimmed.Contains("form=summary"),
                   "…and dropping project= as the scan notice says yields summary rows, not a refusal");
 
+            // The scan notice's SLIM-DOWN clause is only true for a call that passed something to slim with. Both
+            // directions, because a fix that dropped the clause everywhere would satisfy the first arm and lose a
+            // remedy that is genuinely actionable on the second. No wrong-lever pattern can see this either —
+            // project= is real on housecarl_records, and only the CALL makes naming it inert.
+            static string? ScanCut(string resp) =>
+                resp.Split('\n').FirstOrDefault(l => l.Contains("... [truncated: rendered") && l.Contains(" returned matches before hitting"));
+            var sumCut = ScanCut(RecordsTools.Records(svc, types: new[] { "WEAP" }, max_chars: 300));
+            Check(sumCut is not null && sumCut.Contains("lower limit= or raise max_chars") && !sumCut.Contains("drop "),
+                  "…a summary-form scan's cut names no project= to drop (it passed none, and IS the summary render)");
+            var fldCut = ScanCut(RecordsTools.Records(svc, types: new[] { "WEAP" }, max_chars: 300, project: scanFields));
+            Check(fldCut is not null && fldCut.Contains("drop project= (summary rows)"),
+                  "…and a fields-form scan's cut still says to drop project=, which is actionable there");
+            var offSumCut = ScanCut(RecordsTools.Records(svc, types: new[] { "WEAP" }, source: Je($"\"{oldName}\""), max_chars: 12));
+            Check(offSumCut is not null && offSumCut.Contains("lower limit= or raise max_chars") && !offSumCut.Contains("drop "),
+                  "…and the OFF-ORDER scan names none either (it passes no field paths at all)");
+
             // The batch notice's SELECTION clause is a function of the selection LANE, not of the tool: the same
             // Wire.RenderBatch serves the formids= lane and two scan-derived body lanes, and "request fewer formids"
             // is inert on a call that named no formids. Both directions are asserted, because a fix that swapped the

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -280,8 +280,8 @@ internal static class Artifacts
     {
         using var writer = new ResultArtifact.Writer();
         foreach (var row in rows)
-            writer.WriteRow((w, ms) => JsonWire.WriteTreeRow(w, row, ms, int.MaxValue),
-                            row.Error is null ? row.Type : null);
+            writer.WriteRow((w, ms) => JsonWire.WriteTreeRow(w, row, ms, int.MaxValue, LeverNames.Records),
+                            row.Error is null ? row.Type : null);   // a records-only artifact: the rows speak the records vocabulary (#439)
         var (manifest, err) = writer.Save(path, "housecarl_records", query, "formid",
                                           new[] { "formid", "type", "editorid", "reference", "touchers", "nodes" },
                                           "input order", rows.Count, epoch ?? "");

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -126,12 +126,15 @@ internal static class Artifacts
     /// (fields=), or summary rows — the SAME row shapes the json render emits, via the SAME row writers, filled
     /// off the SAME pinned view the response's epoch names (ResolveReadOn/ResolveSummaryOn — a spill must never
     /// mix builds the header claims it didn't). Returns the SpillInfo for the response marker, or a named error
-    /// the caller renders (an unwritable path must fail LOUD, not produce a response claiming a file — Q3).</summary>
+    /// the caller renders (an unwritable path must fail LOUD, not produce a response claiming a file — Q3).
+    /// <para><paramref name="rowCap"/> is the per-row field budget. The artifact IS the answer, so production
+    /// writes rows uncapped and never passes it; it exists so the row writer's truncation seam can be DRIVEN,
+    /// because a seam nothing can reach is a seam nothing can prove (#439 gate review).</para></summary>
     public static (SpillInfo? Spill, string? Error) WriteCrossQuery(
         LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields,
         bool resolveNames, bool winnerFields, int depth,
         string path, string reason, IReadOnlyList<KeyValuePair<string, string>> query,
-        LeverNames? levers = null)
+        LeverNames? levers = null, int rowCap = int.MaxValue)
     {
         using var writer = new ResultArtifact.Writer();
         string[] schema;
@@ -170,7 +173,9 @@ internal static class Artifacts
                         w.WriteEndObject();
                     });
                 else
-                    writer.WriteRow((w, ms) => JsonWire.WriteReadRecord(w, o, ms, int.MaxValue, matches), o.Record!.Type);
+                    // The row writer composes its own field-truncation note, so it needs the caller's vocabulary
+                    // like every other seam — a records artifact row must not say "narrow with fields=" (#439).
+                    writer.WriteRow((w, ms) => JsonWire.WriteReadRecord(w, o, ms, rowCap, matches, levers: levers), o.Record!.Type);
             }
         }
         else                                                                  // summary rows
@@ -219,9 +224,13 @@ internal static class Artifacts
 
     /// <summary>Build + save the artifact for a batch_record_detail result — one row per input, in input order,
     /// exactly the rows the json render emits (per-item errors included: the artifact is the complete answer, and
-    /// a dropped error row would make the file claim a cleaner batch than the call returned).</summary>
+    /// a dropped error row would make the file claim a cleaner batch than the call returned).
+    /// <para><paramref name="levers"/> and <paramref name="rowCap"/> carry the same contract as
+    /// <see cref="WriteCrossQuery"/>: this writer's rows compose a field-truncation note too, so they need the
+    /// caller's vocabulary, and production writes them uncapped.</para></summary>
     public static (SpillInfo? Spill, string? Error) WriteBatch(
-        IReadOnlyList<ReadOutcome> outcomes, string path, string reason, IReadOnlyList<KeyValuePair<string, string>> query)
+        IReadOnlyList<ReadOutcome> outcomes, string path, string reason, IReadOnlyList<KeyValuePair<string, string>> query,
+        LeverNames? levers = null, int rowCap = int.MaxValue)
     {
         using var writer = new ResultArtifact.Writer();
         foreach (var o in outcomes)
@@ -229,7 +238,7 @@ internal static class Artifacts
             if (o.Error is not null)
                 writer.WriteRow((w, _) => { w.WriteStartObject(); w.WriteString("formid", o.FormKey.ToString()); w.WriteString("error", o.Error); w.WriteEndObject(); });
             else
-                writer.WriteRow((w, ms) => JsonWire.WriteReadRecord(w, o, ms, int.MaxValue), o.Record!.Type);
+                writer.WriteRow((w, ms) => JsonWire.WriteReadRecord(w, o, ms, rowCap, levers: levers), o.Record!.Type);
         }
         // The batch's ONE build (first consulted row). A batch of pure parse-failures never consulted a build and
         // carries "" — such an artifact refuses epoch-checked re-entry against ANY build, which is the honest answer.

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -130,7 +130,8 @@ internal static class Artifacts
     public static (SpillInfo? Spill, string? Error) WriteCrossQuery(
         LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields,
         bool resolveNames, bool winnerFields, int depth,
-        string path, string reason, IReadOnlyList<KeyValuePair<string, string>> query)
+        string path, string reason, IReadOnlyList<KeyValuePair<string, string>> query,
+        LeverNames? levers = null)
     {
         using var writer = new ResultArtifact.Writer();
         string[] schema;
@@ -157,7 +158,8 @@ internal static class Artifacts
                 var fk = q.Keys[i];
                 string? matches = q.MatchedTargets is { } mt && i < mt.Count ? mt[i] : null;
                 var o = svc.ResolveReadOn(q, fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false, depth,
-                                          resolveNames: resolveNames, linkMemo: linkMemo);
+                                          resolveNames: resolveNames, linkMemo: linkMemo,
+                                          containerHint: (levers ?? LeverNames.Legacy).ContainerHint);   // an artifact row is read by the same caller (#439)
                 if (o.Error is null && o.OwnedChildFields is { } af)   // #342: the rows' labels need their clause on line 1
                     foreach (var annotatedPath in af.Keys) annotated.Add(annotatedPath);
                 if (o.Error is not null)

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -303,8 +303,10 @@ static class JsonWire
     /// <param name="emitted">Collects the annotated paths this array ACTUALLY carried — the response-level clause is
     /// stated over these, so a field the truncation above dropped states nothing (Aaron's finding 1, json twin).</param>
     static void WriteFieldsArray(Utf8JsonWriter w, RecordFields r, MemoryStream ms, int cap,
-                                 IReadOnlyDictionary<string, OwnedChildShape>? annotated = null, ICollection<string>? emitted = null)
+                                 IReadOnlyDictionary<string, OwnedChildShape>? annotated = null, ICollection<string>? emitted = null,
+                                 LeverNames? levers = null)
     {
+        var lv = levers ?? LeverNames.Legacy;
         w.WriteStartArray("fields");
         for (int i = 0; i < r.Fields.Count; i++)
         {
@@ -313,7 +315,7 @@ static class JsonWire
             {
                 w.WriteStartObject();
                 w.WriteString("path", "…");   // …
-                w.WriteString("note", $"[truncated at max_chars: {i} of {r.Fields.Count} fields shown; narrow with fields=, lower depth=, or raise max_chars]");
+                w.WriteString("note", $"[truncated at max_chars: {i} of {r.Fields.Count} fields shown; narrow with {lv.Fields}, lower {lv.Depth}, or raise max_chars]");
                 w.WriteEndObject();
                 break;
             }
@@ -351,7 +353,8 @@ static class JsonWire
     /// belongs on it — written AFTER <c>fields</c> and only over what <c>fields</c> carried. It used to be the
     /// object's second key, ahead of the very array it described (Aaron's finding 3).</param>
     internal static void WriteReadRecord(Utf8JsonWriter w, ReadOutcome o, MemoryStream ms, int cap, string? matches = null,
-                                         string? epoch = null, ICollection<string>? childFields = null, bool stateChildNote = false)
+                                         string? epoch = null, ICollection<string>? childFields = null, bool stateChildNote = false,
+                                         LeverNames? levers = null)
     {
         var r = o.Record!;
         w.WriteStartObject();
@@ -363,7 +366,7 @@ static class JsonWire
         w.WriteNumber("override_depth", o.OverrideDepth);
         WriteNullable(w, "source", o.SourcePlugin);   // the body these field VALUES came from (scoped plugin vs winner)
         if (matches is not null) w.WriteString("matches", matches);
-        WriteFieldsArray(w, r, ms, cap, o.OwnedChildFields, childFields);
+        WriteFieldsArray(w, r, ms, cap, o.OwnedChildFields, childFields, levers);
         if (stateChildNote && childFields is IReadOnlyCollection<string> { Count: > 0 } stated) WriteOwnedChildNote(w, stated);
         w.WriteEndObject();
     }
@@ -409,8 +412,10 @@ static class JsonWire
     public static string RenderBatch(IReadOnlyList<ReadOutcome> outcomes, int maxChars)
         => RenderBatch(outcomes, maxChars, null, out _);
 
+    /// <summary><paramref name="levers"/>: the CALLER's lever vocabulary for the remedy sentences the row bodies
+    /// compose — this renderer is shared by both tool generations (#439). Omitted means the 1.x spelling.</summary>
     public static string RenderBatch(IReadOnlyList<ReadOutcome> outcomes, int maxChars, SpillState? spill, out bool truncated,
-                                     IReadOnlyList<KeyValuePair<string, string>>? envelope = null)
+                                     IReadOnlyList<KeyValuePair<string, string>>? envelope = null, LeverNames? levers = null)
     {
         truncated = false;
         int cap = Cap(maxChars);
@@ -433,7 +438,7 @@ static class JsonWire
                 w.Flush();
                 if (ms.Length >= cap) { rowsTruncated = true; break; }
                 if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", o.FormKey.ToString()); w.WriteString("error", o.Error); w.WriteEndObject(); }
-                else WriteReadRecord(w, o, ms, cap, childFields: childFields);
+                else WriteReadRecord(w, o, ms, cap, childFields: childFields, levers: levers);
                 rendered++;
             }
             w.WriteEndArray();
@@ -657,8 +662,13 @@ static class JsonWire
     /// <summary>One §4.1 tree row — the provider stack with per-node deltas against the row's reference pole.
     /// Shared by the json render and the artifact writer: THIS is what makes trees spillable (PR #306
     /// fold-decision 1 — the 1.x conflict_tree had no row form; the tree FORM does).</summary>
-    internal static void WriteTreeRow(Utf8JsonWriter w, LoadOrderService.TreeRow row, MemoryStream ms, int cap)
+    internal static void WriteTreeRow(Utf8JsonWriter w, LoadOrderService.TreeRow row, MemoryStream ms, int cap,
+                                      LeverNames? levers = null)
     {
+        // This row's notice was hand-written in the records spelling because the tree form is a 2.0 form. A literal
+        // that happens to agree with its caller is the next one to drift — the vocabulary comes from the carrier
+        // like every other remedy here, and the default arm is what proves the carrier is wired (#439).
+        var lv = levers ?? LeverNames.Legacy;
         w.WriteStartObject();
         w.WriteString("formid", row.Formid);
         if (row.Error is not null)
@@ -679,7 +689,7 @@ static class JsonWire
             if (ms.Length >= cap)
             {
                 w.WriteStartObject();
-                w.WriteString("note", "[nodes truncated at max_chars — raise max_chars or narrow with project.fields]");
+                w.WriteString("note", $"[nodes truncated at max_chars — raise max_chars or narrow with {lv.Fields}]");
                 w.WriteEndObject();
                 break;
             }
@@ -706,7 +716,7 @@ static class JsonWire
     public static string RenderTree(IReadOnlyList<LoadOrderService.TreeRow> rows, int maxChars, string? epoch,
                                     IReadOnlyList<KeyValuePair<string, string>> envelope,
                                     IReadOnlyList<KeyValuePair<string, int>> counts,
-                                    SpillState? spill, out bool truncated)
+                                    SpillState? spill, out bool truncated, LeverNames? levers = null)
     {
         truncated = false;
         int cap = Cap(maxChars);
@@ -725,7 +735,7 @@ static class JsonWire
                 if (manifestOnly) break;
                 w.Flush();
                 if (ms.Length >= cap) { rowsTruncated = true; break; }
-                WriteTreeRow(w, row, ms, cap);
+                WriteTreeRow(w, row, ms, cap, levers);
                 rendered++;
             }
             w.WriteEndArray();
@@ -991,7 +1001,7 @@ static class JsonWire
     /// auto-spill trigger handed back to the tool layer.</summary>
     public static string RenderCrossQuery(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, int maxChars, bool resolveNames, bool winnerFields, int depth,
                                           SpillState? spill, out bool truncated,
-                                          IReadOnlyList<KeyValuePair<string, string>>? envelope = null)
+                                          IReadOnlyList<KeyValuePair<string, string>>? envelope = null, LeverNames? levers = null)
     {
         truncated = false;
         int cap = Cap(maxChars);
@@ -1052,9 +1062,10 @@ static class JsonWire
                         // winner_fields=: read the WINNER's body (source=null) regardless of scan scope; the record's
                         // "source" field still names the body read, so the json carries the same source/winner truth.
                         // Pinned to the scan's build (PR #305 review) — the document's epoch names ONE build.
-                        var o = svc.ResolveReadOn(q, fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false, depth, resolveNames: resolveNames, linkMemo: linkMemo);
+                        var o = svc.ResolveReadOn(q, fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false, depth, resolveNames: resolveNames, linkMemo: linkMemo,
+                                                  containerHint: (levers ?? LeverNames.Legacy).ContainerHint);   // a collapsed cell names the caller's own expansion knob (#439)
                         if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", fk.ToString()); w.WriteString("error", o.Error); if (matches is not null) w.WriteString("matches", matches); w.WriteEndObject(); }
-                        else WriteReadRecord(w, o, ms, cap, matches, childFields: childFields);
+                        else WriteReadRecord(w, o, ms, cap, matches, childFields: childFields, levers: levers);
                     }
                     else
                     {
@@ -1107,7 +1118,7 @@ static class JsonWire
 
     public static string RenderCrossQueryDense(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, int maxChars, bool resolveNames, bool winnerFields,
                                                SpillState? spill, out bool truncated,
-                                               IReadOnlyList<KeyValuePair<string, string>>? envelope = null)
+                                               IReadOnlyList<KeyValuePair<string, string>>? envelope = null, LeverNames? levers = null)
     {
         truncated = false;
         int cap = Cap(maxChars);
@@ -1162,7 +1173,7 @@ static class JsonWire
                     if (detail)
                     {
                         var o = svc.ResolveReadOn(q, fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false,
-                                                  resolveNames: resolveNames, linkMemo: linkMemo, containerHint: Wire.DenseContainerHint);   // dense refuses depth>1 — hint the format hop with the knob (#231); pinned to the scan's build
+                                                  resolveNames: resolveNames, linkMemo: linkMemo, containerHint: (levers ?? LeverNames.Legacy).DenseContainerHint);   // dense refuses depth>1 — hint the format hop with the knob (#231); pinned to the scan's build
                         if (o.Error is not null) { (errors ??= new()).Add((fk.ToString(), o.Error)); rendered++; continue; }
                         var r = o.Record!;
                         w.WriteStartArray();

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -666,8 +666,10 @@ static class JsonWire
                                       LeverNames? levers = null)
     {
         // This row's notice was hand-written in the records spelling because the tree form is a 2.0 form. A literal
-        // that happens to agree with its caller is the next one to drift — the vocabulary comes from the carrier
-        // like every other remedy here, and the default arm is what proves the carrier is wired (#439).
+        // that happens to agree with its caller is the next one to drift, so the vocabulary comes from the carrier
+        // like every other remedy here. Note both callers pass Records explicitly (RenderTree via the tool layer,
+        // Artifacts.WriteTree for the spilled rows) — the Legacy default below is unreached, and is kept only so
+        // this row obeys the same "default is 1.x" rule as every other seam rather than becoming the exception.
         var lv = levers ?? LeverNames.Legacy;
         w.WriteStartObject();
         w.WriteString("formid", row.Formid);
@@ -1040,7 +1042,7 @@ static class JsonWire
             {
                 bool detail = fields is { Count: > 0 };
                 bool anyScoped = detail && q.Sources is { } ss && ss.Take(q.Keys.Count).Any(s => s is not null);   // P5
-                string? p5 = anyScoped ? ScopedFieldsNote(winnerFields, q.WhereWinner) : null;
+                string? p5 = anyScoped ? ScopedFieldsNote(winnerFields, q.WhereWinner, levers) : null;
                 w.WriteNumber("total", q.Total);
                 w.WriteBoolean("capped", q.Capped);
                 WriteNullable(w, "epoch", q.Epoch);                         // §2.1.1: offset= windows tile ONLY within one epoch
@@ -1090,15 +1092,21 @@ static class JsonWire
     /// <paramref name="whereWinner"/> (#233) is true when the MATCH decided on the live winner (where_source=winner) —
     /// then the note must NOT claim the match was selected on the scoped body (the D2 no-drift rule). Shared by the
     /// text, json, and dense renders so the note can never drift across the three.</summary>
-    internal static string ScopedFieldsNote(bool winnerFields, bool whereWinner)
+    internal static string ScopedFieldsNote(bool winnerFields, bool whereWinner, LeverNames? levers = null)
     {
+        // Two of these four arms are REMEDIES ("pass X …" — they predict a later call), so they can only be true
+        // for a caller that HAS that lever; housecarl_records refuses "winner_fields" by alias (#439). The other
+        // two are labels echoing what was passed, and they carry the caller's token for the same reason: a label
+        // naming a spelling the caller did not use is the next remedy to be copied out of. where_source= is spelled
+        // identically by both generations, so it stays a literal.
+        var wf = (levers ?? LeverNames.Legacy).WinnerFields;
         if (whereWinner)
             return winnerFields
-                ? "the MATCH and the field values are both the load-order WINNER's (where_source=winner, winner_fields=true)."
-                : "the MATCH was selected on the load-order WINNER (where_source=winner), but the field values shown are each match's SCOPED plugin's OWN version — pass winner_fields=true to display the winner too.";
+                ? $"the MATCH and the field values are both the load-order WINNER's (where_source=winner, {wf})."
+                : $"the MATCH was selected on the load-order WINNER (where_source=winner), but the field values shown are each match's SCOPED plugin's OWN version — pass {wf} to display the winner too.";
         return winnerFields
-            ? "field values are the load-order WINNER's (winner_fields=true); each match was SELECTED on its scoped plugin's body."
-            : "field values are each match's SCOPED plugin's OWN version, NOT the live load-order winner — pass winner_fields=true for load-order truth.";
+            ? $"field values are the load-order WINNER's ({wf}); each match was SELECTED on its scoped plugin's body."
+            : $"field values are each match's SCOPED plugin's OWN version, NOT the live load-order winner — pass {wf} for load-order truth.";
     }
 
     // ---- housecarl_cross_plugin_query format=dense (#223) -------------------------------------------
@@ -1139,7 +1147,7 @@ static class JsonWire
                 WriteNullable(w, "epoch", q.Epoch);                           // §2.1.1
                 if (q.Offset > 0) w.WriteNumber("offset", q.Offset);
                 if (q.ScopeLabel is not null) w.WriteString("scope", q.ScopeLabel);
-                WriteNotes(w, q, anyScoped ? ScopedFieldsNote(winnerFields, q.WhereWinner) : null);
+                WriteNotes(w, q, anyScoped ? ScopedFieldsNote(winnerFields, q.WhereWinner, levers) : null);
 
                 bool hasMatches = q.MatchedTargets is not null;               // multi-target references= → one extra column
                 w.WriteStartArray("columns");

--- a/src/housecarl-mcp/LeverNames.cs
+++ b/src/housecarl-mcp/LeverNames.cs
@@ -22,11 +22,12 @@ namespace HousecarlMcp;
 /// </summary>
 public sealed class LeverNames
 {
-    private LeverNames(string fields, string depth, string? conflictTree)
+    private LeverNames(string fields, string depth, string? conflictTree, string winnerFields)
     {
         Fields = fields;
         Depth = depth;
         ConflictTree = conflictTree;
+        WinnerFields = winnerFields;
     }
 
     /// <summary>How this caller spells the field selector, including the '=' — "fields=" or "project.fields=".</summary>
@@ -41,13 +42,19 @@ public sealed class LeverNames
     /// parameter, which is the defect this type exists to stop. Null means "leave it unnamed".</summary>
     public string? ConflictTree { get; }
 
+    /// <summary>How this caller asks for the WINNER's field values on a scoped scan, as a complete token —
+    /// "winner_fields=true" or "fields_source=\"winner\"". The two generations do not merely scope this one
+    /// differently, they renamed it: housecarl_records refuses "winner_fields" by alias and points at
+    /// fields_source="winner", so the P5 scoped-vs-winner note has to carry the caller's own token.</summary>
+    public string WinnerFields { get; }
+
     /// <summary>The 1.x read tools' spelling. The DEFAULT everywhere, so nothing renders differently
     /// until a caller asks for its own vocabulary.</summary>
-    public static readonly LeverNames Legacy = new("fields=", "depth=", "conflict_tree");
+    public static readonly LeverNames Legacy = new("fields=", "depth=", "conflict_tree", "winner_fields=true");
 
     /// <summary>housecarl_records: the selector and the expansion knob are form-scoped under project=,
     /// and there is no conflict_tree parameter at all.</summary>
-    public static readonly LeverNames Records = new("project.fields=", "project.depth=", null);
+    public static readonly LeverNames Records = new("project.fields=", "project.depth=", null, "fields_source=\"winner\"");
 
     /// <summary>The two slimming levers named together, as the cross-query truncation notice names them.
     /// A caller with no conflict-tree lever gets the selector alone rather than a lever it cannot pass.</summary>

--- a/src/housecarl-mcp/LeverNames.cs
+++ b/src/housecarl-mcp/LeverNames.cs
@@ -22,12 +22,13 @@ namespace HousecarlMcp;
 /// </summary>
 public sealed class LeverNames
 {
-    private LeverNames(string fields, string depth, string? conflictTree, string winnerFields)
+    private LeverNames(string fields, string depth, string? conflictTree, string winnerFields, string slimScan)
     {
         Fields = fields;
         Depth = depth;
         ConflictTree = conflictTree;
         WinnerFields = winnerFields;
+        SlimScan = slimScan;
     }
 
     /// <summary>How this caller spells the field selector, including the '=' — "fields=" or "project.fields=".</summary>
@@ -50,15 +51,21 @@ public sealed class LeverNames
 
     /// <summary>The 1.x read tools' spelling. The DEFAULT everywhere, so nothing renders differently
     /// until a caller asks for its own vocabulary.</summary>
-    public static readonly LeverNames Legacy = new("fields=", "depth=", "conflict_tree", "winner_fields=true");
+    public static readonly LeverNames Legacy = new("fields=", "depth=", "conflict_tree", "winner_fields=true", "fields=/conflict_tree");
 
     /// <summary>housecarl_records: the selector and the expansion knob are form-scoped under project=,
     /// and there is no conflict_tree parameter at all.</summary>
-    public static readonly LeverNames Records = new("project.fields=", "project.depth=", null, "fields_source=\"winner\"");
+    public static readonly LeverNames Records = new("project.fields=", "project.depth=", null, "fields_source=\"winner\"", "project= (summary rows)");
 
-    /// <summary>The two slimming levers named together, as the cross-query truncation notice names them.
-    /// A caller with no conflict-tree lever gets the selector alone rather than a lever it cannot pass.</summary>
-    public string FieldsOrTree => ConflictTree is null ? Fields : Fields + "/" + ConflictTree;
+    /// <summary>What a scan's truncation notice tells the caller to DROP to slim each row.
+    ///
+    /// Not simply the selector: this remedy has to name something the caller can actually drop and re-run.
+    /// On the 1.x tools that is the two slimming levers together. On housecarl_records it is NOT
+    /// <see cref="Fields"/> — the 'fields' form REQUIRES its field paths and refuses without them, so "drop
+    /// project.fields=" names a next call the tool rejects (round 2 drove it). Dropping the whole project=
+    /// construct is the actionable move: form defaults to 'summary', which is the slim render this remedy is
+    /// pointing at anyway.</summary>
+    public string SlimScan { get; }
 
     /// <summary>The hint appended to a COLLAPSED container cell ("[list: 3 item(s)]"), naming the knob that
     /// expands it. Threaded as ReadEngine's containerHint, which already carries a per-call string —

--- a/src/housecarl-mcp/LeverNames.cs
+++ b/src/housecarl-mcp/LeverNames.cs
@@ -23,12 +23,13 @@ namespace HousecarlMcp;
 /// </summary>
 public sealed class LeverNames
 {
-    private LeverNames(string fields, string depth, string winnerFields, string slimScan)
+    private LeverNames(string fields, string depth, string winnerFields, string slimScan, string batchSelection)
     {
         Fields = fields;
         Depth = depth;
         WinnerFields = winnerFields;
         SlimScan = slimScan;
+        BatchSelection = batchSelection;
     }
 
     /// <summary>How this caller spells the field selector, including the '=' — "fields=" or "project.fields=".</summary>
@@ -46,11 +47,12 @@ public sealed class LeverNames
 
     /// <summary>The 1.x read tools' spelling. The DEFAULT everywhere, so nothing renders differently
     /// until a caller asks for its own vocabulary.</summary>
-    public static readonly LeverNames Legacy = new("fields=", "depth=", "winner_fields=true", "fields=/conflict_tree");
+    public static readonly LeverNames Legacy = new("fields=", "depth=", "winner_fields=true", "fields=/conflict_tree", "request fewer formids");
 
     /// <summary>housecarl_records: the selector and the expansion knob are form-scoped under project=,
-    /// and there is no conflict_tree parameter at all.</summary>
-    public static readonly LeverNames Records = new("project.fields=", "project.depth=", "fields_source=\"winner\"", "project= (summary rows)");
+    /// and there is no conflict_tree parameter at all. This is the FORMIDS lane's vocabulary — a
+    /// scan-derived body lane says its selection differently (<see cref="OnScanSelection"/>).</summary>
+    public static readonly LeverNames Records = new("project.fields=", "project.depth=", "fields_source=\"winner\"", "project= (summary rows)", "request fewer formids");
 
     /// <summary>What a scan's truncation notice tells the caller to DROP to slim each row.
     ///
@@ -61,6 +63,20 @@ public sealed class LeverNames
     /// construct is the actionable move: form defaults to 'summary', which is the slim render this remedy is
     /// pointing at anyway.</summary>
     public string SlimScan { get; }
+
+    /// <summary>What a BATCH's truncation notice tells the caller to do to put fewer records in the response.
+    ///
+    /// This is the one lever whose name depends on the SELECTION LANE rather than on the tool: a batch whose
+    /// rows the caller named by hand is narrowed by naming fewer of them, and a batch whose rows a SCAN
+    /// selected is narrowed by the scan's window. housecarl_records has both lanes — formids= reaches
+    /// Wire.RenderBatch, and so do the scan-derived body lanes (form='everything', and the off-order scan) —
+    /// so the caller's lane, not the caller's tool, decides the sentence. See <see cref="OnScanSelection"/>.</summary>
+    public string BatchSelection { get; }
+
+    /// <summary>This vocabulary as spoken on a SCAN-derived body lane: the rows came from a scan, so the lever
+    /// that puts fewer of them in the response is limit=, not a formids list the caller never wrote. Every other
+    /// lever is unchanged — the selection lane is a third axis, not a different tool.</summary>
+    public LeverNames OnScanSelection() => new(Fields, Depth, WinnerFields, SlimScan, "lower limit=");
 
     /// <summary>The hint appended to a COLLAPSED container cell ("[list: 3 item(s)]"), naming the knob that
     /// expands it. Threaded as ReadEngine's containerHint, which already carries a per-call string —

--- a/src/housecarl-mcp/LeverNames.cs
+++ b/src/housecarl-mcp/LeverNames.cs
@@ -1,0 +1,65 @@
+namespace HousecarlMcp;
+
+/// <summary>
+/// The lever names a REMEDY is allowed to name: the parameters the CALLING tool actually has.
+///
+/// A remedy sentence predicts what a LATER call produces ("narrow with fields=, lower depth="), so it is
+/// only true for a caller that HAS those parameters. The body renderers are shared by both tool
+/// generations — <c>housecarl_records</c> drives the same <see cref="Wire"/> / <see cref="JsonWire"/>
+/// methods the 1.x read tools do — and a remedy composed inside a shared renderer can therefore only
+/// speak one vocabulary. It spoke the 1.x one, so a <c>housecarl_records</c> caller was told to narrow
+/// with <c>fields=</c> and lower <c>depth=</c>, which on that tool are <c>project.fields=</c> and
+/// <c>project.depth=</c> (#439, the #343 class).
+///
+/// This carries the caller's spelling INTO the renderer. It changes WHO is named a lever, never which
+/// levers a family offers: the divergences between remedy families are correct and stay (housecarl_resolve
+/// has no fields=, housecarl_effect_chain has no offset=, and their leaner sentences are right — audited
+/// on #439, settled decision #10). The one place the SET changes is a lever the calling tool does not
+/// have at all: see <see cref="ConflictTree"/>.
+///
+/// <see cref="Legacy"/> is the default at every threaded seam, so a 1.x call site that passes nothing
+/// renders exactly the bytes it rendered before.
+/// </summary>
+public sealed class LeverNames
+{
+    private LeverNames(string fields, string depth, string? conflictTree)
+    {
+        Fields = fields;
+        Depth = depth;
+        ConflictTree = conflictTree;
+    }
+
+    /// <summary>How this caller spells the field selector, including the '=' — "fields=" or "project.fields=".</summary>
+    public string Fields { get; }
+
+    /// <summary>How this caller spells the content-expansion knob — "depth=" or "project.depth=".</summary>
+    public string Depth { get; }
+
+    /// <summary>How this caller spells the conflict-tree toggle, or NULL when it has no such lever.
+    /// housecarl_records does not: the tree is a PROJECT FORM there (project.form='tree'), a different
+    /// call shape, not a way to slim a scan — so a remedy offering it as one would be inventing a
+    /// parameter, which is the defect this type exists to stop. Null means "leave it unnamed".</summary>
+    public string? ConflictTree { get; }
+
+    /// <summary>The 1.x read tools' spelling. The DEFAULT everywhere, so nothing renders differently
+    /// until a caller asks for its own vocabulary.</summary>
+    public static readonly LeverNames Legacy = new("fields=", "depth=", "conflict_tree");
+
+    /// <summary>housecarl_records: the selector and the expansion knob are form-scoped under project=,
+    /// and there is no conflict_tree parameter at all.</summary>
+    public static readonly LeverNames Records = new("project.fields=", "project.depth=", null);
+
+    /// <summary>The two slimming levers named together, as the cross-query truncation notice names them.
+    /// A caller with no conflict-tree lever gets the selector alone rather than a lever it cannot pass.</summary>
+    public string FieldsOrTree => ConflictTree is null ? Fields : Fields + "/" + ConflictTree;
+
+    /// <summary>The hint appended to a COLLAPSED container cell ("[list: 3 item(s)]"), naming the knob that
+    /// expands it. Threaded as ReadEngine's containerHint, which already carries a per-call string —
+    /// the core default names the 1.x spelling.</summary>
+    public string ContainerHint => $" — pass {Depth}2 to expand";
+
+    /// <summary>The dense render's container hint: dense refuses depth&gt;1 (positional cells align 1:1 with the
+    /// requested paths — #231), so the plain hint would send the caller into that refusal blind. Names the
+    /// format hop with the knob.</summary>
+    public string DenseContainerHint => $" — pass {Depth}2 with format=text/json to expand (dense cells are positional)";
+}

--- a/src/housecarl-mcp/LeverNames.cs
+++ b/src/housecarl-mcp/LeverNames.cs
@@ -23,7 +23,7 @@ namespace HousecarlMcp;
 /// </summary>
 public sealed class LeverNames
 {
-    private LeverNames(string fields, string depth, string winnerFields, string slimScan, string batchSelection)
+    private LeverNames(string fields, string depth, string winnerFields, string? slimScan, string batchSelection)
     {
         Fields = fields;
         Depth = depth;
@@ -61,8 +61,18 @@ public sealed class LeverNames
     /// <see cref="Fields"/> — the 'fields' form REQUIRES its field paths and refuses without them, so "drop
     /// project.fields=" names a next call the tool rejects (round 2 drove it). Dropping the whole project=
     /// construct is the actionable move: form defaults to 'summary', which is the slim render this remedy is
-    /// pointing at anyway.</summary>
-    public string SlimScan { get; }
+    /// pointing at anyway.
+    ///
+    /// NULL when the call passed no such construct at all, and the clause is then omitted rather than rendered
+    /// over nothing: housecarl_records defaults to form='summary' and its off-order scan never passes a project
+    /// block, so "drop project= (summary rows)" told those callers to drop what they had not written and promised
+    /// them the rows they were already reading. See <see cref="WithNothingToDrop"/>.</summary>
+    public string? SlimScan { get; }
+
+    /// <summary>This vocabulary as spoken by a call that passed NOTHING to slim rows with. The scan truncation
+    /// notice drops its "drop …" clause entirely and keeps the two levers that are real on such a call — a lower
+    /// limit= and a higher max_chars.</summary>
+    public LeverNames WithNothingToDrop() => new(Fields, Depth, WinnerFields, null, BatchSelection);
 
     /// <summary>What a BATCH's truncation notice tells the caller to do to put fewer records in the response.
     ///

--- a/src/housecarl-mcp/LeverNames.cs
+++ b/src/housecarl-mcp/LeverNames.cs
@@ -15,18 +15,18 @@ namespace HousecarlMcp;
 /// levers a family offers: the divergences between remedy families are correct and stay (housecarl_resolve
 /// has no fields=, housecarl_effect_chain has no offset=, and their leaner sentences are right — audited
 /// on #439, settled decision #10). The one place the SET changes is a lever the calling tool does not
-/// have at all: see <see cref="ConflictTree"/>.
+/// have at all: see <see cref="SlimScan"/>, where the 1.x phrase names conflict_tree and the records
+/// phrase cannot, because that tool has no such parameter in any spelling.
 ///
 /// <see cref="Legacy"/> is the default at every threaded seam, so a 1.x call site that passes nothing
 /// renders exactly the bytes it rendered before.
 /// </summary>
 public sealed class LeverNames
 {
-    private LeverNames(string fields, string depth, string? conflictTree, string winnerFields, string slimScan)
+    private LeverNames(string fields, string depth, string winnerFields, string slimScan)
     {
         Fields = fields;
         Depth = depth;
-        ConflictTree = conflictTree;
         WinnerFields = winnerFields;
         SlimScan = slimScan;
     }
@@ -37,11 +37,6 @@ public sealed class LeverNames
     /// <summary>How this caller spells the content-expansion knob — "depth=" or "project.depth=".</summary>
     public string Depth { get; }
 
-    /// <summary>How this caller spells the conflict-tree toggle, or NULL when it has no such lever.
-    /// housecarl_records does not: the tree is a PROJECT FORM there (project.form='tree'), a different
-    /// call shape, not a way to slim a scan — so a remedy offering it as one would be inventing a
-    /// parameter, which is the defect this type exists to stop. Null means "leave it unnamed".</summary>
-    public string? ConflictTree { get; }
 
     /// <summary>How this caller asks for the WINNER's field values on a scoped scan, as a complete token —
     /// "winner_fields=true" or "fields_source=\"winner\"". The two generations do not merely scope this one
@@ -51,11 +46,11 @@ public sealed class LeverNames
 
     /// <summary>The 1.x read tools' spelling. The DEFAULT everywhere, so nothing renders differently
     /// until a caller asks for its own vocabulary.</summary>
-    public static readonly LeverNames Legacy = new("fields=", "depth=", "conflict_tree", "winner_fields=true", "fields=/conflict_tree");
+    public static readonly LeverNames Legacy = new("fields=", "depth=", "winner_fields=true", "fields=/conflict_tree");
 
     /// <summary>housecarl_records: the selector and the expansion knob are form-scoped under project=,
     /// and there is no conflict_tree parameter at all.</summary>
-    public static readonly LeverNames Records = new("project.fields=", "project.depth=", null, "fields_source=\"winner\"", "project= (summary rows)");
+    public static readonly LeverNames Records = new("project.fields=", "project.depth=", "fields_source=\"winner\"", "project= (summary rows)");
 
     /// <summary>What a scan's truncation notice tells the caller to DROP to slim each row.
     ///

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2841,8 +2841,9 @@ public sealed class LoadOrderService : IDisposable
     /// batch twin of housecarl_read_record's plugin= (HCBR-2026-07-15): a formid that plugin doesn't touch yields
     /// its own per-item error (ResolveRead's "does not define this record"), never failing the batch.</summary>
     public IReadOnlyList<ReadOutcome> ResolveBatch(IReadOnlyList<string> formids, IReadOnlyList<string>? fields, bool conflictTree, int depth = 1,
-                                                   bool resolveNames = false, string? plugin = null)
-        => ResolveBatch(formids, fields, conflictTree, depth, resolveNames, plugin, null, out _, out _);
+                                                   bool resolveNames = false, string? plugin = null,
+                                                   string? containerHint = ReadEngine.DepthExpandHint)
+        => ResolveBatch(formids, fields, conflictTree, depth, resolveNames, plugin, null, out _, out _, containerHint);
 
     /// <summary>The §2.1.1-aware overload: <paramref name="artifactDemand"/> (a formids=@artifact input) is
     /// checked against THIS capture's epoch — the same build that would answer — and a mismatch hands back
@@ -2850,7 +2851,8 @@ public sealed class LoadOrderService : IDisposable
     /// refusal renders stamped, per the PR #305 contract).</summary>
     public IReadOnlyList<ReadOutcome> ResolveBatch(IReadOnlyList<string> formids, IReadOnlyList<string>? fields, bool conflictTree, int depth,
                                                    bool resolveNames, string? plugin, ArtifactDemand? artifactDemand,
-                                                   out string? artifactRefusal, out string? refusalEpoch)
+                                                   out string? artifactRefusal, out string? refusalEpoch,
+                                                   string? containerHint = ReadEngine.DepthExpandHint)
     {
         artifactRefusal = null; refusalEpoch = null;
         var resolver = Resolver;                // build/refresh ONCE for the batch
@@ -2869,7 +2871,7 @@ public sealed class LoadOrderService : IDisposable
             FormKey fk;
             try { fk = FormKey.Factory(raw.Trim()); }
             catch (Exception ex) { outcomes.Add(ReadOutcome.Fail(default, $"bad FormID '{raw}': {ex.Message}")); continue; }
-            outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo)
+            outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint)
                          with { Epoch = view.Epoch, Pin = pin });   // the batch's ONE build, stamped + pinned per item (SPEC §2.1.1)
         }
         return outcomes;

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2949,7 +2949,8 @@ public sealed class LoadOrderService : IDisposable
         IReadOnlyList<string> formids, string plugin, string? mod,
         IReadOnlyList<string>? fields, int depth, bool resolveNames,
         ArtifactDemand? artifactDemand,
-        out PoleInfo? pole, out string? refusal, out string? refusalEpoch)
+        out PoleInfo? pole, out string? refusal, out string? refusalEpoch,
+        string? containerHint = ReadEngine.DepthExpandHint)
     {
         pole = null; refusal = null; refusalEpoch = null;
         var resolver = Resolver;
@@ -2983,7 +2984,7 @@ public sealed class LoadOrderService : IDisposable
                 FormKey fk;
                 try { fk = FormKey.Factory(raw.Trim()); }
                 catch (Exception ex) { outcomes.Add(ReadOutcome.Fail(default, $"bad FormID '{raw}': {ex.Message}")); continue; }
-                outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, false, depth, resolveNames, linkMemo)
+                outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, false, depth, resolveNames, linkMemo, containerHint)
                              with { Epoch = view.Epoch, Pin = pin });
             }
             return outcomes;
@@ -3058,7 +3059,7 @@ public sealed class LoadOrderService : IDisposable
                         with { Epoch = view.Epoch, Pin = pin };
                     continue;
                 }
-                var record = ReadEngine.ReadFields(rec, fields, depth);          // materialise while the overlay is open
+                var record = ReadEngine.ReadFields(rec, fields, depth, containerHint);          // materialise while the overlay is open
                 if (resolveNames) record = AnnotateLinks(record, view, session!, linkMemo!);
                 var winner = view.ResolveWinner(fk);                             // winner CONTEXT where the record also lives in the order
                 results[index] = new ReadOutcome(fk, record, plugin, winner?.WinnerPlugin,
@@ -3432,7 +3433,8 @@ public sealed class LoadOrderService : IDisposable
     /// that on the envelope.</summary>
     public IReadOnlyList<ReadOutcome> OverlayPostBatch(
         IReadOnlyList<string> formids, IReadOnlyList<string>? fields, int depth, bool resolveNames,
-        ArtifactDemand? demand, out string? refusal, out string? refusalEpoch, out string? epoch)
+        ArtifactDemand? demand, out string? refusal, out string? refusalEpoch, out string? epoch,
+        string? containerHint = ReadEngine.DepthExpandHint)
     {
         refusal = null; refusalEpoch = null;
         var resolver = Resolver;
@@ -3500,7 +3502,7 @@ public sealed class LoadOrderService : IDisposable
                     continue;
                 }
             }
-            var record = ReadEngine.ReadFields(bodyToRead!, fields, depth);
+            var record = ReadEngine.ReadFields(bodyToRead!, fields, depth, containerHint);
             if (resolveNames) record = AnnotateLinks(record, view, session, overlayLinkMemo ??= new Dictionary<FormKey, ResolvedRef>());
             var ok = new ReadOutcome(fk, record, winner.Value.WinnerPlugin, winner.Value.WinnerPlugin,
                                      winner.Value.OverrideDepth, null, null)

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -1065,7 +1065,7 @@ static class Wire
                 truncated = true;
                 sb.Append("... [truncated: rendered ").Append(rendered).Append(" of ").Append(q.Keys.Count)
                   .Append(" returned matches before hitting max_chars=").Append(cap)
-                  .Append("; lower limit=, drop ").Append(lv.FieldsOrTree).Append(", or raise max_chars]\n");
+                  .Append("; lower limit=, drop ").Append(lv.SlimScan).Append(", or raise max_chars]\n");
                 break;
             }
             var fk = q.Keys[i];

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -1065,7 +1065,11 @@ static class Wire
                 truncated = true;
                 sb.Append("... [truncated: rendered ").Append(rendered).Append(" of ").Append(q.Keys.Count)
                   .Append(" returned matches before hitting max_chars=").Append(cap)
-                  .Append("; lower limit=, drop ").Append(lv.SlimScan).Append(", or raise max_chars]\n");
+                  // The slim-down clause is only true for a call that passed something to slim WITH — see
+                  // LeverNames.SlimScan. A call that passed nothing gets the two levers that are real on it.
+                  .Append(lv.SlimScan is null
+                              ? "; lower limit= or raise max_chars]\n"
+                              : $"; lower limit=, drop {lv.SlimScan}, or raise max_chars]\n");
                 break;
             }
             var fk = q.Keys[i];

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -991,7 +991,7 @@ static class Wire
                 truncated = true;
                 sb.Append("... [truncated: rendered ").Append(rendered).Append(" of ").Append(outcomes.Count)
                   .Append(" records before hitting max_chars=").Append(cap)
-                  .Append("; request fewer formids, pass ").Append(lv.Fields).Append(" to slim each, or raise max_chars]\n");
+                  .Append("; ").Append(lv.BatchSelection).Append(", pass ").Append(lv.Fields).Append(" to slim each, or raise max_chars]\n");
                 break;
             }
             sb.Append('\n');

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -903,8 +903,9 @@ static class Wire
     /// the diff view and the #342 precise tier, so the annotation costs no record fetch of its own. Without
     /// conflict_tree the outcome keeps the cheap index-only annotation the service already put on it.</summary>
     static void AppendRecordBlock(StringBuilder sb, LoadOrderService svc, ReadOutcome o, IReadOnlyList<string>? fields,
-                                  bool conflictTree, int cap, ChildNotes notes)
+                                  bool conflictTree, int cap, ChildNotes notes, LeverNames? levers = null)
     {
+        var lv = levers ?? LeverNames.Legacy;
         var outcome = o;
         LoadOrderService.TreeFill? fill = null;
         bool precise = false;
@@ -932,8 +933,8 @@ static class Wire
             foreach (var shape in annotated.Values) notes.May(ClauseOf(shape, precise));
         // The RESERVE is held back from the budget, never from the number the render QUOTES: a cut that told the
         // caller "at max_chars=1124" when they passed 2000 would be a wrong sentence of its own.
-        AppendRecord(sb, outcome, cap, notes.Reserve, precise, notes);
-        if (conflictTree) AppendConflictTree(sb, svc, outcome, fields, cap, fill?.View, notes.Reserve);
+        AppendRecord(sb, outcome, cap, notes.Reserve, precise, notes, lv);
+        if (conflictTree) AppendConflictTree(sb, svc, outcome, fields, cap, fill?.View, notes.Reserve, lv);
     }
 
     /// <summary>Which clause an annotated field earns: the cheap tier knows only that other plugins were not read,
@@ -965,10 +966,14 @@ static class Wire
     public static string RenderBatch(LoadOrderService svc, IReadOnlyList<ReadOutcome> outcomes, IReadOnlyList<string>? fields, bool conflictTree, int maxChars)
         => RenderBatch(svc, outcomes, fields, conflictTree, maxChars, null, out _);
 
+    /// <summary><paramref name="levers"/> is the CALLER's lever vocabulary for the remedy sentences below —
+    /// this renderer is shared by both tool generations and they spell the selector differently (#439).
+    /// Omitted means the 1.x spelling, so a 1.x call site renders byte-identically.</summary>
     public static string RenderBatch(LoadOrderService svc, IReadOnlyList<ReadOutcome> outcomes, IReadOnlyList<string>? fields, bool conflictTree, int maxChars,
-                                     SpillState? spill, out bool truncated)
+                                     SpillState? spill, out bool truncated, LeverNames? levers = null)
     {
         truncated = false;
+        var lv = levers ?? LeverNames.Legacy;
         int cap = Cap(maxChars);
         var notes = new ChildNotes();   // #342: accumulated over the rows actually rendered, not over the input list
         var sb = new StringBuilder();
@@ -986,12 +991,12 @@ static class Wire
                 truncated = true;
                 sb.Append("... [truncated: rendered ").Append(rendered).Append(" of ").Append(outcomes.Count)
                   .Append(" records before hitting max_chars=").Append(cap)
-                  .Append("; request fewer formids, pass fields= to slim each, or raise max_chars]\n");
+                  .Append("; request fewer formids, pass ").Append(lv.Fields).Append(" to slim each, or raise max_chars]\n");
                 break;
             }
             sb.Append('\n');
             if (o.Error is not null) sb.Append("error: ").Append(o.Error).Append('\n');
-            else AppendRecordBlock(sb, svc, o, fields, conflictTree, cap, notes);
+            else AppendRecordBlock(sb, svc, o, fields, conflictTree, cap, notes, lv);
             rendered++;
         }
         AppendOwnedChildNotes(sb, notes);
@@ -1001,12 +1006,8 @@ static class Wire
 
     // ---- housecarl_cross_plugin_query ---------------------------------------------------------------
 
-    /// <summary>The container hint for the DENSE render's field cells: dense refuses depth&gt;1 (positional cells align
-    /// 1:1 with the requested paths — #231), so the generic " — pass depth=2 to expand" alone would send the caller
-    /// into that refusal blind. Name the format hop with the knob. Used only by
-    /// <see cref="JsonWire.RenderCrossQueryDense"/>; the text/json renders take depth= directly and use the generic
-    /// <see cref="HousecarlCore.ReadEngine.DepthExpandHint"/>.</summary>
-    internal const string DenseContainerHint = " — pass depth=2 with format=text/json to expand (dense cells are positional)";
+    // The dense render's container hint moved to LeverNames.DenseContainerHint (#439): dense refuses depth>1, so
+    // the hint names the format hop with the knob — and the knob is spelled per caller like every other lever.
 
     public static string RenderCrossQuery(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, bool conflictTree, int maxChars,
                                           bool resolveNames = false, bool winnerFields = false, int depth = 1)
@@ -1016,9 +1017,11 @@ static class Wire
     /// spilled marker / to_file manifest-only mode / failed-spill warning), and <paramref name="truncated"/> hands
     /// the row-level max_chars cut back to the tool layer — the auto-spill trigger.</summary>
     public static string RenderCrossQuery(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, bool conflictTree, int maxChars,
-                                          bool resolveNames, bool winnerFields, int depth, SpillState? spill, out bool truncated)
+                                          bool resolveNames, bool winnerFields, int depth, SpillState? spill, out bool truncated,
+                                          LeverNames? levers = null)
     {
         truncated = false;
+        var lv = levers ?? LeverNames.Legacy;
         // A post-capture refusal is stamped (PR #305 contract) — e.g. the artifact epoch-mismatch refusal, which
         // consulted the build to compare against it. Pre-capture validation refusals carry null and render bare.
         if (q.Error is not null) return "error: " + q.Error + (q.Epoch is not null ? $"\nepoch={q.Epoch}" : "");
@@ -1062,7 +1065,7 @@ static class Wire
                 truncated = true;
                 sb.Append("... [truncated: rendered ").Append(rendered).Append(" of ").Append(q.Keys.Count)
                   .Append(" returned matches before hitting max_chars=").Append(cap)
-                  .Append("; lower limit=, drop fields=/conflict_tree, or raise max_chars]\n");
+                  .Append("; lower limit=, drop ").Append(lv.FieldsOrTree).Append(", or raise max_chars]\n");
                 break;
             }
             var fk = q.Keys[i];
@@ -1073,11 +1076,12 @@ static class Wire
                 // body the scan filtered (scoped plugin under plugins=, else winner) — so display never contradicts filter.
                 // PINNED to the scan's build (ResolveReadOn / the q-carrying AppendConflictTree): the header's epoch
                 // names ONE build, so every fill must read it (PR #305 review).
-                var o = svc.ResolveReadOn(q, fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, conflictTree, depth, resolveNames: resolveNames, linkMemo: linkMemo);
+                var o = svc.ResolveReadOn(q, fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, conflictTree, depth, resolveNames: resolveNames, linkMemo: linkMemo,
+                                          containerHint: lv.ContainerHint);   // a collapsed cell names the caller's own expansion knob (#439)
                 sb.Append('\n');
                 if (matches is not null) sb.Append("  ").Append(fk).Append("  matches=").Append(matches).Append('\n');
                 if (o.Error is not null) sb.Append(fk).Append(": error: ").Append(o.Error).Append('\n');
-                else AppendRecordBlock(sb, svc, o, fields, conflictTree, cap, notes);   // o carries the scan's pin
+                else AppendRecordBlock(sb, svc, o, fields, conflictTree, cap, notes, lv);   // o carries the scan's pin
             }
             else
             {
@@ -1832,8 +1836,10 @@ static class Wire
     /// the lanes that render a record outside a #342-annotated response (readback, verify).</summary>
     /// <param name="reserve">Chars held back for the response-level clauses this render may still state: the field
     /// loop stops that much earlier, while the notice still quotes the caller's own <paramref name="cap"/>.</param>
-    static void AppendRecord(StringBuilder sb, ReadOutcome o, int cap, int reserve = 0, bool precise = false, ChildNotes? notes = null)
+    static void AppendRecord(StringBuilder sb, ReadOutcome o, int cap, int reserve = 0, bool precise = false, ChildNotes? notes = null,
+                             LeverNames? levers = null)
     {
+        var lv = levers ?? LeverNames.Legacy;
         var r = o.Record!;
         sb.Append("type=").Append(r.Type)
           .Append("  formid=").Append(r.FormKey)
@@ -1847,7 +1853,7 @@ static class Wire
             {
                 sb.Append("  ... [truncated: showing ").Append(i).Append(" of ").Append(r.Fields.Count)
                   .Append(" field lines at max_chars=").Append(cap)
-                  .Append("; narrow with fields=, lower depth=, or raise max_chars]\n");
+                  .Append("; narrow with ").Append(lv.Fields).Append(", lower ").Append(lv.Depth).Append(", or raise max_chars]\n");
                 break;
             }
             var f = r.Fields[i];
@@ -1877,8 +1883,9 @@ static class Wire
     /// <param name="reserve">Chars held back for the #342 response-level clauses — the same split
     /// <see cref="AppendRecord"/> makes: budget against <c>cap - reserve</c>, quote <c>cap</c>.</param>
     static void AppendConflictTree(StringBuilder sb, LoadOrderService svc, ReadOutcome o, IReadOnlyList<string>? fields, int cap,
-                                   ConflictTreeView? prefetched = null, int reserve = 0)
+                                   ConflictTreeView? prefetched = null, int reserve = 0, LeverNames? levers = null)
     {
+        var lv = levers ?? LeverNames.Legacy;
         var tp = o.TouchingPlugins;
         if (tp is null) return;
         sb.Append("conflict_tree: ").Append(tp.Count).Append(tp.Count == 1 ? " plugin touches" : " plugins touch")
@@ -1888,7 +1895,7 @@ static class Wire
             if (sb.Length >= cap - reserve && i < tp.Count - 1)            // budget gone mid-list — name the rest + the winner, stop
             {
                 sb.Append("  ... [").Append(tp.Count - i).Append(" more plugins omitted at max_chars=").Append(cap)
-                  .Append("; winner (last in load order) = ").Append(tp[^1]).Append("; raise max_chars or narrow with fields=]\n");
+                  .Append("; winner (last in load order) = ").Append(tp[^1]).Append("; raise max_chars or narrow with ").Append(lv.Fields).Append("]\n");
                 return;                                                    // and skip the diff (the all-bodies fetch too) — already over budget
             }
             sb.Append("  ").Append(i + 1).Append(". ").Append(tp[i]).Append(i == tp.Count - 1 ? "  (winner)" : "").Append('\n');
@@ -1921,14 +1928,14 @@ static class Wire
             if (sb.Length >= cap - reserve)
             {
                 sb.Append("  ... [truncated: response hit max_chars=").Append(cap)
-                  .Append("; pass fields= to narrow the diff or raise max_chars]\n");
+                  .Append("; pass ").Append(lv.Fields).Append(" to narrow the diff or raise max_chars]\n");
                 return;
             }
             var node = tree.Nodes[n];
             var diff = FieldsDiff.Compare(node.Record, winnerNode.Record);
             string line = diff.Deltas.Count > 0
                 ? string.Join("; ", diff.Deltas)
-                  + (diff.Complete ? "" : " [comparison TRUNCATED at the expansion cap — only value mismatches observed on both sides are shown; list contents and one-sided fields were NOT compared; narrow with fields= to fully compare]")
+                  + (diff.Complete ? "" : " [comparison TRUNCATED at the expansion cap — only value mismatches observed on both sides are shown; list contents and one-sided fields were NOT compared; narrow with " + lv.Fields + " to fully compare]")
                 : diff.Complete
                     // No deltas. Surface HOW MANY modeled fields read identical to the winner (item 4.3) — node-
                     // neutral, because this renders for every touching plugin including the master (Nodes[0]),
@@ -1938,13 +1945,13 @@ static class Wire
                     ? (fields is { Count: > 0 }
                         ? IdenticalAcrossFields(diff)
                         : IdenticalWholeRecord(diff))
-                    : "(no differences found, but the comparison was TRUNCATED at the expansion cap — NOT a verified ITM; narrow with fields= to fully compare)";
+                    : "(no differences found, but the comparison was TRUNCATED at the expansion cap — NOT a verified ITM; narrow with " + lv.Fields + " to fully compare)";
             // One node's joined deltas are unbounded (two divergent deep reads can carry thousands); slice
             // against the remaining char budget with the same explicit notice the other cuts use (Q3).
             int room = cap - reserve - sb.Length;
             if (line.Length > room)
                 line = string.Concat(line.AsSpan(0, Math.Max(0, room)),
-                    " ... [delta line truncated at max_chars; narrow with fields= or raise max_chars]");
+                    " ... [delta line truncated at max_chars; narrow with " + lv.Fields + " or raise max_chars]");
             sb.Append("  ").Append(node.Plugin).Append(": ").Append(line).Append('\n');
         }
     }

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -1054,7 +1054,7 @@ static class Wire
         // the silent-wrong trap (a defining esp's AR 38 vs the winner's live AR 200). Name it loud, once (Q3). The
         // helper is 4-way over (winner_fields=, where_source=) so the note never claims a scoped-body MATCH the
         // where_source=winner scan didn't make (D2 no-drift). Shared with the json/dense renders — one source of truth.
-        if (anyScoped) sb.Append("note: ").Append(JsonWire.ScopedFieldsNote(winnerFields, q.WhereWinner)).Append('\n');
+        if (anyScoped) sb.Append("note: ").Append(JsonWire.ScopedFieldsNote(winnerFields, q.WhereWinner, lv)).Append('\n');
 
         int rendered = 0;
         var notes = new ChildNotes();   // #342: accumulated over the rows actually rendered

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -579,7 +579,7 @@ public static class RecordsTools
             SpillState? spill2 = null;
             if (wantFile)
             {
-                var (s, aerr) = Artifacts.WriteBatch(outcomes, toFile!, "to_file", Echo());
+                var (s, aerr) = Artifacts.WriteBatch(outcomes, toFile!, "to_file", Echo(), LeverNames.Records);
                 if (aerr is not null) return json ? JsonWire.RenderError(aerr, epoch2) : "error: " + aerr;
                 spill2 = SpillState.Spilled(s!, manifestOnly: true);
             }
@@ -591,7 +591,7 @@ public static class RecordsTools
             if (spill2 is null && truncated2)
             {
                 var path = ResultsStore.NextPath("housecarl_records", epoch2 ?? "none");
-                var (s, aerr) = Artifacts.WriteBatch(outcomes, path, "ceiling", Echo());
+                var (s, aerr) = Artifacts.WriteBatch(outcomes, path, "ceiling", Echo(), LeverNames.Records);
                 if (aerr is not null) ResultsStore.Release(path);
                 rendered2 = Render2(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
             }
@@ -1229,7 +1229,7 @@ public static class RecordsTools
                 SpillState? evSpill = null;
                 if (wantFile)
                 {
-                    var (s, aerr) = Artifacts.WriteBatch(bodies, toFile!, "to_file", Echo());
+                    var (s, aerr) = Artifacts.WriteBatch(bodies, toFile!, "to_file", Echo(), evLevers);
                     if (aerr is not null) return json ? JsonWire.RenderError(aerr, bodyEpoch) : "error: " + aerr;
                     evSpill = SpillState.Spilled(s!, manifestOnly: true);
                 }
@@ -1237,7 +1237,7 @@ public static class RecordsTools
                 if (evSpill is null && evTrunc)
                 {
                     var path = ResultsStore.NextPath("housecarl_records", bodyEpoch ?? "none");
-                    var (s, aerr) = Artifacts.WriteBatch(bodies, path, "ceiling", Echo());
+                    var (s, aerr) = Artifacts.WriteBatch(bodies, path, "ceiling", Echo(), evLevers);
                     if (aerr is not null) ResultsStore.Release(path);
                     evRendered = RenderEv(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
                 }
@@ -1442,7 +1442,7 @@ public static class RecordsTools
                 var offEpoch = bodies.FirstOrDefault(o => o.Epoch is not null)?.Epoch ?? outcome.Epoch;
                 if (wantFile)
                 {
-                    var (sp, aerr) = Artifacts.WriteBatch(bodies, toFile!, "to_file", Echo());
+                    var (sp, aerr) = Artifacts.WriteBatch(bodies, toFile!, "to_file", Echo(), offLevers);
                     if (aerr is not null) return json ? JsonWire.RenderError(aerr, offEpoch) : "error: " + aerr;
                     offSpill = SpillState.Spilled(sp!, manifestOnly: true);
                 }
@@ -1450,7 +1450,7 @@ public static class RecordsTools
                 if (offSpill is null && offTrunc)
                 {
                     var path = ResultsStore.NextPath("housecarl_records", offEpoch ?? "none");
-                    var (sp, aerr) = Artifacts.WriteBatch(bodies, path, "ceiling", Echo());
+                    var (sp, aerr) = Artifacts.WriteBatch(bodies, path, "ceiling", Echo(), offLevers);
                     if (aerr is not null) ResultsStore.Release(path);
                     offRendered = RenderOff(aerr is null ? SpillState.Spilled(sp!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
                 }

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -538,7 +538,7 @@ public static class RecordsTools
             else if (srcName is null)
             {
                 if (srcOverlay) Arm("skypatcher overlay (pre) = winner — the body the INI layer starts from");
-                outcomes = svc.ResolveBatch(ids, readFields, false, depth, resolveNames, null, demand, out var refusal, out var refusalEpoch);
+                outcomes = svc.ResolveBatch(ids, readFields, false, depth, resolveNames, null, demand, out var refusal, out var refusalEpoch, LeverNames.Records.ContainerHint);
                 if (refusal is not null)
                     return json ? JsonWire.RenderError(refusal, refusalEpoch)
                                 : "error: " + refusal + (refusalEpoch is not null ? $"\nepoch={refusalEpoch}" : "");
@@ -583,8 +583,8 @@ public static class RecordsTools
             }
             string Render2(SpillState? sp, out bool trunc) => form == "summary"
                 ? RenderRecordsSummary(winOutcomes, json, headerLine, envelope, max_chars, sp, out trunc)
-                : json ? JsonWire.RenderBatch(winOutcomes, max_chars, sp, out trunc, envelope)
-                       : headerLine + "\n" + Wire.RenderBatch(svc, winOutcomes, projFields, false, max_chars, sp, out trunc);
+                : json ? JsonWire.RenderBatch(winOutcomes, max_chars, sp, out trunc, envelope, LeverNames.Records)
+                       : headerLine + "\n" + Wire.RenderBatch(svc, winOutcomes, projFields, false, max_chars, sp, out trunc, LeverNames.Records);
             var rendered2 = Render2(spill2, out var truncated2);
             if (spill2 is null && truncated2)
             {
@@ -857,7 +857,7 @@ public static class RecordsTools
             }
             var treeCounts = new[] { KvI("count", rows.Count), KvI("contested", contested), KvI("errors", errs) };
             string Render(SpillState? sp, out bool trunc) => json
-                ? JsonWire.RenderTree(winRows, max_chars, epoch, envelope, treeCounts, sp, out trunc)
+                ? JsonWire.RenderTree(winRows, max_chars, epoch, envelope, treeCounts, sp, out trunc, LeverNames.Records)
                 : RenderRecordsTree(winRows, rows.Count, contested, errs, projFields is { Length: > 0 }, headerLine, epoch, max_chars, sp, out trunc);
             var rendered = Render(spill, out var truncated);
             if (spill is null && truncated)
@@ -1167,7 +1167,7 @@ public static class RecordsTools
                     // retargets display to the winner exactly as on the fields form.
                     var srcs = outcome.Sources;
                     if (winnerFields || srcs is null || srcs.Take(keys.Count).All(s => s is null))
-                        bodies = svc.ResolveBatch(keys, null, false, depth, resolveNames);
+                        bodies = svc.ResolveBatch(keys, null, false, depth, resolveNames, containerHint: LeverNames.Records.ContainerHint);
                     else
                     {
                         var byIndex = new ReadOutcome[keys.Count];
@@ -1182,12 +1182,12 @@ public static class RecordsTools
                         }
                         if (winnerIdx.Count > 0)
                         {
-                            var res = svc.ResolveBatch(winnerIdx.Select(i => keys[i]).ToList(), null, false, depth, resolveNames);
+                            var res = svc.ResolveBatch(winnerIdx.Select(i => keys[i]).ToList(), null, false, depth, resolveNames, containerHint: LeverNames.Records.ContainerHint);
                             for (int i = 0; i < winnerIdx.Count; i++) byIndex[winnerIdx[i]] = res[i];
                         }
                         foreach (var kv in bySource)
                         {
-                            var res = svc.ResolveBatch(kv.Value.Select(i => keys[i]).ToList(), null, false, depth, resolveNames, kv.Key);
+                            var res = svc.ResolveBatch(kv.Value.Select(i => keys[i]).ToList(), null, false, depth, resolveNames, kv.Key, LeverNames.Records.ContainerHint);
                             for (int i = 0; i < kv.Value.Count; i++) byIndex[kv.Value[i]] = res[i];
                         }
                         bodies = byIndex;
@@ -1219,8 +1219,8 @@ public static class RecordsTools
                 envelope.Add(new("total", outcome.Total.ToString()));
                 headerLine += $"\n{outcome.Total} match(es); bodies for the {keys.Count}-row window below";
                 string RenderEv(SpillState? sp, out bool trunc) => json
-                    ? JsonWire.RenderBatch(bodies, max_chars, sp, out trunc, envelope)
-                    : headerLine + "\n" + Wire.RenderBatch(svc, bodies, null, false, max_chars, sp, out trunc);
+                    ? JsonWire.RenderBatch(bodies, max_chars, sp, out trunc, envelope, LeverNames.Records)
+                    : headerLine + "\n" + Wire.RenderBatch(svc, bodies, null, false, max_chars, sp, out trunc, LeverNames.Records);
                 SpillState? evSpill = null;
                 if (wantFile)
                 {
@@ -1243,22 +1243,22 @@ public static class RecordsTools
             SpillState? spill = null;
             if (wantFile && outcome.Error is null)
             {
-                var (s, aerr) = Artifacts.WriteCrossQuery(svc, outcome, projFields, resolveNames, winnerFields, depth, toFile!, "to_file", Echo());
+                var (s, aerr) = Artifacts.WriteCrossQuery(svc, outcome, projFields, resolveNames, winnerFields, depth, toFile!, "to_file", Echo(), LeverNames.Records);
                 if (aerr is not null)
                     return fmt is Wire.QueryFormat.Text ? "error: " + aerr : JsonWire.RenderError(aerr, outcome.Epoch);
                 spill = SpillState.Spilled(s!, manifestOnly: true);
             }
             string Render(SpillState? sp, out bool trunc) => fmt switch
             {
-                Wire.QueryFormat.Dense when groupBy is null => JsonWire.RenderCrossQueryDense(svc, outcome, projFields, max_chars, resolveNames, winnerFields, sp, out trunc, envelope),
-                Wire.QueryFormat.Dense or Wire.QueryFormat.Json => JsonWire.RenderCrossQuery(svc, outcome, projFields, max_chars, resolveNames, winnerFields, depth, sp, out trunc, envelope),
-                _ => headerLine + "\n" + Wire.RenderCrossQuery(svc, outcome, projFields, false, max_chars, resolveNames, winnerFields, depth, sp, out trunc),
+                Wire.QueryFormat.Dense when groupBy is null => JsonWire.RenderCrossQueryDense(svc, outcome, projFields, max_chars, resolveNames, winnerFields, sp, out trunc, envelope, LeverNames.Records),
+                Wire.QueryFormat.Dense or Wire.QueryFormat.Json => JsonWire.RenderCrossQuery(svc, outcome, projFields, max_chars, resolveNames, winnerFields, depth, sp, out trunc, envelope, LeverNames.Records),
+                _ => headerLine + "\n" + Wire.RenderCrossQuery(svc, outcome, projFields, false, max_chars, resolveNames, winnerFields, depth, sp, out trunc, LeverNames.Records),
             };
             var rendered = Render(spill, out var truncated);
             if (spill is null && truncated && outcome.Error is null)
             {
                 var path = ResultsStore.NextPath("housecarl_records", outcome.Epoch ?? "none");
-                var (s, aerr) = Artifacts.WriteCrossQuery(svc, outcome, projFields, resolveNames, winnerFields, depth, path, "ceiling", Echo());
+                var (s, aerr) = Artifacts.WriteCrossQuery(svc, outcome, projFields, resolveNames, winnerFields, depth, path, "ceiling", Echo(), LeverNames.Records);
                 if (aerr is not null) ResultsStore.Release(path);
                 rendered = Render(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
             }
@@ -1424,8 +1424,8 @@ public static class RecordsTools
                 envelope.Add(new("total", outcome.Total.ToString()));
                 headerLine += $"\n{outcome.Total} match(es); bodies for the {keys.Count}-row window below";
                 string RenderOff(SpillState? sp, out bool trunc) => json
-                    ? JsonWire.RenderBatch(bodies, max_chars, sp, out trunc, envelope)
-                    : headerLine + "\n" + Wire.RenderBatch(svc, bodies, form == "fields" ? projFields : null, false, max_chars, sp, out trunc);
+                    ? JsonWire.RenderBatch(bodies, max_chars, sp, out trunc, envelope, LeverNames.Records)
+                    : headerLine + "\n" + Wire.RenderBatch(svc, bodies, form == "fields" ? projFields : null, false, max_chars, sp, out trunc, LeverNames.Records);
                 SpillState? offSpill = null;
                 var offEpoch = bodies.FirstOrDefault(o => o.Epoch is not null)?.Epoch ?? outcome.Epoch;
                 if (wantFile)
@@ -1450,21 +1450,21 @@ public static class RecordsTools
             SpillState? spill = null;
             if (wantFile && outcome.Error is null)
             {
-                var (sp, aerr) = Artifacts.WriteCrossQuery(svc, outcome, null, false, false, 1, toFile!, "to_file", Echo());
+                var (sp, aerr) = Artifacts.WriteCrossQuery(svc, outcome, null, false, false, 1, toFile!, "to_file", Echo(), LeverNames.Records);
                 if (aerr is not null)
                     return fmt is Wire.QueryFormat.Text ? "error: " + aerr : JsonWire.RenderError(aerr, outcome.Epoch);
                 spill = SpillState.Spilled(sp!, manifestOnly: true);
             }
             string Render(SpillState? sp, out bool trunc) => fmt switch
             {
-                Wire.QueryFormat.Dense or Wire.QueryFormat.Json => JsonWire.RenderCrossQuery(svc, outcome, null, max_chars, false, false, 1, sp, out trunc, envelope),
-                _ => headerLine + "\n" + Wire.RenderCrossQuery(svc, outcome, null, false, max_chars, false, false, 1, sp, out trunc),
+                Wire.QueryFormat.Dense or Wire.QueryFormat.Json => JsonWire.RenderCrossQuery(svc, outcome, null, max_chars, false, false, 1, sp, out trunc, envelope, LeverNames.Records),
+                _ => headerLine + "\n" + Wire.RenderCrossQuery(svc, outcome, null, false, max_chars, false, false, 1, sp, out trunc, LeverNames.Records),
             };
             var rendered = Render(spill, out var truncated);
             if (spill is null && truncated && outcome.Error is null)
             {
                 var path = ResultsStore.NextPath("housecarl_records", outcome.Epoch ?? "none");
-                var (sp, aerr) = Artifacts.WriteCrossQuery(svc, outcome, null, false, false, 1, path, "ceiling", Echo());
+                var (sp, aerr) = Artifacts.WriteCrossQuery(svc, outcome, null, false, false, 1, path, "ceiling", Echo(), LeverNames.Records);
                 if (aerr is not null) ResultsStore.Release(path);
                 rendered = Render(aerr is null ? SpillState.Spilled(sp!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
             }

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -1220,9 +1220,12 @@ public static class RecordsTools
                 var bodyEpoch = bodyEpochs.FirstOrDefault() ?? outcome.Epoch;
                 envelope.Add(new("total", outcome.Total.ToString()));
                 headerLine += $"\n{outcome.Total} match(es); bodies for the {keys.Count}-row window below";
+                // These bodies were selected by a SCAN, not by a formids list, so the batch notice's selection
+                // clause names limit= — the lever that actually windows this response (#439 gate review).
+                var evLevers = LeverNames.Records.OnScanSelection();
                 string RenderEv(SpillState? sp, out bool trunc) => json
-                    ? JsonWire.RenderBatch(bodies, max_chars, sp, out trunc, envelope, LeverNames.Records)
-                    : headerLine + "\n" + Wire.RenderBatch(svc, bodies, null, false, max_chars, sp, out trunc, LeverNames.Records);
+                    ? JsonWire.RenderBatch(bodies, max_chars, sp, out trunc, envelope, evLevers)
+                    : headerLine + "\n" + Wire.RenderBatch(svc, bodies, null, false, max_chars, sp, out trunc, evLevers);
                 SpillState? evSpill = null;
                 if (wantFile)
                 {
@@ -1426,9 +1429,11 @@ public static class RecordsTools
                 }
                 envelope.Add(new("total", outcome.Total.ToString()));
                 headerLine += $"\n{outcome.Total} match(es); bodies for the {keys.Count}-row window below";
+                // Selected by the off-order FILE scan — same third axis as the in-order body lane above.
+                var offLevers = LeverNames.Records.OnScanSelection();
                 string RenderOff(SpillState? sp, out bool trunc) => json
-                    ? JsonWire.RenderBatch(bodies, max_chars, sp, out trunc, envelope, LeverNames.Records)
-                    : headerLine + "\n" + Wire.RenderBatch(svc, bodies, form == "fields" ? projFields : null, false, max_chars, sp, out trunc, LeverNames.Records);
+                    ? JsonWire.RenderBatch(bodies, max_chars, sp, out trunc, envelope, offLevers)
+                    : headerLine + "\n" + Wire.RenderBatch(svc, bodies, form == "fields" ? projFields : null, false, max_chars, sp, out trunc, offLevers);
                 SpillState? offSpill = null;
                 var offEpoch = bodies.FirstOrDefault(o => o.Epoch is not null)?.Epoch ?? outcome.Epoch;
                 if (wantFile)

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -1253,11 +1253,15 @@ public static class RecordsTools
                     return fmt is Wire.QueryFormat.Text ? "error: " + aerr : JsonWire.RenderError(aerr, outcome.Epoch);
                 spill = SpillState.Spilled(s!, manifestOnly: true);
             }
+            // "drop project= (summary rows)" is only actionable for a call whose rows are DETAIL rows — a
+            // summary-form scan (the default) is already reading the render that clause points at, and has no
+            // project= to drop. The call site decides that from its own parameters (#439 gate review).
+            var qLevers = projFields is { Length: > 0 } ? LeverNames.Records : LeverNames.Records.WithNothingToDrop();
             string Render(SpillState? sp, out bool trunc) => fmt switch
             {
-                Wire.QueryFormat.Dense when groupBy is null => JsonWire.RenderCrossQueryDense(svc, outcome, projFields, max_chars, resolveNames, winnerFields, sp, out trunc, envelope, LeverNames.Records),
-                Wire.QueryFormat.Dense or Wire.QueryFormat.Json => JsonWire.RenderCrossQuery(svc, outcome, projFields, max_chars, resolveNames, winnerFields, depth, sp, out trunc, envelope, LeverNames.Records),
-                _ => headerLine + "\n" + Wire.RenderCrossQuery(svc, outcome, projFields, false, max_chars, resolveNames, winnerFields, depth, sp, out trunc, LeverNames.Records),
+                Wire.QueryFormat.Dense when groupBy is null => JsonWire.RenderCrossQueryDense(svc, outcome, projFields, max_chars, resolveNames, winnerFields, sp, out trunc, envelope, qLevers),
+                Wire.QueryFormat.Dense or Wire.QueryFormat.Json => JsonWire.RenderCrossQuery(svc, outcome, projFields, max_chars, resolveNames, winnerFields, depth, sp, out trunc, envelope, qLevers),
+                _ => headerLine + "\n" + Wire.RenderCrossQuery(svc, outcome, projFields, false, max_chars, resolveNames, winnerFields, depth, sp, out trunc, qLevers),
             };
             var rendered = Render(spill, out var truncated);
             if (spill is null && truncated && outcome.Error is null)
@@ -1463,10 +1467,13 @@ public static class RecordsTools
                     return fmt is Wire.QueryFormat.Text ? "error: " + aerr : JsonWire.RenderError(aerr, outcome.Epoch);
                 spill = SpillState.Spilled(sp!, manifestOnly: true);
             }
+            // The off-order scan passes no field paths at all, so it never has a project= to drop — unconditional
+            // here, where the in-order lane above has to ask.
+            var offQLevers = LeverNames.Records.WithNothingToDrop();
             string Render(SpillState? sp, out bool trunc) => fmt switch
             {
-                Wire.QueryFormat.Dense or Wire.QueryFormat.Json => JsonWire.RenderCrossQuery(svc, outcome, null, max_chars, false, false, 1, sp, out trunc, envelope, LeverNames.Records),
-                _ => headerLine + "\n" + Wire.RenderCrossQuery(svc, outcome, null, false, max_chars, false, false, 1, sp, out trunc, LeverNames.Records),
+                Wire.QueryFormat.Dense or Wire.QueryFormat.Json => JsonWire.RenderCrossQuery(svc, outcome, null, max_chars, false, false, 1, sp, out trunc, envelope, offQLevers),
+                _ => headerLine + "\n" + Wire.RenderCrossQuery(svc, outcome, null, false, max_chars, false, false, 1, sp, out trunc, offQLevers),
             };
             var rendered = Render(spill, out var truncated);
             if (spill is null && truncated && outcome.Error is null)

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -221,7 +221,7 @@ public static class RecordsTools
             // rather than silently becoming 1.
             if (form is not ("fields" or "everything"))
                 return Wire.Refuse(json, comparisonForm
-                    ? $"error: project.depth belongs to the 'fields'/'everything' forms — the '{form}' comparison always deep-reads BOTH sides at the diff engine's fixed depth so line sets correspond (narrow with project.fields instead)."
+                    ? $"error: project.depth belongs to the 'fields'/'everything' forms — the '{form}' comparison always deep-reads BOTH sides at the diff engine's fixed depth so line sets correspond (narrow with {LeverNames.Records.Fields} instead)."
                     : $"error: project.depth expands field contents and belongs to the 'fields'/'everything' forms (got form='{form}').");
             if (dv < 1)
                 return Wire.Refuse(json, $"error: project.depth={dv} — depth must be >= 1 (1 shows a container as a collapsed summary; higher opens it).");
@@ -1582,7 +1582,7 @@ public static class RecordsTools
             if (d.Deltas.Count == 0)
             {
                 if (!d.Complete)
-                    sb.Append("  no differing fields in what was read, but the deep read was TRUNCATED at the cap — NOT a clean 'identical' (Q3). Narrow with project.fields to compare in full.\n");
+                    sb.Append("  no differing fields in what was read, but the deep read was TRUNCATED at the cap — NOT a clean 'identical' (Q3). Narrow with ").Append(LeverNames.Records.Fields).Append(" to compare in full.\n");
                 else if (d.AgreedCount > 0)
                     sb.Append("  identical across the fields read (").Append(d.AgreedCount).Append(" value leaf/leaves agree).\n");
                 else
@@ -1597,13 +1597,13 @@ public static class RecordsTools
                     if (sb.Length >= cap)
                     {
                         truncated = true;
-                        sb.Append("    ... [delta lines cut at max_chars=").Append(cap).Append(" — raise max_chars or narrow with project.fields]\n");
+                        sb.Append("    ... [delta lines cut at max_chars=").Append(cap).Append(" — raise max_chars or narrow with ").Append(LeverNames.Records.Fields).Append("]\n");
                         break;
                     }
                     sb.Append("    - ").Append(delta).Append('\n');
                 }
                 if (!d.Complete)
-                    sb.Append("  note: the deep read was TRUNCATED — list-content and one-sided-presence deltas are SUPPRESSED; narrow with project.fields to compare those in full.\n");
+                    sb.Append("  note: the deep read was TRUNCATED — list-content and one-sided-presence deltas are SUPPRESSED; narrow with ").Append(LeverNames.Records.Fields).Append(" to compare those in full.\n");
             }
             rendered++;
         }
@@ -1653,7 +1653,7 @@ public static class RecordsTools
                 if (sb.Length >= cap)
                 {
                     truncated = true;
-                    sb.Append("    ... [nodes cut at max_chars=").Append(cap).Append(" — raise max_chars or narrow with project.fields]\n");
+                    sb.Append("    ... [nodes cut at max_chars=").Append(cap).Append(" — raise max_chars or narrow with ").Append(LeverNames.Records.Fields).Append("]\n");
                     break;
                 }
                 sb.Append("    ").Append(n.Plugin).Append(n.IsWinner ? " (winner)" : "").Append(": ");

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -526,7 +526,8 @@ public static class RecordsTools
             {
                 // The overlay POST source: every record's winner replayed through the SkyPatcher INI layer, the
                 // replayed body read at the caller's own depth (absorbs skypatcher_read's post-state view).
-                outcomes = svc.OverlayPostBatch(ids, readFields, depth, resolveNames, demand, out var ovRefusal, out var ovEpoch, out _);
+                outcomes = svc.OverlayPostBatch(ids, readFields, depth, resolveNames, demand, out var ovRefusal, out var ovEpoch, out _,
+                                                LeverNames.Records.ContainerHint);
                 if (ovRefusal is not null)
                     return json ? JsonWire.RenderError(ovRefusal, ovEpoch)
                                 : "error: " + ovRefusal + (ovEpoch is not null ? $"\nepoch={ovEpoch}" : "");
@@ -547,7 +548,8 @@ public static class RecordsTools
             else
             {
                 outcomes = svc.ResolveBatchFromPole(ids, srcName, srcMod, readFields, depth, resolveNames, demand,
-                                                    out pole, out var refusal, out var refusalEpoch);
+                                                    out pole, out var refusal, out var refusalEpoch,
+                                                    LeverNames.Records.ContainerHint);
                 if (refusal is not null)
                     return json ? JsonWire.RenderError(refusal, refusalEpoch)
                                 : "error: " + refusal + (refusalEpoch is not null ? $"\nepoch={refusalEpoch}" : "");
@@ -1151,7 +1153,7 @@ public static class RecordsTools
                 if (srcName is not null)
                 {
                     bodies = svc.ResolveBatchFromPole(keys, srcName, srcMod, form == "fields" ? projFields : null, depth, resolveNames, null,
-                                                      out _, out var bref, out var brefEpoch);
+                                                      out _, out var bref, out var brefEpoch, LeverNames.Records.ContainerHint);
                     // A refusal is judged on the NAMED cause, never on row count (review: a zero-match scan is an
                     // honest EMPTY result, and the pole lane's real refusals were being replaced by a generic one).
                     if (bref is not null)
@@ -1408,7 +1410,8 @@ public static class RecordsTools
             {
                 var keys = outcome.Keys.Select(k => k.ToString()).ToList();
                 var bodies = svc.ResolveBatchFromPole(keys, pole.Plugin, srcMod, form == "fields" ? projFields : null,
-                                                      depth, resolveNames, null, out _, out var bref, out var brefEpoch);
+                                                      depth, resolveNames, null, out _, out var bref, out var brefEpoch,
+                                                      LeverNames.Records.ContainerHint);
                 if (bref is not null)
                     return json ? JsonWire.RenderError(bref, brefEpoch)
                                 : "error: " + bref + (brefEpoch is not null ? $"\nepoch={brefEpoch}" : "");


### PR DESCRIPTION
Fixes #439

A remedy predicts what a LATER call produces, so it is only true for a caller that has the
parameters it names. The body renderers are shared by both tool generations, so a remedy composed
inside one could only speak one vocabulary — and it spoke the 1.x one. A `housecarl_records`
caller was told to narrow with `fields=` and lower `depth=`, which on that tool are
`project.fields=` and `project.depth=`.

`LeverNames` carries the caller's spelling into the renderer. `Legacy` is the default at every
seam, so 1.x call sites render byte-identically; `housecarl_records` passes `Records`.

---

## The claim this PR makes

> `housecarl_records` truncation and expansion notices name that tool's own parameters on the
> **`fields`, `tree` and `delta`** forms and the **`summary` form's scan cut**, for the
> **collapsed-container hint on every `source=` lane**, and for the **scoped-vs-winner note** —
> verified on `format="text"` and `"json"`, with the container hint additionally verified on
> `"dense"` and in `to_file=` artifact rows. A truncation cut's own **selection** and **slim-down**
> clauses name the lever that is real for the CALL — its selection lane, and whether it passed
> anything to slim with — verified on `"text"`, the only format that writes them.

It is deliberately **not** a completeness claim. An earlier draft was, twice, and both times a
review round proved it false. What is **not** covered is named in the CHANGELOG and filed:
the `everything` form (#445) and the walk/chain lane (#446).

**Every clause has its own sabotage-RED cell.** A clause with no cell is not in the claim.

| Clause | Cell | Verdict |
|---|---|---|
| the records vocabulary itself (canary, hand-proven at `2b037a2`) | `canary/records-selector` | RED |
| the depth knob's spelling | `records-depth` | RED |
| the absent lever (`conflict_tree`) | `records-conflict-tree` | RED |
| the renamed lever (`winner_fields` to `fields_source`) | `records-winner-fields` | RED |
| the `=` on the selector | `clause/selector-equals` | RED |
| the scan slim-down stays actionable | `clause/slim-scan` | RED |
| `delta` form, text | `clause/delta-text` | RED |
| `tree` form, text | `clause/tree-text` | RED |
| field truncation, json / text | `json/WriteFieldsArray-carrier`, `text/AppendRecord-carrier` | RED |
| tool entry, json / text | `entry/json-RenderBatch`, `entry/text-RenderBatch` | RED |
| container hint: winner / active pole / off-order pole / overlay post | `entry/container-hint`, `pole/active-arm`, `pole/offorder-arm`, `overlay/post` | RED |
| the tree row's hand-diverged literal | `json/WriteTreeRow-carrier` | RED |
| dense transport | `dense/carrier` | RED |
| artifact rows | `spill/carrier` | RED |
| P5 note: text / json / dense | `p5/text`, `p5/json`, `p5/dense` | RED |
| the truncated-comparison sentence (was a declared GREEN) | `clause/delta-identical` | RED |
| the batch cut's selection clause: scan lane / formids lane / both deciding call sites | `gate1/scan-lane`, `gate1/formids-lane`, `gate1/entry-everything`, `gate1/entry-offorder` | RED |
| the harvest's capitalisation blind spot | `gate2/ignorecase` | RED |
| the scan cut's slim-down clause: omit branch / keep branch / both deciding call sites | `gate3/omit-branch`, `gate3/keep-branch`, `gate3/inorder-callsite`, `gate3/offorder-callsite` | RED |
| artifact ROW writers: cross-query / batch | `gate4/crossquery-row`, `gate4/batch-row` | RED |

**34 RED, canary RED, tree clean after every restore, and nothing declared GREEN.** The one cell
that was declared rather than deleted — `clause/delta-identical`, the "comparison TRUNCATED …
compare in full" sentence — is a live RED cell now: the gate review's second finding produced the
fixture that drives it, so that sentence is in the claim and #447 loses the item.

**1.x identity:** 14 of 14 sites compose byte-identically to their pre-fix literals under `Legacy`,
checked against the blobs at `fbfe015` — re-run after the gate folds and unchanged, which is the
point: the lane-aware clauses must not move any 1.x output, and they do not. One declared deviation:
`WriteTreeRow`, which was hand-written in the records spelling and is carrier output now
(RED-checked specifically). Two sites still hold a bare literal and are correct as they stand:
a 1.x tool's own `Description` prose, and `Wire.RenderPluginFile`, whose only caller is
`housecarl_read_plugin_file` — both unreachable from records, verified by caller grep.

`ci-all` **132/132 guards, 3012/3012 checks**. PR A's `refusal-completeness-guard` is green and
untouched — no arm of it changed on this branch.

## Overlap with PR A, re-measured against merged `main`

| File | PR-A-changed lines (`2fd7b6e..fbfe015`) | remedy-notice lines | overlap |
|---|---|---|---|
| `ReadTools.cs` | 56 | 10 | **0** |
| `JsonWire.cs` | 59 | 4 | **0** |
| `RecordsTools.cs` | 80 | 0 | **0** |

Non-vacuous: widening the range to the whole history makes the same detector report 10 overlaps.

---

## Review rounds

Two rounds, three fresh agents each, own worktrees, seeded with the decision record and the
settled-decisions list only. Both rounds ended in an escalation rather than a fold-and-continue.

### Round 1 — ~11 findings, 2 refused (18%)

Three seams the carrier had not been threaded through, found independently by all three:

- `ResolveBatchFromPole` and `OverlayPostBatch` had **no `containerHint` parameter at all**, so the
  four records call sites could not pass one — `source=` and the SkyPatcher post view kept saying
  `pass depth=2 to expand`. (`overlay:pre` was already correct, so two arms of one parameter
  disagreed.)
- `ScopedFieldsNote` named `winner_fields=true` on all three transports. That lever is *renamed* on
  records, not re-scoped.
- `format="dense"` and the spilled artifact rows were threaded but unasserted — removing the carrier
  from either left the guard **green**.

**Refused:** "the json-lane `conflict_tree` assertion is vacuous" — real but harmless, an
absence-assertion that cannot fail today and remains a live net. And "`drop project.fields=` is
only conditionally actionable" — **this refusal was wrong**, see round 2.

**Class stop → escalation.** The recurring class was the design property that `Legacy`-as-default
makes every missed seam silent. Aaron ruled: widen the fix, the guard and the claim on this branch;
file the no-default carrier design separately (#444).

### Round 2 — 12 findings, 0 refused

Nothing was refused because every finding was reproduced against source or driven as a probe.

- **The strike:** `Wire.RenderEffectChain` takes no carrier at all; a records reverse walk is told
  `raise limit=`, which on that tool windows the seeds while `walk.max_nodes` is the bound. Driven
  at `limit=5000` — byte-identical output. Filed as #446.
- **A new class, which #444 as filed would not have prevented:** the carrier is per-TOOL, records'
  levers are per-FORM. `form="everything"` names `project.fields=`, which that form refuses.
  Filed as #445.
- **The guard still covered ~10 of 29 seams.** Reverting the carrier on 14 lines left it green while
  `everything` and the off-order *scan* lane emitted the original defect. Filed as #447.
- **My overturned refusal:** on `form="fields"`, dropping `project.fields` refuses — the sentence's
  literal follow-up fails, which is this branch's own definition of the defect. Having the lever is
  not the test; the next call working is. Folded as `SlimScan`, which names `project= (summary rows)`
  for records and keeps `fields=/conflict_tree` byte-identical for 1.x. One assertion now *follows*
  the remedy rather than reading it: drop `project=` and require the summary render it promised.

**Class stop → escalation.** Aaron ruled (iii): land with the scoped claim, charter the
`(tool, form)` + required-argument redesign as its own work, and gate the push on every clause of
the scoped sentence having a sabotage-RED arm first.

### Three errors of mine, corrected on the branch

1. **A guard cell that went RED for the wrong reason.** `pole/offorder-arm`'s pattern matched twice
   and it was mutating an unrelated read path 2000 lines away. The sweep now asserts each cell's
   occurrence count. With that fixed the cell came back **GREEN** — no probe reached the off-order
   pole at all — which is commit `1aa74a3`.
2. **A CHANGELOG sentence that overclaimed** while correcting the previous one for overclaiming:
   "all of it applies on text, json and dense, and to artifact rows" was wrong in three places.
   Measured, dense composes no truncation notice and artifact rows carry the container hint alone.
3. **I widened a key allowlist instead of retiring it.** Round 2 then found `truncation_note` occurs
   **nowhere** in the product source — the spelling is `truncated_note` — so one of its three keys
   had never matched anything and `scan_note` was never listed. The harvest names no keys now.

---

## Gate review — Aaron's four findings, all folded

His independent review found four, all triaged FOLD. No new rounds were run (§11: fresh eyes are for
before the PR opens). One commit per finding, each RED-checked from a committed state.

| # | Finding | Fold | Cells |
|---|---|---|---|
| 1 | `request fewer formids` is inert on the two scan-derived lanes of `Wire.RenderBatch` | `d726117` — `LeverNames.BatchSelection` + `OnScanSelection()`; the call sites declare their lane | `gate1/*` (4) |
| 2 | `remedyLine` was case-sensitive, so a capitalised remedy was dropped before assertion | `5bc3a96` — `RegexOptions.IgnoreCase` + a permanent fixture that drives the hidden site | `gate2/ignorecase`, `clause/delta-identical` |
| 3 | `drop project= (summary rows)` is inert on the form this tool defaults to | `3e0026e` — `SlimScan` nullable; the clause is omitted where there is nothing to drop | `gate3/*` (4) |
| 4 | `levers` reaches the artifact read but not the row writer | `3117710` — both row writers take it, and a `rowCap` so the dormant note can be driven | `gate4/*` (2) |

**Finding 1 was inside the claim, not outside it.** The claim covers the `fields` form, and the
in-order body lane serves `form="fields"` under `plugins=`+`source=`. The claim as written was false
for that case; the fold is what makes it true.

**Finding 2 closed a declared GREEN.** `clause/delta-identical` was declared rather than dropped
because the fixture could not reach `!d.Complete`. The route is `ReadEngine`'s expansion budget, not
`ConflictDiffDepth`: a form list one element past `MaxExpandNodes` truncates, and a copy override
supplies the zero-delta half. That sentence is in the claim now, and #447 loses the item.

**Finding 4 was folded one method wider than written**, and deliberately: `Artifacts.WriteBatch` had
no `levers` parameter at all, writes rows through the same `WriteReadRecord`, and is reached by four
`housecarl_records` call sites. Aaron's stated reason for folding the cross-query line applies to it
word for word, so closing one and leaving the other would have left the hazard live. Called out on
the thread rather than widened quietly.

Findings 1 and 3 established a third axis for #444 — the vocabulary is a function of
**(tool, form, selection lane)** — commented there with both folds as the measured instances.

## Filed, not folded

| # | What |
|---|---|
| #442 | summary rows label override depth `depth=`, colliding with `project.depth=` (label class) |
| #443 | the `group_by=type` aggregate refusal names 1.x levers, composed in the scan engine |
| #444 | the no-default carrier design — **re-scoped** to `(tool, form)`, with #445 as its acceptance fixture |
| #445 | the per-form vocabulary class (`everything` form) |
| #446 | `RenderEffectChain`'s no-op `raise limit=` remedy |
| #447 | the guard's uncovered seams — the `clause/delta-identical` item is closed by the gate fold, the rest stand |
| #448 | dense silently drops `project.depth>1` where the 1.x sibling refuses loud |
| #449 | `to_file=` artifact rows carry scoped values without the scoped-vs-winner note |

**No regression anywhere.** On `main`, `form="everything"` says `narrow with fields=` and refuses as
an unknown parameter; on this branch it says `project.fields=` and refuses as a wrong-form
parameter. Equally broken, differently worded — and everywhere else the branch is a real
improvement with 1.x identity proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

