### PR TITLE
fix(schema): published tool schemas carry no $ref, so strict providers can load the server

### DIFF
--- a/docs/architecture/tool-schema-publication.md
+++ b/docs/architecture/tool-schema-publication.md
@@ -1,14 +1,17 @@
 # Tool schema publication
 
 **Class:** LIVING. Subsystem: `src/housecarl-mcp/ToolSchemas.cs`, registered from `Program.cs`.
-Pinned by `binding-shim-guard`'s SCHEMA arm (the real published surface) and
-`schema-flatten-guard` (the flattening mechanism, over synthetic documents).
+Pinned by `binding-shim-guard`'s SCHEMA arms (the real published surface) and
+`schema-flatten-guard` (the flattening mechanism, over synthetic documents for the shapes the
+real surface cannot produce, and over the real pre-flatten surface for the emission grammar and
+the strict reader).
 
 houseCARL's MCP tools are discovered by an assembly scan, and the SDK generates each tool's
 `inputSchema` from its C# method signature. Two things that generator cannot get right on its
 own are corrected once, at registration, before anything is served. Both change only what is
-**published**; what a tool *accepts* is decided by its own reader, which is stricter than the
-SDK binder.
+**published**. The argument-binding shim does read a published schema, but only its top-level
+`properties` — never the nested part these passes rewrite — and the composed payloads are then
+read by `ListParams.Read<T>`, which consults no schema and is stricter than the SDK binder.
 
 ## Why the rewrite happens at registration
 

--- a/docs/architecture/tool-schema-publication.md
+++ b/docs/architecture/tool-schema-publication.md
@@ -64,9 +64,19 @@ the open node accepts what the recursive form accepted, and the binder never con
 schema in the first place. `$defs` is dropped once nothing refers to it, because an unreferenced
 definition still carries its cycle to a validator that walks definitions.
 
-A pointer that does **not** resolve is left exactly as it is. Replacing it with an open node
-would hide a broken rebase behind a schema that looks finished; left in place, it fails the one
-invariant the guard asserts — no published tool schema carries a same-document `$ref`.
+A `$ref` the pass does **not** handle is left exactly as it is — a pointer that resolves
+nowhere, and equally a form that is not a same-document pointer at all (a plain-name anchor, a
+`$ref` that is not even a JSON string). Replacing one with an open node would hide a broken
+rebase behind a schema that looks finished, and reading one as a string would throw out of the
+`PostConfigure` these passes run in and fail the server's whole start.
+
+Left in place, it fails the one invariant the guard asserts — **no published tool schema
+carries a `$ref` member, in any spelling.** That predicate is deliberately wider than this
+pass's own resolve gate and shares no code with it: an earlier version of the arm spelled the
+detector the way the flattener spells its gate, so a `$ref` the pass could not resolve was also
+one the detector could not see, and an anchor-form `{"$ref":"Node"}` injected into all 51
+schemas passed green. A detector that inherits its subject's blind spot measures nothing at the
+only moment it matters.
 
 The bound is a cost/legibility trade, not a correctness one: raising it deepens every recursive
 branch of every affected schema (at 1, the five affected tools grew ~3 KB each).

--- a/docs/architecture/tool-schema-publication.md
+++ b/docs/architecture/tool-schema-publication.md
@@ -1,0 +1,69 @@
+# Tool schema publication
+
+**Class:** LIVING. Subsystem: `src/housecarl-mcp/ToolSchemas.cs`, registered from `Program.cs`.
+Pinned by `binding-shim-guard`'s SCHEMA arm (the real published surface) and
+`schema-flatten-guard` (the flattening mechanism, over synthetic documents).
+
+houseCARL's MCP tools are discovered by an assembly scan, and the SDK generates each tool's
+`inputSchema` from its C# method signature. Two things that generator cannot get right on its
+own are corrected once, at registration, before anything is served. Both change only what is
+**published**; what a tool *accepts* is decided by its own reader, which is stricter than the
+SDK binder.
+
+## Why the rewrite happens at registration
+
+The SDK's `WithToolsFromAssembly` has no overload carrying
+`McpServerToolCreateOptions.SchemaCreateOptions`, so the per-node `TransformSchemaNode` hook
+cannot reach an assembly-scanned tool. `Tool.InputSchema` is settable (and validates what it is
+given), so the schema is rewritten instead — as a post-configure over `McpServerOptions`, which
+is the one place the final tool collection exists whichever transport built the host. The
+assembly scan registers each tool as a *factory*, so no instance exists while the service
+collection is being built, and stdio and HTTP build their hosts separately: a post-configure
+keeps this on one line inside the shared registration rather than a call site per transport
+that could drift apart.
+
+## Pass 1 — the `@file` union
+
+A list-valued input accepts either an inline array of objects or the string
+`"@<absolute path>"` (SPEC §5.1). C# has no type for that union, so the parameter is declared
+`JsonElement` — and a schema generated from the declared type says "anything" (`{}`). The
+element shape then lives only in the tool description, where a client's schema rendering cannot
+use it.
+
+So those parameters are republished as `anyOf[<the generated element-array schema>, string]`.
+The array arm is **generated from the C# element type** by the same generator the SDK uses, so
+adding a member to `ApplyOp` updates the published schema automatically — only the union
+wrapper and the string arm are written by hand. The parameter's `[Description]` moves onto the
+union node, where a client renders it.
+
+A generated sub-schema is a standalone document: every `"#/..."` pointer inside it is relative
+to *its own* root. Nesting it under `properties/<param>/anyOf/0` breaks all of them unless they
+are rebased first, and its `$defs` must be hoisted to the tool schema's root for `#/$defs/…` to
+resolve at all.
+
+## Pass 2 — no `$ref` in a published schema
+
+The schema generator does not expand a recursive type. It inlines it once and terminates the
+second occurrence with a **positional back-reference** — `$ref: "#/properties/ops/anyOf/0/…"`
+pointing at an ancestor. houseCARL's write DTOs are recursive by design (`StructInput` → the
+`sets[]` element → its `compose` → `StructInput` again), so five tools published a cyclic
+schema.
+
+That is legal JSON Schema, and the Anthropic and OpenAI APIs accept it. A growing set of
+smaller and relay-hosted models validate `tools/list` conservatively and reject recursion
+outright — and the rejection takes down the **whole server**, not the offending tool, with an
+error that does not name houseCARL (issue #451).
+
+So every same-document pointer is inlined. A cycle is expanded a bounded number of times
+(`MaxSelfExpansions`) and then closed with an open node: the target's `type`, the parameter's
+own description, and a clause saying nesting continues below that level. Nothing is narrowed —
+the open node accepts what the recursive form accepted, and the binder never consulted the
+schema in the first place. `$defs` is dropped once nothing refers to it, because an unreferenced
+definition still carries its cycle to a validator that walks definitions.
+
+A pointer that does **not** resolve is left exactly as it is. Replacing it with an open node
+would hide a broken rebase behind a schema that looks finished; left in place, it fails the one
+invariant the guard asserts — no published tool schema carries a same-document `$ref`.
+
+The bound is a cost/legibility trade, not a correctness one: raising it deepens every recursive
+branch of every affected schema (at 1, the five affected tools grew ~3 KB each).

--- a/docs/decisions/0002-published-tool-schemas-carry-no-ref.md
+++ b/docs/decisions/0002-published-tool-schemas-carry-no-ref.md
@@ -27,7 +27,8 @@ feature that some validators reject is a liability regardless of who is technica
 1. A cycle is expanded a bounded number of times and then **closed with an open node** — the
    target's `type`, the parameter's own description, and a clause saying nesting continues.
    Nothing is narrowed: the schema at the bound accepts what the recursive form accepted, and
-   what a tool accepts was never decided by the published schema.
+   nothing reads the nested part of a published schema, so rewriting it cannot move what a
+   tool accepts (see the Consequences below for what does read one).
 2. `$defs` is dropped once nothing refers to it — an unreferenced definition still carries its
    cycle to a validator that walks definitions.
 3. A pointer that does **not** resolve is left in place, not replaced by an open node. A broken
@@ -43,8 +44,13 @@ feature that some validators reject is a liability regardless of who is technica
   (~6% of `tools/list`). Raising the bound deepens every recursive branch of every schema.
 - The invariant is guarded generically over all tools, so a future recursive DTO is covered
   by construction rather than by remembering this decision.
-- Anything that consumes a published schema may now assume it is self-contained. Nothing
-  currently does — the argument-binding shim reads only top-level `properties`.
+- Anything that consumes a published schema may now assume it is self-contained. One thing
+  does: the argument-binding shim is schema-driven off `InputSchema`, coercing argument shapes
+  and refusing unknown or missing parameters. It reads only the top-level `properties` and
+  never descends into `items`/`anyOf`, which is the whole of what this pass rewrites — so the
+  flattening is invisible to it. That is a measured property of today's shim, not a rule
+  binding it: a future consumer that walks nested schemas is now free to, and would have been
+  reading a cyclic document before.
 - Should a provider one day reject something else in these schemas, the fix has a home: this
   is a publication layer that already normalizes what the generator emits.
 

--- a/docs/decisions/0002-published-tool-schemas-carry-no-ref.md
+++ b/docs/decisions/0002-published-tool-schemas-carry-no-ref.md
@@ -1,0 +1,51 @@
+# ADR 0002 — Published tool schemas carry no `$ref`
+
+**Class:** ARCHIVE (ADR). Immutable once merged; superseded by a later ADR, never edited.
+**Date:** 2026-09-01 · **Status:** accepted · **Issue:** #451
+
+## Context
+
+houseCARL's write DTOs are recursive by design: a composed struct carries nested edits, and a
+nested edit may compose another struct. The MCP SDK's schema generator does not expand a
+recursive type — it inlines one level and terminates the next with a positional back-reference
+(`$ref` at an ancestor), so five tools published a cyclic `inputSchema`.
+
+That is legal JSON Schema. The Anthropic and OpenAI APIs accept it, and houseCARL shipped it
+for months. But an external report (#451) measured a provider that validates `tools/list`
+strictly and answers `Recursive JSON schemas are not currently supported` — refusing the
+**entire server**, not the offending tool, with an error naming neither houseCARL nor the
+schema. The user's only workaround was toggling the MCP server off for that model.
+
+The set of clients between a model and a tool list is not ours and keeps growing. A schema
+feature that some validators reject is a liability regardless of who is technically correct.
+
+## Decision
+
+**No published tool schema contains a same-document `$ref`.** At registration, after the
+`@file` union rewrite, every same-document pointer is inlined:
+
+1. A cycle is expanded a bounded number of times and then **closed with an open node** — the
+   target's `type`, the parameter's own description, and a clause saying nesting continues.
+   Nothing is narrowed: the schema at the bound accepts what the recursive form accepted, and
+   what a tool accepts was never decided by the published schema.
+2. `$defs` is dropped once nothing refers to it — an unreferenced definition still carries its
+   cycle to a validator that walks definitions.
+3. A pointer that does **not** resolve is left in place, not replaced by an open node. A broken
+   rebase must stay visible rather than hide behind a schema that looks finished.
+4. This is unconditional, not a config switch. The flattened form is accepted everywhere the
+   recursive form is, so a switch would add a knob with no reachable benefit, leave the default
+   broken for the users who hit this, and double what the guards must hold.
+
+## Consequences
+
+- The recursive shape stays legible to a caller — it is spelled out concretely to the bound
+  rather than amputated — at the cost of schema size. The five affected tools grew ~3 KB each
+  (~6% of `tools/list`). Raising the bound deepens every recursive branch of every schema.
+- The invariant is guarded generically over all tools, so a future recursive DTO is covered
+  by construction rather than by remembering this decision.
+- Anything that consumes a published schema may now assume it is self-contained. Nothing
+  currently does — the argument-binding shim reads only top-level `properties`.
+- Should a provider one day reject something else in these schemas, the fix has a home: this
+  is a publication layer that already normalizes what the generator emits.
+
+Mechanics and the rest of the layer: `docs/architecture/tool-schema-publication.md`.

--- a/docs/decisions/0002-published-tool-schemas-carry-no-ref.md
+++ b/docs/decisions/0002-published-tool-schemas-carry-no-ref.md
@@ -21,8 +21,14 @@ feature that some validators reject is a liability regardless of who is technica
 
 ## Decision
 
-**No published tool schema contains a same-document `$ref`.** At registration, after the
-`@file` union rewrite, every same-document pointer is inlined:
+**No published tool schema carries a `$ref` member, in any spelling.** That is wider than
+"contains a same-document pointer" on purpose: spelling the invariant the same way as the
+flattener's own resolve gate is what made an earlier version of the guard vacuous — a `$ref`
+the pass could not resolve was also one the detector could not see, so an anchor-form
+`{"$ref":"Node"}` injected into all 51 schemas passed green. The guard asks only whether the
+member is there.
+
+At registration, after the `@file` union rewrite, every same-document pointer is inlined:
 
 1. A cycle is expanded a bounded number of times and then **closed with an open node** — the
    target's `type`, the parameter's own description, and a clause saying nesting continues.
@@ -31,8 +37,11 @@ feature that some validators reject is a liability regardless of who is technica
    tool accepts (see the Consequences below for what does read one).
 2. `$defs` is dropped once nothing refers to it — an unreferenced definition still carries its
    cycle to a validator that walks definitions.
-3. A pointer that does **not** resolve is left in place, not replaced by an open node. A broken
-   rebase must stay visible rather than hide behind a schema that looks finished.
+3. A `$ref` the pass does **not** handle — a pointer that does not resolve, a form that is not
+   a same-document pointer at all — is left in place, not replaced by an open node and not
+   thrown on. A broken rebase must stay visible rather than hide behind a schema that looks
+   finished, and the wider invariant above is what makes leaving it a report rather than a
+   silence.
 4. This is unconditional, not a config switch. The flattened form is accepted everywhere the
    recursive form is, so a switch would add a knob with no reachable benefit, leave the default
    broken for the users who hit this, and double what the guards must hold.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -20,8 +20,8 @@ saying it sets an expectation their install may contradict. Say what is known, a
   (`Recursive JSON schemas are not currently supported`) that names neither houseCARL nor a tool, so the only
   way through was turning the MCP server off for that model. The nested shape is now written out concretely to
   a bounded depth and then closed with a node that keeps the type but stops constraining what is inside it, and
-  says so in its own description. What the tools accept is unchanged — arguments are read by each tool's own
-  reader, never by the published schema.
+  says so in its own description. What the tools accept is unchanged — nothing reads the nested part of a
+  published schema, so rewriting it cannot move an acceptance decision.
   Check it from your client's tool list: no houseCARL schema carries a `$ref`.
 
 - **`housecarl_records` truncation and expansion notices name that tool's own parameters — on the forms and

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,16 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **The tool schemas houseCARL publishes no longer contain a `$ref`, so a provider that rejects recursive
+  schemas can load the server.** Every tool that takes a composed struct declared a nested shape referring
+  back to itself — how a JSON Schema generator spells a recursive type. Providers that validate the tool list
+  strictly reject recursion and refuse the *whole* server at connect time, with an error
+  (`Recursive JSON schemas are not currently supported`) that names neither houseCARL nor a tool, so the only
+  way through was turning the MCP server off for that model. The nested shape is now written out concretely to
+  a bounded depth and then closed with a node that accepts anything and says so in its own description. What
+  the tools accept is unchanged — arguments are read by each tool's own reader, never by the published schema.
+  Check it from your client's tool list: no houseCARL schema carries a `$ref`.
+
 - **`housecarl_records` truncation and expansion notices name that tool's own parameters — on the forms and
   lanes listed here.** When a read hit `max_chars`, the notice told you to narrow with `fields=` and lower
   `depth=`; on that tool those are spelled `project.fields=` and `project.depth=`, so following the advice

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -19,8 +19,9 @@ saying it sets an expectation their install may contradict. Say what is known, a
   strictly reject recursion and refuse the *whole* server at connect time, with an error
   (`Recursive JSON schemas are not currently supported`) that names neither houseCARL nor a tool, so the only
   way through was turning the MCP server off for that model. The nested shape is now written out concretely to
-  a bounded depth and then closed with a node that accepts anything and says so in its own description. What
-  the tools accept is unchanged — arguments are read by each tool's own reader, never by the published schema.
+  a bounded depth and then closed with a node that keeps the type but stops constraining what is inside it, and
+  says so in its own description. What the tools accept is unchanged — arguments are read by each tool's own
+  reader, never by the published schema.
   Check it from your client's tool list: no houseCARL schema carries a `$ref`.
 
 - **`housecarl_records` truncation and expansion notices name that tool's own parameters — on the forms and

--- a/src/housecarl-generator/ApplyGuardProbe.cs
+++ b/src/housecarl-generator/ApplyGuardProbe.cs
@@ -550,7 +550,7 @@ public static class ApplyGuardProbe
         Check("a bad field path refuses the whole call with nothing written (all-or-nothing preserved)",
             badPath.StartsWith("error:"), badPath);
 
-        // ROUND-4 FOLD [medium] — the COMPOSED payloads through the NEW strict reader. ReadListParam is a
+        // ROUND-4 FOLD [medium] — the COMPOSED payloads through the NEW strict reader. ListParams.Read<T> is a
         // brand-new deserialization path replacing BOTH the SDK binder (1.x inline) and the old from_file=
         // reader, and UnmappedMemberHandling.Disallow applies RECURSIVELY down StructInput -> NestedSet ->
         // StructInput. Nothing above sends one, so the recursive shape was schema-pinned but never executed —

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -572,6 +572,11 @@ public static class BindingShimProbe
     {
         int failures = 0;
 
+        // The derivation the expansion arms below stand on, fixtured against shapes today's DTOs cannot produce
+        // end-to-end. Its two rules are visible only under those shapes, so nothing on the real surface would
+        // redden if either were dropped.
+        failures += DerivationFixtureArm();
+
         // One row per ToolSchemas.FileListParams entry — (tool, parameter, a member that proves the generator ran
         // over the real C# type). PR #311 review [low]: this arm used to hardcode housecarl_apply, so
         // housecarl_create's records= row was covered only by the generic dangling-$ref sweep — and a dropped or
@@ -675,18 +680,18 @@ public static class BindingShimProbe
                 found, "tool absent from tools/list");
             if (!found) continue;
 
-            // The recursion STEP, derived: the one site whose pointer is a prefix of its own path is a positional
-            // back-reference to an ancestor, and the path segment between them IS one turn of the cycle. Every site
-            // aiming at that same pointer re-enters the same shape, whichever member the generator reached first —
-            // so the walk below is indifferent to [JsonPropertyName] declaration order, which an earlier fixed-level
-            // pin was not (reordering ApplyOp.Compose/Composes made it report an amputation that had not happened).
-            string? step = null, cycle = null;
-            foreach (var (path, node) in sites)
-                if (node["$ref"]?.GetValue<string>() is { } p && path.Length > p.Length
-                    && path.StartsWith(p, StringComparison.Ordinal))
-                { step = path[p.Length..]; cycle = p; }
-            failures += Check($"SCHEMA: {tool.Name} — a recursion step is derivable from its own pre-flatten refs",
-                step is not null, "no $ref points at one of its own ancestors; the expansion arm has nothing to measure");
+            // The recursion STEP and CYCLE, derived from this tool's own refs — the rules live in DeriveRecursions.
+            // EXACTLY one is required. A tool carrying two distinct cycles is refused here, never measured on
+            // whichever one the walk saw last: that is a claim quantified over a population and verified over a
+            // narrower subset, which is the class this branch was stopped on.
+            var derived = DeriveRecursions(sites);
+            failures += Check($"SCHEMA: {tool.Name} — exactly one recursion step is derivable from its own pre-flatten refs (got {derived.Count})",
+                derived.Count == 1,
+                derived.Count == 0
+                    ? "no $ref points at one of its own ancestors on a segment boundary; the expansion arm has nothing to measure"
+                    : "distinct cycles: " + string.Join(" | ", derived.Select(d => $"{d.Cycle} +{d.Step}")));
+            string? step = derived.Count == 1 ? derived[0].Step : null;
+            string? cycle = derived.Count == 1 ? derived[0].Cycle : null;
 
             foreach (var (path, node) in sites)
             {
@@ -696,7 +701,7 @@ public static class BindingShimProbe
                     pubNode is { ValueKind: JsonValueKind.Object } n && SpellsOutStructure(n),
                     pubNode is { } got ? Trunc(got) : "<path does not resolve in the published schema>");
 
-                if (step is null || node["$ref"]?.GetValue<string>() != cycle) continue;
+                if (step is null || RefPointer(node) != cycle) continue;
                 recursive++;
                 var (levels, closedOpen, detail) = WalkRecursion(published, path, step);
                 // The bound is a RULED value (decision record entry 15, Aaron: "keep 1"), spelled here independently
@@ -716,6 +721,78 @@ public static class BindingShimProbe
             subjects > 0, "the pre-flatten surface yielded no $ref sites at all");
         failures += Check($"SCHEMA: at least one derived subject is recursive ({recursive} of {subjects})",
             recursive > 0, "no site re-enters its own pointer; nothing measured the bound");
+        return failures;
+    }
+
+    /// <summary>The <c>$ref</c> pointer on a node, or null when the member is absent or does not hold a JSON
+    /// string. The safe spelling on purpose: a non-string <c>$ref</c> is a form neither pass understands, and the
+    /// invariant arm above is what reports it — reading it as a string here would take the guard down first.</summary>
+    static string? RefPointer(JsonObject node) =>
+        node["$ref"] is JsonValue v && v.TryGetValue<string>(out var s) ? s : null;
+
+    /// <summary>Every DISTINCT (step, cycle) derivable from one tool's pre-flatten <c>$ref</c> sites. A site whose
+    /// pointer is a proper ancestor of its own path is a positional back-reference, and the path segment between
+    /// them is one turn of that cycle; every site aiming at the same pointer re-enters the same shape, so the walk
+    /// is indifferent to [JsonPropertyName] declaration order, which an earlier fixed-level pin was not.
+    ///
+    /// Two rules make the derivation say what it means, and neither is visible on today's surface:
+    /// <list type="bullet">
+    /// <item>the prefix must end ON a JSON-pointer segment boundary. A bare string prefix makes a sibling whose
+    /// wire name EXTENDS the target's into a false ancestor, and the derived step is then a fragment of a member
+    /// name that resolves nowhere — a RED on a schema the pass flattened correctly. Today's surface survives that
+    /// on one character (<c>.../compose/properties/sets</c> against <c>.../composes/items/properties/sets</c>),
+    /// which is a coincidence of two member names, not a property anyone declared.</item>
+    /// <item>every distinct pair is returned, never the last one. The caller refuses a tool that yields more than
+    /// one. Measured 2026-09-01: a second recursive family on <c>StructInput</c> took the recursive population
+    /// from 10 of 30 sites to 5 of 45 — the original compose/sets cycle measured on NO tool — with the guard
+    /// fully green, because the later pair overwrote the first and only its own sites then matched.</item>
+    /// </list></summary>
+    internal static List<(string Step, string Cycle)> DeriveRecursions(IEnumerable<(string Path, JsonObject Node)> sites)
+    {
+        var found = new List<(string Step, string Cycle)>();
+        foreach (var (path, node) in sites)
+        {
+            if (RefPointer(node) is not { } p || path.Length <= p.Length
+                || !path.StartsWith(p, StringComparison.Ordinal) || path[p.Length] != '/') continue;
+            var pair = (Step: path[p.Length..], Cycle: p);
+            if (!found.Contains(pair)) found.Add(pair);
+        }
+        return found;
+    }
+
+    /// <summary>FIXTURES for <see cref="DeriveRecursions"/>. Both shapes were measured on the real surface under
+    /// sabotage (a second <c>NestedSet[]</c> member on <c>StructInput</c>, 2026-09-01) and neither is producible by
+    /// the DTOs as they stand, so the rules they pin have no end-to-end producer to redden — the same standing as
+    /// schema-flatten-guard's $defs and mutual-recursion arms.</summary>
+    static int DerivationFixtureArm()
+    {
+        const string R = "#/properties/operations/items/properties";
+        static (string, JsonObject) Site(string path, string pointer) => (path, new JsonObject { ["$ref"] = pointer });
+
+        var failures = 0;
+
+        // TWO FAMILIES — the pointers the sabotage actually emitted. Both pairs must come back: reporting one is
+        // how the guard claimed a tool's coverage while measuring a single cycle of it.
+        var twoFamilies = DeriveRecursions(new[]
+        {
+            Site($"{R}/compose/properties/sets/items/properties/compose/properties/sets", $"{R}/compose/properties/sets"),
+            Site($"{R}/compose/properties/sets/items/properties/compose/properties/alt/items", $"{R}/compose/properties/sets/items"),
+        });
+        failures += Check("SCHEMA-FIXTURE: a surface carrying two distinct cycles derives BOTH, so the caller can refuse it",
+            twoFamilies.Count == 2, string.Join(" | ", twoFamilies.Select(d => $"{d.Cycle} +{d.Step}")));
+
+        // SEGMENT BOUNDARY — a sibling whose wire name extends the target's is not an ancestor, and today's
+        // near-miss (composes against compose) is not one either. Exactly the real cycle survives.
+        var boundary = DeriveRecursions(new[]
+        {
+            Site($"{R}/compose/properties/sets/items/properties/compose/properties/sets", $"{R}/compose/properties/sets"),
+            Site($"{R}/compose/properties/setsx", $"{R}/compose/properties/sets"),
+            Site($"{R}/composes/items/properties/sets", $"{R}/compose/properties/sets"),
+        });
+        failures += Check("SCHEMA-FIXTURE: a sibling whose wire name EXTENDS the ref target is not read as an ancestor",
+            boundary.Count == 1 && boundary[0].Step == "/items/properties/compose/properties/sets",
+            string.Join(" | ", boundary.Select(d => $"{d.Cycle} +{d.Step}")));
+
         return failures;
     }
 

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -312,10 +312,9 @@ public static class BindingShimProbe
             // -- SCHEMA: the @file union ToolSchemas publishes, and the invariant that made it necessary.
             //    ops=/assignments= are declared JsonElement (no C# type expresses "array OR '@path'"), so the
             //    generator would publish {}; ToolSchemas republishes anyOf[<generated element array>, string].
