### PR TITLE
Move the spike-era proof and discovery modes out of the write engine

### DIFF
--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -16,15 +16,15 @@ namespace HousecarlCore;
 /// list element, polymorphic arm). It is blind to which record it edits, which is what makes coverage a property
 /// of Mutagen's model rather than of a hand-written per-type map.
 ///
-/// <para>Two contracts every entry point here keeps: a request is validated against the corpus rulebook before
-/// anything is mutated, and a path the engine cannot navigate or a value it cannot coerce is refused by name
-/// rather than skipped. The default destination is a new mod; the in-place lane is the caller's explicit,
-/// consented request, gated above this layer. <c>apply-guard</c> drives all three from the tool surface.</para>
+/// <para>What it keeps: a path it cannot navigate or a value it cannot coerce is refused by name, never skipped.
+/// <b>Corpus-rulebook validation is the CALLER's, not this layer's</b> — <see cref="ApplyVerb"/> is public and
+/// validates nothing, so a direct or CLI caller that skips pre-flight mutates unvalidated. <c>apply-guard</c>
+/// proves the pre-flight, refusal and lane contracts for the <c>housecarl_apply</c> path only.</para>
 ///
-/// <para>What the engine writes is proven per KIND by <c>oracle</c> — each cell run twice, through here and
-/// through a hand-written typed setter, and required byte-identical.</para>
+/// <para>Per-KIND equivalence against a hand-written typed setter is proven by <c>oracle</c> — hand-run, not in
+/// <c>ci-all</c>.</para>
 ///
-/// <para>The acceptance proof and the build-start diagnostics moved to <c>WriteDiagnosticsProbe</c>
+/// <para>The acceptance proof and the hand-run diagnostics moved to <c>WriteDiagnosticsProbe</c>
 /// (housecarl-generator) with #453. Still here, and still console entry points in a library: the <c>patch</c> /
 /// <c>show</c> / <c>condition-patch</c> dev harnesses, and the <c>coerce-audit</c> / <c>coerce-selftest</c>
 /// CI probes.</para>

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -17,12 +17,13 @@ namespace HousecarlCore;
 /// of Mutagen's model rather than of a hand-written per-type map.
 ///
 /// <para>What it keeps: a path it cannot navigate or a value it cannot coerce is refused by name, never skipped.
-/// <b>Corpus-rulebook validation is the CALLER's, not this layer's</b> — <see cref="ApplyVerb"/> is public and
-/// validates nothing, so a direct or CLI caller that skips pre-flight mutates unvalidated. <c>apply-guard</c>
-/// proves the pre-flight, refusal and lane contracts for the <c>housecarl_apply</c> path only.</para>
+/// <b>Corpus-rulebook validation is the CALLER's, not this layer's</b> — <see cref="ApplyVerb"/> is public and does
+/// no rulebook check (it makes its own structural refusals, but nothing about identity fields, verb-vs-cardinality,
+/// enum-key legality or range), so a direct or CLI caller that skips pre-flight mutates unvalidated.
+/// <c>apply-guard</c> proves the pre-flight, refusal and lane contracts for the <c>housecarl_apply</c> path only.</para>
 ///
-/// <para>Per-KIND equivalence against a hand-written typed setter is proven by <c>oracle</c> — hand-run, not in
-/// <c>ci-all</c>.</para>
+/// <para>Byte-equivalence against a hand-written typed setter is proven by <c>oracle</c>, over the cells it
+/// enumerates — hand-run, not in <c>ci-all</c>.</para>
 ///
 /// <para>The acceptance proof and the hand-run diagnostics moved to <c>WriteDiagnosticsProbe</c>
 /// (housecarl-generator) with #453. Still here, and still console entry points in a library: the <c>patch</c> /
@@ -337,8 +338,7 @@ public static class WriteEngine
     //  RE-TARGET it to a different real form THROUGH THE ENGINE (pre-flight rooted at the arm + ApplyVerb -> SetFloi),
     //  and emit ONE reviewable single-master .esp. Aaron opens it in xEdit and confirms the condition now points at
     //  the new target; the original stays byte-for-byte untouched (Q3). The write is ARM-ROOTED — the same engine
-    //  entry BuildStruct's nested Sets use; reaching arm sub-fields from a record-root path is the broader arm-breadth
-    //  nav surface (reconciles at the final completion sweep), deliberately not this wave.
+    //  entry BuildStruct's nested Sets use.
     //    dotnet run --project src/housecarl-generator condition-patch \
     //        --source "<plugin>" [--target XXXXXX:Plugin.esp] [--out <path>] [--name <patch>]
     // ======================================================================

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -17,9 +17,14 @@ namespace HousecarlCore;
 /// of Mutagen's model rather than of a hand-written per-type map.
 ///
 /// <para>What it keeps: a path it cannot navigate or a value it cannot coerce is refused by name, never skipped.
-/// <b>Corpus-rulebook validation is the CALLER's, not this layer's</b> — <see cref="ApplyVerb"/> is public and does
-/// no rulebook check (it makes its own structural refusals, but nothing about identity fields, verb-vs-cardinality,
-/// enum-key legality or range), so a direct or CLI caller that skips pre-flight mutates unvalidated.
+/// <b>Corpus-rulebook validation is the CALLER's, not this layer's</b> — <see cref="ApplyVerb"/> is public and runs
+/// no rulebook check. It does refuse most of what pre-flight would, just with a CLR/structural message rather than
+/// a corpus-derived one: a verb the collection does not take (<c>ApplyDictVerb</c>'s <c>default:</c> arm), a dict
+/// key that is not a legal enum member (<c>Coerce</c> → <c>Enum.Parse</c>), a value out of its type's range
+/// (<c>byte.Parse</c>) all throw here. The genuinely rulebook-only residue is narrower: record IDENTITY —
+/// <c>FormKey</c> is settable on every concrete Mutagen record, so nothing in this layer stops a caller rewriting
+/// it and only the rulebook's flat identity reject does — and legality the corpus declares that no CLR type
+/// expresses. That residue is what a direct or CLI caller skipping pre-flight mutates unvalidated.
 /// <c>apply-guard</c> proves the pre-flight, refusal and lane contracts for the <c>housecarl_apply</c> path only.</para>
 ///
 /// <para>Byte-equivalence against a hand-written typed setter is proven by <c>oracle</c>, over the cells it

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -11,143 +11,26 @@ using Noggog;
 namespace HousecarlCore;
 
 /// <summary>
-/// Step 4 — the reflection-driven write engine.
+/// The reflection-driven write engine: overlay → <c>GetOrAddAsOverride</c> → reflect the property → coerce →
+/// set → write with masters, for <b>any</b> record group and along <b>nested</b> paths (substruct, dict-by-key,
+/// list element, polymorphic arm). It is blind to which record it edits, which is what makes coverage a property
+/// of Mutagen's model rather than of a hand-written per-type map.
 ///
-/// The spike (<c>dev/references/spike/ReflectionWrite.cs</c>) proved the core mechanism
-/// (overlay → GetOrAddAsOverride → reflect property → coerce → SetValue → write-with-masters,
-/// 4/4 byte-identical) but only via <i>typed</i> accessors on <c>Armor</c>. This engine
-/// generalises it to <b>any</b> record group and to <b>nested</b> paths (substruct → dict-by-key),
-/// which is the net-new, highest-risk delta (step-4 plan §2 #1).
+/// <para>Two contracts every entry point here keeps: a request is validated against the corpus rulebook before
+/// anything is mutated, and a path the engine cannot navigate or a value it cannot coerce is refused by name
+/// rather than skipped. The default destination is a new mod; the in-place lane is the caller's explicit,
+/// consented request, gated above this layer. <c>apply-guard</c> drives all three from the tool surface.</para>
 ///
