### PR TITLE
test: comment sweep of src/housecarl-mcp-tests

### DIFF
--- a/src/housecarl-mcp-tests/AliasActivationTests.cs
+++ b/src/housecarl-mcp-tests/AliasActivationTests.cs
@@ -1,4 +1,3 @@
-// Converted-from: BindingShimProbe
 using System.Text.Json;
 using HousecarlMcp;
 using ModelContextProtocol.Protocol;
@@ -8,27 +7,17 @@ using Xunit.Abstractions;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// The SPEC §5.3 alias table, held against the REAL published schemas — the executable form of "dormant by
-/// construction". (BindingShimProbe's CENSUS arm.)
+/// The alias table, held against the REAL published schemas.
 ///
-/// <para>The probe computed each row's activation set from the served schemas and diffed it against a
-/// 144-row eyeballed literal. The literal caught two classes: a row that silently fails to fire (a mistyped
-/// candidate) and a row that fires somewhere its author never checked. It also, being a literal, said nothing
-/// about whether an activation WORKS — the census never sent a call.</para>
-///
-/// <para>Here the population is one cell per activation, derived from the shipped
+/// <para>The population is one cell per activation, derived from the shipped
 /// <see cref="ToolCallShim.ResolveAliases"/> run over the surface's own generated schemas, and every cell is
-/// then DRIVEN OVER THE WIRE. So a row that computes as active but dead-ends at the caller is a named RED,
-/// which the literal could not see, and a row's activation set is an output of the surface rather than of who
-/// remembered to re-eyeball a list. A row that fires nowhere produces no cell — the same silence the literal
-/// gave it — which is correct for the reverse edges of the synonym pairs, dormant by construction.</para>
+/// then driven over the wire — so a row that computes as active but dead-ends at the caller is a named
+/// failure, and a row's activation set is an output of the surface rather than a maintained list. A row that
+/// fires nowhere produces no cell, which is correct for the reverse edges of the synonym pairs: they are
+/// dormant by construction.</para>
 ///
-/// <para><b>Not carried, deliberately (OWED):</b> the exact-set half — "no row fires anywhere unintended".
-/// "Unintended" was the human judgement the literal encoded; an oracle for it is either the activation
-/// arithmetic compared against itself, or a checked-in expectation somebody maintains, which is the shape
-/// this surface has spent the wave removing. Closing it honestly wants a generated-and-reviewed snapshot
-/// (write the derived set to a data file on an update run, diff it in review), which is guard growth rather
-/// than a conversion fold.</para>
+/// <para>The other half — "no row fires anywhere unintended" — is not asserted here; it would need a
+/// generated-and-reviewed snapshot of the derived set.</para>
 /// </summary>
 [Collection("server")]
 [Trait("tier", "stdio")]
@@ -134,17 +123,15 @@ public sealed class AliasActivationTests
     public static IEnumerable<object[]> Hints() =>
         HintActivations().Select(a => new object[] { a.Tool, a.Old });
 
-    // ---- the arms ---------------------------------------------------------------------------------------
+    // ---- the tests --------------------------------------------------------------------------------------
 
     /// <summary>
     /// One cell per rename activation: the old spelling, sent to that tool over the wire, must not come back
-    /// as an unknown parameter — the correction the row exists to skip — and the shim must land it on the
-    /// SAME declared parameter against the schema the server actually published.
+    /// as an unknown parameter, and the shim must land it on the SAME declared parameter against the schema
+    /// the server actually published.
     ///
-    /// <para>Both halves matter. The wire says the row works end-to-end; the target check says it works onto
-    /// the pole its own row names, which a wire arm cannot see whenever the target takes any JSON (a
-    /// re-review finding on this table pointed a write tool's row at a read-only pole and the wire stayed
-    /// green).</para>
+    /// <para>Both halves matter. The wire says the row works end-to-end; the target check says it lands on
+    /// the pole its own row names, which the wire cannot see whenever the target takes any JSON.</para>
     /// </summary>
     [Theory]
     [MemberData(nameof(Renames))]
@@ -161,11 +148,8 @@ public sealed class AliasActivationTests
         Assert.DoesNotContain(ServerFixture.GenericError, r.Text, StringComparison.Ordinal);
     }
 
-    /// <summary>
-    /// One cell per dissolution activation: the retired spelling is refused BY NAME and the refusal carries
-    /// that row's own hint. The census computed which gates were satisfied; it never checked that anything
-    /// reached the caller, which is the row's entire purpose.
-    /// </summary>
+    /// <summary>One cell per dissolution activation: the retired spelling is refused BY NAME and the refusal
+    /// carries that row's own hint, reaching the caller — which is the row's entire purpose.</summary>
     [Theory]
     [MemberData(nameof(Hints))]
     public void EveryDissolutionActivationReachesTheCallerWithItsOwnHint(string tool, string old)
@@ -177,16 +161,10 @@ public sealed class AliasActivationTests
         Assert.Contains($"unknown parameter: {old} ({hint})", r.Text, StringComparison.Ordinal);
     }
 
-    /// <summary>
-    /// The vacuity canary, the number a reviewer reads, AND the direction a derived population cannot see on
-    /// its own.
-    ///
-    /// <para>The population comes from the alias table, so a row that stops firing takes its own subject away
-    /// with it: mistype a live candidate and the activation and its cell vanish together, silently. That is one
-    /// of the two classes the retired literal caught, and it is the reason the counts are now PINNED as well as
-    /// printed. A count is not the eyeballed 144-row literal — it is one number per sweep, it moves only when
-    /// the surface or the table moves, and the printed listing beside it says which row changed.</para>
-    /// </summary>
+    /// <summary>An empty population would make every cell above pass, and a derived population cannot see a row
+    /// that stopped firing: mistyping a live candidate makes the activation and its cell vanish together,
+    /// silently. So the counts are pinned as well as printed — they move only when the surface or the table
+    /// moves, and the listing beside them says which row changed.</summary>
     [Fact]
     public void BothActivationSweepsHaveSubjects()
     {
@@ -203,8 +181,8 @@ public sealed class AliasActivationTests
         Assert.NotEmpty(renames);
         Assert.NotEmpty(hints);
 
-        // The dormant-row direction. Measured on this surface at the 1.x cut; a change here is either a real
-        // surface change (update the number, and the listing above names the row) or a row that went dead.
+        // A change here is either a real surface change (update the number; the listing above names the row)
+        // or a row that went dead.
         Assert.Equal(91, renames.Length);
         Assert.Equal(23, hints.Length);
     }