-            //    The load-bearing check is the LAST one: the generator terminates a recursive type with a
-            //    POSITIONAL "#/..." back-reference relative to its own document, so nesting a generated
-            //    sub-schema silently produces a dangling $ref — a broken schema, strictly worse than the {}
-            //    it replaced. That check is generic over every tool, not just this one.
+            //    The load-bearing check is the generic one: the generator terminates a recursive type with a
+            //    POSITIONAL "#/..." back-reference, which strict providers reject outright (#451) and which a
+            //    nested-without-rebasing sub-schema leaves dangling. No published schema may carry one.
             failures += SchemaArm(tools);
         }
         catch (Exception ex)
@@ -565,7 +564,8 @@ public static class BindingShimProbe
     };
 
     /// <summary>The published-schema arm (W3): the SPEC §5.1 <c>@file</c> union on the JsonElement-typed list
-    /// parameters, plus the same-document-pointer invariant every tool's schema must satisfy.</summary>
+    /// parameters, the no-same-document-<c>$ref</c> invariant every tool's schema must satisfy (#451), and the
+    /// bounded inline expansion that keeps the recursive shape legible once the pointers are gone.</summary>
     static int SchemaArm(JsonElement toolsList)
     {
         int failures = 0;
@@ -608,18 +608,49 @@ public static class BindingShimProbe
             }
         }
 
-        // GENERIC: every same-document $ref in every published schema must resolve. This is what catches a
-        // generated sub-schema nested without rebasing its pointers.
-        var dangling = new List<string>();
+        // GENERIC (#451): no published schema carries a same-document $ref at all. Strict providers reject a
+        // recursive schema and refuse the WHOLE server at tools/list, and the StructInput -> NestedSet.compose
+        // chain published one on five tools. ToolSchemas.FlattenRefs inlines every pointer that resolves and
+        // leaves the ones that do not, so this single arm catches both recursion that escaped the pass and the
+        // un-rebased pointer the old dangling-$ref sweep watched for (which this replaces, strictly stronger).
+        var refs = new List<string>();
         foreach (var t in toolsList.GetProperty("tools").EnumerateArray())
         {
             if (!t.TryGetProperty("inputSchema", out var schema)) continue;
             var name = t.GetProperty("name").GetString()!;
             foreach (var r in CollectRefs(schema))
-                if (!PointerResolves(schema, r)) dangling.Add($"{name}: {r}");
+                if (r.StartsWith('#')) refs.Add($"{name}: {r} {(PointerResolves(schema, r) ? "(resolves)" : "(DANGLING)")}");
         }
-        failures += Check($"SCHEMA: every same-document $ref in every published tool schema resolves ({dangling.Count} dangling)",
-            dangling.Count == 0, string.Join(" | ", dangling.Take(5)));
+        failures += Check($"SCHEMA: no published tool schema carries a same-document $ref ({refs.Count} found)",
+            refs.Count == 0, string.Join(" | ", refs.Take(5)));
+
+        // The recursion is EXPANDED, not amputated. Deleting the recursive branch would satisfy the arm above
+        // while silently telling callers a nested compose is not a thing — so walk the chain that carried the
+        // $ref and require a real object schema at each level, then the open node at the bound.
+        JsonElement applySchema = default;
+        foreach (var t in toolsList.GetProperty("tools").EnumerateArray())
+            if (t.GetProperty("name").GetString() == "housecarl_apply") { applySchema = t.GetProperty("inputSchema"); break; }
+
+        const string composeStep = "/properties/sets/items/properties/compose";
+        var chain = "#/properties/ops/anyOf/0/items/properties/compose";
+        for (var level = 1; level <= 3; level++)
+        {
+            var node = Pointer(applySchema, chain);
+            var concrete = node is { ValueKind: JsonValueKind.Object } n
+                        && n.TryGetProperty("properties", out var mem)
+                        && mem.TryGetProperty("type", out _) && mem.TryGetProperty("sets", out _);
+            failures += Check($"SCHEMA: housecarl_apply ops= spells the compose chain out concretely at nesting level {level}",
+                concrete, node?.GetRawText() ?? "pointer does not resolve");
+            chain += composeStep;
+        }
+        var bound = Pointer(applySchema, "#/properties/ops/anyOf/0/items/properties/compose"
+                                       + composeStep + composeStep + "/properties/sets");
+        failures += Check("SCHEMA: at the bound the chain closes on an OPEN node — typed, unconstrained, and saying so",
+            bound is { ValueKind: JsonValueKind.Object } b
+            && b.TryGetProperty("type", out _) && !b.TryGetProperty("items", out _)
+            && b.TryGetProperty("description", out var boundDesc)
+            && boundDesc.GetString()!.Contains("Nesting continues", StringComparison.Ordinal),
+            bound?.GetRawText() ?? "pointer does not resolve");
         return failures;
     }
 
@@ -642,28 +673,31 @@ public static class BindingShimProbe
         }
     }
 
-    /// <summary>Walk a same-document JSON pointer ("#/a/b/0"). Anything not starting with '#' is external and
-    /// counts as resolvable — this arm polices the pointers we rebase, not the whole of JSON Schema.</summary>
+    /// <summary>Anything not starting with '#' is external and counts as resolvable — these arms police the
+    /// pointers we rebase, not the whole of JSON Schema.</summary>
     static bool PointerResolves(JsonElement root, string reference)
+        => !reference.StartsWith('#') || Pointer(root, reference) is not null;
+
+    /// <summary>Walk a same-document JSON pointer ("#/a/b/0"), or null where it does not resolve.</summary>
+    static JsonElement? Pointer(JsonElement root, string reference)
     {
-        if (!reference.StartsWith('#')) return true;
         var cur = root;
         foreach (var raw in reference[1..].Split('/', StringSplitOptions.RemoveEmptyEntries))
         {
             var seg = raw.Replace("~1", "/").Replace("~0", "~");
             if (cur.ValueKind == JsonValueKind.Object)
             {
-                if (!cur.TryGetProperty(seg, out var next)) return false;
+                if (!cur.TryGetProperty(seg, out var next)) return null;
                 cur = next;
             }
             else if (cur.ValueKind == JsonValueKind.Array)
             {
-                if (!int.TryParse(seg, out var i) || i < 0 || i >= cur.GetArrayLength()) return false;
+                if (!int.TryParse(seg, out var i) || i < 0 || i >= cur.GetArrayLength()) return null;
                 cur = cur[i];
             }
-            else return false;
+            else return null;
         }
-        return true;
+        return cur;
     }
 
     /// <summary>Compute the activation census from the served tools/list and diff it against

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
+using HousecarlMcp;
 
 namespace HousecarlGenerator;
 
@@ -608,100 +610,182 @@ public static class BindingShimProbe
             }
         }
 
-        // GENERIC (#451): no published schema carries a same-document $ref at all. Strict providers reject a
-        // recursive schema and refuse the WHOLE server at tools/list, and the StructInput -> NestedSet.compose
-        // chain published one on five tools. ToolSchemas.FlattenRefs inlines every pointer that resolves and
-        // leaves the ones that do not, so this single arm catches both recursion that escaped the pass and the
-        // un-rebased pointer the old dangling-$ref sweep watched for (which this replaces, strictly stronger).
+        // GENERIC (#451) — THE INVARIANT: zero $ref members anywhere in any published schema, whatever they hold.
+        // Strict providers reject a recursive schema and refuse the WHOLE server at tools/list, naming no tool, and
+        // the StructInput -> NestedSet.compose chain published one on five tools.
+        //
+        // The predicate is deliberately WIDER than the flattener's, and shares no code with it: ToolSchemas gates
+        // inlining on a same-document pointer (a string starting with '#') because that is what it knows how to
+        // resolve, and this arm asks only whether the MEMBER is there. Spelling them the same way is what made the
+        // earlier version of this arm vacuous — a $ref the pass could not resolve was also a $ref the detector
+        // could not see, so an anchor-form {"$ref":"Node"} injected into all 51 schemas passed green. A detector
+        // that inherits the subject's blind spot measures nothing at the only moment it matters. This one still
+        // reports whether a survivor resolves, as detail, because that says which failure it is: a pointer the
+        // pass left behind (a broken rebase) or a spelling it never understood.
         var refs = new List<string>();
         foreach (var t in toolsList.GetProperty("tools").EnumerateArray())
         {
             if (!t.TryGetProperty("inputSchema", out var schema)) continue;
             var name = t.GetProperty("name").GetString()!;
-            foreach (var r in CollectRefs(schema))
-                if (r.StartsWith('#')) refs.Add($"{name}: {r} {(PointerResolves(schema, r) ? "(resolves)" : "(DANGLING)")}");
+            foreach (var (path, value) in CollectRefMembers(schema, "#"))
+            {
+                var note = value.ValueKind != JsonValueKind.String ? "(NON-STRING)"
+                    : PointerResolves(schema, value.GetString()!) ? "(resolves)" : "(DANGLING)";
+                refs.Add($"{name}: {path} = {Trunc(value)} {note}");
+            }
         }