-/// Build order (plan §9): generic lifecycle (confirmed via <c>write-api</c>) → path navigation +
-/// Set, driven first to the NPC-skills acceptance target (<c>npc-skills</c>) — the riskiest piece,
-/// proven earliest. Corpus pre-flight validation, the remaining verbs, and the oracle layer follow.
+/// <para>What the engine writes is proven per KIND by <c>oracle</c> — each cell run twice, through here and
+/// through a hand-written typed setter, and required byte-identical.</para>
 ///
-/// Modes: <c>write-api</c> (discovery), <c>npc-skills</c> (the acceptance proof).
+/// <para>The acceptance proof and the build-start diagnostics moved to <c>WriteDiagnosticsProbe</c>
+/// (housecarl-generator) with #453. Still here, and still console entry points in a library: the <c>patch</c> /
+/// <c>show</c> / <c>condition-patch</c> dev harnesses, and the <c>coerce-audit</c> / <c>coerce-selftest</c>
+/// CI probes.</para>
 /// </summary>
 public static class WriteEngine
 {
-    const string DefaultSourcePath =
-        @"C:\Program Files (x86)\Steam\steamapps\common\Skyrim Special Edition\Data\Skyrim.esm";
-
-    // ======================================================================
-    //  THE ACCEPTANCE PROOF — NPC skills by name (plan §3 P-ADDR / §5.1)
-    //  Path (verified against corpus): Npc → PlayerSkills → SkillValues → [OneHanded] = 50.
-    //  This is the dict-set-inside-a-substruct kind — the single thing most likely to surface
-    //  a real navigation problem, so we build it first.
-    // ======================================================================
-    public static int RunNpcSkillsProof(string[] args)
-    {
-        var sourcePath = args.Length > 0 ? args[0] : DefaultSourcePath;
-        if (!File.Exists(sourcePath))
-        {
-            Console.Error.WriteLine($"error: source plugin not found: {sourcePath}");
-            return 1;
-        }
-
-        var outDir = Path.GetFullPath(Path.Combine("write-output", "npc-skills"));
-        if (Directory.Exists(outDir)) Directory.Delete(outDir, recursive: true);
-        Directory.CreateDirectory(outDir);
-        var outPath = Path.Combine(outDir, "HousecarlWriteProof.esp");
-
-        Console.WriteLine($"Source plugin: {sourcePath}");
-        Console.WriteLine($"Output patch:  {outPath}");
-        Console.WriteLine();
-
-        var shaBefore = Sha(sourcePath);
-
-        // --- find a target NPC (typed scan — harness scaffolding; the engine below is generic) ---
-        var sourceMod = SkyrimMod.CreateFromBinaryOverlay(sourcePath, SkyrimRelease.SkyrimSE);
-        INpcGetter? target = null;
-        foreach (var n in sourceMod.Npcs)
-        {
-            if (n.PlayerSkills?.SkillValues is { } sv && sv.ContainsKey(Skill.OneHanded))
-            {
-                target = n;
-                break;
-            }
-        }
-        if (target is null)
-        {
-            Console.Error.WriteLine("error: no NPC with PlayerSkills.SkillValues[OneHanded] found in source");
-            return 1;
-        }
-        var beforeVal = target.PlayerSkills!.SkillValues[Skill.OneHanded];
-        Console.WriteLine($"Target NPC:    {target.FormKey} ({target.EditorID})");
-        Console.WriteLine($"  OneHanded before: {beforeVal}");
-        Console.WriteLine();
-
-        // --- PRE-FLIGHT VALIDATION (plan §3 P-VALIDATE) — the write goes through the rulebook first ---
-        const byte newVal = 50;
-        var rulebook = CorpusRulebook.Load();
-        Console.WriteLine($"Rulebook loaded: {rulebook.TypeCount} types.");
-        var req = new WriteRequest
-        {
-            RecordType = "Npc",
-            Path = new[] { "PlayerSkills", "SkillValues" },
-            Verb = "Set",
-            Key = "OneHanded",
-            Value = newVal.ToString(CultureInfo.InvariantCulture),
-        };
-
-        void Probe(string label, WriteRequest r, bool expectOk)
-        {
-            var msg = rulebook.Validate(r);
-            var ok = msg is null;
-            var mark = ok == expectOk ? "OK" : "!! UNEXPECTED";
-            Console.WriteLine($"  [{mark}] {label} -> {(ok ? "ACCEPT" : "REJECT: " + msg)}");
-        }
-
-        Console.WriteLine("Pre-flight probes (1 accept + 5 fail-loud rejects):");
-        Probe("real write: Npc PlayerSkills.SkillValues[OneHanded]=50", req, expectOk: true);
-        Probe("unknown record type", new() { RecordType = "Bogus", Path = new[] { "X" }, Verb = "Set", Value = "1" }, expectOk: false);
-        Probe("unknown field", new() { RecordType = "Npc", Path = new[] { "Bogus" }, Verb = "Set", Value = "1" }, expectOk: false);
-        Probe("illegal enum key", new() { RecordType = "Npc", Path = new[] { "PlayerSkills", "SkillValues" }, Verb = "Set", Key = "BogusSkill", Value = "50" }, expectOk: false);
-        Probe("wrong verb for cardinality (SetAtIndex on dict)", new() { RecordType = "Npc", Path = new[] { "PlayerSkills", "SkillValues" }, Verb = "SetAtIndex", Key = "0", Value = "50" }, expectOk: false);
-        Probe("value out of range (Byte=999)", new() { RecordType = "Npc", Path = new[] { "PlayerSkills", "SkillValues" }, Verb = "Set", Key = "OneHanded", Value = "999" }, expectOk: false);
-        Probe("identity reject: Npc.FormKey", new() { RecordType = "Npc", Path = new[] { "FormKey" }, Verb = "Set", Value = "123456:Skyrim.esm" }, expectOk: false);
-        Probe("substruct-whole reject: Npc.PlayerSkills (navigate-in)", new() { RecordType = "Npc", Path = new[] { "PlayerSkills" }, Verb = "Set", Value = "x" }, expectOk: false);
-        Probe("TranslatedString accept: Npc.Name=Bob", new() { RecordType = "Npc", Path = new[] { "Name" }, Verb = "Set", Value = "Bob" }, expectOk: true);
-        Console.WriteLine();
-
-        // Q3: refuse to mutate if the real request does not pass pre-flight.
-        if (rulebook.Validate(req) is { } reject)
-        {
-            Console.Error.WriteLine($"FAIL: real write rejected by pre-flight: {reject}");
-            return 1;
-        }
-
-        // --- THE ENGINE PATH (fully generic — resolves group from the record's runtime type) ---
-        var patchMod = new SkyrimMod(new ModKey("HousecarlWriteProof", ModType.Plugin), SkyrimRelease.SkyrimSE);
-        var patchRecord = GenericGetOrAddAsOverride(patchMod, target);
-        ApplyVerb(patchRecord, req);
-
-        WritePatch(patchMod, sourceMod, outPath);
-        Console.WriteLine($"Wrote patch ({new FileInfo(outPath).Length} bytes).");
-        Console.WriteLine();
-
-        // --- verify: re-open the patch, read the value back ---
-        var patchBack = SkyrimMod.CreateFromBinaryOverlay(outPath, SkyrimRelease.SkyrimSE);
-        if (!patchBack.Npcs.TryGetValue(target.FormKey, out var patchedNpc))
-        {
-            Console.Error.WriteLine("FAIL: patched NPC not found in written patch");
-            return 1;
-        }
-        var afterVal = patchedNpc.PlayerSkills?.SkillValues?.GetValueOrDefault(Skill.OneHanded);
-        Console.WriteLine($"  OneHanded after (read back from patch): {afterVal}");
-
-        var shaAfter = Sha(sourcePath);
-        var sourceUnchanged = shaBefore == shaAfter;
-        Console.WriteLine($"  Source unchanged: {(sourceUnchanged ? "YES" : "NO")}");
-        Console.WriteLine();
-
-        var pass = afterVal == newVal && sourceUnchanged;
-        Console.WriteLine(pass
-            ? "=== PASS: nested dict-in-substruct Set landed; original untouched ==="
-            : "=== FAIL ===");
-        return pass ? 0 : 1;
-    }
-
     // ======================================================================
     //  WAVE 2 — generic real-patch dev harness (concrete edits -> a real .esp).
     //  The embryo of the eventual MCP housecarl_set_field tool: take a concrete request
@@ -457,12 +340,15 @@ public static class WriteEngine
     //  entry BuildStruct's nested Sets use; reaching arm sub-fields from a record-root path is the broader arm-breadth
     //  nav surface (reconciles at the final completion sweep), deliberately not this wave.
     //    dotnet run --project src/housecarl-generator condition-patch \
-    //        [--source "<plugin>"] [--target XXXXXX:Plugin.esp] [--out <path>] [--name <patch>]
+    //        --source "<plugin>" [--target XXXXXX:Plugin.esp] [--out <path>] [--name <patch>]
     // ======================================================================
     public static int RunConditionPatch(string[] args)
     {
         var f = ParseFlags(args);
-        var source = f.GetValueOrDefault("source") ?? DefaultSourcePath;
+        // --source is required, as it is on the sibling patch/show harnesses. It used to default to one
+        // machine's Steam install, which failed naming a path the caller never typed (#453).
+        var source = f.GetValueOrDefault("source");
+        if (source is null) { Console.Error.WriteLine("error: missing required --source"); return 1; }
         if (!File.Exists(source)) { Console.Error.WriteLine($"error: source plugin not found: {source}"); return 1; }
 
         var shaBefore = Sha(source);
@@ -3704,185 +3590,10 @@ public static class WriteEngine
         return ok == samples.Count ? 0 : 1;
     }
 
-    // ======================================================================
-    //  BUILD-START API DISCOVERY  (write-api) — kept as a Mutagen-bump guard
-    // ======================================================================
-    public static int RunDiscovery(string[] args)
-    {
-        Console.WriteLine("=== Mutagen assemblies loaded ===");
-        var mutagen = AppDomain.CurrentDomain.GetAssemblies()
-            .Where(a => (a.GetName().Name ?? "").StartsWith("Mutagen"))
-            .OrderBy(a => a.GetName().Name)
-            .ToList();
-        foreach (var a in mutagen)
-            Console.WriteLine($"  {a.GetName().Name} {a.GetName().Version}");
-        Console.WriteLine();
-
-        Console.WriteLine("=== GetOrAddAsOverride (static / extension) ===");
-        foreach (var asm in mutagen)
-            foreach (var t in SafeTypes(asm).Where(t => t is { IsAbstract: true, IsSealed: true }))
-                foreach (var m in t.GetMethods(BindingFlags.Public | BindingFlags.Static)
-                             .Where(m => m.Name == "GetOrAddAsOverride"))
-                    Console.WriteLine($"  {Pretty(t)}.{Sig(m)}");
-        Console.WriteLine();
-
-        var armorsProp = typeof(SkyrimMod).GetProperty("Armors")!;
-        var groupType = armorsProp.PropertyType;
-        Console.WriteLine($"=== SkyrimMod.Armors : {Pretty(groupType)} ===");
-        foreach (var m in groupType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
-                     .Where(m => m.Name is "GetOrAddAsOverride" or "Add" or "Set" or "Remove"))
-            Console.WriteLine($"  (instance) {Sig(m)}");
-        Console.WriteLine();
-
-        Console.WriteLine($"=== SkyrimMod group-typed properties: {CountGroupProps()} total ===");
-        Console.WriteLine("=== discovery complete ===");
-        return 0;
-    }
-
-    /// <summary>Build-start confirm for polymorphic arm-SWAP: how is an arm instantiated, and does it assign?</summary>
-    public static int RunPolyProbe(string[] args)
-    {
-        var asm = typeof(SkyrimMod).Assembly;
-        var archProp = typeof(IMagicEffect).GetProperty("Archetype")!;
-        Console.WriteLine($"IMagicEffect.Archetype : {Pretty(archProp.PropertyType)}  canWrite={archProp.CanWrite}");
-        Console.WriteLine();
-
-        foreach (var name in new[] { "MagicEffectLightArchetype", "MagicEffectArchetype", "MagicEffectSummonCreatureArchetype" })
-        {
-            var t = asm.GetType("Mutagen.Bethesda.Skyrim." + name);
-            if (t is null) { Console.WriteLine($"{name}: TYPE NOT FOUND"); continue; }
-            Console.WriteLine($"{name}:");
-            foreach (var c in t.GetConstructors())
-                Console.WriteLine($"    ctor({string.Join(", ", c.GetParameters().Select(p => $"{Pretty(p.ParameterType)} {p.Name}"))})");
-            object? inst = null;
-            try { inst = System.Activator.CreateInstance(t); Console.WriteLine("    Activator.CreateInstance() -> OK"); }
-            catch (Exception ex) { Console.WriteLine($"    Activator.CreateInstance() -> {ex.GetType().Name}: {ex.InnerException?.Message ?? ex.Message}"); }
-            if (inst is not null)
-            {
-                Console.WriteLine($"    assignable to Archetype: {archProp.PropertyType.IsInstanceOfType(inst)}");
-                var wf = inst.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                    .Where(p => p.CanWrite && p.GetIndexParameters().Length == 0).Select(p => $"{p.Name}:{Pretty(p.PropertyType)}").Take(10);
-                Console.WriteLine($"    writable fields: {string.Join(", ", wf)}");
-            }
-        }
-        Console.WriteLine();
-
-        var src = args.Length > 0 ? args[0] : DefaultSourcePath;
-        var mod = SkyrimMod.CreateFromBinaryOverlay(src, SkyrimRelease.SkyrimSE);
-        foreach (var m in mod.MagicEffects)
-            if (m.Archetype is not null) { Console.WriteLine($"sample MGEF {m.FormKey} archetype concrete: {m.Archetype.GetType().Name}"); break; }
-        return 0;
-    }
-
-    /// <summary>
-    /// Characterization probe (substruct-probe): enumerate every NAVIGATE-INTO substruct field — substruct
-    /// cardinality, non-record TypeRef, not whole-coercible (TranslatedString-style) — and report, per distinct
-    /// target type, how many field-sites are NULLABLE (so the substruct can be absent and would need materializing)
-    /// and whether the concrete class has a parameterless ctor. The no-paramless-ctor targets are the "tricky
-    /// shapes" the absent-collection handoff flagged: the ones absent-substruct materialization must handle beyond a
-    /// plain Activator.CreateInstance. Pure corpus + reflection, no plugins — answers "do we need a plugin to prove
-    /// this?" and sizes the engine-fix design BEFORE building it.
-    /// </summary>
-    public static int RunSubstructProbe(string[] args)
-    {
-        var corpusPath = args.Length > 0 ? args[0] : CorpusRulebook.CorpusPath;
-        Corpus corpus;
-        try { corpus = CorpusRulebook.LoadCorpus(corpusPath); }
-        catch (Exception ex) { Console.Error.WriteLine($"error: {ex.Message}"); return 1; }
-        var asm = typeof(SkyrimMod).Assembly;
-
-        bool IsRecord(string n) => corpus.Types.TryGetValue(n, out var t) && t.Kind == "record";
-
-        // distinct navigate-into substruct target -> (total sites, nullable sites, sample owner.field, representative AQ)
-        var navInto = new SortedDictionary<string, (int sites, int nullableSites, string sample, string? aq)>(StringComparer.Ordinal);
-        int wholeCoercible = 0, recordSubstructs = 0;
-        foreach (var ts in corpus.Types.Values)
-        foreach (var f in ts.Fields)
-        {
-            if (f.Cardinality != "substruct" || f.TypeRef is not { } tr) continue;
-            if (IsRecord(tr)) { recordSubstructs++; continue; }        // owned child record — never MATERIALIZED (a present one is navigable)
-            var saq = f.MutableTypeAssemblyQualified ?? f.GetterTypeAssemblyQualified;
-            if (ResolveType(saq) is { } st && CanCoerce(st)) { wholeCoercible++; continue; } // TranslatedString-style — set wholesale
-            (int sites, int nullableSites, string sample, string? aq) e =
-                navInto.TryGetValue(tr, out var v) ? v : (0, 0, $"{ts.Name}.{f.Name}", (string?)null);
-            navInto[tr] = (e.sites + 1, e.nullableSites + (f.Nullable ? 1 : 0), e.sample, e.aq ?? saq);
-        }
-
-        Console.WriteLine($"=== substruct-probe over {corpus.TotalTypes} types ===");
-        Console.WriteLine($"Navigate-into substruct target types (non-record, non-whole-coercible): {navInto.Count} distinct");
-        Console.WriteLine($"  (skipped: {wholeCoercible} whole-coercible substruct site(s); {recordSubstructs} record-substruct site(s))");
-        Console.WriteLine();
-
-        int resolved = 0, paramless = 0, trickyInScope = 0, trickyGetOnly = 0, unresolved = 0;
-        var trickyList = new List<string>();
-        foreach (var (name, info) in navInto)
-        {
-            var concrete = ResolveConcreteSubstruct(asm, name, info.aq);
-            var settable = SampleSettable(asm, info.sample);     // can the sample owner-field be null (absent), i.e. in materialization scope?
-            if (concrete is null) { unresolved++; Console.WriteLine($"  [UNRESOLVED]        {name,-44} sites={info.sites}  e.g. {info.sample}"); continue; }
-            resolved++;
-            if (concrete.GetConstructor(Type.EmptyTypes) is not null) { paramless++; continue; }
-            // No parameterless ctor. If the owner-field is GET-ONLY it is always-present (never absent) -> out of materialization scope.
-            var ctors = string.Join(" | ", concrete.GetConstructors()
-                .Select(c => "(" + string.Join(", ", c.GetParameters().Select(p => $"{Pretty(p.ParameterType)} {p.Name}")) + ")"));
-            var scope = settable switch { false => "GET-ONLY (always present, out of scope)", true => "SETTABLE (can be absent -> needs composition)", _ => "settable?=unknown" };
-            if (settable == false) trickyGetOnly++; else { trickyInScope++; trickyList.Add(name); }
-            Console.WriteLine($"  [NO PARAMLESS CTOR] {Pretty(concrete),-40} {scope,-44} ctors: {(ctors.Length == 0 ? "(none public)" : ctors)}  e.g. {info.sample}");
-        }
-
-        Console.WriteLine();
-        Console.WriteLine($"Resolved concrete: {resolved}/{navInto.Count} (unresolved {unresolved}).");
-        Console.WriteLine($"  parameterless ctor (simple Activator materialization suffices): {paramless}");
-        Console.WriteLine($"  NO paramless ctor, GET-ONLY owner field (always present, never absent — out of scope): {trickyGetOnly}");
-        Console.WriteLine($"  NO paramless ctor, SETTABLE owner field (real composition gap — must be NAMED + deferred): {trickyInScope}" + (trickyList.Count > 0 ? " -> " + string.Join(", ", trickyList.Distinct()) : ""));
-        Console.WriteLine();
-        Console.WriteLine(trickyInScope == 0 && unresolved == 0
-            ? "=== substruct-probe: every ABSENT-ABLE navigate-into substruct has a parameterless ctor — simple materialization suffices (the no-ctor cases are all get-only/always-present) ==="
-            : $"=== substruct-probe: {trickyInScope} settable no-ctor target(s) are a composition gap to NAME; {unresolved} unresolved — see above ===");
-        return 0;
-    }
-
-    /// <summary>Resolve the concrete owner type of a "Owner.Field" sample and report whether that field is settable
-    /// (CanWrite) — i.e. whether the substruct can be null/absent (materialization scope) vs get-only/always-present.</summary>
-    static bool? SampleSettable(Assembly asm, string sample)
-    {
-        int dot = sample.LastIndexOf('.');
-        if (dot <= 0) return null;
-        var owner = ResolveConcreteSubstruct(asm, sample[..dot], null);
-        if (owner is null) return null;
-        return ResolveProperty(owner, sample[(dot + 1)..])?.CanWrite;
-    }
-
-    /// <summary>Resolve the concrete settable class for a substruct target (the type the engine instantiates to
-    /// materialize an absent one). Resolve the declared runtime type from the field's AQ first (handles CLOSED
-    /// GENERICS like GenderedItem&lt;ArmorModel&gt;); map a mutable/getter interface to its concrete impl; fall back
-    /// to a same-name non-abstract class. Returns the concrete (or the resolved type if already a usable class).</summary>
-    static Type? ResolveConcreteSubstruct(Assembly asm, string catalogName, string? aq)
-    {
-        var t = aq is null ? null : ResolveType(aq);
-        if (t is not null && ConcreteOf(t) is { } c) return c;          // interface→concrete (incl. closed generics) via the shared mapper
-        var direct = asm.GetType("Mutagen.Bethesda.Skyrim." + catalogName);
-        if (direct is { IsClass: true, IsAbstract: false }) return direct;
-        return SafeTypes(asm).FirstOrDefault(x => x.IsClass && !x.IsAbstract && x.Name == catalogName) ?? t ?? direct;
-    }
-
-    static int CountGroupProps() =>
-        typeof(SkyrimMod).GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .Count(p => Pretty(p.PropertyType).Contains("Group"));
-
     static IEnumerable<Type> SafeTypes(Assembly a)
     {
         try { return a.GetTypes(); }
         catch (ReflectionTypeLoadException ex) { return ex.Types.Where(t => t is not null)!; }
-    }
-
-    static string Sig(MethodInfo m)
-    {
-        var gen = m.IsGenericMethodDefinition
-            ? "<" + string.Join(",", m.GetGenericArguments().Select(g => g.Name)) + ">"
-            : "";
-        var ps = string.Join(", ", m.GetParameters().Select(p => $"{Pretty(p.ParameterType)} {p.Name}"));
-        return $"{m.Name}{gen}({ps}) -> {Pretty(m.ReturnType)}";
     }
 
     static string Pretty(Type t)

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -78,19 +78,19 @@ if (args.Length > 0 && args[0] == "f1-i14") return F1MeasureProbe.RunI14(args[1.
 if (args.Length > 0 && args[0] == "sig") return Probe.RunSig();
 
 // Step 4 write engine: build-start discovery of Mutagen's generic group-override surface.
-if (args.Length > 0 && args[0] == "write-api") return WriteEngine.RunDiscovery(args[1..]);
+if (args.Length > 0 && args[0] == "write-api") return WriteDiagnosticsProbe.RunDiscovery(args[1..]);
 
 // Step 4 write engine: NPC-skills-by-name acceptance proof (nested dict-in-substruct Set).
-if (args.Length > 0 && args[0] == "npc-skills") return WriteEngine.RunNpcSkillsProof(args[1..]);
+if (args.Length > 0 && args[0] == "npc-skills") return WriteDiagnosticsProbe.RunNpcSkillsProof(args[1..]);
 
 // Step 5 oracle: per-kind byte-identical cells (Path A engine vs Path B hand-written setter).
 if (args.Length > 0 && args[0] == "oracle") return WriteOracle.Run(args[1..]);
 
 // Step 5 build-start confirm: polymorphic arm-swap instantiation mechanism.
-if (args.Length > 0 && args[0] == "poly-probe") return WriteEngine.RunPolyProbe(args[1..]);
+if (args.Length > 0 && args[0] == "poly-probe") return WriteDiagnosticsProbe.RunPolyProbe(args[1..]);
 
 // Absent-substruct characterization: which navigate-into substructs lack a parameterless ctor (the tricky shapes).
-if (args.Length > 0 && args[0] == "substruct-probe") return WriteEngine.RunSubstructProbe(args[1..]);
+if (args.Length > 0 && args[0] == "substruct-probe") return WriteDiagnosticsProbe.RunSubstructProbe(args[1..]);
 
 // Wave 3 scout: recon Mutagen's nested-group override API (Cell/Placed*/INFO/Navmesh/Landscape) — the highest-risk unknown.
 if (args.Length > 0 && args[0] == "nested-probe") return NestedProbe.RunNestedProbe(args[1..]);

--- a/src/housecarl-generator/WriteDiagnosticsProbe.cs
+++ b/src/housecarl-generator/WriteDiagnosticsProbe.cs
@@ -101,7 +101,7 @@ public static class WriteDiagnosticsProbe
             Console.WriteLine($"  [{mark}] {label} -> {(ok ? "ACCEPT" : "REJECT: " + msg)}");
         }
 
-        Console.WriteLine("Pre-flight probes (1 accept + 5 fail-loud rejects):");
+        Console.WriteLine("Pre-flight probes (2 accepts + 7 fail-loud rejects):");
         Probe("real write: Npc PlayerSkills.SkillValues[OneHanded]=50", req, expectOk: true);
         Probe("unknown record type", new() { RecordType = "Bogus", Path = new[] { "X" }, Verb = "Set", Value = "1" }, expectOk: false);
         Probe("unknown field", new() { RecordType = "Npc", Path = new[] { "Bogus" }, Verb = "Set", Value = "1" }, expectOk: false);

--- a/src/housecarl-generator/WriteDiagnosticsProbe.cs
+++ b/src/housecarl-generator/WriteDiagnosticsProbe.cs
@@ -1,0 +1,354 @@
+using System.Globalization;
+using System.Reflection;
+using System.Security.Cryptography;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// Hand-run diagnostics and the original acceptance proof for the reflection write engine. None of these is a CI
+/// probe and nothing on the tool surface reaches them — they are driven from the command line when a question
+/// about the engine or about Mutagen needs answering.
+///
+/// <list type="bullet">
+/// <item><c>npc-skills</c> — the step-4 acceptance proof: a nested dict-in-substruct Set
+/// (Npc.PlayerSkills.SkillValues[OneHanded]) through pre-flight and the engine, read back off the written patch,
+/// source SHA unchanged. <see cref="WriteOracle"/> covers the same cell against a hand-written setter.</item>
+/// <item><c>write-api</c> — what Mutagen exposes for override/write, printed. Run it after a Mutagen bump.</item>
+/// <item><c>poly-probe</c> — can a polymorphic arm be instantiated and assigned.</item>
+/// <item><c>substruct-probe</c> — every navigate-into substruct target, and which of them a materializing engine
+/// cannot build with a parameterless ctor. Corpus + reflection; needs no plugin.</item>
+/// </list>
+///
+/// They lived in <see cref="WriteEngine"/> until #453 moved them here, beside the probes they resemble; a 2026-05
+/// review had already asked for the split. The engine's own header lists what stayed behind.
+/// </summary>
+public static class WriteDiagnosticsProbe
+{
+    // A convenience default for the two modes that read a plugin. Both take a path as argv[0] instead; this
+    // one machine's install is not assumed to exist anywhere.
+    const string DefaultSourcePath =
+        @"C:\Program Files (x86)\Steam\steamapps\common\Skyrim Special Edition\Data\Skyrim.esm";
+
+    // ======================================================================
+    //  THE ACCEPTANCE PROOF — NPC skills by name (plan §3 P-ADDR / §5.1)
+    //  Path (verified against corpus): Npc → PlayerSkills → SkillValues → [OneHanded] = 50.
+    //  This is the dict-set-inside-a-substruct kind — the single thing most likely to surface
+    //  a real navigation problem, so we build it first.
+    // ======================================================================
+    public static int RunNpcSkillsProof(string[] args)
+    {
+        var sourcePath = args.Length > 0 ? args[0] : DefaultSourcePath;
+        if (!File.Exists(sourcePath))
+        {
+            Console.Error.WriteLine($"error: source plugin not found: {sourcePath}");
+            return 1;
+        }
+
+        var outDir = Path.GetFullPath(Path.Combine("write-output", "npc-skills"));
+        if (Directory.Exists(outDir)) Directory.Delete(outDir, recursive: true);
+        Directory.CreateDirectory(outDir);
+        var outPath = Path.Combine(outDir, "HousecarlWriteProof.esp");
+
+        Console.WriteLine($"Source plugin: {sourcePath}");
+        Console.WriteLine($"Output patch:  {outPath}");
+        Console.WriteLine();
+
+        var shaBefore = Sha(sourcePath);
+
+        // --- find a target NPC (typed scan — harness scaffolding; the engine below is generic) ---
+        var sourceMod = SkyrimMod.CreateFromBinaryOverlay(sourcePath, SkyrimRelease.SkyrimSE);
+        INpcGetter? target = null;
+        foreach (var n in sourceMod.Npcs)
+        {
+            if (n.PlayerSkills?.SkillValues is { } sv && sv.ContainsKey(Skill.OneHanded))
+            {
+                target = n;
+                break;
+            }
+        }
+        if (target is null)
+        {
+            Console.Error.WriteLine("error: no NPC with PlayerSkills.SkillValues[OneHanded] found in source");
+            return 1;
+        }
+        var beforeVal = target.PlayerSkills!.SkillValues[Skill.OneHanded];
+        Console.WriteLine($"Target NPC:    {target.FormKey} ({target.EditorID})");
+        Console.WriteLine($"  OneHanded before: {beforeVal}");
+        Console.WriteLine();
+
+        // --- PRE-FLIGHT VALIDATION (plan §3 P-VALIDATE) — the write goes through the rulebook first ---
+        const byte newVal = 50;
+        var rulebook = CorpusRulebook.Load();
+        Console.WriteLine($"Rulebook loaded: {rulebook.TypeCount} types.");
+        var req = new WriteRequest
+        {
+            RecordType = "Npc",
+            Path = new[] { "PlayerSkills", "SkillValues" },
+            Verb = "Set",
+            Key = "OneHanded",
+            Value = newVal.ToString(CultureInfo.InvariantCulture),
+        };
+
+        void Probe(string label, WriteRequest r, bool expectOk)
+        {
+            var msg = rulebook.Validate(r);
+            var ok = msg is null;
+            var mark = ok == expectOk ? "OK" : "!! UNEXPECTED";
+            Console.WriteLine($"  [{mark}] {label} -> {(ok ? "ACCEPT" : "REJECT: " + msg)}");
+        }
+
+        Console.WriteLine("Pre-flight probes (1 accept + 5 fail-loud rejects):");
+        Probe("real write: Npc PlayerSkills.SkillValues[OneHanded]=50", req, expectOk: true);
+        Probe("unknown record type", new() { RecordType = "Bogus", Path = new[] { "X" }, Verb = "Set", Value = "1" }, expectOk: false);
+        Probe("unknown field", new() { RecordType = "Npc", Path = new[] { "Bogus" }, Verb = "Set", Value = "1" }, expectOk: false);
+        Probe("illegal enum key", new() { RecordType = "Npc", Path = new[] { "PlayerSkills", "SkillValues" }, Verb = "Set", Key = "BogusSkill", Value = "50" }, expectOk: false);
+        Probe("wrong verb for cardinality (SetAtIndex on dict)", new() { RecordType = "Npc", Path = new[] { "PlayerSkills", "SkillValues" }, Verb = "SetAtIndex", Key = "0", Value = "50" }, expectOk: false);
+        Probe("value out of range (Byte=999)", new() { RecordType = "Npc", Path = new[] { "PlayerSkills", "SkillValues" }, Verb = "Set", Key = "OneHanded", Value = "999" }, expectOk: false);
+        Probe("identity reject: Npc.FormKey", new() { RecordType = "Npc", Path = new[] { "FormKey" }, Verb = "Set", Value = "123456:Skyrim.esm" }, expectOk: false);
+        Probe("substruct-whole reject: Npc.PlayerSkills (navigate-in)", new() { RecordType = "Npc", Path = new[] { "PlayerSkills" }, Verb = "Set", Value = "x" }, expectOk: false);
+        Probe("TranslatedString accept: Npc.Name=Bob", new() { RecordType = "Npc", Path = new[] { "Name" }, Verb = "Set", Value = "Bob" }, expectOk: true);
+        Console.WriteLine();
+
+        // Q3: refuse to mutate if the real request does not pass pre-flight.
+        if (rulebook.Validate(req) is { } reject)
+        {
+            Console.Error.WriteLine($"FAIL: real write rejected by pre-flight: {reject}");
+            return 1;
+        }
+
+        // --- THE ENGINE PATH (fully generic — resolves group from the record's runtime type) ---
+        var patchMod = new SkyrimMod(new ModKey("HousecarlWriteProof", ModType.Plugin), SkyrimRelease.SkyrimSE);
+        var patchRecord = WriteEngine.GenericGetOrAddAsOverride(patchMod, target);
+        WriteEngine.ApplyVerb(patchRecord, req);
+
+        WriteEngine.WritePatch(patchMod, sourceMod, outPath);
+        Console.WriteLine($"Wrote patch ({new FileInfo(outPath).Length} bytes).");
+        Console.WriteLine();
+
+        // --- verify: re-open the patch, read the value back ---
+        var patchBack = SkyrimMod.CreateFromBinaryOverlay(outPath, SkyrimRelease.SkyrimSE);
+        if (!patchBack.Npcs.TryGetValue(target.FormKey, out var patchedNpc))
+        {
+            Console.Error.WriteLine("FAIL: patched NPC not found in written patch");
+            return 1;
+        }
+        var afterVal = patchedNpc.PlayerSkills?.SkillValues?.GetValueOrDefault(Skill.OneHanded);
+        Console.WriteLine($"  OneHanded after (read back from patch): {afterVal}");
+
+        var shaAfter = Sha(sourcePath);
+        var sourceUnchanged = shaBefore == shaAfter;
+        Console.WriteLine($"  Source unchanged: {(sourceUnchanged ? "YES" : "NO")}");
+        Console.WriteLine();
+
+        var pass = afterVal == newVal && sourceUnchanged;
+        Console.WriteLine(pass
+            ? "=== PASS: nested dict-in-substruct Set landed; original untouched ==="
+            : "=== FAIL ===");
+        return pass ? 0 : 1;
+    }
+
+    // ======================================================================
+    //  BUILD-START API DISCOVERY  (write-api) — kept as a Mutagen-bump guard
+    // ======================================================================
+    public static int RunDiscovery(string[] args)
+    {
+        Console.WriteLine("=== Mutagen assemblies loaded ===");
+        var mutagen = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => (a.GetName().Name ?? "").StartsWith("Mutagen"))
+            .OrderBy(a => a.GetName().Name)
+            .ToList();
+        foreach (var a in mutagen)
+            Console.WriteLine($"  {a.GetName().Name} {a.GetName().Version}");
+        Console.WriteLine();
+
+        Console.WriteLine("=== GetOrAddAsOverride (static / extension) ===");
+        foreach (var asm in mutagen)
+            foreach (var t in SafeTypes(asm).Where(t => t is { IsAbstract: true, IsSealed: true }))
+                foreach (var m in t.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                             .Where(m => m.Name == "GetOrAddAsOverride"))
+                    Console.WriteLine($"  {Pretty(t)}.{Sig(m)}");
+        Console.WriteLine();
+
+        var armorsProp = typeof(SkyrimMod).GetProperty("Armors")!;
+        var groupType = armorsProp.PropertyType;
+        Console.WriteLine($"=== SkyrimMod.Armors : {Pretty(groupType)} ===");
+        foreach (var m in groupType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                     .Where(m => m.Name is "GetOrAddAsOverride" or "Add" or "Set" or "Remove"))
+            Console.WriteLine($"  (instance) {Sig(m)}");
+        Console.WriteLine();
+
+        Console.WriteLine($"=== SkyrimMod group-typed properties: {CountGroupProps()} total ===");
+        Console.WriteLine("=== discovery complete ===");
+        return 0;
+    }
+
+    /// <summary>Build-start confirm for polymorphic arm-SWAP: how is an arm instantiated, and does it assign?</summary>
+    public static int RunPolyProbe(string[] args)
+    {
+        var asm = typeof(SkyrimMod).Assembly;
+        var archProp = typeof(IMagicEffect).GetProperty("Archetype")!;
+        Console.WriteLine($"IMagicEffect.Archetype : {Pretty(archProp.PropertyType)}  canWrite={archProp.CanWrite}");
+        Console.WriteLine();
+
+        foreach (var name in new[] { "MagicEffectLightArchetype", "MagicEffectArchetype", "MagicEffectSummonCreatureArchetype" })
+        {
+            var t = asm.GetType("Mutagen.Bethesda.Skyrim." + name);
+            if (t is null) { Console.WriteLine($"{name}: TYPE NOT FOUND"); continue; }
+            Console.WriteLine($"{name}:");
+            foreach (var c in t.GetConstructors())
+                Console.WriteLine($"    ctor({string.Join(", ", c.GetParameters().Select(p => $"{Pretty(p.ParameterType)} {p.Name}"))})");
+            object? inst = null;
+            try { inst = System.Activator.CreateInstance(t); Console.WriteLine("    Activator.CreateInstance() -> OK"); }
+            catch (Exception ex) { Console.WriteLine($"    Activator.CreateInstance() -> {ex.GetType().Name}: {ex.InnerException?.Message ?? ex.Message}"); }
+            if (inst is not null)
+            {
+                Console.WriteLine($"    assignable to Archetype: {archProp.PropertyType.IsInstanceOfType(inst)}");
+                var wf = inst.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                    .Where(p => p.CanWrite && p.GetIndexParameters().Length == 0).Select(p => $"{p.Name}:{Pretty(p.PropertyType)}").Take(10);
+                Console.WriteLine($"    writable fields: {string.Join(", ", wf)}");
+            }
+        }
+        Console.WriteLine();
+
+        var src = args.Length > 0 ? args[0] : DefaultSourcePath;
+        var mod = SkyrimMod.CreateFromBinaryOverlay(src, SkyrimRelease.SkyrimSE);
+        foreach (var m in mod.MagicEffects)
+            if (m.Archetype is not null) { Console.WriteLine($"sample MGEF {m.FormKey} archetype concrete: {m.Archetype.GetType().Name}"); break; }
+        return 0;
+    }
+
+    /// <summary>
+    /// Characterization probe (substruct-probe): enumerate every NAVIGATE-INTO substruct field — substruct
+    /// cardinality, non-record TypeRef, not whole-coercible (TranslatedString-style) — and report, per distinct
+    /// target type, how many field-sites are NULLABLE (so the substruct can be absent and would need materializing)
+    /// and whether the concrete class has a parameterless ctor. The no-paramless-ctor targets are the "tricky
+    /// shapes" the absent-collection handoff flagged: the ones absent-substruct materialization must handle beyond a
+    /// plain Activator.CreateInstance. Pure corpus + reflection, no plugins — answers "do we need a plugin to prove
+    /// this?" and sizes the engine-fix design BEFORE building it.
+    /// </summary>
+    public static int RunSubstructProbe(string[] args)
+    {
+        var corpusPath = args.Length > 0 ? args[0] : CorpusRulebook.CorpusPath;
+        Corpus corpus;
+        try { corpus = CorpusRulebook.LoadCorpus(corpusPath); }
+        catch (Exception ex) { Console.Error.WriteLine($"error: {ex.Message}"); return 1; }
+        var asm = typeof(SkyrimMod).Assembly;
+
+        bool IsRecord(string n) => corpus.Types.TryGetValue(n, out var t) && t.Kind == "record";
+
+        // distinct navigate-into substruct target -> (total sites, nullable sites, sample owner.field, representative AQ)
+        var navInto = new SortedDictionary<string, (int sites, int nullableSites, string sample, string? aq)>(StringComparer.Ordinal);
+        int wholeCoercible = 0, recordSubstructs = 0;
+        foreach (var ts in corpus.Types.Values)
+        foreach (var f in ts.Fields)
+        {
+            if (f.Cardinality != "substruct" || f.TypeRef is not { } tr) continue;
+            if (IsRecord(tr)) { recordSubstructs++; continue; }        // owned child record — never MATERIALIZED (a present one is navigable)
+            var saq = f.MutableTypeAssemblyQualified ?? f.GetterTypeAssemblyQualified;
+            if (WriteEngine.ResolveType(saq) is { } st && WriteEngine.CanCoerce(st)) { wholeCoercible++; continue; } // TranslatedString-style — set wholesale
+            (int sites, int nullableSites, string sample, string? aq) e =
+                navInto.TryGetValue(tr, out var v) ? v : (0, 0, $"{ts.Name}.{f.Name}", (string?)null);
+            navInto[tr] = (e.sites + 1, e.nullableSites + (f.Nullable ? 1 : 0), e.sample, e.aq ?? saq);
+        }
+
+        Console.WriteLine($"=== substruct-probe over {corpus.TotalTypes} types ===");
+        Console.WriteLine($"Navigate-into substruct target types (non-record, non-whole-coercible): {navInto.Count} distinct");
+        Console.WriteLine($"  (skipped: {wholeCoercible} whole-coercible substruct site(s); {recordSubstructs} record-substruct site(s))");
+        Console.WriteLine();
+
+        int resolved = 0, paramless = 0, trickyInScope = 0, trickyGetOnly = 0, unresolved = 0;
+        var trickyList = new List<string>();
+        foreach (var (name, info) in navInto)
+        {
+            var concrete = ResolveConcreteSubstruct(asm, name, info.aq);
+            var settable = SampleSettable(asm, info.sample);     // can the sample owner-field be null (absent), i.e. in materialization scope?
+            if (concrete is null) { unresolved++; Console.WriteLine($"  [UNRESOLVED]        {name,-44} sites={info.sites}  e.g. {info.sample}"); continue; }
+            resolved++;
+            if (concrete.GetConstructor(Type.EmptyTypes) is not null) { paramless++; continue; }
+            // No parameterless ctor. If the owner-field is GET-ONLY it is always-present (never absent) -> out of materialization scope.
+            var ctors = string.Join(" | ", concrete.GetConstructors()
+                .Select(c => "(" + string.Join(", ", c.GetParameters().Select(p => $"{Pretty(p.ParameterType)} {p.Name}")) + ")"));
+            var scope = settable switch { false => "GET-ONLY (always present, out of scope)", true => "SETTABLE (can be absent -> needs composition)", _ => "settable?=unknown" };
+            if (settable == false) trickyGetOnly++; else { trickyInScope++; trickyList.Add(name); }
+            Console.WriteLine($"  [NO PARAMLESS CTOR] {Pretty(concrete),-40} {scope,-44} ctors: {(ctors.Length == 0 ? "(none public)" : ctors)}  e.g. {info.sample}");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"Resolved concrete: {resolved}/{navInto.Count} (unresolved {unresolved}).");
+        Console.WriteLine($"  parameterless ctor (simple Activator materialization suffices): {paramless}");
+        Console.WriteLine($"  NO paramless ctor, GET-ONLY owner field (always present, never absent — out of scope): {trickyGetOnly}");
+        Console.WriteLine($"  NO paramless ctor, SETTABLE owner field (real composition gap — must be NAMED + deferred): {trickyInScope}" + (trickyList.Count > 0 ? " -> " + string.Join(", ", trickyList.Distinct()) : ""));
+        Console.WriteLine();
+        Console.WriteLine(trickyInScope == 0 && unresolved == 0
+            ? "=== substruct-probe: every ABSENT-ABLE navigate-into substruct has a parameterless ctor — simple materialization suffices (the no-ctor cases are all get-only/always-present) ==="
+            : $"=== substruct-probe: {trickyInScope} settable no-ctor target(s) are a composition gap to NAME; {unresolved} unresolved — see above ===");
+        return 0;
+    }
+
+    /// <summary>Resolve the concrete owner type of a "Owner.Field" sample and report whether that field is settable
+    /// (CanWrite) — i.e. whether the substruct can be null/absent (materialization scope) vs get-only/always-present.</summary>
+    static bool? SampleSettable(Assembly asm, string sample)
+    {
+        int dot = sample.LastIndexOf('.');
+        if (dot <= 0) return null;
+        var owner = ResolveConcreteSubstruct(asm, sample[..dot], null);
+        if (owner is null) return null;
+        return WriteEngine.ResolveProperty(owner, sample[(dot + 1)..])?.CanWrite;
+    }
+
+    /// <summary>Resolve the concrete settable class for a substruct target (the type the engine instantiates to
+    /// materialize an absent one). Resolve the declared runtime type from the field's AQ first (handles CLOSED
+    /// GENERICS like GenderedItem&lt;ArmorModel&gt;); map a mutable/getter interface to its concrete impl; fall back
+    /// to a same-name non-abstract class. Returns the concrete (or the resolved type if already a usable class).</summary>
+    static Type? ResolveConcreteSubstruct(Assembly asm, string catalogName, string? aq)
+    {
+        var t = aq is null ? null : WriteEngine.ResolveType(aq);
+        if (t is not null && WriteEngine.ConcreteOf(t) is { } c) return c;          // interface→concrete (incl. closed generics) via the shared mapper
+        var direct = asm.GetType("Mutagen.Bethesda.Skyrim." + catalogName);
+        if (direct is { IsClass: true, IsAbstract: false }) return direct;
+        return SafeTypes(asm).FirstOrDefault(x => x.IsClass && !x.IsAbstract && x.Name == catalogName) ?? t ?? direct;
+    }
+
+    static int CountGroupProps() =>
+        typeof(SkyrimMod).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Count(p => Pretty(p.PropertyType).Contains("Group"));
+
+    static string Sig(MethodInfo m)
+    {
+        var gen = m.IsGenericMethodDefinition
+            ? "<" + string.Join(",", m.GetGenericArguments().Select(g => g.Name)) + ">"
+            : "";
+        var ps = string.Join(", ", m.GetParameters().Select(p => $"{Pretty(p.ParameterType)} {p.Name}"));
+        return $"{m.Name}{gen}({ps}) -> {Pretty(m.ReturnType)}";
+    }
+
+    static string Sha(string path)
+    {
+        using var fs = File.OpenRead(path);
+        using var sha = SHA256.Create();
+        return Convert.ToHexString(sha.ComputeHash(fs));
+    }
+
+    static IEnumerable<Type> SafeTypes(Assembly a)
+    {
+        try { return a.GetTypes(); }
+        catch (ReflectionTypeLoadException ex) { return ex.Types.Where(t => t is not null)!; }
+    }
+
+    static string Pretty(Type t)
+    {
+        if (t.IsByRef) return Pretty(t.GetElementType()!) + "&";
+        if (t.IsGenericType)
+        {
+            var name = t.Name;
+            var tick = name.IndexOf('`');
+            if (tick > 0) name = name[..tick];
+            return $"{name}<{string.Join(", ", t.GetGenericArguments().Select(Pretty))}>";
+        }
+        return t.Name;
+    }
+}

--- a/src/housecarl-generator/WriteDiagnosticsProbe.cs
+++ b/src/housecarl-generator/WriteDiagnosticsProbe.cs
@@ -23,13 +23,13 @@ namespace HousecarlGenerator;
 /// cannot build with a parameterless ctor. Corpus + reflection; needs no plugin.</item>
 /// </list>
 ///
-/// They lived in <see cref="WriteEngine"/> until #453 moved them here, beside the probes they resemble; a 2026-05
-/// review had already asked for the split. The engine's own header lists what stayed behind.
+/// They lived in <see cref="WriteEngine"/> until #453 moved them here, beside the probes they resemble. The
+/// engine's own header lists what stayed behind.
 /// </summary>
 public static class WriteDiagnosticsProbe
 {
-    // A convenience default for the two modes that read a plugin. Both take a path as argv[0] instead; this
-    // one machine's install is not assumed to exist anywhere.
+    // A convenience default for the two modes that read a plugin; both take a path as argv[0] instead. It names
+    // one machine's install and is not assumed to exist — each of those two refuses by name when it does not.
     const string DefaultSourcePath =
         @"C:\Program Files (x86)\Steam\steamapps\common\Skyrim Special Edition\Data\Skyrim.esm";
 
@@ -215,6 +215,11 @@ public static class WriteDiagnosticsProbe
         Console.WriteLine();
 
         var src = args.Length > 0 ? args[0] : DefaultSourcePath;
+        if (!File.Exists(src))
+        {
+            Console.Error.WriteLine($"error: source plugin not found: {src}");
+            return 1;
+        }
         var mod = SkyrimMod.CreateFromBinaryOverlay(src, SkyrimRelease.SkyrimSE);
         foreach (var m in mod.MagicEffects)
             if (m.Archetype is not null) { Console.WriteLine($"sample MGEF {m.FormKey} archetype concrete: {m.Archetype.GetType().Name}"); break; }


### PR DESCRIPTION
Fixes #453

Moves the spike-era proof and discovery modes out of `housecarl-core`'s `WriteEngine.cs` (the shipping library) into `WriteDiagnosticsProbe.cs` in `housecarl-generator`, and removes the hardcoded Steam path from core.

## What moved

`npc-skills` (the step-4 acceptance proof), `write-api`, `poly-probe`, `substruct-probe` — all hand-run, all reachable only from `Program.cs` dispatch, none on the tool surface — plus their exclusive helpers. Cross-file calls are now `WriteEngine.`-qualified; no access level widened (the callees are `internal`, reached through the pre-existing `InternalsVisibleTo("housecarl-generator")`). The move in fact *narrows* the shipped surface: four `public` dev-only methods leave the library that ships in the plugin.

`DefaultSourcePath` is gone from `housecarl-core`. Its last user, `condition-patch`, now **requires `--source`**, matching its siblings `patch` and `show`. The old default failed with `source plugin not found: C:\Program Files (x86)\…` — naming a path the caller never typed.

`WriteEngine.cs`: 4,362 → 4,066 lines.

## What did NOT move, deliberately

`patch` / `show` / `condition-patch` (live dev harnesses; `patch` is driven by `insert-at-index-guard` in CI) and `coerce-audit` / `coerce-selftest` (live `ci-all` probes). Console modes in a library is the same smell, but these are live tools, not spike residue. `WriteEngine.ParseFlags` has nine call sites across six generator probes, so relocating it is its own change.

That residue is filed as **#463** and is not this PR's concern.

## Verification

- `ci-all` **132/132**.
- Relocation verified mechanically three times independently (mine + two reviewers): a line-set comparison of every removed `WriteEngine.cs` line against the new file, normalising the `WriteEngine.` qualifier, leaves exactly the intended deltas. Local `Sha`/`SafeTypes`/`Pretty` copies are semantically identical to the originals (per the generator's existing convention — `ConditionProbe`, `CoordCellProbe` and others each carry their own).
- Outputs byte-identical base vs branch for `write-api`, `substruct-probe`, `npc-skills`, `poly-probe <plugin>`, `condition-patch --source <plugin>`. `npc-skills` still prints `=== PASS: nested dict-in-substruct Set landed; original untouched ===`.
- `condition-patch` both directions: no `--source` → `error: missing required --source`; with one → writes the patch, reads the re-targeted condition back, source unchanged.
- Verified no access level widened, no overload re-binding, no static-init/lifetime change, no assembly-location dependence, and nothing anywhere in the repo still points at the moved code by its old home.

No sabotage sweep and no new guard: this branch adds no CI machinery, and the two refusals it does add are hand-verified in both directions. Writing a CI guard for a hand-run dev harness would be disproportionate — stated here rather than left as an unexplained gap.

## Review rounds (CLAUDE.md §5 #11)

Conducted by a fresh session, not the branch's author (rule 9 seam). Two rounds, four independent reviewers, each in its own worktree.

**Round 1** — two reviewers (move fidelity; claims-vs-code).
- Fidelity reviewer: **no highs, no mediums.** Verified the relocation clean on every axis above.
- Claims reviewer: one **high** — the rewritten header claimed "a request is validated against the corpus rulebook before anything is mutated" for every entry point. `ApplyVerb` is public and does no rulebook check; the engine's own comment says pre-flight only "normally" gates it, and this branch's own moved proof calls `rulebook.Validate` itself before `ApplyVerb`. **Folded** per DOC_HYGIENE §8 (a guarantee without a probe is a claim, not a guarantee).
- Also folded: `poly-probe` crashed with an unhandled Mutagen exception on the default path while a new comment said it couldn't — given the named refusal its sibling has, verified both directions; the review-round citation in source (§7 — the `#453` pointer stays, that's §7's stated exception); `oracle` presented as a standing proof when it is hand-run; `substruct-probe` mislabelled a build-start diagnostic.
- **Refused (2):** the "still here" inventory as a §6 duplicate — settled decision 4 puts it there deliberately and both reviewers verified it exact, with no unnamed sixth entry point. And, initially, the stale `WriteCensus`/`condition-patch` arm-navigation comments, on the grounds the branch didn't touch them.

**Round 2** — two fresh reviewers (behaviour; claims-vs-code).
- Behaviour reviewer: **no highs, no mediums.** Three lows, each verified as pre-existing and identical on base — a non-plugin file still crashing one case past the new guard, an empty-string argument echoing an empty path, and a value-less `--source` binding to the literal `"true"` (shared with `RunPatch`/`RunShow`).
- Claims reviewer: two mediums. My round-1 fold's "`ApplyVerb` validates nothing" was over-broad and contradicted the line above it — `ApplyVerb` does refuse structurally by name; what it omits is the *rulebook* check. **Folded.** And it corrected my round-1 refusal: the branch *does* touch the `condition-patch` comment block, so §8's "cleaned when a file is touched" applies. **Folded**, minimally — the claim measured false is deleted rather than replaced with a capability claim this branch has no probe for.
- The two reviewers disagreed on the `ApplyVerb` sentence; both were half-right, which is what produced the precision fix rather than a revert.

**Refusals stated with grounds, so the rate is visible:** three findings refused across the two rounds — the §6 inventory duplicate (settled by decision 4, verified accurate), and the three pre-existing lows above, which are defects in code this branch does not change and are shared with sibling harnesses. Folding them would widen a relocation branch.

Stopped at two rounds: round 2's behaviour pass was clean at medium and above, and what remained was one clause of the reviewing session's own prose plus pre-existing comments — convergence rather than a recurring class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