--- a/src/housecarl-mcp-tests/ArtifactWorld.cs
+++ b/src/housecarl-mcp-tests/ArtifactWorld.cs
@@ -4,12 +4,9 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// The §2.1.1 artifact family's own fixture: a <see cref="RecordsWorld"/> plus a PRIVATE auto-spill results
-/// directory. The results directory matters — <c>ResultsStore.Dir</c> otherwise resolves to the server binary's
-/// folder, so every truncating call in this family would write artifacts into the build output and read each
-/// other's spills when a test asks "which file did this call leave behind".
-/// </summary>
+/// <summary>The artifact family's fixture: a <see cref="RecordsWorld"/> plus a PRIVATE auto-spill results
+/// directory. Without the override <c>ResultsStore.Dir</c> resolves to the server binary's folder, so
+/// truncating calls would write artifacts into the build output and read each other's spills.</summary>
 public sealed class ArtifactFixture : IDisposable
 {
     public RecordsWorld W { get; }
@@ -63,7 +60,7 @@ public abstract class ArtifactTestBase
     protected static readonly RecordsTools.RecordsProject Identity = new() { form = "identity" };
     protected static readonly RecordsTools.RecordsProject Everything = new() { form = "everything" };
 
-    /// <summary>A refusal: the text lane's own discriminant plus what the arm claims it names.</summary>
+    /// <summary>A refusal: the text lane's own discriminant plus what the caller claims it names.</summary>
     protected static void Refused(string response, params string[] mustName)
     {
         Assert.StartsWith("error:", response);

--- a/src/housecarl-mcp-tests/AssemblyInfo.cs
+++ b/src/housecarl-mcp-tests/AssemblyInfo.cs
@@ -1,14 +1,5 @@
 using Xunit;
 
-// Test parallelisation is OFF, and the reason is a product property, not a test one:
-// `CorpusRulebook.CorpusPath` is a process-global mutable static that every world must point at its own
-// generated corpus. Two worlds alive at once — which is exactly what xUnit's default cross-collection
-// parallelism produces — have one of them reading the other's corpus, and the first Dispose deletes it
-// out from under the survivor. Measured, not assumed: it turned 126 green tests into 30 failures the
-// moment a second world appeared.
-//
-// This is harness-plan debt 7 ("fixed temp dirs make concurrent probe runs mutually destructive") in its
-// real form: the probes were never parallel, so the static was never a problem. A standard runner wants
-// parallelism by default, and it will keep wanting it. Retiring the static is W7 work the conversion
-// surfaces rather than solves.
+// Parallelisation is off: CorpusRulebook.CorpusPath is a process-global every world repoints, so two live
+// worlds read each other's corpus and the first Dispose deletes it under the survivor.
 [assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/src/housecarl-mcp-tests/BulkRecordsWorld.cs
+++ b/src/housecarl-mcp-tests/BulkRecordsWorld.cs
@@ -15,7 +15,7 @@ namespace HousecarlMcpTests;
 /// two keyword-bearing weapons and an armor, and a replacer that OVERRIDES one weapon (changing both its
 /// damage and its EditorID) and DEFINES a third weapon carrying BOTH keywords plus a second armor.
 ///
-/// <para>That shape is what the scan-lane arms need and the shared <see cref="RecordsWorld"/> does not
+/// <para>That shape is what the scan-lane tests need and the shared <see cref="RecordsWorld"/> does not
 /// carry: reverse lookups with a record hitting two targets at once, a defined-vs-overridden split for
 /// aggregate counts, a scoped-body-vs-winner value pair on the same record, and a link that no plugin
 /// defines. The shared world is frozen, so this one is its own.</para>
@@ -58,8 +58,8 @@ public sealed class BulkRecordsWorld : IDisposable
 
     public BulkRecordsWorld()
     {
-        // Same process-global discipline RecordsWorld records: capture before repointing, restore before
-        // the directory the new value names is deleted.
+        // CorpusRulebook.CorpusPath is a process-global: capture before repointing, and restore before the
+        // directory the new value names is deleted.
         _priorCorpusPath = CorpusRulebook.CorpusPath;
 
         Root = Path.Combine(Path.GetTempPath(), "hc-bulk-tests-" + Guid.NewGuid().ToString("N"));
@@ -154,7 +154,7 @@ public sealed class BulkRecordsWorld : IDisposable
 /// separates them.
 ///
 /// <para>Its own world, not a third plugin in <see cref="BulkRecordsWorld"/>: an extra active plugin
-/// would move every count the scan arms assert.</para>
+/// would move every count the scan tests assert.</para>
 /// </summary>
 public sealed class EngineImplicitLinkWorld : IDisposable
 {

--- a/src/housecarl-mcp-tests/CheckErrorsFamilyTests.cs
+++ b/src/housecarl-mcp-tests/CheckErrorsFamilyTests.cs
@@ -8,22 +8,9 @@ using static HousecarlMcpTests.CheckErrorsFixtures;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// The errors family's own 28 facts <c>CheckErrorsProbe.cs</c> asserted through the deleted 1.x single-family
-/// renderer (<c>Wire.RenderCheckErrors</c> / <c>JsonWire.RenderCheckErrors</c>), re-asserted here against the
-/// merged <c>Wire.RenderCheck</c> / <c>JsonWire.RenderCheck</c> a surviving tool (<c>housecarl_check</c>) actually
-/// calls. Numbered per <c>dev/session-handoffs/render-halves-scratch/PHASE-1-record.md</c> §5's fact list, as
-/// narrowed by <c>checkmerge-coverage-audit.md</c> (facts 21 and 29 are dropped — already covered on the merged
-/// surface by <c>CheckMergeProbe</c>'s <c>CAP-LADDER</c> and <c>RESERVE-DECLARED-IS-RESERVE-DEMANDED</c> arms — and
-/// fact 25 is narrowed to its uncovered MINIMALITY half). Rationale for the DTO-vs-live driving-lane split is in
-/// <c>docs/architecture/check-family-tests.md</c>.
-///
-/// <para>Every PARTIAL the audit found stays on this list because the covered half belongs to another family
-/// (scripts or dialogue) — each such test says so in its own comment.</para>
-///
-/// <para><b>Converted-from: CheckErrorsProbe</b>. <c>CheckErrorsProbe.cs</c> is deleted in the same commit
-/// that lands the last fact below.</para>
-/// </summary>
+/// <summary>The errors family's facts, asserted against the merged <c>Wire.RenderCheck</c> /
+/// <c>JsonWire.RenderCheck</c> that <c>housecarl_check</c> calls. Why some facts are driven at the DTO and others
+/// live is in <c>docs/architecture/check-family-tests.md</c>.</summary>
 [Trait("tier", "integration")]
 [Collection("check-errors")]
 public sealed class CheckErrorsFamilyTests
@@ -42,8 +29,8 @@ public sealed class CheckErrorsFamilyTests
         var r = Svc.CheckErrors(null, 1000, findings: new[] { "missing_masters" });
 
         var text = Text(r, 20000);
-        // Anchored on the surrounding bullet separators the head composes it between, so an insertion right
-        // after the "· " that precedes this clause cannot hide behind a same-suffix match.
+        // Anchored on the surrounding bullet separators, so an inserted line right after the "· " that precedes
+        // this clause cannot hide behind a same-suffix match.
         Assert.Contains("· dangling refs NOT CHECKED (findings= excluded 'dangling') · ", text);
         Assert.DoesNotContain("0 dangling ref(s)", text);
 
@@ -64,8 +51,8 @@ public sealed class CheckErrorsFamilyTests
     }
 
     // ---- fact 2 -------------------------------------------------------------------------------------
-    // The json head restates the text head's totals, and under counts_only carries the histogram OBJECT (not
-    // merely the flat totals CheckMergeProbe's ACCOUNTING-PER-FAMILY already covers).
+    // The json head restates the text head's totals, and under counts_only carries the histogram OBJECT, not
+    // merely the flat totals.
 
     [Fact]
     public void Fact2_JsonHeadRestatesTextTotals_AndCountsOnlyCarriesTheHistogramObjects()
@@ -143,14 +130,14 @@ public sealed class CheckErrorsFamilyTests
         Assert.DoesNotContain("plugin(s) that could not be parsed are named above", whole);
 
         var cut = Text(r, 400);
-        // Anchored on the PRECEDING clause's own full stop so a sabotage inserted right after the sentence's
+        // Anchored on the PRECEDING clause's own full stop so a line inserted right after the sentence's
         // leading space (before the "0") cannot hide behind a same-suffix match.
         Assert.Contains("plugin section(s) were rendered. 0 of 1 plugin(s) that could not be parsed are named " +
                          "above.", cut);
     }
 
     // ---- fact 7 -------------------------------------------------------------------------------------
-    // The counts_only unread honesty tail states rows-named-of-total per transport, and json wraps it as
+    // The counts_only unread tail states rows-named-of-total per transport, and json wraps it as
     // total/rows/rendered/truncated. Driven DTO-level: the live world has no per-record scan error to plant.
 
     [Fact]
@@ -180,8 +167,7 @@ public sealed class CheckErrorsFamilyTests
 
     // ---- fact 8 -------------------------------------------------------------------------------------
     // A response cut only by limit= names the budget as the cause, states visible-of-found, and offers limit= and
-    // NOT max_chars= — the errors family's own arm; CheckMergeProbe's DIALOGUE-SEED-BUDGET cluster covers this
-    // shape for the dialogue family only (checkmerge-coverage-audit.md, fact 8).
+    // NOT max_chars=.
 
     [Fact]
     public void Fact8_LimitOnlyCut_NamesTheBudget_StatesVisibleOfFound_OffersLimitNotMaxChars()
@@ -207,10 +193,9 @@ public sealed class CheckErrorsFamilyTests
         var text = Text(r, 400);
         Assert.Contains("[accounting: 0 of the 6 dangling ref(s) found by this sweep appear above. 6 did not fit " +
                          "this response (max_chars=400). 0 of 3 plugin section(s) were rendered.", text);
-        // Positive control for EntryLines, whose only consumer is the Assert.Empty below. Without it, rewording
-        // the dangling-entry render (dropping "any", say) makes the helper return an empty array for EVERY
-        // response, and the emptiness assertion passes for every possible render including one that emits all
-        // six. Six is the accounting line's own number, one line up.
+        // Positive control for EntryLines: a reworded dangling-entry render would make it return empty for every
+        // response, and the emptiness assertion below would pass whatever was emitted. Six is the accounting
+        // line's own number, one line up.
         Assert.Equal(6, EntryLines(Text(r, 0)).Length);
         Assert.Empty(EntryLines(text));
         Assert.DoesNotContain("Raise limit=", text);
@@ -255,7 +240,7 @@ public sealed class CheckErrorsFamilyTests
     public void Fact12_BySourceRoster_NamesWholeDroppedPlugins_EmptyWhenNothingDropped()
     {
         var capped = Text(Svc.CheckErrors(null, 1, findings: null), 20000);
-        // Anchored on the PRECEDING clause's own full stop, so a sabotage inserted right after the lead's leading
+        // Anchored on the PRECEDING clause's own full stop, so a line inserted right after the lead's leading
         // space cannot hide behind a same-suffix match.
         Assert.Contains("ran out. Missing here, by source plugin: " + W.BaseName + " (3), " + W.ModName +
                          " (1), " + W.PatchName + " (1).", capped);
@@ -272,11 +257,9 @@ public sealed class CheckErrorsFamilyTests
     {
         var r = Svc.CheckErrors(null, 1000, findings: null);
 
-        // Driven at a PARTIAL cut, searched rather than pinned. At any cap this world's json renders empty
-        // (everything below ~4000 chars) both agreements read 0 == 0, so the arm could only ever have caught an
-        // OVER-count: measured, an under-report of either number stayed green on both verification surfaces
-        // (round 1). A partial cut is the shape the old RESPONSE-CUT-JSON-NUMBERS-MATCH-THE-DOCUMENT arm drove,
-        // and it is the only shape in which "the number disagrees with its own document" is observable.
+        // Driven at a PARTIAL cut, searched for rather than pinned: where the json renders empty or whole both
+        // agreements read 0 == 0 or N == N, and a partial cut is the only shape in which "the number disagrees
+        // with its own document" is observable.
         JsonElement fam = default;
         int visible = 0, entries = 0, rendered = 0, objects = 0;
         for (int cap = 400; cap <= 20000; cap += 100)
@@ -295,8 +278,8 @@ public sealed class CheckErrorsFamilyTests
         Assert.Equal(entries, visible);
         Assert.Equal(objects, rendered);
 
-        // The three conjuncts the conversion dropped: the section total is the sweep's, not the render's; the
-        // response cut is named as the cause; and the listing budget is named as NOT a cause (limit=1000 here).
+        // The section total is the sweep's, not the render's; the response cut is named as the cause; and the
+        // listing budget is named as NOT a cause (limit=1000 here).
         var acct = fam.GetProperty("accounting");
         Assert.Equal(r.Reports.Count, acct.GetProperty("sections_with_findings").GetInt32());
         Assert.True(acct.GetProperty("dangling_missing_by_response_cut").GetInt32() > 0,
@@ -312,8 +295,8 @@ public sealed class CheckErrorsFamilyTests
     public void Fact14_BaselineLinePrintsOnlyWhereABaseMasterWasSwept_AndNamesThatSubset()
     {
         var swept = Text(Svc.CheckErrors(null, 1000, findings: null), 20000);
-        // Extended past the plugin-name parenthesis into the very next clause, so a sabotage inserted right
-        // after it cannot hide behind a same-prefix match.
+        // Extended past the plugin-name parenthesis into the very next clause, so a line inserted right after
+        // it cannot hide behind a same-prefix match.
         Assert.Contains("baseline: " + CheckErrorsWorld.BaselineDangling + " of " + CheckErrorsWorld.TotalDangling +
                          " dangling ref(s) come from the base-game master(s) this sweep covered (" + W.BaseName +
                          ") — vanilla leftovers rather than anything this load order introduced; " +
@@ -368,17 +351,17 @@ public sealed class CheckErrorsFamilyTests
         Assert.Contains("dangling ref(s) by SOURCE plugin (the plugin the broken refs come FROM) (3 distinct):", text);
         Assert.Contains("... [3 more row(s) — raise max_chars= to see them]", text);
 
-        // Both axes are cut before their first row fits — the tight max_chars=900 cap is what stops them here,
-        // not histogramLimit=1 (SweepEmission.HistogramCut: a row-limit break never sets cutByBudget, so a row
-        // limit that actually bound would name "limit" — this cap binds first, and both axes report "max_chars").
+        // Both axes are cut before their first row fits, and it is max_chars=900 that stops them, not
+        // histogramLimit=1: a row-limit break would name "limit" instead, so the cap binding first is what makes
+        // both axes report "max_chars".
         var fam = ErrorsFamily(Json(r, 900, histogramLimit: 1));
         Assert.Equal(0, fam.GetProperty("dangling_by_target_plugin").GetProperty("rendered").GetInt32());
         Assert.Equal("max_chars", fam.GetProperty("dangling_by_target_plugin").GetProperty("cut_by").GetString());
         Assert.Equal(0, fam.GetProperty("dangling_by_source_plugin").GetProperty("rendered").GetInt32());
         Assert.Equal("max_chars", fam.GetProperty("dangling_by_source_plugin").GetProperty("cut_by").GetString());
 
-        // The OTHER knob: a cap wide enough that the row limit itself is what stops the axis names "limit"
-        // instead — the two knobs move different things, and the disclosure has to name the one that fired.
+        // The other knob: at a cap wide enough that the row limit itself stops the axis, the disclosure names
+        // "limit" instead — it has to name the knob that fired.
         var wideCap = Text(r, 4000, histogramLimit: 1);
         Assert.Contains("... [1 more row(s) — raise limit= to see them]", wideCap);
         Assert.Contains("... [2 more row(s) — raise limit= to see them]", wideCap);
@@ -462,7 +445,7 @@ public sealed class CheckErrorsFamilyTests
         }
     }
 
-    // ---- fact 25 (narrowed to its uncovered MINIMALITY half; sufficiency is CAP-LADDER's) -----------------
+    // ---- fact 25 -----------------------------------------------------------------------------------------
     // The overrun remedy names the smallest cap that fits within the digit-width slack, and re-rendering at that
     // number clears the notice.
 
@@ -478,16 +461,15 @@ public sealed class CheckErrorsFamilyTests
 
         // Sufficient: the notice clears exactly at the named cap.
         Assert.DoesNotContain("raise it to at least", Text(r, raiseTo));
-        // Minimal within slack: two below the named cap, the notice is still present — the remedy is not
-        // wildly larger than the true floor (measured true floor on this world: raiseTo - 1).
+        // Minimal within slack: two below the named cap the notice is still present, so the remedy is not
+        // wildly larger than the true floor (which is one below the named cap on this world).
         Assert.Contains("raise it to at least", Text(r, raiseTo - 2));
     }
 
     // ---- fact 26 ------------------------------------------------------------------------------------------
     // A section is whole or absent: a rendered section carries its scan error, its missing-master line and its
-    // unscannable count, and the only droppable units are a whole section or one entry. The missing-master half
-    // is covered by CheckMasterRemedyTests; this proves the section stays WHOLE even when its entries got no
-    // listing budget at all (checkmerge-coverage-audit.md, fact 26).
+    // unscannable count, and the only droppable units are a whole section or one entry. Here the section stays
+    // whole even when its entries got no listing budget at all.
 
     [Fact]
     public void Fact26_ASectionIsWholeOrAbsent_ItsFixedPartRendersEvenWithZeroEntryBudget()
@@ -496,10 +478,8 @@ public sealed class CheckErrorsFamilyTests
 
         Assert.Contains("[ERROR] " + W.PatchName, text);
         Assert.Contains("missing master(s) NOT installed anywhere in the MO2 install: " + W.GoneName, text);
-        // The section rendered whole even though this plugin's OWN dangling entry got none of the budget — read
-        // SECTION-SCOPED. The old spelling searched the whole response for the plugin name immediately followed by
-        // the dangling header, a span the composer never emits at ANY budget (the missing-master line always sits
-        // between them), so it passed identically at limit=1000 and never exercised the zero-entry-budget case.
+        // Read SECTION-SCOPED: the missing-master line always sits between the plugin name and the dangling
+        // header, so a whole-response search for those two adjacent cannot fail at any budget.
         Assert.DoesNotContain("dangling reference(s)", PluginSection(text, W.PatchName));
 
         // The control that gives the absence its meaning: with budget to spare the SAME section DOES carry its
@@ -528,9 +508,6 @@ public sealed class CheckErrorsFamilyTests
 
     // ---- fact 28 ------------------------------------------------------------------------------------------
     // exclude= narrowing is stated in the response, and a fully-excluded base master leaves no baseline line.
-    // The narrowing note itself is covered on the SCRIPTS family by ORCH-EXCLUDE-FILTER-NOTE-IS-STATED
-    // (checkmerge-coverage-audit.md, fact 28); this is the errors-family half plus the baseline suppression,
-    // neither of which that arm reaches.
 
     [Fact]
     public void Fact28_ExcludeNarrowingIsStated_AndAFullyExcludedBaseMasterLeavesNoBaselineLine()
@@ -542,13 +519,13 @@ public sealed class CheckErrorsFamilyTests
     }
 
     // ---- fact 30 ------------------------------------------------------------------------------------------
-    // The overrun sentence enumerates the closing lines the response cannot drop, and reads true in the lane
-    // that owes none (only ONE of the two causes fired, not both).
+    // The overrun sentence enumerates the closing lines the response cannot drop, and reads true when only ONE
+    // of the two cut causes fired.
 
     [Fact]
     public void Fact30_TheOverrunSentenceEnumeratesTheUndroppableLines_TrueEvenWhenOnlyOneCauseFired()
     {
-        // Only a max_chars cut fires here (limit is ample) — the lane that "owes" nothing to the listing budget.
+        // Only a max_chars cut fires here; limit is ample, so nothing is missing for want of listing budget.
         var text = Text(Svc.CheckErrors(null, 1000, findings: null), 400);
 
         Assert.Contains("what it must carry whatever the budget — its header, the accounting above, the closing " +

--- a/src/housecarl-mcp-tests/CheckErrorsFixtures.cs
+++ b/src/housecarl-mcp-tests/CheckErrorsFixtures.cs
@@ -5,11 +5,9 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// The shapes and readers the errors family's DTO-level arms share. Rationale — why these facts are driven at the
-/// render rather than end to end, and what each reader is for — is in
-/// <c>docs/architecture/check-family-tests.md</c>.
-/// </summary>
+/// <summary>The shapes and readers the errors family's DTO-level tests share. Why these facts are driven at the
+/// render rather than end to end, and what each reader is for, is in
+/// <c>docs/architecture/check-family-tests.md</c>.</summary>
 internal static class CheckErrorsFixtures
 {
     /// <summary>The epoch every hand-shaped result carries, so a stamp is never the thing that varies.</summary>
@@ -65,12 +63,9 @@ internal static class CheckErrorsFixtures
         JsonDocument.Parse(json).RootElement.GetProperty("families")
                     .GetProperty(SweepFamilySelection.Token(SweepFamily.Errors));
 
-    /// <summary>ONE plugin's own <c>[ERROR]</c> section — its header line plus the indented body lines that belong
-    /// to it, stopping at the first line that is not one of them. Read section-scoped, because a whole-response
-    /// search for a span composed ACROSS two of a section's lines cannot distinguish "the renderer stopped
-    /// emitting this" from "the renderer never emits those two lines adjacent" — the second is what a
-    /// <c>DoesNotContain(plugin + "\n  dangling reference(s)")</c> was actually asserting, and it could not fail
-    /// (pre-green review 1a, finding 1: the missing-master line always sits between the two).</summary>
+    /// <summary>One plugin's <c>[ERROR]</c> section: its header plus the indented lines under it. Read
+    /// section-scoped — the composer never emits two of a section's lines adjacent, so a whole-response search
+    /// for a span across them cannot fail.</summary>
     internal static string PluginSection(string response, string plugin)
     {
         var lines = response.Split('\n');

--- a/src/housecarl-mcp-tests/CheckErrorsWorld.cs
+++ b/src/housecarl-mcp-tests/CheckErrorsWorld.cs
@@ -8,9 +8,9 @@ using Xunit;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// The synthetic MO2 instance the errors family's own arms are driven over — the world #486 PR 2 owed, built
-/// because <see cref="CheckWorld"/> is frozen (its arms take fixture-known totals from it, so a later need gets
-/// its own world rather than an edit to that one).
+/// The synthetic MO2 instance the errors family's tests are driven over. Its own world because
+/// <see cref="CheckWorld"/> is frozen: tests take fixture-known totals from it, so a later need gets its own
+/// world rather than an edit to that one.
 ///
 /// <para>What it carries, and why each piece is here:</para>
 /// <list type="bullet">
@@ -31,10 +31,10 @@ namespace HousecarlMcpTests;
 /// so a fixture drift fails there rather than everywhere): six dangling refs over three plugins, three of them
 /// baseline; one missing master; one unparseable plugin.</para>
 ///
-/// <para><b>The world is frozen</b>, in the sense <see cref="BulkRecordsWorld"/> states: arms take those totals
-/// from it, so a later need builds its own world instead of editing this one. It does not repoint
-/// <c>CorpusRulebook.CorpusPath</c> — the errors sweep reads master tables and FormLinks, never the record
-/// rulebook — so it generates no corpus and touches no process-global.</para>
+/// <para><b>The world is frozen</b>: tests take those totals from it, so a later need builds its own world
+/// instead of editing this one. It does not repoint <c>CorpusRulebook.CorpusPath</c> — the errors sweep reads
+/// master tables and FormLinks, never the record rulebook — so it generates no corpus and touches no
+/// process-global.</para>
 /// </summary>
 public sealed class CheckErrorsWorld : IDisposable
 {
@@ -125,9 +125,9 @@ public sealed class CheckErrorsWorld : IDisposable
     }
 }
 
-/// <summary>The world, built once for the whole <c>check-errors</c> collection. Every arm over it is read-only, and
-/// two test classes share it — a class fixture would build the four Mutagen plugin writes and the index once per
-/// class, which is twice.</summary>
+/// <summary>The world, built once for the whole <c>check-errors</c> collection. Every test over it is read-only,
+/// and two test classes share it — a class fixture would build the four Mutagen plugin writes and the index once
+/// per class, which is twice.</summary>
 public sealed class CheckErrorsWorldFixture : IDisposable
 {
     public CheckErrorsWorld W { get; } = new();

--- a/src/housecarl-mcp-tests/CheckExcludeGrammarTests.cs
+++ b/src/housecarl-mcp-tests/CheckExcludeGrammarTests.cs
@@ -10,23 +10,19 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// The synthetic MO2 instance the <c>exclude=</c> arms are driven over: a base master BY FILENAME
-/// (<c>Skyrim.esm</c>, which is what Mutagen's Implicits set matches on) carrying three dangling refs, and a
-/// plugin mastering it carrying two more. Five dangling refs in the order, three of them in the base master.
-///
-/// <para><c>Skyrim.esm</c> is in <c>loadorder.txt</c> and ABSENT from <c>plugins.txt</c> — which is exactly what
-/// makes it IMPLICIT (force-loaded), the fact the <c>implicit</c> token is defined by.</para>
-/// </summary>
+/// <summary>The synthetic MO2 instance the <c>exclude=</c> tests run over: a base master named
+/// <c>Skyrim.esm</c> (the filename Mutagen's Implicits set matches on) carrying three dangling refs, plus a
+/// plugin mastering it carrying two more — five in the order. <c>Skyrim.esm</c> is in <c>loadorder.txt</c> and
+/// absent from <c>plugins.txt</c>, which is what makes it implicit (force-loaded).</summary>
 public sealed class CheckWorld : IDisposable
 {
     public string Root { get; }
     public string Instance { get; }
     public string ProfileDir { get; }
-    /// <summary>The profile's plugin list — the file the composition-read arms hold open.</summary>
+    /// <summary>The profile's plugin list — the file the composition-read tests hold open.</summary>
     public string PluginsTxt => Path.Combine(ProfileDir, "plugins.txt");
 
-    /// <summary>The base master, excluded by name in the arms that name a plugin.</summary>
+    /// <summary>The base master, excluded by name in the tests that name a plugin.</summary>
     public string BaseMasterName => "Skyrim.esm";
 
     public LoadOrderService Svc { get; }
@@ -69,11 +65,10 @@ public sealed class CheckWorld : IDisposable
         var store = new UserConfigStore(Path.Combine(Root, "houseCARL.user.json"));
         Svc = LoadOrderService.WithInstance(Instance, 0, store);
 
-        // ONE SWEEP BEFORE ANY TEST RUNS, and it is load-bearing rather than tidiness. Two arms hold
-        // plugins.txt open exclusively to fault the composition read; they are about what the service does
-        // with a read it cannot make NOW, not about a service that never read at all. The composition cache
-        // is keyed on mtime, which holding a handle does not move, so warming it here makes those arms
-        // independent of the order xUnit happens to run methods in.
+        // One sweep before any test runs, and it is load-bearing. Two tests hold plugins.txt open exclusively
+        // to fault the composition read; they are about a read the service cannot make NOW, not one it never
+        // made. The composition cache is keyed on mtime, which holding a handle does not move, so warming it
+        // here makes those tests independent of the order xUnit runs methods in.
         CheckTools.CheckTool(Svc);
     }
 
@@ -84,7 +79,7 @@ public sealed class CheckWorld : IDisposable
     }
 }
 
-/// <summary>The world, built once for the class. Every arm below is read-only over it.</summary>
+/// <summary>The world, built once for the class. Every test below is read-only over it.</summary>
 public sealed class CheckWorldFixture : IDisposable
 {
     public CheckWorld W { get; } = new();
@@ -94,17 +89,13 @@ public sealed class CheckWorldFixture : IDisposable
 /// <summary>
 /// <c>exclude=</c>'s grammar, driven END TO END through the surface a caller reaches:
 /// <see cref="CheckTools.CheckTool"/> -> <see cref="LoadOrderService.CheckErrors"/> -> <c>ErrorCheck.Run</c>,
-/// over a synthetic MO2 instance.
+/// over a synthetic MO2 instance. Driven at the tool rather than the core, because that is the only lane in
+/// which the parameter's journey across the two layers is observable — a core call takes an already-resolved
+/// exclusion.
 ///
-/// <para>These arms came from the tool-layer block of the check-errors probe, deleted with the 1.x tool they
-/// drove. Every other <c>exclude=</c> cell in that probe calls the core engine directly with an
-/// already-resolved exclusion, so the parameter's journey across the two layers was covered by nothing:
-/// passing <c>null</c> in place of <c>exclude</c> at the tool call site, or in place of <c>excluded</c> at the
-/// service's <c>ErrorCheck.Run</c> calls, left the whole suite green.</para>
-///
-/// <para>Every arm asserts the sweep's own TOTALS as numbers, read off the errors family's head line, because
-/// they are fixture-known: five dangling refs across two plugins, three of them in the base master. An
-/// exclusion that does not reach the core returns five.</para>
+/// <para>Every test asserts the sweep's own totals as numbers off the errors family's head line, since they are
+/// fixture-known: five dangling refs across two plugins, three in the base master. An exclusion that does not
+/// reach the core returns five.</para>
 /// </summary>
 [Trait("tier", "integration")]
 public sealed class CheckExcludeGrammarTests : IClassFixture<CheckWorldFixture>
@@ -145,7 +136,7 @@ public sealed class CheckExcludeGrammarTests : IClassFixture<CheckWorldFixture>
         return lines.Length > 1 ? lines[0] + " | " + lines[1] : lines[0];
     }
 
-    // ---- the arms --------------------------------------------------------------------------------------
+    // ---- the tests -------------------------------------------------------------------------------------
 
     [Fact]
     public void TheSyntheticInstanceSweepsBothPluginsAndFindsAllFiveDanglingRefs_TheBaselineEveryExclusionIsMeasuredAgainst()
@@ -228,15 +219,9 @@ public sealed class CheckExcludeGrammarTests : IClassFixture<CheckWorldFixture>
         catch (Exception ex) { return $"(unparseable: {ex.GetType().Name})"; }
     }
 
-    /// <summary>
-    /// The <c>implicit</c> group is the only value whose members come from a READ that can fail. The fault is
-    /// real rather than mocked: the profile's plugins.txt held open exclusively, which is what the refusal's own
-    /// message is about.
-    ///
-    /// <para>Prose, not a value: what is asserted is that the caller was REFUSED and told which group could not
-    /// be resolved, and a refusal exists only as its sentence. The tokens pinned are the two the message must
-    /// carry — its own opening claim, and the group name, off the product's constant.</para>
-    /// </summary>
+    /// <summary>The <c>implicit</c> group is the only value whose members come from a read that can fail, so the
+    /// fault is real rather than mocked: plugins.txt held open exclusively. Asserted as prose because a refusal
+    /// exists only as its sentence; the group name comes off the product's constant.</summary>
     [Fact]
     public void WhenTheProfileCompositionCannotBeRead_TheCallerWhoAskedForTheImplicitGroupIsRefusedAndToldWhy()
     {
@@ -262,14 +247,10 @@ public sealed class CheckExcludeGrammarTests : IClassFixture<CheckWorldFixture>
         Assert.Equal(2, Dangling(locked));
     }
 
-    /// <summary>
-    /// Q3 at the surface: a bad value refuses through the TOOL, not just in the resolver's own unit test, and
-    /// names the value alongside the real token set rather than sweeping with the exclusion quietly dropped.
-    ///
-    /// <para>Prose, not a value: a refusal has no totals to read. The token set is taken from
-    /// <see cref="SweepExclusion.Tokens"/> so a token added to the product arrives here rather than needing a
-    /// line in a list somebody has to remember.</para>
-    /// </summary>
+    /// <summary>A bad value refuses through the TOOL, not just in the resolver's own unit test, and names the
+    /// value alongside the real token set rather than sweeping with the exclusion quietly dropped. The token set
+    /// is taken from <see cref="SweepExclusion.Tokens"/> so a token added to the product arrives here by
+    /// itself.</summary>
     [Fact]
     public void AnUnknownGroupValueRefusesAtTheToolSurface_NamingTheValueAndTheRealTokenSet()
     {
@@ -282,16 +263,10 @@ public sealed class CheckExcludeGrammarTests : IClassFixture<CheckWorldFixture>
     }
 }
 
-/// <summary>
-/// The <c>exclude=</c> parameter's <c>[Description]</c> against the vocabulary the parameter actually accepts.
-/// A tool parameter's prose is a SECOND spelling of an accepted set, and a token added to the set and not to
-/// the description is undiscoverable to the caller who only reads the description.
-///
-/// <para>The converse — a word in the description that is NOT an accepted token — is deliberately not checked:
-/// the description is prose, and every ordinary word in it would have to be exempted. What protects that
-/// direction is the unknown-group refusal above, which names the real set to a caller who believed a wrong
-/// word.</para>
-/// </summary>
+/// <summary>The <c>exclude=</c> parameter's <c>[Description]</c> against the vocabulary the parameter accepts:
+/// a token added to the set and not to the description is undiscoverable. The converse — a word in the
+/// description that is not a token — is deliberately not checked, since the description is prose; the
+/// unknown-group refusal above covers that direction.</summary>
 [Trait("tier", "unit")]
 public sealed class CheckExcludeGrammarDescriptionTests
 {
@@ -310,8 +285,6 @@ public sealed class CheckExcludeGrammarDescriptionTests
         return text!;
     }
 
-    // Prose, not a value: the claim is about what one caller-facing sentence SAYS, and the only artifact
-    // carrying it is the sentence.
     [Theory]
     [MemberData(nameof(AcceptedTokens))]
     public void TheExcludeDescriptionNamesEveryTokenTheParameterAccepts(string token) =>

--- a/src/housecarl-mcp-tests/CheckMasterRemedyJsonTests.cs
+++ b/src/housecarl-mcp-tests/CheckMasterRemedyJsonTests.cs
@@ -9,15 +9,13 @@ namespace HousecarlMcpTests;
 /// The json twin of the missing-master remedy: <c>format='json'</c> carries the SAME install-vs-enable split the
 /// text render prints, as a member of the plugin object rather than as a sentence.
 ///
-/// <para><b>Why it has to.</b> The text lane says "NOT installed anywhere … [install them]" for one master and
-/// "installed but NOT ACTIVE … [enable them]" for another. The json lane carried one undifferentiated
-/// <c>missing_masters</c> array, so the identical call in the other format returned two names with nothing to
-/// tell them apart, and a json caller could not pick the remedy that would work. Two transports saying different
-/// things about one sweep is the divergence the merged surface exists to make impossible.</para>
+/// <para>The text lane says "NOT installed anywhere … [install them]" for one master and "installed but NOT
+/// ACTIVE … [enable them]" for another. Without the split in json, a caller in that format gets two names with
+/// nothing to tell them apart and cannot pick the remedy that works.</para>
 ///
 /// <para><b>null is not empty.</b> <c>installed_but_inactive_masters</c> is an array where the split was made and
 /// <c>null</c> where it was not — the rule <see cref="PluginErrors"/>'s own summary states. Empty would claim
-/// "none of these is merely disabled", which is an assertion about an install nobody looked at.</para>
+/// "none of these is merely disabled", an assertion about an install nobody looked at.</para>
 ///
 /// <para>Driven over the same synthetic MO2 instance as <see cref="CheckMasterRemedyTests"/>, through the method
 /// the MCP server publishes, for the reason that class states.</para>
@@ -34,10 +32,9 @@ public sealed class CheckMasterRemedyJsonTests : IClassFixture<CheckMasterRemedy
 
     static string[] Strings(JsonElement a) => a.EnumerateArray().Select(e => e.GetString()!).ToArray();
 
-    /// <summary>Both shortfalls in <c>missing_masters</c> — the count and the list are unchanged — and exactly the
-    /// one whose file is in a disabled mod in <c>installed_but_inactive_masters</c>. The absent master must NOT be
-    /// in the subset: telling a caller to enable a file that is not in the install is the wrong remedy delivered
-    /// confidently, which is worse than the union sentence this replaced.</summary>
+    /// <summary>Both shortfalls stay in <c>missing_masters</c>, and exactly the one whose file is in a disabled
+    /// mod appears in <c>installed_but_inactive_masters</c>. The absent master must NOT be in the subset —
+    /// telling a caller to enable a file that is not installed is a confident wrong remedy.</summary>
     [Fact]
     public void TheJsonPluginObjectCarriesTheInstalledButInactiveSubsetAlongsideTheUnionList()
     {
@@ -75,11 +72,10 @@ public sealed class CheckMasterRemedyJsonTests : IClassFixture<CheckMasterRemedy
     /// what <c>ClassifyMissingMasters</c> returns unchanged when the composition cannot be read — leaves the member
     /// <c>null</c>, not <c>[]</c>.
     ///
-    /// <para>Driven at the render rather than end to end, and deliberately: reaching that catch needs an MO2
-    /// profile whose composition read THROWS, which a fixture can only produce by making the instance
-    /// unreadable mid-call. The unclassified report is the same input the catch hands the render, and the text
-    /// lane's twin arm (<c>AnUnclassifiedReportKeepsTheUnionRemedy_NullIsNotAnEmptySubset</c>) is driven the
-    /// same way for the same reason.</para></summary>
+    /// <para>Driven at the render rather than end to end: reaching that catch needs a composition read that
+    /// THROWS, which a fixture can only produce by making the instance unreadable mid-call. The unclassified
+    /// report is the same input the catch hands the render, and the text lane's twin
+    /// (<c>AnUnclassifiedReportKeepsTheUnionRemedy_NullIsNotAnEmptySubset</c>) is driven the same way.</para></summary>
     [Fact]
     public void AnUnclassifiedReportLeavesTheJsonSubsetNull_NotAnEmptyArray()
     {

--- a/src/housecarl-mcp-tests/CheckMasterRemedyTests.cs
+++ b/src/housecarl-mcp-tests/CheckMasterRemedyTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// The synthetic MO2 instance the missing-master REMEDY arms are driven over. Three declared masters on one
+/// The synthetic MO2 instance the missing-master remedy tests are driven over. Three declared masters on one
 /// active plugin, one per standing:
 /// <list type="bullet">
 /// <item><c>Skyrim.esm</c> — in <c>loadorder.txt</c>, absent from <c>plugins.txt</c>, so force-loaded and
@@ -101,7 +101,7 @@ public sealed class CheckMasterRemedyWorld : IDisposable
     }
 }
 
-/// <summary>The world, built once for the class. Every arm below is read-only over it.</summary>
+/// <summary>The world, built once for the class. Every test below is read-only over it.</summary>
 public sealed class CheckMasterRemedyFixture : IDisposable
 {
     public CheckMasterRemedyWorld W { get; } = new();
@@ -112,22 +112,19 @@ public sealed class CheckMasterRemedyFixture : IDisposable
 /// <c>housecarl_check findings=["missing_masters"]</c> names, per unsatisfied master, WHICH shortfall it is —
 /// so the remedy the caller reads is the one that will work.
 ///
-/// <para>The finding class is unchanged: one class, one count, one union list. What changed is the remedy.
-/// The line used to read "install/enable it", which is two remedies handed to a caller who then has to go
-/// find out which applies; a master present only in a disabled mod wants ENABLE, and one that is not in the
-/// install at all wants INSTALL. That distinction was PR #148's false-negative fix and it lived on
-/// <c>read_plugin_file</c>'s advisory, which the 1.x cut deleted along with the tool.</para>
+/// <para>The finding class carries one class, one count and one union list; the split is a render fact. A
+/// master present only in a disabled mod wants ENABLE, and one that is not in the install at all wants
+/// INSTALL.</para>
 ///
-/// <para><b>Where these are driven.</b> Through <see cref="CheckTools.CheckTool"/> — the method the MCP
-/// server publishes and binds arguments into — over a synthetic MO2 instance, the same lane
-/// <see cref="CheckExcludeGrammarTests"/> uses. Not through a render call: the render is reached the way a
-/// caller reaches it. The stdio fixture cannot carry this: <c>ServerFixture</c> runs an UNCONFIGURED server
-/// (its own summary says the config check answers before any value is interpreted), so no wire-driven call
-/// can reach a sweep at all, and pointing that fixture at an instance would change a shared fixture.</para>
+/// <para>Driven through <see cref="CheckTools.CheckTool"/> — the method the MCP server publishes and binds
+/// arguments into — over a synthetic MO2 instance, so the render is reached the way a caller reaches it. The
+/// stdio fixture cannot carry this: <c>ServerFixture</c> runs an UNCONFIGURED server, so no wire-driven call
+/// reaches a sweep at all, and pointing that shared fixture at an instance would change it for everything
+/// else.</para>
 ///
 /// <para>Every expected sentence is a fixture-known value — the fixture decides which master is in which
-/// standing, and the arm names that master in the line it must appear on. A remedy printed against the wrong
-/// master fails on the name, not merely on the wording.</para>
+/// standing, and each test names that master in the line it must appear on, so a remedy printed against the
+/// wrong master fails on the name rather than merely on the wording.</para>
 /// </summary>
 [Trait("tier", "integration")]
 public sealed class CheckMasterRemedyTests : IClassFixture<CheckMasterRemedyFixture>
@@ -181,7 +178,7 @@ public sealed class CheckMasterRemedyTests : IClassFixture<CheckMasterRemedyFixt
         Assert.DoesNotContain(UnionRemedy, PatchSweep());
     }
 
-    /// <summary>The satisfied master is in neither line. Without this the two arms above would pass over a
+    /// <summary>The satisfied master is in neither line. Without this the two tests above would pass over a
     /// render that listed every declared master under both remedies.</summary>
     [Fact]
     public void ASatisfiedMasterIsNamedOnNeitherRemedyLine()

--- a/src/housecarl-mcp-tests/CheckMasterTickedButAbsentTests.cs
+++ b/src/housecarl-mcp-tests/CheckMasterTickedButAbsentTests.cs
@@ -8,17 +8,16 @@ using Xunit;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// The one standing <see cref="CheckMasterRemedyWorld"/> does not carry: a master that is TICKED in
-/// <c>plugins.txt</c> and has no on-disk copy anywhere in the install — the state MO2 is left in when a mod
-/// folder is deleted outside it and the profile keeps the stale tick.
+/// A master TICKED in <c>plugins.txt</c> with no on-disk copy anywhere in the install — the state MO2 is left
+/// in when a mod folder is deleted outside it and the profile keeps the stale tick.
 ///
-/// <para>It is its own world because the tick is a property of the PROFILE, not of a plugin: the same
-/// <c>plugins.txt</c> cannot carry a name both ticked and unticked, so the L1 world's untick-and-absent case
-/// and this one cannot share a fixture.</para>
+/// <para>Its own world because the tick is a property of the PROFILE, not of a plugin: one
+/// <c>plugins.txt</c> cannot carry a name both ticked and unticked, so this case cannot share a fixture with
+/// the unticked-and-absent one in <see cref="CheckMasterRemedyWorld"/>.</para>
 ///
 /// <list type="bullet">
 /// <item><c>Skyrim.esm</c> — in <c>loadorder.txt</c>, absent from <c>plugins.txt</c>, so force-loaded and
-///   SATISFIED. The control that keeps an assertion about the absent master from being a blanket claim.</item>
+///   SATISFIED. The control that keeps a claim about the absent master from being a blanket one.</item>
 /// <item><c>HcTaAbsent.esm</c> — listed in <c>loadorder.txt</c> AND ticked in <c>plugins.txt</c>, while the
 ///   file itself was written outside the instance (no mod folder, no overwrite layer, not game Data). It is
 ///   active by the profile's account and installed nowhere. Its remedy is install.</item>
@@ -88,7 +87,7 @@ public sealed class CheckMasterTickedButAbsentWorld : IDisposable
     }
 }
 
-/// <summary>The world, built once for the class. Every arm below is read-only over it.</summary>
+/// <summary>The world, built once for the class. Every test below is read-only over it.</summary>
 public sealed class CheckMasterTickedButAbsentFixture : IDisposable
 {
     public CheckMasterTickedButAbsentWorld W { get; } = new();
@@ -99,22 +98,20 @@ public sealed class CheckMasterTickedButAbsentFixture : IDisposable
 /// A declared master that is ticked in <c>plugins.txt</c> but has no on-disk copy is reported — by BOTH
 /// surfaces that classify declared masters — and it is reported as NOT INSTALLED.
 ///
-/// <para><b>The shortfall a tick cannot cure.</b> Whether a master will load is two facts, not one: the
-/// profile has to list it as active AND the install has to provide a file. A profile can assert the first
-/// with the second false — that is exactly what a stale tick is — so a filter that tests only the active
-/// half drops the name before anything looks for the file, and the plugin's refs into it dangle with nothing
-/// said. Q3: the "won't load without them" warning must fire exactly when it applies.</para>
+/// <para>Whether a master will load is two facts, not one: the profile has to list it as active AND the
+/// install has to provide a file. A stale tick asserts the first with the second false, so a filter testing
+/// only the active half drops the name before anything looks for the file and the plugin's refs into it
+/// dangle with nothing said.</para>
 ///
 /// <para><b>Two surfaces, one fixture.</b> <see cref="LoadOrderService.ReadPluginFile"/> decides
 /// unsatisfied-ness from the COMPOSITION it just parsed; <c>housecarl_check</c>'s errors family decides it
-/// from the BUILT active order, which drops a listed name the install does not provide. They are different
-/// derivations of the same question, so both are armed here over one install — a divergence is then a
-/// disagreement about this instance rather than about two.</para>
+/// from the BUILT active order, which drops a listed name the install does not provide. Different derivations
+/// of the same question, so both run over one install and a divergence is a disagreement about this instance
+/// rather than about two.</para>
 ///
-/// <para>Driven through <see cref="CheckTools.CheckTool"/> for the same reason
-/// <see cref="CheckMasterRemedyTests"/> is: it is the method the MCP server publishes and binds arguments
-/// into, and the stdio <c>ServerFixture</c> runs an UNCONFIGURED server that answers before any value is
-/// interpreted, so no wire-driven call there can reach a sweep at all.</para>
+/// <para>Driven through <see cref="CheckTools.CheckTool"/> because it is the method the MCP server publishes
+/// and binds arguments into; the stdio <c>ServerFixture</c> runs an unconfigured server that answers before
+/// any value is interpreted, so no wire-driven call there reaches a sweep.</para>
 /// </summary>
 [Trait("tier", "integration")]
 public sealed class CheckMasterTickedButAbsentTests : IClassFixture<CheckMasterTickedButAbsentFixture>
@@ -131,8 +128,8 @@ public sealed class CheckMasterTickedButAbsentTests : IClassFixture<CheckMasterT
         response.Split('\n').Select(l => l.Trim()).FirstOrDefault(l => l.StartsWith(prefix, StringComparison.Ordinal));
 
     /// <summary>The ENGINE half. <c>ReadPluginFile</c>'s advisory splits declared masters into the two
-    /// shortfalls; a ticked-but-absent one belongs in the INSTALL list, and the arm asserts the union first so
-    /// a name dropped from both is distinguishable from a name filed under the wrong remedy.</summary>
+    /// shortfalls; a ticked-but-absent one belongs in the INSTALL list. The union is asserted first so a name
+    /// dropped from both is distinguishable from a name filed under the wrong remedy.</summary>
     [Fact]
     public void ReadPluginFileNamesATickedButAbsentMasterAsMissing_NotInNeitherList()
     {
@@ -140,14 +137,14 @@ public sealed class CheckMasterTickedButAbsentTests : IClassFixture<CheckMasterT
 
         Assert.Null(o.Error);
         Assert.Contains(W.AbsentName, o.Masters);
-        // The union FIRST: the regression this arm exists for is a name reported in neither list.
+        // The union first: the failure this guards against is a name reported in neither list.
         Assert.Contains(W.AbsentName, o.MissingMasters.Concat(o.InactiveMasters));
         // And it is the INSTALL case — no copy exists anywhere, so "enable it" would be a remedy that cannot work.
         Assert.Equal(new[] { W.AbsentName }, o.MissingMasters);
         Assert.Empty(o.InactiveMasters);
     }
 
-    /// <summary>The satisfied master stays out of both lists — without this the arm above would pass over an
+    /// <summary>The satisfied master stays out of both lists — without this the test above would pass over an
     /// advisory that listed every declared master as unsatisfied.</summary>
     [Fact]
     public void ReadPluginFileLeavesTheForceLoadedMasterOutOfBothShortfalls()
@@ -160,8 +157,7 @@ public sealed class CheckMasterTickedButAbsentTests : IClassFixture<CheckMasterT
 
     /// <summary>The LIVE half, over the same install: <c>housecarl_check</c>'s missing-master remedy names the
     /// ticked-but-absent master on the INSTALL line. Its derivation differs — the built active order drops a
-    /// listed name nothing provides, so the name arrives at the splitter already unsatisfied — and this arm is
-    /// what makes that a measured fact about the shipped surface rather than a reading of the code.</summary>
+    /// listed name nothing provides, so the name arrives at the splitter already unsatisfied.</summary>
     [Fact]
     public void TheCheckRemedyNamesTheTickedButAbsentMasterOnTheInstallLine()
     {

--- a/src/housecarl-mcp-tests/CheckWirePathTests.cs
+++ b/src/housecarl-mcp-tests/CheckWirePathTests.cs
@@ -5,22 +5,18 @@ using Xunit;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// <c>housecarl_check</c> driven over stdio — the path #470 left unproven.
+/// <c>housecarl_check</c> driven over stdio. Every other check test calls <c>CheckTools.CheckTool</c> as a
+/// C# method, so none of them exercises its published schema, its argument binding, or the ToolCallShim.
 ///
-/// Every existing check guard calls <c>CheckTools.CheckTool</c> as a C# method, which is why none of them
-/// noticed the tool was unpublished, and why none of them has ever exercised its published schema, its
-/// argument binding, or the ToolCallShim. These are fresh tests against the JSON-RPC response.
+/// <para>The config check runs BEFORE the <c>findings=</c> vocabulary is parsed, so every value that binds —
+/// a legal family, a class, or a nonsense token — comes back with the same config prompt. These tests
+/// therefore prove exactly two things: the argument binds, and the tool body was entered. They cannot prove
+/// the vocabulary, which is covered over <c>SweepFamilySelection.TryParse</c>; the ones that can fail here
+/// are the negative ones below.</para>
 ///
-/// <para><b>What an unconfigured server can and cannot prove.</b> The config check runs BEFORE the
-/// <c>findings=</c> vocabulary is parsed, so every value that binds — a legal family, a class, or a
-/// nonsense token — comes back with the same config prompt. So these arms prove exactly two things: the
-/// argument BINDS, and the tool BODY was entered. They do not and cannot prove the vocabulary; that is
-/// guarded where it lives, over <c>SweepFamilySelection.TryParse</c>. The arms that CAN fail here are the
-/// negative ones below, and they are measured RED.</para>
-///
-/// <para>The subject set is derived from <see cref="SweepFamilySelection.Registered"/> — the same list the
-/// product builds its own refusal vocabulary from — so a family added to the surface arrives here as a new
-/// named cell rather than needing a line in a list somebody has to remember.</para>
+/// <para>The subject set is derived from <see cref="SweepFamilySelection.Registered"/>, the same list the
+/// product builds its refusal vocabulary from, so a family added to the surface arrives here as a new named
+/// case rather than needing a line in a hand-kept list.</para>
 /// </summary>
 [Collection("server")]
 [Trait("tier", "stdio")]
@@ -34,13 +30,10 @@ public sealed class CheckWirePathTests
 
     // ---- the parameter population ----------------------------------------------------------------------
 
-    /// <summary>
-    /// The tool's caller-facing parameters, off the method the SDK builds the schema FROM. MemberData has to
-    /// be static, so this cannot read the running server; the arm below pins it to the wire instead, which is
-    /// the stronger statement anyway — it fails if the two ever disagree.
-    /// The method also takes an injected service argument, which carries no <c>[Description]</c> and is not a
-    /// caller parameter; the pin is what proves that filter right rather than my say-so.
-    /// </summary>
+    /// <summary>The tool's caller-facing parameters, off the method the SDK builds the schema from. MemberData
+    /// must be static, so this cannot read the running server; the test below pins it to the wire instead. The
+    /// method also takes an injected service argument, which carries no <c>[Description]</c> and is not a
+    /// caller parameter — that pin is what proves the filter right.</summary>
     public static IEnumerable<object[]> DeclaredParameters() =>
         CheckToolParameters().Select(p => new object[] { p.Name! });
 
@@ -51,11 +44,9 @@ public sealed class CheckWirePathTests
             .Where(p => p.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>() is not null)
             .ToArray();
 
-    /// <summary>
-    /// The population pin AND the vacuity canary in one: the parameters this sweep drives are exactly the
-    /// properties the server publishes. A parameter added without a description, or published under another
-    /// spelling, shows up here rather than quietly leaving the sweep short.
-    /// </summary>
+    /// <summary>The parameters this sweep drives are exactly the properties the server publishes — an empty
+    /// population, a parameter added without a description, or one published under another spelling shows up
+    /// here rather than quietly leaving the sweep short.</summary>
     [Fact]
     public void TheParametersDrivenAreExactlyTheOnesPublished_SoTheSweepIsNotShort()
     {
@@ -69,18 +60,10 @@ public sealed class CheckWirePathTests
         Assert.Equal(published, declared);
     }
 
-    /// <summary>
-    /// Every caller-facing parameter, sent over the wire on its own. Three of the twelve were driven when
-    /// this file was written and nine had never been sent at all, on the one tool whose wire path had never
-    /// been driven before this PR — a hand-picked population, short by exactly what nobody thought of.
-    ///
-    /// <para>The value is generated from the declared TYPE and is deliberately nonsense content ("zzz", a
-    /// formid that cannot parse). That is sound because of the property this class's summary states: on an
-    /// unconfigured server the config check runs before any value is interpreted, so anything that BINDS
-    /// answers with the config prompt whatever it says. Measured before this test was written — all twelve
-    /// parameters driven with garbage-but-well-typed values reached the body. So a RED here means the
-    /// argument did not bind, which is the only thing this sweep claims.</para>
-    /// </summary>
+    /// <summary>Every caller-facing parameter, sent over the wire on its own. The value is generated from the
+    /// declared type and its content is deliberately nonsense: on an unconfigured server the config check runs
+    /// before any value is interpreted, so anything that binds answers with the config prompt whatever it
+    /// says. A failure here therefore means the argument did not bind, which is all this sweep claims.</summary>
     [Theory]
     [MemberData(nameof(DeclaredParameters))]
     public void EveryPublishedParameterBindsOverTheWireAndReachesTheToolBody(string parameter)
@@ -127,15 +110,10 @@ public sealed class CheckWirePathTests
         Assert.True(r.BodyRan, r.Describe());
     }
 
-    /// <summary>
-    /// The ToolCallShim's coercion path, on a check argument. HCBR-2026-06-11-01's live shape was a
-    /// list-valued parameter sent as a bare string; the shim wraps it. Never exercised on this tool before.
-    ///
-    /// <para>This arm proves the bare string BINDS and reaches the body — it cannot see what the shim
-    /// produced, because an unconfigured server answers the same for any value that binds. A coercion
-    /// yielding an empty array would pass here. The value itself is asserted in
-    /// <see cref="ToolCallShimCoercionTests"/>; the name says only what this one measures.</para>
-    /// </summary>
+    /// <summary>The ToolCallShim's coercion path on a check argument: a list-valued parameter sent as a bare
+    /// string, which the shim wraps. This proves only that the bare string binds and reaches the body — an
+    /// unconfigured server answers the same for any value that binds, so a coercion yielding an empty array
+    /// would pass here. The produced value is asserted in <see cref="ToolCallShimCoercionTests"/>.</summary>
     [Fact]
     public void FindingsSentAsABareStringBindsAndReachesTheBody()
     {
@@ -145,7 +123,7 @@ public sealed class CheckWirePathTests
         Assert.True(r.BodyRan, r.Describe());
     }
 
-    // ---- the arms that can actually fail: binding refusals, named --------------------------------------
+    // ---- the tests that can actually fail: binding refusals, named -------------------------------------
 
     [Fact]
     public void FindingsSentAsAnObjectIsRefusedByTypeAndTheRefusalNamesTheParameterAndBothTypes()

--- a/src/housecarl-mcp-tests/CiAllRefusalTests.cs
+++ b/src/housecarl-mcp-tests/CiAllRefusalTests.cs
@@ -6,14 +6,9 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// <see cref="CiAll"/>'s two written refusals, and the reason they can be read.
-///
-/// <para>Both are sentences a person has to act on: a guard whose entry point the runner cannot dispatch, and
-/// two guards claiming one CI verb. Neither fires on a green repo, so the fixture population is emitted here
-/// — a dynamic assembly carrying the offending shapes — and handed to the same scan the runner uses. The
-/// derivation of the SHIPPED population is untouched: it is still the runner's own reference closure.</para>
-/// </summary>
+/// <summary><see cref="CiAll"/>'s two written refusals: an entry point the runner cannot dispatch, and two
+/// guards claiming one CI verb. Neither fires on a green repo, so the offending shapes are emitted here as a
+/// dynamic assembly and handed to the same scan the runner uses.</summary>
 [Trait("tier", "unit")]
 public sealed class CiAllRefusalTests
 {
@@ -51,10 +46,8 @@ public sealed class CiAllRefusalTests
         return asm;
     }
 
-    /// <summary>
-    /// The verb clash arrives as the InvalidOperationException it was written as, naming both hosts — not
-    /// wrapped in a TypeInitializationException, which is what a static field initializer made of it.
-    /// </summary>
+    /// <summary>The verb clash arrives as an InvalidOperationException naming both hosts, not wrapped in a
+    /// TypeInitializationException.</summary>
     [Fact]
     public void TwoGuardsClaimingOneVerbRefuseWithBothHostsNamed_NotAsATypeInitializerFailure()
     {
@@ -80,15 +73,10 @@ public sealed class CiAllRefusalTests
         Assert.Contains("public static int", ex.Message, StringComparison.Ordinal);
     }
 
-    /// <summary>
-    /// Nothing on <see cref="CiAll"/> is built by the type initializer.
-    ///
-    /// <para>A static field that is <c>initonly</c> can only be filled there, and a refusal thrown out of a
-    /// type initializer is wrapped in a TypeInitializationException that the CLR caches against the type for
-    /// the process: the sentence is buried in an inner exception, and every later test touching the class
-    /// fails with the same wrapper instead of its own measurement. So the invariant is the absence, derived —
-    /// not a list of the members we remembered to make lazy.</para>
-    /// </summary>
+    /// <summary>Nothing on <see cref="CiAll"/> is built by the type initializer: an <c>initonly</c> static can
+    /// only be filled there, and a refusal thrown from a type initializer comes back as a
+    /// TypeInitializationException the CLR caches against the type for the process, so the sentence is buried
+    /// and every later test on the class fails with that wrapper. Derived, not a hand list.</summary>
     [Fact]
     public void NoStaticOnCiAllIsFilledByTheTypeInitializer_SoARefusalReachesTheCallerAsItself()
     {

--- a/src/housecarl-mcp-tests/DialogueFamilyTests.cs
+++ b/src/housecarl-mcp-tests/DialogueFamilyTests.cs
@@ -7,15 +7,8 @@ using Xunit;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// The dialogue family's facts <c>DialogueInfoOrderProbe.cs</c> and <c>DialogueValidateGuardProbe.cs</c>
-/// asserted through the deleted <c>DialogueWire.Render</c> (#486's whole-report renderer), re-asserted here
-/// against the LIVE surfaces that render them today: <c>housecarl_records project=info_order</c> for D1-D3,
-/// and <c>housecarl_check findings=["dialogue"]</c> for D4/V1. Numbered D1-D5/V1 per
-/// <c>dev/session-handoffs/render-halves-scratch/PHASE-1-record.md</c> §5's phase-4 fact list (D5, the
-/// <c>RenderOrderOnly</c> helper's honesty gates over synthesized views, is not re-tested here — it was fixed
-/// IN PLACE in <c>DialogueInfoOrderProbe.cs</c> by rewriting the helper onto the surviving
-/// <c>DialogueWire.AppendInfoOrderView</c>, so the ~8 arms built on it (UNREAD-RENDER, RENDER-BIG-TOPIC,
-/// RENDER-CLAIM-GATES, RENDER-HEAD-SPLIT) kept running unmoved in the probe itself).
+/// The dialogue family's facts, driven against the surfaces that render them: <c>housecarl_records
+/// project=info_order</c> for D1-D3, and <c>housecarl_check findings=["dialogue"]</c> for D4/V1.
 ///
 /// <para>D1/D2 and V1 are driven on the shared <see cref="DialogueWorld"/>. The three lock facts (D3, D4a,
 /// D4b) each construct their OWN world via <c>new()</c> — never the shared one, per <see cref="DialogueWorld"/>'s
@@ -64,7 +57,7 @@ public sealed class DialogueFamilyTests
     }
 
     // ---- fact D2 --------------------------------------------------------------------------------------
-    // The retracted PNAM-zero caveat stays absent.
+    // The PNAM-zero caveat stays absent.
 
     [Fact]
     public void FactD2_TheRetractedCaveatStaysAbsent()
@@ -76,8 +69,8 @@ public sealed class DialogueFamilyTests
     }
 
     // ---- fact D3 --------------------------------------------------------------------------------------
-    // UNREAD-WIRED: a locked contributor yields an INCOMPLETE render naming the unread plugin — the same fix,
-    // end to end through the production path, over a world this test constructs itself.
+    // UNREAD-WIRED: a locked contributor yields an INCOMPLETE render naming the unread plugin, over a world
+    // this test constructs itself.
 
     [Fact]
     public void FactD3_UnreadWired()
@@ -96,8 +89,7 @@ public sealed class DialogueFamilyTests
     // ---- fact D4 (a) ------------------------------------------------------------------------------------
     // DEFINER-LOCK-LOUD: an unreadable definer is loud — a plugin can only override a record by declaring the
     // defining plugin as a master, so opening the override REQUIRES the definer, and the fetch throws before
-    // any order code runs. The merged surface says "the check did not finish — {CheckError}", not the retired
-    // "could NOT complete" wording.
+    // any order code runs.
 
     [Fact]
     public void FactD4a_DefinerLockIsLoud()
@@ -111,10 +103,9 @@ public sealed class DialogueFamilyTests
 
         Assert.NotNull(result.Error);
         // Read PAST the seed. The sweep composes the refusal as "{seed}: {refusal}." and the seed is
-        // "<id>:HcDvMaster.esp" because the topic is DEFINED in the master — so a whole-response
-        // Contains(MasterName) is satisfied by the seed's own echo whichever plugin actually failed, and holding
-        // LastPath instead left it green (pre-green review 1b, finding 2). The refusal itself has to name the
-        // locked plugin, and only the locked one.
+        // "<id>:HcDvMaster.esp" because the topic is DEFINED in the master, so a whole-response
+        // Contains(MasterName) is satisfied by the seed's own echo whichever plugin actually failed. The
+        // refusal itself has to name the locked plugin, and only the locked one.
         var refusal = AfterSeed(text, Fid(w.Topic));
         Assert.Contains("the check did not finish", refusal);
         Assert.Contains("IOException", refusal);
@@ -139,7 +130,7 @@ public sealed class DialogueFamilyTests
 
         Assert.NotNull(result.Error);
         // Read past the seed for the same reason as D4a, though here the seed names a DIFFERENT plugin from the
-        // locked one — the same shape gets the same treatment so the two facts stay comparable.
+        // locked one.
         var refusal = AfterSeed(text, Fid(w.Topic));
         Assert.Contains("the check did not finish", refusal);
         Assert.Contains("IOException", refusal);
@@ -195,23 +186,17 @@ public sealed class DialogueFamilyTests
         return text[(i + seed.Length + 1)..];
     }
 
-    /// <summary>ONE seed's own block: the head line containing <paramref name="marker"/> and the indented findings
+    /// <summary>One seed's own block: the head line containing <paramref name="marker"/> and the indented findings
     /// under it, stopping at the NEXT seed's head — or at the family's accounting or boundary, whichever comes first.
     ///
-    /// <para>It terminated on the next BLANK line until round 2, and carried that clause as a residual until
-    /// Aaron's gate; the predicate above now names the same one terminator this paragraph does. The seed heads are
-    /// contiguous
+    /// <para>The terminator must be the next head, not the next blank line: the seed heads are contiguous
     /// (<c>ReadSentences.DialogueSeedHead</c> ends in one newline and the next head follows it directly), so the
-    /// first blank line in a three-seed response comes AFTER the third seed: every block spanned every seed below
-    /// it, and an assertion that a seed states its own verdict was satisfied by a sibling's. Measured — deleting
-    /// the DLVW verdict outright left the arm green. The terminator is the next head, which is what
-    /// "this seed's own report" was always supposed to mean.</para>
+    /// first blank line comes after the LAST seed and every block would span every seed below it — a seed's
+    /// verdict could then be satisfied by a sibling's.</para>
     ///
-    /// <para>The START is anchored to a HEAD line for the same reason, and that is not belt-and-braces: with the
-    /// terminator fixed and the start still "the first line containing the marker", the quest block resolved to the
-    /// DLVW seed's scope sentence, which names "quest (QUST)" as the record to validate for a graph surface. The
-    /// old span ran past it to the real quest head and passed on that. A kind label is a head's vocabulary, so the
-    /// head is what the search reads.</para></summary>
+    /// <para>The start is anchored to a HEAD line rather than the first line containing the marker: a kind label
+    /// also appears in a seed's scope sentence, so a marker search would resolve the quest block to the DLVW
+    /// seed.</para></summary>
     static string SeedBlock(string response, string marker)
     {
         var lines = response.Split('\n');

--- a/src/housecarl-mcp-tests/DialogueWorld.cs
+++ b/src/housecarl-mcp-tests/DialogueWorld.cs
@@ -8,27 +8,24 @@ using Xunit;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// The synthetic MO2 world the dialogue family's info-order and CK-parity facts are driven against. Ported
-/// from <c>DialogueInfoOrderProbe</c> / <c>DialogueValidateGuardProbe</c> (#486 PR 2) as a real MO2 instance.
+/// The synthetic MO2 world the dialogue family's info-order and CK-parity facts are driven against.
 ///
 /// <para>Three plugins: <see cref="MasterName"/> (the topic + the CK-parity-complete view/branch/quest seeds),
 /// <see cref="MidName"/> (re-lists 6 of the topic's 8 INFOs, PNAM-chained, in reverse — moves nothing),
-/// <see cref="LastName"/> — the WINNER — (re-lists ONLY INFO 0 with no PNAM, which evicts it to the tail: the
-/// reported #275 shape). <see cref="Order"/>'s expected sequence proves the merge.</para>
+/// <see cref="LastName"/> — the WINNER — (re-lists ONLY INFO 0 with no PNAM, which evicts it to the
+/// tail).</para>
 ///
 /// <para><b>Never the shared instance for a test that locks a file.</b> Each of the three dialogue lock facts
 /// (<c>UNREAD-WIRED</c>, <c>DEFINER-LOCK-LOUD</c>, <c>WINNER-LOCK-LOUD</c>) constructs its OWN
 /// <see cref="DialogueWorld"/> via <c>new()</c> rather than the shared collection fixture — a held file is
 /// unreadable to anything else in the process, so sharing it would make every other test's readability depend
-/// on scheduling (the same rule <c>ScriptsWorld</c>'s own doc states, and why <c>HeldOpenTests</c> builds its
-/// own one-plugin world instead of locking the shared one).</para>
+/// on scheduling.</para>
 ///
 /// <para><b>A lock test must force the index build FIRST</b> — call <c>Svc.Stats()</c> on a fresh world before
-/// taking the hold. Measured on this fixture: locking a plugin before the first real query makes the index build
-/// SILENTLY EXCLUDE it, which changes the topic's winner instead of surfacing a read failure, so the lock facts
-/// would quietly assert something else. The silent exclusion itself is the product-level concern in issue #353,
-/// not a property of this fixture; the <c>Stats()</c> call is how these tests stay out of its way, and deleting
-/// it changes what the three lock tests measure without failing anything.</para>
+/// taking the hold. Locking a plugin before the first real query makes the index build SILENTLY EXCLUDE it,
+/// which changes the topic's winner instead of surfacing a read failure, so the lock facts would quietly
+/// assert something else. Deleting the <c>Stats()</c> call changes what those tests measure without failing
+/// anything.</para>
 /// </summary>
 public sealed class DialogueWorld : IDisposable
 {
@@ -50,7 +47,7 @@ public sealed class DialogueWorld : IDisposable
     /// <summary>The 8 INFO FormKeys in their ORIGINAL (master) order.</summary>
     public IReadOnlyList<FormKey> Info { get; }
 
-    /// <summary>The line evicted from #1 to #8 by <see cref="LastName"/>'s no-PNAM re-list — the #275 shape.</summary>
+    /// <summary>The line evicted from #1 to #8 by <see cref="LastName"/>'s no-PNAM re-list.</summary>
     public FormKey MovedLine => Info[0];
 
     public FormKey ViewOk { get; }

--- a/src/housecarl-mcp-tests/EpochCheckSweepTests.cs
+++ b/src/housecarl-mcp-tests/EpochCheckSweepTests.cs
@@ -6,24 +6,10 @@ using static HousecarlMcpTests.CheckErrorsFixtures;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// <c>EpochGuardProbe</c>'s epoch-stamp facts that survive #486 PR 2, re-asserted against the merged
-/// <c>Wire.RenderCheck</c> / <c>JsonWire.RenderCheck</c> and <c>housecarl_records</c> — the surfaces that emit
-/// them today (the probe drove the deleted 1.x single-family renderers). Numbered E1-E8 per
-/// <c>dev/session-handoffs/render-halves-scratch/PHASE-1-record.md</c> §5's phase-3 fact list.
-///
-/// <para>E1 (the three response-shape stamp arms) and E3 (a post-capture refusal's own DTO stamp) are NOT
-/// re-tested here: E1 was repaired in place in phase 1 (an arity fix on a surviving renderer, not a fact this PR
-/// owes) and E3 is already covered — <c>RecordsArtifactTests.StaleReEntry_TheRefusalIsStampedWithTheBuildItConsulted</c>
-/// / <c>.StaleReEntryJson_IsAnErrorAndEpochDocument</c> and <c>RecordsRefusalGrammarTests.TheOffOrderRefusalCarriesTheBuildItConsultedNotEpochNull</c>.
-/// E2's TEXT half is covered by <c>RecordsListLaneTests.IdentityForm_LabelsTheListStatesTheFormAndStampsTheEpoch</c>;
-/// only its JSON half is fresh here.</para>
-///
-/// <para>Driven on <see cref="EpochWorld"/> — a dedicated fixture (never the shared errors/scripts worlds) because
-/// E7/E8 need an OFF-ORDER plugin and E5 needs an ENABLED-but-unparseable one, neither of which
-/// <see cref="ScriptsWorld"/> or the errors family's world carries. Every hand-shaped value below was captured
-/// from the live render, not composed from memory of the source.</para>
-/// </summary>
+/// <summary>The epoch-stamp facts of <c>Wire.RenderCheck</c> / <c>JsonWire.RenderCheck</c> and
+/// <c>housecarl_records</c>. Driven on <see cref="EpochWorld"/> rather than a shared world because the off-order
+/// tests need an OFF-ORDER plugin and the refusal test an ENABLED-but-unparseable one, which no other fixture
+/// carries.</summary>
 [Collection("epoch")]
 [Trait("tier", "integration")]
 public sealed class EpochCheckSweepTests
@@ -33,8 +19,9 @@ public sealed class EpochCheckSweepTests
 
     LoadOrderService Svc => W.Svc;
 
-    // ---- fact E2 (json half only — the text half is covered elsewhere) ------------------------------------
+    // ---- fact E2 -----------------------------------------------------------------------------------------
     // A single successful record read's JSON render carries the capture's epoch at the document's top level.
+    // Its text half is covered by RecordsListLaneTests.
 
     [Fact]
     public void FactE2_ASingleRecordReadsJsonRenderCarriesTheCapturesEpoch()
@@ -93,15 +80,14 @@ public sealed class EpochCheckSweepTests
         var locateDoc = JsonDocument.Parse(locateJson).RootElement;
         Assert.False(locateDoc.GetProperty("ok").GetBoolean());
         Assert.Equal(current, locateDoc.GetProperty("epoch").GetString());
-        // Read over the WHOLE document, not its root: the key's one writer is inside the family object, so a root
-        // TryGetProperty is false whatever the refusal path does and could never have failed. A refusal that grew
-        // a coverage claim anywhere reddens this (pre-green review 1b, finding 4). FactE8 is the proven-positive
-        // counterpart — it reads the key back off the success path.
+        // Read over the WHOLE document, not its root: the key's one writer sits inside the family object, so a
+        // root TryGetProperty is false whatever the refusal path does and could never fail. FactE8 reads the same
+        // key back off the success path, so this negative is not vacuous.
         Assert.DoesNotContain("epoch_covers_all_inputs", locateJson);
 
         var excluded = Svc.CheckErrors(new[] { EpochWorld.BadName }, 1000);
-        // The whole composed refusal, anchored to the plugin it names, rather than the bare word "excluded" — the
-        // word alone survives any rewriting of the sentence around it and is emitted by other refusals too.
+        // The whole composed refusal, anchored to the plugin it names: the bare word "excluded" is emitted by
+        // other refusals too and survives any rewording around it.
         Assert.Contains($"plugin '{EpochWorld.BadName}' was excluded from this session because it could not be " +
                          "parsed", excluded.Error);
         Assert.Contains("fix or remove it upstream; it cannot be checked.", excluded.Error);
@@ -128,15 +114,12 @@ public sealed class EpochCheckSweepTests
         var offOrder = Svc.CheckErrors(new[] { EpochWorld.OldName }, 1000);
         Assert.True(offOrder.Error is null && offOrder.OffOrderScanned is { Count: > 0 });
         var offOrderText = Wire.RenderCheck(new CheckSweep(Sel("errors"), Errors: offOrder), 20000);
-        // The WHOLE qualifier. A 22-character prefix of a 72-character sentence leaves the half that says what the
-        // qualifier MEANS unpinned — the tail could be replaced wholesale and this stayed green (pre-green review
-        // 1a, finding 2).
+        // The WHOLE qualifier: a prefix of it leaves the half saying what the qualifier MEANS unpinned.
         Assert.Contains("(indexed plugins only — off-order file content is outside the fingerprint)", offOrderText);
 
         var allIndexed = Svc.CheckErrors(null, 1000);
         var allIndexedText = Wire.RenderCheck(new CheckSweep(Sel("errors"), Errors: allIndexed), 20000);
-        // The negative stays on the SHORT needle deliberately — a negative is strongest with the least text, and a
-        // long one would pass over a qualifier that came back reworded.
+        // The negative stays on the SHORT needle: a longer one would pass over a reworded qualifier.
         Assert.DoesNotContain("(indexed plugins only", allIndexedText);
     }
 

--- a/src/housecarl-mcp-tests/EpochWorld.cs
+++ b/src/housecarl-mcp-tests/EpochWorld.cs
@@ -7,15 +7,14 @@ using Xunit;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// The synthetic MO2 world the epoch stamp's off-order and excluded-plugin facts are driven against (SPEC
-/// §2.1.1). Three plugins: an ACTIVE master every sweep indexes, an OFF-ORDER plugin sitting in a DISABLED mod
-/// folder (on disk, not in the active order — the "diff against a disabled old patch" shape), and an
-/// UNPARSEABLE plugin that is ENABLED, so the index build excludes it wholesale and a scope naming it hits the
-/// CORE sweep frame's excluded-plugin refusal.
+/// The synthetic MO2 world the epoch stamp's off-order and excluded-plugin facts are driven against. Three
+/// plugins: an ACTIVE master every sweep indexes, an OFF-ORDER plugin sitting in a DISABLED mod folder (on
+/// disk, not in the active order — the "diff against a disabled old patch" shape), and an UNPARSEABLE plugin
+/// that is ENABLED, so the index build excludes it wholesale and a scope naming it hits the CORE sweep frame's
+/// excluded-plugin refusal.
 ///
-/// <para>Ported from <c>EpochGuardProbe</c>'s world (#486 PR 2) as a real MO2 instance, in
-/// <see cref="RecordsWorld"/>'s shape, so it is reachable both by <see cref="LoadOrderService"/> directly and by
-/// <c>housecarl_check</c> off the built server.</para>
+/// <para>A real MO2 instance in <see cref="RecordsWorld"/>'s shape, so it is reachable both by
+/// <see cref="LoadOrderService"/> directly and by <c>housecarl_check</c> off the built server.</para>
 ///
 /// <para><b>Frozen</b>: tests take fixture-known names from it; a later need gets its own world.</para>
 /// </summary>

--- a/src/housecarl-mcp-tests/HarnessBridgeTests.cs
+++ b/src/housecarl-mcp-tests/HarnessBridgeTests.cs
@@ -4,17 +4,10 @@ using Xunit.Abstractions;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// The bridge: one test that runs the old probe harness, so `dotnet test` is the single entry point for
-/// both harnesses during the two-harness window.
-///
-/// It shells the built generator's `ci-all` and fails on a non-zero exit. The bridge shrinks on its own as
-/// families convert, and goes when the last probe does.
-///
-/// Tier `bridge` because it is neither cheap nor isolated: it runs ~1.5 minutes and duplicates a step CI
-/// already has. CI excludes this tier from its `dotnet test` step for exactly that reason (see ci.yml);
-/// a local `dotnet test` with no filter runs it, which is the point.
-/// </summary>
+/// <summary>One test that shells the built generator's <c>ci-all</c> and fails on a non-zero exit, so
+/// <c>dotnet test</c> is the single entry point for both harnesses. Tier <c>bridge</c> because it is neither
+/// cheap nor isolated — it runs about 1.5 minutes and duplicates a step CI already has, so CI excludes the
+/// tier from its <c>dotnet test</c> step (see ci.yml) while a local unfiltered run includes it.</summary>
 [Trait("tier", "bridge")]
 public sealed class HarnessBridgeTests
 {

--- a/src/housecarl-mcp-tests/HarnessPaths.cs
+++ b/src/housecarl-mcp-tests/HarnessPaths.cs
@@ -1,12 +1,8 @@
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// Where the repo is, and which build configuration this test run belongs to.
-///
-/// Both are DERIVED from the running assembly's own location, never passed in or guessed: a helper that
-/// silently falls back to a default is how a harness test passes while measuring the wrong tree.
-/// Every failure here throws rather than returning a fallback.
-/// </summary>
+/// <summary>Where the repo is, and which build configuration this run belongs to — both derived from the running
+/// assembly's own location. Every failure throws rather than falling back, so a test cannot measure the wrong
+/// tree.</summary>
 static class HarnessPaths
 {
     /// <summary>The repo root — the directory holding housecarl.sln, found by walking up from this assembly.</summary>

--- a/src/housecarl-mcp-tests/HeldOpen.cs
+++ b/src/housecarl-mcp-tests/HeldOpen.cs
@@ -1,10 +1,7 @@
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// Holds one file open with <see cref="FileShare.None"/> for the lifetime of the object — MO2 or xEdit
-/// sitting on a plugin. Where it was ported from and what it is for:
-/// <c>docs/architecture/test-project-fixtures.md</c>.
-/// </summary>
+/// <summary>Holds one file open with <see cref="FileShare.None"/> for the lifetime of the object — MO2 or xEdit
+/// sitting on a plugin. Details: <c>docs/architecture/test-project-fixtures.md</c>.</summary>
 public sealed class HeldOpen : IDisposable
 {
     readonly FileStream _stream;

--- a/src/housecarl-mcp-tests/HeldOpenTests.cs
+++ b/src/housecarl-mcp-tests/HeldOpenTests.cs
@@ -6,8 +6,8 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>The file-lock harness's own proofs. Why each arm builds its own world, and what the lock
-/// mechanism is: <c>docs/architecture/test-project-fixtures.md</c>.</summary>
+/// <summary>The file-lock harness's own tests. Why each builds its own world, and what the lock mechanism
+/// is: <c>docs/architecture/test-project-fixtures.md</c>.</summary>
 [Trait("tier", "integration")]
 public sealed class HeldOpenTests
 {
@@ -33,18 +33,16 @@ public sealed class HeldOpenTests
         }
 
         /// <summary>Windows refuses this while any handle on the plugin is open, so a throw here IS an
-        /// undisposed overlay. Call it as an arm's LAST line, after releasing the hold — never from
+        /// undisposed overlay. Call it as a test's LAST line, after releasing the hold — never from
         /// <see cref="Dispose"/>, which would replace a real assertion failure with its own.</summary>
         public void AssertNoHandlesLeft() => Directory.Delete(Root, true);
 
         public void Dispose() { try { Directory.Delete(Root, true); } catch { /* temp cleanup best-effort */ } }
     }
 
-    /// <summary>The engine's single-plugin open, with the overlay disposed after — a memory-mapped overlay
-    /// left undisposed keeps a handle on the plugin for the rest of the process.
-    /// <para><paramref name="use"/> must MATERIALISE everything it returns: the overlay is unmapped before the
-    /// value crosses the return. Why a mod or a record getter is refused rather than trusted:
-    /// <c>docs/architecture/test-project-fixtures.md</c>.</para></summary>
+    /// <summary>The engine's single-plugin open, with the overlay disposed after — an undisposed memory-mapped
+    /// overlay keeps a handle on the plugin for the rest of the process. <paramref name="use"/> must
+    /// MATERIALISE everything it returns: the overlay is unmapped before the value crosses the return.</summary>
     static T Read<T>(string path, Func<ISkyrimModGetter, T> use)
     {
         if (typeof(IModGetter).IsAssignableFrom(typeof(T)) || typeof(IMajorRecordGetter).IsAssignableFrom(typeof(T)))
@@ -60,7 +58,7 @@ public sealed class HeldOpenTests
     /// <summary>The same read, when the point is only whether it faults.</summary>
     static void Read(string path) => Read(path, _ => 0);
 
-    /// <summary><c>Assert.Throws</c> is what states no quietly-empty plugin came back (Q3).</summary>
+    /// <summary><c>Assert.Throws</c> is what states no quietly-empty plugin came back.</summary>
     [Fact]
     public void WhileHeldTheEngineReadFaultsLoudly_AndReturnsNoQuietlyEmptyPlugin()
     {
@@ -76,7 +74,7 @@ public sealed class HeldOpenTests
         world.AssertNoHandlesLeft();
     }
 
-    /// <summary>The vacuity check on the arm above: a file that was never readable would fault identically
+    /// <summary>The vacuity check on the test above: a file that was never readable would fault identically
     /// with a broken lock.</summary>
     [Fact]
     public void AfterTheHoldIsDisposedTheSameReadSucceeds()

--- a/src/housecarl-mcp-tests/LinePump.cs
+++ b/src/housecarl-mcp-tests/LinePump.cs
@@ -2,21 +2,10 @@ using System.Collections.Concurrent;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// One background reader draining a text stream into a queue, so that a caller which gives up waiting
-/// cannot orphan a read.
-///
-/// <para>This exists because of the shape it replaces. Reading a line under a deadline as
-/// <c>Task.Run(reader.ReadLine)</c> plus <c>Wait(remaining)</c> looks like a bounded read and is not one:
-/// <see cref="TextReader.ReadLine"/> is not cancellable, so when the wait expires the read is still parked
-/// on the shared stream and consumes the next line that arrives. In a shared stdio fixture that is not one
-/// failed test — the accounting is one line behind from then on, every later call waits its whole deadline,
-/// and the original slow call is indistinguishable from the wreckage it caused.</para>
-///
-/// <para>With exactly one reader on the stream, forever, there is no second read to orphan: a line that
-/// arrives late is queued, and the caller it was meant for either takes it or skips it by id. The class of
-/// defect is gone rather than handled.</para>
-/// </summary>
+/// <summary>One background reader draining a text stream into a queue, so a caller that gives up waiting
+/// cannot orphan a read. <see cref="TextReader.ReadLine"/> is not cancellable, so a per-call timed read left
+/// parked on a shared stream would swallow the next line and put every later caller one line behind; with
+/// exactly one reader, a late line is simply queued for whoever wants it.</summary>
 public sealed class LinePump : IDisposable
 {
     readonly BlockingCollection<string> _lines = new();

--- a/src/housecarl-mcp-tests/MasterSplitInstallLocationsTests.cs
+++ b/src/housecarl-mcp-tests/MasterSplitInstallLocationsTests.cs
@@ -4,14 +4,13 @@ using Xunit;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// An install with one plugin file in EVERY layer <c>CandidateFolders</c> covers, plus one name that is in none
-/// of them. It exists to pin what "installed" means for the install-vs-enable split: the split's answer has to
-/// be the same set of places a locate searches, or the remedy names a file the locate cannot find.
+/// An install with one plugin file in every layer <c>CandidateFolders</c> covers, plus one name in none of
+/// them. It pins what "installed" means for the install-vs-enable split: the split's answer has to cover the
+/// same places a locate searches, or the remedy names a file the locate cannot find.
 ///
-/// <para>The files here are empty — the split stats and enumerates NAMES and never opens anything, so a real
-/// Mutagen plugin would only make the fixture slower. That is also why this world needs no
-/// <c>LoadOrderService</c>: the name set comes from <see cref="Mo2LoadOrder.AllPluginFileNames"/>, which takes
-/// the composition and the three directories directly.</para>
+/// <para>The files are empty — the split enumerates names and never opens anything. That is also why this
+/// world needs no <c>LoadOrderService</c>: the name set comes from
+/// <see cref="Mo2LoadOrder.AllPluginFileNames"/>, which takes the composition and the three directories.</para>
 /// </summary>
 public sealed class MasterSplitInstallLocationsWorld : IDisposable
 {
@@ -74,17 +73,11 @@ public sealed class MasterSplitInstallLocationsFixture : IDisposable
 
 /// <summary>
 /// <see cref="Mo2LoadOrder.SplitUnsatisfiedMasters"/> files each unsatisfied master by whether the install
-/// provides a copy of it, reading the name set its caller already built.
+/// provides a copy of it, reading the name set its caller already built — one install walk per sweep rather
+/// than one per name.
 ///
-/// <para><b>Why it takes the set.</b> A whole-order sweep makes this split once per report, and the form that
-/// walked the install itself re-derived it per NAME: a master installed nowhere short-circuits nothing, so it
-/// paid the enabled mods, the disabled mods, the unlisted-folder listing and Data before answering, and the
-/// next plugin declaring the same name paid it all again. The answer never depended on which report asked, so
-/// neither does the read — the caller pays one walk for the sweep and asks it per report.</para>
-///
-/// <para><b>What is asserted.</b> Fixture-known lists. The fixture decides where each file lives and the arms
-/// name the list each master has to land in, so a change that moved the split off, say, the unlisted-folder
-/// layer fails here on the name rather than on a count.</para>
+/// <para>Asserted against fixture-known lists: the fixture decides where each file lives and each test names
+/// the list a master has to land in, so a split that dropped one install layer fails on the name, not a count.</para>
 /// </summary>
 [Trait("tier", "unit")]
 public sealed class MasterSplitInstallLocationsTests : IClassFixture<MasterSplitInstallLocationsFixture>
@@ -99,10 +92,8 @@ public sealed class MasterSplitInstallLocationsTests : IClassFixture<MasterSplit
     };
 
     /// <summary>Everything installed anywhere the locate looks is the ENABLE case; the one name in none of those
-    /// folders is the INSTALL case. Five layers, because a split blind to one of them hands out the wrong remedy
-    /// for every master that lives there — and the set it reads is the one
-    /// <see cref="Mo2LoadOrder.AllPluginFileNames"/> builds, so the layers it covers are the layers a locate
-    /// searches.</summary>
+    /// folders is the INSTALL case. All five layers, because a split blind to one hands out the wrong remedy for
+    /// every master living there.</summary>
     [Fact]
     public void TheSplitFilesEachMasterByWhichInstallLayerHoldsItsFile()
     {
@@ -130,9 +121,9 @@ public sealed class MasterSplitInstallLocationsTests : IClassFixture<MasterSplit
         Assert.Equal(new[] { W.InOverwrite, W.InEnabledMod }, inactive);
     }
 
-    /// <summary>A name is reduced to its FILENAME, and padding trimmed, before it is looked up. The per-name
-    /// stat this replaced did that reduction itself; dropping it would file a name that is not already bare as
-    /// uninstalled while the file sits in the install, which is the wrong remedy rather than a missing one.</summary>
+    /// <summary>A name is reduced to its filename, and padding trimmed, before it is looked up. Without that, a
+    /// name that is not already bare is filed as uninstalled while its file sits in the install — the wrong
+    /// remedy rather than a missing one.</summary>
     [Fact]
     public void ANameIsReducedToItsFilenameBeforeItIsLookedUp()
     {

--- a/src/housecarl-mcp-tests/OwnedChildRemedyGrammarTests.cs
+++ b/src/housecarl-mcp-tests/OwnedChildRemedyGrammarTests.cs
@@ -9,31 +9,17 @@ using Xunit.Abstractions;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// #498 — the wrong-lever grammar grid over the TREE form, with its subject set derived from the record
-/// types the records surface can render a declarers block for.
+/// The wrong-lever grammar grid over the TREE form, with its subject set derived from the record types the
+/// records surface can render a declarers block for.
 ///
-/// <para><b>The gap this closes.</b> <see cref="RemedyHarvest"/> reaches the tree form only through
-/// <c>RecordsWorld</c>, whose whole record population is weapons, spells, an armour, magic effects, a form
-/// list and two NPCs — not one child-bearing type among them. So every cut notice the declarers block emits
-/// was outside the grid, and the grid stayed green across the gap. That is the hand-enumerated-population
-/// failure at a guard: the subject set came from whatever a shared fixture happened to contain rather than
-/// from the surface the guard claims to cover.</para>
+/// <para>The owner set is <c>WriteEngine.ChildBearingProperties</c> over every concrete record type Mutagen
+/// models — the same by-construction set <c>OwnedChildContent.Fields</c> splits by shape. The subjects are
+/// found by asking the fixture's own load order for a record of each owner type, so nothing here names a
+/// FormKey, and <see cref="TheSubjectSetCoversEveryShapeTheSurfaceRendersADeclarersBlockFor"/> fails by name
+/// when a shape the surface renders has no subject.</para>
 ///
-/// <para><b>What is derived here.</b> The owner set is
-/// <c>WriteEngine.ChildBearingProperties</c> over every concrete record type Mutagen models — the same
-/// by-construction set <c>OwnedChildContent.Fields</c> splits by shape and <c>ReadSentences.FieldList</c>
-/// consumes. The SUBJECTS are then found by asking the fixture's own load order for a record of each owner
-/// type, so nothing here names a FormKey. And the completeness of that is itself asserted: a shape the
-/// surface renders that no subject covers fails
-/// <see cref="TheSubjectSetCoversEveryShapeTheSurfaceRendersADeclarersBlockFor"/> by name. The grid's own
-/// theory cases still run, narrowed past the missing subject — the class goes red either way, but it is the
-/// completeness arm that says so, not a refusal that stops the run.</para>
-///
-/// <para><c>RecordsWorld</c> stays frozen, and <see cref="RecordsRemedyGrammarTests"/>' arms are untouched.
-/// The lever vocabulary, the remedy discriminant, the per-lane harvest and the lane list all come from
-/// <see cref="RemedyHarvest"/>, so there is one home for each. The first cut of this grid spelled its own
-/// two-lane list and so covered two of the four lanes the surface renders, which is the
-/// hand-enumerated-population failure #498 was filed about arriving one level above the subjects.</para>
+/// <para>The lever vocabulary, the remedy discriminant, the per-lane harvest and the lane list all come from
+/// <see cref="RemedyHarvest"/>, so there is one home for each.</para>
 /// </summary>
 [Trait("tier", "integration")]
 public sealed class OwnedChildRemedyGrammarTests : IClassFixture<OwnedChildFixture>
@@ -49,12 +35,9 @@ public sealed class OwnedChildRemedyGrammarTests : IClassFixture<OwnedChildFixtu
 
     // ---- the surface's own child-bearing set ------------------------------------------------------------
 
-    /// <summary>
-    /// Every concrete record type Mutagen models. The twin of
-    /// <c>WriteSurfaceGuardProbe.ConcreteRecordTypes</c>, which is internal to a project this one cannot see;
-    /// the two converge when that probe converts. The rule is a Mutagen fact, not a houseCARL one: a class in
-    /// Mutagen's own assembly, not abstract, not a binary overlay, that is an <c>IMajorRecord</c>.
-    /// </summary>
+    /// <summary>Every concrete record type Mutagen models. The rule is a Mutagen fact, not a houseCARL one: a
+    /// class in Mutagen's own assembly, not abstract, not a binary overlay, that is an
+    /// <c>IMajorRecord</c>.</summary>
     static IReadOnlyList<Type> ConcreteRecordTypes() =>
         typeof(Weapon).Assembly.GetTypes()
             .Where(t => t.IsClass && !t.IsAbstract && !t.Name.EndsWith("BinaryOverlay", StringComparison.Ordinal)
@@ -75,8 +58,8 @@ public sealed class OwnedChildRemedyGrammarTests : IClassFixture<OwnedChildFixtu
             try
             {
                 // Every IMajorRecord is an IMajorRecordGetter, so the cast cannot yield null and a null check
-                // here would be an arm that cannot fail. What CAN happen is that the type has no
-                // (FormKey, SkyrimRelease) constructor, and that throws — which is the case this explains.
+                // here could not fail. What CAN happen is that the type has no (FormKey, SkyrimRelease)
+                // constructor, and that throws — which is the case this catch explains.
                 blank = (IMajorRecordGetter)System.Activator.CreateInstance(t, FormKey.Null, SkyrimRelease.SkyrimSE)!;
             }
             catch (Exception ex)
@@ -102,16 +85,11 @@ public sealed class OwnedChildRemedyGrammarTests : IClassFixture<OwnedChildFixtu
 
     Dictionary<Type, string>? _subjects;
 
-    /// <summary>
-    /// One subject per child-bearing owner type the fixture actually carries, FOUND rather than named: every
-    /// plugin in the world is walked, and each record is mapped to its concrete type through the product's own
-    /// getter mapping (<c>WriteEngine.PrimaryGetter</c> → <c>ConcreteOf</c>, the same two steps
-    /// <c>OwnedChildContent.Fields</c> takes, and for the same reason — an overlay body is not the type it was
-    /// written against, and asking the runtime type directly loses exactly the SINGULAR owned children).
-    ///
-    /// <para>Not a <c>types=</c> scan: that lane needs the generated corpus, which this world does not stand
-    /// up. Walking the plugins needs nothing but the files the fixture already wrote.</para>
-    /// </summary>
+    /// <summary>One subject per child-bearing owner type the fixture carries, found rather than named: each
+    /// record is mapped to its concrete type through <c>WriteEngine.PrimaryGetter</c> → <c>ConcreteOf</c>,
+    /// because an overlay body is not the type it was written against and asking the runtime type directly
+    /// loses the SINGULAR owned children. Walking the plugin files rather than a <c>types=</c> scan, which
+    /// would need the generated corpus this world does not stand up.</summary>
     IReadOnlyDictionary<Type, string> Subjects()
     {
         if (_subjects is not null) return _subjects;
@@ -138,11 +116,8 @@ public sealed class OwnedChildRemedyGrammarTests : IClassFixture<OwnedChildFixtu
 
     string? SubjectOf(Type type) => Subjects().TryGetValue(type, out var fid) ? fid : null;
 
-    /// <summary>
-    /// THE COMPLETENESS REFUSAL. The grid below is only worth its runtime if its subjects cover the shapes
-    /// the surface renders; a subject set that has drifted short of the surface must stop the run rather
-    /// than shrink the grid in silence.
-    /// </summary>
+    /// <summary>The grid below is only worth its runtime if its subjects cover the shapes the surface renders,
+    /// so a subject set short of the surface fails here rather than shrinking the grid in silence.</summary>
     [Fact]
     public void TheSubjectSetCoversEveryShapeTheSurfaceRendersADeclarersBlockFor()
     {
@@ -185,8 +160,7 @@ public sealed class OwnedChildRemedyGrammarTests : IClassFixture<OwnedChildFixtu
 
     // ---- the grid ---------------------------------------------------------------------------------------
 
-    /// <summary>The tree form, on every child-bearing owner type, in every lane the harvest knows — the
-    /// population <see cref="RemedyHarvest"/> could not reach.</summary>
+    /// <summary>The tree form, on every child-bearing owner type, in every lane the harvest knows.</summary>
     public static TheoryData<string, string> LanesAndLevers()
     {
         var data = new TheoryData<string, string>();
@@ -218,13 +192,10 @@ public sealed class OwnedChildRemedyGrammarTests : IClassFixture<OwnedChildFixtu
         return data;
     }
 
-    /// <summary>
-    /// Per lane, the grid is measuring something: the lane either rendered sentences this harvest could read,
-    /// or the product REFUSED the tree form on that lane by name. Both are real outcomes and the second is a
-    /// fact about the surface — <c>format='dense'</c> renders positional columns against a fixed field set
-    /// and the tree form's rows are variable-length, so the product refuses the pair outright. A lane that
-    /// rendered nothing AND refused nothing is a lane this grid is running blind over.
-    /// </summary>
+    /// <summary>Per lane, the grid must be measuring something: the lane either rendered sentences this harvest
+    /// could read, or the product refused the tree form on that lane by name (<c>format='dense'</c> renders
+    /// positional columns against a fixed field set, and the tree form's rows are variable-length, so the pair
+    /// is refused outright). Rendering nothing and refusing nothing means the grid is running blind.</summary>
     [Theory, MemberData(nameof(EveryLane))]
     public void EveryLaneEitherRendersSentencesThisGridReads_OrRefusesTheTreeFormByName(string lane)
     {
@@ -243,11 +214,8 @@ public sealed class OwnedChildRemedyGrammarTests : IClassFixture<OwnedChildFixtu
             "rather than create.");
     }
 
-    /// <summary>
-    /// The cut notices are reached SOMEWHERE. Held across the lanes rather than per lane, because a lane can
-    /// legitimately never cut: the artifact lane spills the complete result by definition, so its rows carry
-    /// the declarers block and never a "raise max_chars" tail.
-    /// </summary>
+    /// <summary>The cut notices are reached somewhere. Held across the lanes rather than per lane, because the
+    /// artifact lane spills the complete result by definition and so never cuts.</summary>
     [Fact]
     public void TheTreeFormsCutNoticesAreReachedOverAChildBearingRecord()
     {
@@ -276,10 +244,8 @@ public sealed class OwnedChildRemedyGrammarTests : IClassFixture<OwnedChildFixtu
         return _responses[lane];
     }
 
-    /// <summary>
-    /// Every string one lane emits for the tree form over one subject per child-bearing owner type, at a cap
-    /// low enough to make the declarers block and the node walk render their cut notices.
-    /// </summary>
+    /// <summary>Every string one lane emits for the tree form over one subject per child-bearing owner type, at
+    /// a cap low enough to make the declarers block and the node walk render their cut notices.</summary>
     IReadOnlyList<string> Harvest(string lane)
     {
         if (_harvest.TryGetValue(lane, out var got)) return got;
@@ -291,7 +257,7 @@ public sealed class OwnedChildRemedyGrammarTests : IClassFixture<OwnedChildFixtu
         foreach (var type in SurfaceOwners().Keys.OrderBy(t => t.Name, StringComparer.Ordinal))
         {
             var subject = SubjectOf(type);
-            if (subject is null) continue;   // the completeness arm above is what fails on this
+            if (subject is null) continue;   // the completeness test above is what fails on this
 
             foreach (var cap in new[] { 0, 900, 400 })
             {

--- a/src/housecarl-mcp-tests/OwnerRankExemptionTests.cs
+++ b/src/housecarl-mcp-tests/OwnerRankExemptionTests.cs
@@ -7,23 +7,20 @@ using Xunit;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// #207's exemption, re-homed. A container item owned by a FACTION carries a COED block of two words: the owner
-/// FormID, and a second word that is a <c>RequiredRank</c> int. When the owner faction lives in a MASTER — every
-/// override this sweep reads — Mutagen cannot type the owner arm and falls back to <c>UntypedOwner</c>, which
-/// exposes BOTH words as FormLinks; a rank of <c>-1</c> (<c>0xFFFFFFFF</c>, id <c>FFFFFF</c>) then read as a
-/// dangling reference. <c>ErrorCheck.UntypedOwnerVariableData</c> drops only that SECOND word.
+/// A container item owned by a FACTION carries a COED block of two words: the owner FormID, and a second word
+/// that is a <c>RequiredRank</c> int. When the owner faction lives in a MASTER — every override this sweep
+/// reads — Mutagen cannot type the owner arm and falls back to <c>UntypedOwner</c>, which exposes BOTH words as
+/// FormLinks; a rank of <c>-1</c> (<c>0xFFFFFFFF</c>, id <c>FFFFFF</c>) then reads as a dangling reference.
+/// <c>ErrorCheck.UntypedOwnerVariableData</c> drops only that SECOND word.
 ///
-/// <para>The exemption trades off in both directions and both directions are armed here: exempt too little and
-/// #207 returns; exempt too much and the owner FORM stops being swept, so a genuinely broken owner goes silent.
-/// The three arms were <c>OWNER-RANK</c> / <c>OWNER-DATA-CHECKED</c> / <c>OWNER-RANK-TOTAL</c> in
-/// <c>CheckErrorsProbe.cs</c>; they never called a deleted renderer, and #486 PR 2's whole-file deletion took
-/// them with it. Aaron ruled this cluster back on the branch (2026-09-03) while the rest of that population is
-/// chartered separately.</para>
+/// <para>The exemption trades off both ways and both are covered here: exempt too little and the rank word is
+/// reported as dangling again; exempt too much and the owner FORM stops being swept, so a genuinely broken
+/// owner goes silent.</para>
 ///
 /// <para>Driven at DTO level on <c>ErrorCheck.Run</c> over a fixture of this file's own — never a shared world,
 /// because a faction-owned container with an absent owner master is a shape no other test wants. Asserted
-/// STRUCTURALLY, keyed by record (#492's shape): the FormKeys in <c>Dangling</c> and the names in
-/// <c>MissingMasters</c>, never a rendered sentence.</para>
+/// structurally, keyed by record: the FormKeys in <c>Dangling</c> and the names in <c>MissingMasters</c>, never
+/// a rendered sentence.</para>
 /// </summary>
 [Trait("tier", "integration")]
 public sealed class OwnerRankExemptionTests : IDisposable

--- a/src/housecarl-mcp-tests/PexWriter.cs
+++ b/src/housecarl-mcp-tests/PexWriter.cs
@@ -4,6 +4,7 @@ using Mutagen.Bethesda.Pex;
 namespace HousecarlMcpTests;
 
 /// <summary>Writes byte-valid single-object Skyrim <c>.pex</c> files with a chosen table of Auto properties.
+/// A copy, not a project reference on the generator's own writer: the test project must not depend on it.
 /// What the fixture uses it for: <c>docs/architecture/test-project-fixtures.md</c>.</summary>
 public static class PexWriter
 {

--- a/src/housecarl-mcp-tests/PexWriter.cs
+++ b/src/housecarl-mcp-tests/PexWriter.cs
@@ -3,11 +3,8 @@ using Mutagen.Bethesda.Pex;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// Writes byte-valid single-object Skyrim <c>.pex</c> files with a chosen table of Auto properties. Ported
-/// from <c>src/housecarl-generator/ScriptPropertyCheckProbe.cs</c> rather than referenced; why, and what
-/// the fixture uses it for: <c>docs/architecture/test-project-fixtures.md</c>.
-/// </summary>
+/// <summary>Writes byte-valid single-object Skyrim <c>.pex</c> files with a chosen table of Auto properties.
+/// What the fixture uses it for: <c>docs/architecture/test-project-fixtures.md</c>.</summary>
 public static class PexWriter
 {
     /// <summary>One Auto property: the property record plus its <c>::Name_var</c> backing variable, which

--- a/src/housecarl-mcp-tests/PreFlattenSchemas.cs
+++ b/src/housecarl-mcp-tests/PreFlattenSchemas.cs
@@ -1,4 +1,3 @@
-// Converted-from: BindingShimProbe
 using System.ComponentModel;
 using System.Reflection;
 using System.Text.Json;
@@ -12,12 +11,10 @@ namespace HousecarlMcpTests;
 
 /// <summary>
 /// The tool surface as the SDK's schema generator emits it, BEFORE <c>ToolSchemas.PublishSchemas</c> runs,
-/// plus the pointer arithmetic the published-schema arms stand on.
-///
-/// <para>Guard machinery, not product code — the probe carried the same functions, and the two
-/// <c>SCHEMA-FIXTURE</c> arms in <see cref="PublishedSchemaShapeTests"/> guard THESE, exactly as they guarded
-/// the probe's copies. Kept here rather than reached across into <c>housecarl-generator</c>'s
-/// <c>PreFlattenSurface</c>, which is internal to a project this test assembly is not a friend of.</para>
+/// plus the pointer arithmetic the published-schema tests stand on. Test machinery, not product code; the
+/// derivation rules here are themselves checked in <see cref="PublishedSchemaShapeTests"/>. Kept here rather
+/// than reached across into <c>housecarl-generator</c>'s <c>PreFlattenSurface</c>, which is internal to a
+/// project this test assembly is not a friend of.
 ///
 /// <para>The registration mirrors the server's own scan line and stops there: no transport, no server
 /// identity, and above all no schema publication pass, because that pass mutates <c>InputSchema</c> in place
@@ -29,8 +26,7 @@ internal static class PreFlattenSchemas
     internal readonly record struct Tool(string Name, JsonObject Schema);
 
     /// <summary>Every registered tool's pre-flatten schema, in registration order. Throws rather than
-    /// returning empty: a derivation that finds no tools is a broken derivation, and every arm built on it
-    /// would pass vacuously.</summary>
+    /// returning empty: an empty result would make every test built on it pass vacuously.</summary>
     internal static IReadOnlyList<Tool> Read()
     {
         var services = new ServiceCollection();
@@ -123,8 +119,8 @@ internal static class PreFlattenSchemas
     }
 
     /// <summary>The <c>$ref</c> pointer on a node, or null when the member is absent or does not hold a JSON
-    /// string. The safe spelling on purpose: a non-string <c>$ref</c> is a form neither pass understands, and
-    /// the invariant arm is what reports it — reading it as a string here would take the guard down first.</summary>
+    /// string. Safe on purpose: a non-string <c>$ref</c> is a form neither pass understands, and the invariant
+    /// test is what reports it — reading it as a string here would throw before that test could.</summary>
     internal static string? RefPointer(JsonObject node) =>
         node["$ref"] is JsonValue v && v.TryGetValue<string>(out var s) ? s : null;
 
@@ -133,16 +129,11 @@ internal static class PreFlattenSchemas
     /// pointer is a proper ancestor of its own path is a positional back-reference, and the path segment
     /// between them is one turn of that cycle.
     ///
-    /// <para>Two rules make the derivation say what it means, and neither is visible on today's surface —
-    /// which is why the fixture arms exist:</para>
-    /// <list type="bullet">
-    /// <item>the prefix must end ON a JSON-pointer segment boundary. A bare string prefix makes a sibling
-    /// whose wire name EXTENDS the target's into a false ancestor, and the derived step is then a fragment of
-    /// a member name that resolves nowhere — a RED on a schema the pass flattened correctly.</item>
-    /// <item>every distinct pair is returned, never the last one. The caller refuses a tool that yields more
-    /// than one: a later pair overwriting the first leaves the guard measuring one cycle while claiming the
-    /// tool's coverage.</item>
-    /// </list>
+    /// <para>Two rules, neither exercised by today's surface, so each has its own fixture test: the prefix must
+    /// end ON a JSON-pointer segment boundary, or a sibling whose wire name merely EXTENDS the target's reads as
+    /// a false ancestor and the derived step resolves nowhere; and every distinct pair is returned rather than
+    /// the last, so a caller can refuse a tool carrying more than one cycle instead of measuring whichever the
+    /// walk saw last.</para>
     /// </summary>
     internal static List<(string Step, string Cycle)> DeriveRecursions(
         IEnumerable<(string Path, JsonObject Node)> sites)
@@ -220,7 +211,7 @@ internal static class PreFlattenSchemas
         }
     }
 
-    /// <summary>Anything not starting with '#' is external and counts as resolvable — these arms police the
+    /// <summary>Anything not starting with '#' is external and counts as resolvable — these tests police the
     /// pointers the publication pass rebases, not the whole of JSON Schema.</summary>
     internal static bool PointerResolves(JsonElement root, string reference)
         => !reference.StartsWith('#') || Pointer(root, reference) is not null;

--- a/src/housecarl-mcp-tests/PublishedNameAnchorTests.cs
+++ b/src/housecarl-mcp-tests/PublishedNameAnchorTests.cs
@@ -4,18 +4,11 @@ using Xunit.Abstractions;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// The rename oracle for the published tool names.
-///
-/// <para>Since the tool-name registry landed (ADR 0004), shipped code and almost every test name a tool by
-/// referencing a <c>ToolNames</c> constant. That is what makes deleting a tool a compile error — and it also
-/// means a typo in a constant's VALUE moves the declared set, the registered set and the published set
-/// together, so every set-equality cell stays green while the surface renames itself.</para>
-///
-/// <para>The 1.9 capture anchors the names 1.9 published as literals, which covers 39 of the 46. The seven
-/// 2.0-era names had no literal anchor outside the guard harness that is being retired. This holds the
-/// published set against a checked-in capture of literals, in both directions.</para>
-/// </summary>
+/// <summary>The rename oracle for the published tool names. Shipped code and almost every test name a tool
+/// through a <c>ToolNames</c> constant, so a typo in a constant's VALUE moves the declared, registered and
+/// published sets together and every set-equality test stays green while the surface renames itself. The
+/// checked-in capture is the only place the names are spelled as literals; it is held against the published
+/// set in both directions.</summary>
 [Collection("server")]
 [Trait("tier", "stdio")]
 public sealed class PublishedNameAnchorTests
@@ -35,7 +28,7 @@ public sealed class PublishedNameAnchorTests
                        .OrderBy(n => n, StringComparer.Ordinal)
                        .ToArray();
 
-        // Vacuity canary: an emptied or reshaped capture would satisfy both claims below it.
+        // An emptied or reshaped capture would satisfy both claims below it.
         Assert.True(names.Length > 0,
             $"'{CapturePath}' lists no tools, so both anchor claims are vacuous. The capture is the only " +
             "place these names are spelled as literals; an empty one is a broken oracle, not an empty surface.");

--- a/src/housecarl-mcp-tests/PublishedSchemaShapeTests.cs
+++ b/src/housecarl-mcp-tests/PublishedSchemaShapeTests.cs
@@ -1,4 +1,3 @@
-// Converted-from: BindingShimProbe
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -10,18 +9,14 @@ using Xunit.Abstractions;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// The schemas the server actually SERVES: the SPEC §5.1 <c>@file</c> union on the JsonElement-typed list
-/// parameters, and the no-same-document-<c>$ref</c> invariant every published schema must satisfy (#451).
-/// (BindingShimProbe's SCHEMA arms.)
+/// The schemas the server actually SERVES: the <c>@file</c> union on the JsonElement-typed list parameters, and
+/// the no-<c>$ref</c> invariant every published schema must satisfy. Read off the served surface rather than the
+/// generator's output because a strict provider rejects a recursive schema by refusing the WHOLE server at
+/// <c>tools/list</c>, naming no tool.
 ///
-/// <para>Why the served surface and not the generator's output: a strict provider rejects a recursive schema
-/// and refuses the WHOLE server at <c>tools/list</c>, naming no tool. The <c>StructInput → NestedSet.compose</c>
-/// chain published one on five tools.</para>
-///
-/// <para>Every subject set here is DERIVED. The union rows come off <see cref="ToolSchemas.FileListParams"/>
-/// and their expected members off each row's own element type; the <c>$ref</c> sites come off the pre-flatten
-/// surface. The predecessor named its tools by hand and four of the five ref-carrying tools had no expansion
-/// arm at all, so a bound of 0 applied to their subtrees would have collapsed them with both guards green.</para>
+/// <para>Every subject set here is DERIVED, never named by hand: the union rows come off
+/// <see cref="ToolSchemas.FileListParams"/> and their expected members off each row's own element type, and the
+/// <c>$ref</c> sites come off the pre-flatten surface.</para>
 /// </summary>
 [Collection("server")]
 [Trait("tier", "stdio")]
@@ -63,11 +58,9 @@ public sealed class PublishedSchemaShapeTests
             "to dangle, so the generic sweep passes over it silently.");
     }
 
-    /// <summary>
-    /// No C# type expresses "an array of ops OR the string '@path'", so the generator publishes <c>{}</c> for
-    /// the declared <c>JsonElement</c>; the publication pass republishes the union. Asserted per row — an
-    /// earlier version hard-coded one tool, and the row it missed was covered only by the generic sweep.
-    /// </summary>
+    /// <summary>No C# type expresses "an array of ops OR the string '@path'", so the generator publishes
+    /// <c>{}</c> for the declared <c>JsonElement</c> and the publication pass republishes the union. Asserted
+    /// once per row.</summary>
     [Theory]
     [MemberData(nameof(FileListUnions))]
     public void EveryFileListUnionPublishesAnyOfGeneratedArrayOrString(string tool, string parameter)
@@ -81,11 +74,9 @@ public sealed class PublishedSchemaShapeTests
         Assert.Equal("string", arms[1].GetProperty("type").GetString());
     }
 
-    /// <summary>
-    /// The array arm must be the GENERATED element schema, not an empty placeholder. The expected member set
-    /// is reflected off the row's own element type, so adding a member to the DTO tracks here by construction
-    /// — the predecessor named one sample member per row by hand.
-    /// </summary>
+    /// <summary>The array arm must be the GENERATED element schema, not an empty placeholder. The expected
+    /// member set is reflected off the row's own element type, so adding a member to the DTO tracks here by
+    /// construction.</summary>
     [Theory]
     [MemberData(nameof(FileListUnions))]
     public void EveryFileListUnionsArrayArmCarriesItsGeneratedElementMembers(string tool, string parameter)
@@ -99,17 +90,16 @@ public sealed class PublishedSchemaShapeTests
         Assert.Equal(WireMembersOf(Row(tool, parameter).ElementArrayType), published);
     }
 
-    // ---- #451: the $ref invariant -----------------------------------------------------------------------
+    // ---- the $ref invariant -----------------------------------------------------------------------------
 
     /// <summary>
     /// Zero <c>$ref</c> members anywhere in any published schema, whatever they hold.
     ///
     /// <para>The predicate is deliberately WIDER than the flattener's and shares no code with it: the
-    /// publication pass gates inlining on a same-document pointer because that is what it knows how to
-    /// resolve, and this arm asks only whether the MEMBER is there. Spelling them the same way is what made
-    /// the earlier version vacuous — an anchor-form <c>{"$ref":"Node"}</c> injected into all 51 schemas
-    /// passed green, because a ref the pass could not see was also one the detector could not see. Whether a
-    /// survivor resolves is reported as detail, since that says WHICH failure it is.</para>
+    /// publication pass gates inlining on a same-document pointer because that is what it knows how to resolve,
+    /// while this asks only whether the MEMBER is there. Spelled the same way, a ref the pass cannot see would
+    /// also be one the detector cannot see. Whether a survivor resolves is reported as detail, since that says
+    /// WHICH failure it is.</para>
     /// </summary>
     [Fact]
     public void NoPublishedToolSchemaCarriesARefMemberInAnySpelling()
@@ -131,9 +121,9 @@ public sealed class PublishedSchemaShapeTests
 
     // ---- anti-amputation, over subjects derived from the pre-flatten surface ----------------------------
     //
-    // The invariant above is satisfied just as well by DELETING every recursive branch, which would tell
-    // callers a nested compose is not a thing — a narrowing of the published contract with nothing to notice.
-    // So every site that carried a $ref BEFORE the pass must still be spelled out after it.
+    // The invariant above is satisfied just as well by DELETING every recursive branch, which would narrow the
+    // published contract silently. So every site that carried a $ref BEFORE the pass must still be spelled out
+    // after it.
     //
     // The @file union pass is replayed on the pre-flatten document because the published one has it and the
     // pointers must line up. The flatten replaces each ref node IN PLACE, so a pre-flatten ref path is the
@@ -183,13 +173,9 @@ public sealed class PublishedSchemaShapeTests
         Assert.True(_s.PublishedTools.ContainsKey(tool),
                     $"{tool} carries pre-flatten $ref sites but tools/list does not publish it.");
 
-    /// <summary>
-    /// EXACTLY one recursion step must be derivable from a tool's own refs. A tool carrying two distinct
-    /// cycles is refused here rather than measured on whichever the walk saw last — that is a claim
-    /// quantified over a population and verified over a narrower subset, which is the class this arm exists
-    /// to stop. (Measured 2026-09-01: a second recursive family took the recursive population from 10 of 30
-    /// sites to 5 of 45, the original cycle measured on NO tool, with the guard fully green.)
-    /// </summary>
+    /// <summary>EXACTLY one recursion step must be derivable from a tool's own refs. A tool carrying two
+    /// distinct cycles is refused here rather than measured on whichever the walk saw last, which would leave
+    /// the tests below claiming a whole population while checking a narrower subset of it.</summary>
     [Theory]
     [MemberData(nameof(RefCarryingTools))]
     public void ExactlyOneRecursionStepIsDerivableFromACarriersOwnRefSites(string tool)
@@ -216,12 +202,9 @@ public sealed class PublishedSchemaShapeTests
             (node is { } got ? PreFlattenSchemas.Trunc(got) : "<path does not resolve in the published schema>"));
     }
 
-    /// <summary>
-    /// The bound is a RULED value, spelled here independently of the constant on purpose: reading
-    /// <c>ToolSchemas.MaxSelfExpansions</c> would make this arm agree with any bound, including the 0 that
-    /// open-nodes the non-cyclic leaves too. Changing it reddens here, which is the point — it is a
-    /// published-contract change and has to be re-ratified, not slid in.
-    /// </summary>
+    /// <summary>The bound is spelled here independently of <c>ToolSchemas.MaxSelfExpansions</c> on purpose:
+    /// reading the constant would make this agree with any bound, including the 0 that open-nodes the non-cyclic
+    /// leaves too. Changing the bound is a published-contract change, and it has to fail here.</summary>
     [Theory]
     [MemberData(nameof(RecursiveSites))]
     public void EveryRecursiveSiteExpandsExactlyOneLevelBeforeClosing(string tool, string path)
@@ -245,8 +228,8 @@ public sealed class PublishedSchemaShapeTests
         Assert.True(closedOpen, $"{tool} {PreFlattenSchemas.Tail(path)}: {detail}");
     }
 
-    /// <summary>Without this, every derived arm above is vacuously green the moment the pre-flatten read
-    /// stops returning what it is supposed to.</summary>
+    /// <summary>Without this, every derived test above passes vacuously the moment the pre-flatten read stops
+    /// returning what it is supposed to.</summary>
     [Fact]
     public void TheDerivedSubjectSetIsNonEmpty()
     {
@@ -268,17 +251,16 @@ public sealed class PublishedSchemaShapeTests
 
     // ---- the derivation's own fixtures -------------------------------------------------------------------
     //
-    // Both shapes were measured on the real surface under sabotage (a second NestedSet[] member on
-    // StructInput, 2026-09-01) and neither is producible by the DTOs as they stand, so the rules they pin
-    // have no end-to-end producer to redden.
+    // Neither shape is producible by the DTOs as they stand, so the derivation rules they pin have nothing
+    // end to end that would fail if the rules broke. They are pinned here instead.
 
     const string R = "#/properties/operations/items/properties";
 
     static (string, JsonObject) Site(string path, string pointer) =>
         (path, new JsonObject { ["$ref"] = pointer });
 
-    /// <summary>Both pairs must come back: reporting one is how the guard claimed a tool's coverage while
-    /// measuring a single cycle of it.</summary>
+    /// <summary>Both pairs must come back; reporting only one would let a tool's coverage be claimed while a
+    /// single cycle of it was checked.</summary>
     [Fact]
     [Trait("tier", "unit")]
     public void ASurfaceCarryingTwoDistinctCyclesDerivesBothSoTheCallerCanRefuseIt()

--- a/src/housecarl-mcp-tests/RecordsArtifactTests.cs
+++ b/src/housecarl-mcp-tests/RecordsArtifactTests.cs
@@ -6,16 +6,9 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-// SPEC §2.1.1 — the artifact disposition on housecarl_records: to_file, auto-spill at the render ceiling,
-// @artifact re-entry, the epoch check, the results store's own hygiene, and error-row identity.
-//
-// The arms come from the tool-surface-2.0 W1 artifact guard, which drove the retired 1.x read tools
-// (batch_record_detail / cross_plugin_query / resolve). The machinery is shared and unchanged — Artifacts,
-// ResultArtifact, ResultsStore — so what those arms claimed is re-asserted here against the 2.0 lanes that
-// absorbed them: project.form='identity' for the resolve lane, 'everything' for the batch lane, and the
-// types=/where= scan for the cross-query lane. Two of the old arms have no 2.0 expression and are not
-// carried: conflict_tree= has no spelling on this schema, and the successor form='tree' HAS a row form
-// and spills like any other (see RecordsComparisonFormTests).
+// The artifact disposition on housecarl_records: to_file, auto-spill at the render ceiling, @artifact
+// re-entry, the epoch check, the results store's own hygiene, and error-row identity. The lanes exercised are
+// project.form='identity', 'everything', and the types=/where= scan.
 
 /// <summary>to_file, auto-spill, re-entry, the store's refusals, and error-row identity — everything that
 /// reads one stable build.</summary>
@@ -24,12 +17,12 @@ public sealed class RecordsArtifactTests : ArtifactTestBase, IClassFixture<Artif
 {
     public RecordsArtifactTests(ArtifactFixture f) : base(f) { }
 
-    /// <summary>The scan population the artifact arms measure against, read off the product's own accounting
-    /// rather than counted by hand here.</summary>
+    /// <summary>The scan population these tests measure against, read off the product's own accounting rather
+    /// than counted by hand here.</summary>
     int SpellTotal => Je(RecordsTools.Records(Svc, types: new[] { "SPEL" }, format: "json")).GetProperty("total").GetInt32();
     int WeaponTotal => Je(RecordsTools.Records(Svc, types: new[] { "WEAP" }, format: "json")).GetProperty("total").GetInt32();
 
-    // ---- 2: to_file — the forced disposition -------------------------------------------------------
+    // ---- to_file — the forced disposition ----------------------------------------------------------
 
     [Fact]
     public void ToFile_TheArtifactIsCompleteAndStampedWithTheScannedBuild()
@@ -42,12 +35,9 @@ public sealed class RecordsArtifactTests : ArtifactTestBase, IClassFixture<Artif
         Assert.Equal(W.Epoch0, m.Epoch);
     }
 
-    /// <summary>The manifest's provenance stamp. It records WHICH TOOL wrote the artifact and is read back
-    /// into a live re-entry refusal ("artifact '…' (from X) …"), so a stamp naming a deleted tool is a dead
-    /// name in a sentence a caller reads. THREE of the writers were shared with 1.x tools the cut deleted —
-    /// the scan writer, the batch writer and the identity writer — and nothing asserted any stamp until these
-    /// arms. The population is derived below rather than counted by hand, which is how the batch writer was
-    /// missed the first time.</summary>
+    /// <summary>The manifest's provenance stamp records WHICH TOOL wrote the artifact, and it is read back into
+    /// a live re-entry refusal ("artifact '…' (from X) …"), so a wrong stamp is a wrong name in a sentence a
+    /// caller reads.</summary>
     [Fact]
     public void ToFile_TheManifestStampsTheToolThatActuallyWroteIt_Scan()
     {
@@ -57,8 +47,8 @@ public sealed class RecordsArtifactTests : ArtifactTestBase, IClassFixture<Artif
         Assert.Equal(ToolNames.Records, ManifestOf(art).Tool);
     }
 
-    /// <summary>The identity writer is the second stamp site, and it is a different code path — a per-writer
-    /// arm, not one arm standing in for both.</summary>
+    /// <summary>The identity writer is a second stamp site on a different code path, so it gets its own
+    /// test.</summary>
     [Fact]
     public void ToFile_TheManifestStampsTheToolThatActuallyWroteIt_Identity()
     {
@@ -69,10 +59,9 @@ public sealed class RecordsArtifactTests : ArtifactTestBase, IClassFixture<Artif
         Assert.Equal(ToolNames.Records, ManifestOf(art).Tool);
     }
 
-    /// <summary>The stamp population, DERIVED from the writer's own source rather than from a list: every
+    /// <summary>The stamp population read out of the writer's own source rather than listed here: every
     /// <c>writer.Save(path, …)</c> call site in <c>Artifacts.cs</c> must pass the <c>ToolNames</c> constant, not
-    /// a literal. A new writer added tomorrow is in the population without an edit here, and a literal spelling
-    /// anywhere — dead name or live one — is RED.</summary>
+    /// a literal, so a new writer is covered without an edit here.</summary>
     [Fact]
     public void EveryArtifactWritersProvenanceStampInterpolatesTheToolNameConstant()
     {
@@ -84,9 +73,9 @@ public sealed class RecordsArtifactTests : ArtifactTestBase, IClassFixture<Artif
             Assert.Equal("ToolNames.Records", m.Groups[1].Value.Trim());
     }
 
-    /// <summary>And driven: for every form the tool declares — the list read out of the tool's OWN refusal, so
-    /// it cannot drift from the surface — a <c>to_file=</c> call that is served must stamp the constant. Forms
-    /// that refuse <c>to_file=</c> are skipped and counted, never silently passed.</summary>
+    /// <summary>For every form the tool declares — the list read out of the tool's own refusal, so it cannot
+    /// drift from the surface — a served <c>to_file=</c> call must stamp the constant. Forms that refuse
+    /// <c>to_file=</c> are skipped and counted, never silently passed.</summary>
     [Fact]
     public void EveryFormThatSpillsToAFile_StampsTheToolThatWroteIt()
     {
@@ -154,8 +143,8 @@ public sealed class RecordsArtifactTests : ArtifactTestBase, IClassFixture<Artif
     [Fact]
     public void AnArtifactDeclaringNoIdentityColumnRefusesReEntryByName()
     {
-        // The count-table artifact the aggregate form used to produce: records now refuses aggregate+to_file
-        // up front, so the file is built through the same writer that lane used.
+        // records refuses aggregate+to_file up front, so the count-table file is built here through the same
+        // writer that lane used.
         var p = CountTableArtifact("counts.jsonl");
         var (_, _, err) = ResultArtifact.ReadIdentity(p, File.ReadAllText(p));
         Assert.Contains("NO identity column", err);
@@ -173,7 +162,7 @@ public sealed class RecordsArtifactTests : ArtifactTestBase, IClassFixture<Artif
     public void ToFilePlusOffset_IsRefusedBecauseTheArtifactIsNeverAWindow() =>
         Refused(RecordsTools.Records(Svc, types: new[] { "SPEL" }, offset: 2, to_file: Art("y.jsonl")), "offset");
 
-    // ---- 3: auto-spill at the inline ceiling -------------------------------------------------------
+    // ---- auto-spill at the inline ceiling ----------------------------------------------------------
 
     const int TinyScan = 200;    // below the scan render's floor for this world
     const int TinyList = 120;    // below the identity render's floor for three rows
@@ -262,7 +251,7 @@ public sealed class RecordsArtifactTests : ArtifactTestBase, IClassFixture<Artif
         Assert.True(doc.TryGetProperty("spill_error", out _));
     }
 
-    // ---- 4: @file re-entry against the same build --------------------------------------------------
+    // ---- @file re-entry against the same build -----------------------------------------------------
 
     [Fact]
     public void ArtifactReEntry_TheBodyLaneReadsEveryIdentityInTheFile()
@@ -304,7 +293,7 @@ public sealed class RecordsArtifactTests : ArtifactTestBase, IClassFixture<Artif
         Refused(RecordsTools.Records(Svc, formids: new[] { "@" + CountTableArtifact("counts-door.jsonl") }),
                 "NO identity column");
 
-    // ---- 7: the honesty folds ----------------------------------------------------------------------
+    // ---- the spill marker tells the truth about what it holds --------------------------------------
 
     [Fact]
     public void AWindowedAutoSpillSaysWindowAndNeverClaimsTheCompleteResult()
@@ -376,7 +365,7 @@ public sealed class RecordsArtifactTests : ArtifactTestBase, IClassFixture<Artif
         Refused(RecordsTools.Records(Svc, types: new[] { "SPEL" }, to_file: Path.Combine(ResultsDir, "mine.jsonl")),
                 "pruned by age");
 
-    // ---- 8: error rows are not identity-bearing ----------------------------------------------------
+    // ---- error rows are not identity-bearing -------------------------------------------------------
 
     [Fact]
     public void AnArtifactKeepsItsErrorRowWhileIdentityExtractionYieldsOnlyTheResolvedFormids()
@@ -428,7 +417,7 @@ public sealed class RecordsArtifactTests : ArtifactTestBase, IClassFixture<Artif
 
     // ---- fixture builders --------------------------------------------------------------------------
 
-    /// <summary>An identity artifact over the world's weapons — the file the re-entry arms read back.</summary>
+    /// <summary>An identity artifact over the world's weapons — the file the re-entry tests read back.</summary>
     string IdentityArtifact(string name)
     {
         var art = Art(name);
@@ -481,7 +470,7 @@ public sealed class RecordsArtifactTests : ArtifactTestBase, IClassFixture<Artif
 }
 
 /// <summary>
-/// The epoch check. This class owns its OWN world per test: every arm changes a plugin's mtime, which
+/// The epoch check. This class owns its own world per test: every test changes a plugin's mtime, which
 /// re-fingerprints the build — a shared world would hand the change to whatever ran next.
 /// </summary>
 [Trait("tier", "integration")]
@@ -559,8 +548,8 @@ public sealed class RecordsArtifactEpochTests : IDisposable
         var art = Stale("stale-stamp.jsonl");
         var now = Now;
         var r = RecordsTools.Records(_w.Svc, formids: new[] { "@" + art }, project: Everything);
-        // The stamp alone cannot carry this arm: a SERVED response stamps the same epoch, so without the
-        // refusal assertion the test stays green while the epoch check is gone entirely.
+        // A served response stamps the same epoch, so without the refusal assertion this test would pass with
+        // the epoch check gone entirely.
         Assert.StartsWith("error:", r);
         Assert.Contains($"epoch={now}", r);
     }

--- a/src/housecarl-mcp-tests/RecordsBindingShimTests.cs
+++ b/src/housecarl-mcp-tests/RecordsBindingShimTests.cs
@@ -1,4 +1,3 @@
-// Converted-from: BindingShimProbe
 using System.Text.Json;
 using HousecarlMcp;
 using ModelContextProtocol.Protocol;
@@ -7,24 +6,16 @@ using Xunit;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// The tool-argument binding shim, driven over stdio against <c>housecarl_records</c> —
-/// HCBR-2026-06-11-01's arms, re-pointed off the 1.x read tools onto the 2.0 tool that absorbed them.
+/// The tool-argument binding shim, driven over stdio against <c>housecarl_records</c>. The shim is
+/// schema-driven off each tool's published <c>InputSchema</c> with no per-tool wiring, so the claims are
+/// about the engine and this tool is only the carrier.
 ///
-/// <para>The original guard drove <c>housecarl_cross_plugin_query</c>, <c>housecarl_read_record</c>,
-/// <c>housecarl_read_plugin_file</c> and <c>housecarl_batch_record_detail</c>: 20 of its 25 literal wire
-/// calls were on tools this cut deletes. The shim is schema-driven off each tool's own published
-/// <c>InputSchema</c> with no per-tool wiring, so the claims are about the ENGINE and the tool was only the
-/// carrier — but the carrier the 2.0 read surface actually presents is this one, so this is where they are
-/// re-driven.</para>
-///
-/// <para><b>What the wire can and cannot prove.</b> The unconfigured server answers every call that BINDS
-/// with the same trained config prompt, whatever the argument said. So a coercion that bound fine and threw
-/// the caller's value away is invisible to a wire arm — a bare string wrapped into an EMPTY array would pass
-/// one. That is the silent-wrong-answer class, so the coercion arms below assert the PRODUCED VALUE too, by
-/// running <see cref="ToolCallShim.Coerce"/> against the schema the server actually published for that
-/// parameter. <see cref="ToolCallShimCoercionTests"/> asserts the same values against representative
-/// hand-written schemas; the schema here is the real one, which is the half that says the coercion fires on
-/// <c>housecarl_records</c> at all.</para>
+/// <para>An unconfigured server answers every call that BINDS with the same config prompt, whatever the
+/// argument said, so a coercion that bound fine and threw the caller's value away is invisible over the wire
+/// — a bare string wrapped into an empty array would pass. The coercion tests below therefore assert the
+/// produced value too, by running <see cref="ToolCallShim.Coerce"/> against the schema the server published
+/// for that parameter. <see cref="ToolCallShimCoercionTests"/> asserts the same values against hand-written
+/// schemas; the real schema here is what says the coercion fires on <c>housecarl_records</c> at all.</para>
 /// </summary>
 [Collection("server")]
 [Trait("tier", "stdio")]
@@ -56,14 +47,10 @@ public sealed class RecordsBindingShimTests
         return request.Arguments!;
     }
 
-    // ---- A: the fix did not degrade the published schema ------------------------------------------------
+    // ---- the published schema is not degraded -----------------------------------------------------------
 
-    /// <summary>
-    /// The guard against ever "fixing" the shape problem with serializer-options converters, which would
-    /// collapse the generated schema and remove the model's shape hint. (Probe arm A, read off
-    /// <c>cross_plugin_query</c>'s <c>plugins=</c>; the 2.0 list parameter carrying the same claim is
-    /// <c>formids=</c>.)
-    /// </summary>
+    /// <summary>The shape problem must never be "fixed" with serializer-options converters: that collapses
+    /// the generated schema and removes the model's shape hint.</summary>
     [Fact]
     public void ThePublishedFormidsParameterStillDeclaresAnArray_NotCollapsedByASerializerConverter()
     {
@@ -74,9 +61,9 @@ public sealed class RecordsBindingShimTests
                         StringComparison.Ordinal);
     }
 
-    // ---- B/B2/B3/C: the coercion arms -------------------------------------------------------------------
+    // ---- the coercions ----------------------------------------------------------------------------------
 
-    /// <summary>THE live failing shape (HCBR-2026-06-11-01): a list parameter sent as a bare string.</summary>
+    /// <summary>A list parameter sent as a bare string.</summary>
     [Fact]
     public void FormidsAsABareStringBecomesAOneElementArrayAndTheCallReachesTheBody()
     {
@@ -92,11 +79,8 @@ public sealed class RecordsBindingShimTests
         Assert.True(r.BodyRan, r.Describe());
     }
 
-    /// <summary>
-    /// The verified live Claude Code shape (#36): the whole array serialized as a JSON STRING. It must parse
-    /// as the array it spells — never a one-element array holding the unparsed text, which binds and then
-    /// fails later, misleadingly.
-    /// </summary>
+    /// <summary>The whole array serialized as a JSON string. It must parse as the array it spells, never a
+    /// one-element array holding the unparsed text, which binds and then fails later.</summary>
     [Fact]
     public void FormidsAsAStringEncodedJsonArrayBecomesThatArrayAndTheCallReachesTheBody()
     {
@@ -168,12 +152,10 @@ public sealed class RecordsBindingShimTests
         Assert.True(r.BodyRan, r.Describe());
     }
 
-    // ---- G/G2: the refusals that name the offending parameter -------------------------------------------
+    // ---- the refusals that name the offending parameter -------------------------------------------------
 
-    /// <summary>
-    /// An UNCOERCIBLE wrong-type shape still fails — but named, naming the OFFENDING PARAMETER and the kind
-    /// received (#222), caught before binding rather than as a byte-offset error over the whole argument list.
-    /// </summary>
+    /// <summary>An uncoercible wrong-type shape still fails, naming the offending parameter and the kind
+    /// received, caught before binding rather than as a byte-offset error over the whole argument list.</summary>
     [Fact]
     public void AnObjectWhereAnIntegerIsDeclaredIsRefusedNamingTheParameterAndTheKindReceived()
     {
@@ -184,11 +166,8 @@ public sealed class RecordsBindingShimTests
         Assert.Contains("limit (expects integer, received object)", r.Text, StringComparison.Ordinal);
     }
 
-    /// <summary>
-    /// #222's exact class: a bad value for a declared BOOLEAN used to throw "could not be converted to
-    /// System.Boolean" with a byte offset and NO parameter name. It must name the parameter AND the type it
-    /// expects, before binding — and the body must never run (no config prompt).
-    /// </summary>
+    /// <summary>A bad value for a declared boolean must name the parameter and the type it expects, before
+    /// binding, and the body must never run (no config prompt).</summary>
     [Fact]
     public void AWrongTypeStringForABooleanIsRefusedNamingTheParameterAndTheTypeItExpects()
     {
@@ -199,14 +178,11 @@ public sealed class RecordsBindingShimTests
         Assert.Contains("conflicts_only (expects boolean, received string)", r.Text, StringComparison.Ordinal);
     }
 
-    // ---- I/I2: the unknown-parameter refusal ------------------------------------------------------------
+    // ---- the unknown-parameter refusal ------------------------------------------------------------------
 
-    /// <summary>
-    /// HCBR-2026-07-12: the SDK binder SILENTLY IGNORES an undeclared argument, so the call ran with the
-    /// caller's intent dropped and no correction reached them. The refusal names the offender and lists what
-    /// the tool accepts — asserted as SET EQUALITY against the published property list, so a list that goes
-    /// short (the probe sampled one name) fails here.
-    /// </summary>
+    /// <summary>The SDK binder silently ignores an undeclared argument, dropping the caller's intent with no
+    /// correction. The refusal names the offender and lists what the tool accepts, asserted as set equality
+    /// against the published property list so a list that goes short fails here.</summary>
     [Fact]
     public void AnUndeclaredParameterIsRefusedByNameAndTheRefusalListsWhatTheToolAccepts()
     {
@@ -232,13 +208,11 @@ public sealed class RecordsBindingShimTests
         Assert.True(r.BodyRan, r.Describe());
     }
 
-    // ---- J1-J5, J10: the alias layer (#221, #304) -------------------------------------------------------
+    // ---- the alias layer --------------------------------------------------------------------------------
 
-    /// <summary>
-    /// #221: a 1.x spelling the tool does not declare is renamed to the canonical parameter its own row
-    /// names. On <c>housecarl_records</c> the first declared candidate for <c>plugin</c> is <c>source</c>
-    /// — the whose-version pole — so this asserts the pole as a value, not merely that something bound.
-    /// </summary>
+    /// <summary>A spelling the tool does not declare is renamed to the canonical parameter its own row names.
+    /// The first declared candidate for <c>plugin</c> here is <c>source</c>, the whose-version pole, so the
+    /// pole is asserted as a value rather than merely that something bound.</summary>
     [Fact]
     public void TheAliasPluginIsResolvedToRecordsOwnSourceAndTheCallReachesTheBody()
     {
@@ -252,11 +226,8 @@ public sealed class RecordsBindingShimTests
         Assert.True(r.BodyRan, r.Describe());
     }
 
-    /// <summary>
-    /// #221: the permanent underscore/case bridge, resolved by normalization alone. The arm proves the
-    /// bridge rather than a table row by asserting the table has NO row for this spelling — the probe's
-    /// <c>form_id</c> → <c>formid</c> pair cannot say that on this tool, because <c>formid</c> IS a row here.
-    /// </summary>
+    /// <summary>The underscore/case bridge, resolved by normalization alone. It is the bridge and not a table
+    /// row that is proved, by asserting the table has no row for this spelling.</summary>
     [Fact]
     public void AnUnderscoreVariantIsResolvedToItsDeclaredParameterByNormalizationAlone()
     {
@@ -272,12 +243,10 @@ public sealed class RecordsBindingShimTests
         Assert.True(r.BodyRan, r.Describe());
     }
 
-    /// <summary>
-    /// #221: a spelling resolved via the SYNONYM GROUP rather than by normalization equality —
-    /// <c>plugin_name</c> normalizes to "pluginname", which no declared parameter of this tool matches, so
-    /// the bridge cannot place it and only the table's row can. The pole it lands on is the one the value's
-    /// kind can bind: a filename string is the whose-version pole, and the scope pole takes an object.
-    /// </summary>
+    /// <summary>A spelling resolved via the synonym group rather than by normalization equality:
+    /// <c>plugin_name</c> normalizes to "pluginname", which no declared parameter matches, so only the
+    /// table's row can place it. The pole it lands on is the one the value's kind can bind — a filename
+    /// string is the whose-version pole, while the scope pole takes an object.</summary>
     [Fact]
     public void TheAliasPluginNameIsResolvedThroughTheSynonymGroupNotByNormalizationEquality()
     {
@@ -294,15 +263,11 @@ public sealed class RecordsBindingShimTests
         Assert.True(r.BodyRan, r.Describe());
     }
 
-    /// <summary>
-    /// #221 GUARD — a DECLARED parameter is never treated as an alias. <c>plugins</c> is a rename row's old
-    /// spelling on other tools (it maps onto a scalar <c>plugin=</c> there), and <c>housecarl_records</c>
-    /// declares it, so the row has something here to be kept away from.
-    ///
-    /// <para>Asserted as a value, because the wire cannot see this one: <c>records.source</c> is declared
-    /// <c>JsonElement</c> and takes any JSON, so a rename onto it would still reach the tool body and answer
-    /// with the same config prompt as the correct call.</para>
-    /// </summary>
+    /// <summary>A declared parameter is never treated as an alias. <c>plugins</c> is a rename row's old
+    /// spelling on other tools and <c>housecarl_records</c> declares it, so the row has something here to be
+    /// kept away from. Asserted as a value because the wire cannot see it: <c>records.source</c> is declared
+    /// <c>JsonElement</c> and takes any JSON, so a rename onto it would still reach the body and answer with
+    /// the same config prompt as the correct call.</summary>
     [Fact]
     public void RecordsOwnDeclaredPluginsIsNeverTreatedAsAnAlias()
     {
@@ -315,11 +280,9 @@ public sealed class RecordsBindingShimTests
                      args["plugins"].GetProperty("names").EnumerateArray().Select(e => e.GetString()).ToArray());
     }
 
-    /// <summary>
-    /// #221 GUARD — an explicit canonical value is never clobbered. With <c>source</c> supplied, the stray
-    /// <c>plugin</c> has no free target, so it is left for the unknown-parameter path and NAMED, rather than
-    /// silently merged over the caller's own value.
-    /// </summary>
+    /// <summary>An explicit canonical value is never clobbered: with <c>source</c> supplied the stray
+    /// <c>plugin</c> has no free target, so it is left for the unknown-parameter path and named rather than
+    /// silently merged over the caller's own value.</summary>
     [Fact]
     public void AnAliasWhoseCanonicalIsAlreadySuppliedIsNamedUnknown_NotMergedOverIt()
     {
@@ -332,11 +295,9 @@ public sealed class RecordsBindingShimTests
         Assert.Contains("unknown parameter: plugin", r.Text, StringComparison.Ordinal);
     }
 
-    /// <summary>
-    /// The kind gate must not reach the NORMALIZATION bridge: a case variant names the RIGHT parameter, so
-    /// the rename proceeds even for an unbindable value and the TYPE refusal names the real parameter and
-    /// fault — never an unknown-parameter refusal denying that the parameter exists.
-    /// </summary>
+    /// <summary>The kind gate must not reach the normalization bridge: a case variant names the right
+    /// parameter, so the rename proceeds even for an unbindable value and the type refusal names the real
+    /// parameter and fault, never an unknown-parameter refusal denying it exists.</summary>
     [Fact]
     public void ACaseVariantKeyCarryingAnUnbindableValueGetsTheTypeRefusal_NotUnknownParameter()
     {
@@ -347,13 +308,11 @@ public sealed class RecordsBindingShimTests
         Assert.Contains("conflicts_only (expects boolean, received string)", r.Text, StringComparison.Ordinal);
     }
 
-    // ---- J11: the structured parameters over the SDK's JSON->POCO path ----------------------------------
+    // ---- the structured parameters over the SDK's JSON->POCO path ---------------------------------------
 
-    /// <summary>
-    /// The one seam a direct C# call on <c>RecordsTools.Records</c> cannot cover: the SDK's JSON→POCO
-    /// deserialization of the published nested schema. The form-scoped <c>project=</c> object and the
-    /// polymorphic <c>source=</c> (here a bare string) must bind and reach the tool body.
-    /// </summary>
+    /// <summary>The one seam a direct C# call on <c>RecordsTools.Records</c> cannot cover: the SDK's
+    /// JSON→POCO deserialization of the published nested schema. The form-scoped <c>project=</c> object and
+    /// the polymorphic <c>source=</c> (here a bare string) must bind and reach the tool body.</summary>
     [Fact]
     public void TheNestedProjectObjectAndAStringSourceBindOverTheWire()
     {

--- a/src/housecarl-mcp-tests/RecordsBulkSelectTests.cs
+++ b/src/housecarl-mcp-tests/RecordsBulkSelectTests.cs
@@ -7,13 +7,6 @@ namespace HousecarlMcpTests;
 /// <summary>
 /// The list lane of <c>housecarl_records</c>: the identity form's rows, the per-item error shape, the
 /// named-plugin SOURCE pole, the record object's json contract, and link annotation.
-///
-/// <para>These arms come from the tool-layer blocks of <c>BulkPrimitivesWave2Probe</c>, which drove the
-/// same claims through <c>housecarl_resolve</c>, <c>housecarl_read_record</c> and
-/// <c>housecarl_batch_record_detail</c>. Those three tools are deleted; the probe file survives, because
-/// the rest of it drives <c>LoadOrderService</c> directly. Arms that pinned a 1.x-only shape — the sibling
-/// batch tool's shared memo, the conflict_tree/json refusal, the retired cross-tool redirect — are not
-/// carried over: they have no spelling on the 2.0 surface.</para>
 /// </summary>
 [Collection("bulk-records")]
 [Trait("tier", "integration")]
@@ -79,10 +72,7 @@ public sealed class RecordsBulkSelectTests : BulkRecordsTestBase
 
     // ---- max_chars on the identity lane -----------------------------------------------------------
 
-    /// <summary>
-    /// The 1.x tool DROPPED rows at the ceiling and said so. On this surface max_chars caps the RENDER
-    /// only — the complete result spills to an artifact — so the surviving claim is that nothing is lost.
-    /// </summary>
+    /// <summary>max_chars caps the RENDER only — the complete result spills to an artifact, so no row is lost.</summary>
     [Fact]
     public void AnIdentityRenderOverMaxCharsSpillsTheCompleteResultInsteadOfDroppingRows()
     {
@@ -236,12 +226,11 @@ public sealed class RecordsBulkSelectTests : BulkRecordsTestBase
 }
 
 /// <summary>
-/// #230 — the two hardcoded engine references (PlayerRef 000014, Player 000007) resolve to their identity
-/// instead of reading as unresolved, and the exemption stays exactly two forms wide.
+/// The two hardcoded engine references (PlayerRef 000014, Player 000007) resolve to their identity instead of
+/// reading as unresolved, and the exemption stays exactly two forms wide.
 ///
-/// <para>Its own world: the carrier plugin masters a Skyrim.esm that is deliberately not in the active
-/// order, so both 000014 and 000015 fail ordinary winner resolution and only the exemption separates
-/// them. (From <c>BulkPrimitivesWave2Probe</c>'s P3/P7 #230 blocks.)</para>
+/// <para>Its own world: the carrier plugin masters a Skyrim.esm deliberately kept out of the active order, so
+/// both 000014 and 000015 fail ordinary winner resolution and only the exemption separates them.</para>
 /// </summary>
 [Trait("tier", "integration")]
 public sealed class RecordsEngineImplicitLinkTests : IDisposable

--- a/src/housecarl-mcp-tests/RecordsComparisonFormTests.cs
+++ b/src/housecarl-mcp-tests/RecordsComparisonFormTests.cs
@@ -1,14 +1,10 @@
-// Converted-from: RecordsGuardProbe
 using HousecarlMcp;
 using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// SPEC §3 / §4.3 / §6.1 — the comparison and traversal forms (delta, tree, chain, info_order), the
-/// source/versus poles, and the compositions between them, plus the PR #309 review folds.
-/// (RecordsGuardProbe arm 6.)
-/// </summary>
+/// <summary>The comparison and traversal forms (delta, tree, chain, info_order), the source/versus poles, and
+/// the compositions between them.</summary>
 [Collection("records")]
 [Trait("tier", "integration")]
 public sealed class RecordsComparisonFormTests : RecordsTestBase
@@ -22,7 +18,7 @@ public sealed class RecordsComparisonFormTests : RecordsTestBase
         RecordsTools.Records(Svc, formids: new[] { Fid(rec) }, source: Plugin(subject),
                              versus: Plugin("previous_provider"), project: Delta);
 
-    // ---- the four §4.3 pins over the 3-deep stack on W0 (master < mid < override) -----------------
+    // ---- delta over the 3-deep stack on W0 (master < mid < override) ------------------------------
 
     [Fact]
     public void DeltaP1_SubjectWins_TheReferenceIsThePluginImmediatelyBelow() =>
@@ -174,7 +170,7 @@ public sealed class RecordsComparisonFormTests : RecordsTestBase
     public void ScopeVsPolePlusSummaryRefusesByName_ThePoleChangesNothingThere() =>
         Refused(RecordsTools.Records(Svc, plugins: Scope(W.MasterName), source: Plugin(W.OverrideName)), "identity facts");
 
-    // ---- PR #309 review folds -------------------------------------------------------------------------
+    // ---- selection, walk and artifact compositions ----------------------------------------------------
 
     [Fact]
     public void FoldF1_ConflictsOnlyPlusFormidsEvaluatesWhere_TheContestedButNonMatchingKeyDropsOut()
@@ -241,7 +237,7 @@ public sealed class RecordsComparisonFormTests : RecordsTestBase
                                     walk: new RecordsTools.RecordsWalk { direction = "reverse" }, limit: 1, project: Chain),
                "HcRecSpellA", "HcRecSpellC");
 
-    // ---- PR #309 round-3 folds -------------------------------------------------------------------------
+    // ---- json envelopes and fields_source compositions -------------------------------------------------
 
     [Fact]
     public void Fold3F1_AScanLaneDeltasJsonEnvelopeCarriesExactlyOneSourceProperty() =>
@@ -285,7 +281,7 @@ public sealed class RecordsComparisonFormTests : RecordsTestBase
         Refused(RecordsTools.Records(Svc, types: new[] { "SPEL" }, format: "dense", walk: new RecordsTools.RecordsWalk()),
                 "dense");
 
-    // ---- PR #309 round-4 folds --------------------------------------------------------------------------
+    // ---- tree envelopes and fields_source under a walk --------------------------------------------------
 
     [Fact]
     public void Fold4R31_AnOffOrderTreesEnvelopeKeepsTheSelectionArmInSourceAndTheReferenceInVersus()

--- a/src/housecarl-mcp-tests/RecordsDuplicateFilenameTests.cs
+++ b/src/housecarl-mcp-tests/RecordsDuplicateFilenameTests.cs
@@ -1,22 +1,12 @@
-// Converted-from: RecordsGuardProbe
 using System.Text.Json;
 using HousecarlMcp;
 using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// SPEC §4.2 — the one-pole source arms when a plugin FILENAME appears in more than one mod folder.
-/// (RecordsGuardProbe arm 3.)
-///
-/// <para>These own a PRIVATE world, one per test, because the case only exists once a duplicate plugin file
-/// is on disk — a mutation of the mods directory. Written first as a single test that created and deleted
-/// the duplicate inside the SHARED world's mods dir: it was the only test in that collection writing what
-/// its siblings read, so a process death inside the try, or a delete losing to a file lock, would have left
-/// every later off-order test in the class getting "SEVERAL mod folders" and pointing nowhere near the
-/// cause. A private world costs a build each and removes the hazard, and it lets the two assertions be two
-/// tests, which is what the harness rule asks for.</para>
-/// </summary>
+/// <summary>The one-pole source when a plugin FILENAME appears in more than one mod folder. These own a
+/// PRIVATE world, one per test, because the case only exists once a duplicate plugin file is on disk — a
+/// mutation of the mods directory that a shared world's other tests would read.</summary>
 [Trait("tier", "integration")]
 public sealed class RecordsDuplicateFilenameTests : IDisposable
 {

--- a/src/housecarl-mcp-tests/RecordsListLaneTests.cs
+++ b/src/housecarl-mcp-tests/RecordsListLaneTests.cs
@@ -1,13 +1,10 @@
-// Converted-from: RecordsGuardProbe
 using HousecarlMcp;
 using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// SPEC §4.2 / §6.1 — the formids= (list) lane: identity form, the one-pole source arms, the
-/// touchers-named refusals, aggregate and census. (RecordsGuardProbe arm 3.)
-/// </summary>
+/// <summary>The formids= (list) lane: identity form, the one-pole source cases, the touchers-named refusals,
+/// aggregate and census.</summary>
 [Collection("records")]
 [Trait("tier", "integration")]
 public sealed class RecordsListLaneTests : RecordsTestBase

--- a/src/housecarl-mcp-tests/RecordsOffOrderPathTests.cs
+++ b/src/housecarl-mcp-tests/RecordsOffOrderPathTests.cs
@@ -5,15 +5,12 @@ using Xunit;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// The three off-order-by-path facts <c>BulkPrimitivesWave3Probe.cs</c> asserted through the deleted
-/// <c>LoadOrderService.DiffRecord</c> (#486), re-asserted here against <c>housecarl_records project=delta</c> —
-/// the surface a surviving tool calls. Numbered B4/B5/B7 per
-/// <c>dev/session-handoffs/render-halves-scratch/PHASE-1-record.md</c> §5's phase-4 fact list. B1/B2/B3/B6/B8/B9/B10
-/// are already covered elsewhere (named in the phase-4 record); this file carries only what was not.
+/// Off-order-by-path facts on <c>housecarl_records project=delta</c>: a plugin addressed by path from a
+/// disabled mod, a same-named copy outside every install root, and <c>fields=</c> narrowing a delta.
 ///
 /// <para>Driven on the shared, frozen <see cref="RecordsWorld"/> — <c>OldFile</c> is already the disabled-mod
-/// pole B4 needs, and B5 copies it once into <see cref="RecordsWorld.Scratch"/> (a scratch path, never touching
-/// the frozen fixture's own files) for the outside-the-install shape.</para>
+/// pole, and the outside-the-install case copies it into <see cref="RecordsWorld.Scratch"/> so the frozen
+/// fixture's own files are never touched.</para>
 /// </summary>
 [Collection("records")]
 [Trait("tier", "integration")]
@@ -41,12 +38,9 @@ public sealed class RecordsOffOrderPathTests : RecordsTestBase
                              "which is switched OFF in MO2 — switch it on, then re-sort)";
         Served(r, label);
 
-        // B12/B13's surviving carrier. The old arms counted the mod name and the remedy inside the deleted
-        // read_plugin_file banner; this label is composed the same way (the located Where plus WhyNotActive), so
-        // the #271 defect — the providing mod named twice in one breath, the remedy stated twice — is still
-        // reachable and is armed here rather than dying with the banner. Counted within ONE label (the record's
-        // own subject line): the same label is emitted twice per response by design, in the header and per record.
-        // Counted in the QUOTED form, because the echoed path carries the mod's folder name and that is not a naming.
+        // The providing mod and the remedy must each be stated once, not twice in one breath. Counted within ONE
+        // label — the record's own subject line — because the same label is emitted in the header and per record
+        // by design; and counted in the QUOTED form, because the echoed path also carries the mod's folder name.
         var subject = Assert.Single(r.Split('\n'), l => l.TrimStart().StartsWith("subject:", StringComparison.Ordinal));
         Assert.Equal(1, CountOf(subject, "'OldMod'"));
         Assert.Equal(1, CountOf(subject, "switch it on"));
@@ -92,9 +86,9 @@ public sealed class RecordsOffOrderPathTests : RecordsTestBase
         Assert.Equal(1, CountOf(named, "BasicStats."));
 
         // The control that makes the narrowing mean something. This pair differs in exactly ONE field, so a
-        // fields= naming the Damage path alone is byte-identical to the un-narrowed delta and the assertions above
-        // pass with fields= deleted (pre-green review 1b, finding 1). Naming a DIFFERENT path is the discriminating
-        // call: it must report NO difference, and it reports the Damage delta the moment fields= stops narrowing.
+        // fields= naming the Damage path alone is identical to the un-narrowed delta and the assertions above pass
+        // with fields= deleted. Naming a DIFFERENT path discriminates: it must report no difference, and it reports
+        // the Damage delta the moment fields= stops narrowing.
         var elsewhere = Delta("EditorID");
         Assert.Contains("identical across the fields read", elsewhere);
         Assert.DoesNotContain("BasicStats.Damage", elsewhere);

--- a/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
+++ b/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
@@ -10,12 +10,10 @@ using Xunit;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// The synthetic MO2 world for the owned-child content annotation (#342): a BASE master that DECLARES child
-/// records, a MID plugin that touches the same cell declaring nothing, and a TOP winner shaped like an
-/// Occlusion.esp override — it touches the parent and carries no children at all.
-///
-/// <para>Its own world rather than the shared one: every arm here needs a parent record whose winner carries an
-/// EMPTY child collection that a lower plugin fills, and no shared-world record has that shape.</para>
+/// The synthetic MO2 world for the owned-child content annotation: a BASE master that declares child records,
+/// a MID plugin that touches the same cell declaring nothing, and a TOP winner that touches the parent and
+/// carries no children at all. Its own world — no shared-world record has a winner whose child collection is
+/// empty while a lower plugin fills it.
 /// </summary>
 public sealed class OwnedChildWorld : IDisposable
 {
@@ -37,8 +35,8 @@ public sealed class OwnedChildWorld : IDisposable
     /// <summary>SELF — only the winner declares.</summary>
     public FormKey CellE { get; }
     /// <summary>TWO LOWER DECLARERS — base AND mid declare Temporary and Persistent; the winner declares nothing,
-    /// and nothing anywhere declares Landscape or NavigationMeshes. The precise tier's own fixture (#485): the
-    /// positive names two plugins, and the two untouched fields are the negative it must state rather than omit.</summary>
+    /// and nothing anywhere declares Landscape or NavigationMeshes, so the precise tier has both a positive
+    /// naming two plugins and a negative it must state rather than omit.</summary>
     public FormKey CellF { get; }
     public FormKey Topic { get; }
     /// <summary>A 3-toucher record with no child-bearing field at all.</summary>
@@ -157,8 +155,7 @@ public sealed class OwnedChildWorld : IDisposable
             e.Temporary.Add(new PlacedObject(new FormKey(topKey, 0xB50), SkyrimRelease.SkyrimSE) { EditorID = "HcOcTopETemp0" });
             FileInterior(m, e);
 
-            // CellF's winner: it touches the cell and declares NOTHING — the Occlusion.esp shape, with two lower
-            // plugins declaring below it.
+            // CellF's winner touches the cell and declares nothing, with two lower plugins declaring below it.
             FileInterior(m, new Cell(CellF, SkyrimRelease.SkyrimSE) { EditorID = "HcOcCellF", Flags = Cell.Flag.IsInteriorCell });
 
             var t = new DialogTopic(Topic, SkyrimRelease.SkyrimSE) { EditorID = "HcOcTopic" };
@@ -215,7 +212,7 @@ public sealed class OwnedChildWorld : IDisposable
     }
 }
 
-/// <summary>One world per class — every arm below is a read.</summary>
+/// <summary>One world per class — every test below is a read.</summary>
 public sealed class OwnedChildFixture : IDisposable
 {
     public OwnedChildWorld W { get; } = new();
@@ -223,17 +220,11 @@ public sealed class OwnedChildFixture : IDisposable
 }
 
 /// <summary>
-/// #342 — the owned-child content annotation, driven through <c>housecarl_records</c>: a parent's child records
-/// (a cell's placed references, a topic's INFO lines, a worldspace's cells) are declared per plugin and assembled
+/// The owned-child content annotation, driven through <c>housecarl_records</c>: a parent's child records (a
+/// cell's placed references, a topic's INFO lines, a worldspace's cells) are declared per plugin and assembled
 /// by the game from every plugin that declares them, so a winner that touches the parent for an unrelated reason
-/// reports an empty collection the game fills.
-///
-/// <para>The arms come from the tool-layer half of <c>OwnedChildContentProbe</c> — the ones whose subject was a
-/// value returned by <c>read_record</c> / <c>batch_record_detail</c>. Both tiers are here now: the CHEAP one on
-/// the default read, and — restored by #485 after the cut deleted it with the <c>conflict_tree=true</c> lever
-/// that was its only caller — the PRECISE one on <c>project={"form":"tree"}</c>, the 2.0 form that fetches every
-/// provider body anyway. The probe's engine-level arms (<c>OwnedChildContent.DeclaresChild</c> / <c>ShapeOf</c> /
-/// <c>Fields</c>, and <c>ReadSentences.DeclarersNote</c>'s own composition) stay where they are.</para>
+/// reports an empty collection the game fills. Both tiers are covered: the cheap one on the default read, and
+/// the precise one on <c>project={"form":"tree"}</c>, the form that fetches every provider body anyway.
 /// </summary>
 [Trait("tier", "integration")]
 public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
@@ -503,9 +494,8 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     // ---- the remedy the clause names ------------------------------------------------------------
     //
     // The clause tells the caller where to get the read this one did not do: the same formids under
-    // project={"form": "tree"}. These arms MAKE that call, so the remedy is pinned by what comes back rather
-    // than by the wording — a sentence naming a lane nobody drives is how the clause came to name two deleted
-    // tools in the first place. One test per promise the sentence makes.
+    // project={"form": "tree"}. These tests MAKE that call, so the remedy is pinned by what comes back rather
+    // than by the wording. One test per promise the sentence makes.
 
     string Tree(FormKey fk, string? format = null, string? toFile = null, int maxChars = 0) =>
         RecordsTools.Records(Svc, formids: new[] { OwnedChildWorld.Fid(fk) }, format: format, to_file: toFile,
@@ -565,11 +555,11 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
         Assert.Contains(art, r);
     }
 
-    // ---- the precise tier the remedy now carries (#485) -------------------------------------------
+    // ---- the precise tier the remedy carries -------------------------------------------------------
     //
     // The cheap tier says "other plugins touch this record and their declarations were not read". The tree
     // form has already read them, so it says WHICH — and, the half no cheap tier can reach, that NONE do.
-    // Every arm below pins a WHOLE rendered line composed from the sentence consts and the fixture's own
+    // Each test below pins a WHOLE rendered line composed from the sentence consts and the fixture's own
     // plugin names, so a second branch of DeclarersNote cannot satisfy it.
 
     [Fact]
@@ -577,11 +567,10 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
         Assert.Contains($"Temporary: {ReadSentences.DeclaredBy} {_w.BaseName}, {_w.MidName}",
                         DeclarersBlock(Tree(_w.CellF)));
 
-    /// <summary>The whole block for the two-declarer cell, in one assertion: two collection fields naming both
-    /// lower plugins, and two fields nobody declares stating so — Landscape in its own SINGULAR voice (a count,
-    /// never the collection negative's plural "declares child record**s**"), NavigationMeshes
-    /// in the collection one. A tier that emitted only the positives, or only the fields it had something to say
-    /// about, fails here rather than passing on a substring.</summary>
+    /// <summary>The whole block for the two-declarer cell in one assertion: two collection fields naming both
+    /// lower plugins, and two fields nobody declares stating so — Landscape in the SINGULAR voice (a count, never
+    /// the collection negative's plural), NavigationMeshes in the collection one. A tier that emitted only the
+    /// positives, or only the fields it had something to say about, fails here.</summary>
     [Fact]
     public void ThePreciseTierStatesEveryChildBearingFieldOfTheType_PositiveAndNegativeAlike() =>
         Assert.Equal(new[]
@@ -592,9 +581,8 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
             $"Temporary: {ReadSentences.DeclaredBy} {_w.BaseName}, {_w.MidName}",
         }, DeclarersBlock(Tree(_w.CellF)));
 
-    /// <summary>The SINGULAR negative, on its own: a count of zero, never the collection voice's plural claim
-    /// ("not the merged total" is simply false about a singular child — the same objection applies
-    /// just as hard to the empty answer as to the positive one).</summary>
+    /// <summary>The SINGULAR negative on its own: a count of zero, never the collection voice's plural claim,
+    /// which is false about a singular child whether the answer is empty or not.</summary>
     [Fact]
     public void ASingularFieldNobodyCarriesIsCountedZero_NeverTheCollectionVoice()
     {
@@ -603,13 +591,13 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
         Assert.DoesNotContain("child records", line);
     }
 
-    /// <summary>The NEGATIVE on its own, and the claim is that it is a SENTENCE. The tier this restores said
-    /// nothing at all here, which a caller cannot tell apart from the tier not having run.</summary>
+    /// <summary>The negative on its own, and the claim is that it is a SENTENCE: silence here is
+    /// indistinguishable to a caller from the tier not having run.</summary>
     [Fact]
     public void AFieldNoProviderDeclaresInGetsTheNoneSentence_NeverSilence() =>
         Assert.Contains($"NavigationMeshes: {ReadSentences.NoDeclarers}", DeclarersBlock(Tree(_w.CellF)));
 
-    /// <summary>The SINGULAR arm: Cell.Landscape is ONE record its providers override, so the line is a COUNT.
+    /// <summary>The SINGULAR case: Cell.Landscape is ONE record its providers override, so the line is a COUNT.
     /// Naming them would be the collection sentence, which is false of this shape.</summary>
     [Fact]
     public void ASingularChildFieldIsCountedNotNamed() =>
@@ -627,9 +615,8 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     public void ARecordTypeThatOwnsNoChildrenGetsNoBlockAtAll() =>
         Assert.DoesNotContain(ReadSentences.DeclarersLead, Tree(_w.Weapon));
 
-    /// <summary>The remedy arm the review standard asks for: the cheap tier's clause tells a caller the tree form
-    /// names the declarers. This MAKES that call, on the fields the clause itself named, and asserts every one of
-    /// them comes back with a precise answer — so the promise is pinned by what returns, not by the wording.</summary>
+    /// <summary>The cheap tier's clause tells a caller the tree form names the declarers. This MAKES that call, on
+    /// the fields the clause itself named, so the promise is pinned by what returns, not by the wording.</summary>
     [Fact]
     public void TheRemedyNamedByTheCheapClauseAnswersPreciselyForEveryFieldTheClauseNamed()
     {
@@ -679,18 +666,15 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
 
     // ---- the declarers block respects max_chars like every other row content ------------------------------
     //
-    // AppendChildDeclarers/WriteTreeRow used to append the whole block with no cap check of their own. A
-    // sole-provider row (CellC: nothing to diff, so nothing else in the row loop would ever notice the overrun)
-    // measurably returned its full text (844 chars uncapped, as the SINGULAR-voice fix in round 1 left it)
-    // against a 200-char max_chars with truncated=false — the ClauseReserve class of bug (ReadSentences.cs's own
-    // docstring on that const), which means the auto-spill that exists to make an over-cap answer complete never
-    // fires.
+    // A sole-provider row has nothing to diff, so nothing else in the row loop notices an overrun: without a cap
+    // check in AppendChildDeclarers/WriteTreeRow the block returns its full text with truncated=false, and the
+    // auto-spill that exists to make an over-cap answer complete never fires.
 
     [Fact]
     public void ATextRowsDeclarersBlockAloneCanTripMaxChars_AndTheResponseIsMarkedTruncated()
     {
         // CellC is a SOLE-toucher row: row.Nodes.Count <= 1, so the diff loop (which has its own cap check) never
-        // runs — before the fix this was the one path with NO cap check between the block and the end of the row.
+        // runs, leaving the block-to-end-of-row stretch as the only path a cap check has to cover.
         var r = Tree(_w.CellC, maxChars: 200);
         Assert.Contains("spilled: complete result", r);
     }
@@ -698,10 +682,9 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     [Fact]
     public void Json_ATextRowsDeclarersBlockAloneCanTripMaxChars_AndTheResponseIsMarkedTruncated()
     {
-        // 400: past the envelope + row header + declarers block (so WriteTreeRow's own cap check fires and cuts
-        // it mid-row, writing an inline "[child declarers cut …]" note), short of the whole row (1911 chars
-        // uncapped in json) — the shape that used to leave the RESPONSE-level truncated flag false while the
-        // row's own content already says it was cut.
+        // 400 is past the envelope + row header + declarers block, so WriteTreeRow's cap check fires and cuts
+        // mid-row with an inline "[child declarers cut …]" note, and short of the whole row (1911 chars uncapped
+        // in json) — the shape where the response-level truncated flag has to agree with the row's own note.
         using var doc = JsonDocument.Parse(Tree(_w.CellC, format: "json", maxChars: 400));
         Assert.True(doc.RootElement.GetProperty("truncated").GetBoolean());
         Assert.True(doc.RootElement.TryGetProperty("spilled", out _));
@@ -710,24 +693,21 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     [Fact]
     public void ARowWithRoomForItsDeclarersBlockIsNotMarkedTruncatedByIt()
     {
-        // The control: the same sole-provider shape, but a cap generous enough that nothing spills — proves the
-        // fix's cap check does not fire on every row, only an over-cap one.
+        // The control: the same sole-provider shape at a cap generous enough that nothing spills, so the cap
+        // check is shown to fire only on an over-cap row.
         var r = Tree(_w.CellC, maxChars: 4000);
         Assert.DoesNotContain("spilled:", r);
     }
 
     // ---- the block's own TAIL, not just its per-line checks -------------------------------------------------
     //
-    // The per-field checks run BEFORE each line and never after the last one, so the LAST line pushing sb.Length
-    // past cap goes unnoticed — nothing downstream catches it once the row ends there. Measured on CellC (4-line
-    // block, full text 844 chars, its SINGULAR Landscape line reading "carried by 0 provider(s)"): a
-    // StringBuilder holding cap-or-more AFTER the final line (before TrimEnd('\n') removes one char) is the
-    // boundary, at max_chars=845; 846 is the first cap the same content fits inside.
+    // The per-field checks run BEFORE each line and never after the last one, so a final line that pushes
+    // sb.Length past the cap goes unnoticed — nothing downstream catches it once the row ends there.
     //
-    // The tail-trip arm is driven on CellF (3 touchers), not CellC: `truncated` says the ANSWER is incomplete and
-    // drives the spill, so it is set at the tail only for a row that LOST something — the diff a multi-provider
-    // row never reached. CellC at the same tail loses nothing and is the DoesNotContain control two arms down
-    // (ASoleProviderRowWhoseCompleteBlockEndsPastTheCapClaimsNothingWasCut).
+    // The tail-trip case is driven on CellF (3 touchers), not CellC: `truncated` says the ANSWER is incomplete
+    // and drives the spill, so it is set at the tail only for a row that LOST something — the diff a
+    // multi-provider row never reached. CellC at the same tail loses nothing and is the DoesNotContain control
+    // two tests down (ASoleProviderRowWhoseCompleteBlockEndsPastTheCapClaimsNothingWasCut).
 
     [Fact]
     public void ATextRowsDeclarersBlockTailAloneCanTripMaxChars_AndTheResponseIsMarkedTruncated() =>
@@ -737,10 +717,9 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     public void ARowWhoseDeclarersBlockFitsExactlyAtTheTailIsNotMarkedTruncated() =>
         Assert.DoesNotContain("spilled:", Tree(_w.CellC, maxChars: 846));
 
-    /// <summary>When the block IS cut on a multi-provider row, the row stops there — it used to fall through into
-    /// an unconditional "diff (field deltas…):" header for a section the cap already forbade. Measured on CellF
-    /// (3 touchers): at every cap that cuts the declarers block, no diff header follows it. The row DOES carry
-    /// the "[nodes cut" notice — the diff it never reached is a real loss, and each notice claims one thing.</summary>
+    /// <summary>When the block is cut on a multi-provider row the row stops there: no "diff (field deltas…):"
+    /// header may follow for a section the cap already forbade. The row does carry the "[nodes cut" notice — the
+    /// diff it never reached is a real loss, and each notice claims one thing.</summary>
     [Fact]
     public void ACutDeclarersBlockEndsTheRow_NoEmptyDiffHeaderOverASectionThatNeverRendered()
     {
@@ -755,8 +734,7 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     // The tail is reachable only when the field loop ran to completion, so at the tail nothing in the block was
     // ever cut. A "[child declarers cut …]" notice there is false in every case it can fire, and its remedy
     // (project.fields=) points at narrowing a block that is already complete. What the row loses at the tail is
-    // its DIFF — or, on a sole-provider row, nothing at all. Measured windows on the current render: CellC
-    // (sole provider) 806-845, CellF (3 touchers) 812-864.
+    // its DIFF — or, on a sole-provider row, nothing at all.
 
     [Fact]
     public void ASoleProviderRowWhoseCompleteBlockEndsPastTheCapClaimsNothingWasCut()
@@ -766,7 +744,7 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
         Assert.Contains("NavigationMeshes: ", r);
         Assert.DoesNotContain("[child declarers cut", r);   // …so nothing may say it was cut,
         Assert.DoesNotContain("[nodes cut", r);             // and a sole provider loses no diff either.
-        // …and nothing ELSE may say it either: `truncated` reaches TreeResponse, which writes a JSONL artifact
+        // …and nothing else may say it either: `truncated` reaches TreeResponse, which writes a JSONL artifact
         // and re-renders with "spilled: complete result". A row that lost nothing does not spill.
         Assert.DoesNotContain("spilled", r);
     }
@@ -798,8 +776,8 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
 
     /// <summary>The SOLE-provider control for the same cut branch: CellC at 700 drops declarer lines (its block
     /// runs 588-805 before completing), so the declarers notice fires — and there is no diff to lose, so the
-    /// nodes notice must NOT. This arm stays green whether or not the `!declarersCut` guard is there; it is what
-    /// pins the notice to the row's actual loss rather than to the branch it came back through.</summary>
+    /// nodes notice must NOT — which pins each notice to the row's actual loss rather than to the branch it
+    /// came back through.</summary>
     [Fact]
     public void ASoleProviderRowCutMidBlockSaysTheDeclarersWereCutAndNamesNoDiff()
     {
@@ -812,8 +790,8 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
 
     /// <summary>The block's OTHER early return — the framing reserve, which returns before a single declarer line
     /// is written — comes back through the same caller line, so a multi-provider row refused the framing carries
-    /// both notices too. Measured on CellF the way 587 was measured on CellC: 625 is the last cap that refuses the
-    /// framing line, 626 the first it fits inside.</summary>
+    /// both notices too. On CellF, 625 is the last cap that refuses the framing line and 626 the first it fits
+    /// inside.</summary>
     [Fact]
     public void TheFramingReserveBranchOnAMultiProviderRowNamesBothTheDeclarersAndTheDiff()
     {
@@ -828,8 +806,8 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     // The block's framing line is invariant text of a known length, so checking only sb.Length < cap before it
     // writes its whole length past the cap with nothing able to take it back — json reserves the identical
     // sentence (JsonWire's DeclarersLeadReserve) and the cheap tier reserves its own clause (ClauseReserve).
-    // Measured on CellC: the block starts at 294 chars, so 587 is the last cap the framing does not fit in and
-    // 588 the first that it does.
+    // On CellC the block starts at 294 chars, so 587 is the last cap the framing does not fit in and 588 the
+    // first that it does.
 
     [Fact]
     public void TheFramingLineIsReservedAgainstMaxChars_NotWrittenPastIt()
@@ -876,11 +854,10 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
 
     // ---- the new remedy sentences never name a lever housecarl_records lacks -------------------------------
     //
-    // RecordsRemedyGrammarTests' own harvest (RemedyHarvest.cs) probes the tree form only through RecordsWorld's
-    // fixture, which has no child-bearing record type at all — WEAP owns no children, so the four
-    // "[child declarers cut ...]" notices this branch adds never entered that harvest and the wrong-lever grid
-    // never saw them. RecordsWorld is a frozen shared fixture (not touched here); the same check, run directly
-    // against a fixture that HAS a child-bearing type, closes the gap without it.
+    // RecordsRemedyGrammarTests' harvest (RemedyHarvest.cs) reaches the tree form only through RecordsWorld,
+    // which carries no child-bearing record type — WEAP owns no children — so the "[child declarers cut ...]"
+    // notices never reach the wrong-lever grid there. RecordsWorld is a frozen shared fixture, so the same check
+    // runs here instead, against a fixture that has a child-bearing type.
 
     [Fact]
     public void TheChildDeclarersCutNoticesNameNoWrongLever()
@@ -904,9 +881,9 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     // ---- WriteTreeRow's bool return, isolated from the declarers path ---------------------------------------
     //
     // On a row WITH declarers, the response-level lead-reserve check covers for a missing return value, so the
-    // existing cap arms pass whether or not WriteTreeRow's own return is plumbed into rowsTruncated. WEAP has no
-    // child-bearing fields at all — anyDeclarers is false, so this arm depends ONLY on the nodes-branch return
-    // value plumbed into rowsTruncated, with nothing else able to cover for it.
+    // existing cap tests pass whether or not WriteTreeRow's own return is plumbed into rowsTruncated. WEAP has
+    // no child-bearing fields at all — anyDeclarers is false, so this test depends ONLY on the nodes-branch
+    // return value plumbed into rowsTruncated, with nothing else able to cover for it.
 
     [Fact]
     public void Json_ANoChildrenRowsNodesCutStillSetsTruncated_NotCoveredByTheDeclarersLeadCheck()
@@ -923,10 +900,10 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
         Assert.False(doc.RootElement.GetProperty("truncated").GetBoolean());
     }
 
-    // ---- the block's fields= narrowing (settled item 14) — documented and deliberate, previously UNGUARDED ----
+    // ---- the block's fields= narrowing -----------------------------------------------------------------------
     //
-    // Deleting the fields= filter from ResolveTreePinned's `wanted` derivation left the FULL 885-test suite green
-    // — a documented, deliberate behavior that had no arm anywhere pinning it.
+    // Nothing else in the suite pins the fields= filter in ResolveTreePinned's `wanted` derivation: deleting it
+    // reddens only what follows.
 
     [Fact]
     public void FieldsNarrowsTheBlockToTheNamedTopLevelField_NotTheWholeType()
@@ -939,8 +916,8 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
         Assert.DoesNotContain("NavigationMeshes:", r);
     }
 
-    /// <summary>A path INSIDE a child-bearing field (settled item 14's bracketed-path case) narrows the block to
-    /// NOTHING — it matches the caller's request by NAME, not the path the response emitted.</summary>
+    /// <summary>A path INSIDE a child-bearing field narrows the block to NOTHING: it matches the caller's request
+    /// by NAME, not by the path the response emitted.</summary>
     [Fact]
     public void FieldsWithABracketedPathInsideAChildBearingFieldYieldsNoBlockAtAll()
     {
@@ -992,9 +969,9 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     // ---- …and the UNREADABLE half of the same sentence elides the same way, so it gets the same remedy -------
     //
     // DeclarersNote drops unreadable names past DeclarerNameCap behind a bare ", …", on a field of EITHER shape.
-    // The remedy used to be appended only for a COLLECTION field's `declaring` overflow, so the structurally
-    // identical elision one clause later in the same sentence had no pointer at all — and a SINGULAR field
-    // (Cell.Landscape) could never get one, because the Collection guard never fires there.
+    // The remedy has to be appended for the unreadable elision as well as a COLLECTION field's `declaring`
+    // overflow: a SINGULAR field (Cell.Landscape) never reaches the Collection guard, so gating on it alone
+    // leaves that elision with no pointer at all.
 
     static LoadOrderService.TreeRow UnreadableRow(OwnedChildShape shape, int declaring, int unreadable) => new(
         "000001:Test.esm", "Cell", "TestCell",
@@ -1053,14 +1030,11 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
 
     // ---- json's response-level lead respects cap too, not just the row-level array --------------------------
     //
-    // child_declarers_note used to be written unconditionally after `truncated` was already computed — a
-    // Utf8JsonWriter cannot un-write it once appended, so the cap has to be checked BEFORE deciding to write it,
-    // not after, and against every byte that still lands afterwards: the note's own cost (DeclarersLeadReserve),
-    // the `truncated` boolean written between the check and the note (TruncatedPropertyReserve), and the root
-    // close (Framing.RootClose). Reserving only the first left the framing landing past cap by the width of the
-    // other two. Re-measured on CellC's json tree (full 1911 chars) against the current reserve: 1911 is the last
-    // cap that drops the note and spills, 1912 the first that keeps it — and at 1912 the document is 1911 chars,
-    // inside the cap rather than one line past it.
+    // A Utf8JsonWriter cannot un-write child_declarers_note once appended, so the cap is checked BEFORE deciding
+    // to write it, and against every byte that still lands afterwards: the note's own cost
+    // (DeclarersLeadReserve), the `truncated` boolean written between the check and the note
+    // (TruncatedPropertyReserve), and the root close (Framing.RootClose). On CellC's json tree (1911 chars full),
+    // 1911 is the last cap that drops the note and spills, 1912 the first that keeps it.
 
     [Fact]
     public void Json_TheResponseLevelLeadIsDroppedRatherThanOverrunningCap_AndTruncatedIsSet()
@@ -1152,8 +1126,8 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
         Assert.False(doc.RootElement.TryGetProperty("notes", out _));
     }
 
-    /// <summary>The tree's owned-child block: the lines under its lead, trimmed — so an arm about what the block
-    /// says cannot pass on a match in the toucher list above it or the diff below it.</summary>
+    /// <summary>The tree's owned-child block: the lines under its lead, trimmed, so an assertion about what the
+    /// block says cannot pass on a match in the toucher list above it or the diff below it.</summary>
     static IReadOnlyList<string> DeclarersBlock(string tree)
     {
         var lines = tree.Replace("\r\n", "\n").Split('\n');
@@ -1166,7 +1140,7 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     }
 
     /// <summary>The tree's per-plugin delta block, i.e. everything after the "diff (field deltas…)" header —
-    /// so an arm about what the diff says cannot pass on a match in the toucher list above it.</summary>
+    /// so an assertion about what the diff says cannot pass on a match in the toucher list above it.</summary>
     static string DiffBlock(string tree)
     {
         int i = tree.IndexOf("diff (field deltas", StringComparison.Ordinal);

--- a/src/housecarl-mcp-tests/RecordsPluginFileSourceTests.cs
+++ b/src/housecarl-mcp-tests/RecordsPluginFileSourceTests.cs
@@ -8,13 +8,8 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// The source pole that reads a plugin FILE rather than the load order: the arms come from the tool-layer half of
-/// <c>ReadPluginFileProbe</c> (the four <c>ReadTools.ReadPluginFile</c> renders — the rest of that probe drives
-/// <c>LoadOrderService.ReadPluginFile</c> directly and survives the cut untouched) and from the two
-/// <c>ReadTools.DiffRecord</c> renders in <c>BulkPrimitivesWave3Probe</c> — that renderer went with the 1.x
-/// pairwise-diff service at #486, so these arms are where those two facts are stated now.
-/// </summary>
+/// <summary>The source pole that reads a plugin FILE rather than the load order, and the delta projection's
+/// two renders. Driven at the tool layer, so what is held is the rendered form.</summary>
 [Collection("records")]
 [Trait("tier", "integration")]
 public sealed class RecordsPluginFileSourceTests : RecordsTestBase
@@ -59,7 +54,7 @@ public sealed class RecordsPluginFileSourceTests : RecordsTestBase
         Assert.Contains("OUT-OF-LOAD-ORDER", doc.RootElement.GetProperty("source").GetString());
     }
 
-    // ---- the delta render (diff_record's two tool-layer arms) -------------------------------------
+    // ---- the delta render ------------------------------------------------------------------------
 
     [Fact]
     public void TheDeltaTextRenderCarriesTheRecordHeaderTheFieldDeltaAndTheReferenceLabel()
@@ -80,12 +75,8 @@ public sealed class RecordsPluginFileSourceTests : RecordsTestBase
     }
 }
 
-/// <summary>
-/// A three-plugin order whose middle plugin is a valid header followed by a truncated body — the overlay open
-/// throws, so the load-order index EXCLUDES it. The reads below are the two <c>read_record</c> arms of
-/// <c>ExcludedMasterWriteProbe</c>, whose subject is the read side of that exclusion; that probe's write arms
-/// drive shipped 2.0 tools and stay where they are.
-/// </summary>
+/// <summary>A three-plugin order whose middle plugin is a valid header followed by a truncated body — the
+/// overlay open throws, so the load-order index EXCLUDES it.</summary>
 public sealed class ExcludedPluginWorld : IDisposable
 {
     public string Root { get; }
@@ -168,8 +159,8 @@ public sealed class RecordsExcludedPluginSourceTests : IClassFixture<ExcludedPlu
     readonly ExcludedPluginWorld _w;
     public RecordsExcludedPluginSourceTests(ExcludedPluginFixture f) => _w = f.W;
 
-    /// <summary>1.x refused the whole call; the records lane answers per item, which is its own contract. What
-    /// carries over unchanged is that the plugin is NAMED with the reason, never quietly served some other body.</summary>
+    /// <summary>The records lane answers per item, and the excluded plugin is NAMED with the reason rather
+    /// than quietly served some other body.</summary>
     [Fact]
     public void APoleNamingTheExcludedPluginAnswersAPerItemErrorNamingItAndTheReason()
     {

--- a/src/housecarl-mcp-tests/RecordsRefusalGrammarTests.cs
+++ b/src/housecarl-mcp-tests/RecordsRefusalGrammarTests.cs
@@ -1,19 +1,13 @@
-// Converted-from: RecordsGuardProbe
 using System.Text.Json;
 using HousecarlMcp;
 using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// #403 — one refusal shape per transport: a json caller gets a json refusal every time, a per-ROW failure
-/// is never a refused call, and a served census does not answer to the refusal discriminant.
-/// (RecordsGuardProbe arm 6 — refusal grammar.)
-///
-/// <para>Content pins, deliberately not wiring pins: `ok`, `false`, `error` and the text lane's `error: `
-/// prefix are spelled out here, so emptying or renaming the render-side construction fails these tests
-/// instead of moving with them.</para>
-/// </summary>
+/// <summary>One refusal shape per transport: a json caller gets a json refusal every time, a per-ROW failure
+/// is never a refused call, and a served census does not answer to the refusal discriminant. The literals
+/// (<c>ok</c>, <c>error</c>, the text lane's <c>error: </c> prefix) are spelled out rather than read off the
+/// render side, so a rename fails these tests instead of moving with them.</summary>
 [Collection("records")]
 [Trait("tier", "integration")]
 public sealed class RecordsRefusalGrammarTests : RecordsTestBase
@@ -43,8 +37,8 @@ public sealed class RecordsRefusalGrammarTests : RecordsTestBase
     public void TheSentenceIsTheOneTheCallerNeeds_ItNamesTheRuleItBroke() =>
         Assert.Contains("is not a form", Doc(RefusalJson()).GetProperty("error").GetString()!);
 
-    // StartsWith rather than a [..7] slice: the slice threw ArgumentOutOfRangeException on any sentence
-    // shorter than seven characters, turning a clean assertion failure into an unrelated exception.
+    // StartsWith rather than a [..7] slice: a sentence shorter than seven characters would throw
+    // ArgumentOutOfRangeException instead of failing the assertion.
     [Fact]
     public void TheJsonSentenceCarriesNoTextLaneErrorPrefix_ThePropertyNameAlreadySaysWhatItIs() =>
         Assert.False(Doc(RefusalJson()).GetProperty("error").GetString()!.StartsWith("error: ", StringComparison.Ordinal),
@@ -54,9 +48,8 @@ public sealed class RecordsRefusalGrammarTests : RecordsTestBase
     public void TheTextTwinIsStillProseOpeningErrorColon() =>
         Assert.StartsWith("error: ", RefusalText());
 
-    // Same slice hazard the comment above records, one test down: on a text lane that answered empty — the
-    // regression this file exists to catch — the range operator threw ArgumentOutOfRangeException before the
-    // two sentences were ever compared. Assert the prefix first, then slice what is known to carry it.
+    // Same slice hazard: on a text lane that answers empty the range operator throws before the two sentences
+    // are compared. Assert the prefix first, then slice what is known to carry it.
     [Fact]
     public void BothTransportsStateOneSentenceNotTwoSpellingsOfIt()
     {
@@ -116,7 +109,7 @@ public sealed class RecordsRefusalGrammarTests : RecordsTestBase
     public void TheResolvedCountIsResolvedBesideErrorsSayingWhatItCounts() =>
         Assert.Equal(JsonValueKind.Number, CensusDoc().GetProperty("resolved").ValueKind);
 
-    // ---- settled #4: a POST-capture refusal is stamped with the build it consulted ---------------------
+    // ---- a POST-capture refusal is stamped with the build it consulted --------------------------------
 
     JsonElement OffOrderRefusal() =>
         Doc(RecordsTools.Records(Svc, types: new[] { "WEAP" }, source: Plugin(W.OldName),

--- a/src/housecarl-mcp-tests/RecordsRemedyGrammarTests.cs
+++ b/src/housecarl-mcp-tests/RecordsRemedyGrammarTests.cs
@@ -1,4 +1,3 @@
-// Converted-from: RecordsGuardProbe
 using System.Text.RegularExpressions;
 using HousecarlCore;
 using HousecarlMcp;
@@ -6,16 +5,10 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// A remedy predicts what a later call produces. <c>housecarl_records</c> spells its field selector
-/// <c>project.fields=</c>; the 1.x read tools spell it <c>fields=</c>, and the json body renderers are shared
-/// by both generations — so a remedy composed inside one can name the other's vocabulary.
-/// (RecordsGuardProbe arm 7.)
-///
-/// <para>The two grids the probe wrote as nested loops are <c>[Theory]</c>s here: the per-probe bite check
-/// and the lane × wrong-lever sweep. Each cell is now a named, individually-runnable test that reports which
-/// probe or which lever failed, instead of one label per iteration in a console log.</para>
-/// </summary>
+/// <summary>A remedy predicts what a later call produces. <c>housecarl_records</c> spells its field selector
+/// <c>project.fields=</c> while the 1.x read tools spell it <c>fields=</c>, and the json body renderers are
+/// shared by both, so a remedy composed inside one can name the other's vocabulary. The theories are the
+/// per-family sentence check and the lane × wrong-lever sweep.</summary>
 [Collection("records")]
 [Trait("tier", "integration")]
 public sealed class RecordsRemedyGrammarTests : RecordsTestBase
@@ -74,7 +67,7 @@ public sealed class RecordsRemedyGrammarTests : RecordsTestBase
         Assert.True(bad.Count == 0, $"{lane} sentences tell the caller to {claim}:\n  " + string.Join("\n  ", bad));
     }
 
-    // ---- the single-response arms -----------------------------------------------------------------------
+    // ---- the single-response checks ---------------------------------------------------------------------
 
     [Fact]
     public void AMaxCharsStarvedFieldsReadEmitsATruncationNoticeAtAll() =>

--- a/src/housecarl-mcp-tests/RecordsRetiredNameRemedyTests.cs
+++ b/src/housecarl-mcp-tests/RecordsRetiredNameRemedyTests.cs
@@ -4,18 +4,16 @@ using Xunit;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// The chain lane's refusals and its render header named tools the cut deleted, and one of them was a REMEDY
-/// naming a call — <c>cross_plugin_query references=</c> — that a caller following it can no longer make.
+/// No refusal or render header on <c>housecarl_records</c>' chain and scan lanes may name a retired tool, and
+/// every remedy one of them names must be a call a caller can actually make.
 ///
-/// <para>Every arm here DRIVES the sentence rather than reading it: the refusal text asserted below is what
-/// <c>housecarl_records</c> actually emits, and the remedy each one names is called separately and asserted
+/// <para>Each test drives the sentence rather than reading it, and calls the remedy separately to assert it is
 /// served. The population of retired names comes from <see cref="AliasTable.AllRetiredTools"/>, so a name
 /// retired later is covered without editing this file.</para>
 ///
-/// <para>What is NOT covered here, stated rather than implied: the unscannable-record note
-/// (<c>LoadOrderService</c> and <c>EffectChain</c>, "Inspect one with …") fires only when a record's body
-/// THROWS on fetch, which needs a deliberately malformed plugin this test project has no world for. Its
-/// remedy shape is driven below; the note's own text is not.</para>
+/// <para>Not covered: the unscannable-record note (<c>LoadOrderService</c> and <c>EffectChain</c>, "Inspect one
+/// with …") fires only when a record's body THROWS on fetch, which needs a deliberately malformed plugin this
+/// test project has no world for. Its remedy shape is driven below; the note's own text is not.</para>
 /// </summary>
 [Trait("tier", "integration")]
 public sealed class RecordsRetiredNameRemedyTests : IDisposable
@@ -29,18 +27,14 @@ public sealed class RecordsRetiredNameRemedyTests : IDisposable
     static RecordsTools.RecordsProject Chain => new() { form = "chain" };
     static RecordsTools.RecordsWalk Reverse => new() { direction = "reverse" };
 
-    /// <summary>Every name the redirect table calls retired. Derived, so this arm grows with the table.</summary>
+    /// <summary>Every name the redirect table calls retired, so the population grows with the table.</summary>
     static IEnumerable<string> RetiredNames() => AliasTable.AllRetiredTools.Select(r => r.Old);
 
-    /// <summary>The spellings this arm can decide, derived from each retired name's own shape rather than from
-    /// a list somebody kept.
-    ///
-    /// <para>Every retired name is checked in its full <c>housecarl_</c> spelling. The BARE spelling — which is
-    /// what all six repaired sentences actually carried, and what the retired vocabulary arm never matched — is
-    /// checked only where it contains an underscore, because a single-word bare name is a word of ordinary
-    /// English: <c>resolve</c> collides with "resolves to a Weapon" in this very refusal, and <c>remove</c>,
-    /// <c>forward</c>, <c>create</c> and <c>apply</c> collide with prose everywhere. Stated rather than papered
-    /// over: a sentence writing "use resolve" is outside this arm, and only its prefixed spelling is caught.</para></summary>
+    /// <summary>The spellings these tests can decide, derived from each retired name's own shape. Every retired
+    /// name is checked in its full <c>housecarl_</c> spelling; the bare spelling only where it contains an
+    /// underscore, because a single-word bare name is ordinary English — <c>resolve</c> collides with "resolves
+    /// to a Weapon" in these very refusals, and <c>remove</c>, <c>forward</c>, <c>create</c> and <c>apply</c>
+    /// collide with prose everywhere. A sentence writing "use resolve" is therefore not caught.</summary>
     static IEnumerable<string> DecidableSpellings()
     {
         foreach (var full in RetiredNames())
@@ -95,8 +89,7 @@ public sealed class RecordsRetiredNameRemedyTests : IDisposable
         AssertNamesNoRetiredTool(r);
     }
 
-    /// <summary>The served render's own header. It opened <c>"effect_chain for …"</c> — a deleted tool's name
-    /// printed to every caller of a lane that survives.</summary>
+    /// <summary>The served render's own header, which every caller of this lane sees.</summary>
     [Fact]
     public void TheServedChainRender_DoesNotOpenWithARetiredToolName()
     {
@@ -104,7 +97,7 @@ public sealed class RecordsRetiredNameRemedyTests : IDisposable
                                      project: Chain, walk: Reverse);
 
         Assert.False(r.StartsWith("error:", StringComparison.Ordinal), "refused: " + r.Split('\n')[0]);
-        Assert.Contains("0 error(s)", r);      // served, so the header this arm is about is the subject
+        Assert.Contains("0 error(s)", r);      // served, so the header is what the check below reads
         AssertNamesNoRetiredTool(r);
     }
 
@@ -115,10 +108,8 @@ public sealed class RecordsRetiredNameRemedyTests : IDisposable
     public static IEnumerable<object[]> Transports() =>
         Enum.GetNames<Wire.QueryFormat>().Select(n => new object[] { n.ToLowerInvariant() });
 
-    /// <summary>The scan lane's text header opened <c>cross_plugin_query: N matches</c> — the highest-traffic
-    /// render on the surviving surface, and the branch renamed it to <c>scan:</c> with nothing holding it.
-    /// Sabotaging it back left the whole suite and ci-all green. Held here over every declared transport, through
-    /// the same derived retired-name oracle the chain header uses.</summary>
+    /// <summary>The scan lane's header, the highest-traffic render on the surface, held over every declared
+    /// transport through the same derived retired-name check the chain header uses.</summary>
     [Theory]
     [MemberData(nameof(Transports))]
     public void AServedScanRenderNamesNoRetiredTool(string format)
@@ -154,9 +145,9 @@ public sealed class RecordsRetiredNameRemedyTests : IDisposable
         Assert.False(r.StartsWith("error:", StringComparison.Ordinal), "refused: " + r.Split('\n')[0]);
     }
 
-    /// <summary>The other branch, and the reason the sentence says "with types= or plugins=" rather than just
-    /// naming <c>references=</c>: unbounded, the same call is refused. Without this arm the clause could be
-    /// dropped and nothing would notice.</summary>
+    /// <summary>Why the sentence says "with types= or plugins=" rather than just naming <c>references=</c>:
+    /// unbounded, the same call is refused. Without this the clause could be dropped and nothing would
+    /// notice.</summary>
     [Fact]
     public void TheSameRemedyUnbounded_IsRefused_SoTheBoundingClauseIsLoadBearing()
     {

--- a/src/housecarl-mcp-tests/RecordsScanLaneTests.cs
+++ b/src/housecarl-mcp-tests/RecordsScanLaneTests.cs
@@ -1,20 +1,17 @@
-// Converted-from: RecordsGuardProbe
 using HousecarlMcp;
 using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// SPEC §2.2 / §6.1 — the types=/plugins= (scan) lane, form-scoping, the off-order scan arm, and the
-/// PR #307 review folds. (RecordsGuardProbe arms 4 and 4b.)
-/// </summary>
+/// <summary>The types=/plugins= (scan) lane: form-scoping, the off-order scan case, and the composition and
+/// refusal rules over it.</summary>
 [Collection("records")]
 [Trait("tier", "integration")]
 public sealed class RecordsScanLaneTests : RecordsTestBase
 {
     public RecordsScanLaneTests(RecordsFixture f) : base(f) { }
 
-    // ---- 4: the scan lane ------------------------------------------------------------------------
+    // ---- the scan lane ---------------------------------------------------------------------------
 
     [Fact]
     public void TypesIsASet_TheScanStreamsTheUnionOfWeapAndArmo() =>
@@ -118,7 +115,7 @@ public sealed class RecordsScanLaneTests : RecordsTestBase
         Served(RecordsTools.Records(Svc, source: Plugin(W.OldName), types: new[] { "WEAP" },
                                     where: new[] { "BasicStats.Damage >= 50" }), "HcRecW1");
 
-    // ---- 4b: PR #307 review folds ----------------------------------------------------------------
+    // ---- composition, deleted records, paging and the refusals -----------------------------------
 
     [Fact]
     public void TheWinnerTermSeesADeletedRecord_ResolutionIsARealFactAboutIt() =>

--- a/src/housecarl-mcp-tests/RecordsScanProjectionTests.cs
+++ b/src/housecarl-mcp-tests/RecordsScanProjectionTests.cs
@@ -9,13 +9,8 @@ namespace HousecarlMcpTests;
 /// dense columnar render, container expansion at depth, the reverse-lookup un-merge, exact-window paging,
 /// and the scoped-body-vs-winner notes on both the match axis and the display axis.
 ///
-/// <para>These arms come from the tool-layer blocks of <c>BulkQueryPrimitivesProbe</c> and
-/// <c>BulkPrimitivesWave2Probe</c>, which drove them through <c>housecarl_cross_plugin_query</c>. That
-/// tool is deleted; both probe files survive, because the rest of each drives
-/// <c>LoadOrderService.CrossQuery</c> directly. Arms that pinned pairings 2.0 has no spelling for —
-/// group_by with fields=, group_by with conflict_tree, depth outside its forms, dense rendering an
-/// aggregate — are not carried over; the form-scoping rule that replaced them is asserted in
-/// <c>RecordsScanLaneTests</c>.</para>
+/// <para>The rule that a projection form scopes which pairings are legal is asserted in
+/// <c>RecordsScanLaneTests</c>, not here.</para>
 /// </summary>
 [Collection("bulk-records")]
 [Trait("tier", "integration")]
@@ -67,8 +62,8 @@ public sealed class RecordsScanProjectionTests : BulkRecordsTestBase
         Assert.Contains("before hitting max_chars=", r);
     }
 
-    /// <summary>The same Q3 note must reach BOTH transports — json is never the degraded one — so the
-    /// json sentence is compared VERBATIM against the text render rather than re-spelled here.</summary>
+    /// <summary>The same note must reach BOTH transports — json is never the degraded one — so the json
+    /// sentence is compared verbatim against the text render rather than re-spelled here.</summary>
     [Fact]
     public void AWrongPredicatePathsAccountingNoteReachesBothTransportsVerbatim()
     {
@@ -219,8 +214,8 @@ public sealed class RecordsScanProjectionTests : BulkRecordsTestBase
         RecordsTools.Records(Svc, types: Weap, plugins: MasterScope, fields_source: fieldsSource,
                              format: "json", project: Fields(DamagePath));
 
-    /// <summary>The trap is that a scoped value reads as load-order truth. The note must name the lever
-    /// THIS tool has — the 1.x sentence pointed at a parameter housecarl_records does not carry.</summary>
+    /// <summary>The trap is that a scoped value reads as load-order truth, so the note has to name a lever
+    /// this tool actually carries.</summary>
     [Fact]
     public void TheScopedValuesNoteNamesTheDisplayRetargetLeverThisToolHas() =>
         Served(ScopedText(), "SCOPED plugin's OWN version", "fields_source=\"winner\"");

--- a/src/housecarl-mcp-tests/RecordsScanRefusalRepairTests.cs
+++ b/src/housecarl-mcp-tests/RecordsScanRefusalRepairTests.cs
@@ -6,19 +6,13 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// Two repairs the 1.x cut forced on <c>housecarl_records</c>' scan lane, each with an arm per branch.
+/// <summary>Two refusals on <c>housecarl_records</c>' scan lane, each held in both directions.
 ///
-/// <para>The 1.x scan tool refused <c>format='dense'</c> paired with a depth greater than 1, by name. That
-/// refusal lived inside the tool's own body, so deleting the tool deleted the refusal and left this tool
-/// accepting the pairing and silently answering at depth 1 — while its own description says depth expansion
-/// is inexpressible in dense. Both directions are held here: the pairing refuses, and dense without it is
-/// still served.</para>
+/// <para>Depth expansion is inexpressible in <c>format='dense'</c>, so the pairing must refuse by name rather
+/// than silently answer at depth 1 — and dense without a depth must still be served.</para>
 ///
-/// <para>The scan's no-scope refusal listed the 1.x tool's parameter spellings. The class of defect is not
-/// "one wrong word" but "a remedy naming a parameter the tool does not declare", so the arm derives the
-/// declared set off the tool method and holds every <c>xxx=</c> the sentence names against it.</para>
-/// </summary>
+/// <para>A refusal must not name a parameter the tool does not declare, so the declared set is reflected off
+/// the tool method and every <c>xxx=</c> a refusal names is held against it.</para></summary>
 [Trait("tier", "integration")]
 public sealed class RecordsScanRefusalRepairTests : IDisposable
 {
@@ -38,8 +32,8 @@ public sealed class RecordsScanRefusalRepairTests : IDisposable
         Assert.Contains("format='dense'", r);
     }
 
-    /// <summary>The other branch. Without this the refusal above could be widened to reject dense outright
-    /// and nothing would notice.</summary>
+    /// <summary>Without this the refusal above could be widened to reject dense outright and nothing would
+    /// notice.</summary>
     [Fact]
     public void DenseAtTheDefaultDepth_IsStillServed()
     {
@@ -48,10 +42,9 @@ public sealed class RecordsScanRefusalRepairTests : IDisposable
         Assert.False(r.StartsWith("error:", StringComparison.Ordinal), "refused: " + r.Split('\n')[0]);
     }
 
-    /// <summary>The LIST lane's arm. The dense+depth refusal above ends "or drop project.depth for the dense
-    /// summary cells" — a remedy that is only followable in the scan lane, because a <c>formids=</c> read
-    /// refuses dense outright. Fired in the list lane it would hand the caller a second refusal, so it is
-    /// gated to the scan lane and the list lane answers with its own complete sentence.</summary>
+    /// <summary>The list lane. The dense+depth refusal above ends "or drop project.depth for the dense summary
+    /// cells" — followable only in the scan lane, because a <c>formids=</c> read refuses dense outright. So that
+    /// refusal is gated to the scan lane and the list lane answers with its own complete sentence.</summary>
     [Fact]
     public void DenseWithADepthInTheFormidsLane_GetsTheListLanesOwnRefusal_NotTheDepthOne()
     {
@@ -63,8 +56,8 @@ public sealed class RecordsScanRefusalRepairTests : IDisposable
         Assert.DoesNotContain("drop project.depth", r);
     }
 
-    /// <summary>And the remedy that sentence DOES name is followable: the same read in text is served. Without
-    /// this the list lane's refusal could name a transport that is also refused.</summary>
+    /// <summary>The remedy that sentence does name is followable: the same read in text is served. Without this
+    /// the list lane's refusal could name a transport that is also refused.</summary>
     [Fact]
     public void TheRemedyTheListLanesDenseRefusalNames_IsServed()
     {
@@ -83,10 +76,10 @@ public sealed class RecordsScanRefusalRepairTests : IDisposable
         Assert.False(r.StartsWith("error:", StringComparison.Ordinal), "refused: " + r.Split('\n')[0]);
     }
 
-    /// <summary>Every spelling the tool DECLARES: its own parameters, plus the members of the structured ones —
-    /// a refusal legitimately says <c>project.group_by=</c>, and <c>group_by</c> is a member of the project object
-    /// rather than a top-level argument. Both halves are reflected off the method the SDK builds the schema from,
-    /// so a renamed parameter or member moves the subject with it instead of needing an edit here.</summary>
+    /// <summary>Every spelling the tool declares: its own parameters plus the members of the structured ones — a
+    /// refusal legitimately says <c>project.group_by=</c>, and <c>group_by</c> is a member of the project object
+    /// rather than a top-level argument. Both halves come off the method the SDK builds the schema from, so a
+    /// rename moves the subject instead of needing an edit here.</summary>
     static HashSet<string> DeclaredParameters()
     {
         var m = typeof(RecordsTools).GetMethods(BindingFlags.Public | BindingFlags.Static)
@@ -104,25 +97,19 @@ public sealed class RecordsScanRefusalRepairTests : IDisposable
         return names;
     }
 
-    /// <summary>The subject set, DERIVED from the tool's own declared surface rather than typed out.
-    ///
-    /// <para>One row per declared parameter of <c>housecarl_records</c>, each supplying a plausible value for that
-    /// parameter and nothing else, plus one row supplying nothing at all. A call that comes back served is skipped
-    /// by the arm and counted; a call that is refused has its sentence held against the declared set. So a
-    /// parameter added to the tool tomorrow gets a row here without an edit, which is the property a hand-typed
-    /// list cannot have — CLAUDE.md §5 #11's derived-subject-set rule.</para>
-    ///
-    /// <para>What this population still does not reach, stated rather than implied: refusals that need a
-    /// COMBINATION of parameters to fire. The arm prints its own coverage (how many rows refused) so the reach is
-    /// a number a reader can see, not an assumption.</para></summary>
+    /// <summary>One row per declared parameter of <c>housecarl_records</c>, each supplying a plausible value for
+    /// that parameter and nothing else, plus one row supplying nothing at all — derived from the tool's declared
+    /// surface, so a parameter added later gets a row without an edit. A served call is skipped and counted; a
+    /// refused one has its sentence held against the declared set. Refusals needing a COMBINATION of parameters
+    /// are out of reach of this population.</summary>
     public static IEnumerable<object[]> UnderSpecifiedCalls()
     {
         yield return new object[] { "<nothing>" };
         foreach (var p in ToolParameterNames()) yield return new object[] { p };
     }
 
-    /// <summary>The declared parameter names, off the same reflected method the declared-spelling set uses — the
-    /// two halves of this arm cannot drift apart because they read the same source.</summary>
+    /// <summary>The declared parameter names, off the same reflected method the declared-spelling set uses, so
+    /// the two halves cannot drift apart.</summary>
     static IEnumerable<string> ToolParameterNames() =>
         ToolMethod().GetParameters()
                     .Select(p => p.Name!)
@@ -156,20 +143,8 @@ public sealed class RecordsScanRefusalRepairTests : IDisposable
         _                    => RecordsTools.Records(_w.Svc),
     };
 
-    /// <summary>
-    /// The class this arm exists for: a remedy naming a parameter the tool does not declare. The instance that
-    /// prompted it was the scan's no-scope refusal in the service, which told the caller to pass <c>type=</c> and
-    /// <c>editorid_contains=</c> — the 1.x scan tool's spellings, which this tool has as <c>types=</c> and the
-    /// <c>where=</c> grammar's editorid term.
-    ///
-    /// <para>That exact sentence is NOT what this arm drives, and saying so is the point: measured, this tool
-    /// refuses an unscoped call with its own sentence first, so the service's copy is unreachable from here. It
-    /// was corrected anyway; what is PINNED is the reachable family — the refusals these four calls actually
-    /// produce. The declared set is reflected off the tool method and the members of its structured parameters,
-    /// so a rename moves the subject rather than needing an edit here.</para>
-    /// </summary>
-    /// <summary>The arm's own coverage, as a number. A derived population that stops refusing anything is a
-    /// vacuous arm passing quietly — this fails if fewer rows refuse than the shapes known to refuse today.</summary>
+    /// <summary>The population's own coverage, as a number: a derived population that stops refusing anything
+    /// would pass quietly, so this fails if fewer rows refuse than the shapes known to refuse today.</summary>
     [Fact]
     public void TheDerivedPopulationActuallyReachesRefusals()
     {
@@ -193,7 +168,7 @@ public sealed class RecordsScanRefusalRepairTests : IDisposable
                          .Distinct(StringComparer.Ordinal)
                          .ToArray();
 
-        // Vacuity canary: a refusal naming no parameter would satisfy the claim below without testing it.
+        // A refusal naming no parameter at all would satisfy the claim below without testing it.
         Assert.True(named.Length > 0, $"the refusal for '{which}' names no parameter at all: {r}");
 
         var undeclared = named.Where(n => !declared.Contains(n)).OrderBy(n => n, StringComparer.Ordinal).ToArray();

--- a/src/housecarl-mcp-tests/RecordsTestBase.cs
+++ b/src/housecarl-mcp-tests/RecordsTestBase.cs
@@ -45,7 +45,7 @@ public abstract class RecordsTestBase
         foreach (var s in mustName) Assert.Contains(s, response);
     }
 
-    /// <summary>Served, not refused, and naming what the arm claims.</summary>
+    /// <summary>Served, not refused, and naming what the test claims.</summary>
     protected static void Served(string response, params string[] mustName)
     {
         Assert.False(response.StartsWith("error:", StringComparison.Ordinal), "refused: " + First(response));

--- a/src/housecarl-mcp-tests/RecordsTransportTests.cs
+++ b/src/housecarl-mcp-tests/RecordsTransportTests.cs
@@ -1,16 +1,11 @@
-// Converted-from: RecordsGuardProbe
 using HousecarlMcp;
 using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// SPEC §2.1.1 — to_file artifacts and @artifact re-entry, epoch-checked. (RecordsGuardProbe arm 5.)
-///
-/// <para>This class owns its OWN world: the staleness arm changes a plugin's mtime, which re-fingerprints
-/// the build. In the linear probe that mutation sat in the middle of one procedure and every arm after it
-/// silently inherited a different world; here the blast radius is one class.</para>
-/// </summary>
+/// <summary>to_file artifacts and @artifact re-entry, epoch-checked. This class owns its OWN world because
+/// the staleness test changes a plugin's mtime, which re-fingerprints the build for anything sharing
+/// it.</summary>
 [Trait("tier", "integration")]
 public sealed class RecordsTransportTests : IDisposable
 {
@@ -31,12 +26,8 @@ public sealed class RecordsTransportTests : IDisposable
                                     { form = "fields", fields = new[] { "BasicStats.Damage" } });
     }
 
-    /// <summary>
-    /// to_file creates the artifact's parent directory. In the linear probe this was covered by accident —
-    /// three arms wrote into results/ before anything created it — and the conversion pre-creates the
-    /// directory everywhere, so the coverage was lost silently. Asserted deliberately here: a change making
-    /// to_file throw or refuse on a missing parent would otherwise ship with the whole suite green.
-    /// </summary>
+    /// <summary>to_file creates the artifact's parent directory. Every other test here pre-creates it, so
+    /// without this one a to_file that threw or refused on a missing parent would ship green.</summary>
     [Fact]
     public void ToFile_CreatesItsParentDirectory_TheCallerNeedNotMakeItFirst()
     {

--- a/src/housecarl-mcp-tests/RecordsWorld.cs
+++ b/src/housecarl-mcp-tests/RecordsWorld.cs
@@ -1,4 +1,3 @@
-// Converted-from: RecordsGuardProbe
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records;
@@ -16,8 +15,7 @@ namespace HousecarlMcpTests;
 /// old patch that serves as the off-order pole.
 ///
 /// <para>One instance is shared by every read-only test through <see cref="RecordsFixture"/>. A test that
-/// MUTATES the world (the epoch-staleness arm rewrites a plugin's mtime) constructs its own instance —
-/// the linear probe could hide that ordering dependency inside one procedure; a test project cannot.</para>
+/// MUTATES the world (rewriting a plugin's mtime, say) constructs its own instance.</para>
 /// </summary>
 public sealed class RecordsWorld : IDisposable
 {
@@ -59,11 +57,9 @@ public sealed class RecordsWorld : IDisposable
 
     public RecordsWorld()
     {
-        // CorpusRulebook.CorpusPath is a process-global that this world has to repoint at its own generated
-        // corpus. Capture the prior value HERE so Dispose can put it back: Dispose deletes Root, and a
-        // static left naming Root/corpus-gen/corpus.json would then name a directory that no longer exists,
-        // breaking whatever runs next. Which tests survive that is an accident of collection scheduling, not
-        // a property — so the restore happens by construction instead.
+        // CorpusRulebook.CorpusPath is a process-global this world repoints at its own generated corpus.
+        // Capture the prior value here so Dispose can put it back: Dispose deletes Root, and a static left
+        // naming a path under Root would name a directory that no longer exists.
         _priorCorpusPath = CorpusRulebook.CorpusPath;
 
         Root = Path.Combine(Path.GetTempPath(), "hc-records-tests-" + Guid.NewGuid().ToString("N"));
@@ -192,8 +188,8 @@ public sealed class RecordsFixture : IDisposable
     readonly Dictionary<Type, object> _memo = new();
 
     /// <summary>
-    /// Build-once-per-collection derived state. xUnit constructs the test CLASS per test method, so a
-    /// derivation that drives dozens of tool calls (the remedy harvest) belongs on the fixture, not the class.
+    /// Build-once-per-collection derived state. xUnit constructs the test class per test method, so a
+    /// derivation that drives dozens of tool calls belongs on the fixture, not the class.
     /// </summary>
     public T Shared<T>(Func<RecordsWorld, T> make) where T : class
     {

--- a/src/housecarl-mcp-tests/RecordsWorldLifecycleTests.cs
+++ b/src/housecarl-mcp-tests/RecordsWorldLifecycleTests.cs
@@ -3,18 +3,11 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// What a <see cref="RecordsWorld"/> leaves behind when it disposes.
-///
-/// <para>A world repoints <c>CorpusRulebook.CorpusPath</c> — a process-global — at its own generated corpus,
-/// and its Dispose deletes the directory that corpus lives in. If the static is not put back, everything
-/// after the last private world resolves types against a path that no longer exists. The retired harness
-/// carried this protection (a captured prior value restored in a finally); the conversion dropped it, and
-/// what hid the loss was which collection xUnit happened to run first.</para>
-///
-/// <para>Deliberately NOT in the "records" collection: that collection's fixture repoints the static when it
-/// is constructed, which is precisely the accident that made the missing restore invisible.</para>
-/// </summary>
+/// <summary>What a <see cref="RecordsWorld"/> leaves behind when it disposes: it repoints the process-global
+/// <c>CorpusRulebook.CorpusPath</c> at its own generated corpus and deletes that directory on Dispose, so an
+/// unrestored static leaves everything after it resolving types against a path that no longer exists.
+/// Deliberately NOT in the "records" collection — that collection's fixture repoints the static itself, which
+/// would hide a missing restore.</summary>
 [Trait("tier", "integration")]
 public sealed class RecordsWorldLifecycleTests
 {
@@ -38,8 +31,8 @@ public sealed class RecordsWorldLifecycleTests
             {
                 worldCorpus = CorpusRulebook.CorpusPath;
 
-                // Vacuity canary: if a world stopped repointing the static there would be nothing to restore
-                // and every claim below would pass for the wrong reason.
+                // If a world stopped repointing the static there would be nothing to restore, and every claim
+                // below would pass for the wrong reason.
                 Assert.NotEqual(prior, worldCorpus);
                 Assert.StartsWith(w.Root, worldCorpus, StringComparison.OrdinalIgnoreCase);
             }

--- a/src/housecarl-mcp-tests/RemedyHarvest.cs
+++ b/src/housecarl-mcp-tests/RemedyHarvest.cs
@@ -1,4 +1,3 @@
-// Converted-from: RecordsGuardProbe
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using HousecarlCore;
@@ -6,15 +5,9 @@ using HousecarlMcp;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// Every remedy sentence <c>housecarl_records</c> emits, harvested once per collection across the site
-/// families (fields / container / tree / scan / delta / poles / scoped / spilled artifact) and the three
-/// transports plus the artifact rows.
-///
-/// <para>The harvest names NO lever and filters on NO key: an over-harvest costs a triage row, an
-/// under-harvest hides a wrong lever. The only shape filter is on the LITERAL — a multi-word sentence vs a
-/// bare key — never on which lever a sentence names.</para>
-/// </summary>
+/// <summary>Every remedy sentence <c>housecarl_records</c> emits, harvested once per collection across the
+/// site families and the transports plus the artifact rows. The harvest names NO lever and filters on NO key
+/// — only on the literal shape of a sentence — because an under-harvest would hide a wrong lever.</summary>
 public sealed class RemedyHarvest
 {
     public static readonly Regex RemedyLine = new(

--- a/src/housecarl-mcp-tests/RepoProjects.cs
+++ b/src/housecarl-mcp-tests/RepoProjects.cs
@@ -4,19 +4,16 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// The repo's own projects, read off the csproj files rather than assumed from folder names. One project's
-/// assembly name differs from its directory (houseCARL-Setup), so "src/&lt;assembly name&gt;" is a convention
-/// that is already false once.
-/// </summary>
+/// <summary>The repo's own projects, read off the csproj files rather than assumed from folder names: one
+/// project's assembly name differs from its directory (houseCARL-Setup).</summary>
 static class RepoProjects
 {
     static readonly Regex AssemblyNameElement =
         new(@"<AssemblyName>\s*([^<\s]+)\s*</AssemblyName>", RegexOptions.Compiled);
 
-    /// <summary>Every project under src/: its assembly name and the directory holding its csproj. Cached on
-    /// first read rather than in a field initializer, for the reason <see cref="AllAssemblies"/> gives — the
-    /// refusal in <see cref="Discover"/> would otherwise arrive wrapped, and poison the class for the run.</summary>
+    /// <summary>Every project under src/: its assembly name and the directory holding its csproj. Cached on first
+    /// read rather than in a field initializer, so <see cref="Discover"/>'s refusal arrives as the assertion it is
+    /// instead of a TypeInitializationException that poisons the class for the run.</summary>
     public static IReadOnlyList<(string AssemblyName, string Directory)> All => _projects ??= Discover();
 
     static (string AssemblyName, string Directory)[]? _projects;
@@ -56,39 +53,27 @@ static class RepoProjects
         return hits[0];
     }
 
-    /// <summary>
-    /// The built assembly for one project. Already-loaded assemblies come back from the runtime; the rest are
-    /// loaded from <see cref="LocateAssembly"/>. A project that has no build output at all is loud: skipping
-    /// it would shrink every population derived from this list, which is the failure those populations exist
-    /// to catch. One home, because two walks over the repo's projects were about to spell this twice.
-    /// </summary>
+    /// <summary>The built assembly for one project — already-loaded ones from the runtime, the rest via
+    /// <see cref="LocateAssembly"/>. A project with no build output is loud rather than skipped: skipping shrinks
+    /// every population derived from this list.</summary>
     public static Assembly BuiltAssembly(string assemblyName, string directory) =>
         AppDomain.CurrentDomain.GetAssemblies()
             .FirstOrDefault(a => string.Equals(a.GetName().Name, assemblyName, StringComparison.OrdinalIgnoreCase))
         ?? Assembly.LoadFrom(LocateAssembly(assemblyName, directory));
 
-    /// <summary>
-    /// Which file this class would load <paramref name="assemblyName"/> from: the copy beside the running test
-    /// assembly first, the project's own build output second.
-    ///
-    /// <para>App base first because it is the build under test. A project tree holds every configuration it has
-    /// ever built, so "newest under bin/" picked a Debug dll during a Release run whenever Debug happened to be
-    /// the more recent build. <c>LoadFrom</c> loads into the DEFAULT load context, so <c>CiAll</c>'s later
-    /// <c>Assembly.Load(reference)</c> for the same name resolved to that same stale instance — both
-    /// derivations reflecting one build nobody asked for, and a guard present only in the configuration under
-    /// test invisible to both, green. It was order-dependent too: whichever population was built first decided
-    /// which dll the rest of the run saw.</para>
-    /// </summary>
+    /// <summary>Which file this class loads <paramref name="assemblyName"/> from: the copy beside the running test
+    /// assembly first, since that is the build under test, and the project's own build output second. A project
+    /// tree holds every configuration it has ever built, so picking the newest under bin/ can hand a Release run a
+    /// Debug dll — and <c>LoadFrom</c> loads into the DEFAULT context, so every later <c>Assembly.Load</c> for that
+    /// name resolves to the same instance.</summary>
     internal static string LocateAssembly(string assemblyName, string directory)
     {
         var beside = Path.Combine(AppContext.BaseDirectory, assemblyName + ".dll");
         if (File.Exists(beside)) return beside;
 
-        // Enumerated from the PROJECT directory — which exists by construction, its csproj having been read
-        // out of it — and then filtered to the bin tree. Enumerating bin/ directly threw
-        // DirectoryNotFoundException on a project that had never been built, which is the one case the
-        // refusal below is written for: the written sentence was unreachable and the reader got a bare path
-        // exception instead.
+        // Enumerated from the PROJECT directory (which exists, its csproj having been read out of it) and then
+        // filtered to the bin tree: enumerating bin/ directly throws DirectoryNotFoundException on a project that
+        // was never built, which is the one case the refusal below is written for.
         var binSegment = Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar;
         var dll = Directory.EnumerateFiles(directory, assemblyName + ".dll", SearchOption.AllDirectories)
                            .Where(p => p.Contains(binSegment, StringComparison.OrdinalIgnoreCase))
@@ -106,16 +91,11 @@ static class RepoProjects
 
     static Assembly[]? _allAssemblies;
 
-    /// <summary>
-    /// Every project's built assembly: the repo-wide population, derived from the csproj files rather than
-    /// from any one assembly's reference closure. A closure only reaches what its root REFERENCES, which is a
-    /// different set from "the repo's own assemblies" and is short in a direction nothing announces.
-    ///
-    /// <para>A method rather than a property initializer on purpose: <see cref="BuiltAssembly"/> can refuse,
-    /// and a refusal thrown out of a static initializer arrives as a TypeInitializationException that then
-    /// poisons every other test touching this class for the rest of the run. From here it arrives as the
-    /// assertion it is, in the test that asked.</para>
-    /// </summary>
+    /// <summary>Every project's built assembly, derived from the csproj files rather than from one assembly's
+    /// reference closure — a closure reaches only what its root references, which is a smaller set than the repo's
+    /// own assemblies. A method rather than a property initializer because <see cref="BuiltAssembly"/> can refuse,
+    /// and a refusal out of a static initializer arrives as a TypeInitializationException that poisons every other
+    /// test touching this class.</summary>
     public static IReadOnlyList<Assembly> AllAssemblies() =>
         _allAssemblies ??= All.Select(p => BuiltAssembly(p.AssemblyName, p.Directory))
                               .OrderBy(a => a.GetName().Name, StringComparer.Ordinal)

--- a/src/housecarl-mcp-tests/RepoProjectsTests.cs
+++ b/src/housecarl-mcp-tests/RepoProjectsTests.cs
@@ -3,11 +3,9 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// <see cref="RepoProjects"/>'s own arms. The class decides which BUILD every repo-wide population reflects,
-/// so a wrong choice here is not a test failure — it is every derived population quietly measuring a
-/// different build from the one under test.
-/// </summary>
+/// <summary><see cref="RepoProjects"/> decides which BUILD every repo-wide population reflects, so a wrong
+/// choice here means every derived population quietly measures a different build from the one under
+/// test.</summary>
 [Trait("tier", "unit")]
 public sealed class RepoProjectsTests
 {
@@ -19,16 +17,10 @@ public sealed class RepoProjectsTests
         File.SetLastWriteTimeUtc(path, DateTime.UtcNow.AddDays(ageDays));
     }
 
-    /// <summary>
-    /// The dll beside the test assembly wins over a NEWER one in the project tree.
-    ///
-    /// <para>The decoy is the failure as it happened: a project tree carrying a second configuration's build,
-    /// more recently written than the one under test. "Newest under bin/" loaded that one, into the default
-    /// load context, where every later Assembly.Load for the same name resolved to it too.</para>
-    ///
-    /// <para>Nothing is loaded here — the assertion is over the path chosen, and the arm ends by confirming no
-    /// assembly of that name entered the process.</para>
-    /// </summary>
+    /// <summary>The dll beside the test assembly wins over a NEWER one in the project tree — picking by
+    /// timestamp would load a second configuration's build into the default context, where every later
+    /// Assembly.Load for that name resolves to it too. Nothing is loaded here: the assertion is over the path
+    /// chosen, and the test ends by confirming no assembly of that name entered the process.</summary>
     [Fact]
     public void TheDllBesideTheTestAssemblyWinsOverANewerOneInTheProjectTree_TheBuildUnderTestIsTheOneReflected()
     {
@@ -57,10 +49,8 @@ public sealed class RepoProjectsTests
         Assert.False(Directory.Exists(projectDir), $"The fixture left {projectDir} behind.");
     }
 
-    /// <summary>
-    /// The project tree is still the fallback. A project whose output is not copied beside the test assembly
-    /// has to be found where it was built, or the population this class exists to derive goes short.
-    /// </summary>
+    /// <summary>The project tree is still the fallback: a project whose output is not copied beside the test
+    /// assembly has to be found where it was built, or the derived population goes short.</summary>
     [Fact]
     public void WithNothingBesideTheTestAssemblyTheProjectsOwnBuildOutputIsUsed_TheFallbackIsNotDead()
     {

--- a/src/housecarl-mcp-tests/RetiredNameRedirectTests.cs
+++ b/src/housecarl-mcp-tests/RetiredNameRedirectTests.cs
@@ -7,22 +7,12 @@ using Xunit.Abstractions;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// #472 — the retired-name redirect, swept against what 1.9 actually PUBLISHED rather than against a
-/// maintained list.
+/// The retired-name redirect, swept against what 1.9 actually published rather than against a maintained list.
 ///
-/// <para>BindingShimProbe's D3 arm takes its subjects from <c>AliasTable.AllRetiredTools</c> minus the
-/// running server's registered set. The right-hand side is derived from the wire; the left-hand side is a
-/// list somebody maintains. So D3 proves every retired name the table KNOWS ABOUT redirects to a live tool
-/// — it cannot prove the table is complete. Delete a tool, forget its row, and D3 sweeps the rows it has,
-/// reports clean, and a caller on old docs gets a bare "Unknown tool".</para>
-///
-/// <para>Here the subject set is every tool houseCARL 1.9.0 published, captured off the shipped 1.9 server
-/// (see data/tools-list-1.9.0.json for its provenance). Each one is either still on the surface or must
-/// redirect — a deleted tool with no row is a RED cell by construction, not an invisible omission.</para>
-///
-/// <para>This replaced BindingShimProbe's D3 arm, which converted whole at the cut. It is the stronger form:
-/// D3's subjects came from the alias table itself, so a deleted tool nobody added a row for was invisible to
-/// it; these come from the frozen capture, so that case is RED.</para>
+/// <para>The subject set is every tool houseCARL 1.9.0 published, captured off the shipped 1.9 server
+/// (data/tools-list-1.9.0.json). Each one is either still on the surface or must redirect. Taking the subjects
+/// from <c>AliasTable</c> instead would only prove the rows it already has: a tool deleted with no row added
+/// would be invisible, and a caller on old docs would get a bare "Unknown tool".</para>
 /// </summary>
 [Collection("server")]
 [Trait("tier", "stdio")]
@@ -95,8 +85,8 @@ public sealed class RetiredNameRedirectTests
     }
 
     /// <summary>
-    /// The vacuity canary. If every 1.9 name is still registered, the theory above asserts nothing and
-    /// passes 45 times — a broken sweep reported as a clean one.
+    /// If every 1.9 name is still registered, the theory above asserts nothing and passes on every row — a
+    /// vacuous sweep reported as a clean one.
     /// </summary>
     [Fact]
     public void TheSweepHasSubjects_SomeToolNineteenPublishedIsGoneFromTheSurface()

--- a/src/housecarl-mcp-tests/ScriptsFamilyTests.cs
+++ b/src/housecarl-mcp-tests/ScriptsFamilyTests.cs
@@ -6,27 +6,11 @@ using static HousecarlMcpTests.ScriptsFixtures;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// The scripts family's own 13 facts <c>ScriptPropertyCheckProbe.cs</c> asserted through the deleted 1.x
-/// single-family renderer (<c>Wire.RenderScriptCheck</c> / <c>JsonWire.RenderScriptCheck</c>), re-asserted here
-/// against the merged <c>Wire.RenderCheck</c> / <c>JsonWire.RenderCheck</c> a surviving tool
-/// (<c>housecarl_check</c>) actually calls. Numbered S1-S13 per
-/// <c>dev/session-handoffs/render-halves-scratch/PHASE-1-record.md</c> §5's phase-3 fact list — the probe's 27
-/// old <c>Check(...)</c> arms consolidate into these 13 facts, one test per fact rather than per old assertion.
-///
-/// <para>Facts drivable on the shared, frozen <see cref="ScriptsWorld"/> go through
-/// <c>LoadOrderService.ValidateScripts</c> (the engine member <c>housecarl_check</c> calls); facts needing a scan
-/// error, an excluded-plugin roster, or a cap-band the shared world cannot produce are driven DTO-level through
-/// <see cref="ScriptsFixtures.Result"/>, the same split <c>CheckErrorsFamilyTests</c> uses. Every hand-shaped
-/// value below was captured from the LIVE render (a scratch harness against the built assemblies, never
-/// committed) rather than composed from memory of the source — the wording a merged accounting produces is not
-/// always what the old single-family probe assumed.</para>
-///
-/// <para><b>Converted-from: ScriptPropertyCheckProbe</b>. <c>ScriptPropertyCheckProbe.cs</c> is deleted in
-/// the same commit that lands the last fact below — the commit that ends the overlap
-/// <c>docs/architecture/test-project-fixtures.md</c> describes, where the scripts family lived in both the
-/// probe harness and this one.</para>
-/// </summary>
+/// <summary>The scripts family's 13 facts (S1-S13) against <c>Wire.RenderCheck</c> /
+/// <c>JsonWire.RenderCheck</c>, the renderers <c>housecarl_check</c> calls. Facts drivable on the shared,
+/// frozen <see cref="ScriptsWorld"/> go through <c>LoadOrderService.ValidateScripts</c>; facts needing a scan
+/// error, an excluded-plugin roster, or a cap band that world cannot produce are driven DTO-level through
+/// <see cref="ScriptsFixtures.Result"/>, the same split <c>CheckErrorsFamilyTests</c> uses.</summary>
 [Collection("scripts")]
 [Trait("tier", "integration")]
 public sealed class ScriptsFamilyTests
@@ -250,7 +234,7 @@ public sealed class ScriptsFamilyTests
 
     // ---- fact S10 -------------------------------------------------------------------------------------
     // The counts_only histogram axis is in the response at every cap and states how many of its rows are
-    // missing — the axis is never silently dropped (#392).
+    // missing — the axis is never silently dropped.
 
     [Fact]
     public void FactS10_HistogramAxisNeverDropsSilently_AcrossABand()
@@ -279,9 +263,8 @@ public sealed class ScriptsFamilyTests
             Enumerable.Range(0, 3).ToDictionary(i => $"HcSpBroken{i}.esp", i => new string('r', 300)));
 
         // Searched, not a fixed number: which cap admits the accounting but not a single roster row is a fact
-        // about the fixture's own size, not a literal that survives an unrelated wording change elsewhere in
-        // the same response. (The comment said this before; the code held a hardcoded 200 — pre-green review 1a,
-        // finding 3. S12 below walks the band the same way for the PARTIAL split.)
+        // about the fixture's own size, and a literal would not survive an unrelated wording change elsewhere
+        // in the same response.
         string? cut = null;
         for (int cap = 100; cap <= 3000 && cut is null; cap += 10)
         {
@@ -308,10 +291,9 @@ public sealed class ScriptsFamilyTests
         var excludedFat = Result(countsOnly: true, excludedPlugins:
             Enumerable.Range(0, 3).ToDictionary(i => $"HcSpBroken{i}.esp", i => new string('r', 300)));
 
-        // Walk the band rather than pin one measured cap: the first partial split (neither 0 nor all 3 named)
-        // is a fact about the fixture's own size, and pinning the literal cap that produces it would make this
-        // arm fragile to any unrelated wording change elsewhere in the same response (measured: a sabotage of
-        // an unrelated sentence shifted this fixture's split point by ~10 chars).
+        // Walk the band rather than pin one cap: the first partial split (neither 0 nor all 3 named) is a fact
+        // about the fixture's own size, and a pinned literal would break on any unrelated wording change
+        // elsewhere in the same response, which can shift the split point by ~10 chars.
         bool sawPartial = false;
         for (int cap = 200; cap <= 3000 && !sawPartial; cap += 10)
         {

--- a/src/housecarl-mcp-tests/ScriptsFixtures.cs
+++ b/src/housecarl-mcp-tests/ScriptsFixtures.cs
@@ -5,11 +5,9 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// The shapes and readers the scripts family's DTO-level arms share — the scripts-family twin of
-/// <see cref="CheckErrorsFixtures"/>. Rationale for the DTO-vs-live driving-lane split is in
-/// <c>docs/architecture/check-family-tests.md</c>.
-/// </summary>
+/// <summary>The shapes and readers the scripts family's DTO-level tests share — the scripts-family twin of
+/// <see cref="CheckErrorsFixtures"/>. Why some tests drive DTOs and others drive live:
+/// <c>docs/architecture/check-family-tests.md</c>.</summary>
 internal static class ScriptsFixtures
 {
     /// <summary>The epoch every hand-shaped result carries, so a stamp is never the thing that varies.</summary>

--- a/src/housecarl-mcp-tests/ScriptsWorld.cs
+++ b/src/housecarl-mcp-tests/ScriptsWorld.cs
@@ -7,17 +7,13 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// The synthetic MO2 world the script-property surface is driven against: one plugin of five records plus
-/// the loose <c>Scripts/HcSpBase.pex</c> + <c>Scripts/HcSpChild.pex</c> pair that DECLARES what those
-/// records do or do not bind. Where the records came from, why it is an MO2 instance rather than the
-/// probe's bare directory, and why it generates no corpus:
-/// <c>docs/architecture/test-project-fixtures.md</c>.
+/// <summary>The synthetic MO2 world the script-property surface is driven against: one plugin of five records plus
+/// the loose <c>Scripts/HcSpBase.pex</c> + <c>Scripts/HcSpChild.pex</c> pair declaring what those records do or do
+/// not bind (<c>docs/architecture/test-project-fixtures.md</c>).
 ///
-/// <para>Shared through <see cref="ScriptsFixture"/> and FROZEN: tests take fixture-known totals from it,
-/// so a later need gets its own world rather than an edit to this one, and a test that holds a file open
-/// builds its own instance.</para>
-/// </summary>
+/// <para>Shared through <see cref="ScriptsFixture"/> and frozen: tests take fixture-known totals from it, so a
+/// later need gets its own world rather than an edit to this one, and a test that holds a file open builds its
+/// own instance.</para></summary>
 public sealed class ScriptsWorld : IDisposable
 {
     // ---- fixture-known names: the vocabulary every assertion spells ------------------------------------
@@ -28,7 +24,7 @@ public sealed class ScriptsWorld : IDisposable
     /// <summary>The ancestor <see cref="ChildScript"/> extends — where <c>InheritedThing</c> is declared.</summary>
     public const string BaseScript = "HcSpBase";
 
-    /// <summary>The script attached with NO compiled .pex on disk — the unverifiable case (Q3).</summary>
+    /// <summary>The script attached with NO compiled .pex on disk — the unverifiable case.</summary>
     public const string MissingScript = "HcSpNoPex";
 
     public const string FootgunEditorId = "HcSpFootgun";
@@ -40,7 +36,7 @@ public sealed class ScriptsWorld : IDisposable
     /// <summary>The property declared on the ANCESTOR script, reachable only by walking the extends chain.</summary>
     public const string InheritedProperty = "InheritedThing";
 
-    /// <summary>The unbound OBJECT property — the reported silent-None footgun.</summary>
+    /// <summary>The unbound OBJECT property — it reads as None at runtime with no error.</summary>
     public const string ObjectProperty = "MySpell";
 
     /// <summary>An object property the footgun DOES bind, to a non-null form.</summary>
@@ -72,7 +68,7 @@ public sealed class ScriptsWorld : IDisposable
     public string ModsDir { get; }
     public string ScriptsDir { get; }
 
-    /// <summary>The shared world's plugin. An arm that would HOLD it open builds its own world instead.</summary>
+    /// <summary>The shared world's plugin. A test that would HOLD it open builds its own world instead.</summary>
     public string PluginPath { get; }
 
     public string PluginName { get; }
@@ -117,8 +113,8 @@ public sealed class ScriptsWorld : IDisposable
         // A non-null in-plugin FormKey for "bound" object props — the target need not exist, only IsNull is read.
         var self = new FormKey(key, 0x000801);
 
-        // wFootgun — the reported failure shape. MyAliasBound is bound via a quest alias (Object null,
-        // Alias >= 0): it must count as BOUND, and must NOT be flagged bound-but-null.
+        // wFootgun — MyAliasBound is bound via a quest alias (Object null, Alias >= 0): it counts as BOUND, and is
+        // not flagged bound-but-null.
         var footgun = mod.Weapons.AddNew(); footgun.EditorID = FootgunEditorId;
         footgun.VirtualMachineAdapter = Vmad(ChildScript,
             ObjProp(BoundProperty, self), ObjProp(NullProperty, FormKey.Null), AliasProp(AliasBoundProperty, 2));
@@ -167,7 +163,7 @@ public sealed class ScriptsWorld : IDisposable
         Svc = LoadOrderService.WithInstance(Instance, 0, store);
     }
 
-    // ---- VMAD builders (ported from the probe's fixture builders) ---------------------------------------
+    // ---- VMAD builders ---------------------------------------------------------------------------------
 
     /// <summary>A VMAD binding ONE script with the given bound properties.</summary>
     static VirtualMachineAdapter Vmad(string scriptClass, params ScriptProperty[] props)

--- a/src/housecarl-mcp-tests/ScriptsWorldTests.cs
+++ b/src/housecarl-mcp-tests/ScriptsWorldTests.cs
@@ -6,8 +6,8 @@ using Xunit;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// The Papyrus fixture's own proofs: that <see cref="ScriptsWorld"/> is what it claims to be, so the arms
-/// built on it can assert findings without also proving their fixture. What each arm rests on:
+/// The Papyrus fixture's own proofs: that <see cref="ScriptsWorld"/> is what it claims to be, so the tests
+/// built on it can assert findings without also proving their fixture. What each rests on:
 /// <c>docs/architecture/test-project-fixtures.md</c>.
 /// </summary>
 [Collection("scripts")]
@@ -16,8 +16,8 @@ public sealed class ScriptsWorldTests
     readonly ScriptsWorld _w;
     public ScriptsWorldTests(ScriptsFixture f) => _w = f.W;
 
-    /// <summary>PEX-ROUNDTRIP, re-homed from <c>ScriptPropertyCheckProbe</c>. Everything else in the fixture
-    /// rests on this: a .pex the product cannot read makes every declaration unverifiable.</summary>
+    /// <summary>Everything else in the fixture rests on this: a .pex the product cannot read makes every
+    /// declaration unverifiable.</summary>
     [Fact]
     [Trait("tier", "integration")]
     public void ThePlantedChildPexReadsBackWithItsAutoPropertyAndItsParentClass()
@@ -94,9 +94,9 @@ public sealed class ScriptsWorldTests
             reported);
     }
 
-    /// <summary>The fixture's vacuity canary: the counts survive a world whose .pex files never resolved, so
-    /// the declarations are observed instead. Both finding sets are pinned WHOLE — <c>MyDefaulted</c> and
-    /// <c>MyAliasBound</c> exist to produce no finding, and only a set comparison asserts an absence.</summary>
+    /// <summary>The counts alone survive a world whose .pex files never resolved, so the declarations are
+    /// observed instead. Both finding sets are pinned WHOLE — <c>MyDefaulted</c> and <c>MyAliasBound</c> exist
+    /// to produce no finding, and only a set comparison asserts an absence.</summary>
     [Fact]
     [Trait("tier", "integration")]
     public void BothPlantedPexFilesResolveThroughTheLooseLayer_SoTheDeclarationsAreRealNotUnverifiable()
@@ -129,9 +129,9 @@ public sealed class ScriptsWorldTests
         Assert.Equal(ScriptsWorld.BaseScript, inherited.DeclaringScript, ignoreCase: true);
     }
 
-    /// <summary>ONE wire-path smoke test — the fixture is reachable through the live surface, which is what
-    /// makes it usable by the arms built on it. Its OWN server: the shared <see cref="ServerFixture"/> is
-    /// deliberately unconfigured and every stdio test reads "the body ran" off its config prompt.</summary>
+    /// <summary>One wire-path smoke test: the fixture is reachable through the live surface. It gets its OWN
+    /// server, because the shared <see cref="ServerFixture"/> is deliberately unconfigured and every stdio test
+    /// reads "the body ran" off its config prompt.</summary>
     [Fact]
     [Trait("tier", "stdio")]
     public void CheckOverTheWireReportsTheFixtureKnownScriptCountAndNamesTheUnverifiableScript()
@@ -149,8 +149,8 @@ public sealed class ScriptsWorldTests
 
         Assert.False(r.IsError, r.Describe());
         Assert.DoesNotContain(ServerFixture.ConfigPrompt, r.Text, StringComparison.Ordinal);
-        // A fixture-known count, kept as the cheap canary that a scripts response came back at all — it
-        // cannot tell a resolved fixture from a broken one; the two assertions below can.
+        // A fixture-known count: cheap proof a scripts response came back at all. It cannot tell a resolved
+        // fixture from a broken one; the two assertions below can.
         Assert.Contains($"{ScriptsWorld.RecordsWithScripts} record(s) with scripts", r.Text, StringComparison.Ordinal);
 
         // The unverifiable attribution, spelled the way the sweep composes it — names the .pex it looked for.

--- a/src/housecarl-mcp-tests/SeqStandingLimitRemedyTests.cs
+++ b/src/housecarl-mcp-tests/SeqStandingLimitRemedyTests.cs
@@ -3,21 +3,10 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// <c>housecarl_write_seq</c>'s standing-limit sentence names a call, and the cut changed which call: it used
-/// to say "use housecarl_validate_dialogue", and the repair pointed it at <c>housecarl_check
-/// findings=["dialogue"]</c>.
-///
-/// <para>Driven, that repair was incomplete. The dialogue family REFUSES a call with no <c>seeds=</c> — it
-/// validates the topics and quests the caller names and deliberately will not sweep the whole order — so a
-/// caller following the sentence as written landed on a second refusal. The sentence now names
-/// <c>seeds=</c>, and both directions are held here: with seeds the call is accepted, without them it is
-/// refused, which is what makes the clause load-bearing rather than decoration.</para>
-///
-/// <para>The seed here is not a quest, so the response carries a per-seed error — that is the family's normal
-/// output and is not a refusal of the CALL. What this arm asserts is the parameter journey the sentence
-/// promises: the call is accepted, and the tool does not send the caller back for a missing parameter.</para>
-/// </summary>
+/// <summary><c>housecarl_write_seq</c>'s standing-limit sentence tells the caller to run the dialogue check,
+/// which REFUSES a call with no <c>seeds=</c> — it validates only the topics and quests named and will not
+/// sweep the whole order. Both directions are held here, so the sentence's <c>seeds=</c> clause is
+/// load-bearing rather than decoration.</summary>
 [Trait("tier", "integration")]
 public sealed class SeqStandingLimitRemedyTests : IClassFixture<CheckWorldFixture>
 {
@@ -32,11 +21,9 @@ public sealed class SeqStandingLimitRemedyTests : IClassFixture<CheckWorldFixtur
         Assert.Contains(ToolNames.Check, WriteSentences.Twins.SeqStandingLimit);
     }
 
-    /// <summary>What this arm can honestly claim, and what it cannot. This fixture has no DIAL/QUST/DLVW/DLBR
-    /// record, so it cannot show a content-valid seed being SERVED. What it does show is the exact defect the
-    /// repair was for: with <c>seeds=</c> present the tool no longer sends the caller back for the missing
-    /// parameter — the response is about the seed's CONTENT, which is a caller-supplied fact, not about the
-    /// shape of the call the sentence told them to make.</summary>
+    /// <summary>This fixture has no DIAL/QUST/DLVW/DLBR record, so it cannot show a content-valid seed being
+    /// SERVED. What it shows is that with <c>seeds=</c> present the response is about the seed's CONTENT, not
+    /// about a missing parameter.</summary>
     [Fact]
     public void TheCallTheSentenceNames_WithSeeds_IsNotSentBackForAMissingParameter()
     {

--- a/src/housecarl-mcp-tests/ServerFixture.cs
+++ b/src/housecarl-mcp-tests/ServerFixture.cs
@@ -6,16 +6,12 @@ using Xunit;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// The built housecarl-mcp.exe, spun up ONCE and driven over stdio — the wire, not a C# method call.
+/// The built housecarl-mcp.exe, started once and driven over stdio — what a caller can reach is
+/// <c>tools/list</c>, never the <c>[McpServerTool]</c> attributes in source.
 ///
-/// This is the oracle #470 asks for: what a caller can actually reach is `tools/list`, never the
-/// <c>[McpServerTool]</c> attributes in source. Those two diverged silently for twelve days and no guard
-/// noticed, because every check-family guard called <c>CheckTools.CheckTool</c> directly.
-///
-/// The server boots against a FRESH EMPTY data dir, so there is no houseCARL.user.json and it is
-/// deterministically unconfigured — on a dev box too, where a real user config may sit beside the exe.
-/// "The tool body ran" is then observable as the trained config prompt: binding failures answer with the
-/// SDK's generic error instead, which is exactly the difference these tests are about.
+/// The server boots against a fresh empty data dir, so there is no houseCARL.user.json and it is
+/// deterministically unconfigured even on a dev box where a real user config sits beside the exe. "The tool
+/// body ran" is then observable as the config prompt; a binding failure answers with the SDK's generic error.
 /// </summary>
 public sealed class ServerFixture : IDisposable
 {
@@ -131,10 +127,8 @@ public sealed class ServerFixture : IDisposable
 
     JsonElement Rpc(string method, object @params)
     {
-        // One timeout poisons the fixture. This server is shared by every stdio test in the run, so a
-        // genuinely hung call is a property of the server, not of the one test that happened to find it —
-        // letting each later test spend its own full deadline turns one cause into seventy identical
-        // timeouts and buries it. Fail fast, and name the call that actually broke.
+        // One timeout poisons the fixture. Every stdio test shares this server, so letting each later test
+        // spend its own full deadline turns one hung call into a run full of identical timeouts.
         if (_poison is { } first)
             throw new InvalidOperationException(
                 $"The shared server fixture is poisoned by an earlier timeout — {first} This call was not " +

--- a/src/housecarl-mcp-tests/ServerTransportTests.cs
+++ b/src/housecarl-mcp-tests/ServerTransportTests.cs
@@ -7,9 +7,9 @@ namespace HousecarlMcpTests;
 /// The stdio transport underneath <see cref="ServerFixture"/>: exactly one reader on the server's stream,
 /// and one timeout that stops the run rather than repeating itself once per remaining test.
 ///
-/// <para>Both properties are about the SHARED fixture. 73 stdio tests drive one server process, so a read
-/// that outlives its caller, or a hang that every later test re-discovers on its own 60-second budget, are
-/// run-level failures wearing a single test's name.</para>
+/// <para>Both properties are about the SHARED fixture: every stdio test drives one server process, so a read
+/// that outlives its caller, or a hang each later test re-discovers on its own 60-second budget, is a
+/// run-level failure wearing a single test's name.</para>
 /// </summary>
 public sealed class ServerTransportTests
 {
@@ -38,9 +38,8 @@ public sealed class ServerTransportTests
     }
 
     /// <summary>
-    /// The orphaned-read defect, stated as a property. Measured RED against the shape this replaced: with
-    /// a per-call <c>Task.Run(ReadLine)</c> the abandoned read takes "A" and the next caller is handed "B",
-    /// one line behind for the rest of the process.
+    /// A read that outlives its caller must not consume a line: with a per-call read the abandoned one takes
+    /// "A" and the next caller is handed "B", one line behind for the rest of the process.
     /// </summary>
     [Fact]
     [Trait("tier", "unit")]
@@ -82,18 +81,12 @@ public sealed class ServerTransportTests
     }
 
     /// <summary>
-    /// One timeout is terminal for the fixture. The later call fails immediately, and its message names the
-    /// method and id of the FIRST timeout — so a slow runner produces one cause instead of seventy copies
-    /// of its own wreckage.
+    /// One timeout is terminal for the fixture: the later call fails at once, and its message names the method
+    /// and id of the first timeout.
     ///
-    /// <para>Driven on a PRIVATE fixture with its deadline shortened; poisoning the shared one would be the
-    /// very failure this arm describes.</para>
-    ///
-    /// <para>What discriminates here is the exception and its wording, not the clock. Measured: with the
-    /// poison removed, this scenario's second call SUCCEEDS — the pump queued the late response and the id
-    /// check skipped it — so the run would carry on past a timeout it had already suffered. The 60-second
-    /// cascade the poison is really aimed at needs a server that is hung rather than merely slow, which is
-    /// not honestly fixturable here; the elapsed bound below is a floor on "immediately", not the proof.</para>
+    /// <para>Driven on a PRIVATE fixture with its deadline shortened — poisoning the shared one is the very
+    /// failure described here. What discriminates is the exception and its wording, not the clock: a genuinely
+    /// hung server is not fixturable, so the elapsed bound below is only a floor on "immediately".</para>
     /// </summary>
     [Fact]
     [Trait("tier", "stdio")]

--- a/src/housecarl-mcp-tests/SourcePoleRemedyTests.cs
+++ b/src/housecarl-mcp-tests/SourcePoleRemedyTests.cs
@@ -6,22 +6,10 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// The <c>source=</c> family of remedies, each one FOLLOWED rather than read.
-///
-/// <para>Seven sentences this branch wrote or rewrote spelled the successor call as
-/// <c>housecarl_records source="…"</c> with no select term. <c>source=</c> names WHICH VERSION to read; it is not
-/// a selection, and the tool refuses a call carrying only a source pole. Every one of those sentences therefore
-/// told a caller to make a call that comes back refused — the same defect the chain lane's remedies had, in a
-/// family the chain sweep did not reach.</para>
-///
-/// <para><b>The population here is HAND-DRAWN, and that is the honest description of it.</b> It is the ten sites
-/// two independent reviewers derived and drove, not a set computed from the surface. The derived form — every
-/// shipped prose site that names a call, held against whether that call is refused — is chartered work, not this
-/// PR's: the oracle it needs is per-sentence reachability, which no containment net gives. Filed as #483, with
-/// these ten sites as its first cells. Until it exists, a sentence added tomorrow with the same shape is caught
-/// by nobody.</para>
-/// </summary>
+/// <summary>The <c>source=</c> family of remedies, each one followed rather than read. <c>source=</c> names
+/// WHICH VERSION to read, not a selection, so a sentence naming it without a select term sends the caller to a
+/// call the tool refuses. The population is hand-drawn: these are named sites, not a set computed from the
+/// surface, so a sentence added later with the same shape is not caught here.</summary>
 [Collection("records")]
 [Trait("tier", "integration")]
 public sealed class SourcePoleRemedyTests : RecordsTestBase
@@ -34,10 +22,10 @@ public sealed class SourcePoleRemedyTests : RecordsTestBase
         Assert.Contains(mustName, r);
     }
 
-    // ---- the control: what every one of these sentences used to tell the caller to do -----------------
+    // ---- the control: a source pole on its own -------------------------------------------------------
 
-    /// <summary>The whole reason the seven sentences changed. Without this arm the select terms could be
-    /// dropped again and nothing would notice.</summary>
+    /// <summary>Without this the select terms could be dropped back out of those sentences and nothing would
+    /// notice.</summary>
     [Theory]
     [InlineData("plugin")]
     [InlineData("overlay")]
@@ -70,8 +58,8 @@ public sealed class SourcePoleRemedyTests : RecordsTestBase
         Served(RecordsTools.Records(Svc, formids: new[] { Fid(W.Weapons[0]) }, source: Overlay("post")));
 
     /// <summary>The copy read-back sentences: "read its records back with housecarl_records source="&lt;the
-    /// patch&gt;.esp" types=["NPC_"]". Driven against a plugin that HAS no NPC_ record, which is the point — an
-    /// empty result is served, not refused; only the missing selection was ever the refusal.</summary>
+    /// patch&gt;.esp" types=["NPC_"]". Driven against a plugin with no NPC_ record, which is the point: an empty
+    /// result is served, not refused — only a missing selection refuses.</summary>
     [Fact]
     public void TheCopyReadBackCall_TypesOverTheWrittenPatch_IsServed() =>
         Served(RecordsTools.Records(Svc, source: Plugin(W.OldName), types: new[] { "NPC_" }));
@@ -79,9 +67,8 @@ public sealed class SourcePoleRemedyTests : RecordsTestBase
     // ---- the sentence that could NOT be made followable, and says so --------------------------------
 
     /// <summary>The copy's masters claim. `housecarl_records` renders no plugin's master list in any form or
-    /// transport, so no select term makes that remedy answer its own question; the sentences now state the bound
-    /// and name the weaker check that IS available. This arm holds the weaker check followable, and the bound
-    /// stated — a sentence that promises nothing must not quietly start promising again.</summary>
+    /// transport, so no select term makes that remedy answer its own question; the sentences state the bound and
+    /// name the weaker check that IS available. Held here: that weaker check is followable.</summary>
     [Fact]
     public void TheWeakerMastersCheckTheCopySentencesName_IsServed()
     {
@@ -91,13 +78,10 @@ public sealed class SourcePoleRemedyTests : RecordsTestBase
         Assert.Contains("missing master", r);
     }
 
-    // ---- the sentences themselves, pinned to the call their arms drive ------------------------------
+    // ---- the sentences themselves, pinned to the call above -----------------------------------------
     //
-    // The arms above prove the CALL works. They do not, on their own, prove the SENTENCE still names it:
-    // measured by sabotage, dropping the select term back out of three of these sentences left both gates
-    // green. These three pins close that, each against the shipped text rather than a copy of it. The
-    // general form — every prose site that names a call, held against whether that call is refused — is
-    // #483's chartered work, not this PR's.
+    // The tests above prove the CALL works; they do not prove the SENTENCE still names it. These three pins
+    // read the shipped text itself rather than a copy of it.
 
     static readonly string[] SelectTerms =
         { "formids=", "types=", "plugins=", "where=", "references=", "conflicts_only=" };
@@ -120,16 +104,11 @@ public sealed class SourcePoleRemedyTests : RecordsTestBase
         Assert.Contains(SelectTerms, t => sentence.Contains(t, StringComparison.Ordinal));
     }
 
-    /// <summary>The on-disk-but-not-listed advisory, RENDERED by the shipped method rather than read from
-    /// source. It names `housecarl_records` with a source pole, so it must name a selection with it.
-    ///
-    /// <para>The arm asserts it reached the records-naming branch rather than skipping when it does not — an
-    /// early return here is the arm-that-cannot-fail shape, and it was one: the first version of this pin
-    /// skipped silently and stayed green while the sentence was sabotaged.</para>
-    ///
-    /// <para>The sibling UNTICKED-in-plugins.txt advisory (the "IS installed, but UNTICKED" branch) is the same
-    /// sentence shape and is NOT pinned here: this world has no installed-but-unticked plugin, and inventing
-    /// one would be a fixture change rather than a pin. Stated rather than implied.</para></summary>
+    /// <summary>The on-disk-but-not-listed advisory, rendered by the shipped method rather than read from
+    /// source. It names `housecarl_records` with a source pole, so it must name a selection with it. The test
+    /// asserts it reached the records-naming branch instead of skipping — an early return here could not fail.
+    /// The sibling installed-but-unticked advisory is the same sentence shape and is not pinned: this world has
+    /// no such plugin.</summary>
     [Fact]
     public void TheOnDiskNotListedAdvisoryNamesASelectionBesideItsSourcePole()
     {
@@ -143,9 +122,8 @@ public sealed class SourcePoleRemedyTests : RecordsTestBase
         Assert.Contains(SelectTerms, t => text!.Contains(t, StringComparison.Ordinal));
     }
 
-    /// <summary>The copy tool's standalone line, against the shipped source. It is rendered inside a write
-    /// path this test project has no fixture for, so the pin is on the text: the promise it used to make must
-    /// stay gone, and the bound it states must stay stated.</summary>
+    /// <summary>The copy tool's standalone line, against the shipped source. It is rendered inside a write path
+    /// this test project has no fixture for, so the pin is on the text rather than on a render.</summary>
     [Fact]
     public void TheCopyToolsStandaloneLineStatesTheBoundAndPromisesNothing()
     {

--- a/src/housecarl-mcp-tests/ToolCallShimCoercionTests.cs
+++ b/src/housecarl-mcp-tests/ToolCallShimCoercionTests.cs
@@ -4,19 +4,11 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// What the ToolCallShim's coercion actually PRODUCES, asserted as a value.
-///
-/// The wire arms in <see cref="CheckWirePathTests"/> can only see that an argument bound and the tool body
-/// was entered: an unconfigured server answers with the same config prompt whatever the value says. So a
-/// coercion that bound fine and threw the caller's value away was invisible to them — a shim wrapping a bare
-/// string into an EMPTY array instead of a one-element one passed the whole suite, and the caller who wrote
-/// <c>{"plugins":"MyMod.esp"}</c> would have got the whole load order swept with a clean answer. That is the
-/// silent-wrong-answer class, not a binding failure, and it is why these assert the element itself.
-///
-/// The schemas here are the shapes the real published schema uses (nullable unions — <c>["array","null"]</c>
-/// is how the server spells an optional list), not invented ones.
-/// </summary>
+/// <summary>What the ToolCallShim's coercion PRODUCES, asserted as a value. The wire tests in
+/// <see cref="CheckWirePathTests"/> can only see that an argument bound, so a coercion that binds and drops
+/// the caller's value is invisible there — the failure is a silently wrong answer, not a binding error. The
+/// schemas are the shapes the published schema uses: <c>["array","null"]</c> is how the server spells an
+/// optional list.</summary>
 [Trait("tier", "unit")]
 public sealed class ToolCallShimCoercionTests
 {

--- a/src/housecarl-mcp-tests/ToolCallShimWirePathTests.cs
+++ b/src/housecarl-mcp-tests/ToolCallShimWirePathTests.cs
@@ -1,18 +1,14 @@
-// Converted-from: BindingShimProbe
 using System.Text.Json;
 using Xunit;
 
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// The binding shim's arms whose 2.0 subject is NOT <c>housecarl_records</c> — the required-parameter
-/// refusals, and the alias clique on the write and reshape tools.
+/// The binding shim's required-parameter refusals, and the alias clique on the write and reshape tools.
 ///
-/// <para>The required arms were driven on <c>housecarl_batch_record_detail</c>, which this cut deletes.
-/// <c>housecarl_records</c> cannot host them: it declares no required parameter, deliberately. So rather
-/// than picking a replacement tool by hand, the population is DERIVED from the wire — every published tool
-/// whose own schema carries a <c>required</c> list — which makes the sweep a function of the surface and
-/// leaves nothing for a later tool to fall out of.</para>
+/// <para>The population is derived from the wire — every published tool whose own schema carries a
+/// <c>required</c> list — so the sweep is a function of the surface and no later tool can fall out of it.
+/// (<c>housecarl_records</c> declares no required parameter, deliberately.)</para>
 /// </summary>
 [Collection("server")]
 [Trait("tier", "stdio")]
@@ -21,12 +17,10 @@ public sealed class ToolCallShimWirePathTests
     readonly ServerFixture _s;
     public ToolCallShimWirePathTests(ServerFixture s) => _s = s;
 
-    /// <summary>
-    /// Every tool that declares required parameters, one theory row each. MemberData has to be static, so it
-    /// cannot read the injected fixture; the population comes off the same generator the server publishes
-    /// from, and the assertions then read the required list off the LIVE fixture — so a tool whose two
-    /// spellings ever disagreed would fail on the name it prints rather than quietly leaving the sweep short.
-    /// </summary>
+    /// <summary>Every tool that declares required parameters, one theory row each. MemberData has to be static,
+    /// so it cannot read the injected fixture; the population comes off the same generator the server publishes
+    /// from, and the assertions read the required list off the LIVE fixture, so a disagreement between the two
+    /// fails by name rather than quietly leaving the sweep short.</summary>
     public static IEnumerable<object[]> ToolsWithRequiredParameters()
     {
         foreach (var tool in PreFlattenSchemas.Read())
@@ -39,12 +33,10 @@ public sealed class ToolCallShimWirePathTests
         _s.PublishedTools[tool].GetProperty("inputSchema").GetProperty("required")
           .EnumerateArray().Select(e => e.GetString()!).ToArray();
 
-    // ---- D and H: the required-parameter refusals -------------------------------------------------------
+    // ---- the required-parameter refusals ----------------------------------------------------------------
 
-    /// <summary>
-    /// The audit's other failing call: <c>{}</c> with a required parameter missing. It must be a NAMED
-    /// refusal naming EVERY missing parameter, never the SDK's generic "An error occurred invoking".
-    /// </summary>
+    /// <summary><c>{}</c> with a required parameter missing must be a named refusal naming EVERY missing
+    /// parameter, never the SDK's generic "An error occurred invoking".</summary>
     [Theory]
     [MemberData(nameof(ToolsWithRequiredParameters))]
     public void EveryToolWithARequiredParameterRefusesAnEmptyCallNamingEveryMissingParameter(string tool)
@@ -63,12 +55,9 @@ public sealed class ToolCallShimWirePathTests
                         "Supplied: (none).", r.Text, StringComparison.Ordinal);
     }
 
-    /// <summary>
-    /// The 2026-06-12 hunt, proven over stdio on <c>nexus_mod</c>: an EXPLICIT JSON null for a required
-    /// parameter read as supplied, the SDK bound null, and the tool body NullReferenced into Guard's
-    /// "internal houseCARL failure… capture a bug report" misdirection. It must be the same named
-    /// missing-parameter refusal, and it must say the value was an explicit null rather than absent.
-    /// </summary>
+    /// <summary>An EXPLICIT JSON null for a required parameter must be the same named missing-parameter
+    /// refusal, saying the value was an explicit null rather than absent. Read as supplied, it binds null and
+    /// the tool body NullReferences into Guard's "internal houseCARL failure" misdirection.</summary>
     [Theory]
     [MemberData(nameof(ToolsWithRequiredParameters))]
     public void AnExplicitNullForARequiredParameterIsRefusedAsMissingAndSaysItWasNull(string tool)
@@ -87,14 +76,11 @@ public sealed class ToolCallShimWirePathTests
                         $"Supplied: {first}.", r.Text, StringComparison.Ordinal);
     }
 
-    // ---- D2 (#224): an optional complex list must not break the empty call ------------------------------
+    // ---- an optional complex list must not break the empty call -----------------------------------------
 
-    /// <summary>
-    /// #224: the ops list is OFF the schema's required list — what to do when it is absent is judged in the
+    /// <summary>The ops list is OFF the schema's required list — what to do when it is absent is judged in the
     /// tool BODY. Through the full binding/shim stack an empty <c>{}</c> must still bind cleanly: no required
-    /// check fires, no binder throw on the absent complex array, and the body runs. RED if optionalizing the
-    /// parameter ever breaks <c>{}</c> binding (PR #241 review NOTE 4).
-    /// </summary>
+    /// check fires, no binder throw on the absent complex array, and the body runs.</summary>
     [Fact]
     public void ApplyWithNoArgumentsBindsWithNoRequiredRefusalAndReachesTheBody()
     {
@@ -105,12 +91,10 @@ public sealed class ToolCallShimWirePathTests
         Assert.True(r.BodyRan, r.Describe());
     }
 
-    // ---- J6-J9: the plugin/plugins/plugin_name clique on the surviving tools ----------------------------
+    // ---- the plugin/plugins/plugin_name clique ----------------------------------------------------------
 
-    /// <summary>
-    /// PR #304 review F1: the 1.x plugin clique stays a full set of edges. <c>plugin=</c> binds on a tool
-    /// whose declared parameter is <c>plugin_name</c>.
-    /// </summary>
+    /// <summary>The plugin clique stays a full set of edges: <c>plugin=</c> binds on a tool whose declared
+    /// parameter is <c>plugin_name</c>.</summary>
     [Fact]
     public void CreatePluginResolvesTheAliasPluginOntoItsOwnPluginNameAndReachesTheBody()
     {
@@ -121,12 +105,9 @@ public sealed class ToolCallShimWirePathTests
         Assert.True(r.BodyRan, r.Describe());
     }
 
-    /// <summary>
-    /// The reverse edge of the same clique: <c>plugin_name=</c> binds on a tool whose declared parameter is
-    /// bare <c>plugin</c>. Re-pointed from <c>housecarl_read_plugin_file</c> — the surviving tool declaring a
-    /// bare <c>plugin=</c> is <c>housecarl_compact_plugin</c>, where the rename also satisfies the required
-    /// check, so reaching the body is itself evidence the rename happened.
-    /// </summary>
+    /// <summary>The reverse edge of the same clique: <c>plugin_name=</c> binds on a tool whose declared
+    /// parameter is bare <c>plugin</c>. On <c>compact_plugin</c> the rename also satisfies the required check,
+    /// so reaching the body is itself evidence the rename happened.</summary>
     [Fact]
     public void CompactPluginResolvesTheAliasPluginNameOntoItsOwnPluginAndReachesTheBody()
     {
@@ -138,11 +119,9 @@ public sealed class ToolCallShimWirePathTests
         Assert.True(r.BodyRan, r.Describe());
     }
 
-    /// <summary>
-    /// PR #304 review F3: a stray <c>target=</c> on a tool that has none stays the named unknown WITH the
-    /// supported list — never a rename onto <c>in_place</c> that answers with a type error about a key the
-    /// caller never sent.
-    /// </summary>
+    /// <summary>A stray <c>target=</c> on a tool that has none stays the named unknown WITH the supported list
+    /// — never a rename onto <c>in_place</c> that answers with a type error about a key the caller never
+    /// sent.</summary>
     [Fact]
     public void AStrayTargetOnCompactPluginIsANamedUnknown_NotAnInPlaceTypeError()
     {
@@ -154,15 +133,13 @@ public sealed class ToolCallShimWirePathTests
         Assert.DoesNotContain("in_place (expects", r.Text, StringComparison.Ordinal);
     }
 
-    /// <summary>
-    /// PR #304 review F5, the kind gate: a plural spelling carrying an ARRAY must not be renamed onto a
-    /// SCALAR parameter. The refusal keeps the caller's OWN key, so the correction they read is about the
-    /// argument they actually sent. Re-pointed from <c>read_record(formids=[…])</c> onto the surviving
-    /// plural-array/scalar pair, <c>compact_plugin(plugins=[…])</c> over its declared <c>plugin=</c>.
+    /// <summary>The kind gate: a plural spelling carrying an ARRAY must not be renamed onto a SCALAR
+    /// parameter, and the refusal keeps the caller's OWN key so the correction is about the argument they
+    /// actually sent.
     ///
     /// <para>The scalar control is the other half of the gate: the SAME spelling carrying a STRING is
-    /// compatible with the scalar pole, so it does rename and the call runs. Without it this arm would pass
-    /// just as well against a gate that refused the spelling outright.</para>
+    /// compatible with the scalar pole, so it does rename and the call runs. Without it this test would pass
+    /// against a gate that refused the spelling outright.</para>
     /// </summary>
     [Fact]
     public void AnArrayUnderAPluralSpellingIsNotRenamedOntoAScalarParameter_TheRefusalKeepsTheCallersKey()

--- a/src/housecarl-mcp-tests/ToolNameRegistryTests.cs
+++ b/src/housecarl-mcp-tests/ToolNameRegistryTests.cs
@@ -4,23 +4,12 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// The registry's completeness, held from both ends: the set of <c>ToolNames</c> constants, the set of tool
-/// names the source DECLARES, and the set the SDK actually REGISTERS must be one set.
-///
-/// This is what makes the registry safe to stop regenerating. The scripts under
-/// <c>scripts/tool-names/</c> ran once and are not re-run, so a tool added tomorrow gets its constant by
-/// hand — and these cells fail until it does, naming the tool that is missing one.
-///
-/// The declared/registered halves are the pair #470 turned on: <c>[McpServerTool]</c> on the method makes a
-/// tool DECLARED, and <c>WithToolsFromAssembly()</c> additionally needs <c>[McpServerToolType]</c> on the
-/// declaring type to REGISTER it. Those sets were different for twelve days. Holding all three equal means a
-/// future declared-but-unregistered tool fails here by construction, rather than being noticed.
-///
-/// No side is a hand list: constants come from reflection over <see cref="ToolNames"/>, the other two from
-/// reflection over the shipped tool assembly.
-/// Rationale: <c>docs/decisions/0004-tool-names-are-compile-time-constants.md</c>.
-/// </summary>
+/// <summary>The <c>ToolNames</c> constants, the tool names the source DECLARES (<c>[McpServerTool]</c> on the
+/// method), and the names the SDK REGISTERS (<c>WithToolsFromAssembly()</c> also needs
+/// <c>[McpServerToolType]</c> on the declaring type) must be one set. Nothing here is regenerated and no side
+/// is a hand list — all three come from reflection, so a new tool without a constant, or a declared tool no
+/// caller can reach, fails here. Rationale:
+/// <c>docs/decisions/0004-tool-names-are-compile-time-constants.md</c>.</summary>
 public sealed class ToolNameRegistryTests
 {
     const BindingFlags Members = BindingFlags.Public | BindingFlags.NonPublic

--- a/src/housecarl-mcp-tests/ToolSurfaceCensusTests.cs
+++ b/src/housecarl-mcp-tests/ToolSurfaceCensusTests.cs
@@ -6,21 +6,9 @@ using Xunit.Abstractions;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// #470's own class, guarded from both sides: what the source DECLARES and what the wire PUBLISHES must be
-/// the same set.
-///
-/// The bug was that they were not, and could not be seen to differ: <c>CheckTools</c> carried
-/// <c>[McpServerTool]</c> on its method but no <c>[McpServerToolType]</c> on the class, and
-/// <c>WithToolsFromAssembly()</c> discovers only marked types. Every count anyone quoted came from the
-/// attributes, so the tool read as shipped for twelve days while no client could call it.
-///
-/// Neither side is a hand list: the declared side is reflected over the assembly the server REGISTERS from
-/// — <c>ToolSurface.Assembly</c>, the same property Program.cs passes to <c>WithToolsFromAssembly</c> — and
-/// the published side is `tools/list` off the running server. Naming that assembly by picking a type
-/// expected to live in it was the earlier shape, and it agreed with the registration by coincidence of
-/// layout rather than by construction.
-/// </summary>
+/// <summary>What the source declares and what the wire publishes must be the same set. Neither side is a
+/// hand list: the declared side reflects over <c>ToolSurface.Assembly</c>, the property Program.cs passes to
+/// <c>WithToolsFromAssembly</c>, and the published side is `tools/list` off the running server.</summary>
 public sealed class ToolSurfaceCensusTests
 {
     /// <summary>Every method on the tool surface carrying [McpServerTool], with the type that declares it.</summary>
@@ -36,10 +24,8 @@ public sealed class ToolSurfaceCensusTests
     public static IEnumerable<object[]> DeclaringTypes() =>
         DeclaredToolMethods().Select(x => x.Type).Distinct().Select(t => new object[] { t.FullName! });
 
-    /// <summary>
-    /// The defect itself, reflected: a type that declares a tool must be discoverable as a tool type.
-    /// One named cell per declaring type, so a RED says which file to open.
-    /// </summary>
+    /// <summary>A type that declares a tool must be discoverable as a tool type. One named case per
+    /// declaring type, so a failure says which file to open.</summary>
     [Theory]
     [Trait("tier", "unit")]
     [MemberData(nameof(DeclaringTypes))]
@@ -69,25 +55,15 @@ public sealed class ToolSurfaceCensusTests
 
     // ---- the tool surface is ONE assembly ---------------------------------------------------------------
     //
-    // The server registers from exactly one assembly, so a tool declared in a second one is declared, guarded,
-    // documented and unreachable — #470's shape, one level up. Nothing in the build stops that: it needs a
-    // project reference to the MCP SDK and nothing else.
-    //
-    // It is NOT latent everywhere. housecarl-generator already compiles against the MCP SDK, so a marked type
-    // there needs no csproj change at all; housecarl-core is the assembly that would. A latent arm still has
-    // to be shown to fire, so the check is a function over a population and the fixture arm hands it a
-    // population that contains an offender.
+    // The server registers from exactly one assembly, so a tool declared in a second one is unreachable, and
+    // nothing in the build stops that — it takes only a project reference to the MCP SDK, which
+    // housecarl-generator already has. The check is a function over a population so the fixture test below can
+    // hand it a population that contains an offender.
 
-    /// <summary>
-    /// The repo's shipped assemblies: every project under src/ except this test project, which is not shipped
-    /// and deliberately declares an offender fixture below.
-    ///
-    /// <para>The population is the repo's own project list, not the tool surface's reference closure. A
-    /// closure reaches only what its root REFERENCES: housecarl-generator references housecarl-mcp rather
-    /// than the reverse, so walking outward from the tool surface left out the one shipped assembly that
-    /// already carries the MCP SDK reference — the assembly a split would land in first, invisible to the arm
-    /// written to catch it.</para>
-    /// </summary>
+    /// <summary>The repo's shipped assemblies: every project under src/ except this test project, which is
+    /// not shipped and declares an offender fixture below. The population is the repo's own project list, not
+    /// the tool surface's reference closure — a closure reaches only what its root references, and
+    /// housecarl-generator references housecarl-mcp rather than the reverse.</summary>
     static Assembly[] ShippedAssemblies()
     {
         var self = typeof(ToolSurfaceCensusTests).Assembly;
@@ -118,7 +94,7 @@ public sealed class ToolSurfaceCensusTests
         var population = ShippedAssemblies();
         var registered = HousecarlMcp.ToolSurface.Assembly;
 
-        // Vacuity canary: a population of one is a claim about nothing.
+        // A population of one is a claim about nothing: with no second assembly the check below cannot fail.
         Assert.True(population.Length > 1,
             "The shipped-assembly walk found only " + string.Join(", ", population.Select(a => a.GetName().Name)) +
             ". With nothing but the tool surface in the population there is no second assembly to check, so " +
@@ -135,14 +111,9 @@ public sealed class ToolSurfaceCensusTests
 
     // ---- ToolSurface.Assembly is the ONE home for "which assembly is the tool surface" ------------------
     //
-    // The discarded spelling is `typeof(SomeToolType).Assembly` — a sentence about where a type happens to
-    // live, which agrees with the registration only by coincidence of layout. ToolSurface.cs says it is the
-    // one home, and that sentence has to be true of the tree it ships on.
-    //
-    // BOTH sides of this population are derived: the type names come off the tool-surface assembly by
-    // reflection, the files off the repo's own project list. A hand-list of "the sites we know about" is
-    // exactly what went short here twice — the first pass repointed the two a reviewer named and left two
-    // live ci-all guards on the old spelling, and a second hand pass over those left three more.
+    // The discarded spelling is `typeof(SomeToolType).Assembly`, which agrees with the registration only while
+    // the type stays put. Both sides of the population are derived — the type names off the tool-surface
+    // assembly by reflection, the files off the repo's own project list — so no hand-list can go short.
 
     static readonly Regex TypeofAssembly =
         new(@"typeof\(\s*([A-Za-z_][A-Za-z0-9_.]*)\s*\)\s*\.\s*Assembly", RegexOptions.Compiled);
@@ -173,14 +144,9 @@ public sealed class ToolSurfaceCensusTests
 
     static readonly HashSet<string> NoLocalNames = new(StringComparer.Ordinal);
 
-    /// <summary>
-    /// The names declared by the project the scanned file lives in — the names a bare `typeof(X)` in that file
-    /// could be about other than the tool surface.
-    ///
-    /// <para>Empty for a file in the tool-surface project itself: a surface type's name there is not an
-    /// ambiguity to resolve, it IS the surface, and the discarded spelling is exactly as discarded in that
-    /// project as in any other. Empty too for a file under no project, which the scan does not produce.</para>
-    /// </summary>
+    /// <summary>The names declared by the project the scanned file lives in — what a bare `typeof(X)` in that
+    /// file could mean other than the tool surface. Empty for a file in the tool-surface project itself, where
+    /// a surface type's name is the surface, and for a file under no project.</summary>
     static HashSet<string> NamesDeclaredWhereTheFileLives(string file)
     {
         var owner = RepoProjects.All
@@ -200,18 +166,15 @@ public sealed class ToolSurfaceCensusTests
     /// <summary>
     /// Whether a `typeof(<paramref name="named"/>)` expression names a type on the tool surface.
     ///
-    /// <para>A qualified name has to be consistent with a real surface type's full name, because a simple name
+    /// <para>A qualified name must be consistent with a real surface type's full name, because a simple name
     /// is not unique across assemblies — <c>typeof(HousecarlSetup.Program).Assembly</c> names a different
-    /// project's <c>Program</c>, and matching on the last segment alone reported it as an offender.</para>
+    /// project's <c>Program</c>, so matching on the last segment alone reports it wrongly.</para>
     ///
-    /// <para>A bare name matches every surface type's simple name, MINUS the names the file's own project
-    /// declares (<paramref name="declaredWhereItLives"/>). That subtraction is the whole collision fix: the
-    /// day housecarl-core or housecarl-generator gains a type sharing a name with one in housecarl-mcp, every
-    /// <c>typeof(ThatType).Assembly</c> in that project would otherwise be reported, with a remedy that would
-    /// change what the expression means. Where the name is NOT declared locally there is no other type it
-    /// could be, which is why the set stays whole — narrowing it to the tool types instead would have stopped
-    /// catching four of the six spellings this branch repointed, <c>typeof(ApplyOp)</c> and
-    /// <c>typeof(ToolSchemas)</c> among them.</para>
+    /// <para>A bare name matches every surface type's simple name minus the names the file's own project
+    /// declares (<paramref name="declaredWhereItLives"/>), so a name shared between projects is not reported
+    /// where the local type is what the expression means. The surface set stays whole rather than narrowing to
+    /// the tool types, which would stop catching spellings like <c>typeof(ApplyOp)</c> and
+    /// <c>typeof(ToolSchemas)</c>.</para>
     /// </summary>
     static bool NamesASurfaceType(string named, (HashSet<string> Simple, string[] Full) surface,
                                   HashSet<string> declaredWhereItLives) =>
@@ -221,7 +184,7 @@ public sealed class ToolSurfaceCensusTests
 
     /// <summary>The type names in <paramref name="source"/> that a `typeof(…).Assembly` expression uses to
     /// mean the tool surface, read as if the source were the file at <paramref name="file"/>. One home for the
-    /// reading, so an arm measures what the scan measures.</summary>
+    /// reading, so a test measures what the scan measures.</summary>
     static string[] SurfaceNamingExpressionsIn(string file, string source,
                                                (HashSet<string> Simple, string[] Full) surface)
     {
@@ -240,7 +203,7 @@ public sealed class ToolSurfaceCensusTests
     {
         var surfaceTypes = SurfaceTypeNames();
 
-        // Vacuity canary: an empty name set would make every file below clean by arithmetic.
+        // An empty name set would make every file below clean by arithmetic.
         Assert.True(surfaceTypes.Simple.Count > 0,
             "Reflection over ToolSurface.Assembly found no types, so nothing below can match and this arm " +
             "passes over any spelling. The reflection is broken, not the source.");
@@ -260,15 +223,11 @@ public sealed class ToolSurfaceCensusTests
             "expression agrees with that only while the type stays put.");
     }
 
-    /// <summary>
-    /// Every .cs file under the repo's projects, except the one file this fact is allowed to live in.
-    ///
-    /// <para>The exemption is a full path, not a filename. Filtering on the bare name excused any file called
-    /// ToolSurface.cs anywhere under src/, so a second home — src/housecarl-generator/ToolSurface.cs, say —
-    /// would never have entered the scan at all, and a guard whose whole subject is "this fact lives in
-    /// exactly one place" would have been defeated by giving the second place the same name. The home is
-    /// derived: the project producing the tool-surface assembly, plus the filename.</para>
-    /// </summary>
+    /// <summary>Every .cs file under the repo's projects, except the one file this fact is allowed to live in.
+    /// The exemption is a full path, not a filename: filtering on the bare name would excuse a second
+    /// ToolSurface.cs anywhere under src/, defeating a check whose subject is that the fact lives in one
+    /// place. The home is derived from the project producing the tool-surface assembly plus the
+    /// filename.</summary>
     static string[] ScannedFiles() =>
         RepoProjects.All
             .SelectMany(p => Directory.EnumerateFiles(p.Directory, "*.cs", SearchOption.AllDirectories))
@@ -297,15 +256,10 @@ public sealed class ToolSurfaceCensusTests
     static string Rel(string full) =>
         Path.GetRelativePath(HarnessPaths.RepoRoot, full).Replace('\\', '/');
 
-    /// <summary>
-    /// The six sites this branch repointed, with the spelling each carried before it was.
-    ///
-    /// <para>A historical fixture, not a population: it is the record of what actually occurred in this tree,
-    /// and the only way to hold a change to the READING against the offenders the reading is for. Two of the
-    /// six are one row when reported — same file, same name — which is why the assertion is over the six
-    /// sites rather than over a row count. The names are stored, not the expressions: this file is scanned
-    /// like any other, and a literal <c>typeof(X).Assembly</c> here would be an offender in it.</para>
-    /// </summary>
+    /// <summary>Real offender sites, with the spelling each carried — a fixture to hold any change to the
+    /// reading against. Two rows are the same file and name and report as one, so the assertion counts sites
+    /// rather than rows. Type names are stored, not whole expressions: this file is scanned like any other, so
+    /// a literal <c>typeof(X).Assembly</c> here would be an offender in it.</summary>
     static readonly (string File, string TypeName)[] TheRepointedSites =
     {
         ("src/housecarl-generator/RegisteredTools.cs",                 "WriteTools"),
@@ -316,17 +270,9 @@ public sealed class ToolSurfaceCensusTests
         ("src/housecarl-generator/PreFlattenSurface.cs",               "ToolSchemas"),
     };
 
-    // 2026-09-03: two rows naming `ReadTools` removed at the cut (#468) — the type is deleted, so nothing can
-    // collide with its name; the six remaining rows keep the claim.
-
-    /// <summary>
-    /// Every spelling the repointing removed is still read as naming the tool surface.
-    ///
-    /// <para>This is what stops a fix to the false-positive side from being paid for in teeth. Narrowing the
-    /// bare-name set to the tool types the server discovers would have gone green everywhere while quietly
-    /// losing four of these — the three <c>typeof(ApplyOp)</c> sites and PreFlattenSurface's
-    /// <c>typeof(ToolSchemas)</c>, which was a second WithToolsFromAssembly call site.</para>
-    /// </summary>
+    /// <summary>Every spelling above is still read as naming the tool surface, so a fix to the false-positive
+    /// side cannot be paid for in teeth — narrowing the bare-name set to the tool types the server discovers
+    /// would pass everywhere while losing four of these.</summary>
     [Fact]
     [Trait("tier", "unit")]
     public void EverySpellingThisBranchRepointedIsStillCaught_TheCollisionFixCostsNoTeeth()
@@ -349,14 +295,9 @@ public sealed class ToolSurfaceCensusTests
             "lost teeth, whatever else it fixed.");
     }
 
-    /// <summary>
-    /// The bare-name branch skips a name only where the file's own project declares it — and reports the same
-    /// spelling in a project that does not.
-    ///
-    /// <para>Both cells are derived: the colliding name is one the tool surface and some other project both
-    /// declare, off their built assemblies, and the second cell reuses that same name in a project that does
-    /// not declare it. Neither touches disk — the reading takes the path a file would have.</para>
-    /// </summary>
+    /// <summary>The bare-name branch skips a name only where the file's own project declares it, and reports
+    /// the same spelling in a project that does not. Both cases are derived off the built assemblies, and
+    /// neither touches disk — the reading only takes the path a file would have.</summary>
     [Fact]
     [Trait("tier", "unit")]
     public void ABareNameIsSkippedOnlyWhereTheFilesOwnProjectDeclaresIt_NoNuisanceRedNoLostTeeth()
@@ -395,15 +336,10 @@ public sealed class ToolSurfaceCensusTests
                                                 expression, surface));
     }
 
-    /// <summary>
-    /// A SECOND file called ToolSurface.cs is still scanned. The exemption is the one home's path; the name
-    /// is not a licence.
-    ///
-    /// <para>The fixture is planted in another project's directory, in the tree the scan walks, and removed in
-    /// a finally. Its content is a comment: the scan reads source as text, so a comment carries the same
-    /// expression a statement would, and it cannot break a build if anything compiles this tree while it
-    /// exists.</para>
-    /// </summary>
+    /// <summary>A second file called ToolSurface.cs is still scanned — the exemption is the one home's path,
+    /// not the name. The fixture is planted in another project's directory inside the tree the scan walks and
+    /// removed in a finally; its content is a comment, because the scan reads source as text and a comment
+    /// cannot break a build that runs while the file exists.</summary>
     [Fact]
     [Trait("tier", "unit")]
     public void ASecondFileCalledToolSurfaceCsIsStillScanned_TheExemptionIsAPathNotAFilename()
@@ -497,11 +433,8 @@ public sealed class ToolSurfaceCensusWireTests
     [Fact]
     public void ToolsListNamesHousecarlCheck_TheWholePointOf470()
     {
-        // The literal is deliberate: every other assertion over this name reads ToolNames.Check and so
-        // follows a change to the constant's VALUE, while a literal does not. Deliberately redundant now
-        // — data/tools-list-2.0.json spells all 46 published names as literals and PublishedNameAnchorTests
-        // is the rename oracle for every one of them, in both directions. This cell is the belt beside
-        // those braces for the one name #470 was about, and it costs a line.
+        // The literal is deliberate: every other assertion over this name reads ToolNames.Check and so follows
+        // a change to the constant's value, while a literal does not.
         Assert.Contains("housecarl_check", _s.PublishedNames);
     }
 }

--- a/src/housecarl-mcp-tests/WhereGrammarTests.cs
+++ b/src/housecarl-mcp-tests/WhereGrammarTests.cs
@@ -1,4 +1,3 @@
-// Converted-from: RecordsGuardProbe
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records;
 using HousecarlCore;
@@ -6,15 +5,9 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>
-/// SPEC §2.2 / §4.2 — the W2 where-grammar terms, evaluated in memory over synthesized bodies against
-/// brute-force oracles. No load order, no service: these are predicate semantics.
-/// (RecordsGuardProbe arms 1 and 2, and the arm-4b polarity folds that belong with them.)
-///
-/// Tier note: "unit" names what these tests ASSERT — predicate semantics in memory, no service call.
-/// They still draw their synthesized bodies from the shared collection fixture, so `--filter tier=unit`
-/// pays the world build until those bodies are lifted off the world. Stated, not hidden.
-/// </summary>
+/// <summary>The where-grammar terms, evaluated in memory over synthesized bodies against brute-force oracles.
+/// No load order and no service call, which is what the "unit" tier names — but the bodies still come from the
+/// shared collection fixture, so <c>--filter tier=unit</c> pays the world build.</summary>
 [Collection("records")]
 [Trait("tier", "unit")]
 public sealed class WhereGrammarTests
@@ -132,7 +125,7 @@ public sealed class WhereGrammarTests
         Assert.Contains("NoSuchField->editorid", set.AccountingNote() ?? "");
     }
 
-    // ---- 4b polarity folds over the no-EditorID record --------------------------------------------
+    // ---- polarity over the no-EditorID record -----------------------------------------------------
 
     [Fact]
     public void EditoridNotEqual_KeepsTheNoEditoridRecord_NotEqualIsUnambiguouslyTrueThere() =>
@@ -148,10 +141,8 @@ public sealed class WhereGrammarTests
         Assert.Equal(WeaponsExcept(_w.Weapons[0]), Run("editorid not in [HcRecW0]", _w.WeaponBodies));
 }
 
-/// <summary>
-/// SPEC §2.2 — the parse refusals, named before any scan. One row per refusal: the clause and the word the
-/// caller needs to see in the sentence.
-/// </summary>
+/// <summary>The parse refusals, named before any scan. One row per refusal: the clause and the word the
+/// caller needs to see in the sentence.</summary>
 [Trait("tier", "unit")]
 public sealed class WhereParseRefusalTests
 {


### PR DESCRIPTION
The comments under `src/housecarl-mcp-tests` are swept into the plain register: each one keeps the constraints the code cannot express — a fixture's required contents, a process-global that forces serialisation, a Mutagen or Windows or xUnit quirk, why a test is driven at one layer rather than another, why an assertion is anchored where it is, and the cap boundaries that explain a magic number — and loses the narrative around them: probe provenance, review-round findings, dated measurements, "measured, not assumed" essays, and the issue and section citations. The banned vocabulary goes with it (canary, sabotage, residue, fold, arm as a name for an assertion, Q3, Aaron-go); `arm` as a switch or union arm stays, as does "cornerstone". Comments only, no behaviour change.

65 files changed, +865/-1579. Two of the changed lines are code lines whose trailing comment was reworded; the code text on them is byte-identical.

Verification:

- `dotnet build housecarl.sln -c Release` - 0 errors, 89 pre-existing warnings.
- `dotnet test src/housecarl-mcp-tests -c Release --no-build --filter "tier!=bridge"` - 984 passed, 0 failed.
- `dotnet src/housecarl-generator/bin/Release/net9.0/housecarl-generator.dll ci-all` - ALL PASS.

No CHANGELOG line: a user notices nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