-        failures += Check($"SCHEMA: no published tool schema carries a same-document $ref ({refs.Count} found)",
+        failures += Check($"SCHEMA: no published tool schema carries a $ref member, in any spelling ({refs.Count} found)",
             refs.Count == 0, string.Join(" | ", refs.Take(5)));
 
-        // The recursion is EXPANDED, not amputated. Deleting the recursive branch would satisfy the arm above
-        // while silently telling callers a nested compose is not a thing — so walk each chain that carried a
-        // $ref and require a real object schema at every level, then the open node where it closes.
-        JsonElement applySchema = default;
-        foreach (var t in toolsList.GetProperty("tools").EnumerateArray())
-            if (t.GetProperty("name").GetString() == "housecarl_apply") { applySchema = t.GetProperty("inputSchema"); break; }
+        // ANTI-AMPUTATION / ANTI-EXPANSION, over subjects DERIVED from the pre-flatten surface at guard time.
+        // The invariant above is satisfied just as well by DELETING every recursive branch, which would tell
+        // callers a nested compose is not a thing — a narrowing of the published contract with nothing to notice.
+        // So every site that carried a $ref before the pass must still be spelled out after it.
+        //
+        // No tool and no arm is named here (#451, "derive, don't enumerate"). The earlier version walked
+        // housecarl_apply only; four of the five ref-carrying tools had no expansion arm at all, so a bound of 0
+        // applied to their subtree collapsed their compose/fields/ctor_args/sets to bare open nodes with both
+        // guards fully green. The subject set is now an OUTPUT of the surface: it shrinks by itself when the 2.0
+        // demolition deletes the three 1.x ref-carrying tools, where a hand-list would have gone stale and passed.
+        //
+        // PreFlattenSurface reads the raw generated schemas; the @file union pass is replayed here because the
+        // published document has it and the pointers must line up. FlattenRefs replaces each ref node IN PLACE,
+        // so a pre-flatten ref path is the same path in the published document — that is what makes the subjects
+        // portable across the two surfaces.
+        var subjects = 0;
+        var recursive = 0;
+        var carriers = new List<string>();
 
-        // BOTH recursive arms, and no depth hardcoded to a named one. ApplyOp carries `compose` AND `composes`,
-        // which reference the same pointer, so the arm the generator reaches first spends budget the other then
-        // lacks: today `compose` publishes three concrete levels and `composes` two. WHICH arm gets which is C#
-        // member declaration ORDER, not the bound — so pinning a named arm at a fixed level reports amputation on
-        // a pure member reorder, and leaves the shallower arm measured by nothing. The order-free facts: every arm
-        // is concrete for at least two levels, every arm closes on the open node, and the levels across the arms
-        // total five (MaxSelfExpansions = 1 spent once per arm over one shared pointer).
-        var depths = new List<int>();
-        foreach (var (arm, start) in new[]
+        foreach (var tool in PreFlattenSurface.Read())
         {
-            ("compose",  "#/properties/ops/anyOf/0/items/properties/compose"),
-            ("composes", "#/properties/ops/anyOf/0/items/properties/composes/items"),
-        })
-        {
-            var (levels, closedOpen, detail) = WalkComposeChain(applySchema, start);
-            depths.Add(levels);
-            failures += Check($"SCHEMA: housecarl_apply ops= spells the {arm} chain out concretely (>= 2 levels, got {levels})",
-                levels >= 2, detail);
-            failures += Check($"SCHEMA: the {arm} chain closes on an OPEN node — typed, unconstrained, and saying so",
-                closedOpen, detail);
+            var pre = (JsonObject)tool.Schema.DeepClone();
+            var unions = ToolSchemas.FileListParams.Where(p => p.Tool == tool.Name).ToList();
+            if (unions.Count > 0) ToolSchemas.RewriteFileListUnions(pre, unions);
+
+            var sites = PreFlattenSurface.RefNodes(pre);
+            if (sites.Count == 0) continue;
+            carriers.Add($"{tool.Name}:{sites.Count}");
+
+            JsonElement published = default;
+            var found = false;
+            foreach (var t in toolsList.GetProperty("tools").EnumerateArray())
+                if (t.GetProperty("name").GetString() == tool.Name)
+                { published = t.GetProperty("inputSchema"); found = true; break; }
+            failures += Check($"SCHEMA: {tool.Name} carries {sites.Count} pre-flatten $ref sites and is published",
+                found, "tool absent from tools/list");
+            if (!found) continue;
+
+            // The recursion STEP, derived: the one site whose pointer is a prefix of its own path is a positional
+            // back-reference to an ancestor, and the path segment between them IS one turn of the cycle. Every site
+            // aiming at that same pointer re-enters the same shape, whichever member the generator reached first —
+            // so the walk below is indifferent to [JsonPropertyName] declaration order, which an earlier fixed-level
+            // pin was not (reordering ApplyOp.Compose/Composes made it report an amputation that had not happened).
+            string? step = null, cycle = null;
+            foreach (var (path, node) in sites)
+                if (node["$ref"]?.GetValue<string>() is { } p && path.Length > p.Length
+                    && path.StartsWith(p, StringComparison.Ordinal))
+                { step = path[p.Length..]; cycle = p; }
+            failures += Check($"SCHEMA: {tool.Name} — a recursion step is derivable from its own pre-flatten refs",
+                step is not null, "no $ref points at one of its own ancestors; the expansion arm has nothing to measure");
+
+            foreach (var (path, node) in sites)
+            {
+                subjects++;
+                var pubNode = Pointer(published, path);
+                failures += Check($"SCHEMA: {tool.Name} {Tail(path)} survives the pass spelled out, not amputated to an open node",
+                    pubNode is { ValueKind: JsonValueKind.Object } n && SpellsOutStructure(n),
+                    pubNode is { } got ? Trunc(got) : "<path does not resolve in the published schema>");
+
+                if (step is null || node["$ref"]?.GetValue<string>() != cycle) continue;
+                recursive++;
+                var (levels, closedOpen, detail) = WalkRecursion(published, path, step);
+                // The bound is a RULED value (decision record entry 15, Aaron: "keep 1"), spelled here independently
+                // of the constant on purpose: reading ToolSchemas.MaxSelfExpansions would make this arm agree with
+                // any bound, including the 0 that open-nodes the non-cyclic leaves too. Changing the bound reddens
+                // here, which is the point — it is a published-contract change and has to be re-ratified, not slid in.
+                failures += Check($"SCHEMA: {tool.Name} {Tail(path)} expands exactly 1 level before closing (the ruled bound; got {levels})",
+                    levels == 1, detail);
+                failures += Check($"SCHEMA: {tool.Name} {Tail(path)} closes on an OPEN node — typed, unconstrained, and saying nesting continues",
+                    closedOpen, detail);
+            }
         }
-        failures += Check($"SCHEMA: the two recursive arms share one pointer budget — concrete levels total 5 (got {string.Join("+", depths)})",
-            depths.Sum() == 5, string.Join("+", depths));
+
+        // A derivation that finds nothing is a broken derivation, never a pass: without these two, every arm above
+        // is vacuously green the moment PreFlattenSurface stops returning what it is supposed to.
+        failures += Check($"SCHEMA: the derived subject set is non-empty — {subjects} pre-flatten $ref sites across {carriers.Count} tools [{string.Join(" ", carriers)}]",
+            subjects > 0, "the pre-flatten surface yielded no $ref sites at all");
+        failures += Check($"SCHEMA: at least one derived subject is recursive ({recursive} of {subjects})",
+            recursive > 0, "no site re-enters its own pointer; nothing measured the bound");
         return failures;
     }
 
-    /// <summary>Walk one published compose chain (struct → sets[] → compose → …) from <paramref name="start"/>,
-    /// counting the levels spelled out concretely and reporting whether it ends on the open node the bound writes.
-    /// Walks instead of pinning a depth, so it is indifferent to which recursive arm the generator reached first.</summary>
-    static (int Levels, bool ClosedOpen, string Detail) WalkComposeChain(JsonElement schema, string start)
+    /// <summary>True when a published node states structure rather than merely closing. <see cref="ToolSchemas"/>'s
+    /// terminator emits exactly a <c>type</c> and a <c>description</c>, so any member beyond those two is the node
+    /// still saying what it contains — which is what amputation removes.</summary>
+    static bool SpellsOutStructure(JsonElement node)
     {
-        var node = Pointer(schema, start);
+        foreach (var p in node.EnumerateObject())
+            if (p.Name is not ("type" or "description")) return true;
+        return false;
+    }
+
+    /// <summary>Walk one recursive chain from <paramref name="start"/> by repeatedly appending the derived
+    /// <paramref name="step"/>, counting the levels spelled out concretely and reporting whether it ends on the
+    /// open node the bound writes.</summary>
+    static (int Levels, bool ClosedOpen, string Detail) WalkRecursion(JsonElement schema, string start, string step)
+    {
         var levels = 0;
+        var cur = start;
         while (true)
         {
-            if (node is not { ValueKind: JsonValueKind.Object } n)
+            if (Pointer(schema, cur) is not { ValueKind: JsonValueKind.Object } node)
                 return (levels, false, $"level {levels + 1} does not resolve to an object schema");
-            if (!n.TryGetProperty("properties", out var members))
-                return (levels, false, $"level {levels + 1} is not spelled out concretely: {Trunc(n)}");
-            if (!members.TryGetProperty("type", out _) || !members.TryGetProperty("sets", out var sets))
-                return (levels, false, $"level {levels + 1} is missing type=/sets=: {Trunc(n)}");
-            levels++;
-            if (!sets.TryGetProperty("items", out var items))
+            if (!SpellsOutStructure(node))
                 return (levels,
-                    sets.TryGetProperty("type", out _)
-                    && sets.TryGetProperty("description", out var d)
+                    node.TryGetProperty("type", out _)
+                    && node.TryGetProperty("description", out var d)
                     && d.GetString()?.Contains("Nesting continues", StringComparison.Ordinal) == true,
-                    $"closing node after {levels} levels: {Trunc(sets)}");
-            if (!items.TryGetProperty("properties", out var element) || !element.TryGetProperty("compose", out var next))
-                return (levels, false, $"the sets= element at level {levels} carries no compose=: {Trunc(items)}");
-            node = next;
+                    $"closed at level {levels + 1}: {Trunc(node)}");
+            levels++;
+            cur += step;
+            // The bound exists so this terminates; an unbounded chain is a finding, not a hang.
+            if (levels > 8) return (levels, false, $"still concrete at level {levels} — the chain is not closing");
         }
+    }
+
+    /// <summary>The tail of a JSON pointer, for labels that stay readable at 100-odd characters of path.</summary>
+    static string Tail(string pointer)
+    {
+        var parts = pointer.Split('/');
+        return parts.Length <= 4 ? pointer : ".../" + string.Join("/", parts[^4..]);
     }
 
     static string Trunc(JsonElement e) { var s = e.GetRawText(); return s.Length > 240 ? s[..240] + "…" : s; }
 
-    /// <summary>Every <c>$ref</c> string anywhere in a schema document.</summary>
-    static IEnumerable<string> CollectRefs(JsonElement node)
+    /// <summary>Every <c>$ref</c> MEMBER anywhere in a schema document, by pointer, with what it holds.
+    /// <para>No filter on the value: a non-string <c>$ref</c>, a plain-name anchor, an external URI and a
+    /// same-document pointer all count the same, because the invariant is about the member being there at all.
+    /// The predecessor yielded only string values and the caller then kept only those starting with '#' — the
+    /// same test <see cref="ToolSchemas"/> gates inlining on, which is exactly why anything the pass could not
+    /// resolve was also invisible to the arm policing it.</para></summary>
+    static IEnumerable<(string Path, JsonElement Value)> CollectRefMembers(JsonElement node, string path)
     {
         switch (node.ValueKind)
         {
             case JsonValueKind.Object:
                 foreach (var p in node.EnumerateObject())
                 {
-                    if (p.Name == "$ref" && p.Value.ValueKind == JsonValueKind.String) yield return p.Value.GetString()!;
-                    else foreach (var r in CollectRefs(p.Value)) yield return r;
+                    if (p.Name == "$ref") yield return (path, p.Value);
+                    foreach (var r in CollectRefMembers(p.Value, $"{path}/{p.Name}")) yield return r;
                 }
                 break;
             case JsonValueKind.Array:
+                var i = 0;
                 foreach (var item in node.EnumerateArray())
-                    foreach (var r in CollectRefs(item)) yield return r;
+                {
+                    foreach (var r in CollectRefMembers(item, $"{path}/{i}")) yield return r;
+                    i++;
+                }
                 break;
         }
     }

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -625,34 +625,67 @@ public static class BindingShimProbe
             refs.Count == 0, string.Join(" | ", refs.Take(5)));
 
         // The recursion is EXPANDED, not amputated. Deleting the recursive branch would satisfy the arm above
-        // while silently telling callers a nested compose is not a thing — so walk the chain that carried the
-        // $ref and require a real object schema at each level, then the open node at the bound.
+        // while silently telling callers a nested compose is not a thing — so walk each chain that carried a
+        // $ref and require a real object schema at every level, then the open node where it closes.
         JsonElement applySchema = default;
         foreach (var t in toolsList.GetProperty("tools").EnumerateArray())
             if (t.GetProperty("name").GetString() == "housecarl_apply") { applySchema = t.GetProperty("inputSchema"); break; }
 
-        const string composeStep = "/properties/sets/items/properties/compose";
-        var chain = "#/properties/ops/anyOf/0/items/properties/compose";
-        for (var level = 1; level <= 3; level++)
+        // BOTH recursive arms, and no depth hardcoded to a named one. ApplyOp carries `compose` AND `composes`,
+        // which reference the same pointer, so the arm the generator reaches first spends budget the other then
+        // lacks: today `compose` publishes three concrete levels and `composes` two. WHICH arm gets which is C#
+        // member declaration ORDER, not the bound — so pinning a named arm at a fixed level reports amputation on
+        // a pure member reorder, and leaves the shallower arm measured by nothing. The order-free facts: every arm
+        // is concrete for at least two levels, every arm closes on the open node, and the levels across the arms
+        // total five (MaxSelfExpansions = 1 spent once per arm over one shared pointer).
+        var depths = new List<int>();
+        foreach (var (arm, start) in new[]
         {
-            var node = Pointer(applySchema, chain);
-            var concrete = node is { ValueKind: JsonValueKind.Object } n
-                        && n.TryGetProperty("properties", out var mem)
-                        && mem.TryGetProperty("type", out _) && mem.TryGetProperty("sets", out _);
-            failures += Check($"SCHEMA: housecarl_apply ops= spells the compose chain out concretely at nesting level {level}",
-                concrete, node?.GetRawText() ?? "pointer does not resolve");
-            chain += composeStep;
+            ("compose",  "#/properties/ops/anyOf/0/items/properties/compose"),
+            ("composes", "#/properties/ops/anyOf/0/items/properties/composes/items"),
+        })
+        {
+            var (levels, closedOpen, detail) = WalkComposeChain(applySchema, start);
+            depths.Add(levels);
+            failures += Check($"SCHEMA: housecarl_apply ops= spells the {arm} chain out concretely (>= 2 levels, got {levels})",
+                levels >= 2, detail);
+            failures += Check($"SCHEMA: the {arm} chain closes on an OPEN node — typed, unconstrained, and saying so",
+                closedOpen, detail);
         }
-        var bound = Pointer(applySchema, "#/properties/ops/anyOf/0/items/properties/compose"
-                                       + composeStep + composeStep + "/properties/sets");
-        failures += Check("SCHEMA: at the bound the chain closes on an OPEN node — typed, unconstrained, and saying so",
-            bound is { ValueKind: JsonValueKind.Object } b
-            && b.TryGetProperty("type", out _) && !b.TryGetProperty("items", out _)
-            && b.TryGetProperty("description", out var boundDesc)
-            && boundDesc.GetString()!.Contains("Nesting continues", StringComparison.Ordinal),
-            bound?.GetRawText() ?? "pointer does not resolve");
+        failures += Check($"SCHEMA: the two recursive arms share one pointer budget — concrete levels total 5 (got {string.Join("+", depths)})",
+            depths.Sum() == 5, string.Join("+", depths));
         return failures;
     }
+
+    /// <summary>Walk one published compose chain (struct → sets[] → compose → …) from <paramref name="start"/>,
+    /// counting the levels spelled out concretely and reporting whether it ends on the open node the bound writes.
+    /// Walks instead of pinning a depth, so it is indifferent to which recursive arm the generator reached first.</summary>
+    static (int Levels, bool ClosedOpen, string Detail) WalkComposeChain(JsonElement schema, string start)
+    {
+        var node = Pointer(schema, start);
+        var levels = 0;
+        while (true)
+        {
+            if (node is not { ValueKind: JsonValueKind.Object } n)
+                return (levels, false, $"level {levels + 1} does not resolve to an object schema");
+            if (!n.TryGetProperty("properties", out var members))
+                return (levels, false, $"level {levels + 1} is not spelled out concretely: {Trunc(n)}");
+            if (!members.TryGetProperty("type", out _) || !members.TryGetProperty("sets", out var sets))
+                return (levels, false, $"level {levels + 1} is missing type=/sets=: {Trunc(n)}");
+            levels++;
+            if (!sets.TryGetProperty("items", out var items))
+                return (levels,
+                    sets.TryGetProperty("type", out _)
+                    && sets.TryGetProperty("description", out var d)
+                    && d.GetString()?.Contains("Nesting continues", StringComparison.Ordinal) == true,
+                    $"closing node after {levels} levels: {Trunc(sets)}");
+            if (!items.TryGetProperty("properties", out var element) || !element.TryGetProperty("compose", out var next))
+                return (levels, false, $"the sets= element at level {levels} carries no compose=: {Trunc(items)}");
+            node = next;
+        }
+    }
+
+    static string Trunc(JsonElement e) { var s = e.GetRawText(); return s.Length > 240 ? s[..240] + "…" : s; }
 
     /// <summary>Every <c>$ref</c> string anywhere in a schema document.</summary>
     static IEnumerable<string> CollectRefs(JsonElement node)

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -150,8 +150,10 @@ public static class CiAll
         ("bulk-create-guard", BulkCreateGuardProbe.RunGuard),
         ("create-abstract-group-guard", CreateGlobalProbe.RunGuard),
         ("binding-shim-guard", BindingShimProbe.RunGuard),
