### PR TITLE
docs: name the first two design principles the cornerstones

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ It is one C# process built on Mutagen. Users start at [README.md](README.md). Th
 - **Errors are one plain sentence: what went wrong and what to try.** A tool never returns a silently wrong answer or a silently degraded mode. When it cannot do the thing, it says so.
 - **Reads are lazy, freshness is cheap.** Records parse on access from a binary overlay; nothing holds the load order in memory or keeps plugin file handles open at rest; a change on disk is picked up by an mtime check. One process, no daemon, no live tracking of MO2.
 
-A design question that these four do not settle goes to the PRFAQ (`dev/PRFAQ/`, the problem statement and press release first) and then to Aaron. If something blocks you, say so before working around it.
+Code comments call the first two of these the cornerstones. A design question that these four do not settle goes to the PRFAQ (`dev/PRFAQ/`, the problem statement and press release first) and then to Aaron. If something blocks you, say so before working around it.
 
 ## How to work
 


### PR DESCRIPTION
One sentence in CLAUDE.md: "Code comments call the first two of these the cornerstones." About 130 code comments cite the cornerstones by that word; the rewrite kept the two principles (coverage generated from Mutagen, one grammar closed under composition) and dropped the label, so a session reading those comments could not resolve it. Docs-only, one line, no review pass run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)