### PR TITLE
#486 PR 1 of 2: the test project gets a Papyrus fixture and a file-lock harness

### DIFF
--- a/docs/architecture/test-project-fixtures.md
+++ b/docs/architecture/test-project-fixtures.md
@@ -1,0 +1,122 @@
+# Test-project fixtures: the Papyrus world and the file-lock harness
+
+**Class:** LIVING. Subsystem: `src/housecarl-mcp-tests/{PexWriter,ScriptsWorld,HeldOpen}.cs`.
+Pinned by `ScriptsWorldTests` and `HeldOpenTests` in the same project.
+
+Two pieces of machinery the test project did not have before #486 PR 1, each in its own file, plus the
+tests that prove the machinery is what it claims to be. They exist because #486 PR 2 rewrites 197 old
+assertion sites as 147 arms, and 28 of those are script-property arms that need a `.pex` fixture while
+three are dialogue arms that need a held file. Nothing under `src/housecarl-mcp`, `src/housecarl-core`
+or `src/housecarl-generator` is involved.
+
+## `PexWriter` — ported, not referenced
+
+`WritePex` / `Decl` / `AutoObj` / `AutoScalar` are lifted from `src/housecarl-generator/ScriptPropertyCheckProbe.cs`
+(modulo accessibility and namespace). They write a byte-valid single-object Skyrim `.pex` carrying a chosen
+table of Auto properties: the property record plus its `::Name_var` backing variable, Flags =
+`Read|Write|AutoVar`, no handler functions, a non-null DocString, an empty auto-state and the empty `''`
+state.
+
+It is a **port rather than a project reference** because #486 PR 2 may delete the probe file that holds
+the generator's copy. The two copies coexist only until that PR lands; this one is the survivor. The
+probe's copy carries a stale `Mutagen 0.53.1` comment that was deliberately not carried over — the csproj
+pins 0.54.4.
+
+The writer has one branch worth naming: an Auto scalar may carry a baked initializer on its backing
+variable. The product reads that (`ScriptPropertyCheck`: a scalar with an initializer is not reported
+unbound), so the branch is what makes the fixture's `MyDefaulted` mean anything.
+
+## `ScriptsWorld` — the probe's records, re-homed as an MO2 instance
+
+The five records the probe plants are carried over with the same EditorIDs, VMAD shapes and property
+bindings: a footgun weapon (binds one non-null form, one null form, one quest alias; leaves three
+properties unbound), a fully-bound control, a weapon whose script has no compiled `.pex`, a script-free
+weapon, and a quest whose script hangs off an *alias* rather than the quest itself. Plus the loose
+`HcSpBase.pex` / `HcSpChild.pex` pair that declares what those records do or do not bind.
+
+**What is not the probe's is the world around them.** The probe built a bare temp directory and called
+`LoadOrderResolver.Build` + `AssetResolver.Build` directly, which the shipped tool surface cannot be
+pointed at. `ScriptsWorld` is a real MO2 instance in `RecordsWorld`'s shape — `ModOrganizer.ini`, a
+`profiles/Default/` triple, one mod folder holding both the plugin and its `Scripts\` folder — behind
+`LoadOrderService.WithInstance`. That is what lets the same fixture be driven by the service *and* by
+`housecarl_check` off the built server.
+
+It does **not** repoint `CorpusRulebook.CorpusPath`. `RecordsWorld` must, and pays for the restore-on-dispose
+care that costs; the script-property sweep reads VMADs and `.pex` tables and never the record rulebook, so
+this world generates no corpus and touches no process-global.
+
+It cannot be handed to the core `ScriptPropertyCheck.Run(resolver, assets, …)` directly: `LoadOrderService`'s
+`Resolver` and `Assets` are private and the world does not re-derive them. Nothing needs that seam —
+`ValidateScripts` carries every knob the core sweep takes — so it is not opened speculatively.
+
+**The world is frozen**, in the sense `BulkRecordsWorld` states: tests take fixture-known totals from it, so
+a later need gets its own world rather than an edit to this one. A test that *mutates* — holding a plugin
+open is a mutation by another name, since a held file is unreadable by anything else in the process —
+builds its own instance instead, or the world's readability would depend on test scheduling. That is why
+`HeldOpenTests` builds its own one-plugin world rather than locking this one's `PluginPath`.
+
+### The `HcSpNoPex` collision, and what the assertions rest on
+
+The no-`.pex` record's EditorID is `HcSpNoPex`, which is also the name of the script it attaches. Renaming
+would break the same-EditorIDs fidelity PR 1 is scoped to, so the fixture keeps the collision and the
+**assertions are anchored around it**: a bare `Assert.Contains("HcSpNoPex", …)` is satisfied by the record
+header alone, so the wire arm asserts the composed reason line (`'Scripts\HcSpNoPex.pex' is not on disk`)
+instead, which no record header can produce. If PR 2 finds the collision costs its arms more than it saves,
+renaming there is a fixture change with its own review.
+
+### Why the arms assert what they assert
+
+`ScriptCheckResult.RecordsWithScripts` is incremented *before* any `.pex` is opened, so a world whose
+planted `.pex` files were never found still reports four script-bearing records with every declaration
+silently unverifiable. Counting cannot tell a resolved fixture from a missing one; the declarations have to
+be observed. The loose-layer arm does that — the child's own declaration proves the mod's `Scripts\` folder
+is on the asset path at all, and the ancestor's proves the extends chain was walked to a second file.
+
+Two of the fixture's properties exist to produce **no** finding: `MyDefaulted` (the baked initializer) and
+`MyAliasBound` (an alias binding, which must not read as bound-but-null). Only a whole-set comparison can
+assert an absence, so both finding sets are pinned whole rather than sampled with a predicate.
+
+Text assertions over the rendered document pin a **whole composed line spelled from fixture-known values**,
+never a fragment: the phrase "declared but NOT bound" is emitted by both the object and the scalar render
+branch, so a fragment of it is satisfied by the wrong finding. Where a structured result carries the same
+fact, the service arm asserts that and the wire arm keeps one text line for reachability.
+
+One wire-path smoke test drives `housecarl_set_mo2_instance` then `housecarl_check findings=["scripts"]`
+off the built server, to prove the fixture is reachable through the live surface PR 2's arms will use. It
+spins its **own** server process: the shared `ServerFixture` is deliberately unconfigured and every stdio
+test in the run reads "the body ran" off its config prompt, so configuring it would retune all of them.
+
+### ADR 0003 rule 2 — the scripts family is briefly in both harnesses
+
+`ScriptsWorldTests` drives `ValidateScripts` and `housecarl_check findings=["scripts"]` while
+`ScriptPropertyCheckProbe.cs` still guards the same family in `ci-all`; one probe arm (PEX-ROUNDTRIP) is
+re-homed here. No family is converted, so no `Converted-from:` marker is owed and the mechanical guard —
+which is decidable only on that marker — has nothing to check. The literal rule is already documented RED
+at birth for the duration of the ruled sequence (`HarnessResidueTests`, the one-way conversion section).
+The overlap closes when #486 PR 2 deletes the probe, adds the marker and drops its baseline key.
+
+## `HeldOpen` — the file-lock harness
+
+An `IDisposable` that holds one file with `FileShare.None` and releases on dispose: MO2 or xEdit sitting on
+a plugin, which is the scenario houseCARL's no-handles-at-rest design explicitly invites. The mechanism is
+ported from `DialogueInfoOrderProbe.cs`'s `UNREAD-WIRED` / `DEFINER-LOCK-LOUD` / `WINNER-LOCK-LOUD` arms.
+
+The one thing it adds over an inline `FileStream` is that **acquisition failure throws**. Each of those
+probe arms wraps its own open in a try/catch whose catch marks the arm FAILED, because an arm that could
+not take the lock has not driven the path it names and would otherwise assert nothing while still reporting
+a pass. `Hold` makes that branch unreachable by omission.
+
+Nothing else was ported. The arms' own assertions are on product results (`CheckError`, the rendered
+sentence), which are PR 2's subject.
+
+The proofs use `LoadOrderResolver.OpenOverlay` as "an engine read" — the engine's documented single
+overlay-open choke point — which keeps the harness's proofs about the harness rather than pre-empting PR 2.
+A binary overlay is memory-mapped, so an undisposed one keeps a handle on the plugin for the rest of the
+process; the arms dispose it the way every product call site does, and each arm's last line calls
+`AssertNoHandlesLeft()` — a loud `Directory.Delete`, which Windows refuses while any handle is open. That
+runs at the end of the body rather than from `Dispose`, because a throwing `Dispose` replaces a real
+assertion failure with its own.
+
+The sharing-violation arm asserts the exact exception type and `ERROR_SHARING_VIOLATION` (HResult
+`0x80070020`), not the message text: the BCL composes that message and it is a localizable resource string,
+so a substring of it would pin .NET rather than the harness.

--- a/docs/architecture/test-project-fixtures.md
+++ b/docs/architecture/test-project-fixtures.md
@@ -120,3 +120,18 @@ assertion failure with its own.
 The sharing-violation arm asserts the exact exception type and `ERROR_SHARING_VIOLATION` (HResult
 `0x80070020`), not the message text: the BCL composes that message and it is a localizable resource string,
 so a substring of it would pin .NET rather than the harness.
+
+### `Read<T>` — `use` must materialise everything it returns
+
+The arms' `Read<T>` helper unmaps the overlay in a `finally`, so the overlay is gone *before* the value
+crosses the return. Every value-returning call site must therefore materialise inside `use` — a string, a
+count, a copy — and the helper refuses a `T` that is an `IModGetter` or an `IMajorRecordGetter` before it
+opens the plugin at all. That refusal exists because the failure is otherwise silent: measured on this
+fixture, `Read(path, mod => Assert.Single(mod.Weapons))` returned a record whose `EditorID` then read back
+correctly off the unmapped view and the arm reported a pass. The documented outcomes are an
+`ObjectDisposedException` at best and an `AccessViolationException` that takes the runner down at worst, and
+which one a caller gets is not the caller's to choose — so the hazard is refused at the type rather than
+left to the fixture's size. The check is a static one on `typeof(T)`: a caller who erases the type (returning
+`object`) walks past it, which is the limit of what a cheap guard buys. Same contract the product states on
+`OverlaySession` ("the service reads fields off a fetched body before its session disposes"); this is that
+sentence, restated where PR 2's three dialogue lock arms will read it.

--- a/docs/architecture/test-project-fixtures.md
+++ b/docs/architecture/test-project-fixtures.md
@@ -26,6 +26,17 @@ The writer has one branch worth naming: an Auto scalar may carry a baked initial
 variable. The product reads that (`ScriptPropertyCheck`: a scalar with an initializer is not reported
 unbound), so the branch is what makes the fixture's `MyDefaulted` mean anything.
 
+That branch writes `VariableType.Integer` while stamping the backing variable's `TypeName` from the caller's
+declared type, so it is only honest for an `Int`. `AutoScalar("MyFlag", "Bool", 1)` would produce
+`TypeName = "Bool"` over `VariableType = Integer` — a pairing no Papyrus compiler emits, which the product
+would then read off `VariableType` and render as `Bool Property MyFlag = 1 Auto`. An arm built on that
+fixture would assert product behaviour against a `.pex` shape the game never produces and stay green while
+claiming to model a defaulted Bool. So the writer **refuses** a non-`Int` declared type with an initializer,
+`ArgumentException` naming the property, the type and the value: the parameter name `initInt` was the only
+thing carrying the restriction, and #486 PR 2 spells 28 script-property arms against this machinery. Both
+branches are pinned — `TheWriterRefusesABakedInitializerOnANonIntScalar` and
+`TheWriterStillBakesAnIntScalarInitializerAndItRoundTrips`.
+
 ## `ScriptsWorld` — the probe's records, re-homed as an MO2 instance
 
 The five records the probe plants are carried over with the same EditorIDs, VMAD shapes and property

--- a/docs/architecture/test-project-fixtures.md
+++ b/docs/architecture/test-project-fixtures.md
@@ -92,6 +92,15 @@ never a fragment: the phrase "declared but NOT bound" is emitted by both the obj
 branch, so a fragment of it is satisfied by the wrong finding. Where a structured result carries the same
 fact, the service arm asserts that and the wire arm keeps one text line for reachability.
 
+A whole line is still not a whole anchor. Two records in this world carry the object-branch line for
+`MySpell`: the footgun, and the alias quest, whose alias script is the same `HcSpChild` and binds nothing —
+and because `MySpell`'s declaring script equals its attached script, `ComposeScriptRecordUnit` omits the
+`[declared in …]` clause for both, so the two lines are byte-identical. The wire arm therefore asserts the
+footgun's `[UNBOUND]` record header **immediately followed by** that line, as one composed span: the header
+carries the FormKey, the EditorID and the plugin, which no other record can produce. Measured: with the
+footgun's `VirtualMachineAdapter` dropped from the fixture the line-only assertion stayed green off the
+quest; the anchored one goes red.
+
 One wire-path smoke test drives `housecarl_set_mo2_instance` then `housecarl_check findings=["scripts"]`
 off the built server, to prove the fixture is reachable through the live surface PR 2's arms will use. It
 spins its **own** server process: the shared `ServerFixture` is deliberately unconfigured and every stdio

--- a/src/housecarl-mcp-tests/HeldOpen.cs
+++ b/src/housecarl-mcp-tests/HeldOpen.cs
@@ -1,22 +1,9 @@
-// The file-lock harness (#486 PR 1, item 2). Mechanism ported from
-// src/housecarl-generator/DialogueInfoOrderProbe.cs's UNREAD-WIRED / DEFINER-LOCK-LOUD / WINNER-LOCK-LOUD
-// arms, which each open a plugin FileShare.None, drive a product path across the lock, and assert the
-// product faulted LOUDLY rather than reporting a clean-looking result. The test project had nothing for
-// that before this file.
-
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// Holds one file open with <see cref="FileShare.None"/> for the lifetime of the object, and releases it on
-/// dispose — MO2 or xEdit sitting on a plugin, which is the scenario houseCARL's no-handles-at-rest design
-/// explicitly invites. A read attempted while the hold is alive cannot open the file.
-///
-/// <para><b>Acquisition failure is loud, by construction.</b> Each of the three probe arms this is ported
-/// from wraps its own <c>new FileStream(...)</c> in a try/catch whose catch marks the arm FAILED — because
-/// an arm that could not take the lock has not driven the path it names, and a swallowed acquisition would
-/// leave it asserting nothing at all while still reporting a pass. <see cref="Hold"/> throws a message that
-/// names the path and the underlying reason, so that failure mode cannot be reached by omission: there is no
-/// "returns null and the caller moved on" branch to forget to check.</para>
+/// Holds one file open with <see cref="FileShare.None"/> for the lifetime of the object — MO2 or xEdit
+/// sitting on a plugin. Where it was ported from and what it is for:
+/// <c>docs/architecture/test-project-fixtures.md</c>.
 /// </summary>
 public sealed class HeldOpen : IDisposable
 {
@@ -25,7 +12,7 @@ public sealed class HeldOpen : IDisposable
     HeldOpen(FileStream stream) => _stream = stream;
 
     /// <summary>Take an exclusive hold on <paramref name="path"/>. Throws — naming the path and the reason —
-    /// if the hold cannot be taken, including when the path does not exist.</summary>
+    /// if the hold cannot be taken, so no caller can proceed lockless past a swallowed failure.</summary>
     public static HeldOpen Hold(string path)
     {
         try

--- a/src/housecarl-mcp-tests/HeldOpen.cs
+++ b/src/housecarl-mcp-tests/HeldOpen.cs
@@ -1,0 +1,48 @@
+// The file-lock harness (#486 PR 1, item 2). Mechanism ported from
+// src/housecarl-generator/DialogueInfoOrderProbe.cs's UNREAD-WIRED / DEFINER-LOCK-LOUD / WINNER-LOCK-LOUD
+// arms, which each open a plugin FileShare.None, drive a product path across the lock, and assert the
+// product faulted LOUDLY rather than reporting a clean-looking result. The test project had nothing for
+// that before this file.
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// Holds one file open with <see cref="FileShare.None"/> for the lifetime of the object, and releases it on
+/// dispose — MO2 or xEdit sitting on a plugin, which is the scenario houseCARL's no-handles-at-rest design
+/// explicitly invites. A read attempted while the hold is alive cannot open the file.
+///
+/// <para><b>Acquisition failure is loud, by construction.</b> Each of the three probe arms this is ported
+/// from wraps its own <c>new FileStream(...)</c> in a try/catch whose catch marks the arm FAILED — because
+/// an arm that could not take the lock has not driven the path it names, and a swallowed acquisition would
+/// leave it asserting nothing at all while still reporting a pass. <see cref="Hold"/> throws a message that
+/// names the path and the underlying reason, so that failure mode cannot be reached by omission: there is no
+/// "returns null and the caller moved on" branch to forget to check.</para>
+/// </summary>
+public sealed class HeldOpen : IDisposable
+{
+    readonly FileStream _stream;
+
+    /// <summary>The file being held.</summary>
+    public string Path { get; }
+
+    HeldOpen(string path, FileStream stream) { Path = path; _stream = stream; }
+
+    /// <summary>Take an exclusive hold on <paramref name="path"/>. Throws — naming the path and the reason —
+    /// if the hold cannot be taken, including when the path does not exist.</summary>
+    public static HeldOpen Hold(string path)
+    {
+        try
+        {
+            return new HeldOpen(path, new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None));
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"could not take an exclusive hold on '{path}' to simulate a locked file — " +
+                $"{ex.GetType().Name}: {ex.Message}. Nothing was locked, so a test continuing past this " +
+                "point would assert against an ordinary readable file.", ex);
+        }
+    }
+
+    public void Dispose() => _stream.Dispose();
+}

--- a/src/housecarl-mcp-tests/HeldOpen.cs
+++ b/src/housecarl-mcp-tests/HeldOpen.cs
@@ -22,10 +22,7 @@ public sealed class HeldOpen : IDisposable
 {
     readonly FileStream _stream;
 
-    /// <summary>The file being held.</summary>
-    public string Path { get; }
-
-    HeldOpen(string path, FileStream stream) { Path = path; _stream = stream; }
+    HeldOpen(FileStream stream) => _stream = stream;
 
     /// <summary>Take an exclusive hold on <paramref name="path"/>. Throws — naming the path and the reason —
     /// if the hold cannot be taken, including when the path does not exist.</summary>
@@ -33,7 +30,7 @@ public sealed class HeldOpen : IDisposable
     {
         try
         {
-            return new HeldOpen(path, new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None));
+            return new HeldOpen(new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None));
         }
         catch (Exception ex)
         {

--- a/src/housecarl-mcp-tests/HeldOpenTests.cs
+++ b/src/housecarl-mcp-tests/HeldOpenTests.cs
@@ -41,9 +41,17 @@ public sealed class HeldOpenTests
     }
 
     /// <summary>The engine's single-plugin open, with the overlay disposed after — a memory-mapped overlay
-    /// left undisposed keeps a handle on the plugin for the rest of the process.</summary>
+    /// left undisposed keeps a handle on the plugin for the rest of the process.
+    /// <para><paramref name="use"/> must MATERIALISE everything it returns: the overlay is unmapped before the
+    /// value crosses the return. Why a mod or a record getter is refused rather than trusted:
+    /// <c>docs/architecture/test-project-fixtures.md</c>.</para></summary>
     static T Read<T>(string path, Func<ISkyrimModGetter, T> use)
     {
+        if (typeof(IModGetter).IsAssignableFrom(typeof(T)) || typeof(IMajorRecordGetter).IsAssignableFrom(typeof(T)))
+            throw new InvalidOperationException(
+                $"Read<{typeof(T).Name}> would return a view on an overlay this helper unmaps before the return — " +
+                "materialise what you need inside `use` (a string, a count, a copy) and return that instead.");
+
         var overlay = LoadOrderResolver.OpenOverlay(path, null);
         try { return use(overlay); }
         finally { (overlay as IDisposable)?.Dispose(); }
@@ -83,6 +91,24 @@ public sealed class HeldOpenTests
 
         var editorId = Read(world.PluginPath, mod => Assert.Single(mod.Weapons).EditorID);
         Assert.Equal(LockWorld.WeaponEditorId, editorId);
+
+        world.AssertNoHandlesLeft();
+    }
+
+    /// <summary>The materialise contract on <c>Read&lt;T&gt;</c>, made loud: a <c>T</c> that is still a view on
+    /// the overlay is refused before the plugin is opened at all.</summary>
+    [Fact]
+    public void ReadRefusesAValueThatWouldStillBeAViewOnTheUnmappedOverlay()
+    {
+        using var world = new LockWorld();
+
+        // Compiles identically to the materialising call below — which is the whole hazard.
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => Read(world.PluginPath, mod => Assert.Single(mod.Weapons)));
+        Assert.Contains("materialise what you need inside `use`", ex.Message, StringComparison.Ordinal);
+
+        // Vacuity: the same read, materialised, is untouched by the guard.
+        Assert.Equal(LockWorld.WeaponEditorId, Read(world.PluginPath, mod => Assert.Single(mod.Weapons).EditorID));
 
         world.AssertNoHandlesLeft();
     }

--- a/src/housecarl-mcp-tests/HeldOpenTests.cs
+++ b/src/housecarl-mcp-tests/HeldOpenTests.cs
@@ -1,0 +1,102 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// The file-lock harness's own proofs (#486 PR 1). They establish the two facts every arm built on
+/// <see cref="HeldOpen"/> rests on — that the hold really blocks an engine read, and that releasing it
+/// really unblocks the same read — plus the one that keeps a broken hold from passing quietly.
+///
+/// <para>Every arm here builds its OWN world and holds its OWN plugin. A lock is a mutation of shared state
+/// by any other name: a held file is not readable by anything else in the process, so holding one belonging
+/// to a shared fixture would make the world's readability depend on test scheduling. That is the same reason
+/// <see cref="RecordsWorld"/> gives for its mutating arms constructing their own instance.</para>
+/// </summary>
+public sealed class HeldOpenTests
+{
+    /// <summary>A throwaway one-plugin world this test owns outright, deleted when it is done with it.</summary>
+    sealed class LockWorld : IDisposable
+    {
+        public string Root { get; }
+        public string PluginPath { get; }
+        public const string WeaponEditorId = "HcLockW0";
+
+        public LockWorld()
+        {
+            Root = Path.Combine(Path.GetTempPath(), "hc-lock-tests-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Root);
+
+            var key = new ModKey("HcLock", ModType.Plugin);
+            var mod = new SkyrimMod(key, SkyrimRelease.SkyrimSE);
+            var w = mod.Weapons.AddNew();
+            w.EditorID = WeaponEditorId;
+
+            PluginPath = Path.Combine(Root, key.FileName.String);
+            mod.BeginWrite.ToPath(PluginPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        }
+
+        public void Dispose() { try { Directory.Delete(Root, true); } catch { /* temp cleanup best-effort */ } }
+    }
+
+    /// <summary>The engine's own single-plugin open, the read the hold is supposed to block.</summary>
+    static ISkyrimModGetter Read(string path) => LoadOrderResolver.OpenOverlay(path, null);
+
+    /// <summary>
+    /// While the hold is alive the engine read FAULTS — measured, not assumed: the type is
+    /// <see cref="IOException"/> and the message is Windows' own sharing-violation text. The second half is
+    /// the Q3 half and the reason this is not just <c>Assert.Throws</c> with a shrug: the failure mode worth
+    /// guarding is not "some exception", it is a read that comes back looking like a plugin with nothing in
+    /// it. <c>Assert.Throws</c> states that no value was returned at all.
+    /// </summary>
+    [Fact]
+    public void WhileHeldTheEngineReadFaultsLoudly_AndReturnsNoQuietlyEmptyPlugin()
+    {
+        using var world = new LockWorld();
+        using var hold = HeldOpen.Hold(world.PluginPath);
+
+        var ex = Assert.Throws<IOException>(() => Read(world.PluginPath));
+
+        Assert.Contains(Path.GetFileName(world.PluginPath), ex.Message, StringComparison.Ordinal);
+        Assert.Contains("being used by another process", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// After the hold is disposed the SAME read succeeds and yields the plugin's content. This is what stops
+    /// the arm above from passing on a file that was never readable in the first place — a fault before the
+    /// hold and a fault after it are indistinguishable from a working lock, until this runs.
+    /// </summary>
+    [Fact]
+    public void AfterTheHoldIsDisposedTheSameReadSucceeds()
+    {
+        using var world = new LockWorld();
+
+        var hold = HeldOpen.Hold(world.PluginPath);
+        Assert.Throws<IOException>(() => Read(world.PluginPath));
+        hold.Dispose();
+
+        var mod = Read(world.PluginPath);
+        var weapon = Assert.Single(mod.Weapons);
+        Assert.Equal(LockWorld.WeaponEditorId, weapon.EditorID);
+    }
+
+    /// <summary>
+    /// A hold that cannot be taken is itself loud, and names the path. The three probe arms this harness is
+    /// ported from each fail their own assertion when the lock cannot be acquired, for the reason
+    /// <see cref="HeldOpen"/> spells out: a test that silently proceeds without the lock asserts nothing while
+    /// still reporting a pass. A path that does not exist is the cheapest way to reach that branch.
+    /// </summary>
+    [Fact]
+    public void HoldingAPathThatDoesNotExistThrowsAndNamesThePath()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), "hc-lock-absent-" + Guid.NewGuid().ToString("N") + ".esp");
+
+        var ex = Assert.Throws<InvalidOperationException>(() => HeldOpen.Hold(missing));
+
+        Assert.Contains(missing, ex.Message, StringComparison.Ordinal);
+        Assert.IsType<FileNotFoundException>(ex.InnerException);
+    }
+}

--- a/src/housecarl-mcp-tests/HeldOpenTests.cs
+++ b/src/housecarl-mcp-tests/HeldOpenTests.cs
@@ -40,7 +40,14 @@ public sealed class HeldOpenTests
             mod.BeginWrite.ToPath(PluginPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
         }
 
-        public void Dispose() { try { Directory.Delete(Root, true); } catch { /* temp cleanup best-effort */ } }
+        /// <summary>The delete is LOUD, and that is the guard on this file's whole subject. A binary overlay
+        /// is memory-mapped: an undisposed one keeps a handle on the plugin, and Windows will not delete a
+        /// directory holding an open file — so the delete failing IS the leak, reported. Swallowed, the one
+        /// signal that proves the file-handle claim is thrown away, and dropping the overlay dispose in
+        /// <see cref="Read{T}"/> leaves the suite green (measured). The other worlds in this project keep a
+        /// best-effort swallow for a different reason — their deletes race a killed server process and they
+        /// claim no file-handle property; this one does.</summary>
+        public void Dispose() => Directory.Delete(Root, true);
     }
 
     /// <summary>
@@ -62,8 +69,8 @@ public sealed class HeldOpenTests
 
     /// <summary>
     /// While the hold is alive the engine read FAULTS — measured, not assumed: the type is
-    /// <see cref="IOException"/> and the message is Windows' own sharing-violation text. The second half is
-    /// the Q3 half and the reason this is not just <c>Assert.Throws</c> with a shrug: the failure mode worth
+    /// <see cref="IOException"/>, it names the file, and it carries Windows' ERROR_SHARING_VIOLATION. The
+    /// last is the Q3 half and the reason this is not just <c>Assert.Throws</c> with a shrug: the failure mode worth
     /// guarding is not "some exception", it is a read that comes back looking like a plugin with nothing in
     /// it. <c>Assert.Throws</c> states that no value was returned at all.
     /// </summary>
@@ -76,7 +83,12 @@ public sealed class HeldOpenTests
         var ex = Assert.Throws<IOException>(() => Read(world.PluginPath));
 
         Assert.Contains(Path.GetFileName(world.PluginPath), ex.Message, StringComparison.Ordinal);
-        Assert.Contains("being used by another process", ex.Message, StringComparison.Ordinal);
+
+        // ERROR_SHARING_VIOLATION (32) — measured: a FileShare.None collision comes back HResult 0x80070020.
+        // The HRESULT is what tells a sharing violation from any other IOException; the prose that says so
+        // ("...because it is being used by another process") is .NET's own localizable resource string, so
+        // it is not what the arm rests on. The file name above is interpolated, not translated.
+        Assert.Equal(32, ex.HResult & 0xFFFF);
     }
 
     /// <summary>
@@ -112,7 +124,11 @@ public sealed class HeldOpenTests
 
         var ex = Assert.Throws<InvalidOperationException>(() => HeldOpen.Hold(missing));
 
-        Assert.Contains(missing, ex.Message, StringComparison.Ordinal);
+        // Anchored to the sentence HeldOpen COMPOSES, not to a bare substring search for the path: the inner
+        // exception's own message already contains the full path, so `Assert.Contains(missing, ex.Message)`
+        // stays green with HeldOpen's own `'{path}'` deleted (measured). The framework would be carrying the
+        // assertion the arm's name says HeldOpen carries.
+        Assert.Contains($"could not take an exclusive hold on '{missing}'", ex.Message, StringComparison.Ordinal);
         Assert.IsType<FileNotFoundException>(ex.InnerException);
     }
 }

--- a/src/housecarl-mcp-tests/HeldOpenTests.cs
+++ b/src/housecarl-mcp-tests/HeldOpenTests.cs
@@ -6,20 +6,12 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// The file-lock harness's own proofs (#486 PR 1). They establish the two facts every arm built on
-/// <see cref="HeldOpen"/> rests on — that the hold really blocks an engine read, and that releasing it
-/// really unblocks the same read — plus the one that keeps a broken hold from passing quietly.
-///
-/// <para>Every arm here builds its OWN world and holds its OWN plugin. A lock is a mutation of shared state
-/// by any other name: a held file is not readable by anything else in the process, so holding one belonging
-/// to a shared fixture would make the world's readability depend on test scheduling. That is the same reason
-/// <see cref="RecordsWorld"/> gives for its mutating arms constructing their own instance.</para>
-/// </summary>
+/// <summary>The file-lock harness's own proofs. Why each arm builds its own world, and what the lock
+/// mechanism is: <c>docs/architecture/test-project-fixtures.md</c>.</summary>
 [Trait("tier", "integration")]
 public sealed class HeldOpenTests
 {
-    /// <summary>A throwaway one-plugin world this test owns outright, deleted when it is done with it.</summary>
+    /// <summary>A throwaway one-plugin world this test owns outright.</summary>
     sealed class LockWorld : IDisposable
     {
         public string Root { get; }
@@ -40,21 +32,16 @@ public sealed class HeldOpenTests
             mod.BeginWrite.ToPath(PluginPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
         }
 
-        /// <summary>Delete the world, loudly: Windows refuses while any handle on the plugin is open, so a
-        /// throw here IS an undisposed overlay. Call it as an arm's LAST line, after releasing the hold —
-        /// never from <see cref="Dispose"/>, where it would replace a real assertion failure with its own.</summary>
+        /// <summary>Windows refuses this while any handle on the plugin is open, so a throw here IS an
+        /// undisposed overlay. Call it as an arm's LAST line, after releasing the hold — never from
+        /// <see cref="Dispose"/>, which would replace a real assertion failure with its own.</summary>
         public void AssertNoHandlesLeft() => Directory.Delete(Root, true);
 
         public void Dispose() { try { Directory.Delete(Root, true); } catch { /* temp cleanup best-effort */ } }
     }
 
-    /// <summary>
-    /// The engine's own single-plugin open, the read the hold is supposed to block, with the caller's
-    /// <paramref name="use"/> run against the result and the overlay disposed after — the way every product
-    /// call site disposes it. A binary overlay is memory-mapped: an undisposed one keeps its own handle on
-    /// the plugin for the rest of the process, which in this file would leave a locked file behind and stop
-    /// the world's own directory from being deleted. A test about file handles must not leak one.
-    /// </summary>
+    /// <summary>The engine's single-plugin open, with the overlay disposed after — a memory-mapped overlay
+    /// left undisposed keeps a handle on the plugin for the rest of the process.</summary>
     static T Read<T>(string path, Func<ISkyrimModGetter, T> use)
     {
         var overlay = LoadOrderResolver.OpenOverlay(path, null);
@@ -65,13 +52,7 @@ public sealed class HeldOpenTests
     /// <summary>The same read, when the point is only whether it faults.</summary>
     static void Read(string path) => Read(path, _ => 0);
 
-    /// <summary>
-    /// While the hold is alive the engine read FAULTS — measured, not assumed: the type is
-    /// <see cref="IOException"/>, it names the file, and it carries Windows' ERROR_SHARING_VIOLATION. The
-    /// last is the Q3 half and the reason this is not just <c>Assert.Throws</c> with a shrug: the failure mode worth
-    /// guarding is not "some exception", it is a read that comes back looking like a plugin with nothing in
-    /// it. <c>Assert.Throws</c> states that no value was returned at all.
-    /// </summary>
+    /// <summary><c>Assert.Throws</c> is what states no quietly-empty plugin came back (Q3).</summary>
     [Fact]
     public void WhileHeldTheEngineReadFaultsLoudly_AndReturnsNoQuietlyEmptyPlugin()
     {
@@ -80,26 +61,22 @@ public sealed class HeldOpenTests
 
         var ex = Assert.Throws<IOException>(() => Read(world.PluginPath));
 
-        // ERROR_SHARING_VIOLATION. The exact type plus this is the whole discriminator: the BCL composes the
-        // message, so asserting a substring of it would pin .NET, not houseCARL.
+        // ERROR_SHARING_VIOLATION. The BCL composes the message, so a substring of it would pin .NET.
         Assert.Equal(32, ex.HResult & 0xFFFF);
 
         hold.Dispose();
         world.AssertNoHandlesLeft();
     }
 
-    /// <summary>
-    /// After the hold is disposed the SAME read succeeds and yields the plugin's content. This is what stops
-    /// the arm above from passing on a file that was never readable in the first place — a fault before the
-    /// hold and a fault after it are indistinguishable from a working lock, until this runs.
-    /// </summary>
+    /// <summary>The vacuity check on the arm above: a file that was never readable would fault identically
+    /// with a broken lock.</summary>
     [Fact]
     public void AfterTheHoldIsDisposedTheSameReadSucceeds()
     {
         using var world = new LockWorld();
 
-        // `using` as well as the explicit dispose: an assertion that fails before the release must not leave
-        // the exclusive handle alive for the rest of the process. Disposing a FileStream twice is a no-op.
+        // `using` as well as the explicit dispose: an assertion failing before the release must not leave the
+        // exclusive handle alive. Disposing a FileStream twice is a no-op.
         using var hold = HeldOpen.Hold(world.PluginPath);
         Assert.Throws<IOException>(() => Read(world.PluginPath));
         hold.Dispose();
@@ -110,12 +87,8 @@ public sealed class HeldOpenTests
         world.AssertNoHandlesLeft();
     }
 
-    /// <summary>
-    /// A hold that cannot be taken is itself loud, and names the path. The three probe arms this harness is
-    /// ported from each fail their own assertion when the lock cannot be acquired, for the reason
-    /// <see cref="HeldOpen"/> spells out: a test that silently proceeds without the lock asserts nothing while
-    /// still reporting a pass. A path that does not exist is the cheapest way to reach that branch.
-    /// </summary>
+    /// <summary>A hold that cannot be taken is loud — a test proceeding without the lock asserts nothing
+    /// while still reporting a pass.</summary>
     [Fact]
     public void HoldingAPathThatDoesNotExistThrowsAndNamesThePath()
     {
@@ -123,10 +96,8 @@ public sealed class HeldOpenTests
 
         var ex = Assert.Throws<InvalidOperationException>(() => HeldOpen.Hold(missing));
 
-        // Anchored to the sentence HeldOpen COMPOSES, not to a bare substring search for the path: the inner
-        // exception's own message already contains the full path, so `Assert.Contains(missing, ex.Message)`
-        // stays green with HeldOpen's own `'{path}'` deleted (measured). The framework would be carrying the
-        // assertion the arm's name says HeldOpen carries.
+        // The sentence HeldOpen composes, not a bare path search: the inner exception's own message carries
+        // the path, so a search for it stays green with HeldOpen's own half deleted.
         Assert.Contains($"could not take an exclusive hold on '{missing}'", ex.Message, StringComparison.Ordinal);
         Assert.IsType<FileNotFoundException>(ex.InnerException);
     }

--- a/src/housecarl-mcp-tests/HeldOpenTests.cs
+++ b/src/housecarl-mcp-tests/HeldOpenTests.cs
@@ -16,6 +16,7 @@ namespace HousecarlMcpTests;
 /// to a shared fixture would make the world's readability depend on test scheduling. That is the same reason
 /// <see cref="RecordsWorld"/> gives for its mutating arms constructing their own instance.</para>
 /// </summary>
+[Trait("tier", "integration")]
 public sealed class HeldOpenTests
 {
     /// <summary>A throwaway one-plugin world this test owns outright, deleted when it is done with it.</summary>
@@ -42,8 +43,22 @@ public sealed class HeldOpenTests
         public void Dispose() { try { Directory.Delete(Root, true); } catch { /* temp cleanup best-effort */ } }
     }
 
-    /// <summary>The engine's own single-plugin open, the read the hold is supposed to block.</summary>
-    static ISkyrimModGetter Read(string path) => LoadOrderResolver.OpenOverlay(path, null);
+    /// <summary>
+    /// The engine's own single-plugin open, the read the hold is supposed to block, with the caller's
+    /// <paramref name="use"/> run against the result and the overlay disposed after — the way every product
+    /// call site disposes it. A binary overlay is memory-mapped: an undisposed one keeps its own handle on
+    /// the plugin for the rest of the process, which in this file would leave a locked file behind and stop
+    /// the world's own directory from being deleted. A test about file handles must not leak one.
+    /// </summary>
+    static T Read<T>(string path, Func<ISkyrimModGetter, T> use)
+    {
+        var overlay = LoadOrderResolver.OpenOverlay(path, null);
+        try { return use(overlay); }
+        finally { (overlay as IDisposable)?.Dispose(); }
+    }
+
+    /// <summary>The same read, when the point is only whether it faults.</summary>
+    static void Read(string path) => Read(path, _ => 0);
 
     /// <summary>
     /// While the hold is alive the engine read FAULTS — measured, not assumed: the type is
@@ -74,13 +89,14 @@ public sealed class HeldOpenTests
     {
         using var world = new LockWorld();
 
-        var hold = HeldOpen.Hold(world.PluginPath);
+        // `using` as well as the explicit dispose: an assertion that fails before the release must not leave
+        // the exclusive handle alive for the rest of the process. Disposing a FileStream twice is a no-op.
+        using var hold = HeldOpen.Hold(world.PluginPath);
         Assert.Throws<IOException>(() => Read(world.PluginPath));
         hold.Dispose();
 
-        var mod = Read(world.PluginPath);
-        var weapon = Assert.Single(mod.Weapons);
-        Assert.Equal(LockWorld.WeaponEditorId, weapon.EditorID);
+        var editorId = Read(world.PluginPath, mod => Assert.Single(mod.Weapons).EditorID);
+        Assert.Equal(LockWorld.WeaponEditorId, editorId);
     }
 
     /// <summary>

--- a/src/housecarl-mcp-tests/HeldOpenTests.cs
+++ b/src/housecarl-mcp-tests/HeldOpenTests.cs
@@ -40,14 +40,12 @@ public sealed class HeldOpenTests
             mod.BeginWrite.ToPath(PluginPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
         }
 
-        /// <summary>The delete is LOUD, and that is the guard on this file's whole subject. A binary overlay
-        /// is memory-mapped: an undisposed one keeps a handle on the plugin, and Windows will not delete a
-        /// directory holding an open file — so the delete failing IS the leak, reported. Swallowed, the one
-        /// signal that proves the file-handle claim is thrown away, and dropping the overlay dispose in
-        /// <see cref="Read{T}"/> leaves the suite green (measured). The other worlds in this project keep a
-        /// best-effort swallow for a different reason — their deletes race a killed server process and they
-        /// claim no file-handle property; this one does.</summary>
-        public void Dispose() => Directory.Delete(Root, true);
+        /// <summary>Delete the world, loudly: Windows refuses while any handle on the plugin is open, so a
+        /// throw here IS an undisposed overlay. Call it as an arm's LAST line, after releasing the hold —
+        /// never from <see cref="Dispose"/>, where it would replace a real assertion failure with its own.</summary>
+        public void AssertNoHandlesLeft() => Directory.Delete(Root, true);
+
+        public void Dispose() { try { Directory.Delete(Root, true); } catch { /* temp cleanup best-effort */ } }
     }
 
     /// <summary>
@@ -82,13 +80,12 @@ public sealed class HeldOpenTests
 
         var ex = Assert.Throws<IOException>(() => Read(world.PluginPath));
 
-        Assert.Contains(Path.GetFileName(world.PluginPath), ex.Message, StringComparison.Ordinal);
-
-        // ERROR_SHARING_VIOLATION (32) — measured: a FileShare.None collision comes back HResult 0x80070020.
-        // The HRESULT is what tells a sharing violation from any other IOException; the prose that says so
-        // ("...because it is being used by another process") is .NET's own localizable resource string, so
-        // it is not what the arm rests on. The file name above is interpolated, not translated.
+        // ERROR_SHARING_VIOLATION. The exact type plus this is the whole discriminator: the BCL composes the
+        // message, so asserting a substring of it would pin .NET, not houseCARL.
         Assert.Equal(32, ex.HResult & 0xFFFF);
+
+        hold.Dispose();
+        world.AssertNoHandlesLeft();
     }
 
     /// <summary>
@@ -109,6 +106,8 @@ public sealed class HeldOpenTests
 
         var editorId = Read(world.PluginPath, mod => Assert.Single(mod.Weapons).EditorID);
         Assert.Equal(LockWorld.WeaponEditorId, editorId);
+
+        world.AssertNoHandlesLeft();
     }
 
     /// <summary>

--- a/src/housecarl-mcp-tests/PexWriter.cs
+++ b/src/housecarl-mcp-tests/PexWriter.cs
@@ -1,0 +1,76 @@
+// Ported from src/housecarl-generator/ScriptPropertyCheckProbe.cs (WritePex / Decl / AutoObj / AutoScalar).
+//
+// PORTED, not referenced: the generator's copy dies with the probe under #486 PR 2, and the scripts-family
+// arms that PR writes need a .pex writer that outlives it. The two copies are expected to coexist only until
+// that PR lands; this one is the survivor.
+//
+// The test project had NO Papyrus fixture of any kind before this file (#486 PR 1, item 1): nothing under
+// src/housecarl-mcp-tests referenced Pex, VirtualMachineAdapter or ScriptEntry.
+
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Pex;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// Writes byte-valid single-object Skyrim <c>.pex</c> files with a chosen table of Auto properties — the
+/// fixture side of every script-property assertion. The product reads a record's VMAD, then reads the
+/// attached script's compiled <c>.pex</c> (and its ancestors) to learn which properties were DECLARED; a
+/// test can only state "declared but not bound" if it can plant a declaration on disk.
+/// </summary>
+public static class PexWriter
+{
+    /// <summary>One Auto property to plant in a .pex: the property record + its backing variable (every auto
+    /// property has one, <c>::Name_var</c> — an object/scalar with no initializer carries Null data, an
+    /// initialized scalar carries the baked literal). Modeled on a real Skyrim .pex: an Auto property is
+    /// Flags = Read|Write|AutoVar with NO handler functions (the backing var IS the handler), a non-null
+    /// DocString, and the autovar name set.</summary>
+    public sealed record Decl(PexObjectProperty Prop, PexObjectVariable Backing);
+
+    static Decl Auto(string name, string typeName, int? initInt)
+    {
+        var prop = new PexObjectProperty
+        {
+            Name = name,
+            TypeName = typeName,
+            DocString = "",
+            Flags = PropertyFlags.Read | PropertyFlags.Write | PropertyFlags.AutoVar,
+            AutoVarName = $"::{name}_var",
+        };
+        var data = initInt is int v
+            ? new PexObjectVariableData { VariableType = VariableType.Integer, IntValue = v }
+            : new PexObjectVariableData { VariableType = VariableType.Null };
+        var backing = new PexObjectVariable { Name = $"::{name}_var", TypeName = typeName, VariableData = data };
+        return new Decl(prop, backing);
+    }
+
+    /// <summary>An Auto object/form property (no baked default — a FormID can't be a literal).</summary>
+    public static Decl AutoObj(string name, string typeName) => Auto(name, typeName, null);
+
+    /// <summary>An Auto scalar property, optionally with a baked initializer on its backing variable.</summary>
+    public static Decl AutoScalar(string name, string typeName, int? initInt) => Auto(name, typeName, initInt);
+
+    /// <summary>Write a single-object .pex with the given Auto properties + backing variables to
+    /// <paramref name="path"/> via Mutagen's native Pex writer. The object carries a non-null DocString, an
+    /// empty auto-state, and the empty '' state — the minimal byte-valid shell a real Skyrim .pex has. That
+    /// it round-trips is asserted, not assumed: see <c>ScriptsWorldTests</c>'s PEX-ROUNDTRIP arm.</summary>
+    public static void WritePex(string path, string name, string? parent, params Decl[] decls)
+    {
+        var obj = new PexObject { Name = name, ParentClassName = parent ?? "", DocString = "", AutoStateName = "" };
+        obj.States.Add(new PexObjectState { Name = "" });
+        foreach (var d in decls) { obj.Properties.Add(d.Prop); obj.Variables.Add(d.Backing); }
+
+        var pex = new PexFile(GameCategory.Skyrim)
+        {
+            MajorVersion = 3,
+            MinorVersion = 2,
+            GameId = 1,
+            CompilationTime = default,
+            SourceFileName = name + ".psc",
+            Username = "hc",
+            MachineName = "ci",
+        };
+        pex.Objects.Add(obj);
+        pex.WritePexFile(path, GameCategory.Skyrim);   // Mutagen PexMixIn.WritePexFile(outputPath, gameCategory)
+    }
+}

--- a/src/housecarl-mcp-tests/PexWriter.cs
+++ b/src/housecarl-mcp-tests/PexWriter.cs
@@ -1,30 +1,17 @@
-// Ported from src/housecarl-generator/ScriptPropertyCheckProbe.cs (WritePex / Decl / AutoObj / AutoScalar).
-//
-// PORTED, not referenced: the generator's copy dies with the probe under #486 PR 2, and the scripts-family
-// arms that PR writes need a .pex writer that outlives it. The two copies are expected to coexist only until
-// that PR lands; this one is the survivor.
-//
-// The test project had NO Papyrus fixture of any kind before this file (#486 PR 1, item 1): nothing under
-// src/housecarl-mcp-tests referenced Pex, VirtualMachineAdapter or ScriptEntry.
-
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Pex;
 
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// Writes byte-valid single-object Skyrim <c>.pex</c> files with a chosen table of Auto properties — the
-/// fixture side of every script-property assertion. The product reads a record's VMAD, then reads the
-/// attached script's compiled <c>.pex</c> (and its ancestors) to learn which properties were DECLARED; a
-/// test can only state "declared but not bound" if it can plant a declaration on disk.
+/// Writes byte-valid single-object Skyrim <c>.pex</c> files with a chosen table of Auto properties. Ported
+/// from <c>src/housecarl-generator/ScriptPropertyCheckProbe.cs</c> rather than referenced; why, and what
+/// the fixture uses it for: <c>docs/architecture/test-project-fixtures.md</c>.
 /// </summary>
 public static class PexWriter
 {
-    /// <summary>One Auto property to plant in a .pex: the property record + its backing variable (every auto
-    /// property has one, <c>::Name_var</c> — an object/scalar with no initializer carries Null data, an
-    /// initialized scalar carries the baked literal). Modeled on a real Skyrim .pex: an Auto property is
-    /// Flags = Read|Write|AutoVar with NO handler functions (the backing var IS the handler), a non-null
-    /// DocString, and the autovar name set.</summary>
+    /// <summary>One Auto property: the property record plus its <c>::Name_var</c> backing variable, which
+    /// carries Null data for an object or an uninitialized scalar and the baked literal otherwise.</summary>
     public sealed record Decl(PexObjectProperty Prop, PexObjectVariable Backing);
 
     static Decl Auto(string name, string typeName, int? initInt)
@@ -44,18 +31,15 @@ public static class PexWriter
         return new Decl(prop, backing);
     }
 
-    /// <summary>An Auto object/form property (no baked default — a FormID can't be a literal).</summary>
+    /// <summary>An Auto object/form property — no baked default, a FormID cannot be a literal.</summary>
     public static Decl AutoObj(string name, string typeName) => Auto(name, typeName, null);
 
-    /// <summary>An Auto scalar property, optionally with a baked initializer on its backing variable.</summary>
+    /// <summary>An Auto scalar property. A baked initializer is what stops the product reporting it
+    /// unbound, so the two branches are not interchangeable.</summary>
     public static Decl AutoScalar(string name, string typeName, int? initInt) => Auto(name, typeName, initInt);
 
-    /// <summary>Write a single-object .pex with the given Auto properties + backing variables to
-    /// <paramref name="path"/> via Mutagen's native Pex writer. The object carries a non-null DocString, an
-    /// empty auto-state, and the empty '' state — the minimal byte-valid shell a real Skyrim .pex has. That
-    /// it round-trips is asserted, not assumed: see
-    /// <c>ScriptsWorldTests.ThePlantedChildPexReadsBackWithItsAutoPropertyAndItsParentClass</c> (the probe's
-    /// PEX-ROUNDTRIP arm, re-homed).</summary>
+    /// <summary>Write a single-object .pex to <paramref name="path"/>. That it round-trips is asserted, not
+    /// assumed: <c>ScriptsWorldTests.ThePlantedChildPexReadsBackWithItsAutoPropertyAndItsParentClass</c>.</summary>
     public static void WritePex(string path, string name, string? parent, params Decl[] decls)
     {
         var obj = new PexObject { Name = name, ParentClassName = parent ?? "", DocString = "", AutoStateName = "" };
@@ -73,6 +57,6 @@ public static class PexWriter
             MachineName = "ci",
         };
         pex.Objects.Add(obj);
-        pex.WritePexFile(path, GameCategory.Skyrim);   // Mutagen PexMixIn.WritePexFile(outputPath, gameCategory)
+        pex.WritePexFile(path, GameCategory.Skyrim);
     }
 }

--- a/src/housecarl-mcp-tests/PexWriter.cs
+++ b/src/housecarl-mcp-tests/PexWriter.cs
@@ -16,6 +16,16 @@ public static class PexWriter
 
     static Decl Auto(string name, string typeName, int? initInt)
     {
+        // The initializer branch writes VariableType.Integer under the caller's declared TypeName, so only an
+        // Int scalar can carry one. Why it refuses instead of documenting: docs/architecture/test-project-fixtures.md.
+        if (initInt is int bad && !string.Equals(typeName, "Int", StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException(
+                $"a baked initializer was given for '{name}', declared '{typeName}', with value {bad}: this writer "
+                + "only bakes Integer initializers, because an Int scalar with a baked default is the only "
+                + "declared-type/initializer pairing this fixture models. Writing it would pair VariableType.Integer "
+                + $"with TypeName '{typeName}' — a shape no Papyrus compiler emits.",
+                nameof(typeName));
+
         var prop = new PexObjectProperty
         {
             Name = name,

--- a/src/housecarl-mcp-tests/PexWriter.cs
+++ b/src/housecarl-mcp-tests/PexWriter.cs
@@ -53,7 +53,9 @@ public static class PexWriter
     /// <summary>Write a single-object .pex with the given Auto properties + backing variables to
     /// <paramref name="path"/> via Mutagen's native Pex writer. The object carries a non-null DocString, an
     /// empty auto-state, and the empty '' state — the minimal byte-valid shell a real Skyrim .pex has. That
-    /// it round-trips is asserted, not assumed: see <c>ScriptsWorldTests</c>'s PEX-ROUNDTRIP arm.</summary>
+    /// it round-trips is asserted, not assumed: see
+    /// <c>ScriptsWorldTests.ThePlantedChildPexReadsBackWithItsAutoPropertyAndItsParentClass</c> (the probe's
+    /// PEX-ROUNDTRIP arm, re-homed).</summary>
     public static void WritePex(string path, string name, string? parent, params Decl[] decls)
     {
         var obj = new PexObject { Name = name, ParentClassName = parent ?? "", DocString = "", AutoStateName = "" };

--- a/src/housecarl-mcp-tests/ScriptsWorld.cs
+++ b/src/housecarl-mcp-tests/ScriptsWorld.cs
@@ -1,9 +1,14 @@
 // The Papyrus fixture world (#486 PR 1, item 1). Record shapes ported from
 // src/housecarl-generator/ScriptPropertyCheckProbe.cs's RunChecks — same EditorIDs, same VMAD shapes, same
 // property bindings, same planted .pex pair — re-homed as an MO2-INSTANCE world so the same fixture can be
-// driven three ways: the core sweep, the service (LoadOrderService over the instance), and housecarl_check
-// off the built server. The probe's own world was a bare directory + LoadOrderResolver.Build, which the
-// shipped tool surface cannot point at.
+// driven by the service (LoadOrderService.ValidateScripts over the instance) AND by housecarl_check off the
+// built server. The probe's own world was a bare directory + LoadOrderResolver.Build, which the shipped tool
+// surface cannot point at.
+//
+// It cannot be handed to the core ScriptPropertyCheck.Run(resolver, assets, …) directly: LoadOrderService's
+// Resolver and Assets are private and this world does not re-derive them. Nothing needs that seam —
+// ValidateScripts carries every knob the core sweep takes (record scope, property_contains, finding classes,
+// counts_only, exclude, limit) — so it is not opened speculatively.
 
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;

--- a/src/housecarl-mcp-tests/ScriptsWorld.cs
+++ b/src/housecarl-mcp-tests/ScriptsWorld.cs
@@ -1,15 +1,3 @@
-// The Papyrus fixture world (#486 PR 1, item 1). Record shapes ported from
-// src/housecarl-generator/ScriptPropertyCheckProbe.cs's RunChecks — same EditorIDs, same VMAD shapes, same
-// property bindings, same planted .pex pair — re-homed as an MO2-INSTANCE world so the same fixture can be
-// driven by the service (LoadOrderService.ValidateScripts over the instance) AND by housecarl_check off the
-// built server. The probe's own world was a bare directory + LoadOrderResolver.Build, which the shipped tool
-// surface cannot point at.
-//
-// It cannot be handed to the core ScriptPropertyCheck.Run(resolver, assets, …) directly: LoadOrderService's
-// Resolver and Assets are private and this world does not re-derive them. Nothing needs that seam —
-// ValidateScripts carries every knob the core sweep takes (record scope, property_contains, finding classes,
-// counts_only, exclude, limit) — so it is not opened speculatively.
-
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records;
@@ -20,19 +8,15 @@ using Xunit;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// The synthetic MO2 world the script-property surface is driven against: one plugin carrying five records
-/// (a footgun, a fully-bound control, a script with no compiled .pex, a script-free record, and a QUST whose
-/// script hangs off an ALIAS), plus the loose <c>Scripts/HcSpBase.pex</c> + <c>Scripts/HcSpChild.pex</c> pair
-/// that DECLARES the properties those records do or do not bind.
+/// The synthetic MO2 world the script-property surface is driven against: one plugin of five records plus
+/// the loose <c>Scripts/HcSpBase.pex</c> + <c>Scripts/HcSpChild.pex</c> pair that DECLARES what those
+/// records do or do not bind. Where the records came from, why it is an MO2 instance rather than the
+/// probe's bare directory, and why it generates no corpus:
+/// <c>docs/architecture/test-project-fixtures.md</c>.
 ///
-/// <para>One instance is shared by every read-only test through <see cref="ScriptsFixture"/>, and it is
-/// FROZEN: tests take fixture-known totals from it (four script-bearing records), so a later need gets its
-/// own world rather than an edit to this one. A test that MUTATES — the file-lock arms hold a plugin open —
-/// constructs its own instance and never touches this world's files.</para>
-///
-/// <para>No corpus. Unlike <see cref="RecordsWorld"/> this world never repoints
-/// <c>CorpusRulebook.CorpusPath</c>: the script-property sweep reads VMADs and .pex tables, never the record
-/// rulebook, so generating a corpus here would be cost with no subject.</para>
+/// <para>Shared through <see cref="ScriptsFixture"/> and FROZEN: tests take fixture-known totals from it,
+/// so a later need gets its own world rather than an edit to this one, and a test that holds a file open
+/// builds its own instance.</para>
 /// </summary>
 public sealed class ScriptsWorld : IDisposable
 {
@@ -87,7 +71,10 @@ public sealed class ScriptsWorld : IDisposable
     public string Instance { get; }
     public string ModsDir { get; }
     public string ScriptsDir { get; }
+
+    /// <summary>The shared world's plugin. An arm that would HOLD it open builds its own world instead.</summary>
     public string PluginPath { get; }
+
     public string PluginName { get; }
 
     public LoadOrderService Svc { get; }

--- a/src/housecarl-mcp-tests/ScriptsWorld.cs
+++ b/src/housecarl-mcp-tests/ScriptsWorld.cs
@@ -1,0 +1,220 @@
+// The Papyrus fixture world (#486 PR 1, item 1). Record shapes ported from
+// src/housecarl-generator/ScriptPropertyCheckProbe.cs's RunChecks — same EditorIDs, same VMAD shapes, same
+// property bindings, same planted .pex pair — re-homed as an MO2-INSTANCE world so the same fixture can be
+// driven three ways: the core sweep, the service (LoadOrderService over the instance), and housecarl_check
+// off the built server. The probe's own world was a bare directory + LoadOrderResolver.Build, which the
+// shipped tool surface cannot point at.
+
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// The synthetic MO2 world the script-property surface is driven against: one plugin carrying five records
+/// (a footgun, a fully-bound control, a script with no compiled .pex, a script-free record, and a QUST whose
+/// script hangs off an ALIAS), plus the loose <c>Scripts/HcSpBase.pex</c> + <c>Scripts/HcSpChild.pex</c> pair
+/// that DECLARES the properties those records do or do not bind.
+///
+/// <para>One instance is shared by every read-only test through <see cref="ScriptsFixture"/>, and it is
+/// FROZEN: tests take fixture-known totals from it (four script-bearing records), so a later need gets its
+/// own world rather than an edit to this one. A test that MUTATES — the file-lock arms hold a plugin open —
+/// constructs its own instance and never touches this world's files.</para>
+///
+/// <para>No corpus. Unlike <see cref="RecordsWorld"/> this world never repoints
+/// <c>CorpusRulebook.CorpusPath</c>: the script-property sweep reads VMADs and .pex tables, never the record
+/// rulebook, so generating a corpus here would be cost with no subject.</para>
+/// </summary>
+public sealed class ScriptsWorld : IDisposable
+{
+    // ---- fixture-known names: the vocabulary every assertion spells ------------------------------------
+
+    /// <summary>The child script every scripted record in this world attaches.</summary>
+    public const string ChildScript = "HcSpChild";
+
+    /// <summary>The ancestor <see cref="ChildScript"/> extends — where <c>InheritedThing</c> is declared.</summary>
+    public const string BaseScript = "HcSpBase";
+
+    /// <summary>The script attached with NO compiled .pex on disk — the unverifiable case (Q3).</summary>
+    public const string MissingScript = "HcSpNoPex";
+
+    public const string FootgunEditorId = "HcSpFootgun";
+    public const string CleanEditorId = "HcSpClean";
+    public const string NoPexEditorId = "HcSpNoPex";
+    public const string NoVmadEditorId = "HcSpNoVmad";
+    public const string AliasQuestEditorId = "HcSpAliasQuest";
+
+    /// <summary>The property declared on the ANCESTOR script, reachable only by walking the extends chain.</summary>
+    public const string InheritedProperty = "InheritedThing";
+
+    /// <summary>The unbound OBJECT property — the reported silent-None footgun.</summary>
+    public const string ObjectProperty = "MySpell";
+
+    /// <summary>An object property the footgun DOES bind, to a non-null form.</summary>
+    public const string BoundProperty = "MyBoundSpell";
+
+    /// <summary>An Int property with no baked default — unbound reads as an uninitialized SCALAR finding.</summary>
+    public const string ScalarProperty = "MyChance";
+
+    /// <summary>An Int property with a baked default of 5 — unbound is NOT a finding.</summary>
+    public const string DefaultedProperty = "MyDefaulted";
+
+    /// <summary>The baked initializer on <see cref="DefaultedProperty"/>.</summary>
+    public const int DefaultedValue = 5;
+
+    /// <summary>An object property bound through a quest ALIAS (Object null, Alias >= 0) — bound, not null.</summary>
+    public const string AliasBoundProperty = "MyAliasBound";
+
+    /// <summary>An object property bound to a NULL form — the bound-but-null advisory.</summary>
+    public const string NullProperty = "MyNullSpell";
+
+    /// <summary>How many records in this world carry scripts: footgun, clean, noPex, aliasQuest. The
+    /// script-free record is excluded — that exclusion is the whole point of the number.</summary>
+    public const int RecordsWithScripts = 4;
+
+    // ---- the world -------------------------------------------------------------------------------------
+
+    public string Root { get; }
+    public string Instance { get; }
+    public string ModsDir { get; }
+    public string ScriptsDir { get; }
+    public string PluginPath { get; }
+    public string PluginName { get; }
+
+    public LoadOrderService Svc { get; }
+
+    public FormKey Footgun { get; }
+    public FormKey Clean { get; }
+    public FormKey NoPex { get; }
+    public FormKey NoVmad { get; }
+    public FormKey AliasQuest { get; }
+
+    public ScriptsWorld()
+    {
+        Root = Path.Combine(Path.GetTempPath(), "hc-scripts-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(Root, "game", "Data"));
+
+        Instance = Path.Combine(Root, "inst");
+        ModsDir = Path.Combine(Instance, "mods");
+        var modDir = Path.Combine(ModsDir, "ScriptsMod");
+        ScriptsDir = Path.Combine(modDir, "Scripts");
+        Directory.CreateDirectory(ScriptsDir);
+
+        // ---- 1) the two .pex fixtures, under the mod's own Scripts folder (MO2's loose-file layer). ----
+        PexWriter.WritePex(Path.Combine(ScriptsDir, BaseScript + ".pex"), BaseScript, parent: null,
+            PexWriter.AutoObj(InheritedProperty, "ObjectReference"));
+
+        PexWriter.WritePex(Path.Combine(ScriptsDir, ChildScript + ".pex"), ChildScript, parent: BaseScript,
+            PexWriter.AutoObj(ObjectProperty, "Spell"),
+            PexWriter.AutoObj(BoundProperty, "Spell"),
+            PexWriter.AutoScalar(ScalarProperty, "Int", initInt: null),
+            PexWriter.AutoScalar(DefaultedProperty, "Int", initInt: DefaultedValue),  // baked default ⇒ NOT flagged unbound
+            PexWriter.AutoObj(AliasBoundProperty, "Spell"),                           // bound via a quest Alias
+            PexWriter.AutoObj(NullProperty, "Spell"));
+
+        // ---- 2) the plugin of scripted records. ----
+        var key = new ModKey("HcSp", ModType.Plugin);
+        PluginName = key.FileName.String;
+        PluginPath = Path.Combine(modDir, PluginName);
+
+        var mod = new SkyrimMod(key, SkyrimRelease.SkyrimSE);
+        // A non-null in-plugin FormKey for "bound" object props — the target need not exist, only IsNull is read.
+        var self = new FormKey(key, 0x000801);
+
+        // wFootgun — the reported failure shape. MyAliasBound is bound via a quest alias (Object null,
+        // Alias >= 0): it must count as BOUND, and must NOT be flagged bound-but-null.
+        var footgun = mod.Weapons.AddNew(); footgun.EditorID = FootgunEditorId;
+        footgun.VirtualMachineAdapter = Vmad(ChildScript,
+            ObjProp(BoundProperty, self), ObjProp(NullProperty, FormKey.Null), AliasProp(AliasBoundProperty, 2));
+        Footgun = footgun.FormKey;
+
+        // wClean — fully bound: the no-false-positive control.
+        var clean = mod.Weapons.AddNew(); clean.EditorID = CleanEditorId;
+        clean.VirtualMachineAdapter = Vmad(ChildScript,
+            ObjProp(ObjectProperty, self), ObjProp(BoundProperty, self), ObjProp(NullProperty, self),
+            ObjProp(AliasBoundProperty, self), ObjProp(InheritedProperty, self),
+            IntProp(ScalarProperty, 3), IntProp(DefaultedProperty, DefaultedValue));
+        Clean = clean.FormKey;
+
+        // wNoPex — a script with no compiled .pex on disk: unverifiable, never a silent clean.
+        var noPex = mod.Weapons.AddNew(); noPex.EditorID = NoPexEditorId;
+        noPex.VirtualMachineAdapter = Vmad(MissingScript);
+        NoPex = noPex.FormKey;
+
+        // wNoVmad — a script-free record: never counted, never nagged.
+        var noVmad = mod.Weapons.AddNew(); noVmad.EditorID = NoVmadEditorId;
+        NoVmad = noVmad.FormKey;
+
+        // aliasQuest — a QUST whose script hangs off an ALIAS (QuestAdapter.Aliases[].Scripts), NOT the
+        // quest's own Scripts. The alias script binds nothing, so every declared property is unbound.
+        var quest = mod.Quests.AddNew(); quest.EditorID = AliasQuestEditorId;
+        var adapter = new QuestAdapter();
+        var alias = new QuestFragmentAlias { Property = new ScriptObjectProperty { Alias = 0 } };
+        alias.Scripts.Add(new ScriptEntry { Name = ChildScript });
+        adapter.Aliases.Add(alias);
+        quest.VirtualMachineAdapter = adapter;
+        AliasQuest = quest.FormKey;
+
+        mod.BeginWrite.ToPath(PluginPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+        // ---- 3) the MO2 instance around them. ----
+        File.WriteAllText(Path.Combine(Instance, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(Root, "game").Replace(@"\", @"\\") + ")\r\n");
+        var prof = Path.Combine(Instance, "profiles", "Default");
+        Directory.CreateDirectory(prof);
+        File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + PluginName + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*" + PluginName + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n+ScriptsMod\r\n");
+
+        var store = new UserConfigStore(Path.Combine(Root, "user.json"));
+        Svc = LoadOrderService.WithInstance(Instance, 0, store);
+    }
+
+    // ---- VMAD builders (ported from the probe's fixture builders) ---------------------------------------
+
+    /// <summary>A VMAD binding ONE script with the given bound properties.</summary>
+    static VirtualMachineAdapter Vmad(string scriptClass, params ScriptProperty[] props)
+    {
+        var entry = new ScriptEntry { Name = scriptClass };
+        foreach (var p in props) entry.Properties.Add(p);
+        var vmad = new VirtualMachineAdapter();
+        vmad.Scripts.Add(entry);
+        return vmad;
+    }
+
+    static ScriptObjectProperty ObjProp(string name, FormKey obj)
+    {
+        var p = new ScriptObjectProperty { Name = name, Alias = -1 };
+        if (!obj.IsNull) p.Object.SetTo(obj);
+        return p;
+    }
+
+    /// <summary>An object property bound to a quest ALIAS (Alias &gt;= 0), Object left null — the healthy
+    /// shape that must NOT read as bound-but-null.</summary>
+    static ScriptObjectProperty AliasProp(string name, short alias) => new() { Name = name, Alias = alias };
+
+    static ScriptIntProperty IntProp(string name, int data) => new() { Name = name, Data = data };
+
+    public void Dispose()
+    {
+        Svc.Dispose();
+        try { Directory.Delete(Root, true); } catch { /* temp cleanup best-effort */ }
+    }
+}
+
+/// <summary>The shared, read-only Papyrus world. One build per test class collection.</summary>
+public sealed class ScriptsFixture : IDisposable
+{
+    public ScriptsWorld W { get; } = new();
+    public LoadOrderService Svc => W.Svc;
+    public void Dispose() => W.Dispose();
+}
+
+/// <summary>Every Papyrus-fixture test runs in one collection, over one built world.</summary>
+[CollectionDefinition("scripts")]
+public sealed class ScriptsCollection : ICollectionFixture<ScriptsFixture> { }

--- a/src/housecarl-mcp-tests/ScriptsWorldTests.cs
+++ b/src/housecarl-mcp-tests/ScriptsWorldTests.cs
@@ -157,11 +157,14 @@ public sealed class ScriptsWorldTests
         // The unverifiable attribution, spelled the way the sweep composes it — names the .pex it looked for.
         Assert.Contains($@"'Scripts\{ScriptsWorld.MissingScript}.pex' is not on disk", r.Text, StringComparison.Ordinal);
 
-        // The WHOLE object-branch line, spelled from fixture-known values. The scalar branch emits the same
-        // "declared but NOT bound" phrase, so a fragment of it is satisfied by MyChance; only this line is.
+        // The WHOLE object-branch line, spelled from fixture-known values, UNDER THE FOOTGUN'S OWN RECORD
+        // HEADER. The line alone has two carriers in this world — the alias quest declares MySpell through the
+        // same script and binds nothing, so it renders the identical line — and the header is the only thing
+        // that says which record produced it. One composed span, so the two must be adjacent.
         Assert.Contains(
-            $"{ScriptsWorld.ObjectProperty} (Spell) on script {ScriptsWorld.ChildScript}"
-            + " — declared but NOT bound → None at runtime (HIGH: object/form type — the silent no-op)",
+            $"[UNBOUND] {_w.Footgun} (Weapon '{ScriptsWorld.FootgunEditorId}') in {_w.PluginName}\n"
+            + $"  ! {ScriptsWorld.ObjectProperty} (Spell) on script {ScriptsWorld.ChildScript}"
+            + " — declared but NOT bound → None at runtime (HIGH: object/form type — the silent no-op)\n",
             r.Text, StringComparison.Ordinal);
     }
 }

--- a/src/housecarl-mcp-tests/ScriptsWorldTests.cs
+++ b/src/housecarl-mcp-tests/ScriptsWorldTests.cs
@@ -161,10 +161,11 @@ public sealed class ScriptsWorldTests
         // The unverifiable attribution, spelled the way the sweep composes it — names the .pex it looked for.
         Assert.Contains($@"'Scripts\{ScriptsWorld.MissingScript}.pex' is not on disk", r.Text, StringComparison.Ordinal);
 
-        // A finding only a RESOLVED child .pex can produce: the declaration has to have been read for the
-        // property to be known unbound at all.
-        Assert.Contains($"{ScriptsWorld.ObjectProperty} (Spell) on script {ScriptsWorld.ChildScript}",
-                        r.Text, StringComparison.Ordinal);
-        Assert.Contains("declared but NOT bound", r.Text, StringComparison.Ordinal);
+        // The WHOLE object-branch line, spelled from fixture-known values. The scalar branch emits the same
+        // "declared but NOT bound" phrase, so a fragment of it is satisfied by MyChance; only this line is.
+        Assert.Contains(
+            $"{ScriptsWorld.ObjectProperty} (Spell) on script {ScriptsWorld.ChildScript}"
+            + " — declared but NOT bound → None at runtime (HIGH: object/form type — the silent no-op)",
+            r.Text, StringComparison.Ordinal);
     }
 }

--- a/src/housecarl-mcp-tests/ScriptsWorldTests.cs
+++ b/src/housecarl-mcp-tests/ScriptsWorldTests.cs
@@ -6,23 +6,10 @@ using Xunit;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// The Papyrus fixture's own proofs (#486 PR 1). These do not test the script-property surface — they test
-/// that <see cref="ScriptsWorld"/> is what it claims to be, so the arms PR 2 writes on top of it can assert
-/// findings without also having to prove their fixture.
-///
-/// <para>The load-bearing one is the loose-layer arm. <c>ScriptCheckResult.RecordsWithScripts</c> is
-/// incremented before any .pex is opened, so a world whose planted <c>.pex</c> files were never found would
-/// still report four script-bearing records — with every declaration silently unverifiable. Counting alone
-/// therefore cannot tell a resolved fixture from a missing one; the declarations have to be observed.</para>
-///
-/// <para><b>ADR 0003 rule 2 — the scripts family is briefly in both harnesses.</b> These arms drive
-/// <c>ValidateScripts</c> and <c>housecarl_check findings=["scripts"]</c>, so a product regression in
-/// loose-layer resolution or ancestor walking turns them red — while <c>ScriptPropertyCheckProbe.cs</c>
-/// still guards the same family. No <c>Converted-from:</c> marker is carried and none is owed: nothing
-/// here converts a probe. The mechanical guard is decidable only on that marker, and the literal rule is
-/// already documented RED at birth during the ruled sequence (<c>HarnessResidueTests.cs</c>, the one-way
-/// conversion section). The overlap closes when #486's PR 2 deletes the probe, adds the marker and drops
-/// its baseline key; it is stated on this PR for Aaron's gate rather than worked around here.</para>
+/// The Papyrus fixture's own proofs: that <see cref="ScriptsWorld"/> is what it claims to be, so the arms
+/// built on it can assert findings without also proving their fixture. What each arm rests on, and the
+/// ADR 0003 rule-2 overlap that lasts until the probe is deleted:
+/// <c>docs/architecture/test-project-fixtures.md</c>.
 /// </summary>
 [Collection("scripts")]
 public sealed class ScriptsWorldTests
@@ -30,11 +17,8 @@ public sealed class ScriptsWorldTests
     readonly ScriptsWorld _w;
     public ScriptsWorldTests(ScriptsFixture f) => _w = f.W;
 
-    /// <summary>
-    /// PEX-ROUNDTRIP, re-homed from <c>ScriptPropertyCheckProbe</c>: the planted child .pex is a valid
-    /// Skyrim .pex whose Auto property table and parent link survive the write. Everything else in the
-    /// fixture rests on this — a .pex the product cannot read makes every declaration unverifiable.
-    /// </summary>
+    /// <summary>PEX-ROUNDTRIP, re-homed from <c>ScriptPropertyCheckProbe</c>. Everything else in the fixture
+    /// rests on this: a .pex the product cannot read makes every declaration unverifiable.</summary>
     [Fact]
     [Trait("tier", "integration")]
     public void ThePlantedChildPexReadsBackWithItsAutoPropertyAndItsParentClass()
@@ -50,11 +34,8 @@ public sealed class ScriptsWorldTests
         Assert.True(prop.Flags.HasFlag(PropertyFlags.AutoVar));
     }
 
-    /// <summary>
-    /// The world loads through the engine the way <see cref="RecordsWorld"/>'s does — a real MO2 instance
-    /// behind <c>LoadOrderService</c> — and the script-bearing population is exactly the four VMAD-carrying
-    /// records. The script-free weapon is the teeth: it is in the same plugin and must not be counted.
-    /// </summary>
+    /// <summary>The script-bearing population is exactly the four VMAD-carrying records. The script-free
+    /// weapon is the teeth: same plugin, must not be counted.</summary>
     [Fact]
     [Trait("tier", "integration")]
     public void TheServiceSweepsTheInstanceAndExactlyTheVmadCarryingRecordsAreScriptBearing()
@@ -73,21 +54,9 @@ public sealed class ScriptsWorldTests
             reported);
     }
 
-    /// <summary>
-    /// BOTH planted .pex files resolve through the MO2 loose-file layer — the fixture's vacuity canary.
-    /// The child's own declaration and the ancestor's are asserted separately: the child proves the mod's
-    /// <c>Scripts\</c> folder is on the asset path at all, and the inherited one proves the extends chain
-    /// was walked to a SECOND file, which a world with only one resolvable .pex could not produce.
-    ///
-    /// <para>The two finding SETS are pinned whole, not sampled. <c>Assert.Single(collection, predicate)</c>
-    /// states that one element matches — it says nothing about the rest, so an EXTRA finding passes unseen,
-    /// and the two fixture properties whose whole point is that they produce NO finding would be guarded by
-    /// nothing: <c>MyDefaulted</c>, which rests on <see cref="PexWriter"/>'s baked-initializer branch (the
-    /// product suppresses an unbound scalar exactly when the backing variable carries an initializer), and
-    /// <c>MyAliasBound</c>, which rests on <see cref="ScriptsWorld"/> binding through a quest alias (Alias
-    /// >= 0 with a null Object is BOUND, not bound-but-null). Both are absences, and only a set comparison
-    /// can assert an absence.</para>
-    /// </summary>
+    /// <summary>The fixture's vacuity canary: the counts survive a world whose .pex files never resolved, so
+    /// the declarations are observed instead. Both finding sets are pinned WHOLE — <c>MyDefaulted</c> and
+    /// <c>MyAliasBound</c> exist to produce no finding, and only a set comparison asserts an absence.</summary>
     [Fact]
     [Trait("tier", "integration")]
     public void BothPlantedPexFilesResolveThroughTheLooseLayer_SoTheDeclarationsAreRealNotUnverifiable()
@@ -120,25 +89,9 @@ public sealed class ScriptsWorldTests
         Assert.Equal(ScriptsWorld.BaseScript, inherited.DeclaringScript, ignoreCase: true);
     }
 
-    /// <summary>
-    /// ONE wire-path smoke test: the world is reachable through the LIVE surface, driven off the built
-    /// server over stdio — <c>housecarl_set_mo2_instance</c> at this instance, then
-    /// <c>housecarl_check findings=["scripts"]</c>. This is what makes the fixture usable by the arms PR 2
-    /// writes; it is not one of them.
-    ///
-    /// <para>Its own server, never the shared <see cref="ServerFixture"/>: that one is deliberately
-    /// UNCONFIGURED — every stdio test in the run reads "the body ran" off its config prompt — and pointing
-    /// it at an instance would silently retune all of them.</para>
-    ///
-    /// <para><b>Every string asserted here is anchored to something only this world can produce.</b> Three
-    /// looser spellings were measured and refused: the bare words <c>not on disk</c> are in the scripts
-    /// family's boundary sentence, which the renderer writes through the reserve on EVERY scripts response
-    /// (<c>ReadSentences.SweepScriptBoundary</c>); the bare script name <c>HcSpNoPex</c> is also the
-    /// record's own EditorID, printed by the record header regardless; and the record count survives a world
-    /// whose .pex files never resolved, because <c>RecordsWithScripts</c> is incremented before any .pex is
-    /// opened. All three stay green over a broken fixture. The reason line and the unbound finding below
-    /// cannot.</para>
-    /// </summary>
+    /// <summary>ONE wire-path smoke test — the fixture is reachable through the live surface, which is what
+    /// makes it usable by the arms built on it. Its OWN server: the shared <see cref="ServerFixture"/> is
+    /// deliberately unconfigured and every stdio test reads "the body ran" off its config prompt.</summary>
     [Fact]
     [Trait("tier", "stdio")]
     public void CheckOverTheWireReportsTheFixtureKnownScriptCountAndNamesTheUnverifiableScript()
@@ -156,6 +109,8 @@ public sealed class ScriptsWorldTests
 
         Assert.False(r.IsError, r.Describe());
         Assert.DoesNotContain(ServerFixture.ConfigPrompt, r.Text, StringComparison.Ordinal);
+        // A fixture-known count, kept as the cheap canary that a scripts response came back at all — it
+        // cannot tell a resolved fixture from a broken one; the two assertions below can.
         Assert.Contains($"{ScriptsWorld.RecordsWithScripts} record(s) with scripts", r.Text, StringComparison.Ordinal);
 
         // The unverifiable attribution, spelled the way the sweep composes it — names the .pex it looked for.

--- a/src/housecarl-mcp-tests/ScriptsWorldTests.cs
+++ b/src/housecarl-mcp-tests/ScriptsWorldTests.cs
@@ -34,6 +34,47 @@ public sealed class ScriptsWorldTests
         Assert.True(prop.Flags.HasFlag(PropertyFlags.AutoVar));
     }
 
+    /// <summary>The writer bakes an Integer initializer whatever the declared type says, so a non-Int scalar
+    /// with one is refused rather than written as a pairing no Papyrus compiler emits.</summary>
+    [Fact]
+    [Trait("tier", "integration")]
+    public void TheWriterRefusesABakedInitializerOnANonIntScalar()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => PexWriter.AutoScalar("MyFlag", "Bool", 1));
+
+        Assert.Contains(
+            "a baked initializer was given for 'MyFlag', declared 'Bool', with value 1: this writer only bakes "
+            + "Integer initializers, because an Int scalar with a baked default is the only declared-type/"
+            + "initializer pairing this fixture models. Writing it would pair VariableType.Integer with TypeName "
+            + "'Bool' — a shape no Papyrus compiler emits.",
+            ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>The refusal's other branch: the pairing the fixture DOES model still writes, and still reads
+    /// back as a baked Integer — which is what makes <c>MyDefaulted</c> mean anything.</summary>
+    [Fact]
+    [Trait("tier", "integration")]
+    public void TheWriterStillBakesAnIntScalarInitializerAndItRoundTrips()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "hc-pexwriter-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var path = Path.Combine(dir, "HcPwProbe.pex");
+            PexWriter.WritePex(path, "HcPwProbe", parent: null,
+                PexWriter.AutoScalar(ScriptsWorld.ScalarProperty, "Int", ScriptsWorld.DefaultedValue));
+
+            var obj = Assert.Single(PexFile.CreateFromFile(path, GameCategory.Skyrim).Objects);
+            var backing = Assert.Single(obj.Variables,
+                v => string.Equals(v.Name, $"::{ScriptsWorld.ScalarProperty}_var", StringComparison.OrdinalIgnoreCase));
+
+            Assert.Equal("Int", backing.TypeName, ignoreCase: true);
+            Assert.Equal(VariableType.Integer, backing.VariableData!.VariableType);
+            Assert.Equal(ScriptsWorld.DefaultedValue, backing.VariableData.IntValue);
+        }
+        finally { try { Directory.Delete(dir, true); } catch { /* temp cleanup best-effort */ } }
+    }
+
     /// <summary>The script-bearing population is exactly the four VMAD-carrying records. The script-free
     /// weapon is the teeth: same plugin, must not be counted.</summary>
     [Fact]

--- a/src/housecarl-mcp-tests/ScriptsWorldTests.cs
+++ b/src/housecarl-mcp-tests/ScriptsWorldTests.cs
@@ -14,9 +14,17 @@ namespace HousecarlMcpTests;
 /// incremented before any .pex is opened, so a world whose planted <c>.pex</c> files were never found would
 /// still report four script-bearing records — with every declaration silently unverifiable. Counting alone
 /// therefore cannot tell a resolved fixture from a missing one; the declarations have to be observed.</para>
+///
+/// <para><b>ADR 0003 rule 2 — the scripts family is briefly in both harnesses.</b> These arms drive
+/// <c>ValidateScripts</c> and <c>housecarl_check findings=["scripts"]</c>, so a product regression in
+/// loose-layer resolution or ancestor walking turns them red — while <c>ScriptPropertyCheckProbe.cs</c>
+/// still guards the same family. No <c>Converted-from:</c> marker is carried and none is owed: nothing
+/// here converts a probe. The mechanical guard is decidable only on that marker, and the literal rule is
+/// already documented RED at birth during the ruled sequence (<c>HarnessResidueTests.cs</c>, the one-way
+/// conversion section). The overlap closes when #486's PR 2 deletes the probe, adds the marker and drops
+/// its baseline key; it is stated on this PR for Aaron's gate rather than worked around here.</para>
 /// </summary>
 [Collection("scripts")]
-[Trait("tier", "integration")]
 public sealed class ScriptsWorldTests
 {
     readonly ScriptsWorld _w;
@@ -28,6 +36,7 @@ public sealed class ScriptsWorldTests
     /// fixture rests on this — a .pex the product cannot read makes every declaration unverifiable.
     /// </summary>
     [Fact]
+    [Trait("tier", "integration")]
     public void ThePlantedChildPexReadsBackWithItsAutoPropertyAndItsParentClass()
     {
         var back = PexFile.CreateFromFile(
@@ -47,6 +56,7 @@ public sealed class ScriptsWorldTests
     /// records. The script-free weapon is the teeth: it is in the same plugin and must not be counted.
     /// </summary>
     [Fact]
+    [Trait("tier", "integration")]
     public void TheServiceSweepsTheInstanceAndExactlyTheVmadCarryingRecordsAreScriptBearing()
     {
         var res = _w.Svc.ValidateScripts(null, 1000);
@@ -68,14 +78,37 @@ public sealed class ScriptsWorldTests
     /// The child's own declaration and the ancestor's are asserted separately: the child proves the mod's
     /// <c>Scripts\</c> folder is on the asset path at all, and the inherited one proves the extends chain
     /// was walked to a SECOND file, which a world with only one resolvable .pex could not produce.
+    ///
+    /// <para>The two finding SETS are pinned whole, not sampled. <c>Assert.Single(collection, predicate)</c>
+    /// states that one element matches — it says nothing about the rest, so an EXTRA finding passes unseen,
+    /// and the two fixture properties whose whole point is that they produce NO finding would be guarded by
+    /// nothing: <c>MyDefaulted</c>, which rests on <see cref="PexWriter"/>'s baked-initializer branch (the
+    /// product suppresses an unbound scalar exactly when the backing variable carries an initializer), and
+    /// <c>MyAliasBound</c>, which rests on <see cref="ScriptsWorld"/> binding through a quest alias (Alias
+    /// >= 0 with a null Object is BOUND, not bound-but-null). Both are absences, and only a set comparison
+    /// can assert an absence.</para>
     /// </summary>
     [Fact]
+    [Trait("tier", "integration")]
     public void BothPlantedPexFilesResolveThroughTheLooseLayer_SoTheDeclarationsAreRealNotUnverifiable()
     {
         var res = _w.Svc.ValidateScripts(null, 1000);
         var foot = Assert.Single(res.Reports, r => r.Record == _w.Footgun);
 
         Assert.Empty(foot.Unverifiable);   // nothing about this record's script was left unread
+
+        // The unbound set EXACTLY: the two the footgun leaves unbound plus the ancestor's. MyDefaulted is
+        // absent because its backing variable carries a baked initializer; MyBoundSpell, MyNullSpell and
+        // MyAliasBound are absent because the VMAD binds them.
+        Assert.Equal(
+            new[] { ScriptsWorld.InheritedProperty, ScriptsWorld.ScalarProperty, ScriptsWorld.ObjectProperty }
+                .OrderBy(x => x, StringComparer.Ordinal).ToArray(),
+            foot.Unbound.Select(u => u.PropertyName).OrderBy(x => x, StringComparer.Ordinal).ToArray());
+
+        // The bound-but-null set EXACTLY: the null-form binding, and NOT the alias binding.
+        Assert.Equal(
+            new[] { ScriptsWorld.NullProperty },
+            foot.NullObjects.Select(n => n.PropertyName).ToArray());
 
         var own = Assert.Single(foot.Unbound,
             u => string.Equals(u.PropertyName, ScriptsWorld.ObjectProperty, StringComparison.Ordinal));

--- a/src/housecarl-mcp-tests/ScriptsWorldTests.cs
+++ b/src/housecarl-mcp-tests/ScriptsWorldTests.cs
@@ -1,0 +1,117 @@
+using System.Text.Json;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Pex;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// The Papyrus fixture's own proofs (#486 PR 1). These do not test the script-property surface — they test
+/// that <see cref="ScriptsWorld"/> is what it claims to be, so the arms PR 2 writes on top of it can assert
+/// findings without also having to prove their fixture.
+///
+/// <para>The load-bearing one is the loose-layer arm. <c>ScriptCheckResult.RecordsWithScripts</c> is
+/// incremented before any .pex is opened, so a world whose planted <c>.pex</c> files were never found would
+/// still report four script-bearing records — with every declaration silently unverifiable. Counting alone
+/// therefore cannot tell a resolved fixture from a missing one; the declarations have to be observed.</para>
+/// </summary>
+[Collection("scripts")]
+public sealed class ScriptsWorldTests
+{
+    readonly ScriptsWorld _w;
+    public ScriptsWorldTests(ScriptsFixture f) => _w = f.W;
+
+    /// <summary>
+    /// PEX-ROUNDTRIP, re-homed from <c>ScriptPropertyCheckProbe</c>: the planted child .pex is a valid
+    /// Skyrim .pex whose Auto property table and parent link survive the write. Everything else in the
+    /// fixture rests on this — a .pex the product cannot read makes every declaration unverifiable.
+    /// </summary>
+    [Fact]
+    public void ThePlantedChildPexReadsBackWithItsAutoPropertyAndItsParentClass()
+    {
+        var back = PexFile.CreateFromFile(
+            Path.Combine(_w.ScriptsDir, ScriptsWorld.ChildScript + ".pex"), GameCategory.Skyrim);
+
+        var obj = Assert.Single(back.Objects);
+        Assert.Equal(ScriptsWorld.BaseScript, obj.ParentClassName, ignoreCase: true);
+
+        var prop = Assert.Single(obj.Properties,
+            p => string.Equals(p.Name, ScriptsWorld.ObjectProperty, StringComparison.OrdinalIgnoreCase));
+        Assert.True(prop.Flags.HasFlag(PropertyFlags.AutoVar));
+    }
+
+    /// <summary>
+    /// The world loads through the engine the way <see cref="RecordsWorld"/>'s does — a real MO2 instance
+    /// behind <c>LoadOrderService</c> — and the script-bearing population is exactly the four VMAD-carrying
+    /// records. The script-free weapon is the teeth: it is in the same plugin and must not be counted.
+    /// </summary>
+    [Fact]
+    public void TheServiceSweepsTheInstanceAndExactlyTheVmadCarryingRecordsAreScriptBearing()
+    {
+        var res = _w.Svc.ValidateScripts(null, 1000);
+
+        Assert.True(res.Success, res.Error);
+        Assert.Equal(ScriptsWorld.RecordsWithScripts, res.RecordsWithScripts);
+
+        // The fully-bound control reports nothing, and the script-free record is not swept at all — so the
+        // reported set is the other three, named by their fixture-known EditorIDs.
+        var reported = res.Reports.Select(r => r.EditorId).OrderBy(e => e, StringComparer.Ordinal).ToArray();
+        Assert.Equal(
+            new[] { ScriptsWorld.AliasQuestEditorId, ScriptsWorld.FootgunEditorId, ScriptsWorld.NoPexEditorId }
+                .OrderBy(e => e, StringComparer.Ordinal).ToArray(),
+            reported);
+    }
+
+    /// <summary>
+    /// BOTH planted .pex files resolve through the MO2 loose-file layer — the fixture's vacuity canary.
+    /// The child's own declaration and the ancestor's are asserted separately: the child proves the mod's
+    /// <c>Scripts\</c> folder is on the asset path at all, and the inherited one proves the extends chain
+    /// was walked to a SECOND file, which a world with only one resolvable .pex could not produce.
+    /// </summary>
+    [Fact]
+    public void BothPlantedPexFilesResolveThroughTheLooseLayer_SoTheDeclarationsAreRealNotUnverifiable()
+    {
+        var res = _w.Svc.ValidateScripts(null, 1000);
+        var foot = Assert.Single(res.Reports, r => r.Record == _w.Footgun);
+
+        Assert.Empty(foot.Unverifiable);   // nothing about this record's script was left unread
+
+        var own = Assert.Single(foot.Unbound,
+            u => string.Equals(u.PropertyName, ScriptsWorld.ObjectProperty, StringComparison.Ordinal));
+        Assert.True(own.IsObjectType);
+        Assert.Equal(ScriptsWorld.ChildScript, own.DeclaringScript, ignoreCase: true);
+
+        var inherited = Assert.Single(foot.Unbound,
+            u => string.Equals(u.PropertyName, ScriptsWorld.InheritedProperty, StringComparison.Ordinal));
+        Assert.Equal(ScriptsWorld.BaseScript, inherited.DeclaringScript, ignoreCase: true);
+    }
+
+    /// <summary>
+    /// ONE wire-path smoke test: the world is reachable through the LIVE surface, driven off the built
+    /// server over stdio — <c>housecarl_set_mo2_instance</c> at this instance, then
+    /// <c>housecarl_check findings=["scripts"]</c>. This is what makes the fixture usable by the arms PR 2
+    /// writes; it is not one of them.
+    ///
+    /// <para>Its own server, never the shared <see cref="ServerFixture"/>: that one is deliberately
+    /// UNCONFIGURED — every stdio test in the run reads "the body ran" off its config prompt — and pointing
+    /// it at an instance would silently retune all of them.</para>
+    /// </summary>
+    [Fact]
+    [Trait("tier", "stdio")]
+    public void CheckOverTheWireReportsTheFixtureKnownScriptCountAndNamesTheUnverifiableScript()
+    {
+        using var server = new ServerFixture();
+
+        var set = server.Call(ToolNames.SetMo2Instance,
+            $$"""{"path": {{JsonSerializer.Serialize(_w.Instance)}}}""");
+        Assert.False(set.IsError, set.Describe());
+
+        var r = server.Call(ToolNames.Check, """{"findings":["scripts"]}""");
+
+        Assert.False(r.IsError, r.Describe());
+        Assert.DoesNotContain(ServerFixture.ConfigPrompt, r.Text, StringComparison.Ordinal);
+        Assert.Contains($"{ScriptsWorld.RecordsWithScripts} record(s) with scripts", r.Text, StringComparison.Ordinal);
+        Assert.Contains(ScriptsWorld.MissingScript, r.Text, StringComparison.Ordinal);
+        Assert.Contains("not on disk", r.Text, StringComparison.Ordinal);
+    }
+}

--- a/src/housecarl-mcp-tests/ScriptsWorldTests.cs
+++ b/src/housecarl-mcp-tests/ScriptsWorldTests.cs
@@ -16,6 +16,7 @@ namespace HousecarlMcpTests;
 /// therefore cannot tell a resolved fixture from a missing one; the declarations have to be observed.</para>
 /// </summary>
 [Collection("scripts")]
+[Trait("tier", "integration")]
 public sealed class ScriptsWorldTests
 {
     readonly ScriptsWorld _w;
@@ -95,6 +96,15 @@ public sealed class ScriptsWorldTests
     /// <para>Its own server, never the shared <see cref="ServerFixture"/>: that one is deliberately
     /// UNCONFIGURED — every stdio test in the run reads "the body ran" off its config prompt — and pointing
     /// it at an instance would silently retune all of them.</para>
+    ///
+    /// <para><b>Every string asserted here is anchored to something only this world can produce.</b> Three
+    /// looser spellings were measured and refused: the bare words <c>not on disk</c> are in the scripts
+    /// family's boundary sentence, which the renderer writes through the reserve on EVERY scripts response
+    /// (<c>ReadSentences.SweepScriptBoundary</c>); the bare script name <c>HcSpNoPex</c> is also the
+    /// record's own EditorID, printed by the record header regardless; and the record count survives a world
+    /// whose .pex files never resolved, because <c>RecordsWithScripts</c> is incremented before any .pex is
+    /// opened. All three stay green over a broken fixture. The reason line and the unbound finding below
+    /// cannot.</para>
     /// </summary>
     [Fact]
     [Trait("tier", "stdio")]
@@ -102,16 +112,26 @@ public sealed class ScriptsWorldTests
     {
         using var server = new ServerFixture();
 
+        // A bad instance comes back as an in-band "error: …" text result, not an MCP error, so IsError
+        // cannot tell a configured server from a refused one. The confirmation render is what can.
         var set = server.Call(ToolNames.SetMo2Instance,
             $$"""{"path": {{JsonSerializer.Serialize(_w.Instance)}}}""");
-        Assert.False(set.IsError, set.Describe());
+        Assert.Contains($"configured houseCARL -> MO2 instance '{_w.Instance}'", set.Text, StringComparison.Ordinal);
+        Assert.Contains("active profile: Default", set.Text, StringComparison.Ordinal);
 
         var r = server.Call(ToolNames.Check, """{"findings":["scripts"]}""");
 
         Assert.False(r.IsError, r.Describe());
         Assert.DoesNotContain(ServerFixture.ConfigPrompt, r.Text, StringComparison.Ordinal);
         Assert.Contains($"{ScriptsWorld.RecordsWithScripts} record(s) with scripts", r.Text, StringComparison.Ordinal);
-        Assert.Contains(ScriptsWorld.MissingScript, r.Text, StringComparison.Ordinal);
-        Assert.Contains("not on disk", r.Text, StringComparison.Ordinal);
+
+        // The unverifiable attribution, spelled the way the sweep composes it — names the .pex it looked for.
+        Assert.Contains($@"'Scripts\{ScriptsWorld.MissingScript}.pex' is not on disk", r.Text, StringComparison.Ordinal);
+
+        // A finding only a RESOLVED child .pex can produce: the declaration has to have been read for the
+        // property to be known unbound at all.
+        Assert.Contains($"{ScriptsWorld.ObjectProperty} (Spell) on script {ScriptsWorld.ChildScript}",
+                        r.Text, StringComparison.Ordinal);
+        Assert.Contains("declared but NOT bound", r.Text, StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
Lands after #484 on Aaron's sequence; merge that first.

Part of #486 (PR 1 of 2; the issue closes at PR 2).

Two pieces of test machinery `src/housecarl-mcp-tests` did not have — a Papyrus fixture (a `.pex` writer plus the child/base property pair, re-homed as an MO2-instance world) and a file-lock harness — each in its own new file, plus the seven tests that prove the machinery is what it claims to be. Nothing is deleted. No file under `src/housecarl-generator`, `src/housecarl-mcp` or `src/housecarl-core` is touched, and `harness-residue-baseline.json` is not in the diff.

`docs/architecture/test-project-fixtures.md` is new and carries the rationale (ADR 0001's named home).

## Gates, measured from the committed tip

| gate | `main` @ `18709bb` | branch @ `a012b1e` |
|---|---|---|
| `dotnet build housecarl.sln -c Release` | 0 errors | 0 errors |
| `ci-all` | 132/132 ALL PASS | 132/132 ALL PASS |
| `dotnet test src/housecarl-mcp-tests` | 391 passed | 398 passed, 0 failed |
| published tool names | 46 | 46 (this branch publishes and unpublishes nothing) |

Measured again at each of the three tips, not once. Temp residue after every full run: zero `hc-lock-tests-*`, zero `hc-scripts-tests-*`.

## The rounds

Two rounds, four independent reviewers, each in its own isolated worktree, none of them the branch's author. Round 1 was one seeded reviewer plus one gate-replica (seeded with nothing but the branch and base, standing in for a first look with no conventions pointer).

**Round 1 — 0 high, 3 medium, 3 low, 2 nit. All 8 folded (`b7ca93a`), nothing refused** — every finding reproduced in the source when triaged against the code the reviewer cited.

- Two mediums, found independently from different angles: the loose-layer arm sampled findings with `Assert.Single(collection, predicate)` and never read the sizes, leaving `MyDefaulted` (the baked-initializer branch) and `MyAliasBound` (the alias binding) — two fixture properties whose whole point is producing **no** finding — guarded by nothing; and the acquisition-failure arm asserted the path with a bare substring that the inner exception's own message already satisfied. Both sets are now pinned whole; the path assertion is anchored to the sentence `HeldOpen` composes.
- The third medium: `LockWorld.Dispose` swallowed its `Directory.Delete`, so the overlay-leak fix in the previous commit could be reverted with the suite still green.
- Lows and nits: the sharing-violation assertion rested on .NET's localizable resource string and now rests on `ERROR_SHARING_VIOLATION` (HResult `0x80070020`, measured); the wire test carried two `tier` values because xUnit traits are additive and the class carried one; `HeldOpen.Path` was read by nothing and shadowed `System.IO.Path` inside the class; the ADR 0003 overlap and a cross-reference were stated where they belong.

**Round 2 — 0 high, 1 medium, 5 low, 4 nit — and two instances of round 1's class.**

Round 1's class was *an assertion whose real carrier is wider than the subject the arm names*. Round 2 found it twice more: the wire arm asserted the bare phrase `declared but NOT bound`, which `ReadTools` emits from **both** the object and the scalar branch (the fixture carries an unbound scalar, so the scalar branch alone satisfied it); and the lock arm asserted the plugin's file name inside an `IOException` message the BCL composes — the same defect round 1 fixed one method down, which that fold did not sweep for.

That is the same class in two consecutive rounds, so the rounds stopped there under CLAUDE.md §5 #11 and the seam went up for a ruling rather than a third fold. **No round 3.**

### Directed folds (`c3ce6f3`, `a012b1e`)

- The wire arm now asserts the **whole object-branch line**, spelled in the test from fixture-known values, which the scalar branch cannot satisfy. The structured form of the same fact is already asserted by the service arm; the wire arm keeps one text line for reachability.
- The lock arm's BCL-message substring is gone. The exact exception type plus the HResult are the discriminator, and neither is .NET's prose.
- The loud delete became `AssertNoHandlesLeft()`, called as each arm's last line after the hold is released, with `Dispose` best-effort again — a throwing `Dispose` was replacing a real assertion failure with its own.
- Three nits folded: `PluginPath` carries the constraint that an arm holding it open builds its own world; the sentence describing a mutating consumer that does not exist here is gone; the wire arm's count assertion has the clause saying why it is kept (a cheap canary that a scripts response came back at all).

### Refused

**One, and it stands after the ruling:** renaming the wire test so its name lists the unbound-property assertion too. A test name that undersells what it asserts is not a false claim, the name is already ninety characters, and the doc that *did* overstate was corrected instead.

## The derived population

The class's population was derived rather than hand-listed: every assertion on the branch whose expected text is a fragment of something composed elsewhere. **Nine**, all in the two test files.

| disposition | count | which |
|---|---|---|
| fixed this round | 2 | the bare `declared but NOT bound` phrase → the whole object-branch line (**corrected at your gate — see below**); the BCL file-name substring → deleted, type + HResult carry it |
| already anchored to a **fixture-known value** | 4 | the instance path and profile name in the `set_mo2_instance` confirmation; the record count; the composed `'Scripts\HcSpNoPex.pex' is not on disk` reason line, whose script name is the fixture's |
| already anchored to a **whole composed clause** | 2 | the `MySpell (Spell) on script HcSpChild` fragment, now merged into the whole line; `could not take an exclusive hold on '<path>'`, which `HeldOpen` composes (fixed in round 1) |
| not of the class | 1 | `Assert.DoesNotContain(ServerFixture.ConfigPrompt, …)` — a negative assertion against a shared constant, not a hand-spelled fragment |

The remaining assertions on the branch compare against fixture-known constants or structured result members, so none takes its expected value from the expression it checks.

**Correction (gate fold `aff8291`, your comment 3924563619).** The object-branch row above claimed a disposition the assertion had not earned. The whole line ruled out the *scalar* branch as a rival carrier; it did not rule out the second **record**. `HcSpAliasQuest` attaches the same `HcSpChild` through `QuestFragmentAlias.Scripts` and binds nothing, and because `MySpell`'s declaring script equals its attached script `ComposeScriptRecordUnit` omits the `[declared in …]` clause for both — so the quest renders a byte-identical line. The carrier was the line, and the line had two producers. What anchors it now is the footgun's own `[UNBOUND]` record header, asserted **immediately followed by** that line as one composed span: the header carries the FormKey, the EditorID and the plugin, which no other record can produce. Measured with your sabotage — the footgun's `VirtualMachineAdapter` dropped from `ScriptsWorld` (and `RecordsWithScripts` made consistent at 3, so the count canary does not mask the branch under test): at `2ae36cd` the line-only assertion stayed green off the quest; the anchored one is RED at `ScriptsWorldTests.cs:164`. Restored, grep-verified.

Every fixed or changed arm was sabotage-tested RED from a committed state, restored with a grep-verified `git checkout --`, tree clean after each:

| cell | sabotage | result |
|---|---|---|
| 1 | `PexWriter`'s baked initializer always Null | RED — the loose-layer arm (green before round 1's set pin) |
| 2 | `ScriptsWorld.AliasProp` forced to `Alias = -1` | RED — the loose-layer arm (likewise) |
| 3 | `HeldOpen`'s `'{path}'` deleted from its message | RED — the acquisition arm |
| 4 | the overlay dispose removed from `Read<T>` | RED — the leak reported by name |
| 5 | `OpenOverlay(path + ".nope")` | RED, but at the type assertion — `OpenOverlay` rejects a non-plugin extension with `ArgumentException` |
| 6 | `HeldOpen` `FileShare.None` → `FileShare.Read` | RED ×2 — both lock arms |
| 7 | `ReadTools.cs:1824`, the object-branch phrase | **RED — the wire arm.** This is the exact cell a round-2 reviewer measured GREEN before the fold |

**One honest gap, stated rather than papered over.** The HResult assertion cannot be isolated further: `Assert.Throws<IOException>` pins the exact type, so every producible fixture error (`FileNotFoundException`, `DirectoryNotFoundException`, `PathTooLongException`) is excluded before that line is reached, and no honest fixture yields a different plain `IOException` from this read. Its teeth are cell 6. The same was true of the message text it replaced, so nothing was traded away — but it is not a fully isolated arm.

The tier-trait fold was measured, not reasoned: `tier=stdio` selects the wire arm, `tier=integration` now excludes it (it did not before), and CI's `tier!=bridge` still selects it.

## Process observation — a fold's subject set should be derived, not hand-enumerated

`standards/HOUSECARL_REVIEW_ROUNDS.md` §2 already requires a **guard's** subject set to be derived from the surface it claims, never hand-enumerated. Nothing says the same of a **fold's** subject set, and this branch is the evidence for why it should: round 1 fixed the BCL-message assertion the reviewer pointed at and left its identical twin eleven lines away in the same file, which round 2 then found. A fold that changes an assertion of shape X should derive every assertion of shape X on the branch and dispose of the population, which is what the table above now does. Proposing it here rather than editing the standard, since that text is self-governing and yours to gate.

## Open for your gate

- **ADR 0003 rule 2 — the scripts family is briefly in both harnesses.** This branch's PEX-ROUNDTRIP arm re-homes an arm `ScriptPropertyCheckProbe` still runs, and the `RecordsWithScripts == 4` / unverifiable facts duplicate that probe's `RECORDS-COUNT` and `UNVERIFIABLE` arms. The guard is green, and correctly so: no `Converted-from:` marker was added, because adding one while the probes still exist would make `EveryConversionMarkerNamesAProbeThatIsGone_...` red. The overlap is real, deliberate, and a direct consequence of the ruled two-PR shape; it lasts exactly until PR 2 deletes `ScriptPropertyCheckProbe.cs`, adds the marker, and drops its baseline key.
- **The comment register beyond this branch.** ADR 0001 is prospective-immediate, so this branch complies now: the rationale moved to `docs/architecture/test-project-fixtures.md` and the five files' comment density fell from 26–44% to 18–23%. The test project's *neighbouring* files were written after the ADR in the register it retired, which is not this branch's to fix — recorded here as a standing item.

## Settled decisions the reviewers were given

`ruled` — Aaron decided it, in his own words; `inferred` — a session concluded it and Aaron never spoke. Reviewers honour `ruled`; `inferred` they may re-litigate.

1. **`ruled`** — the shape is a follow-up, not part of #484 (*"agree, its a follow up"*, 2026-09-03).
2. **`ruled`** — PR 1's scope: the Papyrus fixture and the file-lock harness as new machinery in their own files, nothing deleted.
3. **`inferred`** — the lane started off `main` in parallel with the #484 merge; its landing still waits for #484.
4. **`inferred`** — the `.pex` writer is ported, not referenced, because PR 2 may delete the probe that holds it.
5. **`inferred`** — the scripts world is an MO2-instance world so `housecarl_check` can drive it, with one wire-path smoke test proving reachability.
6. **`inferred`** — the fixture proofs are the fixture's own tests, not any of the 147 arms.
7. **`inferred`** — no CHANGELOG line: test machinery only, no shipped behaviour, no tool surface.
8. **`inferred`** — no ADR: the architectural decision this sits under is #486's own two-PR shape.
9. **`inferred`** — no `.csproj` change: `Mutagen.Bethesda.Pex` reaches the test project transitively.
10. **`inferred`** — `ScriptsWorld` exposes fixture-known values no test here reads; they are the vocabulary PR 2's arms spell, which PR 1's scope asks for.
11. **`inferred`** — the wire smoke test spins its own server; the shared one is deliberately unconfigured.
12. **`inferred`** — `ScriptsWorld` generates no corpus: the sweep never reads `CorpusRulebook`.
13. **`inferred`** — the lock proofs use `LoadOrderResolver.OpenOverlay` as "an engine read", keeping them about the harness rather than pre-empting PR 2.
14. **`inferred`** — the no-pex record keeps the probe's `HcSpNoPex` EditorID, which collides with the script name; the fixture is unchanged and the assertion is anchored to the composed reason line instead.