-        // The $ref-flattening mechanism (#451), over synthetic documents — the shapes the real published surface
-        // cannot produce. The invariant on the real surface is binding-shim-guard's SCHEMA arm.
+        // The $ref-flattening mechanism (#451): synthetic documents for the shapes the real published surface
+        // cannot produce, the real strict reader for the terminator's accept claim (ARM 6), and every registered
+        // tool's real pre-flatten schema for the emission grammar (ARM 7). The invariant on the served surface is
+        // binding-shim-guard's SCHEMA arms.
         ("schema-flatten-guard", SchemaFlattenProbe.RunGuard),
         ("alias-layer-guard", AliasLayerProbe.RunGuard),
         ("snapshot-view-guard", SnapshotViewProbe.RunGuard),

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -150,6 +150,9 @@ public static class CiAll
         ("bulk-create-guard", BulkCreateGuardProbe.RunGuard),
         ("create-abstract-group-guard", CreateGlobalProbe.RunGuard),
         ("binding-shim-guard", BindingShimProbe.RunGuard),
+        // The $ref-flattening mechanism (#451), over synthetic documents — the shapes the real published surface
+        // cannot produce. The invariant on the real surface is binding-shim-guard's SCHEMA arm.
+        ("schema-flatten-guard", SchemaFlattenProbe.RunGuard),
         ("alias-layer-guard", AliasLayerProbe.RunGuard),
         ("snapshot-view-guard", SnapshotViewProbe.RunGuard),
         // Epoch fingerprint (tool-surface 2.0 W1, SPEC §2.1.1): the captured-index build identity — deterministic

--- a/src/housecarl-generator/PreFlattenSurface.cs
+++ b/src/housecarl-generator/PreFlattenSurface.cs
@@ -1,0 +1,81 @@
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Server;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// The tool surface as the SDK's schema generator emits it, BEFORE <see cref="ToolSchemas.PublishSchemas"/> runs —
+/// the real input to both published-schema passes, read the way the server gets it.
+///
+/// <para>Why it exists: a guard whose claim is about a POPULATION must read that population, not a hand-written
+/// stand-in for it. Both callers previously named their subjects — the expansion arm walked one of the five
+/// ref-carrying tools, and the emission-grammar arm re-derived standalone schemas for six hand-named DTO types
+/// instead of reading the SDK emission path its claim is about. Deriving the subject set here makes the guards'
+/// coverage a consequence of the surface rather than of who remembered to update a list (#451, the
+/// derive-don't-enumerate ruling).</para>
+///
+/// <para>The registration deliberately mirrors <c>Program.AddMcp</c>'s scan line and stops there: no transport,
+/// no server identity, and above all no <see cref="ToolSchemas.PublishSchemas"/>, because that pass mutates
+/// <c>InputSchema</c> in place and would leave nothing pre-flatten to read. This container is its own, so the
+/// server's own registration is untouched either way.</para>
+/// </summary>
+internal static class PreFlattenSurface
+{
+    /// <summary>One tool's name and its raw generated input schema (a fresh parse — callers may mutate it).</summary>
+    internal readonly record struct Tool(string Name, JsonObject Schema);
+
+    /// <summary>Every registered tool's pre-flatten schema, in registration order. Throws rather than returning
+    /// empty: a derivation that finds no tools is a broken derivation, and every arm built on it would pass
+    /// vacuously.</summary>
+    internal static IReadOnlyList<Tool> Read()
+    {
+        var services = new ServiceCollection();
+        services.AddMcpServer().WithToolsFromAssembly(typeof(ToolSchemas).Assembly);
+        using var provider = services.BuildServiceProvider();
+
+        var tools = provider.GetRequiredService<IOptions<McpServerOptions>>().Value.ToolCollection
+            ?? throw new InvalidOperationException(
+                "PreFlattenSurface: the MCP options carry no ToolCollection — the assembly scan did not run.");
+
+        var list = new List<Tool>();
+        foreach (var tool in tools)
+        {
+            if (JsonNode.Parse(tool.ProtocolTool.InputSchema.GetRawText()) is not JsonObject schema)
+                throw new InvalidOperationException(
+                    $"PreFlattenSurface: {tool.ProtocolTool.Name}'s generated schema is not a JSON object.");
+            list.Add(new Tool(tool.ProtocolTool.Name, schema));
+        }
+
+        if (list.Count == 0)
+            throw new InvalidOperationException(
+                "PreFlattenSurface: the assembly scan registered no tools.");
+        return list;
+    }
+
+    /// <summary>Every object carrying a <c>$ref</c> member, by JSON pointer, in <paramref name="root"/>.
+    /// Collects the MEMBER wherever it appears and whatever it holds — no pointer-form test, no resolve test —
+    /// so a spelling neither pass understands is still counted rather than silently skipped.</summary>
+    internal static List<(string Path, JsonObject Node)> RefNodes(JsonObject root)
+    {
+        var found = new List<(string, JsonObject)>();
+        Walk(root, "#");
+        return found;
+
+        void Walk(JsonNode? node, string path)
+        {
+            switch (node)
+            {
+                case JsonObject obj:
+                    if (obj.ContainsKey("$ref")) found.Add((path, obj));
+                    foreach (var kv in obj.ToList()) Walk(kv.Value, $"{path}/{kv.Key}");
+                    break;
+                case JsonArray arr:
+                    for (var i = 0; i < arr.Count; i++) Walk(arr[i], $"{path}/{i}");
+                    break;
+            }
+        }
+    }
+}

--- a/src/housecarl-generator/SchemaFlattenProbe.cs
+++ b/src/housecarl-generator/SchemaFlattenProbe.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using HousecarlMcp;
 
@@ -44,6 +45,7 @@ public static class SchemaFlattenProbe
         MutualRecursionArm();
         SiblingArm();
         UnresolvableArm();
+        TerminatorSentenceArm();
 
         Console.WriteLine();
         Console.WriteLine($"=== schema-flatten-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
@@ -147,5 +149,53 @@ public static class SchemaFlattenProbe
         Check("…and it did not stop the resolvable one beside it from being inlined",
             doc["properties"]?["fine"]?["type"]?.GetValue<string>() == "string",
             doc["properties"]?["fine"]?.ToJsonString());
+    }
+
+    /// <summary>The terminator writes a SENTENCE into the published schema — "nesting continues below this level
+    /// … it is accepted but not spelled out again here". That is a claim about what the caller may send, so it is
+    /// measured rather than asserted: the strict element reader the ToolSchemas header names is driven with a
+    /// compose chain nested well past any bound, and the innermost node must survive the read intact.
+    /// <para>There is no wire-side twin, deliberately: <c>ops</c> is declared <c>JsonElement</c>, so the SDK binder
+    /// accepts any shape at any depth and an arm over it could not fail. This reader IS the gate. Nor does either
+    /// check claim the deep struct is SEMANTICALLY buildable — that is content, decided by the engine, and a
+    /// refusal about it names the content.</para></summary>
+    static void TerminatorSentenceArm()
+    {
+        Console.WriteLine("── ARM 6: the sentence the terminator publishes is true of the reader ──");
+
+        // 6 levels of compose: three past where the schema stops spelling the shape out.
+        var (ops, innermost) = DeepComposeOps(6);
+        var (items, error) = ListParams.Read<ApplyOp>(
+            JsonDocument.Parse(ops).RootElement, "ops", "{formid, field_path, …}");
+
+        Check("a compose nested past the bound is READ, not refused on its shape", error is null, error);
+
+        var node = items?[0].Compose;
+        for (var level = 1; level < 6 && node is not null; level++) node = node.Sets?[0].Compose;
+        Check($"…and the innermost level survives the read intact (type '{innermost}')",
+            node?.Type == innermost, node?.Type ?? "<the chain did not reach level 6>");
+
+        // Past the JSON reader's OWN depth ceiling (STJ's MaxDepth, shared by the transport parse) the read must
+        // still fail loudly. Parsed with headroom here so the READER is what answers rather than this probe's parse.
+        var (past, _) = DeepComposeOps(30);
+        var wide = JsonDocument.Parse(past, new JsonDocumentOptions { MaxDepth = 512 }).RootElement;
+        var (deepItems, deepError) = ListParams.Read<ApplyOp>(wide, "ops", "{formid, field_path, …}");
+        Check("past the reader's own depth ceiling it is a NAMED refusal, never a silent truncation",
+            deepItems is null && deepError is not null && deepError.StartsWith("ops could not be parsed", StringComparison.Ordinal),
+            deepError ?? "<read succeeded — the ceiling moved, so the arm below is measuring nothing>");
+        Check("…and that refusal points AT the nesting it stopped on, not just at the call",
+            deepError?.Contains("compose.sets[0].compose", StringComparison.Ordinal) == true, deepError);
+    }
+
+    /// <summary>One <c>ops</c> array whose single op carries <paramref name="levels"/> of nested compose, each
+    /// level's type naming its own depth so the innermost is identifiable. Returns the JSON and that type name.</summary>
+    internal static (string Json, string InnermostType) DeepComposeOps(int levels)
+    {
+        var innermost = "Level" + levels;
+        var compose = "{\"type\":\"" + innermost + "\",\"fields\":{\"Number\":\"1\"}}";
+        for (var level = levels - 1; level >= 1; level--)
+            compose = "{\"type\":\"Level" + level + "\",\"sets\":[{\"path\":\"Data\",\"compose\":" + compose + "}]}";
+        return ("[{\"formid\":\"012E46:Skyrim.esm\",\"field_path\":\"Ranks\",\"op\":\"Add\",\"compose\":" + compose + "}]",
+                innermost);
     }
 }

--- a/src/housecarl-generator/SchemaFlattenProbe.cs
+++ b/src/housecarl-generator/SchemaFlattenProbe.cs
@@ -218,7 +218,9 @@ public static class SchemaFlattenProbe
             deepError?.Contains("compose.sets[0].compose", StringComparison.Ordinal) == true, deepError);
     }
 
-    /// <summary>ARM 7 — the EMISSION GRAMMAR the pass depends on, over the real pre-flatten generated surface.
+    /// <summary>ARM 7 — the EMISSION GRAMMAR the pass depends on, over the real pre-flatten generated surface:
+    /// every registered tool's <c>ProtocolTool.InputSchema</c> as the SDK's assembly scan produced it, which is
+    /// the exact input <see cref="ToolSchemas.PublishSchemas"/> reads.
     /// <para>Everything the narrowed contract on <see cref="ToolSchemas"/> declares out of scope is safe only
     /// because this generator does not emit it. That is a precondition, and before this arm it was held by review
     /// attention alone — which never carries a completeness claim. So assert the grammar itself: no <c>$defs</c>,
@@ -226,6 +228,14 @@ public static class SchemaFlattenProbe
     /// rule was written for, every target an object schema, and no <c>$ref</c>-shaped value in a NON-schema
     /// position. A generator that drifts on an SDK bump — the shape that would resurrect #451's outage class, or
     /// worse, silently mis-normalize a published schema — goes RED here rather than at a user's server start.</para>
+    /// <para>The subjects are the SURFACE, not a list (#451, "derive, don't enumerate"). This arm used to re-derive
+    /// standalone schemas for six hand-named DTO types through its own <c>CreateJsonSchema</c> call — a second
+    /// emission that resembled the real one but was not it, so the drift claim above was never established for the
+    /// path that actually drifts, and a seventh DTO would have been covered by nobody. Reading the registered tools
+    /// makes coverage a consequence of registration.</para>
+    /// <para>Results are aggregated per grammar rule rather than per subject: 51 tools would otherwise print
+    /// hundreds of near-identical lines, and a rule that holds over the whole population is one claim. Each rule
+    /// names its violators, and the population it ran over is stated so an empty sweep cannot read as a pass.</para>
     /// <para>Deliberately NOT paired with runtime fail-safe handling: catching a malformed emission and publishing
     /// the schema unflattened would trade a loud failure for quietly republishing the recursive form (Q3).</para></summary>
     static void EmissionGrammarArm()
@@ -233,48 +243,85 @@ public static class SchemaFlattenProbe
         Console.WriteLine("── ARM 7: the generator emission grammar the pass depends on ──");
 
         var nonSchema = new[] { "default", "enum", "const", "examples" };
-        foreach (var type in new[]
+        var withDefs = new List<string>();
+        var inValuePosition = new List<string>();
+        var notPointerForm = new List<string>();
+        var badTokens = new List<string>();
+        var extraMembers = new List<string>();
+        var realItems = new List<string>();
+        var nonObjectTarget = new List<string>();
+
+        var tools = PreFlattenSurface.Read();
+        var refSites = 0;
+        var rawSites = 0;
+
+        foreach (var tool in tools)
         {
-            typeof(ApplyOp[]), typeof(Assignment[]), typeof(CreateRecordSpec[]),
-            typeof(CreateFieldOp[]), typeof(StructInput), typeof(NestedSet),
-        })
-        {
-            var raw = AIJsonUtilities.CreateJsonSchema(type, serializerOptions: new(JsonSerializerDefaults.Web)).GetRawText();
-            if (JsonNode.Parse(raw) is not JsonObject doc) { Check($"{type.Name}: generated schema parses", false, raw); continue; }
+            // The grammar precondition is about what FlattenRefs READS, which is the document after the @file
+            // union pass — not the raw scan output. Two of the five ref-carrying tools (the ones whose list
+            // parameters are declared JsonElement) emit no $ref at all until RewriteFileListUnions generates
+            // their element-array arm, so a raw-only scan would leave 12 of the 30 sites the pass handles
+            // ungoverned, and would not see a $defs the union pass introduced either. Replaying the pass in the
+            // same order the server runs it is what makes this the real input rather than a resemblance of it.
+            var doc = (JsonObject)tool.Schema.DeepClone();
+            rawSites += PreFlattenSurface.RefNodes(tool.Schema).Count;
+            var unions = ToolSchemas.FileListParams.Where(p => p.Tool == tool.Name).ToList();
+            if (unions.Count > 0) ToolSchemas.RewriteFileListUnions(doc, unions);
 
             var refNodes = new List<(string Path, JsonObject Node)>();
             var valuePositionRefs = new List<string>();
             CollectRefNodes(doc, "#", null, nonSchema, refNodes, valuePositionRefs);
 
-            Check($"{type.Name}: the generator emits no $defs (the hoist path the pass carries stays dead)",
-                FindKey(doc, "$defs") is null, FindKey(doc, "$defs"));
-            Check($"{type.Name}: no $ref sits in a non-schema position (default/enum/const/examples)",
-                valuePositionRefs.Count == 0, string.Join(" | ", valuePositionRefs.Take(3)));
+            if (FindKey(doc, "$defs") is { } defs) withDefs.Add($"{tool.Name}: {defs}");
+            foreach (var v in valuePositionRefs) inValuePosition.Add($"{tool.Name} {v}");
 
             foreach (var (path, node) in refNodes)
             {
-                var pointer = node["$ref"];
-                var spelling = pointer is JsonValue v && v.TryGetValue<string>(out var s) ? s : null;
-                Check($"{type.Name} {path}: $ref is a STRING in pointer form (\"#/…\"), not a plain-name anchor",
-                    spelling is not null && (spelling == "#" || spelling.StartsWith("#/", StringComparison.Ordinal)),
-                    pointer?.ToJsonString() ?? "<absent>");
-                if (spelling is null) continue;
+                refSites++;
+                var where = $"{tool.Name} {path}";
+                var spelling = node["$ref"] is JsonValue v && v.TryGetValue<string>(out var s) ? s : null;
+                if (spelling is null || !(spelling == "#" || spelling.StartsWith("#/", StringComparison.Ordinal)))
+                {
+                    notPointerForm.Add($"{where} = {node["$ref"]?.ToJsonString() ?? "<absent>"}");
+                    continue;
+                }
 
                 var tokens = spelling.Length > 1 ? spelling[1..].Split('/') : [];
-                Check($"{type.Name} {path}: every reference token is non-empty and unescaped (Resolve tokenizes literally)",
-                    tokens.Skip(1).All(t => t.Length > 0 && !t.Contains('%') && !t.Contains('~')),
-                    spelling);
+                if (!tokens.Skip(1).All(t => t.Length > 0 && !t.Contains('%') && !t.Contains('~')))
+                    badTokens.Add($"{where} = {spelling}");
 
                 var extra = node.Select(kv => kv.Key).Where(k => k is not ("$ref" or "description" or "items")).ToList();
-                Check($"{type.Name} {path}: the ref node carries only the members the merge rule was written for",
-                    extra.Count == 0, string.Join(",", extra));
-                Check($"{type.Name} {path}: an items= sibling is the empty placeholder, never a real constraint",
-                    node["items"] is null or JsonObject { Count: 0 }, node["items"]?.ToJsonString());
-                Check($"{type.Name} {path}: the target resolves to an OBJECT schema, not a boolean schema",
-                    ToolSchemas.Resolve(doc, spelling) is JsonObject,
-                    ToolSchemas.Resolve(doc, spelling)?.ToJsonString() ?? "<does not resolve>");
+                if (extra.Count > 0) extraMembers.Add($"{where}: {string.Join(",", extra)}");
+
+                if (node["items"] is not (null or JsonObject { Count: 0 }))
+                    realItems.Add($"{where}: {node["items"]?.ToJsonString()}");
+
+                if (ToolSchemas.Resolve(doc, spelling) is not JsonObject)
+                    nonObjectTarget.Add($"{where} -> {ToolSchemas.Resolve(doc, spelling)?.ToJsonString() ?? "<does not resolve>"}");
             }
         }
+
+        // A grammar asserted over nothing is asserted over nothing. Both populations are stated and required
+        // non-empty: no tools means the surface read broke, and no ref sites means every per-site rule below
+        // passed without examining anything — which is the exact shape this arm was rebuilt to stop.
+        Check($"the pre-flatten surface yields the registered tools ({tools.Count} scanned)", tools.Count > 0);
+        Check($"…and they carry $ref sites for the per-site rules to run over ({refSites} in the pass's input; {rawSites} straight from the assembly scan, the rest added by the @file union pass)",
+            refSites > 0);
+
+        Check($"no tool's generated schema emits $defs — the hoist path the pass carries stays dead ({tools.Count} tools)",
+            withDefs.Count == 0, string.Join(" | ", withDefs.Take(3)));
+        Check($"no $ref sits in a non-schema position — default/enum/const/examples ({tools.Count} tools)",
+            inValuePosition.Count == 0, string.Join(" | ", inValuePosition.Take(3)));
+        Check($"every $ref is a STRING in pointer form (\"#/…\"), never a plain-name anchor ({refSites} sites)",
+            notPointerForm.Count == 0, string.Join(" | ", notPointerForm.Take(3)));
+        Check($"every reference token is non-empty and unescaped — Resolve tokenizes literally ({refSites} sites)",
+            badTokens.Count == 0, string.Join(" | ", badTokens.Take(3)));
+        Check($"every ref node carries only the members the merge rule was written for ({refSites} sites)",
+            extraMembers.Count == 0, string.Join(" | ", extraMembers.Take(3)));
+        Check($"every items= sibling is the empty placeholder, never a real constraint ({refSites} sites)",
+            realItems.Count == 0, string.Join(" | ", realItems.Take(3)));
+        Check($"every target resolves to an OBJECT schema, not a boolean schema ({refSites} sites)",
+            nonObjectTarget.Count == 0, string.Join(" | ", nonObjectTarget.Take(3)));
     }
 
     /// <summary>Every object carrying a <c>$ref</c>, split by whether it sits in a schema position or under a

--- a/src/housecarl-generator/SchemaFlattenProbe.cs
+++ b/src/housecarl-generator/SchemaFlattenProbe.cs
@@ -1,15 +1,22 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Microsoft.Extensions.AI;
 using HousecarlMcp;
 
 namespace HousecarlGenerator;
 
 /// <summary>
 /// REGRESSION GUARD for <see cref="ToolSchemas"/>'s <c>$ref</c> flattening (#451) — the MECHANISM, over synthetic
-/// documents. <c>binding-shim-guard</c>'s SCHEMA arm covers the invariant on the real published surface; that
-/// surface exercises only the one shape today's DTOs generate (a positional back-reference), so the cases below —
-/// <c>$defs</c> recursion, mutual recursion, the placeholder-sibling merge, an unresolvable pointer — have no
-/// end-to-end producer and would otherwise ship unproven.
+/// documents. <c>binding-shim-guard</c>'s SCHEMA arms cover the invariant on the real published surface, which
+/// exercises only the one shape today's DTOs generate (a positional back-reference carrying a description and an
+/// empty <c>items</c> placeholder). Three of the cases below — <c>$defs</c> recursion, mutual recursion, an
+/// unresolvable pointer — have no end-to-end producer and would otherwise ship unproven. The placeholder-sibling
+/// merge (ARM 4) DOES have one: 20 of the 30 pre-fix published refs carried that empty <c>items</c>, and deleting
+/// the merge reddens <c>binding-shim-guard</c> unaided. It is kept here because this is where the merge rule is
+/// stated, not because nothing else would catch it.
+///
+/// These arms pin the mechanism's stated behaviour; they do NOT establish general JSON Schema conformance. What is
+/// deliberately outside that behaviour is listed on <see cref="ToolSchemas"/>.
 ///
 /// Run: <c>dotnet run --project src/housecarl-generator schema-flatten-guard</c>
 /// </summary>
@@ -46,6 +53,7 @@ public static class SchemaFlattenProbe
         SiblingArm();
         UnresolvableArm();
         TerminatorSentenceArm();
+        EmissionGrammarArm();
 
         Console.WriteLine();
         Console.WriteLine($"=== schema-flatten-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
@@ -169,9 +177,10 @@ public static class SchemaFlattenProbe
     /// measured rather than asserted: the strict element reader the ToolSchemas header names is driven with a
     /// compose chain nested well past any bound, and the innermost node must survive the read intact.
     /// <para>There is no wire-side twin, deliberately: <c>ops</c> is declared <c>JsonElement</c>, so the SDK binder
-    /// accepts any shape at any depth and an arm over it could not fail. This reader IS the gate. Nor does either
-    /// check claim the deep struct is SEMANTICALLY buildable — that is content, decided by the engine, and a
-    /// refusal about it names the content.</para></summary>
+    /// is indifferent to the argument's SHAPE and an arm over that could not fail. (Not to its depth — see the
+    /// transport ceiling noted below.) This reader IS the gate. Nor does either check claim the deep struct is
+    /// SEMANTICALLY buildable — that is content, decided by the engine, and a refusal about it names the
+    /// content.</para></summary>
     static void TerminatorSentenceArm()
     {
         Console.WriteLine("── ARM 6: the sentence the terminator publishes is true of the reader ──");
@@ -190,11 +199,15 @@ public static class SchemaFlattenProbe
 
         // Past the JSON reader's OWN depth ceiling (STJ's MaxDepth) the read must still fail loudly. Parsed with
         // headroom here so the READER is what answers rather than this probe's parse.
-        // What this does NOT model, and a reader of this arm should not assume it does: in real wire flow a
-        // request that deep dies at the TRANSPORT parse first — measured on this branch, a default-options
-        // JsonDocument.Parse throws from ~21 compose levels — so the caller sees an SDK-voiced parse error, not
-        // the named refusal below. Both are loud, which is what the published sentence claims; only this one is
-        // ours. The gap is unreachable by real compose use (live composes nest 1–2).
+        // What this does NOT model, on the INLINE lane: a request nested that deep dies at the TRANSPORT parse
+        // first — measured, a default-options JsonDocument.Parse throws from ~21 compose levels — so an inline
+        // caller sees an SDK-voiced parse error, not the named refusal below. Both are loud, which is what the
+        // published sentence claims; only this one is ours.
+        // The refusal below is NOT unreachable, though, and this arm is not decoration: the @file lane never
+        // crosses the transport parse. ListParams.Read takes File.ReadAllText straight into the strict reader —
+        // what came over the wire was only the short "@<path>" string — so ops="@…" naming a manifest nested past
+        // STJ's MaxDepth of 64 lands on exactly this refusal. Deep composes are not idiomatic (live ones nest
+        // 1–2), but a generated manifest is where depth would come from, and that is the lane it arrives on.
         var (past, _) = DeepComposeOps(30);
         var wide = JsonDocument.Parse(past, new JsonDocumentOptions { MaxDepth = 512 }).RootElement;
         var (deepItems, deepError) = ListParams.Read<ApplyOp>(wide, "ops", "{formid, field_path, …}");
@@ -204,6 +217,98 @@ public static class SchemaFlattenProbe
         Check("…and that refusal points AT the nesting it stopped on, not just at the call",
             deepError?.Contains("compose.sets[0].compose", StringComparison.Ordinal) == true, deepError);
     }
+
+    /// <summary>ARM 7 — the EMISSION GRAMMAR the pass depends on, over the real pre-flatten generated surface.
+    /// <para>Everything the narrowed contract on <see cref="ToolSchemas"/> declares out of scope is safe only
+    /// because this generator does not emit it. That is a precondition, and before this arm it was held by review
+    /// attention alone — which never carries a completeness claim. So assert the grammar itself: no <c>$defs</c>,
+    /// every <c>$ref</c> in pointer form with faithful tokens, every ref node carrying only the members the merge
+    /// rule was written for, every target an object schema, and no <c>$ref</c>-shaped value in a NON-schema
+    /// position. A generator that drifts on an SDK bump — the shape that would resurrect #451's outage class, or
+    /// worse, silently mis-normalize a published schema — goes RED here rather than at a user's server start.</para>
+    /// <para>Deliberately NOT paired with runtime fail-safe handling: catching a malformed emission and publishing
+    /// the schema unflattened would trade a loud failure for quietly republishing the recursive form (Q3).</para></summary>
+    static void EmissionGrammarArm()
+    {
+        Console.WriteLine("── ARM 7: the generator emission grammar the pass depends on ──");
+
+        var nonSchema = new[] { "default", "enum", "const", "examples" };
+        foreach (var type in new[]
+        {
+            typeof(ApplyOp[]), typeof(Assignment[]), typeof(CreateRecordSpec[]),
+            typeof(CreateFieldOp[]), typeof(StructInput), typeof(NestedSet),
+        })
+        {
+            var raw = AIJsonUtilities.CreateJsonSchema(type, serializerOptions: new(JsonSerializerDefaults.Web)).GetRawText();
+            if (JsonNode.Parse(raw) is not JsonObject doc) { Check($"{type.Name}: generated schema parses", false, raw); continue; }
+
+            var refNodes = new List<(string Path, JsonObject Node)>();
+            var valuePositionRefs = new List<string>();
+            CollectRefNodes(doc, "#", null, nonSchema, refNodes, valuePositionRefs);
+
+            Check($"{type.Name}: the generator emits no $defs (the hoist path the pass carries stays dead)",
+                FindKey(doc, "$defs") is null, FindKey(doc, "$defs"));
+            Check($"{type.Name}: no $ref sits in a non-schema position (default/enum/const/examples)",
+                valuePositionRefs.Count == 0, string.Join(" | ", valuePositionRefs.Take(3)));
+
+            foreach (var (path, node) in refNodes)
+            {
+                var pointer = node["$ref"];
+                var spelling = pointer is JsonValue v && v.TryGetValue<string>(out var s) ? s : null;
+                Check($"{type.Name} {path}: $ref is a STRING in pointer form (\"#/…\"), not a plain-name anchor",
+                    spelling is not null && (spelling == "#" || spelling.StartsWith("#/", StringComparison.Ordinal)),
+                    pointer?.ToJsonString() ?? "<absent>");
+                if (spelling is null) continue;
+
+                var tokens = spelling.Length > 1 ? spelling[1..].Split('/') : [];
+                Check($"{type.Name} {path}: every reference token is non-empty and unescaped (Resolve tokenizes literally)",
+                    tokens.Skip(1).All(t => t.Length > 0 && !t.Contains('%') && !t.Contains('~')),
+                    spelling);
+
+                var extra = node.Select(kv => kv.Key).Where(k => k is not ("$ref" or "description" or "items")).ToList();
+                Check($"{type.Name} {path}: the ref node carries only the members the merge rule was written for",
+                    extra.Count == 0, string.Join(",", extra));
+                Check($"{type.Name} {path}: an items= sibling is the empty placeholder, never a real constraint",
+                    node["items"] is null or JsonObject { Count: 0 }, node["items"]?.ToJsonString());
+                Check($"{type.Name} {path}: the target resolves to an OBJECT schema, not a boolean schema",
+                    ToolSchemas.Resolve(doc, spelling) is JsonObject,
+                    ToolSchemas.Resolve(doc, spelling)?.ToJsonString() ?? "<does not resolve>");
+            }
+        }
+    }
+
+    /// <summary>Every object carrying a <c>$ref</c>, split by whether it sits in a schema position or under a
+    /// keyword whose value is DATA (where the pass would rewrite a caller's literal as if it were a schema).</summary>
+    static void CollectRefNodes(JsonNode? node, string path, string? valueKeyAbove, string[] nonSchema,
+                                List<(string, JsonObject)> refNodes, List<string> valuePositionRefs)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                if (obj.ContainsKey("$ref"))
+                {
+                    if (valueKeyAbove is not null) valuePositionRefs.Add($"{path} (under {valueKeyAbove})");
+                    else refNodes.Add((path, obj));
+                }
+                foreach (var kv in obj.ToList())
+                    CollectRefNodes(kv.Value, $"{path}/{kv.Key}",
+                        valueKeyAbove ?? (nonSchema.Contains(kv.Key) ? kv.Key : null), nonSchema, refNodes, valuePositionRefs);
+                break;
+            case JsonArray arr:
+                for (var i = 0; i < arr.Count; i++)
+                    CollectRefNodes(arr[i], $"{path}/{i}", valueKeyAbove, nonSchema, refNodes, valuePositionRefs);
+                break;
+        }
+    }
+
+    /// <summary>The first path at which <paramref name="key"/> appears anywhere in the document, or null.</summary>
+    static string? FindKey(JsonNode? node, string key, string path = "#") => node switch
+    {
+        JsonObject obj => obj.ContainsKey(key) ? $"{path}/{key}"
+            : obj.Select(kv => FindKey(kv.Value, key, $"{path}/{kv.Key}")).FirstOrDefault(h => h is not null),
+        JsonArray arr => Enumerable.Range(0, arr.Count).Select(i => FindKey(arr[i], key, $"{path}/{i}")).FirstOrDefault(h => h is not null),
+        _ => null,
+    };
 
     /// <summary>One <c>ops</c> array whose single op carries <paramref name="levels"/> of nested compose, each
     /// level's type naming its own depth so the innermost is identifiable. Returns the JSON and that type name.</summary>

--- a/src/housecarl-generator/SchemaFlattenProbe.cs
+++ b/src/housecarl-generator/SchemaFlattenProbe.cs
@@ -188,8 +188,13 @@ public static class SchemaFlattenProbe
         Check($"…and the innermost level survives the read intact (type '{innermost}')",
             node?.Type == innermost, node?.Type ?? "<the chain did not reach level 6>");
 
-        // Past the JSON reader's OWN depth ceiling (STJ's MaxDepth, shared by the transport parse) the read must
-        // still fail loudly. Parsed with headroom here so the READER is what answers rather than this probe's parse.
+        // Past the JSON reader's OWN depth ceiling (STJ's MaxDepth) the read must still fail loudly. Parsed with
+        // headroom here so the READER is what answers rather than this probe's parse.
+        // What this does NOT model, and a reader of this arm should not assume it does: in real wire flow a
+        // request that deep dies at the TRANSPORT parse first — measured on this branch, a default-options
+        // JsonDocument.Parse throws from ~21 compose levels — so the caller sees an SDK-voiced parse error, not
+        // the named refusal below. Both are loud, which is what the published sentence claims; only this one is
+        // ours. The gap is unreachable by real compose use (live composes nest 1–2).
         var (past, _) = DeepComposeOps(30);
         var wide = JsonDocument.Parse(past, new JsonDocumentOptions { MaxDepth = 512 }).RootElement;
         var (deepItems, deepError) = ListParams.Read<ApplyOp>(wide, "ops", "{formid, field_path, …}");

--- a/src/housecarl-generator/SchemaFlattenProbe.cs
+++ b/src/housecarl-generator/SchemaFlattenProbe.cs
@@ -6,8 +6,10 @@ using HousecarlMcp;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// REGRESSION GUARD for <see cref="ToolSchemas"/>'s <c>$ref</c> flattening (#451) — the MECHANISM, over synthetic
-/// documents. <c>binding-shim-guard</c>'s SCHEMA arms cover the invariant on the real published surface, which
+/// REGRESSION GUARD for <see cref="ToolSchemas"/>'s <c>$ref</c> flattening (#451) — the MECHANISM. Most arms run
+/// over synthetic documents; ARM 6 drives the real strict reader and ARM 7 reads every registered tool's real
+/// pre-flatten schema, so the scope is no longer synthetic throughout.
+/// <c>binding-shim-guard</c>'s SCHEMA arms cover the invariant on the real published surface, which
 /// exercises only the one shape today's DTOs generate (a positional back-reference carrying a description and an
 /// empty <c>items</c> placeholder). Three of the cases below — <c>$defs</c> recursion, mutual recursion, an
 /// unresolvable pointer — have no end-to-end producer and would otherwise ship unproven. The placeholder-sibling

--- a/src/housecarl-generator/SchemaFlattenProbe.cs
+++ b/src/housecarl-generator/SchemaFlattenProbe.cs
@@ -76,6 +76,19 @@ public static class SchemaFlattenProbe
             && b["description"]?.GetValue<string>() is { } d && d.StartsWith("nested", StringComparison.Ordinal)
             && d.Contains("Nesting continues", StringComparison.Ordinal),
             bound?.ToJsonString());
+
+        // A recursive parameter carrying no description of its own must still say why the node stopped
+        // constraining — otherwise the bound closes silently on exactly the schemas with least to go on.
+        var bare = Parse("""
+        {"properties":{"sets":{"type":"array","items":{"type":"object","properties":{
+          "compose":{"type":"object","properties":{"sets":{"$ref":"#/properties/sets"}}}}}}}}
+        """);
+        ToolSchemas.FlattenRefs(bare);
+        var bareBound = bare["properties"]!["sets"]!["items"]!["properties"]!["compose"]!["properties"]!["sets"]
+            ?["items"]?["properties"]?["compose"]?["properties"]?["sets"];
+        Check("a description-less recursive parameter still gets the clause, not a silent close",
+            bareBound?["description"]?.GetValue<string>()?.StartsWith("Nesting continues", StringComparison.Ordinal) == true,
+            bareBound?.ToJsonString());
     }
 
     /// <summary>The standard recursive spelling other generators emit. Leaving <c>$defs</c> published would keep

--- a/src/housecarl-generator/SchemaFlattenProbe.cs
+++ b/src/housecarl-generator/SchemaFlattenProbe.cs
@@ -155,10 +155,14 @@ public static class SchemaFlattenProbe
     }
 
     /// <summary>A pointer that resolves nowhere is a broken rebase. Publishing an open node in its place would
-    /// hide it behind a schema that looks finished, so it is left for the invariant arm to fail on.</summary>
+    /// hide it behind a schema that looks finished, so it is left for the invariant arm to fail on. A <c>$ref</c>
+    /// that is not a JSON string at all takes the same route (PR #465 gate review): the pass leaves it, rather
+    /// than reading it as a string and throwing out of the <c>PostConfigure</c> it runs in — which would fail the
+    /// server's whole start, naming no tool. Both directions are measured here: the unhandled form survives
+    /// untouched AND the handled one beside it is still inlined.</summary>
     static void UnresolvableArm()
     {
-        Console.WriteLine("── ARM 5: an unresolvable pointer is left in place, not papered over ──");
+        Console.WriteLine("── ARM 5: a form the pass does not handle is left in place, not papered over ──");
         var doc = Parse("""
         {"properties":{"broken":{"$ref":"#/$defs/Missing","description":"d"},
                        "fine":{"$ref":"#/properties/leaf"},
@@ -172,6 +176,28 @@ public static class SchemaFlattenProbe
         Check("…and it did not stop the resolvable one beside it from being inlined",
             doc["properties"]?["fine"]?["type"]?.GetValue<string>() == "string",
             doc["properties"]?["fine"]?.ToJsonString());
+
+        // A $ref holding a boolean, a number, an object and an array — the four ways the member can be present
+        // without being a pointer. Reading any of them as a string throws; the pass must return the document.
+        var nonString = Parse("""
+        {"properties":{"b":{"$ref":true},"n":{"$ref":3},"o":{"$ref":{"a":1}},"a":{"$ref":[1]},
+                       "fine":{"$ref":"#/properties/leaf"},
+                       "leaf":{"type":"string"}}}
+        """);
+        var threw = "";
+        try { ToolSchemas.FlattenRefs(nonString); }
+        catch (Exception ex) { threw = $"{ex.GetType().Name}: {ex.Message}"; }
+        Check("a non-string $ref does not throw the pass — it would take the server's start with it", threw.Length == 0, threw);
+        Check("…each non-string $ref is left exactly as it was, for the invariant arm to report",
+            threw.Length == 0
+            && nonString["properties"]?["b"]?["$ref"]?.ToJsonString() == "true"
+            && nonString["properties"]?["n"]?["$ref"]?.ToJsonString() == "3"
+            && nonString["properties"]?["o"]?["$ref"]?.ToJsonString() == "{\"a\":1}"
+            && nonString["properties"]?["a"]?["$ref"]?.ToJsonString() == "[1]",
+            nonString["properties"]?.ToJsonString());
+        Check("…and the string pointer beside them is still inlined",
+            threw.Length == 0 && nonString["properties"]?["fine"]?["type"]?.GetValue<string>() == "string",
+            nonString["properties"]?["fine"]?.ToJsonString());
     }
 
     /// <summary>The terminator writes a SENTENCE into the published schema — "nesting continues below this level

--- a/src/housecarl-generator/SchemaFlattenProbe.cs
+++ b/src/housecarl-generator/SchemaFlattenProbe.cs
@@ -1,0 +1,151 @@
+using System.Text.Json.Nodes;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REGRESSION GUARD for <see cref="ToolSchemas"/>'s <c>$ref</c> flattening (#451) — the MECHANISM, over synthetic
+/// documents. <c>binding-shim-guard</c>'s SCHEMA arm covers the invariant on the real published surface; that
+/// surface exercises only the one shape today's DTOs generate (a positional back-reference), so the cases below —
+/// <c>$defs</c> recursion, mutual recursion, the placeholder-sibling merge, an unresolvable pointer — have no
+/// end-to-end producer and would otherwise ship unproven.
+///
+/// Run: <c>dotnet run --project src/housecarl-generator schema-flatten-guard</c>
+/// </summary>
+public static class SchemaFlattenProbe
+{
+    static int _pass, _fail;
+
+    static void Check(string label, bool ok, string? got = null)
+    {
+        Console.WriteLine($"   [{(ok ? "PASS" : "FAIL")}] {label}");
+        if (!ok && got is not null) Console.WriteLine($"          got: {(got.Length <= 400 ? got : got[..400] + " …")}");
+        if (ok) _pass++; else _fail++;
+    }
+
+    static JsonObject Parse(string json) => (JsonObject)JsonNode.Parse(json)!;
+
+    /// <summary>Every same-document <c>$ref</c> left in a document, by pointer.</summary>
+    static List<string> Refs(JsonNode? node) => node switch
+    {
+        JsonObject o => o.SelectMany(kv => kv.Key == "$ref" && kv.Value?.GetValue<string>() is { } r && r.StartsWith('#')
+            ? new List<string> { r } : Refs(kv.Value)).ToList(),
+        JsonArray a => a.SelectMany(Refs).ToList(),
+        _ => new List<string>(),
+    };
+
+    public static int RunGuard(string[] args)
+    {
+        _pass = _fail = 0;
+        Console.WriteLine("[schema-flatten-guard] ToolSchemas.FlattenRefs — the $ref-inlining mechanism (#451)");
+
+        PositionalCycleArm();
+        DefsArm();
+        MutualRecursionArm();
+        SiblingArm();
+        UnresolvableArm();
+
+        Console.WriteLine();
+        Console.WriteLine($"=== schema-flatten-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
+        return _fail == 0 ? 0 : 1;
+    }
+
+    /// <summary>The published shape: a self-nesting object whose inner copy back-references an ancestor by
+    /// position. The pointer goes; the shape is expanded, then closed by a typed open node.</summary>
+    static void PositionalCycleArm()
+    {
+        Console.WriteLine("── ARM 1: a positional back-reference is expanded, then closed ──");
+        var doc = Parse("""
+        {"type":"object","properties":{"sets":{"type":"array","items":{"type":"object","properties":{
+          "path":{"type":"string"},
+          "compose":{"type":"object","properties":{"sets":{"description":"nested","$ref":"#/properties/sets"}}}}}}}}
+        """);
+
+        Check("the pass reports it changed the document", ToolSchemas.FlattenRefs(doc));
+        Check("no same-document $ref survives", Refs(doc).Count == 0, doc.ToJsonString());
+
+        var inner = doc["properties"]!["sets"]!["items"]!["properties"]!["compose"]!["properties"]!["sets"];
+        Check("the referenced shape is INLINED, not deleted — the inner copy declares the array's element members",
+            inner?["items"]?["properties"]?["path"] is not null, inner?.ToJsonString());
+
+        var bound = inner?["items"]?["properties"]?["compose"]?["properties"]?["sets"];
+        Check("one level deeper the chain closes on an open node: typed, no items, description says nesting continues",
+            bound is JsonObject b && b["type"] is not null && b["items"] is null
+            && b["description"]?.GetValue<string>() is { } d && d.StartsWith("nested", StringComparison.Ordinal)
+            && d.Contains("Nesting continues", StringComparison.Ordinal),
+            bound?.ToJsonString());
+    }
+
+    /// <summary>The standard recursive spelling other generators emit. Leaving <c>$defs</c> published would keep
+    /// the recursion visible to a validator that walks definitions, so it must not survive.</summary>
+    static void DefsArm()
+    {
+        Console.WriteLine("── ARM 2: a $defs-based cycle is inlined and the definitions are dropped ──");
+        var doc = Parse("""
+        {"type":"object","$defs":{"Node":{"type":"object","properties":{"child":{"$ref":"#/$defs/Node"}}}},
+         "properties":{"root":{"$ref":"#/$defs/Node"}}}
+        """);
+
+        ToolSchemas.FlattenRefs(doc);
+        Check("no same-document $ref survives", Refs(doc).Count == 0, doc.ToJsonString());
+        Check("$defs is gone — an unreferenced definition would still carry the cycle to a validator that walks it",
+            doc["$defs"] is null, doc.ToJsonString());
+        Check("the definition's body was inlined at the use site",
+            doc["properties"]?["root"]?["properties"]?["child"] is not null, doc["properties"]?.ToJsonString());
+    }
+
+    /// <summary>A cycle no single pointer closes: the budget is per pointer, so two pointers must not defeat it.</summary>
+    static void MutualRecursionArm()
+    {
+        Console.WriteLine("── ARM 3: mutual recursion terminates ──");
+        var doc = Parse("""
+        {"$defs":{"A":{"type":"object","properties":{"b":{"$ref":"#/$defs/B"}}},
+                  "B":{"type":"object","properties":{"a":{"$ref":"#/$defs/A"}}}},
+         "properties":{"root":{"$ref":"#/$defs/A"}}}
+        """);
+
+        ToolSchemas.FlattenRefs(doc);
+        Check("no same-document $ref survives", Refs(doc).Count == 0, doc.ToJsonString());
+        Check("both sides of the cycle are spelled out before it closes",
+            doc["properties"]?["root"]?["properties"]?["b"]?["properties"]?["a"] is not null,
+            doc["properties"]?.ToJsonString());
+    }
+
+    /// <summary>The generator leaves members beside a <c>$ref</c>: a real one (the parameter's own description)
+    /// must win over the target's, and an empty placeholder must not overwrite what the target actually says.</summary>
+    static void SiblingArm()
+    {
+        Console.WriteLine("── ARM 4: siblings of a $ref — the local statement wins, the placeholder does not ──");
+        var doc = Parse("""
+        {"$defs":{"Args":{"type":"array","description":"from the definition","items":{"type":"string"}}},
+         "properties":{"args":{"$ref":"#/$defs/Args","description":"this parameter's own teaching","items":{}}}}
+        """);
+
+        ToolSchemas.FlattenRefs(doc);
+        var args = doc["properties"]?["args"];
+        Check("the ref node's own description survives the inline",
+            args?["description"]?.GetValue<string>() == "this parameter's own teaching", args?.ToJsonString());
+        Check("the empty items placeholder does not overwrite the definition's real items",
+            args?["items"]?["type"]?.GetValue<string>() == "string", args?.ToJsonString());
+    }
+
+    /// <summary>A pointer that resolves nowhere is a broken rebase. Publishing an open node in its place would
+    /// hide it behind a schema that looks finished, so it is left for the invariant arm to fail on.</summary>
+    static void UnresolvableArm()
+    {
+        Console.WriteLine("── ARM 5: an unresolvable pointer is left in place, not papered over ──");
+        var doc = Parse("""
+        {"properties":{"broken":{"$ref":"#/$defs/Missing","description":"d"},
+                       "fine":{"$ref":"#/properties/leaf"},
+                       "leaf":{"type":"string"}}}
+        """);
+
+        ToolSchemas.FlattenRefs(doc);
+        Check("the unresolvable pointer is still there, verbatim",
+            doc["properties"]?["broken"]?["$ref"]?.GetValue<string>() == "#/$defs/Missing",
+            doc["properties"]?["broken"]?.ToJsonString());
+        Check("…and it did not stop the resolvable one beside it from being inlined",
+            doc["properties"]?["fine"]?["type"]?.GetValue<string>() == "string",
+            doc["properties"]?["fine"]?.ToJsonString());
+    }
+}

--- a/src/housecarl-mcp/Program.cs
+++ b/src/housecarl-mcp/Program.cs
@@ -164,11 +164,10 @@ static void AddMcp(IServiceCollection services, bool stdio)
     if (stdio) mcp.WithStdioServerTransport();
     else mcp.WithHttpTransport(o => o.Stateless = true);
     mcp.WithToolsFromAssembly();
-    // SPEC §5.1's @file convention forces a list parameter to accept an array OR a string, which C# cannot
-    // express as one type — so those parameters are declared JsonElement and the generator publishes "anything".
-    // This republishes them as anyOf[<the GENERATED element-array schema>, string]. Published shape only; what
+    // The published-schema layer: the SPEC §5.1 @file union (an array OR "@<path>", which C# cannot express as one
+    // type), then inlining every same-document $ref so no published schema is recursive. Published shape only; what
     // the tool ACCEPTS is unchanged (ApplyTools' strict reader). See ToolSchemas.
-    ToolSchemas.PublishFileListUnions(services);
+    ToolSchemas.PublishSchemas(services);
     // The argument-binding shim (HCBR-2026-06-11-01): schema-driven coercion of obvious-intent argument shapes
     // (a bare string where an array is declared, quoted bools/numbers), named refusal of missing required
     // parameters, and a named rewrite of the SDK's generic binding-failure text. See ToolCallShim.

--- a/src/housecarl-mcp/ToolSchemas.cs
+++ b/src/housecarl-mcp/ToolSchemas.cs
@@ -140,17 +140,29 @@ internal static class ToolSchemas
         return changed;
     }
 
+    /// <summary>The <c>$ref</c> pointer on a node, or null when the member is absent or does not hold a JSON
+    /// string. The one place either pass reads a <c>$ref</c>, and it reads it safely: a non-string <c>$ref</c> is
+    /// one of the spellings the class summary lists as outside this pass (a boolean target, a value-position ref),
+    /// so it is LEFT ALONE for the invariant arm to report, exactly as an unresolvable pointer is.
+    /// <c>GetValue&lt;string&gt;()</c> would instead throw <c>InvalidOperationException</c> out of the
+    /// <c>PostConfigure</c> these passes run in, while the host is being built — failing the whole server's start
+    /// on both transports and naming neither houseCARL nor a tool, which is the very shape #451 was filed
+    /// against.</summary>
+    static string? RefPointer(JsonObject node) =>
+        node["$ref"] is JsonValue v && v.TryGetValue<string>(out var s) ? s : null;
+
     /// <summary>Rewrite every same-document JSON pointer in a generated sub-schema so it resolves from the tool
     /// schema's root once the sub-schema has been nested under <paramref name="basePointer"/>. A bare <c>"#"</c>
     /// (the whole document) becomes the base itself; <c>"#/x/y"</c> becomes <c>"&lt;base&gt;/x/y"</c>. A pointer
     /// into <c>$defs</c> is left alone — those definitions were hoisted to the root, which is exactly where
-    /// <c>#/$defs/…</c> already points. External refs (anything not starting with <c>#</c>) are untouched.</summary>
+    /// <c>#/$defs/…</c> already points. External refs (anything not starting with <c>#</c>) are untouched, and so
+    /// is a <c>$ref</c> that is not a JSON string — see <see cref="RefPointer"/>.</summary>
     static void RebaseRefs(JsonNode? node, string basePointer)
     {
         switch (node)
         {
             case JsonObject obj:
-                if (obj["$ref"]?.GetValue<string>() is { } r && r.StartsWith('#') && !r.StartsWith("#/$defs/", StringComparison.Ordinal))
+                if (RefPointer(obj) is { } r && r.StartsWith('#') && !r.StartsWith("#/$defs/", StringComparison.Ordinal))
                     obj["$ref"] = r.Length == 1 ? basePointer : basePointer + r[1..];
                 foreach (var key in obj.Select(kv => kv.Key).ToList())
                     if (key != "$ref") RebaseRefs(obj[key], basePointer);
@@ -162,10 +174,13 @@ internal static class ToolSchemas
     }
 
     /// <summary>Inline every same-document <c>$ref</c> that resolves, bounding each recursive chain at
-    /// <see cref="MaxSelfExpansions"/> expansions of the same pointer. One that does not resolve is left in place
-    /// to fail the invariant <c>binding-shim-guard</c> asserts: no published tool schema contains a same-document
-    /// <c>$ref</c>. Internal so <c>schema-flatten-guard</c> can drive it over synthetic documents — the published
-    /// surface exercises only the shapes today's DTOs happen to generate.</summary>
+    /// <see cref="MaxSelfExpansions"/> expansions of the same pointer. One that does not resolve — or is not a
+    /// same-document pointer, or is not a string at all — is left in place to fail the invariant
+    /// <c>binding-shim-guard</c> asserts: no published tool schema carries a <c>$ref</c> MEMBER, in any spelling.
+    /// That predicate is wider than this pass's gate on purpose, and it is what makes leaving a form this pass
+    /// does not understand a report rather than a silence. Internal so <c>schema-flatten-guard</c> can drive it
+    /// over synthetic documents — the published surface exercises only the shapes today's DTOs happen to
+    /// generate.</summary>
     internal static bool FlattenRefs(JsonObject root)
     {
         // Inlined copies carry the pointers of the document they were copied FROM, so every pointer resolves
@@ -204,7 +219,7 @@ internal static class ToolSchemas
     static JsonNode? Expand(JsonNode? node, JsonObject snapshot, Dictionary<string, int> spent)
     {
         if (node is not JsonObject refNode) return null;
-        if (refNode["$ref"]?.GetValue<string>() is not { } pointer || !pointer.StartsWith('#')) return null;
+        if (RefPointer(refNode) is not { } pointer || !pointer.StartsWith('#')) return null;
 
         // A pointer that does not resolve is left exactly as it is: publishing an open node in its place would
         // hide a broken rebase behind a schema that looks finished. It surfaces as the one $ref the guard forbids.

--- a/src/housecarl-mcp/ToolSchemas.cs
+++ b/src/housecarl-mcp/ToolSchemas.cs
@@ -15,7 +15,20 @@ namespace HousecarlMcp;
 /// <c>ApplyTools.ReadListParam</c>, whose strict reader is deliberately stricter than the SDK binder.</para>
 ///
 /// <para>Why it is shaped this way: <c>docs/architecture/tool-schema-publication.md</c>. What it guarantees is
-/// pinned by <c>binding-shim-guard</c>'s SCHEMA arm and <c>apply-guard</c>.</para>
+/// pinned by <c>binding-shim-guard</c>'s SCHEMA arms (the real served surface) and <c>schema-flatten-guard</c>
+/// (the mechanism).</para>
+///
+/// <para><b>Scope of <see cref="FlattenRefs"/>: it normalizes what THIS SDK's schema generator emits — it is not
+/// a general JSON Schema <c>$ref</c> implementation, and must not be reused as one.</b> It reads a <c>$ref</c> as
+/// a JSON pointer wherever one appears, which is true of generator output and not of JSON Schema at large: plain-name
+/// <c>$anchor</c> fragments, percent-encoded and empty reference tokens, boolean schemas as a pointer target, a
+/// <c>$ref</c>-shaped value sitting under <c>default</c>/<c>enum</c>, and 2020-12's rule that <c>$ref</c> siblings
+/// apply IN ADDITION to the target (this merge lets them override) are all outside what it handles. None is
+/// reachable from today's DTOs, and that is PINNED rather than assumed: <c>schema-flatten-guard</c>'s ARM 7
+/// asserts the emission grammar this depends on — no <c>$defs</c>, pointer-form refs with literal tokens, ref
+/// nodes carrying only a description and an empty <c>items</c> placeholder, every target an object schema, and no
+/// <c>$ref</c> in a value position. A generator that drifts on an SDK bump reddens there, not at a user's server
+/// start. Widen the handling before widening the input, not after.</para>
 /// </summary>
 internal static class ToolSchemas
 {
@@ -41,8 +54,9 @@ internal static class ToolSchemas
 
     /// <summary>Register both passes. Runs as a POST-configure over <c>McpServerOptions</c> — the one place the
     /// final tool collection exists whichever transport built the host, since the assembly scan registers each tool
-    /// as a factory. A tool or parameter not found is skipped; <c>apply-guard</c> asserts the published shape
-    /// end-to-end, so a stale <see cref="FileListParams"/> row fails there rather than degrading quietly.</summary>
+    /// as a factory. A tool or parameter not found is skipped; <c>binding-shim-guard</c>'s SCHEMA arms name every
+    /// union row and assert the published shape, so a stale <see cref="FileListParams"/> row fails there rather
+    /// than degrading quietly. (Not <c>apply-guard</c>, which never reads a published schema.)</summary>
     internal static void PublishSchemas(IServiceCollection services) =>
         services.PostConfigure<McpServerOptions>(options =>
         {
@@ -228,7 +242,7 @@ internal static class ToolSchemas
 
     /// <summary>Walk a same-document JSON pointer ("#", "#/a/b/0") against <paramref name="root"/>, or null if it
     /// does not resolve.</summary>
-    static JsonNode? Resolve(JsonObject root, string pointer)
+    internal static JsonNode? Resolve(JsonObject root, string pointer)
     {
         JsonNode? cur = root;
         foreach (var raw in pointer[1..].Split('/', StringSplitOptions.RemoveEmptyEntries))

--- a/src/housecarl-mcp/ToolSchemas.cs
+++ b/src/housecarl-mcp/ToolSchemas.cs
@@ -7,28 +7,15 @@ using ModelContextProtocol.Server;
 namespace HousecarlMcp;
 
 /// <summary>
-/// Publishes a REAL schema for the list parameters that carry SPEC §5.1's <c>@file</c> convention.
+/// The published-schema layer: rewrites each tool's <c>inputSchema</c> once at registration, after the assembly
+/// scan has built it. Two passes — the SPEC §5.1 <c>@file</c> union on the parameters listed in
+/// <see cref="FileListParams"/>, then <see cref="FlattenRefs"/> over every tool.
 ///
-/// <para>The problem: a list-valued input accepts EITHER an inline array of objects OR the string
-/// <c>"@&lt;absolute path&gt;"</c>. C# has no type for that union, so the parameter is declared
-/// <see cref="JsonElement"/> and the SDK's schema generator — which works from the declared type — publishes
-/// "anything" (<c>{}</c>). The element shape then lives only in the tool description, where a client's schema
-/// rendering cannot use it.</para>
-///
-/// <para>The fix: after the assembly scan has built each tool, replace those property nodes with
-/// <c>anyOf[&lt;the generated array schema&gt;, string]</c>. The array arm is GENERATED from the C# element type
-/// by the same generator the SDK uses — adding a member to <see cref="ApplyOp"/> updates the published schema
-/// automatically, so this is not a hand-maintained copy. Only the union wrapper and the string arm are written
-/// here.</para>
-///
-/// <para>Route note: the SDK's <c>WithToolsFromAssembly</c> has no overload carrying
-/// <c>McpServerToolCreateOptions.SchemaCreateOptions</c>, so the per-node <c>TransformSchemaNode</c> hook cannot
-/// reach an assembly-scanned tool. <see cref="ModelContextProtocol.Protocol.Tool.InputSchema"/> is settable
-/// (and validates what it is given), so the schema is rewritten once at registration instead — which keeps
-/// every tool on the one registration path rather than special-casing one tool's wiring.</para>
-///
-/// <para><b>This changes only what is PUBLISHED, never what is ACCEPTED.</b> Binding still goes through
+/// <para>Changes only what is PUBLISHED, never what is ACCEPTED — binding still goes through
 /// <c>ApplyTools.ReadListParam</c>, whose strict reader is deliberately stricter than the SDK binder.</para>
+///
+/// <para>Why it is shaped this way: <c>docs/architecture/tool-schema-publication.md</c>. What it guarantees is
+/// pinned by <c>binding-shim-guard</c>'s SCHEMA arm and <c>apply-guard</c>.</para>
 /// </summary>
 internal static class ToolSchemas
 {
@@ -45,42 +32,41 @@ internal static class ToolSchemas
     {
         new("housecarl_apply", "ops", typeof(ApplyOp[])),
         new("housecarl_apply", "assignments", typeof(Assignment[])),
-        // W3 PR 2 — the chartered carry from PR #310's decision 1: create's records= is the same JsonElement-typed
-        // @file union, so it publishes the same anyOf. Its element type reaches StructInput/NestedSet through
-        // CreateFieldOp, which is why the $defs hoist below is first-wins BY NAME and sound here: those are
-        // literally the same C# types apply's rows generate, so a duplicate name is a duplicate schema.
         new("housecarl_create", "records", typeof(CreateRecordSpec[])),
     };
 
-    /// <summary>Register the rewrite. It runs as a POST-configure over <c>McpServerOptions</c>, which is the one
-    /// place the final tool collection exists regardless of how the tools got there: the assembly scan registers
-    /// each tool as a FACTORY, so the instances do not exist yet while the service collection is being built, and
-    /// both transports (stdio and http) build their host separately — a post-configure keeps this on ONE line
-    /// inside the shared registration instead of a call site per transport that could drift apart.
-    /// A tool or parameter not found is skipped here; <c>apply-guard</c> asserts the published shape end-to-end,
-    /// so a stale row fails there loudly rather than degrading the surface quietly.</summary>
-    internal static void PublishFileListUnions(IServiceCollection services) =>
+    /// <summary>How many times one pointer may be inlined along a single nesting chain before
+    /// <see cref="Terminator"/> closes it. Raising it deepens every recursive branch of every published schema.</summary>
+    const int MaxSelfExpansions = 1;
+
+    /// <summary>Register both passes. Runs as a POST-configure over <c>McpServerOptions</c> — the one place the
+    /// final tool collection exists whichever transport built the host, since the assembly scan registers each tool
+    /// as a factory. A tool or parameter not found is skipped; <c>apply-guard</c> asserts the published shape
+    /// end-to-end, so a stale <see cref="FileListParams"/> row fails there rather than degrading quietly.</summary>
+    internal static void PublishSchemas(IServiceCollection services) =>
         services.PostConfigure<McpServerOptions>(options =>
         {
             if (options.ToolCollection is not { } tools) return;
             foreach (var tool in tools)
             {
+                if (JsonNode.Parse(tool.ProtocolTool.InputSchema.GetRawText()) is not JsonObject root) continue;
                 var wanted = FileListParams.Where(p => p.Tool == tool.ProtocolTool.Name).ToList();
-                if (wanted.Count == 0) continue;
-                if (Rewrite(tool.ProtocolTool.InputSchema, wanted) is { } rebuilt)
-                    tool.ProtocolTool.InputSchema = rebuilt;
+                var changed = wanted.Count > 0 && RewriteFileListUnions(root, wanted);
+                changed |= FlattenRefs(root);
+                if (changed) tool.ProtocolTool.InputSchema = JsonSerializer.Deserialize<JsonElement>(root.ToJsonString());
             }
         });
 
-    /// <summary>Build the rewritten schema, or null if the shape isn't what we expect (leave it alone rather than
-    /// publish something malformed).</summary>
-    static JsonElement? Rewrite(JsonElement schema, IReadOnlyList<FileListParam> parameters)
+    /// <summary>Republish each listed parameter as <c>anyOf[&lt;the generated element-array schema&gt;, string]</c>.
+    /// The array arm is generated from the C# element type by the same generator the SDK uses, so adding a member to
+    /// <see cref="ApplyOp"/> updates the published schema automatically. Returns false — leaving the schema
+    /// untouched — when the document is not the shape this expects.</summary>
+    static bool RewriteFileListUnions(JsonObject root, IReadOnlyList<FileListParam> parameters)
     {
-        if (JsonNode.Parse(schema.GetRawText()) is not JsonObject root) return null;
-        if (root["properties"] is not JsonObject props) return null;
+        if (root["properties"] is not JsonObject props) return false;
 
-        // $ref inside a generated sub-schema is written "#/$defs/X" — resolved against the ROOT document. So a
-        // generated schema's own $defs must be HOISTED to the tool schema's root, or every reference in it dangles.
+        // A generated sub-schema's "#/$defs/X" resolves against the ROOT document, so its $defs must be hoisted to
+        // the tool schema's root or every such reference dangles.
         var defs = root["$defs"] as JsonObject;
 
         bool changed = false;
@@ -98,11 +84,9 @@ internal static class ToolSchemas
                 defs ??= new JsonObject();
                 foreach (var name in genDefs.Select(kv => kv.Key).ToList())
                 {
-                    // First-wins on the DEFINITION NAME. Sound for today's rows and for `create`'s records= in
-                    // W3 PR 2 — same generator, and the shared shapes (StructInput/NestedSet) are literally the
-                    // same C# types, so a duplicate name is a duplicate schema. It would bind the WRONG
-                    // definition only if two DISTINCT types ever produced the same short name here; if that day
-                    // comes, key the hoist by type rather than by name.
+                    // First-wins BY NAME. Sound only while distinct types cannot produce the same short name here;
+                    // today's rows share literal C# types (StructInput/NestedSet), so a duplicate name is a
+                    // duplicate schema. Key the hoist by type if that stops holding.
                     if (defs.ContainsKey(name)) continue;
                     var node = genDefs[name];
                     genDefs.Remove(name);
@@ -110,16 +94,12 @@ internal static class ToolSchemas
                 }
             }
 
-            // EVERY "#/..." pointer in the generated schema is relative to ITS OWN document root — the standalone
-            // array schema. Nesting that document under properties/<param>/anyOf/0 silently breaks all of them.
-            // This generator terminates a RECURSIVE type (StructInput → NestedSet.compose → StructInput, our
-            // compose/sets chain) with exactly such a positional back-reference, so this is not a hypothetical:
-            // without rebasing, the published schema carries a dangling $ref, which is worse than publishing
-            // nothing at all. Rebase to where the sub-document now lives.
+            // Every "#/..." pointer in the generated schema is relative to ITS OWN document root. Nesting that
+            // document under properties/<param>/anyOf/0 breaks all of them unless they are rebased first.
             RebaseRefs(generated, $"#/properties/{p.Parameter}/anyOf/0");
 
-            // The [Description] the SDK lifted off the parameter is the caller-facing teaching — it survives the
-            // rewrite verbatim, on the union node where a client will render it.
+            // The [Description] the SDK lifted off the parameter is the caller-facing teaching — keep it verbatim,
+            // on the union node where a client will render it.
             var description = existing["description"]?.GetValue<string>();
 
             var union = new JsonObject
@@ -129,7 +109,7 @@ internal static class ToolSchemas
                     new JsonObject
                     {
                         ["type"] = "string",
-                        ["description"] = $"\"@<absolute path>\" — read the same array from a JSON file on disk instead of inlining it.",
+                        ["description"] = "\"@<absolute path>\" — read the same array from a JSON file on disk instead of inlining it.",
                     }),
             };
             if (description is not null) union["description"] = description;
@@ -138,9 +118,8 @@ internal static class ToolSchemas
             changed = true;
         }
 
-        if (!changed) return null;
-        if (defs is not null) root["$defs"] = defs;
-        return JsonSerializer.Deserialize<JsonElement>(root.ToJsonString());
+        if (changed && defs is not null) root["$defs"] = defs;
+        return changed;
     }
 
     /// <summary>Rewrite every same-document JSON pointer in a generated sub-schema so it resolves from the tool
@@ -162,6 +141,104 @@ internal static class ToolSchemas
                 foreach (var item in arr) RebaseRefs(item, basePointer);
                 break;
         }
+    }
+
+    /// <summary>Inline every same-document <c>$ref</c> that resolves, bounding each recursive chain at
+    /// <see cref="MaxSelfExpansions"/> expansions of the same pointer. One that does not resolve is left in place
+    /// to fail the invariant <c>binding-shim-guard</c> asserts: no published tool schema contains a same-document
+    /// <c>$ref</c>. Internal so <c>schema-flatten-guard</c> can drive it over synthetic documents — the published
+    /// surface exercises only the shapes today's DTOs happen to generate.</summary>
+    internal static bool FlattenRefs(JsonObject root)
+    {
+        // Inlined copies carry the pointers of the document they were copied FROM, so every pointer resolves
+        // against an immutable snapshot rather than the tree being rewritten under it.
+        if (root.DeepClone() is not JsonObject snapshot) return false;
+        if (!Inline(root, snapshot, new Dictionary<string, int>(StringComparer.Ordinal))) return false;
+        // Definitions are unreachable once nothing refers to them.
+        root.Remove("$defs");
+        return true;
+    }
+
+    static bool Inline(JsonNode? node, JsonObject snapshot, Dictionary<string, int> spent)
+    {
+        bool changed = false;
+        switch (node)
+        {
+            case JsonObject obj:
+                foreach (var key in obj.Select(kv => kv.Key).ToList())
+                {
+                    if (Expand(obj[key], snapshot, spent) is { } replacement) { obj[key] = replacement; changed = true; }
+                    else changed |= Inline(obj[key], snapshot, spent);
+                }
+                break;
+            case JsonArray arr:
+                for (var i = 0; i < arr.Count; i++)
+                {
+                    if (Expand(arr[i], snapshot, spent) is { } replacement) { arr[i] = replacement; changed = true; }
+                    else changed |= Inline(arr[i], snapshot, spent);
+                }
+                break;
+        }
+        return changed;
+    }
+
+    /// <summary>The replacement for one <c>$ref</c> node, or null if the node carries no same-document ref.</summary>
+    static JsonNode? Expand(JsonNode? node, JsonObject snapshot, Dictionary<string, int> spent)
+    {
+        if (node is not JsonObject refNode) return null;
+        if (refNode["$ref"]?.GetValue<string>() is not { } pointer || !pointer.StartsWith('#')) return null;
+
+        // A pointer that does not resolve is left exactly as it is: publishing an open node in its place would
+        // hide a broken rebase behind a schema that looks finished. It surfaces as the one $ref the guard forbids.
+        if (Resolve(snapshot, pointer) is not JsonObject target) return null;
+        spent.TryGetValue(pointer, out var used);
+        if (used >= MaxSelfExpansions) return Terminator(refNode, target);
+
+        var expanded = (JsonObject)target.DeepClone();
+        // The ref node's own members are this parameter's statement about the target, so they win — except an
+        // empty placeholder the generator leaves beside a $ref, which says nothing the target does not say better.
+        foreach (var member in refNode)
+        {
+            if (member.Key == "$ref") continue;
+            if (member.Value is JsonObject { Count: 0 } && expanded.ContainsKey(member.Key)) continue;
+            expanded[member.Key] = member.Value?.DeepClone();
+        }
+
+        spent[pointer] = used + 1;
+        Inline(expanded, snapshot, spent);
+        spent[pointer] = used;
+        return expanded;
+    }
+
+    /// <summary>Close a recursive chain at the bound: keep the node's own description and the target's <c>type</c>,
+    /// and constrain nothing further. Says exactly what is true — nesting deeper is still accepted, and this
+    /// document stops spelling it out.</summary>
+    static JsonObject Terminator(JsonObject refNode, JsonObject target)
+    {
+        var open = new JsonObject();
+        if (target["type"] is { } type) open["type"] = type.DeepClone();
+        if (refNode["description"]?.GetValue<string>() is { } description)
+            open["description"] = description + " (Nesting continues below this level with the same shape shown above; it is accepted but not spelled out again here.)";
+        return open;
+    }
+
+    /// <summary>Walk a same-document JSON pointer ("#", "#/a/b/0") against <paramref name="root"/>, or null if it
+    /// does not resolve.</summary>
+    static JsonNode? Resolve(JsonObject root, string pointer)
+    {
+        JsonNode? cur = root;
+        foreach (var raw in pointer[1..].Split('/', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var segment = raw.Replace("~1", "/").Replace("~0", "~");
+            cur = cur switch
+            {
+                JsonObject o => o.TryGetPropertyValue(segment, out var next) ? next : null,
+                JsonArray a when int.TryParse(segment, out var i) && i >= 0 && i < a.Count => a[i],
+                _ => null,
+            };
+            if (cur is null) return null;
+        }
+        return cur;
     }
 
     /// <summary>Match the SDK's own wire conventions so the generated arm reads like every other published schema

--- a/src/housecarl-mcp/ToolSchemas.cs
+++ b/src/housecarl-mcp/ToolSchemas.cs
@@ -75,7 +75,7 @@ internal static class ToolSchemas
     /// The array arm is generated from the C# element type by the same generator the SDK uses, so adding a member to
     /// <see cref="ApplyOp"/> updates the published schema automatically. Returns false — leaving the schema
     /// untouched — when the document is not the shape this expects.</summary>
-    static bool RewriteFileListUnions(JsonObject root, IReadOnlyList<FileListParam> parameters)
+    internal static bool RewriteFileListUnions(JsonObject root, IReadOnlyList<FileListParam> parameters)
     {
         if (root["properties"] is not JsonObject props) return false;
 

--- a/src/housecarl-mcp/ToolSchemas.cs
+++ b/src/housecarl-mcp/ToolSchemas.cs
@@ -215,10 +215,14 @@ internal static class ToolSchemas
     /// document stops spelling it out.</summary>
     static JsonObject Terminator(JsonObject refNode, JsonObject target)
     {
+        const string continues = "Nesting continues below this level with the same shape shown above; it is accepted but not spelled out again here.";
         var open = new JsonObject();
         if (target["type"] is { } type) open["type"] = type.DeepClone();
-        if (refNode["description"]?.GetValue<string>() is { } description)
-            open["description"] = description + " (Nesting continues below this level with the same shape shown above; it is accepted but not spelled out again here.)";
+        // The clause goes on unconditionally. A parameter carrying no description of its own would otherwise
+        // close silently — an open node saying nothing about why it stopped constraining.
+        open["description"] = refNode["description"]?.GetValue<string>() is { } description
+            ? description + " (" + continues + ")"
+            : continues;
         return open;
     }
 

--- a/src/housecarl-mcp/ToolSchemas.cs
+++ b/src/housecarl-mcp/ToolSchemas.cs
@@ -11,8 +11,12 @@ namespace HousecarlMcp;
 /// scan has built it. Two passes — the SPEC §5.1 <c>@file</c> union on the parameters listed in
 /// <see cref="FileListParams"/>, then <see cref="FlattenRefs"/> over every tool.
 ///
-/// <para>Changes only what is PUBLISHED, never what is ACCEPTED — binding still goes through
-/// <c>ApplyTools.ReadListParam</c>, whose strict reader is deliberately stricter than the SDK binder.</para>
+/// <para>Changes only what is PUBLISHED, never what is ACCEPTED. Two readers see a call's arguments and neither
+/// is moved by this: <see cref="ToolCallShim"/> coerces and refuses off the published schema, but reads only its
+/// TOP-LEVEL <c>properties</c> and never descends into <c>items</c>/<c>anyOf</c> — which is the nested part this
+/// pass rewrites; and the composed payloads are then read by <c>ListParams.Read&lt;T&gt;</c> (reached through
+/// <c>ApplyTools.ReadOps</c>/<c>ReadAssignments</c>, and from <c>CreateTools</c> for <c>records=</c>), which is
+/// deliberately stricter than the SDK binder and consults no schema at all.</para>
 ///
 /// <para>Why it is shaped this way: <c>docs/architecture/tool-schema-publication.md</c>. What it guarantees is
 /// pinned by <c>binding-shim-guard</c>'s SCHEMA arms (the real served surface) and <c>schema-flatten-guard</c>


### PR DESCRIPTION
Fixes #451.

Five tools published a self-referential `inputSchema`. A provider that validates `tools/list` strictly answers `Recursive JSON schemas are not currently supported` and refuses the **whole server** — naming neither houseCARL nor a tool, so the reporter's only way through was turning the MCP server off for that model. Every same-document `$ref` is now inlined at registration: a cycle is expanded to a bound and closed with an open node that keeps the type, stops constraining, and says in its own description that nesting continues. Measured on the served surface: **30 `$ref` sites across 5 tools → 0 across all 51**, `tools/list` +5.93%, the five affected schemas +2.96–3.22 KB each.

Not a config switch. The report suggested one; it was declined, because the flattened form is accepted everywhere the recursive one is, so the knob buys nothing reachable, leaves the default broken for exactly the users who hit this, and doubles what the guards must hold.

---

## The population correction that decided the guard design

The staged charter for the final wave carried a reasoned-not-run route saying the emission-grammar arm should read the raw pre-flatten `InputSchema` for all 51 tools. Implemented literally, **that yields 18 ref sites. The pass actually handles 30.** `housecarl_apply` and `housecarl_create` emit no `$ref` at all until `RewriteFileListUnions` generates their element-array arm, so a raw-only arm would have left the entire generated-arm population — 12 of 30 sites — ungoverned, and would not have seen a `$defs` the union pass introduced either.

The arm now replays the union pass in the same order the server runs it, and prints both populations so the split stays visible:

```
…they carry $ref sites for the per-site rules to run over
(30 in the pass's input; 18 straight from the assembly scan, the rest added by the @file union pass)
```

The derived population contradicted a hand-carried number, and the contradiction was only visible because the subjects came from the data. That is the ruling this PR ships under doing its job on its first run.

## Rounds, the class-stop, and the ruling

**Two rounds, five independent reviewers, fresh agents in their own worktrees.** Round 1 returned one class from two reviewers (~9 instances, all on synthetic repros): `FlattenRefs` is written and documented as a general JSON-Schema `$ref` inliner but is only correct for this SDK generator's emissions. Disposition: **drop** the algorithm fixes (general implementation is a different charter), **fold** the claim narrowing so the code and probe docs say they normalize *this* generator's output, and ship the narrowing with its precondition **pinned** by an arm over the pre-flatten grammar — unreachability had been claimed by review attention, which never carries a completeness claim.

**Round 2 class-stopped.** One class recurred: *a claim quantified over a population, verified over a hand-named subset or a narrower predicate.* Second project-level appearance (first: PR A / #441, ruled 2026-08-27). Three of the instances were introduced by the review session's **own round-1 folds**, which is why folding stopped rather than continuing to a third round. Instances:

- the detector's predicate (`$ref` value `StartsWith('#')`) was the same test the flattener gates inlining on — anchor-form `{"$ref":"Node"}` injected into all 51 schemas passed **green**;
- the anti-amputation arm walked `housecarl_apply` alone, so four of the five ref-carrying tools had no expansion arm — a bound-0 collapse of the 1.x subtree stayed green on **both** guards;
- ARM 7 re-derived six hand-named DTO schemas through its own generator call instead of reading the real emission path, so its drift claim was never established for the path that actually drifts;
- prose naming a reader that does not exist (`ApplyTools.ReadListParam`; the reader is `ListParams.Read<T>`), and an ADR contradicting itself 17 lines apart on whether anything reads a published schema.

**Aaron ruled the revision:** *"Derive, don't enumerate. I thought we had learned our lesson here."* Option (i), derive-from-surface, with three pins — the invariant predicate is zero `$ref` **members**, any spelling; the expansion arm's subjects are enumerated from the pre-flatten surface at guard time; ARM 7 reads the real `ProtocolTool.InputSchema` for all 51 tools. **One directed wave executed it, and there was no round 4** (directed-completion rule): fresh eyes are for before the PR opens, and a directed fold does not reopen the loop.

Deriving also **removes the residual 1.x coupling**: the subject set shrinks by itself when the demolition deletes the three 1.x ref-carrying tools, where a hand-list would have gone stale and passed.

## What was refused, and on what ground

- **The output-size blowup mitigation — refused in round 1, and the refusal stands.** No mitigation code was written. A size ceiling over a case with no producer is the #426 shape: a conditional asserting what the codebase cannot emit. The measurements (a fully-connected mutual-reference clique: n=7 → 0.9 s / 1.6 MB, n=8 → 8.5 s / 13 MB, n=9 → 203 s / 122 MB) ride as documentation of why the general-inliner claims were narrowed, and for nothing else.
- **The general-inliner algorithm fixes — dropped, not folded.** Nine instances, all verified unreachable from today's generator (empty RFC 6901 tokens, `$anchor` misparse, no percent-decoding, value-position `$ref`, boolean schemas, nested `$defs` survival, sibling-merge widening). Making `FlattenRefs` a correct general inliner is a different charter; what shipped instead is the narrowed claim **plus an arm pinning the grammar it depends on**, so the unreachability is measured rather than asserted.
- **A runtime fail-safe that catches and republishes the recursive schema — refused.** Silent republication is the wrong side of Q3. Loudness here is guard-at-CI, this codebase's standing pattern.
- **Chained refs were not ruled in as separate work.** Nobody decided them; they are a **consequence** of the ruled predicate — a surviving chained ref is a `$ref` member, so the widened invariant reddens on it by construction.
- **`MaxSelfExpansions` stays 1** — at 0 the bound fires on the first occurrence and open-nodes the non-cyclic `fields`/`ctor_args` leaves too, losing real element shapes rather than merely deep nesting. Aaron saw the cost figure and settled it: *"keep 1."*

## Guards

- **`binding-shim-guard`, SCHEMA arms** — over the real served surface, driving the built `housecarl-mcp.exe` over stdio. The invariant is now "no published tool schema carries a `$ref` **member**, in any spelling", deliberately **wider** than the flattener's own resolve gate and sharing no code with it; resolvability is reported as detail, not as the test. The anti-amputation subjects are derived at guard time — this run: *30 pre-flatten `$ref` sites across 5 tools, 10 of them recursive*, with no tool named in the guard. The recursion **step** is derived too (the one site whose pointer is a prefix of its own path is the positional back-reference), which keeps the walk indifferent to `[JsonPropertyName]` declaration order. Both directions are asserted non-empty, so a derivation finding nothing fails instead of passing vacuously. The bound is spelled independently in the guard (`levels == 1`) rather than read from the constant — changing a published contract must be re-ratified, so it reddens.
- **`schema-flatten-guard`** (new, in `ci-all`) — 27 checks. The mechanism over synthetic documents for the shapes today's DTOs cannot produce (`$defs` recursion, mutual recursion, sibling merge, an unresolvable pointer); ARM 6 drives the **real reader** to measure the sentence the terminator publishes; ARM 7 pins the emission grammar over the real pre-flatten surface.

**ARM 6 measures rather than asserts.** The terminator writes *"it is accepted but not spelled out again here"* into the published schema — a claim about accept behaviour that a later call can falsify. Measured through `ListParams.Read<ApplyOp>`: 5/10/15/20 compose levels read with the graph intact to the innermost node; past the JSON reader's own `MaxDepth` (~20 levels, an order of magnitude past live composes, which nest 1–2) it is a **named refusal carrying the element path**, never a silent truncation. No wire-side twin, deliberately: `ops` is declared `JsonElement`, so an arm over the SDK binder could not fail — the #426 shape again.

## Sabotage — 9 cells, run from a committed state

**The canary came first.** C1 (anchor-form `{"$ref":"Node"}` injected into every published schema) was proven RED **by hand, before the sweep script existed**, and only then used as that script's known-RED canary. The ordering is the point: a canary invented alongside the harness it is meant to validate proves nothing about the harness. Builds are captured to a buffer, never piped into `grep -q` (a SIGPIPE'd build leaves the old binary and the guard then measures stale code); every restore is grep-verified and the sweep aborts if any file still holds sabotage.

| Cell | Sabotage | Guard | Verdict |
|---|---|---|---|
| C1 **canary** | anchor-form `{"$ref":"Node"}` in every published schema | binding-shim | RED — invariant arm, **51 found** |
| C2 | effective bound of 0 on the three 1.x tools' subtree | binding-shim | RED — anti-amputation, on **all three** 1.x ref-carrying tools, **24 checks** |
| C3 | the `FlattenRefs` call removed | binding-shim | RED — invariant arm, **30 found** (the pre-fix population exactly) |
| C4 | `MaxSelfExpansions = 2` | binding-shim | RED — "expands exactly 1 level (got 2)" |
| C5 | the terminator's honesty clause reworded | binding-shim | RED — "closes on an OPEN node" |
| C6 | ARM 7's ref-node member set tightened to `{$ref}` | schema-flatten | RED — merge-rule members |
| C7 | ARM 7's no-`$defs` check inverted | schema-flatten | RED — `$defs` arm |
| C8 | `PreFlattenSurface.RefNodes` emptied | binding-shim | RED — "derived subject set is non-empty — 0 sites across 0 tools" |
| C9 **inverse** | `compose`/`composes` `[JsonPropertyName]` order swapped | binding-shim | **GREEN**, as required — a member reorder is not an amputation |

**C1 and C2 are the two regressions that stayed fully green through both review rounds.** C2 now reddens on **`housecarl_create_record`, `housecarl_bulk_create` and `housecarl_bulk_apply` — 8 failing checks each, 24 in total**. Those are exactly the three 1.x tools whose ref pointers route through that subtree; `housecarl_apply` and `housecarl_create` address theirs through `/properties/ops/` and are untouched by this particular cell. **None of the three had an expansion arm before the wave** — the only arm walked `housecarl_apply`, which this sabotage does not touch, which is why it stayed green twice. That is the derived subject set covering three tools nobody would have thought to add by hand, stated as a measurement rather than as a claim.

*(The sabotage table in the branch's decision record named only `housecarl_create_record` here. The population was re-measured at source and corrected in that record's addendum 5 — an expectation narrower than its measured population being, pointedly, this branch's own failure class. The correction only strengthens the claim.)*

## Independent completion verification

The rounds, the wave, and this PR were each conducted by a different session; the branch's author ran none of them. A fresh verifier re-ran the acceptance tests from the committed state at `2db5789`, restoring and grep-verifying after each cell:

| Test | Expected | Measured |
|---|---|---|
| Anchor-form injection after the pass | invariant arm RED, 51 found | **RED, 51 found** |
| Bound-0 collapse on the 1.x subtree | derived expansion arm RED | **RED on 3 tools, 24 checks ("got 0")** |
| `FlattenRefs` call removed | invariant arm RED, 30 found | **RED, 30 found** |
| `MaxSelfExpansions = 2` | "got 2" | **RED, "the ruled bound; got 2"** |
| Terminator clause reworded | "closes on an OPEN node" | **RED** |
| ARM 7 members tightened to `{$ref}` | merge-rule arm RED | **RED, 26/27** |
| ARM 7 no-`$defs` check inverted | `$defs` arm RED | **RED, 26/27** |
| `compose`/`composes` order swapped | both guards GREEN | **GREEN** (subject set still 30/5) |
| `ci-all` | 133/133 | **133/133 ALL PASS** |

ADR 0002's figures were re-measured against the branch as it stands rather than taken from the record: 5 tools declare `compose` and they are exactly the 5 that carried refs; 10 terminator nodes on the surface = the 10 recursive sites; +5.93% on `tools/list` and +2.96–3.22 KB per affected schema; and `ToolCallShim` contains **zero** occurrences of `items` or `anyOf`, which is the ADR's "never descends" claim. The ADR is ARCHIVE the moment this merges, so this was its last edit window.

## Scope

Engine files only — `src/housecarl-mcp/ToolSchemas.cs` plus generator probes. **`RewriteFileListUnions` became `internal`** — the one non-probe code change, the same probe-access pattern `FlattenRefs` already uses, and it exists so ARM 7 replays the union pass rather than re-implementing it; a re-implementation would be a second emission resembling the real one, which is the defect the wave removed. No fix work in any 1.x tool body. Docs: the essay header moved out of `ToolSchemas.cs` to `docs/architecture/tool-schema-publication.md`, ADR 0002 records the invariant, and the `## Unreleased` CHANGELOG line is on the branch.

## For the reply to the reporter

- The recursion was real, is reproduced, and is fixed — thank you for the report; an error naming neither the server nor a tool is exactly why it needed measuring rather than guessing.
- **The `where=` half of the diagnosis is wrong.** `housecarl_cross_plugin_query` and `housecarl_records` publish `where=` as `{"type":["array","null"],"items":{"type":["string","null"]}}` — a string list, not a predicate tree. There are no refs anywhere in them. All 30 refs came from one shape: `StructInput` → the `sets[]` element → its `compose` → `StructInput`.
- **The fix is unconditional — there is nothing to configure.** The suggested `HouseCarl__FlatToolSchemas=true` was declined on purpose: the people who would need to set it are the ones who cannot load the server to set it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
