### PR TITLE
docs(generator): comment sweep of src/housecarl-generator

### DIFF
--- a/src/housecarl-generator/ApplyProof.cs
+++ b/src/housecarl-generator/ApplyProof.cs
@@ -8,20 +8,20 @@ using HousecarlCore;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// MCP §8.4 Beat C build proof — exercise the PUBLIC write cleave (<see cref="WritePatchBuilder.Apply"/>) that the
-/// MCP <c>housecarl_set_field</c> / <c>housecarl_bulk_apply</c> tools call, so the proof transfers to the server BY
-/// CONSTRUCTION (same code path). Five checks, each driven through the cleave against a real, large load order:
+/// Build proof for the PUBLIC write cleave (<see cref="WritePatchBuilder.Apply"/>) that the <c>housecarl_set_field</c>
+/// and <c>housecarl_bulk_apply</c> tools call. It must drive the same code path the tools do, or it proves nothing
+/// about them. Five checks, each against a real, large load order:
 ///
 ///   A — FLAT Set (one weapon's Damage), fresh single-master patch; value reads back; source byte-untouched.
 ///   B — MULTI-edit one patch (two weapons in ONE call) = the bulk_apply shape; both land in one .esp.
-///   C — into=/EXTEND (Aaron's 1.0 requirement): write A's patch, then EXTEND it with a 2nd record; reopen → BOTH
-///       present (the multi-session / handoff lever — file is the state, no server-held accumulation).
+///   C — into=/EXTEND: write A's patch, then EXTEND it with a 2nd record; reopen → BOTH present. The file is the
+///       state; nothing accumulates in the server between calls.
 ///   D — CROSS-MASTER through the cleave (a vanilla leveled list + a cross-master weapon entry) → patch header
 ///       carries ≥2 masters (the cleave routes through the proven multi-master WritePatch).
-///   E — PRE-FLIGHT REJECT: a bad edit refuses the WHOLE call with NO file written (Q3 — no partial patches).
+///   E — PRE-FLIGHT REJECT: a bad edit refuses the WHOLE call with NO file written — no partial patches.
 ///
-/// Every write only ever touches its own output .esp; the vanilla masters + referenced mods are SHA-checked
-/// unchanged. Patches are left in write-output/apply-proof/ for Aaron to open in xEdit.
+/// Every write only ever touches its own output .esp; the vanilla masters and referenced mods are SHA-checked
+/// unchanged. Patches are left in write-output/apply-proof/ to open in xEdit.
 ///
 /// Run: dotnet run --project src/housecarl-generator apply-proof [maxPlugins]
 /// </summary>
@@ -112,7 +112,7 @@ public static class ApplyProof
                 ok ? $"2 ops, masters [{string.Join(",", o.Masters)}], both-land={YN(both)} src-untouched={YN(srcOk)}" : o.Error ?? ""));
         }
 
-        // ============================== C — into= / EXTEND (Aaron's 1.0 requirement) ==============================
+        // ============================== C — into= / EXTEND ==============================
         {
             var outPath = Path.Combine(outDir, "houseCARL_ApplyProof_C.esp");
             ushort w1 = (ushort)(dmg1 + 9), w2 = (ushort)(dmg2 + 9);

--- a/src/housecarl-generator/CheckShapeMatrix.cs
+++ b/src/housecarl-generator/CheckShapeMatrix.cs
@@ -7,15 +7,11 @@ namespace HousecarlGenerator;
 /// THE SHAPE MATRIX for the merged <c>check</c> response — an INVENTORY of the shapes this surface can produce,
 /// with the allocation, cap and remedy properties driven over EVERY one of them.
 ///
-/// <para><b>Why it exists.</b> Review round 2 (2026-08-22) found six separate conditionals with no arm that could
-/// fail, and CLAUDE.md §5 #11's class rule fired on them together: the arms were being written one per FINDING,
-/// never from an inventory of the shapes the surface produces, so whole shapes had no fixture at all. The headline
-/// instance was that no merged <c>counts_only</c> render at a biting cap existed anywhere in <c>check-guard</c> —
-/// which is precisely the shape #394 is about, so <c>HistogramByTarget</c>, <c>HistogramBySource</c>,
+/// <para><b>Why it exists.</b> Arms written one per finding leave whole shapes with no fixture at all: a merged
+/// <c>counts_only</c> render at a biting cap had none, so <c>HistogramByTarget</c>, <c>HistogramBySource</c>,
 /// <c>HistogramByProperty</c>, <c>UnreadRows</c> and <c>ScriptScanRows</c> were never allocated, never charged and
-/// never asked for monotonicity, no-stranding or exactness. Eleven more arms would have made the suite bigger
-/// without making the shape coverage complete. This is the fixture instead: build the shapes once, drive the
-/// properties over all of them.</para>
+/// never asked for monotonicity, no-stranding or exactness. Build the shapes once and drive the properties over
+/// all of them, so coverage follows from the inventory rather than from what anyone thought to add.</para>
 ///
 /// <para><b>The inventory.</b> Every subset of the three families, each in the LISTING and the <c>counts_only</c>
 /// lane, plus the states a family can be in that are not "ran": REFUSED (its own section is a refusal) and
@@ -29,9 +25,9 @@ namespace HousecarlGenerator;
 /// sample. What these arms are about is shape coverage, not scale; <c>check-measure</c> owns scale, on the live
 /// order.</para>
 ///
-/// <para><b>Its known-RED canary.</b> <c>MATRIX-INSIDE-ITS-CAP</c> reproduces A1 — a merged response with a large
-/// roster landing OVER <c>max_chars</c>, measured by hand at 4,494 chars against a 4,000 cap before this file
-/// existed. A matrix that cannot see a defect measured by hand is a broken matrix.</para>
+/// <para><b>Its known-RED case.</b> <c>MATRIX-INSIDE-ITS-CAP</c> reproduces a merged response with a large roster
+/// landing OVER <c>max_chars</c> — 4,494 chars against a 4,000 cap, found by hand. A matrix that cannot see a
+/// defect found by hand is a broken matrix.</para>
 /// </summary>
 internal static class CheckShapeMatrix
 {
@@ -123,7 +119,7 @@ internal static class CheckShapeMatrix
             new CheckSweep(Sel("errors", "scripts"), e, sc, new[] { "HcMxFresh.esp" }));
         // …and the same file named on a call where that family REFUSED. The off-order sentence is now written above
         // whatever the family goes on to say, refusal included, so a refusal section carries a sentence no other
-        // shape puts in the fixed part — and the fixed-part pass has to measure it (round-2 finding B4).
+        // shape puts in the fixed part — and the fixed-part pass has to measure it.
         Add("errors+scripts, listing, off-order, scripts refused",
             new CheckSweep(Sel("errors", "scripts"), e, refusedScripts, new[] { "HcMxFresh.esp" }));
         // ---- NO FAMILY ANSWERED, on DISTINCT grounds ------------------------------------------------
@@ -278,9 +274,9 @@ internal static class CheckShapeMatrix
                             // (6) THE TWO HONESTY LAYERS ARE ONE SHAPE. `unread` (errors) and `scan_errors`
                             // (scripts) answer the same kind of question — what this sweep could NOT read — and a
                             // merged response carries both in one document, so a consumer has to parse them the
-                            // same way. They disagreed: one kept its 1.x wrapper and the other was rebuilt as a
-                            // bare array (Aaron's review of PR #399, finding 1). Asked at EVERY cap, because what
-                            // the wrapper is FOR is saying it was cut, and the cut is what the band produces.
+                            // same way — one keeping a wrapper while the other is a bare array is a defect. Asked
+                            // at EVERY cap, because what the wrapper is FOR is saying it was cut, and the cut is
+                            // what the band produces.
                             honestyCells += HonestyLayers(doc.RootElement, shape.Name, cap, honestyBad);
                         }
                         catch (Exception ex)
@@ -380,11 +376,10 @@ internal static class CheckShapeMatrix
                                 : noticesFollowed > 0 ? $"{noticesFollowed} notices followed, each cleared in one step"
                                                       : "the notice never fired anywhere in the matrix — the arm never saw the case it is for");
 
-        // THE SHAPE #394 IS ABOUT, and the one that had no fixture anywhere. The three properties above are only
-        // worth their names over subjects the allocation actually reaches, so this asks the membership question
-        // directly: every subject any shape PLANS gets room somewhere in its band, and the five subjects a merged
-        // counts_only render carries are among them. Not one of them was allocated or charged anywhere in this
-        // guard before the matrix existed, so every arm above would have been asked of them vacuously.
+        // The three properties above are only worth their names over subjects the allocation actually reaches, so
+        // this asks the membership question directly: every subject any shape PLANS gets room somewhere in its
+        // band, and the five subjects a merged counts_only render carries are among them. Without this, an
+        // unallocated subject leaves every arm above to be asked of it vacuously.
         var countsOnlySubjects = new[]
         {
             SweepSubject.HistogramByTarget, SweepSubject.HistogramBySource, SweepSubject.HistogramByProperty,
@@ -618,9 +613,9 @@ internal static class CheckShapeMatrix
     }
 
     /// <summary>EVERY subject a shape can render — its families' planned subjects AND the response's own, which
-    /// belong to no family. The roster is the second kind, and leaving it out is how a sabotage that stopped
-    /// measuring its demand altogether came back green through the whole sweep: it is allocated, charged and cut
-    /// like any other subject, so every property here has to be asked of it.</summary>
+    /// belong to no family. The roster is the second kind, and leaving it out lets a break that stops measuring its
+    /// demand pass green through the whole sweep: it is allocated, charged and cut like any other subject, so every
+    /// property here has to be asked of it.</summary>
     static SweepSubject[] Subjects(Shape shape)
         => Subjects(CheckOutcome.For(shape.Sweep));
 
@@ -637,11 +632,10 @@ internal static class CheckShapeMatrix
     /// record sections, scan-error rows, unread rows, dangling entries, seed heads, topic blocks, unreachable-seed
     /// rows, roster rows, and every counts_only histogram row.
     ///
-    /// <para><b>Each marker is a string a composer really emits, and one of them was not.</b> The dangling entry
-    /// was counted by <c>"  dangling ref "</c>, which <see cref="ReadTools.ComposeDanglingLine"/> does not write —
-    /// its line ends in the bracketed reason below. So that term was 0 in every response and this fingerprint was
-    /// blind to the one subject the errors family accounts for a unit at a time (Aaron's review of PR #399,
-    /// finding 2 / round-3 B1). A marker is now taken from the composer's own text.</para></summary>
+    /// <para><b>Every marker must be a string a composer really emits.</b> A marker no composer writes makes its
+    /// term 0 in every response, and the fingerprint then goes blind to that subject instead of failing — which is
+    /// what <c>"  dangling ref "</c> did, since <see cref="ReadTools.ComposeDanglingLine"/> ends its line in the
+    /// bracketed reason below. Take each marker from the composer's own text.</para></summary>
     static string TextFingerprint(string t)
         => string.Join("/", new[]
            {

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -71,13 +71,12 @@ public static class CiAll
     /// <summary>
     /// Every attributed guard, roster and standalone alike, ordered by name.
     ///
-    /// <para>A cached method rather than a static field on purpose. <see cref="Discover"/> has two written
-    /// refusals — a wrong entry-point signature, and two guards claiming one verb — and a refusal thrown out
-    /// of a static field initializer arrives as a TypeInitializationException that the CLR then caches against
-    /// the type for the life of the process. In the xUnit host that turned one sentence naming both clashing
-    /// hosts into eight failures reading "The type initializer for 'HousecarlGenerator.CiAll' threw an
-    /// exception", with the sentence buried in an inner exception. From here the refusal arrives as itself, in
-    /// the caller that asked. Every member below is cached the same way for the same reason.</para>
+    /// <para>A cached method rather than a static field on purpose: <see cref="Discover"/> throws two refusals —
+    /// a wrong entry-point signature, and two guards claiming one verb — and out of a static field initializer
+    /// those arrive as a TypeInitializationException the CLR caches against the type for the life of the process,
+    /// burying the sentence in an inner exception and repeating it on every later caller. From here the refusal
+    /// arrives as itself, in the caller that asked. Every member below is cached the same way for the same
+    /// reason.</para>
     /// </summary>
     static Entry[] All() => _all ??= Discover();
 

--- a/src/housecarl-generator/ClassParentsEmitter.cs
+++ b/src/housecarl-generator/ClassParentsEmitter.cs
@@ -5,15 +5,14 @@ namespace HousecarlGenerator;
 
 /// <summary>
 /// Emits vanilla-class-parents.json — the decompiler's baseline child→parent class map, generated
-/// BY CONSTRUCTION from the vanilla Papyrus sources' own `ScriptName X extends Y` headers (the
-/// header scrape the PEX bulk gate proved at 25,919-edge scale). The asset ships beside the exe
-/// (csproj Content item) because it CANNOT be regenerated on a fresh checkout: vanilla sources
-/// install with the Creation Kit, not the game, and not on CI. Regenerate manually on a game
-/// update; the output is sorted so regeneration diffs are stable.
+/// from the vanilla Papyrus sources' own `ScriptName X extends Y` headers. The asset ships beside
+/// the exe (csproj Content item) because it CANNOT be regenerated on a fresh checkout: vanilla
+/// sources install with the Creation Kit, not the game, and not on CI. Regenerate manually on a
+/// game update; the output is sorted so regeneration diffs are stable.
 ///
 /// Why it exists: implicit-UPCAST suppression in <see cref="HousecarlCore.PapyrusDecompiler"/>
 /// needs ancestor chains, and the load-bearing ones are vanilla's (Actor → ObjectReference →
-/// Form). Without the map output stays CORRECT but keeps explicit casts (gate-tier cosmetic).
+/// Form). Without the map, output stays CORRECT but keeps explicit casts.
 ///
 /// Run: dotnet run --project src/housecarl-generator class-parents "&lt;vanilla Source\Scripts&gt;" &lt;out.json&gt;
 /// </summary>

--- a/src/housecarl-generator/CopyDifferentialHarness.cs
+++ b/src/housecarl-generator/CopyDifferentialHarness.cs
@@ -9,9 +9,9 @@ using HousecarlMcp;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// THE PR 3b ACCEPTANCE DIFFERENTIAL — <c>housecarl_copy_npc_appearance</c> (the chartered ancestor) against its 2.0
-/// successor (<c>housecarl_copy</c> + <c>housecarl_apply</c>'s copy zip + <c>housecarl_bulk_place_asset</c>), driven
-/// over CONSTRUCTED MO2 instances, with the artifacts on disk compared.
+/// The acceptance differential: <c>housecarl_copy_npc_appearance</c> (the ancestor) against its 2.0 successor
+/// (<c>housecarl_copy</c> + <c>housecarl_apply</c>'s copy zip + <c>housecarl_bulk_place_asset</c>), driven over
+/// CONSTRUCTED MO2 instances, with the artifacts on disk compared.
 ///
 /// <para><b>It compares two TOOL CALLS, not two service methods.</b> The claim under test is that the successor
 /// reproduces the ancestor's behavior, and "behavior" is what a caller gets from the surface — so both sides go
@@ -25,23 +25,19 @@ namespace HousecarlGenerator;
 /// would be a difference the inventory says is not one; a difference it shows is either matched or an inventoried
 /// intentional divergence, and anything else is a defect in the successor.</para>
 ///
-/// <para><b>Fixture 3 can fail informatively</b>, so its contested-ness is CONSTRUCTED and ASSERTED
-/// here rather than inferred from a tool: two providers for one facegen path (a loose replacer out-sorting a real
-/// BSA), asserted to hold different bytes, with the loose copy asserted to win. Only once that is measured does a
-/// clean diff there STOPS THE RUN. It is not folded, and it is not reported as a pass.</para>
+/// <para><b>Fixture 3 must fail informatively</b>, so its contested-ness is CONSTRUCTED and ASSERTED here rather
+/// than inferred from a tool: two providers for one facegen path (a loose replacer out-sorting a real BSA), asserted
+/// to hold different bytes, with the loose copy asserted to win. Only once that is measured does a clean diff there
+/// stop the run — and it stops it rather than being reported as a pass.</para>
 ///
 /// <para><b>What that stop means, stated honestly.</b> This harness passes <c>source_provider</c> to
-/// <c>bulk_place_asset</c> ITSELF, standing in for the skill, and <c>place_asset</c> is not a tool this branch
-/// changes. So the arm is a FLOW-level claim — "the composed replacement reads the named donor where the ancestor
-/// read the winner" — not proof that a named-donor read was wired here. A clean diff is a reason to go and find
-/// out which of the three moved (the fixture, the flow, or place_asset's source selection); it does not by itself
-/// identify one. The empirical half of this fixture's evidence is Aaron's pass on the live install.</para>
+/// <c>bulk_place_asset</c> ITSELF, standing in for the skill, and it does not change <c>place_asset</c>. So the arm
+/// is a FLOW-level claim — "the composed replacement reads the named donor where the ancestor read the winner" —
+/// not proof that a named-donor read was wired here. A clean diff is a reason to find out which of the three moved
+/// (the fixture, the flow, or place_asset's source selection); it does not by itself identify one.</para>
 ///
-/// <para><b>Fixture 2 compares assets too, since F1.</b> It ran records-only under ruling R1, because the successor
-/// had no disabled-donor asset lane for the ancestor's donor-disk carry to be diffed against; F1 built one, and the
-/// comparison (EMPIRICAL_LEDGER EL-2) is the asset half here. It fails informatively for the same reason fixture 3
-/// does, and by the same construction: its contested path and its donor-only paths are both MEASURED before anything
-/// is compared, so a match cannot be a coincidence and a divergence cannot be a fixture accident.</para>
+/// <para><b>Fixture 2 compares assets too.</b> Its contested path and its donor-only paths are both MEASURED before
+/// anything is compared, so a match cannot be a coincidence and a divergence cannot be a fixture accident.</para>
 ///
 /// Run: dotnet run --project src/housecarl-generator -- copy-differential
 /// </summary>
@@ -121,10 +117,8 @@ public static class CopyDifferentialHarness
             "…and the record the caller ASKED for names the arm that produced it (R2)");
         DiffPatches("clone lane", FindPatch(mods, "F1OldClone"), FindPatch(mods, "F1NewClone"));
 
-        // The skill's Step 1 output, printed in full ONCE. Binding rule from the round-1 incident: a skill step
-        // that describes a tool's output gets RUN before it ships. Three claims in the first draft of the skill
-        // were text nobody had executed, and two of them were false — including a readback section the tool did
-        // not emit at all. Printing it here is cheap and it makes the next author's claim checkable.
+        // The skill's Step 1 output, printed in full ONCE: a skill step that describes a tool's output must be RUN
+        // before it ships, or its claims are text nobody executed. Printing it here makes them checkable.
         Console.WriteLine("  ---- the successor's Step-1 readback, verbatim ----");
         foreach (var line in newClone.Split('\n')) Console.WriteLine("  | " + line.TrimEnd());
         Console.WriteLine("  ---------------------------------------------------");
@@ -160,11 +154,10 @@ public static class CopyDifferentialHarness
         Check(!newBundle.StartsWith("error"), $"attach: the SUCCESSOR's bundle step succeeds ({First(newBundle)})");
         DiffPatches("attach lane", FindPatch(mods, "F1OldAttach"), FindPatch(mods, "F1NewAttach"));
 
-        // ---- the seed-shape boundary REFUSES rather than going quiet (shape ruling (a)) ------------------
+        // ---- the seed-shape boundary REFUSES rather than going quiet ------------------
         // The ancestor has a fixed seed set, so there is no old-vs-new pair to diff here; what the run asserts is
         // that the successor's answer to an unsupported shape is a REFUSAL that names the route, not a silent
-        // no-op and not a wiped list. Asserted in the differential because it is an acceptance claim about the
-        // replacement, and "the suite is green" was true of the silent version too.
+        // no-op and not a wiped list.
         var shape = CopyTools.Copy(svc, donorKey.ToString(), null, new[] { "HeadParts", "Factions" },
                                    new[] { "Race:refuse" }, targetKey.ToString(), null, "F1Shape", null);
         Check(shape.StartsWith("error") && shape.Contains("RankPlacement", StringComparison.Ordinal),
@@ -177,8 +170,8 @@ public static class CopyDifferentialHarness
     }
 
     // ==================================================================================================
-    //  FIXTURE 2 — a DISABLED donor: the off-order read, and the ordered source list read through an
-    //  override. RECORDS ONLY by ruling — the disabled-donor asset lane is not built in this branch.
+    //  FIXTURE 2 — a DISABLED donor: the off-order read, and the ordered source list read through an override,
+    //  plus the asset half below.
     // ==================================================================================================
     static void Fixture2(string root)
     {
@@ -201,9 +194,7 @@ public static class CopyDifferentialHarness
         DiffPatches("disabled donor", oldPatch, newPatch);
 
         // ================================================================================================
-        //  THE ASSET HALF — EL-2. Deferred from PR #346 by ruling R1 because the successor had no
-        //  disabled-donor asset lane to be compared against; F1 built it, and this runs while the
-        //  ancestor still exists to be compared against.
+        //  THE ASSET HALF. It runs only while the ancestor still exists to be compared against.
         // ================================================================================================
         Console.WriteLine();
         Console.WriteLine("  -- EL-2: the deferred asset comparison, per destination path --");
@@ -267,9 +258,9 @@ public static class CopyDifferentialHarness
 
             if (key == "<clone facegeom>")
             {
-                // THE INVENTORIED DIVERGENCE (§12): on a contested path the ancestor reads the VFS winner and
-                // the successor reads the mod the caller named. Its ABSENCE is the failure here — a clean diff
-                // would mean one of the two stopped doing what it is documented to do.
+                // THE INVENTORIED DIVERGENCE: on a contested path the ancestor reads the VFS winner and the
+                // successor reads the mod the caller named. Its ABSENCE is the failure here — a clean diff would
+                // mean one of the two stopped doing what it is documented to do.
                 Check(ob is not null && ob.SequenceEqual(ReplacerMeshBytes),
                     "  the ANCESTOR carried the VFS WINNER's mesh (the replacer's) — the recorded behaviour");
                 Check(nb is not null && nb.SequenceEqual(DonorMeshBytes),
@@ -403,17 +394,15 @@ public static class CopyDifferentialHarness
         // ---- records: a vanilla donor is a transplant in BOTH tools, so the patches should still match ----
         DiffPatches("contested vanilla (records)", FindPatch(mods, "F3Old"), newPatch);
 
-        // ---- the RESPONSE half, which Project() is blind to by construction (inventory F24) --------------
+        // ---- the RESPONSE half, which Project() is blind to by construction --------------
         // Project() compares plugin bytes and the masters list and never the two tools' prose, so a render-level
-        // divergence was invisible to this harness — which is how a base-master donor kept getting a false
-        // standalone claim through three review rounds while every fixture reported NO DIFF. This donor lives in
-        // Dawnguard.esm, so it is exactly that case, and the two renders are compared directly.
+        // divergence — a base-master donor wrongly called a standalone-ization — is invisible to it while every
+        // fixture reports NO DIFF. This donor lives in Dawnguard.esm, so the two renders are compared directly.
         //
-        // Still the transplant case under the CORRECTED condition (F24 is about the bound set being EMPTY, not
-        // about where `from` is defined): this call passes no from_source=, so the universe is ['winner'], and
-        // 'winner' is exempt from binding — the whole load order is not a plugin to copy away from. Name a MOD
-        // here and the bound set stops being empty and the standalone claim becomes the right one; that case is
-        // arm 7h in copy-service-guard, not this one.
+        // Still the transplant case: this call passes no from_source=, so the universe is ['winner'], and 'winner'
+        // is exempt from binding — the whole load order is not a plugin to copy away from. Name a MOD here and the
+        // bound set stops being empty and the standalone claim becomes the right one, which copy-service-guard
+        // covers rather than this harness.
         Check(oldOut.Contains("appearance transplant", StringComparison.Ordinal),
             "the ANCESTOR calls a base-master donor an appearance transplant rather than a standalone-ization");
         Check(newOut.Contains("appearance transplant", StringComparison.Ordinal),
@@ -468,8 +457,8 @@ public static class CopyDifferentialHarness
         var a = Project(oldPath);
         var b = Project(newPath);
         // MULTISET, not set. Except() collapses duplicates, so a patch carrying the SAME projected line twice —
-        // exactly what a double-internalize produces — diffed clean against one carrying it once. The count is the
-        // half that catches a stray duplicate, and this branch had one (a walk that came back round to `from`).
+        // what a double-internalize produces — would diff clean against one carrying it once. The count is the
+        // half that catches a stray duplicate.
         var only = Excess(a, b);
         var extra = Excess(b, a);
         if (only.Count == 0 && extra.Count == 0)
@@ -565,7 +554,7 @@ public static class CopyDifferentialHarness
     /// DISABLED donor. No archive here: see the SCOPE note at the end of <c>Fixture2</c> for why, and for where the
     /// root-archive half of the lane is guarded instead.
     /// <para>Opt-in rather than always-on because fixture 1 asserts against this same tree, and growing it would move
-    /// what a dozen of its arms measure for the sake of a fixture only fixture 2 needs (#333's lesson).</para></summary>
+    /// what a dozen of its arms measure for the sake of a fixture only fixture 2 needs.</para></summary>
     static string BuildInstance(string root, bool donorEnabled, bool withAssets,
         out FormKey donorKey, out FormKey targetKey, out string donorPlugin, out string overrideName)
     {
@@ -582,9 +571,9 @@ public static class CopyDifferentialHarness
         baseMod.Races.Add(new Race(raceA, SkyrimRelease.SkyrimSE) { EditorID = "RaceA" });
         baseMod.Races.Add(new Race(raceB, SkyrimRelease.SkyrimSE) { EditorID = "RaceB" });
         // A shared, ACTIVE armor. It exists so the attach TARGET can carry a WornArmor the donor does NOT — the
-        // case where the ancestor's unconditional assignment CLEARS the target's field. The successor used to
-        // leave the target's value in place and report nothing, which is a face built from two records; nothing in
-        // the earlier fixtures could see it because the donor and the target were unset together.
+        // case where the ancestor's unconditional assignment CLEARS the target's field. A successor that instead
+        // left the target's value in place would build a face out of two records, and no fixture where the donor
+        // and the target are unset together can see that.
         var armorFk = new FormKey(baseKey, 0x802);
         baseMod.Armors.Add(new Armor(armorFk, SkyrimRelease.SkyrimSE) { EditorID = "SharedArmor" });
         WriteMod(mods, "BaseMod", baseMod);
@@ -690,13 +679,14 @@ public static class CopyDifferentialHarness
     }
 
     /// <summary>Every file a patch mod folder holds EXCEPT its plugin, keyed by destination path with the two
-    /// per-side identities folded out: the FaceGen pair's path carries the patch's own plugin name and the clone's
-    /// own FormID, both of which differ between the two runs by construction and neither of which is a behaviour.
-    /// Everything else is compared under its literal path.
+    /// per-side identities normalized away: the FaceGen pair's path carries the patch's own plugin name and the
+    /// clone's own FormID, both of which differ between the two runs by construction and neither of which is a
+    /// behaviour. Everything else is compared under its literal path.
     /// <para><c>meta.ini</c> is excluded and its exclusion is checked rather than assumed. It is MO2 bookkeeping
     /// houseCARL writes for the folder it just made, and it NAMES that folder — so the two runs differ in it for the
-    /// same reason the patch filename differs, which <see cref="Project"/> already folds out on the record side. The
-    /// caller asserts both sides HAVE one, so dropping it cannot hide a side that stopped writing it.</para></summary>
+    /// same reason the patch filename differs, which <see cref="Project"/> already normalizes away on the record
+    /// side. The caller asserts both sides HAVE one, so dropping it cannot hide a side that stopped writing
+    /// it.</para></summary>
     static Dictionary<string, byte[]> CarriedFiles(string? patchFolder, FormKey cloneKey)
     {
         var map = new Dictionary<string, byte[]>(StringComparer.OrdinalIgnoreCase);

--- a/src/housecarl-generator/CorpusGenerator.cs
+++ b/src/housecarl-generator/CorpusGenerator.cs
@@ -9,7 +9,7 @@ using Mutagen.Bethesda.Skyrim;           // IArmorGetter (assembly anchor)
 namespace HousecarlGenerator;
 
 /// <summary>
-/// First-wave step 2 — the cornerstone in code. Walks the entire
+/// The cornerstone in code. Walks the entire
 /// Mutagen.Bethesda.Skyrim type universe via reflection and emits a flat type
 /// catalog covering <b>literally every type Mutagen models</b>: the mod header,
 /// every major record (top-level and nested), every reachable sub-struct, and
@@ -26,13 +26,13 @@ public static class CorpusGenerator
     static readonly List<string> Warnings = new();
 
     /// <summary>
-    /// The #397 coverage-gap anomaly lines, kept in their OWN channel rather than in <see cref="Warnings"/>.
+    /// The coverage-gap anomaly lines, kept in their OWN channel rather than in <see cref="Warnings"/>.
     ///
     /// <see cref="Warnings"/> is an unbounded stream printed under a fixed cap, so a coverage-gap line sharing
-    /// that budget can be truncated away by unrelated warnings that happen to be added first — silently losing
-    /// the one output #397 exists to produce. This channel is printed IN FULL and BEFORE the warnings, so the
-    /// two can never compete for the same budget. It is also the channel the arm-classification-guard's D arm
-    /// reads, so what the guard asserts against is the untruncated set.
+    /// that budget can be truncated away by unrelated warnings added first — silently losing the one output
+    /// this channel exists to produce. It is printed IN FULL and BEFORE the warnings, so the two can never
+    /// compete for the same budget, and it is what arm-classification-guard reads, so the guard asserts
+    /// against the untruncated set.
     /// </summary>
     static readonly List<string> CoverageAnomalies = new();
 
@@ -95,7 +95,7 @@ public static class CorpusGenerator
             }
         }
 
-        // The mod CONTAINER itself (Aaron-go 2026-05-30: in scope). It is neither the header nor a major record,
+        // The mod CONTAINER itself, which is in scope. It is neither the header nor a major record,
         // so record-reachability never reaches it — seed it explicitly. Seeding walks the SkyrimGroup<T> /
         // SkyrimListGroup<T> record-group surface (now handled as collections in IsList), the only path to types
         // like CellBlock. ISkyrimModGetter has two implementers — the writable SkyrimMod and the read-only
@@ -106,8 +106,8 @@ public static class CorpusGenerator
         if (modGetter != null) EnqueueModeledRef(modGetter, seeds);
         else Warnings.Add("ISkyrimModGetter not found — mod container omitted (investigate).");
 
-        // The PEX subsystem (Aaron-go 2026-05-30: in scope; tools prefer .psc source + Papyrus compile, PEX is the
-        // sourceless fallback). Compiled-Papyrus types live in Mutagen.Bethesda.Core, a different assembly than the
+        // The PEX subsystem, also in scope: tools prefer .psc source plus a Papyrus compile, and PEX is the
+        // sourceless fallback. Compiled-Papyrus types live in Mutagen.Bethesda.Core, a different assembly than the
         // Skyrim records, so seed the PEX root (IPexFileGetter) to bring the 16 PEX types into the catalog.
         var pexGetter = typeof(IMajorRecordGetter).Assembly.GetType("Mutagen.Bethesda.Pex.IPexFileGetter");
         if (pexGetter != null) EnqueueModeledRef(pexGetter, seeds);
@@ -123,7 +123,7 @@ public static class CorpusGenerator
         {
             var item = queue.Dequeue();
 
-            // Enums are catalogued as their own kind (decision #6): listed once with their legal values and
+            // Enums are catalogued as their own kind: listed once with their legal values and
             // referenced by name from every field, instead of inlining e.g. ActorValue's 156 values on each
             // of the dozens of fields that use it. An enum's catalog name is its raw type name — enum names
             // don't need the I-/Getter- normalization records and structs go through.
@@ -134,8 +134,8 @@ public static class CorpusGenerator
                 if (catalog.TryGetValue(ename, out var existing))
                 {
                     // Same key + same underlying type = the normal dedup (one enum referenced by many fields).
-                    // Same key + a DIFFERENT type = a residual collision the qualified name failed to resolve —
-                    // fail LOUD (the old code silently skipped enum-vs-enum clashes, the root of the Flag x90 bug).
+                    // Same key + a DIFFERENT type = a collision the qualified name failed to resolve — fail LOUD.
+                    // Silently skipping enum-vs-enum clashes catalogues one enum's values under another's name.
                     if (existing.Kind != "enum" || existing.GetterInterface != efull)
                         Warnings.Add($"Name collision: enum '{ename}' ({efull}) clashes with existing {existing.Kind} '{existing.GetterInterface}' — disambiguate the catalog key.");
                     continue;
@@ -233,12 +233,12 @@ public static class CorpusGenerator
             // DialogResponsesAdapter.ScriptFragments or Npc.Sound) with no new write path. Same Mutagen reflection that
             // builds the write surface, so schema and engine can't disagree. value/enum/formlink already carry correct
             // nullability (Nullable<T> + the FormLinkNullable name-check in ClassifyField).
-            // NOT A REQUIRED-ARM SIGNAL: this poly nullability is a faithful "can this field be absent?", but it is NOT a
-            // "required arm at serialize" predicate, and NO pre-flight gate keys on it. NpcConfiguration.Level reads
-            // Nullable=false yet a null Level serializes fine (nullarm-guard B2), while Condition.Data (also Nullable=false)
-            // throws — same flag, opposite serialize behavior. A gate on the flag would over-reject a legitimately-absent
-            // field or need a hand-curated required-arm list (cornerstone §3), so a genuinely-missing required arm stays
-            // caught at the serialize boundary (WriteEngine.WritePatch's NullArmSerializeException), the honest failure point.
+            // NOT A REQUIRED-ARM SIGNAL: this poly nullability faithfully says "can this field be absent?", but it is
+            // NOT a "required arm at serialize" predicate, and no pre-flight gate may key on it. NpcConfiguration.Level
+            // reads Nullable=false yet a null Level serializes fine, while Condition.Data (also Nullable=false) throws —
+            // same flag, opposite serialize behaviour. A gate on the flag would over-reject a legitimately-absent field,
+            // or need a hand-written required-arm list, which the cornerstone forbids. A genuinely-missing required arm
+            // stays caught at the serialize boundary (WriteEngine.WritePatch's NullArmSerializeException).
             if ((f.Cardinality is "substruct" or "polymorphic") && !f.Nullable
                 && nullCtx.Create(p).ReadState == System.Reflection.NullabilityState.Nullable)
                 f.Nullable = true;
@@ -281,7 +281,7 @@ public static class CorpusGenerator
         }
         if (t.IsEnum)
         {
-            // Reference the enum's catalog entry by name (decision #6); its values live once on that entry
+            // Reference the enum's catalog entry by name; its values live once on that entry
             // and are resolved on demand, not copied onto every field of this enum type. The catalog key is the
             // enum's UNIQUE qualified name (DeclaringType.Name + "." + Name for nested enums), not the bare name:
             // ~90 distinct per-record enums are all named "Flag", and a bare-name catalog silently collapses them
@@ -385,7 +385,7 @@ public static class CorpusGenerator
         // FormLink machinery reaching here as the bare IFormLinkIdentifier (the generic
         // IFormLink<T> is handled above) -> mirror as a form reference, not a struct.
         //
-        // A MAJOR RECORD is cut from that rule first (#335). IMajorRecordGetter itself carries
+        // A MAJOR RECORD is cut from that rule first. IMajorRecordGetter itself carries
         // IFormLinkIdentifier — a record identifies itself (FormKey + Type) exactly the way a link identifies
         // its target — so the bare-link test cannot tell "points at a record" from "IS a record". Every field
         // whose type is a major record is an OWNED CHILD (Cell.Landscape, Worldspace.TopCell): the parent holds
@@ -456,8 +456,8 @@ public static class CorpusGenerator
     /// self-entry is load-bearing for arm DETECTION — it is part of the &gt;1 count that classifies the
     /// union, and dropping it BEFORE the count would demote two-entry unions like ScriptFragments
     /// (<c>[ScriptFragments, SceneScriptFragments]</c>) / SimpleModel (<c>[SimpleModel, Model]</c>)
-    /// back to plain structs, silently losing their real second arm (WRITE_PREFLIGHT_GAP_AUDIT_2026-06-18
-    /// §9). But a base is not a legal arm of ITSELF (the runtime G8 gate already rejects composing one),
+    /// back to plain structs, silently losing their real second arm. But a base is not a legal arm of ITSELF
+    /// (the runtime gate already rejects composing one),
     /// so it must never appear in the emitted list. Strip it here, at emit only, keyed on the base's own
     /// catalog name — detection upstream still counts the raw arm set, so coverage is unchanged.
     /// </summary>
@@ -528,12 +528,11 @@ public static class CorpusGenerator
                     arms.Add(t);
                     break;
                 case ArmClass.WritableButUnextractable:
-                    // #397's Q3 half. This candidate is dropped from the union with the same silence as a
-                    // type that carries nothing, but it is not one: it has settable state, and the drop is
-                    // therefore worth reporting so a human can check it. Whether it is a genuine coverage
-                    // hole is NOT decided here and the line does not claim it — see UnextractableWarning
-                    // and #424. The drop itself is unchanged, and the schema is deliberately NOT extracted
-                    // from the concrete class (see ClassifyArm).
+                    // This candidate is dropped from the union as silently as a type carrying nothing, but it
+                    // is not one: it has settable state, so the drop is reported for a human to check. Whether
+                    // it is a genuine coverage hole is NOT decided here and the line must not claim it — see
+                    // UnextractableWarning. The schema is deliberately NOT extracted from the concrete class
+                    // (see ClassifyArm).
                     if (ReportedUnextractable.Add(t))
                         CoverageAnomalies.Add(UnextractableWarning("union arm", t));
                     break;
@@ -548,9 +547,9 @@ public static class CorpusGenerator
     }
 
     /// <summary>
-    /// Why a concrete union implementer is not an authorable arm — the distinction #397 was filed for.
-    /// Both non-authorable answers are excluded identically (behavior is unchanged by this split); they are
-    /// separated so the emitted anomaly list can tell an exclusion that loses nothing from one that may not.
+    /// Why a concrete union implementer is not an authorable arm. Both non-authorable answers are excluded
+    /// identically; they are separated only so the emitted anomaly list can tell an exclusion that loses
+    /// nothing from one that may not.
     /// </summary>
     internal enum ArmClass
     {
@@ -561,8 +560,8 @@ public static class CorpusGenerator
         ReadOnlyProjection,
         /// <summary>No <c>I{Name}Getter</c> resolved BY NAME, yet the class carries settable state. Reported,
         /// not diagnosed: the name probe misses a type whose getter interface is generic or differently
-        /// named (#424), so this verdict does NOT establish a coverage gap — it establishes that a human
-        /// should check whether the data is reachable elsewhere in the catalogue.</summary>
+        /// named, so this verdict does NOT establish a coverage gap — only that a human should check whether
+        /// the data is reachable elsewhere in the catalogue.</summary>
         WritableButUnextractable,
     }
 
@@ -586,26 +585,24 @@ public static class CorpusGenerator
     /// BookTeachesNothing) — a marker DOES implement its mutable interface, so it stays authorable. It also
     /// leaves a CONCRETE self-listing poly-base (APackageData, ScriptFragments, SimpleModel) in the raw arm
     /// set — those are authorable, so the &gt;1 count is preserved and the self-entry is stripped at emit by
-    /// <see cref="EmittedArmNames"/>, exactly as before.
+    /// <see cref="EmittedArmNames"/>.
     ///
-    /// THE #397 SPLIT. When a getter interface EXISTS, authorability is whether its mutable twin does; no
-    /// twin means a read-only projection, the correct exclusion. When NO getter interface exists, the former
-    /// <c>MutableInterfaceFor(GetterInterfaceFor(t) ?? t)</c> handed the concrete class to
-    /// <see cref="MutableInterfaceFor"/>, whose <c>EndsWith("Getter")</c> test a concrete class never passes —
-    /// so the answer was always "excluded", and "has no getter interface" became indistinguishable in the
-    /// output from "is a read-only projection", though only the second is a correct reason to exclude. That
-    /// conflation is the bug. Split here on whether the class actually carries writable state.
+    /// THE SPLIT. When a getter interface EXISTS, authorability is whether its mutable twin does; no twin
+    /// means a read-only projection, the correct exclusion. When NO getter interface exists, handing the
+    /// concrete class to <see cref="MutableInterfaceFor"/> always answers "excluded" — its
+    /// <c>EndsWith("Getter")</c> test a concrete class never passes — which makes "has no getter interface"
+    /// indistinguishable in the output from "is a read-only projection", though only the second is a correct
+    /// reason to exclude. So split here on whether the class actually carries writable state.
     /// </summary>
     internal static ArmClass ClassifyArm(Type t)
     {
         var gi = GetterInterfaceFor(t);
 
-        // The pre-#397 predicate, reproduced LITERALLY — including the `?? t` fallback, which is load-bearing and
-        // not the dead branch it looks like. A concrete class whose OWN name ends in "Getter"
-        // (FormLinkNullableGetter`1, FormLinkOrIndexGetter`1 in Mutagen.Bethesda.Core) passes
-        // MutableInterfaceFor's arity-stripped EndsWith test and resolves a mutable twin through the fallback,
-        // so it was authorable before and must stay authorable. Computing this from `gi` alone silently flipped
-        // both types; they are in the walk, because BuildCorpus seeds IPexFileGetter from that same assembly.
+        // The `?? t` fallback is load-bearing, not the dead branch it looks like. A concrete class whose OWN name
+        // ends in "Getter" (FormLinkNullableGetter`1, FormLinkOrIndexGetter`1 in Mutagen.Bethesda.Core) passes
+        // MutableInterfaceFor's arity-stripped EndsWith test and resolves a mutable twin through it, so it is
+        // authorable and must stay so. Computing this from `gi` alone silently flips both types, and both are in
+        // the walk because BuildCorpus seeds IPexFileGetter from that same assembly.
         if (MutableInterfaceFor(gi ?? t) != null) return ArmClass.Authorable;
 
         // Not authorable. Everything below only decides WHICH exclusion to report — never whether to exclude.
@@ -618,8 +615,8 @@ public static class CorpusGenerator
     ///
     /// DIAGNOSTIC ONLY, and it decides only which of two ANOMALY LINES is printed — never whether a type is
     /// excluded. It counts against the CONCRETE CLASS, whereas every cataloged entry's writability is computed
-    /// against a MUTABLE INTERFACE (see <see cref="ExtractType"/>). That difference is exactly why #397 rules
-    /// out extracting such a type's schema. The count never reaches the catalog; it only sizes the anomaly.
+    /// against a MUTABLE INTERFACE (see <see cref="ExtractType"/>) — which is why such a type's schema must not
+    /// be extracted. The count never reaches the catalog; it only sizes the anomaly.
     /// </summary>
     static bool HasWritableSurface(Type t) => WritableSurfaceCount(t).writable > 0;
 
@@ -629,8 +626,8 @@ public static class CorpusGenerator
     /// Deliberately NOT <see cref="CollectAllProperties"/>, which the emit path uses (<see cref="ExtractType"/>)
     /// and which this must not perturb: it reads DeclaredOnly and never walks BaseType, so a class inheriting
     /// its state would count zero here and take the deliberately-silent ReadOnlyProjection branch — the silent
-    /// drop #397 exists to remove, in the direction that prints nothing. Keeping the fix classifier-local is why
-    /// this walks itself instead of tightening the shared helper.
+    /// drop this exists to remove, in the direction that prints nothing. Keeping it classifier-local is why this
+    /// walks itself instead of tightening the shared helper.
     ///
     /// The measure is "authorable", and it sits between the two obvious readings — the label the caller prints
     /// says so in both directions, because neither alone describes it. It is NARROWER than
@@ -677,7 +674,7 @@ public static class CorpusGenerator
         "coverage gap.";
 
     /// <summary>
-    /// The anomaly line for a type with no getter interface (#397 part 1).
+    /// The anomaly line for a type with no getter interface.
     ///
     /// It states the MEASUREMENT and nothing else. It deliberately does NOT say the type is a real coverage
     /// gap, and does NOT say the fix belongs upstream in Mutagen — neither is established by "no
@@ -686,8 +683,8 @@ public static class CorpusGenerator
     /// its data ships in the reference today as <c>GenderedItem&lt;Boolean&gt;</c>, 2/2 writable. The name probe
     /// is <c>I{Name}Getter</c> built from <c>Type.Name</c>, which carries the generic arity, so a type whose
     /// getter interface is named differently — or is generic — resolves null here while being perfectly
-    /// extractable. That is a real defect in <see cref="GetterInterfaceFor"/>, filed separately; until it is
-    /// fixed this line must not diagnose, only report, and hand the reader the one check that settles it.
+    /// extractable. That is a real defect in <see cref="GetterInterfaceFor"/>; until it is fixed this line must
+    /// not diagnose, only report, and hand the reader the one check that settles it.
     ///
     /// Shared by the record path and the union-arm path so both name the same thing the same way.
     /// </summary>
@@ -884,14 +881,11 @@ public static class CorpusGenerator
     // ---------------------------------------------------------------- writability guard
     //
     // Companion to Probe's `vocab` check (which guards the mutable-COLLECTION-shape whitelist).
-    // This guards the field-WRITABILITY surface: every field Mutagen models read-only falls into
-    // one of the categories below, verified field-by-field 2026-05-30 against Mutagen 0.53.1 (8424/9087
-    // writable; all 663 read-only accounted for, 0 residue) — a dated measurement, not a current count;
-    // the guard below is dynamic and re-derives the residue on whatever version is referenced.
-    // A non-writable field fitting NONE of them is a possible
-    // regression — a content field that lost its setter via a Mutagen bump or a reflection miss (the
-    // failure mode the generic-getter `1 bug was, CorpusGenerator §MutableInterfaceFor) — and is
-    // surfaced loud in Report's anomaly list, never passed over silently (CLAUDE.md §3 fail-loud).
+    // This guards the field-WRITABILITY surface: every field Mutagen models read-only must fall into one of the
+    // categories below. The guard is dynamic and re-derives the leftovers on whatever Mutagen version is
+    // referenced. A non-writable field fitting NONE of the categories is a possible regression — a content field
+    // that lost its setter to a Mutagen bump, or a reflection miss — and is surfaced loud in Report's anomaly
+    // list, never passed over silently.
     //
     //   R0 identity          — FormKey / ModKey: record identity, read-only by design, any type.
     //   R1 no-mutable-iface  — the type exposes no mutable interface at all (read-only construct:
@@ -1016,7 +1010,7 @@ public static class CorpusGenerator
             sb.AppendLine($"### {t.Name}  _({t.Kind})_");
             sb.AppendLine();
 
-            // Enum entries (decision #6): listed once with their legal values; fields reference them by name.
+            // Enum entries: listed once with their legal values; fields reference them by name.
             if (t.Kind == "enum")
             {
                 sb.AppendLine($"- Values ({t.EnumValues?.Count ?? 0}): {string.Join(", ", t.EnumValues ?? new())}");
@@ -1077,8 +1071,8 @@ public static class CorpusGenerator
             Spotlight(c, name);
 
         // The coverage-gap channel prints FIRST and IN FULL. It deliberately does not share the warning stream's
-        // truncation budget: the warnings are unbounded, so a cap they share is a channel on which the #397 line
-        // can silently vanish behind unrelated noise.
+        // truncation budget: the warnings are unbounded, so a shared cap lets a coverage-gap line vanish silently
+        // behind unrelated noise.
         if (CoverageAnomalies.Count > 0)
         {
             Console.WriteLine($"COVERAGE ANOMALIES ({CoverageAnomalies.Count}) — printed in full, never truncated:");

--- a/src/housecarl-generator/CreateProof.cs
+++ b/src/housecarl-generator/CreateProof.cs
@@ -7,10 +7,10 @@ using HousecarlCore;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// Capability-arc CREATE build proof — exercise <see cref="WritePatchBuilder.CreateRecords"/>, the core the MCP
-/// <c>housecarl_create_record</c> tool calls, so the proof transfers to the server BY CONSTRUCTION (same code path, the
-/// way <see cref="RemoveProof"/> proves removal and <see cref="ApplyProof"/> proves the edit cleave). Each check drives
-/// the core against a LIVE large load order and re-reads the written patch from disk:
+/// Build proof for <see cref="WritePatchBuilder.CreateRecords"/>, the core the <c>housecarl_create_record</c> tool
+/// calls. It must drive the same code path the tool does, or it proves nothing about it (as for
+/// <see cref="RemoveProof"/> and <see cref="ApplyProof"/>). Each check runs against a LIVE large load order and
+/// re-reads the written patch from disk:
 ///
 ///   K1 — FLAT, self-contained: create a Keyword (editorid only) → present on re-read, a fresh LOCAL 0x800+ FormID, and
 ///        a MASTERLESS plugin (references nothing external).
@@ -18,12 +18,12 @@ namespace HousecarlGenerator;
 ///        land via the SAME ApplyVerb path, and the referenced master is DERIVED into the header.
 ///   K3 — EXTEND (into=): create one record fresh, a second into= the same patch → BOTH present, distinct ids (the
 ///        accumulate-across-calls path, re-opening from disk).
-///   K4 — REJECT nested (Q3): create "Cell" (no flat group) → refused loud, NOTHING written.
-///   K5 — REJECT abstract (Q3): create "Global" (abstract T) → refused loud naming concrete subtypes, NOTHING written.
-///   K6 — REJECT no editorid (Q3): create a Keyword with an empty editorid → refused loud, NOTHING written.
+///   K4 — REJECT nested: create "Cell" (no flat group) → refused loud, NOTHING written.
+///   K5 — REJECT abstract: create "Global" (abstract T) → refused loud naming concrete subtypes, NOTHING written.
+///   K6 — REJECT no editorid: create a Keyword with an empty editorid → refused loud, NOTHING written.
 ///
 /// Vanilla masters the proof references are SHA-checked unchanged (create only writes the patch). Patches are left in
-/// write-output/create-proof/ for Aaron to open in xEdit.  Run: dotnet run --project src/housecarl-generator create-proof [maxPlugins]
+/// write-output/create-proof/ to open in xEdit.  Run: dotnet run --project src/housecarl-generator create-proof [maxPlugins]
 /// </summary>
 public static class CreateProof
 {
@@ -83,7 +83,7 @@ public static class CreateProof
             bool localId = created && fk.ID >= 0x800 && string.Equals(fk.ModKey.FileName, Path.GetFileName(outPath), StringComparison.OrdinalIgnoreCase);
             var (cnt, masters) = PatchState(outPath);
             // A self-contained create references nothing, so the DERIVED master set is empty — but every Skyrim plugin
-            // carries the CK baseline masters (Skyrim.esm + Update.esm, Aaron 2026-06-02), force-included by WritePatch.
+            // must carry the CK baseline masters (Skyrim.esm + Update.esm), which WritePatch force-includes.
             bool ckBaseline = cnt == 1 && masters.Count == 2
                 && masters.Any(m => m.Equals("Skyrim.esm", StringComparison.OrdinalIgnoreCase))
                 && masters.Any(m => m.Equals("Update.esm", StringComparison.OrdinalIgnoreCase));
@@ -136,7 +136,7 @@ public static class CreateProof
                 $"s1={YN(s1.Success)} s2-extended={YN(s2.Extended)} both-present={YN(aPresent && bPresent)} distinct={YN(distinct)} count={cnt}"));
         }
 
-        // ===================== K4 — REJECT nested (Q3, no write) =====================
+        // ===================== K4 — REJECT nested (no write) =====================
         {
             var outPath = Path.Combine(outDir, "houseCARL_CreateProof_K4.esp");
             var o = WritePatchBuilder.CreateRecords(resolver, rulebook,
@@ -149,7 +149,7 @@ public static class CreateProof
             results.Add(("K4 reject nested (Cell)", pass, $"refused={YN(refused)} msg-named={YN(named)} no-file={YN(noFile)}"));
         }
 
-        // ===================== K5 — REJECT abstract (Q3, no write) =====================
+        // ===================== K5 — REJECT abstract (no write) =====================
         {
             var outPath = Path.Combine(outDir, "houseCARL_CreateProof_K5.esp");
             var o = WritePatchBuilder.CreateRecords(resolver, rulebook,
@@ -162,7 +162,7 @@ public static class CreateProof
             results.Add(("K5 reject abstract (Global)", pass, $"refused={YN(refused)} msg-named={YN(named)} no-file={YN(noFile)}"));
         }
 
-        // ===================== K6 — REJECT no editorid (Q3, no write) =====================
+        // ===================== K6 — REJECT no editorid (no write) =====================
         {
             var outPath = Path.Combine(outDir, "houseCARL_CreateProof_K6.esp");
             var o = WritePatchBuilder.CreateRecords(resolver, rulebook,

--- a/src/housecarl-generator/HandLiteralLexer.cs
+++ b/src/housecarl-generator/HandLiteralLexer.cs
@@ -107,6 +107,8 @@ public static class HandLiteralLexer
         // A run of three or more quotes opens a RAW literal only when the literal is not VERBATIM. C# has no
         // @"""x""" form: that is a verbatim string whose first character is an escaped quote, and reading it as
         // raw either hands back the wrong text or runs off looking for a three-quote terminator that never comes.
+        // The generator tree is NOT in the guard's scan set and is where that shape is common, so getting this
+        // wrong shows up nowhere: the scanned trees hold the raw and verbatim forms but no @""" to trip on.
         var (text, end) = quoteRun >= 3 && !verbatim
             ? LexRaw(src, quote, quoteRun, to, dollars, depth, outp, holeEnds)
             : LexRegular(src, quote, to, dollars > 0, verbatim, depth, outp, holeEnds);

--- a/src/housecarl-generator/HandLiteralLexer.cs
+++ b/src/housecarl-generator/HandLiteralLexer.cs
@@ -6,28 +6,26 @@ namespace HousecarlGenerator;
 /// READER B — a second, independent statement of "what string literals does this C# file contain", written from
 /// the language's lexical grammar rather than derived from <see cref="RoslynLiteralReader"/>.
 ///
-/// <para><b>Why a second reader exists at all.</b> <c>description-vocab-guard</c> claims its net is every shipped
-/// literal. Both earlier designs of that guard shipped a completeness ARM whose oracle came out of the same
-/// machinery it was certifying, and both were measured green over prose they could not see (#386, two §4
-/// class-stops). The rule that came out of it: a completeness claim needs a SECOND SPELLING. So this file exists
-/// to disagree with Roslyn — <c>INV6-AGREE</c> holds the two literal sets against each other per file, and a
-/// reader that stops early, mis-decodes an escape, or misses a literal inside an interpolation hole turns that arm
-/// red with the file named.</para>
+/// <para><b>Why a second reader exists.</b> <c>description-vocab-guard</c> claims its net is every shipped
+/// literal, and a completeness claim checked by the machinery it certifies proves nothing. So this file must be a
+/// SECOND SPELLING that can disagree with Roslyn: <c>INV6-AGREE</c> holds the two literal sets against each other
+/// per file, and a reader that stops early, mis-decodes an escape, or misses a literal inside an interpolation
+/// hole turns that arm red with the file named.</para>
 ///
-/// <para><b>What "independent" means here, precisely.</b> No code is shared with reader A beyond
+/// <para><b>What "independent" means here.</b> No code may be shared with reader A beyond
 /// <see cref="SourceLiteral"/>, which is a record — a data shape, carrying no opinion about what a literal is.
 /// This lexer is written against the C# lexical grammar directly: the four regular literal flavours (plain,
 /// verbatim <c>@</c>, interpolated <c>$</c>, and both together in either order), raw string literals of any quote
-/// count, the <c>u8</c> suffix, backslash escape decoding including the numeric forms, and — the shape the second
-/// design was class-stopped for — RECURSION INTO INTERPOLATION HOLES, so a literal in a ternary arm inside
-/// <c>$"…{c ? "a" : "b"}…"</c> is read at depth 1 rather than being invisible.</para>
+/// count, the <c>u8</c> suffix, backslash escape decoding including the numeric forms, and RECURSION INTO
+/// INTERPOLATION HOLES, so a literal in a ternary arm inside <c>$"…{c ? "a" : "b"}…"</c> is read at depth 1
+/// rather than being invisible.</para>
 ///
 /// <para><b>Escape decoding is a correctness surface, not a detail.</b> <c>—</c> is how an em dash reaches a
 /// tool description, and a reader that decoded it as the letter <c>u</c> would hold a different string from the
-/// one the compiler builds. <c>\uD83D</c> is a LONE SURROGATE, which C# permits in a string literal — the second
-/// design fed it to <c>char.ConvertFromUtf32</c>, which throws, and the throw collapsed all 38 arms of the guard
-/// while naming no file. <c>\u</c> and <c>\x</c> therefore produce one UTF-16 code unit each, exactly as the
-/// compiler does; only <c>\U</c> composes a surrogate pair.</para>
+/// one the compiler builds. <c>\uD83D</c> is a LONE SURROGATE, which C# permits in a string literal, so handing
+/// it to <c>char.ConvertFromUtf32</c> throws and takes the whole run down naming no file. <c>\u</c> and
+/// <c>\x</c> therefore produce one UTF-16 code unit each, exactly as the compiler does; only <c>\U</c> composes
+/// a surrogate pair.</para>
 /// </summary>
 public static class HandLiteralLexer
 {
@@ -109,10 +107,6 @@ public static class HandLiteralLexer
         // A run of three or more quotes opens a RAW literal only when the literal is not VERBATIM. C# has no
         // @"""x""" form: that is a verbatim string whose first character is an escaped quote, and reading it as
         // raw either hands back the wrong text or runs off looking for a three-quote terminator that never comes.
-        // Measured, so the reason is not hypothetical: the scanned trees hold NO @""" today, but they do hold the
-        // raw and verbatim forms this has to tell apart, and SkseConfigReferenceExtractor.cs is IN one of them
-        // (src/housecarl-core) rather than near one. The generator tree - deliberately not scanned - is full of
-        // the shape, which is where a reader that got this wrong would first be noticed and then not be caught.
         var (text, end) = quoteRun >= 3 && !verbatim
             ? LexRaw(src, quote, quoteRun, to, dollars, depth, outp, holeEnds)
             : LexRegular(src, quote, to, dollars > 0, verbatim, depth, outp, holeEnds);
@@ -145,7 +139,7 @@ public static class HandLiteralLexer
                 if (c == '\\') { j = Unescape(src, j, to, sb); continue; }
                 if (c == '"') { j++; break; }
                 // An unterminated literal is a compile error the parse arm reports; stop at the line end rather
-                // than consuming the rest of the file, which is how the previous design lost whole files.
+                // than consuming the rest of the file, which would silently lose every literal after it.
                 if (c == '\n') { j++; break; }
             }
             if (interpolated && c == '{')
@@ -169,8 +163,7 @@ public static class HandLiteralLexer
     /// <para>A run LONGER than the opener count is a brace of content followed by the opener, not a wider opener:
     /// the extra braces are emitted as text and only the last <paramref name="dollars"/> of the run start the
     /// hole. Taking the whole run as the opener drops those characters, and because a brace is not a letter the
-    /// loss is invisible to the phrase check — it surfaces only as an INV6-AGREE disagreement, which is exactly
-    /// how it was found.</para></summary>
+    /// loss is invisible to the phrase check — it surfaces only as an INV6-AGREE disagreement.</para></summary>
     static (string Text, int End) LexRaw(string src, int quote, int quoteRun, int to, int dollars, int depth, List<SourceLiteral> outp, Dictionary<(int From, int To), int> holeEnds)
     {
         int j = quote + quoteRun, close = -1;
@@ -213,10 +206,9 @@ public static class HandLiteralLexer
     /// is why an indented raw fixture holds the string its author meant rather than the source's indentation. A
     /// single-line raw literal has no such rule and is taken as written.
     /// <para>The line TERMINATORS the source used are kept, not normalized — the compiler keeps them, so a reader
-    /// that normalized would hold a different string from the one the program prints, and the two readers would
-    /// disagree about every multi-line raw literal in a CRLF checkout. That matters here specifically: this repo
-    /// is developed on Windows with git's CRLF conversion on, so the same committed file is LF in one working tree
-    /// and CRLF in another. Which is why the terminators are captured and replayed rather than assumed to be
+    /// that normalized would hold a different string from the one the program prints. This repo is developed on
+    /// Windows with git's CRLF conversion on, so the same committed file is LF in one working tree and CRLF in
+    /// another; the terminators are therefore captured and replayed rather than assumed to be
     /// <c>\n</c>.</para></summary>
     static string StripRawIndent(string content)
     {
@@ -242,11 +234,9 @@ public static class HandLiteralLexer
     /// inside a nested literal does not end the hole early.
     /// <para><b>Memoized per file, and that is not an optimization — it is what makes the reader terminate.</b>
     /// Finding a hole's end LEXES everything inside it (into a sink, for skipping); the caller then hands the same
-    /// span to <see cref="Scan"/>, which lexes it again to emit. Every nesting level therefore did its subtree's
-    /// work twice, so cost was 2ⁿ in nesting depth: measured on this branch, a legal 296-byte file nested 28 deep
-    /// took the whole guard from 1.8s to 21.1s, and each further level doubles it. Nothing bounded the depth and
-    /// nothing timed out, so a file a few characters longer was an unkillable CI job rather than a failure anyone
-    /// could read.</para>
+    /// span to <see cref="Scan"/>, which lexes it again to emit. Without the cache every nesting level does its
+    /// subtree's work twice, so cost is exponential in nesting depth, and nothing bounds the depth or times out —
+    /// a legal file nested a few levels deeper is then an unkillable job rather than a readable failure.</para>
     /// <para>Keyed on <c>(from, to)</c> because the bound varies between callers, and it is a plain dictionary
     /// created in <see cref="Read"/> and threaded down rather than a static: a cache keyed by source INDEX is only
     /// valid for the one string it was built for, and a static one would silently answer for the wrong file. With
@@ -323,9 +313,9 @@ public static class HandLiteralLexer
         {
             'n' => '\n', 't' => '\t', 'r' => '\r', '0' => '\0',
             'a' => '\a', 'b' => '\b', 'f' => '\f', 'v' => '\v',
-            // \e is C# 13's ESCAPE (U+001B). Reader A parses at LanguageVersion.Preview and decodes it; without
-            // this arm reader B fell through to the identity case below and appended a letter 'e', so an ANSI
-            // colour sequence in console prose would make the two disagree about text neither had lost.
+            // \e is C# 13's ESCAPE (U+001B). Reader A parses at LanguageVersion.Preview and decodes it, so without
+            // this arm reader B falls through to the identity case below, appends a letter 'e', and the two
+            // disagree over any ANSI colour sequence in console prose.
             'e' => '\u001b',
             _ => next,
         });

--- a/src/housecarl-generator/LocalizedShapeSweep.cs
+++ b/src/housecarl-generator/LocalizedShapeSweep.cs
@@ -4,14 +4,9 @@ using HousecarlMcp;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// A3 (advisor directive, 2026-08-26): classify every localized plugin in a REAL load order into the strings shapes
-/// and count them. It priced who the localized in-place write actually served — the ruling's own "what would make
-/// this wrong" line turned on this table, so the numbers rode the branch rather than a guess.
-///
-/// <para>The in-place write was then cut for EVERY shape, so the table no longer prices an allowed lane: it prices
-/// the population a refusal has to describe accurately. The column that used to read ALLOW / REFUSE names the refusal
-/// FAMILY instead, and the plugins houseCARL could not OPEN are counted as their own number rather than added to
-/// "flagged localized" — which was a claim about each of them that nothing established.</para>
+/// Classify every localized plugin in a REAL load order into the strings shapes and count them — the population a
+/// refusal message has to describe accurately. The in-place write is refused for EVERY shape, so what differs per
+/// row is the refusal FAMILY, not whether the write is allowed.
 ///
 /// <para>Read-only: opens each plugin's header, enumerates its Strings folder, and opens an adjacent .bsa only when one
 /// is present. Nothing is written.</para>
@@ -58,10 +53,8 @@ public static class LocalizedShapeSweep
             l.Add(name + Detail(a));
         }
 
-        // BROKEN OUT, not summed. "N flagged localized" over every non-NotLocalized shape counts the plugins houseCARL
-        // could not OPEN as localized ones — a claim about each of them that nothing established — and the sweep's
-        // whole job is pricing the population, so the plugins it could not read are their own number rather than
-        // padding for someone else's.
+        // Broken out, not summed: a plugin houseCARL could not OPEN is not evidence that it is localized, so it gets
+        // its own number instead of padding the localized count.
         int localized = counts.Where(kv => LocalizedStrings.ConfirmedLocalized(kv.Key)).Sum(kv => kv.Value.Count);
         int unreadable = counts.Where(kv => !LocalizedStrings.ConfirmedLocalized(kv.Key)).Sum(kv => kv.Value.Count);
         Console.WriteLine($"instance : {instance}");
@@ -73,11 +66,8 @@ public static class LocalizedShapeSweep
         {
             if (shape == LocalizedShape.NotLocalized) continue;
             var l = counts.TryGetValue(shape, out var x) ? x : new List<string>();
-            // NOT A VERDICT COLUMN ANY MORE. It printed ALLOW for LooseComplete, from before the in-place write was
-            // cut for EVERY shape — so the one row labelled ALLOW was the row the branch specifically refuses, and
-            // anyone re-running this after the cut would read "ALLOW LooseComplete 1" and conclude houseCARL will
-            // rewrite ksws07_quest.esm in place. It will not. What differs per row now is the refusal FAMILY, so that
-            // is what the column carries.
+            // Not a verdict column: the in-place write is refused for every shape here, so the column names which
+            // refusal applies, never whether one does.
             var family = LocalizedStrings.ConfirmedLocalized(shape) ? "REFUSE localized " : "REFUSE unreadable";
             Console.WriteLine($"  {family} {shape,-27} {l.Count}");
         }

--- a/src/housecarl-generator/LocalizedStringsFixture.cs
+++ b/src/housecarl-generator/LocalizedStringsFixture.cs
@@ -6,7 +6,7 @@ using Mutagen.Bethesda.Skyrim;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// Shared fixture for the localized-strings arms of the merge and compact service guards (#362). Builds a synthetic MO2
+/// Shared fixture for the localized-strings arms of the merge and compact service guards. Builds a synthetic MO2
 /// instance in the shape the bug needs and nothing else:
 ///
 ///   • a real (empty) <c>Skyrim.esm</c> in the game-Data folder — WITHOUT it <c>LoadOrderResolver.ComputeDataDir</c>
@@ -18,8 +18,8 @@ namespace HousecarlGenerator;
 ///     localized plugin whose own folder carries no strings source — the "Cleaned Base Game Masters" / translation-mod
 ///     pattern, and exactly the read the bare overlay gets wrong.
 ///
-/// A spec with <see cref="Spec.StringsNowhere"/> has its strings DELETED instead of relocated: the residual case, where
-/// the strings exist in neither the plugin's own folder nor game-Data, so no <c>dataDir</c> can resolve them.
+/// A spec with <see cref="Spec.StringsNowhere"/> has its strings DELETED instead of relocated: the case where they
+/// exist in neither the plugin's own folder nor game-Data, so no <c>dataDir</c> can resolve them.
 /// </summary>
 internal static class LocalizedStringsFixture
 {
@@ -27,17 +27,16 @@ internal static class LocalizedStringsFixture
     /// <param name="Key">The plugin's ModKey.</param>
     /// <param name="Name">The localized FULL the weapon carries.</param>
     /// <param name="Desc">The localized DESC the weapon carries.</param>
-    /// <param name="StringsNowhere">Delete the strings rather than relocating them to game-Data (the residual case).</param>
+    /// <param name="StringsNowhere">Delete the strings rather than relocating them to game-Data, so nothing can resolve them.</param>
     /// <param name="LinksTo">A record in an EARLIER spec's plugin to point a FormList at — the external-referencer
     /// shape. The link makes that plugin a declared master of this one, which is what puts this plugin in the
     /// identify pass's answer when the other one is compacted.</param>
-    /// <param name="Localized">Build this one NON-localized. Needed because the in-place lanes now refuse a localized
-    /// plugin outright: an arm about the REFERENCER check has to give the operation a target it will accept, or the
-    /// target check answers first and the arm measures that instead of what it is named for.</param>
+    /// <param name="Localized">Build this one NON-localized. The in-place lanes refuse a localized plugin outright, so
+    /// an arm about the REFERENCER check must give the operation a target it will accept — otherwise the target check
+    /// answers first and the arm measures that instead.</param>
     /// <param name="StringsBeside">LEAVE the strings in the plugin's own folder rather than relocating them to
     /// game-Data. That is the one shape a write may commit rewritten tables for, so an arm about the ACCEPTED path
-    /// needs it — the relocated default is a shape the write refuses, and an arm built on it would be measuring the
-    /// refusal.</param>
+    /// needs it; the relocated default is a shape the write refuses.</param>
     /// <param name="SecondLanguage">Also carry a French value, so a claim about a multi-language plugin surviving a
     /// compaction rests on a language something actually reads back.</param>
     internal sealed record Spec(string ModFolder, ModKey Key, string Name, string Desc, bool StringsNowhere = false,
@@ -135,9 +134,8 @@ internal static class LocalizedStringsFixture
                     var target = Path.Combine(data, "Strings");
                     Directory.CreateDirectory(target);
                     // GetFiles, not EnumerateFiles: the loop MOVES files out of the directory it is walking, and a lazy
-                    // enumerator can skip an entry under that mutation — which the Delete below would then destroy rather
-                    // than relocate. It fails toward a RED arm rather than a false green, but a flaky fixture is worse
-                    // than either.
+                    // enumerator can skip an entry under that mutation — which the Delete below would then destroy
+                    // rather than relocate.
                     foreach (var f in Directory.GetFiles(own)) File.Move(f, Path.Combine(target, Path.GetFileName(f)));
                     Directory.Delete(own, true);
                 }
@@ -174,7 +172,7 @@ internal static class LocalizedStringsFixture
     /// <summary>Read a written plugin's weapon FULL/DESC back with the BARE overlay — deliberately bare, and deliberately
     /// from the OUTPUT's own folder. Merge and compact both build a fresh, NON-localized <c>SkyrimMod</c>, so a correct
     /// output carries its strings INLINE and this read must see them with no dataDir and no strings folder anywhere near
-    /// it. A read that comes back empty here is the blanking #362 describes, whichever end produced it.</summary>
+    /// it. A read that comes back empty here is the string-blanking bug, whichever end produced it.</summary>
     internal static (string? Name, string? Desc) ReadBackBare(string pluginPath, string weaponEdid)
     {
         using var ov = SkyrimMod.CreateFromBinaryOverlay(pluginPath, SkyrimRelease.SkyrimSE);

--- a/src/housecarl-generator/Mo2OrderHarness.cs
+++ b/src/housecarl-generator/Mo2OrderHarness.cs
@@ -2,11 +2,10 @@ using Mutagen.Bethesda.Plugins;
 
 namespace HousecarlGenerator;
 
-// MCP step §8.5: verify Mo2LoadOrder.Build against a real profile's files (loadorder.txt + modlist.txt +
-// plugins.txt). Proves the static-file reader produces a sane true order — masters first, the user's top-priority
-// patches last, the ~110 duplicate-name plugins resolved to a real winning path — then feeds it to the real
-// LoadOrderResolver and spot-checks the depth-879 sanity record. This is the Phase-1 empirical gate before the
-// server consumes it; Phase 2 is Aaron's xEdit winner-IDENTITY cross-check.
+// Verify Mo2LoadOrder.Build against a real profile's files (loadorder.txt + modlist.txt + plugins.txt): masters
+// first, the user's top-priority patches last, the ~110 duplicate-name plugins resolved to a real winning path.
+// Then feed that order to the real LoadOrderResolver and spot-check one deep record. Needs a live MO2 instance,
+// so it is a manual harness, not a CI probe.
 //
 //   dotnet run --project src/housecarl-generator mo2-order [profileDir] [modsDir] [dataDir]
 static class Mo2OrderHarness
@@ -57,7 +56,7 @@ static class Mo2OrderHarness
             foreach (var w in result.Warnings.Take(10)) Console.WriteLine($"  - {w}");
         }
 
-        // Feed the true order into the REAL resolver and spot-check it stands up + the §8.5 sanity record.
+        // Feed the true order into the REAL resolver and spot-check that it stands up.
         Console.WriteLine("\nbuilding LoadOrderResolver on the true order...");
         var rsw = System.Diagnostics.Stopwatch.StartNew();
         using var resolver = LoadOrderResolver.Build(paths);
@@ -70,14 +69,14 @@ static class Mo2OrderHarness
             foreach (var f in resolver.LoadFailures.Take(5)) Console.WriteLine($"    - {f}");
         }
 
-        // §8.5 sanity record: the deepest-known Worldspace 00003C:Skyrim.esm (depth ~879 in the placeholder order).
+        // Sanity record: the deepest-known Worldspace, 00003C:Skyrim.esm.
         var sanity = FormKey.Factory("00003C:Skyrim.esm");
         var winner = resolver.ResolveWinner(sanity);
         Console.WriteLine(winner is null
             ? $"\n00003C:Skyrim.esm  -> NOT FOUND (unexpected)"
             : $"\n00003C:Skyrim.esm  winner={winner.Value.WinnerPlugin}  override_depth={winner.Value.OverrideDepth}");
 
-        // Sanity assertions (loud, not silent) — the cheap structural checks; xEdit identity is Phase 2.
+        // Structural sanity only — that the winners are the RIGHT records is checked against xEdit by hand.
         bool firstIsMaster = paths.Count > 0 && Path.GetFileName(paths[0]).Equals("Skyrim.esm", StringComparison.OrdinalIgnoreCase);
         bool plausibleCount = result.ResolvedCount > 3000;
         Console.WriteLine($"\nchecks: first==Skyrim.esm={firstIsMaster}  resolved>3000={plausibleCount}  resolved==active={result.ResolvedCount == result.ActiveCount}");

--- a/src/housecarl-generator/MultiMasterProof.cs
+++ b/src/housecarl-generator/MultiMasterProof.cs
@@ -9,21 +9,19 @@ using HousecarlCore;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// MCP step (Beat C de-risk) — prove the MULTI-MASTER write path BEFORE building set_field/bulk_apply on it.
+/// Prove the MULTI-MASTER write path that set_field/bulk_apply are built on.
 ///
-/// The standalone <c>patch</c> harness opens ONE plugin, so it can only ever hand the serializer one known master
-/// (the "single-master limit"). That was always an artifact of one-plugin-open, not a wall: the write-proof
-/// serializes cross-master refs byte-identical-to-native by handing the writer the FULL master set. This mode
-/// prototypes the real MCP write path and proves the central modding case Aaron named — a MERGE patch:
+/// The standalone <c>patch</c> harness opens ONE plugin, so it can only ever hand the serializer one known master.
+/// That limit is an artifact of opening one plugin, not of the writer: given the FULL master set, cross-master refs
+/// serialize byte-identical to native. This mode builds the central case, a MERGE patch:
 ///
 ///   build the load-order resolver (every plugin held open as an overlay)
 ///   → take a leveled list DEFINED in a vanilla master (so the only cross-master refs are the ones we add)
-///   → MERGE one weapon entry from each of N distinct mods into it (struct-element Add-from-parts, Phase-6 shape)
+///   → MERGE one weapon entry from each of N distinct mods into it (struct-element Add-from-parts)
 ///   → serialize with the resolver's FULL overlay set as known masters (WriteEngine's multi-master WritePatch)
 ///   → emit ONE reviewable .esp whose header lists EVERY referenced master; sources stay byte-untouched (SHA-checked).
 ///
-/// Aaron opens it in xEdit and confirms the masters + the merged entries. This is the empirical gate that turns the
-/// "inherited fail-loud boundary" into a CLOSED capability the write tools then ride.
+/// The output is checked in xEdit by hand for the masters and the merged entries.
 ///
 /// Run: dotnet run --project src/housecarl-generator multimaster-patch [maxPlugins]
 /// </summary>
@@ -96,7 +94,7 @@ public static class MultiMasterProof
         foreach (var it in crossItems) Console.WriteLine($"      + {it}   (adds master {it.ModKey.FileName})");
         Console.WriteLine();
 
-        // ---- BUILD the Add-entry requests (struct-element Add-from-parts — the proven Phase-6 composition shape). ----
+        // ---- BUILD the Add-entry requests (struct-element Add-from-parts). ----
         var reqs = crossItems.Select(it => new WriteRequest
         {
             RecordType = "LeveledItem",
@@ -114,7 +112,7 @@ public static class MultiMasterProof
             }
         }).ToList();
 
-        // ---- PRE-FLIGHT every request (Q3): refuse to write if ANY rejects. ----
+        // ---- PRE-FLIGHT every request: refuse to write if ANY rejects. ----
         var rulebook = CorpusRulebook.Load();
         var rejects = reqs.Select(r => rulebook.Validate(r)).Where(x => x is not null).ToList();
         if (rejects.Count > 0)
@@ -145,7 +143,7 @@ public static class MultiMasterProof
         catch (Exception ex) { Console.Error.WriteLine($"error: could not override {baseFk} — {ex.Message}"); return 1; }
         foreach (var r in reqs) WriteEngine.ApplyVerb(ov, r);
 
-        // ---- WRITE with the FULL known-master set (the multi-master capability). Time it (measure-first). ----
+        // ---- WRITE with the FULL known-master set, timed. ----
         var sww = Stopwatch.StartNew();
         try { WriteEngine.WritePatch(patchMod, session.AllMasters(), outPath); }
         catch (Exception ex)

--- a/src/housecarl-generator/NestedCreateProof.cs
+++ b/src/housecarl-generator/NestedCreateProof.cs
@@ -7,22 +7,21 @@ using HousecarlCore;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// NESTED-CREATE build proof (nested/dialogue plan, Layer A) — exercises the REAL
-/// <see cref="WritePatchBuilder.CreateRecords"/> (the core the MCP create tool calls) on its NESTED path, so the
-/// proof transfers to the server by construction (the way <see cref="CreateProof"/> proves flat create). Where
-/// STEP 0's scout proved the Mutagen PRIMITIVE in isolation, this proves the mechanism THROUGH the production cleave —
-/// parent override → NestedAddNew → ApplyVerb → multi-master serialize → re-open from disk.
+/// Build proof for the NESTED path of <see cref="WritePatchBuilder.CreateRecords"/>, the core the create tool calls
+/// (<see cref="CreateProof"/> covers the flat path). It must drive the whole production chain — parent override →
+/// NestedAddNew → ApplyVerb → multi-master serialize → re-open from disk — not the Mutagen primitive in isolation,
+/// or it proves nothing about the tool.
 ///
-///   N1 — ONE-SHOT (the unit Aaron confirmed): a DialogTopic (flat) + a DialogResponses/INFO under it (same-call
+///   N1 — ONE-SHOT: a DialogTopic (flat) + a DialogResponses/INFO under it (same-call
 ///        sibling parent) in ONE call → re-open: the INFO is in the NEW topic's Responses, both ids local 0x800+.
 ///   N2 — INFO into an EXISTING topic (FormKey parent): the topic is overridden into the patch carrying its
 ///        original lines, the new INFO appended → re-open: new INFO present AND the original responses survive.
-///   N3 — PlacedObject into an EXISTING Cell, collection='Persistent' (the outcome-(ii) named discriminator) →
+///   N3 — PlacedObject into an EXISTING Cell, collection='Persistent' (the named discriminator) →
 ///        re-open: the new ref is in the cell's Persistent list.
-///   N4 — REJECT a nested type with NO parent (Q3): create 'DialogResponses' alone → refused, names the need for a parent.
-///   N5 — REJECT a parent that can't contain the child (Q3): 'DialogResponses' under a WEAPON FormKey → refused loud.
-///   N6 — REJECT an ambiguous add-target (Q3): 'PlacedObject' into a Cell with NO collection= → refused, names the lists.
-///   N7 — REJECT a forward sibling parent (Q3): an INFO whose parent sibling is declared LATER → refused, the order rule.
+///   N4 — REJECT a nested type with NO parent: create 'DialogResponses' alone → refused, names the need for a parent.
+///   N5 — REJECT a parent that can't contain the child: 'DialogResponses' under a WEAPON FormKey → refused loud.
+///   N6 — REJECT an ambiguous add-target: 'PlacedObject' into a Cell with NO collection= → refused, names the lists.
+///   N7 — REJECT a forward sibling parent: an INFO whose parent sibling is declared LATER → refused, the order rule.
 ///
 /// Vanilla Skyrim.esm is SHA-checked unchanged (create only writes the patch). Patches land in
 /// write-output/nested-create-proof/ for xEdit.  Run: dotnet run --project src/housecarl-generator nested-create-proof [Skyrim.esm]
@@ -88,11 +87,10 @@ public static class NestedCreateProof
         }
 
         // ===================== N2 — INFO into an EXISTING topic (FormKey parent) =====================
-        //   ASSERTS THE MECHANISM only (the new child is allocated + placed under the overridden parent + local id).
+        //   Asserts the MECHANISM only: the new child is allocated, placed under the overridden parent, local id.
         //   It does NOT assert "the parent's existing children survive" — overriding the parent yields an override
-        //   carrying ONLY the new child (sibChildren below). Whether that's correct (Skyrim merges children across
-        //   plugins by record) or lossy (the override replaces the child list) is the merge-vs-replace SEMANTIC,
-        //   reported as an OPEN QUESTION below — NOT decided by guessing (evidence-first, §4).
+        //   carrying ONLY the new child. Whether Skyrim merges children across plugins or the override replaces the
+        //   child list is still unestablished, so it is reported below rather than asserted either way.
         int n2OverrideCount = -1;
         {
             var outPath = Path.Combine(outDir, "houseCARL_NestedCreate_N2.esp");
@@ -112,9 +110,9 @@ public static class NestedCreateProof
                 $"created={YN(ok)} new-info-present={YN(present)} local-id={YN(local)} | override-carries={(responses?.Count ?? -1)} of {origResponses + 1} (orig+new) [merge-semantic: OPEN]{Err(o)}"));
         }
 
-        // ===================== N3 — PlacedObject into an existing Cell, collection='Persistent' (outcome ii) =====================
+        // ===================== N3 — PlacedObject into an existing Cell, collection='Persistent' =====================
         //   Same as N2: asserts the MECHANISM (ref allocated + in the cell's Persistent + local id). The override
-        //   carries only the new ref (not the cell's other 28) — the merge-vs-replace OPEN QUESTION, not asserted.
+        //   carries only the new ref, not the cell's other 28 — the same unestablished question, not asserted.
         int n3OverrideCount = -1;
         {
             var outPath = Path.Combine(outDir, "houseCARL_NestedCreate_N3.esp");
@@ -158,11 +156,10 @@ public static class NestedCreateProof
                 $"created={(o.Success ? o.Created.Count : 0)} both-under-topic={YN(bothUnder)} L2.Prompt=\"{prompt}\" field-landed={YN(fieldLanded)} distinct-ids={YN(distinct)}{Err(o)}"));
         }
 
-        // ===================== N9 — extend= with a parent CARRIED BY THE PATCH (the former gap, now SUPPORTED) =====================
+        // ===================== N9 — extend= with a parent CARRIED BY THE PATCH =====================
         //   Create a topic (call 1), then add an INFO under it in a SEPARATE into= call (call 2). The parent topic lives
-        //   in the PATCH, not the load order — resolved from the patch being extended (Phase 0 opens the patch before
-        //   pre-flight). Asserts the INFO lands under the patch-carried topic; and a GENUINELY-absent parent (in neither
-        //   the load order nor the patch) still refuses LOUD, naming both (Q3).
+        //   in the PATCH, not the load order, so it resolves only because the patch being extended is opened before
+        //   pre-flight. Asserts the INFO lands under it, and that a parent absent from BOTH still refuses loud.
         {
             var outPath = Path.Combine(outDir, "houseCARL_NestedCreate_N9.esp");
             var s1 = WritePatchBuilder.CreateRecords(resolver, rulebook,

--- a/src/housecarl-generator/PreFlattenSurface.cs
+++ b/src/housecarl-generator/PreFlattenSurface.cs
@@ -11,11 +11,8 @@ namespace HousecarlGenerator;
 /// the real input to both published-schema passes, read the way the server gets it.
 ///
 /// <para>Why it exists: a guard whose claim is about a POPULATION must read that population, not a hand-written
-/// stand-in for it. Both callers previously named their subjects — the expansion arm walked one of the five
-/// ref-carrying tools, and the emission-grammar arm re-derived standalone schemas for six hand-named DTO types
-/// instead of reading the SDK emission path its claim is about. Deriving the subject set here makes the guards'
-/// coverage a consequence of the surface rather than of who remembered to update a list (#451, the
-/// derive-don't-enumerate ruling).</para>
+/// stand-in for it. Deriving the subject set here makes each guard's coverage a consequence of the surface rather
+/// than of who remembered to update a list.</para>
 ///
 /// <para>The registration deliberately mirrors <c>Program.AddMcp</c>'s scan line and stops there: no transport,
 /// no server identity, and above all no <see cref="ToolSchemas.PublishSchemas"/>, because that pass mutates
@@ -28,7 +25,7 @@ internal static class PreFlattenSurface
     internal readonly record struct Tool(string Name, JsonObject Schema);
 
     /// <summary>Every registered tool's pre-flatten schema, in registration order. Throws rather than returning
-    /// empty: a derivation that finds no tools is a broken derivation, and every arm built on it would pass
+    /// empty: a derivation that finds no tools is a broken derivation, and every check built on it would pass
     /// vacuously.</summary>
     internal static IReadOnlyList<Tool> Read()
     {

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -1,6 +1,6 @@
 using HousecarlGenerator;
 
-// houseCARL build-time schema generator (first-wave step 2).
+// houseCARL build-time schema generator.
 //
 // Reflects over the entire Mutagen.Bethesda.Skyrim type universe and emits a flat
 // type catalog (corpus.json + corpus.summary.md) covering literally every modeled
@@ -10,261 +10,249 @@ using HousecarlGenerator;
 //         An unrecognised FIRST argument is refused, not read as [outputDir] — so an output directory must be
 //         rooted, carry a separator, or be "." / "..". Anything else is a mode name, and an unknown one exits 2.
 
-// CI optimization Phase 2B: run EVERY CI probe in ONE process (the big Mutagen assembly loads + JITs once;
-// the schema corpus reflects once via CorpusGenerator's memoize). Replaces the per-probe ci.yml steps with one
-// invocation. See CiAll + dev/plans/CI_OPTIMIZATION_RESEARCH_2026-06-24.md.
+// Run EVERY CI probe in ONE process: the big Mutagen assembly loads and JITs once, and the schema corpus is
+// reflected once via CorpusGenerator's memoize, instead of once per probe. See CiAll.
 if (args.Length > 0 && args[0] == "ci-all") return CiAll.RunAll(args[1..]);
 
 // Single-probe runs of any CI guard — roster or standalone — dispatch through the reflected [CiProbe] set, so a
-// guard cannot be runnable locally yet missing from the CI run (the Q3 coverage-gap class). Only the
-// manual/exploratory probes below keep their own explicit dispatch.
+// guard cannot be runnable locally yet missing from the CI run. Only the manual/exploratory probes below keep
+// their own explicit dispatch.
 if (args.Length > 0 && CiAll.TryDispatch(args[0], args[1..], out var ciRc)) return ciRc;
 
-// PR 3b acceptance: the old copy_npc_appearance verb vs its 2.0 successor, over constructed MO2 instances.
-// Deliberately NOT in ci-all — the ancestor dies at 2.0, so this is acceptance evidence re-run on demand
-// (and after every fold that touches the copy path), not a standing guard.
+// The old copy_npc_appearance verb against its 2.0 successor, over constructed MO2 instances. Deliberately NOT
+// in ci-all: it is evidence re-run on demand after a change to the copy path, not a standing guard.
 if (args.Length > 0 && args[0] == "copy-differential") return CopyDifferentialHarness.Run(args[1..]);
 
 // Maintenance diagnostic: re-verify the mutable-collection whitelist on a Mutagen bump.
 if (args.Length > 0 && args[0] == "vocab") return Probe.RunVocab();
 
-// (The per-record `skypatcher-post-state` verb went with LoadOrderService.SkyPatcherPostState at #486 —
-//  the service member had no shipped caller after the 1.x cut. The layer verb below is unaffected.)
-
-// SkyPatcher Wave-2 harness: the whole-layer scan + INI-vs-INI conflict report off a LIVE MO2 instance,
-// rendered exactly as housecarl_skypatcher_layer returns it (the Wave-2 empirical artifact).
+// SkyPatcher harness: the whole-layer scan + INI-vs-INI conflict report off a LIVE MO2 instance, rendered
+// exactly as housecarl_skypatcher_layer returns it.
 if (args.Length > 0 && args[0] == "skypatcher-layer") return SkyPatcherHarness.RunLayer(args[1..]);
 
-// Index-build resilience (Nexus bug): feasibility probe — is group enumeration resumable past a parse throw?
+// Index-build resilience: is group enumeration resumable past a parse throw?
 if (args.Length > 0 && args[0] == "pkcu-probe") return PkcuProbe.Run(args[1..]);
 
-// Index-build resilience (Nexus bug): end-to-end proof the malformed plugin is isolated, not fatal.
+// Index-build resilience: end-to-end proof a malformed plugin is isolated, not fatal.
 if (args.Length > 0 && args[0] == "pkcu-fix-proof") return PkcuProbe.RunFixProof(args[1..]);
 
-// Index-build resilience (Nexus bug): real-scale proof — full MO2 order + 1 malformed plugin, only it excluded.
+// Index-build resilience at real scale: full MO2 order + 1 malformed plugin, only it excluded.
 if (args.Length > 0 && args[0] == "pkcu-scale-proof") return PkcuProbe.RunScaleProof(args[1..]);
 
-// Decompiler baseline hierarchy: emit vanilla-class-parents.json from the CK vanilla sources' own
-// ScriptName-extends headers (committed asset — vanilla sources don't exist on CI; regenerate on game updates).
+// Emit vanilla-class-parents.json from the CK vanilla sources' own ScriptName-extends headers. Committed asset:
+// vanilla sources do not exist on CI, so regenerate by hand on a game update.
 if (args.Length > 0 && args[0] == "class-parents") return ClassParentsEmitter.Run(args[1..]);
 
-// Localized-strings read fix (Heisen 2026-06-24): DLC master resolved to a strings-less mod folder reads Name EMPTY.
+// Localized-strings read: a DLC master resolved to a strings-less mod folder reads Name EMPTY.
 if (args.Length > 0 && args[0] == "strings-resolve-probe") return StringsResolveProbe.Run(args[1..]);
 
-// EXPLORATORY (#368): the MUTABLE strings-aware open + the mutate → WriteInPlace round-trip.
+// EXPLORATORY: the MUTABLE strings-aware open + the mutate-then-WriteInPlace round-trip.
 if (args.Length > 0 && args[0] == "repoint-strings-probe") return RepointStringsProbe.Run(args[1..]);
 if (args.Length > 0 && args[0] == "localized-write-probe") return LocalizedWriteProbe.Run(args[1..]);
 if (args.Length > 0 && args[0] == "localized-shape-sweep") return LocalizedShapeSweep.Run(args[1..]);
 
-// EXPLORATORY (F1): the disabled-mod asset source lane's two binding kickoff measurements.
+// EXPLORATORY: the disabled-mod asset source lane's two binding measurements.
 if (args.Length > 0 && args[0] == "f1-measure") return F1MeasureProbe.Run(args[1..]);
 
-// EXPLORATORY (F1): inventory I14 - does the successor reach a FaceGen beside the SECOND donor-side plugin?
+// EXPLORATORY: does the successor reach a FaceGen beside the SECOND donor-side plugin?
 if (args.Length > 0 && args[0] == "f1-i14") return F1MeasureProbe.RunI14(args[1..]);
 
-// One-shot verify (decision #1): confirm the xEdit 4-char signature reflection path.
+// One-shot verify: confirm the xEdit 4-char signature reflection path.
 if (args.Length > 0 && args[0] == "sig") return Probe.RunSig();
 
-// Step 4 write engine: build-start discovery of Mutagen's generic group-override surface.
+// Write engine: discovery of Mutagen's generic group-override surface.
 if (args.Length > 0 && args[0] == "write-api") return WriteDiagnosticsProbe.RunDiscovery(args[1..]);
 
-// Step 4 write engine: NPC-skills-by-name acceptance proof (nested dict-in-substruct Set).
+// Write engine: NPC-skills-by-name acceptance proof (nested dict-in-substruct Set).
 if (args.Length > 0 && args[0] == "npc-skills") return WriteDiagnosticsProbe.RunNpcSkillsProof(args[1..]);
 
-// Step 5 oracle: per-kind byte-identical cells (Path A engine vs Path B hand-written setter).
+// Oracle: per-kind byte-identical cells (Path A engine vs Path B hand-written setter).
 if (args.Length > 0 && args[0] == "oracle") return WriteOracle.Run(args[1..]);
 
-// Step 5 build-start confirm: polymorphic arm-swap instantiation mechanism.
+// Confirm the polymorphic arm-swap instantiation mechanism.
 if (args.Length > 0 && args[0] == "poly-probe") return WriteDiagnosticsProbe.RunPolyProbe(args[1..]);
 
 // Absent-substruct characterization: which navigate-into substructs lack a parameterless ctor (the tricky shapes).
 if (args.Length > 0 && args[0] == "substruct-probe") return WriteDiagnosticsProbe.RunSubstructProbe(args[1..]);
 
-// Wave 3 scout: recon Mutagen's nested-group override API (Cell/Placed*/INFO/Navmesh/Landscape) — the highest-risk unknown.
+// Recon Mutagen's nested-group override API (Cell/Placed*/INFO/Navmesh/Landscape).
 if (args.Length > 0 && args[0] == "nested-probe") return NestedProbe.RunNestedProbe(args[1..]);
 
-// STEP 0 scout (nested/dialogue plan §1.4, BLOCKING): can houseCARL ALLOCATE a brand-new record INTO a nested parent
-// by construction? Tests DuplicateIntoAsNewRecord (clone-a-sibling) + construct-and-Add-into-collection (new parent),
-// the FormID floor, and characterizes the coordinate-keyed §4-(b) seam. Throwaway recon, fail-loud per shape (Q3).
+// Can houseCARL ALLOCATE a brand-new record INTO a nested parent? Tests DuplicateIntoAsNewRecord (clone-a-sibling)
+// and construct-and-Add-into-collection (new parent), the FormID floor, and the coordinate-keyed cell seam.
+// Throwaway recon; each shape fails loud rather than degrading.
 if (args.Length > 0 && args[0] == "nested-create-probe") return NestedCreateProbe.RunProbe(args[1..]);
 
-// Nested-create build proof (Layer A): drive the REAL WritePatchBuilder.CreateRecords nested path — one-shot
-// topic+INFO, INFO into an existing topic, Placed into a cell (named collection), + the Q3 rejects (no-parent,
-// bad parent, ambiguous collection, forward sibling). Re-opens each patch from disk; Skyrim.esm byte-checked.
+// Nested-create build proof: drive the REAL WritePatchBuilder.CreateRecords nested path — one-shot topic+INFO,
+// INFO into an existing topic, Placed into a cell (named collection), plus the rejects (no-parent, bad parent,
+// ambiguous collection, forward sibling). Re-opens each patch from disk; Skyrim.esm byte-checked.
 if (args.Length > 0 && args[0] == "nested-create-proof") return NestedCreateProof.RunProof(args[1..]);
 
-// STEP 0 scout for the COORDINATE-KEYED §4-(b) seam (exterior/interior Cell + Placed-into-new-cell): round-trips a
-// constructed cell into find-or-built WorldspaceBlock/SubBlock (exterior, floor(grid/32|8)) and CellBlock/SubBlock
-// (interior, FormID digits), checks override is thin, block math vs vanilla, OFST regen, source byte-unchanged.
+// The COORDINATE-KEYED cell seam (exterior/interior Cell + Placed-into-new-cell): round-trips a constructed cell
+// into find-or-built WorldspaceBlock/SubBlock (exterior, floor(grid/32|8)) and CellBlock/SubBlock (interior,
+// FormID digits), checks the override is thin, the block math against vanilla, OFST regen, source byte-unchanged.
 if (args.Length > 0 && args[0] == "coord-cell-probe") return CoordCellProbe.RunProbe(args[1..]);
 
-// Wave 4 scout: recon Mutagen's IFormLinkOrIndex condition-target API — the form-vs-index discriminator (condition oracle), the wave-4 unknown.
+// Recon Mutagen's IFormLinkOrIndex condition-target API — the form-vs-index discriminator.
 if (args.Length > 0 && args[0] == "condition-probe") return ConditionProbe.RunConditionProbe(args[1..]);
 
-// Wave 5 scout: ModHeader mutable-root reachability (the header is a singleton property, not a group/record).
+// ModHeader mutable-root reachability — the header is a singleton property, not a group/record.
 if (args.Length > 0 && args[0] == "header-probe") return Wave5Probe.RunHeaderProbe(args[1..]);
 
-// Wave 5 scout: the PEX read->write round-trip GATE (project_pex_prefer_source_policy) — the wave-5 unknown.
+// The PEX read-to-write round-trip gate.
 if (args.Length > 0 && args[0] == "pex-probe") return Wave5Probe.RunPexProbe(args[1..]);
 
-// NOTE: coerce-audit + coerce-selftest are now CI guards carrying [CiProbe] (the ONE CI source of truth, dispatched
-// for single runs via CiAll.TryDispatch at the top of this file) — no separate dispatch here, by design.
+// coerce-audit and coerce-selftest carry [CiProbe] and dispatch via CiAll.TryDispatch at the top of this file,
+// so they get no separate dispatch here.
 
-// Step 7 write-surface census: corpus-derived reachability map of every writable leaf (the completeness scoreboard).
+// Write-surface census: corpus-derived reachability map of every writable leaf.
 if (args.Length > 0 && args[0] == "write-census") return WriteCensus.Run(args[1..]);
 
-// Wave 0 prove-today: the only-target-moved differ + byte-true drive across the reachable settable surface.
+// The only-target-moved differ + byte-true drive across the reachable settable surface.
 if (args.Length > 0 && args[0] == "write-proof") return WriteProof.RunProof(args[1..]);
 
-// Wave 2 real-patch dev harness: one concrete set_field -> a real reviewable .esp (Aaron xEdit-verifies).
+// Real-patch dev harness: one concrete set_field to a real .esp, checked in xEdit by hand.
 if (args.Length > 0 && args[0] == "patch") return WriteEngine.RunPatch(args[1..]);
 
 // Read-to-plan: resolve a record + print its fields/keywords (the minimum read to author a correct write).
 if (args.Length > 0 && args[0] == "show") return WriteEngine.RunShow(args[1..]);
 
-// Step 6 read surface: resolve a record + emit its fields as round-trippable tokens (inverse of Coerce).
+// Read surface: resolve a record and emit its fields as round-trippable tokens (inverse of Coerce).
 if (args.Length > 0 && args[0] == "read") return ReadEngine.RunRead(args[1..]);
 
-// Step 6 read-proof: read↔write round-trip oracle — read each value leaf, write the token back, assert no-op.
+// Read-proof: read each value leaf, write the token back, assert no-op.
 if (args.Length > 0 && args[0] == "read-proof") return WriteProof.RunReadProof(args[1..]);
 
-// Wave 4 capability lock: re-target one real condition target -> a reviewable .esp (Aaron xEdit-verifies the new target).
+// Re-target one real condition target to an .esp, with the new target checked in xEdit by hand.
 if (args.Length > 0 && args[0] == "condition-patch") return WriteEngine.RunConditionPatch(args[1..]);
 
-// MCP step §8.1: measure-first probe — on-demand vs held-index load-order resolution cost (the FIRST build action; gates fork §6-C).
+// Measure on-demand against held-index load-order resolution cost.
 if (args.Length > 0 && args[0] == "resolve-probe") return ResolveProbe.RunResolveProbe(args[1..]);
 
-// MCP step §8.3 beat 1: measure-first body-fetch probe — cost of resolving a conflict tree's bodies on demand (the one piece §8.1 left open).
+// Measure the cost of resolving a conflict tree's bodies on demand.
 if (args.Length > 0 && args[0] == "body-fetch-probe") return BodyFetchProbe.RunBodyFetchProbe(args[1..]);
 
-// MCP step §8.3: stand up + verify the net-new LoadOrderResolver (held RAM, tree correctness, body-fetch timing, freshness sweep).
+// Stand up and verify LoadOrderResolver: held RAM, tree correctness, body-fetch timing, freshness sweep.
 if (args.Length > 0 && args[0] == "resolve") return ResolveHarness.RunResolve(args[1..]);
 
-// MCP step (Beat C de-risk): prove the MULTI-MASTER write path — a real merge patch (leveled list + cross-master entries) -> reviewable .esp.
+// Prove the MULTI-MASTER write path: a real merge patch (leveled list + cross-master entries) to an .esp.
 if (args.Length > 0 && args[0] == "multimaster-patch") return MultiMasterProof.RunMultiMasterPatch(args[1..]);
 
-// MCP step (Beat C build): prove the PUBLIC write cleave the MCP set_field/bulk_apply/into= tools call (flat + multi + extend + cross-master + reject).
+// Prove the PUBLIC write cleave the set_field/bulk_apply/into= tools call (flat, multi, extend, cross-master, reject).
 if (args.Length > 0 && args[0] == "apply-proof") return ApplyProof.RunApplyProof(args[1..]);
 
-// MCP step §8.5: verify the TRUE active order read from MO2's static profile files (loadorder.txt + modlist.txt + plugins.txt).
+// Verify the TRUE active order read from MO2's static profile files (loadorder.txt + modlist.txt + plugins.txt).
 if (args.Length > 0 && args[0] == "mo2-order") return Mo2OrderHarness.RunMo2Order(args[1..]);
 
-// Capability arc scout (Remove + Create): AddNew/FormID allocation (Create) + write-path master derivation (clean-masters).
+// Remove + Create recon: AddNew/FormID allocation, and write-path master derivation (clean-masters).
 if (args.Length > 0 && args[0] == "remove-create-probe") return RemoveCreateProbe.RunProbe(args[1..]);
 
-// Capability arc scout #2 (remove-record): whole-record removal via mod.Remove(FormKey) — flat + nested + not-found semantics.
+// Remove-record recon: whole-record removal via mod.Remove(FormKey) — flat, nested, and not-found semantics.
 if (args.Length > 0 && args[0] == "remove-record-probe") return RemoveRecordProbe.RunProbe(args[1..]);
 
-// Capability arc remove-record proof: drive WritePatchBuilder.RemoveRecords (the core housecarl_remove_record calls) vs a real, large load order.
+// Drive WritePatchBuilder.RemoveRecords, the core housecarl_remove_record calls, against a real, large load order.
 if (args.Length > 0 && args[0] == "remove-proof") return RemoveProof.RunRemoveProof(args[1..]);
 
-// Capability arc scout #3 (Create — the LAST build): generic AddNew dispatch + FormID allocation + fields-via-ApplyVerb + the nested/abstract-T scope fork.
+// Create recon: generic AddNew dispatch, FormID allocation, fields-via-ApplyVerb, and the nested/abstract-T scope fork.
 if (args.Length > 0 && args[0] == "create-probe") return CreateProbe.RunProbe(args[1..]);
 
-// Capability arc create proof: drive WritePatchBuilder.CreateRecords (the core housecarl_create_record calls) vs a real, large load order.
+// Drive WritePatchBuilder.CreateRecords, the core housecarl_create_record calls, against a real, large load order.
 if (args.Length > 0 && args[0] == "create-proof") return CreateProof.RunCreateProof(args[1..]);
 
-// Master-baseline scout: how to FORCE Skyrim.esm onto every written plugin (Mutagen strips unreferenced masters) — Aaron-flagged bug.
+// How to FORCE Skyrim.esm onto every written plugin, given that Mutagen strips unreferenced masters.
 if (args.Length > 0 && args[0] == "master-probe") return MasterProbe.RunProbe(args[1..]);
 
-// Cleanup-gotcha / Option-B viability: prove a plain overlay LOCKS a plugin, Dispose() RELEASES it promptly, and open->read->dispose latency is invisible (de-risks the LOCKED Option-B fix).
+// Prove a plain overlay LOCKS a plugin, that Dispose() releases it promptly, and that open-read-dispose latency is invisible.
 if (args.Length > 0 && args[0] == "handle-probe") return HandleProbe.RunProbe(args[1..]);
 
-// Cleanup-gotcha / Option-B AT-REST proof: drive the REAL product code (resolver Build -> read via session -> create via write path) on temp copies and assert files are renamable at rest (zero handles held).
+// Drive the REAL product code (resolver Build, read via session, create via write path) on temp copies and assert the files are renamable at rest, i.e. no handles held.
 if (args.Length > 0 && args[0] == "atrest-probe") return AtRestProbe.RunProbe(args[1..]);
 
-// Active-patch write self-lock (Heisen bug 2026-06-08): EXPLORATORY — map the Windows file-sharing semantics of writing
-// into a patch whose own overlay is held by AllMasters() (direct vs temp+Replace vs release-then-write). Decides the fix.
+// Active-patch write self-lock, EXPLORATORY: map the Windows file-sharing semantics of writing into a patch whose
+// own overlay is held by AllMasters() — direct, temp+Replace, and release-then-write.
 if (args.Length > 0 && args[0] == "writelock-probe") return WriteLockProbe.RunProbe(args[1..]);
 
-// Active-patch write self-lock follow-up (PR #24 review): EXPLORATORY — prove Apply's Phase-1 winner-fetch opens a SECOND
-// overlay on the target (when re-editing an own override) that survives AllMastersExcept and still self-locks the serialize.
+// Active-patch write self-lock, EXPLORATORY: prove Apply's winner-fetch opens a SECOND overlay on the target when
+// re-editing an own override, one that survives AllMastersExcept and still self-locks the serialize.
 if (args.Length > 0 && args[0] == "writelock-apply-probe") return WriteLockProbe.RunApplyResidualProbe(args[1..]);
 
-// Active-patch write self-lock follow-up (PR #24 review #2): REAL-DATA proof that a NESTED record (PlacedObject, via the
-// link-cache context path) survives the re-edit-own-override case under the new "release overlay before serialize" invariant.
+// REAL-DATA proof that a NESTED record (PlacedObject, via the link-cache context path) survives the
+// re-edit-own-override case under the "release overlay before serialize" invariant.
 if (args.Length > 0 && args[0] == "writelock-nested-proof") return WriteLockProbe.RunNestedProof(args[1..]);
 
-// In-place write lane Wave 1: REAL-DATA proof of the NESTED own-override re-edit IN PLACE (the LinkCacheFor-on-a-foreign-
-// target overlay path), the one arm the self-contained guard can't synthesize. Needs Skyrim.esm; self-skips on the runner.
+// REAL-DATA proof of the NESTED own-override re-edit IN PLACE (the LinkCacheFor-on-a-foreign-target overlay path),
+// the one arm the self-contained guard cannot synthesize. Needs Skyrim.esm; self-skips on the runner.
 if (args.Length > 0 && args[0] == "inplace-nested-proof") return InPlaceProbe.RunNestedProof(args[1..]);
 
-// In-place write lane Wave 2: REAL-DATA proof of the NESTED own-override REMOVE IN PLACE (typed nested Remove + a real-data
-// WriteInPlace re-serialize on a foreign target). The remove counterpart of inplace-nested-proof. Needs Skyrim.esm; self-skips.
+// REAL-DATA proof of the NESTED own-override REMOVE IN PLACE (typed nested Remove plus a real-data WriteInPlace
+// re-serialize on a foreign target) — the remove counterpart of inplace-nested-proof. Needs Skyrim.esm; self-skips.
 if (args.Length > 0 && args[0] == "inplace-remove-nested-proof") return InPlaceProbe.RunRemoveNestedProof(args[1..]);
 
-// Perk references= crash (HCBR-2026-06-09-03): DIAGNOSIS — run Mutagen's EnumerateFormLinks over every PERK in a
-// real plugin, report which records throw and with what (the evidence the fix is designed from). Skips without Skyrim.esm.
+// Perk references= crash, DIAGNOSIS: run Mutagen's EnumerateFormLinks over every PERK in a real plugin and report
+// which records throw and with what. Skips without Skyrim.esm.
 if (args.Length > 0 && args[0] == "perk-refs-diagnose") return PerkRefsProbe.RunDiagnose(args[1..]);
 
-// Perk references= crash (HCBR-2026-06-09-03): REAL-DATA proof — the report's exact failing call (type=Perk references=)
-// over a live MO2 order through the service layer. Manual; needs --mo2 + --corpus (skips without).
+// Perk references= crash, REAL-DATA proof: the failing call (type=Perk references=) over a live MO2 order through
+// the service layer. Manual; needs --mo2 and --corpus, and skips without them.
 if (args.Length > 0 && args[0] == "perk-refs-proof") return PerkRefsProbe.RunProof(args[1..]);
 
-// Conflict-tree content diff (HCBR-2026-06-09-01): REAL-DATA proof — the report's exact repro (MM_RelentlessFury's
-// "(identical to winner)" false ITM) over a live MO2 order. Manual; needs --mo2 (skips without).
+// Conflict-tree content diff, REAL-DATA proof: the "(identical to winner)" false ITM over a live MO2 order.
+// Manual; needs --mo2, and skips without it.
 if (args.Length > 0 && args[0] == "conflict-diff-proof") return ConflictDiffProbe.RunProof(args[1..]);
 
-// FormID allocation floor (HCBR-2026-06-09-04): EXPLORATORY — pin the Mutagen NextFormID semantics (fresh-mod init,
-// the Iterate serialize recompute that seeds 0, CreateFromBinary rehydration, AddNew-from-0) the fix is designed from.
+// FormID allocation floor, EXPLORATORY: pin the Mutagen NextFormID semantics — fresh-mod init, the Iterate
+// serialize recompute that seeds 0, CreateFromBinary rehydration, AddNew-from-0.
 if (args.Length > 0 && args[0] == "formid-floor-probe") return FormIdFloorProbe.RunProbe(args[1..]);
 
-// ESL / FE-space FormID handling (HCBR-2026-06-15-01 item 5.1): EXPLORATORY — pin the referenced Mutagen version's small-master
-// semantics (legal object-ID range, IsSmallMaster→FE-space encode through our incantation, FE decode round-trip,
-// flag-tracking, index-independence) the guard + any §4 surface-call are built from.
+// ESL / FE-space FormID handling, EXPLORATORY: pin the referenced Mutagen version's small-master semantics —
+// legal object-ID range, IsSmallMaster to FE-space encode, FE decode round-trip, flag-tracking, index-independence.
 if (args.Length > 0 && args[0] == "esl-formid-probe") return EslFormIdProbe.RunProbe(args[1..]);
 
-// ESL ground-truth scan (HCBR-2026-06-15-01 item 5.1): EXPLORATORY — raw-byte scan of REAL plugins to settle
-// whether SSE stores light-master references in FE-space on disk (0xFE high byte) or by master-list index.
+// ESL ground-truth scan, EXPLORATORY: raw-byte scan of REAL plugins to settle whether SSE stores light-master
+// references in FE-space on disk (0xFE high byte) or by master-list index.
 if (args.Length > 0 && args[0] == "esl-real-scan") return EslFormIdProbe.RunRealScan(args[1..]);
 
-// IN-PLACE WRITE LANE, Wave 0 (design-gating, IN_PLACE_WRITE_LANE_PLAN §5.3/§9 STEP-2): MANUAL/REAL-DATA probe —
-// no-op re-serialize a sample of REAL plugins (counter-preserving, the §5.1-correct in-place shape) and measure the
-// whole-plugin byte divergence surface (identical / header-only / body / records-changed / unloadable), so fork #1's
-// round-trip accept/refuse threshold is calibrated on measured reality. Needs --mo2 <instance>; SKIPs without (a
-// synthetic fixture round-trips clean and would reveal nothing). Writes only to temp; read-only on the load order.
+// MANUAL/REAL-DATA probe: no-op re-serialize a sample of REAL plugins (counter-preserving, the correct in-place
+// shape) and measure the whole-plugin byte divergence surface — identical, header-only, body, records-changed,
+// unloadable — so the round-trip accept/refuse threshold is set from measured reality. Needs --mo2 <instance> and
+// SKIPs without one, because a synthetic fixture round-trips clean and would reveal nothing. Writes only to temp;
+// read-only on the load order.
 if (args.Length > 0 && args[0] == "roundtrip-probe") return RoundTripProbe.RunProbe(args[1..]);
 
-// COMPACT/MERGE Wave 1 (COMPACT_MERGE_PLAN §3/§4): EXPLORATORY mechanism pin — settle, self-contained, whether
-// RemapLinks changes a record's OWN identity or only its references, whether MajorRecord.FormKey is settable, and
-// which Mutagen affordance compact must use to renumber a record into the ESL range. Run before building RemapEngine.
+// Compact/merge, EXPLORATORY: settle, self-contained, whether RemapLinks changes a record's OWN identity or only
+// its references, whether MajorRecord.FormKey is settable, and which Mutagen affordance compact must use to
+// renumber a record into the ESL range.
 if (args.Length > 0 && args[0] == "remap-wave1-mech") return RemapWave1Probe.RunMechanism(args[1..]);
 
-// COMPACT/MERGE Wave 1 GATE (self-contained, CI-able) is a [CiProbe] guard, `remap-wave1-guard` —
-// it dispatches through CiAll.TryDispatch above (the ONE CI source of truth), so it is NOT listed here.
+// The self-contained compact/merge gate is a [CiProbe] guard, `remap-wave1-guard`, dispatched by CiAll.TryDispatch
+// above, so it is not listed here.
 
-// COMPACT/MERGE Wave 1 real-data run (MANUAL): ESL-compact a real plugin to a NEW P′ for Aaron to xEdit-verify, and
-// time the identify-pass over the live order. Needs --mo2 <inst> --plugin <Name.esp>; SKIPs without.
+// Compact/merge real-data run, MANUAL: ESL-compact a real plugin to a NEW one for checking in xEdit, and time the
+// identify-pass over the live order. Needs --mo2 <inst> --plugin <Name.esp>, and SKIPs without them.
 if (args.Length > 0 && args[0] == "remap-wave1-real") return RemapWave1Probe.RunReal(args[1..]);
 
-// COMPACT/MERGE Wave 2 (COMPACT_MERGE_PLAN §4): EXPLORATORY mechanism pin — settle, self-contained, whether the
-// recursive Duplicate-and-replace renumber closes the nested-record gap (cell/worldspace/topic children renumber +
-// round-trip on disk), and whether IMajorRecordGetterEnumerable is the by-construction recurse discriminator.
+// Compact/merge, EXPLORATORY: settle, self-contained, whether the recursive Duplicate-and-replace renumber closes
+// the nested-record gap (cell/worldspace/topic children renumber and round-trip on disk), and whether
+// IMajorRecordGetterEnumerable is the recurse discriminator.
 if (args.Length > 0 && args[0] == "remap-wave2-nested-mech") return RemapWave2NestedMechProbe.RunMechanism(args[1..]);
 
-// SKSE-plugin-layer visibility (gap 2026-06-08) MANUAL real-data harness: run housecarl_skse_inventory against a live
-// MO2 instance and print the render + timing (the CI skse-reader-guard pins the decode; this proves the full inventory).
+// MANUAL real-data harness: run housecarl_skse_inventory against a live MO2 instance and print the render and
+// timing. The CI skse-reader-guard pins the decode; this covers the full inventory.
 if (args.Length > 0 && args[0] == "skse-inventory-real") return SkseInventoryProbe.RunReal(args[1..]);
 
-// SKSE tier D (static peek, #199) needs no manual harness of its own — skse-inventory-real --peek --filter <dll>
-// drives the live peek.
+// The SKSE static peek needs no manual harness of its own — skse-inventory-real --peek --filter <dll> drives it.
 
-// SKSE config audit (tier B, #199) MANUAL real-data harness (the live gate: runs the whole audit against a live
-// MO2 instance and prints the audit + timing).
+// SKSE config audit, MANUAL real-data harness: the whole audit against a live MO2 instance, with timing.
 if (args.Length > 0 && args[0] == "skse-config-audit-real") return SkseConfigAuditProbe.RunReal(args[1..]);
 
-// Native-function pairing audit MANUAL real-data harness (the live gate: the whole audit against a live MO2
-// instance, render + timing).
+// Native-function pairing audit, MANUAL real-data harness: the whole audit against a live MO2 instance, with timing.
 if (args.Length > 0 && args[0] == "native-pairing-real") return NativePairingProbe.RunReal(args[1..]);
 
-// UNKNOWN MODE — refused, not silently taken as an output directory (2.0 tidy-up scar, W3 PR 3 housekeeping).
-// Every dispatch above matched nothing, and the corpus fallthrough below reads args[0] as the OUTPUT DIRECTORY. So a
-// mistyped probe name generated the whole corpus into a folder of that name and exited 0: two of them put 13.5 MB of
-// generated files in the working tree, which `git add -A` then nearly committed. A mode and a directory ARE
-// distinguishable — a directory is ROOTED or carries a SEPARATOR (or is "." / "..") — so anything else is refused BY
-// NAME, with the real modes listed and the near misses suggested (Q3: never a silent wrong action). Deliberately NOT
-// "…or it already exists": see IsDirectoryArgument, where that clause was removed after it let a mistyped mode write
-// into ./plugin (review [low] — this comment asserted it 25 lines above the one explaining why it is gone).
+// UNKNOWN MODE — refused, never silently taken as an output directory. Every dispatch above matched nothing, and
+// the corpus fallthrough below reads args[0] as the OUTPUT DIRECTORY, so a mistyped probe name would generate the
+// whole corpus into a folder of that name and exit 0. A mode and a directory are distinguishable — a directory is
+// ROOTED or carries a SEPARATOR (or is "." / "..") — so anything else is refused by name, with the real modes
+// listed and near misses suggested. See IsDirectoryArgument for why "…or it already exists" is not a third clause.
 if (args.Length > 0 && !IsDirectoryArgument(args[0]))
 {
     Console.Error.WriteLine($"unknown mode '{args[0]}' — nothing was generated and nothing was written.");
@@ -282,7 +270,7 @@ if (args.Length > 0 && !IsDirectoryArgument(args[0]))
     Console.Error.WriteLine("Other modes are the manual/exploratory harnesses declared in src/housecarl-generator/Program.cs");
     Console.Error.WriteLine("(they are not in the suggestion pool above — only the CI guards are).");
     // State the RULE, not just the intent: "pass a directory path" alone is advice a caller who typed one has
-    // already followed, and the accepted spellings are not guessable (reviews [low], twice).
+    // already followed, and the accepted spellings are not guessable.
     Console.Error.WriteLine("To GENERATE the corpus into a directory, pass a path that is ROOTED (C:\\…), carries a");
     Console.Error.WriteLine("SEPARATOR (./out), or is \".\" / \"..\" — a BARE name is always read as a mode, even if a");
     Console.Error.WriteLine("folder of that name exists (that clause is what let a mistyped mode write into ./plugin).");
@@ -292,11 +280,10 @@ if (args.Length > 0 && !IsDirectoryArgument(args[0]))
 
 // A mode name is a BARE token; an output directory is rooted or carries a separator.
 //
-// "…or it already exists as a directory" was the obvious third clause, and it reopened the exact hole this check
-// closes (review [low], then reproduced): `plugin`, `src`, `scripts`, `standards`, `release` and `generated` are all
-// real folders at the repo root, so a mistyped mode that collided with one still generated the whole corpus into it —
-// `dotnet run --project src/housecarl-generator plugin` put 7.6 MB into plugin/ while this very fix was being
-// written. An output directory can always be spelled with a separator; a mistyped mode cannot be spelled back.
+// Do not add "…or it already exists as a directory" as a third clause: `plugin`, `src`, `scripts`, `standards`,
+// `release` and `generated` are all real folders at the repo root, so a mistyped mode colliding with one would
+// generate the whole corpus into it. An output directory can always be spelled with a separator; a mistyped mode
+// cannot be spelled back.
 static bool IsDirectoryArgument(string a)
 {
     if (a.Length == 0) return false;

--- a/src/housecarl-generator/ReferenceEmitter.cs
+++ b/src/housecarl-generator/ReferenceEmitter.cs
@@ -5,19 +5,17 @@ using System.Text.Json.Serialization;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// First-wave step 3 — emits the slim reference tree the <c>mutagen-reference</c> skill ships:
-/// per-type JSON schema blocks (one compact line each — JSONL) sharded by kind, plus
-/// <c>index.jsonl</c> mapping every type name + xEdit signature to its {file, line}. This is the
-/// SAME catalog <c>corpus.json</c> holds, minus the assembly-qualified type names (the write tool
-/// keeps those; Claude never needs them) — so the skill's read-content and the write tool's rulebook
-/// physically can't disagree about field names or types: one generator walk, two renderings.
+/// Emits the slim reference tree the <c>mutagen-reference</c> skill ships: per-type JSON schema blocks
+/// (one compact line each — JSONL) sharded by kind, plus <c>index.jsonl</c> mapping every type name +
+/// xEdit signature to its {file, line}. It is the SAME catalog <c>corpus.json</c> holds, minus the
+/// assembly-qualified type names the write tool needs, so one generator walk gives two renderings that
+/// cannot disagree about field names or types.
 ///
-/// Lookup pattern the skill follows: grep <c>index.jsonl</c> for the name/signature, take {file, line},
-/// then read exactly that one line from the shard. The block is one line, so the read is one line —
-/// never whole-load a shard, never answer a schema question from memory (decision #4).
+/// The lookup the skill does: grep <c>index.jsonl</c> for the name or signature, take {file, line}, read
+/// exactly that one line from the shard. Keep every block on ONE line, or that read stops working.
 ///
-/// Terse field keys (n/t/c/w + sparse refs) keep the JSON within ~15% of markdown; the legend lives
-/// once in the skill's SKILL.md. Aaron's human-readable view stays <c>corpus.summary.md</c>.
+/// Terse field keys (n/t/c/w + sparse refs) keep the JSON small; the legend lives once in the skill's
+/// SKILL.md. The human-readable view is <c>corpus.summary.md</c>.
 /// </summary>
 public static class ReferenceEmitter
 {

--- a/src/housecarl-generator/RegisteredTools.cs
+++ b/src/housecarl-generator/RegisteredTools.cs
@@ -7,19 +7,9 @@ namespace HousecarlGenerator;
 /// <summary>The SDK's OWN tool-discovery predicate, in one home: a tool is REGISTERED when
 /// <c>[McpServerToolType]</c> is on the declaring TYPE and <c>[McpServerTool]</c> is on the METHOD — the pair
 /// <c>WithToolsFromAssembly()</c> scans for, and the only derivation any probe may call a tool "registered" by.
-///
-/// <para>The type half is load-bearing, and #470 is what proved it: <c>CheckTools</c> carried the method attribute
-/// and no type attribute, so <c>housecarl_check</c> was declared and never registered for twelve days while a
-/// predicate reading the method alone reported it live. That tool is registered now — the type attribute landed
-/// with this predicate's own PR — so the set of declared-but-unregistered tools is empty, and it is held empty by a
-/// test rather than by anyone remembering: <c>ToolSurfaceCensusTests</c> fails if a type declaring a tool method
-/// carries no <c>[McpServerToolType]</c>.</para>
-///
-/// <para>Two probes wrote that predicate separately and disagreed about it in one PR: the description vocabulary
-/// guard read both attributes, the in-place guard's arm-H sweep read the method alone, so the sweep was
-/// a superset of the surface it claimed (Aaron's gate review on PR #474, finding 4). Nothing was wrongly swept when
-/// that was found — <c>housecarl_check</c> declares no <c>in_place</c> — so the fix removes a latent hole, not a
-/// live one. One home means the two cannot disagree again.</para></summary>
+/// Both halves are load-bearing: a predicate reading the method alone reports a type missing its attribute as
+/// live, and over-reports the surface to every sweep built on it. Every consumer goes through here so two of
+/// them cannot answer the question differently.</summary>
 internal static class RegisteredTools
 {
     const BindingFlags Flags = BindingFlags.Public | BindingFlags.NonPublic
@@ -30,7 +20,7 @@ internal static class RegisteredTools
     static readonly Assembly Surface = ToolSurface.Assembly;
 
     /// <summary>Every registered (tool name, declaring method) pair, ordinal-sorted by name. Callers that need to
-    /// reflect over a tool's PARAMETERS (arm H's in_place sweep) filter this; callers that need only the names call
+    /// reflect over a tool's PARAMETERS filter this; callers that need only the names call
     /// <see cref="Names"/>.</summary>
     internal static List<(string Tool, MethodInfo Method)> All()
     {

--- a/src/housecarl-generator/RemoveProof.cs
+++ b/src/housecarl-generator/RemoveProof.cs
@@ -8,22 +8,22 @@ using HousecarlCore;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// Capability-arc remove-record build proof — exercise <see cref="WritePatchBuilder.RemoveRecords"/>, the core the MCP
-/// <c>housecarl_remove_record</c> tool calls, so the proof transfers to the server BY CONSTRUCTION (same code path, the
-/// way <see cref="ApplyProof"/> proves the edit cleave). Each check SEEDS a patch carrying real override(s)
-/// (the records a removal can target), then removes through the core and re-reads from disk:
+/// Build proof for <see cref="WritePatchBuilder.RemoveRecords"/>, the core the <c>housecarl_remove_record</c> tool
+/// calls. It must drive the same code path the tool does, or it proves nothing about it. Each check SEEDS a patch
+/// carrying real override(s) — the only records a removal can target — then removes through the core and re-reads
+/// from disk:
 ///
 ///   R1 — FLAT, selective: a patch carries two weapon overrides; remove ONE → it's gone, the OTHER survives, sources
 ///        byte-untouched (proves selective whole-record removal + the present-check finds carried records).
 ///   R2 — NESTED: a patch carries a nested-group override (a Cell — no flat SkyrimGroup&lt;T&gt;); remove it through the
-///        real into= flow (RemoveRecords re-opens from disk) → gone (the load-bearing nested proof vs a real, large load order).
+///        real into= flow (RemoveRecords re-opens from disk) → gone.
 ///   R3 — CLEAN-MASTERS: a patch carries ONE override (header lists its master[s]); remove it → 0 records AND an empty
-///        master header (the record-level auto-prune — removing the last referencer drops the master, probe Q5).
-///   R4 — REJECT (Q3): remove a FormKey the patch does NOT carry → refused, NOTHING written (the patch byte-unchanged),
-///        the carried record still present (no silent no-op; the present-check refuses loud).
+///        master header — removing the last referencer drops the master.
+///   R4 — REJECT: remove a FormKey the patch does NOT carry → refused, NOTHING written (the patch byte-unchanged),
+///        the carried record still present. No silent no-op; the present-check refuses loud.
 ///
 /// Every original master/mod the seed touched is SHA-checked unchanged. Patches are left in write-output/remove-proof/
-/// for Aaron to open in xEdit.  Run: dotnet run --project src/housecarl-generator remove-proof [maxPlugins]
+/// to open in xEdit.  Run: dotnet run --project src/housecarl-generator remove-proof [maxPlugins]
 /// </summary>
 public static class RemoveProof
 {
@@ -131,9 +131,9 @@ public static class RemoveProof
         }
 
         // ===================== R3 — CLEAN-MASTERS + Skyrim.esm BASELINE (single override → emptied; baseline pinned) =====================
-        // Removing the patch's only record empties it. Mutagen's derivation still STRIPS unreferenced masters (clean-masters)
-        // — but Skyrim.esm is force-included on every write (Aaron 2026-06-02: every plugin must carry it), so an emptied
-        // patch retains exactly [Skyrim.esm], not []. (Non-baseline clean-masters is shown lean in apply-proof's headers.)
+        // Removing the patch's only record empties it. Mutagen's derivation still STRIPS unreferenced masters — but every
+        // plugin must carry Skyrim.esm, which the write force-includes, so an emptied patch retains exactly [Skyrim.esm],
+        // not [].
         {
             var outPath = Path.Combine(outDir, "houseCARL_RemoveProof_R3.esp");
             var shaBefore = ShaNames(nameToPath, fkA.ModKey.FileName);
@@ -155,7 +155,7 @@ public static class RemoveProof
                 $"before: {cBefore} rec / [{string.Join(",", mBefore)}]  ->  after: {cAfter} rec / [{string.Join(",", mAfter)}]  (Skyrim.esm + Update.esm baseline retained)"));
         }
 
-        // ===================== R4 — REJECT not-carried (Q3, no silent no-op, no write) =====================
+        // ===================== R4 — REJECT not-carried (no silent no-op, no write) =====================
         {
             var outPath = Path.Combine(outDir, "houseCARL_RemoveProof_R4.esp");
             var seed = WritePatchBuilder.Apply(resolver, rulebook, new[]

--- a/src/housecarl-generator/ResolveHarness.cs
+++ b/src/housecarl-generator/ResolveHarness.cs
@@ -35,7 +35,7 @@ public static class ResolveHarness
         using var resolver = LoadOrderResolver.Build(paths);
         sw.Stop();
         var afterBuild = ResolveProbe.Mem();
-        using var session = resolver.OpenSession();   // Option B: body fetches below open plugins on demand, disposed at exit
+        using var session = resolver.OpenSession();   // Body fetches below open plugins on demand; the session closes them at exit
         Console.WriteLine();
         Console.WriteLine($"BUILD: {sw.Elapsed.TotalSeconds:N1}s  | plugins {resolver.PluginCount:N0} | records {resolver.RecordCount:N0} | " +
                           $"conflicts {resolver.ConflictCount:N0} ({(resolver.RecordCount > 0 ? 100.0 * resolver.ConflictCount / resolver.RecordCount : 0):N1}%) | max depth {resolver.MaxDepth}");

--- a/src/housecarl-generator/ResolveHarness.cs
+++ b/src/housecarl-generator/ResolveHarness.cs
@@ -5,12 +5,11 @@ using Mutagen.Bethesda.Skyrim;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// MCP-step §8.3 — verification harness for the net-new <see cref="LoadOrderResolver"/> (housecarl-core).
+/// Verification harness for <see cref="LoadOrderResolver"/>: stand it up against a real, large load order and
+/// measure held RAM, build-and-query correctness, on-demand body-fetch timing, and the freshness stat-sweep cost.
 ///
-/// Mirrors the engine/harness split (§6-B): the resolver is product code in the shared lib; this CLI mode
-/// stands it up against a real, large load order and PROVES it — held RAM (the precise multi-only number
-/// Aaron deferred), build-and-query correctness, on-demand body-fetch timing, and the freshness stat-sweep
-/// cost. Winner IDENTITY is NOT asserted here (placeholder order; §8.5 pins the true active order + xEdit-verifies).
+/// Winner IDENTITY is deliberately NOT asserted here — the plugin order this runs on is a placeholder, not the
+/// user's real active order, so a winner it names would mean nothing.
 ///
 /// Run: dotnet run --project src/housecarl-generator resolve [maxPlugins]
 /// </summary>
@@ -30,7 +29,7 @@ public static class ResolveHarness
         Console.WriteLine($"Plugins (placeholder order — masters first, then mods\\ by name): {paths.Count}" +
                           (maxPlugins > 0 ? $"  (capped to {maxPlugins})" : ""));
 
-        // ---- 1. BUILD — held RAM (the precise multi-only index number) + build time. ----
+        // ---- 1. BUILD — held RAM for the index alone + build time. ----
         var baseline = ResolveProbe.Mem();
         var sw = Stopwatch.StartNew();
         using var resolver = LoadOrderResolver.Build(paths);
@@ -62,7 +61,7 @@ public static class ResolveHarness
         Console.WriteLine($"   winner (last in order) = {tree.Winner.Plugin}  | IsConflict {tree.IsConflict}");
         Console.WriteLine($"   CHECK every node is {tree.RecordType}: {(allSameType ? "PASS" : "FAIL")}  | every fetched body == {deepestFk}: {(allMatchFk ? "PASS" : "FAIL")}");
 
-        // ---- 3. CAPABILITY 4/5 — a spread of trees + a batch (body-fetch timing across depths). ----
+        // ---- 3. A spread of conflict trees — body-fetch timing across depths. ----
         Console.WriteLine();
         Console.WriteLine("---- a spread of conflict trees (capabilities 4 + 5) ----");
         var byDepth = new SortedDictionary<int, FormKey>();
@@ -81,7 +80,7 @@ public static class ResolveHarness
             Console.WriteLine($"   depth {d,-3} {fk}  {t.RecordType,-16} winner={t.Winner.Plugin}  {(ok ? "PASS" : "FAIL")}");
         }
 
-        // ---- 4. CAPABILITY 1/2/6 — one plugin's whole-order conflict status. ----
+        // ---- 4. One plugin's whole-order conflict status. ----
         Console.WriteLine();
         Console.WriteLine("---- a plugin's conflict status (capabilities 1, 2, 6) ----");
         // Pick a non-master plugin that actually participates in conflicts: the one owning the deepest tree's winner.

--- a/src/housecarl-generator/RoslynLiteralReader.cs
+++ b/src/housecarl-generator/RoslynLiteralReader.cs
@@ -10,22 +10,19 @@ namespace HousecarlGenerator;
 /// <para><b>Why the compiler rather than a hand lexer here.</b> <c>description-vocab-guard</c>'s net is "every
 /// string literal in the shipped source trees", and the set of string literals in a C# file is not a matter of
 /// opinion — it is what the compiler decides. Roslyn IS that decision, so this reader cannot disagree with the
-/// build about what a literal is, what an escape decodes to, or where an interpolation hole begins. The second
-/// design's hand lexer got exactly those wrong (a literal inside a hole was invisible; an apostrophe inside such a
-/// literal flipped it into character-literal mode and swallowed the rest of the file) and every arm stayed green,
-/// because the only thing checking the lexer was the lexer.</para>
+/// build about what a literal is, what an escape decodes to, or where an interpolation hole begins.</para>
 ///
-/// <para><b>What it is NOT.</b> It is not the completeness proof. A reader that certifies itself certifies
-/// nothing, which is the failure both prior designs died of — so this reader's output is held against
-/// <see cref="HandLiteralLexer"/>'s, written independently from C#'s lexical grammar and sharing no code with it
-/// (<see cref="SourceLiteral"/> is a data shape, not a tokenizer). <c>INV6-AGREE</c> is the arm; either reader
-/// stopping early makes the two disagree and turns it red, naming the file.</para>
+/// <para><b>What it is NOT.</b> It is not the completeness proof — a reader that certifies itself certifies
+/// nothing. Its output is held against <see cref="HandLiteralLexer"/>'s, written independently from C#'s lexical
+/// grammar and sharing no code with it (<see cref="SourceLiteral"/> is a data shape, not a tokenizer).
+/// <c>INV6-AGREE</c> is the arm; either reader stopping early makes the two disagree and turns it red, naming the
+/// file.</para>
 ///
 /// <para><b>Parsing, not compiling.</b> No references are resolved and no semantic model is built — this is a
-/// syntax parse of one file at a time, and it dominates the guard's cost: the whole run over the shipped surface
-/// takes about two seconds end to end rather than milliseconds. The parse is
-/// run at <see cref="LanguageVersion.Preview"/> so a language feature newer than the pinned package is a PARSE
-/// ERROR that <c>INV6-PARSE</c> reports by name, rather than a construct silently misread into fewer literals.</para>
+/// syntax parse of one file at a time, and it dominates the guard's cost (seconds, not milliseconds, over the
+/// shipped surface). The parse runs at <see cref="LanguageVersion.Preview"/> so a language feature newer than the
+/// pinned package is a PARSE ERROR that <c>INV6-PARSE</c> reports by name, rather than a construct silently
+/// misread into fewer literals.</para>
 /// </summary>
 public static class RoslynLiteralReader
 {
@@ -79,15 +76,13 @@ public static class RoslynLiteralReader
 
     /// <summary>The text-adding calls in a file, keyed by the END offset of the literal each one takes — the key
     /// a merged run carries forward, so a run's TAIL is what gets looked up.
-    /// <para><b>Why the tree and not the text in front of the literal.</b> Until 2026-08-26 the merge asked a
-    /// regex what stood before a literal and read a receiver NAME out of it, which is a guess at a receiver
-    /// rather than the receiver. It got two shipped shapes wrong, both measured: a call with a VALUE argument
-    /// earlier in the chain (<c>sb.Append(count).Append("a"); sb.Append("b");</c>) left a <c>)</c> where the
-    /// pattern wanted a name, and an INDEXER-spelled receiver (<c>cells[i].Sb</c>) could not be spelled by an
-    /// identifier pattern at all. Both refused a run this guard PRINTS that it reads, so a phrase split across
-    /// one reached a caller with INV1 green. Asking the syntax tree instead makes both correct by construction
-    /// rather than by two more alternations: the head receiver is a NODE, whatever it is spelled like, and a
-    /// chain is a parent relation rather than a window of characters.</para>
+    /// <para><b>Why the tree and not the text in front of the literal.</b> Reading a receiver NAME out of the
+    /// characters before a literal is a guess at a receiver rather than the receiver, and it cannot spell two
+    /// shipped shapes at all: a call with a VALUE argument earlier in the chain
+    /// (<c>sb.Append(count).Append("a"); sb.Append("b");</c>) leaves a <c>)</c> where a name is wanted, and an
+    /// INDEXER-spelled receiver (<c>cells[i].Sb</c>) is not an identifier. Both are runs this guard claims to read,
+    /// so a phrase split across one would reach a caller with INV1 green. From the tree the head receiver is a
+    /// NODE whatever it is spelled like, and a chain is a parent relation rather than a window of characters.</para>
     /// <para>This is READER A's knowledge alone, which is why <see cref="AppendCall"/> lives here and not beside
     /// <see cref="SourceLiteral"/>: reader B never sees it, and <c>INV6-AGREE</c> compares the two readers'
     /// LITERALS, below and before any merging. Nothing here can make the two agree.</para></summary>
@@ -103,8 +98,7 @@ public static class RoslynLiteralReader
             // ONE argument, and it must BE the literal: a second argument is a value between the two halves, and
             // a named or by-ref argument is not the text-adding shape either. "Be" rather than "end with" —
             // `sb.Append(name == "…")` closes on a string and appends a bool, so its literal is read by nobody,
-            // and keying that call at the literal's end would merge text no caller sees. Measured: admitting an
-            // expression that merely ends on a literal joins 114 further pairs in the shipped trees.
+            // and keying that call at the literal's end would merge text no caller sees.
             var args = inv.ArgumentList.Arguments;
             if (args.Count != 1 || args[0].NameColon is not null
                 || !args[0].RefKindKeyword.IsKind(SyntaxKind.None)) continue;
@@ -181,13 +175,12 @@ public static class RoslynLiteralReader
     /// <para>The doubled braces are collapsed here rather than taken from the token. A text segment's
     /// <c>ValueText</c> resolves backslash escapes but leaves <c>{{</c> and <c>}}</c> as written — brace
     /// un-doubling happens later, when the compiler lowers the interpolation — so the token's value is not yet the
-    /// string the program prints. Found by <c>INV6-AGREE</c> on shipped GraphQL and JSON-shaped messages, which is
-    /// the disagreement that arm exists to produce.</para>
+    /// string the program prints. It shows up on GraphQL and JSON-shaped messages.</para>
     /// <para><b>Only for the flavours that HAVE escapes.</b> Doubling is how a brace is spelled in the two regular
     /// interpolated forms, so there a doubled brace can only BE an escape and the collapse is exact. A RAW
     /// interpolated string escapes nothing: its hole opens on a run of as many braces as it has dollar signs, and
     /// any shorter run is ordinary content — so collapsing there would hand back a value the compiler never
-    /// builds, and INV6-AGREE would red on correct source naming neither reader. The start token says which
+    /// builds, and INV6-AGREE would go red on correct source naming neither reader. The start token says which
     /// flavour this is, so the question is answered by the parse rather than assumed.</para></summary>
     static string Interpolated(InterpolatedStringExpressionSyntax interp)
     {

--- a/src/housecarl-generator/SkyPatcherHarness.cs
+++ b/src/housecarl-generator/SkyPatcherHarness.cs
@@ -5,23 +5,18 @@ using Mutagen.Bethesda.Plugins;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// SkyPatcher Wave-1 CRUX harness (plan dev/plans/SKYPATCHER_DISTRIBUTOR_TOOL_PLAN_2026-07-08.md §7
-/// Wave 1): stand the REAL service path (<see cref="LoadOrderService.SkyPatcherLayer"/>) up against a
-/// live MO2 instance and print the whole INI layer — the artifact Aaron verifies against xEdit +
-/// in-game (the empirical gate; the promise is proven, not reviewed).
-///
-/// <para>The per-record mode went with <c>LoadOrderService.SkyPatcherPostState</c> (#486): the service
-/// member had no shipped caller once the 1.x read tools were cut, and this harness was the only thing
-/// left driving it. The layer mode is unaffected — it reads its own service member.</para>
+/// Stand the REAL service path (<see cref="LoadOrderService.SkyPatcherLayer"/>) up against a live MO2
+/// instance and print the whole INI layer — the artifact to check against xEdit and in-game. Needs a
+/// live instance, so it is run by hand, not from CI.
 ///
 /// Run: dotnet run --project src/housecarl-generator skypatcher-layer --instance &lt;MO2 instance dir&gt;
 /// </summary>
 public static class SkyPatcherHarness
 {
-    /// <summary>corpus.json is GENERATED, not tracked — run from outside the repo root the default
-    /// relative CorpusPath resolves to nothing and the service's rulebook/type-catalog loads crash
-    /// unnamed. Bootstrap the FloiFieldsProbe way (generate into a unique temp dir, cleaned on exit)
-    /// around <paramref name="body"/> — the ONE bootstrap both harness modes ride (review fold).</summary>
+    /// <summary>corpus.json is GENERATED, not tracked, so when this runs from outside the repo root the
+    /// default relative CorpusPath resolves to nothing and the service's rulebook and type-catalog loads
+    /// crash with no useful message. Generate one into a unique temp dir, cleaned on exit, around
+    /// <paramref name="body"/>.</summary>
     static int WithCorpus(Func<int> body)
     {
         string? tmp = null;
@@ -39,9 +34,8 @@ public static class SkyPatcherHarness
     }
 
     /// <summary>
-    /// The Wave-2 layer harness: the whole SkyPatcher layer + conflict report off a live MO2 instance,
-    /// rendered by the SAME Wire the housecarl_skypatcher_layer tool uses (internals-visible) — what the
-    /// tool will return, verifiable before the plugin repackages.
+    /// The whole SkyPatcher layer + conflict report off a live MO2 instance, rendered by the SAME Wire the
+    /// housecarl_skypatcher_layer tool uses (internals-visible), so what prints is what the tool returns.
     /// Run: dotnet run --project src/housecarl-generator skypatcher-layer --instance &lt;MO2 instance dir&gt; [--filter x]
     /// </summary>
     public static int RunLayer(string[] args)

--- a/src/housecarl-generator/SourceLiteral.cs
+++ b/src/housecarl-generator/SourceLiteral.cs
@@ -1,20 +1,18 @@
 namespace HousecarlGenerator;
 
 /// <summary>
-/// One string literal as a READER hands it back: the decoded value the compiler would build, plus the source span
+/// One string literal as a reader hands it back: the decoded value the compiler would build, plus the source span
 /// that lets adjacent literals be recognised as one authored sentence.
 ///
-/// <para>This record is the ONLY thing <see cref="RoslynLiteralReader"/> and <see cref="HandLiteralLexer"/> share.
-/// That is deliberate and load-bearing: <c>description-vocab-guard</c>'s completeness claim is certified by the
-/// two readers AGREEING, and an agreement between two spellings that share their tokenization would certify
-/// nothing (#386 — both prior designs died of a completeness claim checked by the machinery it certifies). A data
-/// shape is not tokenization; a helper either of them called to decide what a literal IS would be.</para>
+/// <para>This record is the ONLY thing <see cref="RoslynLiteralReader"/> and <see cref="HandLiteralLexer"/> may
+/// share. <c>description-vocab-guard</c> certifies its completeness by the two readers agreeing, so they must not
+/// share any code that decides what a literal IS — a shared data shape is fine, a shared tokenization helper is
+/// not.</para>
 /// </summary>
 /// <param name="Line">1-based line the literal starts on — for the <c>path:line</c> an author is sent to.</param>
-/// <param name="Depth">How many interpolation HOLES enclose this literal. 0 is ordinary top-level text; 1 is a
-/// literal inside <c>$"… {cond ? "arm" : "other"} …"</c>, which is the shape the second design could not see at
-/// all. Only depth-0 literals take part in the <c>+</c>-run merge — a literal inside a hole is its own sentence,
-/// because what surrounds it is an expression rather than prose.</param>
+/// <param name="Depth">How many interpolation holes enclose this literal. 0 is ordinary top-level text; 1 is a
+/// literal inside <c>$"… {cond ? "arm" : "other"} …"</c>. Only depth-0 literals take part in the <c>+</c>-run
+/// merge — a literal inside a hole is its own sentence, because what surrounds it is an expression, not prose.</param>
 /// <param name="Text">The DECODED value: escapes resolved, verbatim doubling collapsed, raw-string indentation
 /// stripped — the string the compiler builds. An interpolated literal keeps its authored text with each hole
 /// rendered as <see cref="HoleMarker"/>, because what fills a hole at runtime is a value, not a claim.</param>
@@ -22,9 +20,9 @@ namespace HousecarlGenerator;
 /// <param name="End">Source offset one past the literal's closing quote.</param>
 public readonly record struct SourceLiteral(int Line, int Depth, string Text, int Start, int End)
 {
-    /// <summary>What both readers put in place of an interpolation hole. Carries no letters, so it can never
-    /// manufacture a phrase that the author did not write; visible in an excerpt, so a reader of a violation can
-    /// see where the value went. The consequence — a phrase split ACROSS a hole is not matched, exactly as a
-    /// phrase split across <c>"a" + x + "b"</c> is not — is a declared boundary of the guard, not an accident.</summary>
+    /// <summary>What both readers put in place of an interpolation hole. It must carry no letters, so it can never
+    /// manufacture a phrase the author did not write, and must stay visible in an excerpt. A phrase split across a
+    /// hole is therefore not matched, exactly as one split across <c>"a" + x + "b"</c> is not — a declared boundary
+    /// of the guard.</summary>
     public const string HoleMarker = "{…}";
 }

--- a/src/housecarl-generator/ToolNameMatch.cs
+++ b/src/housecarl-generator/ToolNameMatch.cs
@@ -4,25 +4,17 @@ namespace HousecarlGenerator;
 /// Whole-identifier matching for tool and skill names, shared by every guard that asks "does this text name
 /// THIS tool".
 ///
-/// It exists because the 2.0 surface renamed tools onto PREFIXES of the 1.x names they absorbed —
-/// <c>housecarl_create</c> ⊂ <c>housecarl_create_record</c>, and the same for remove/forward — so a bare
-/// <c>Contains</c> answers "yes" for a text that names only the retired tool. That is not a hypothetical:
-/// the #468 review rounds measured it holding a guard GREEN while the behaviour under it was gutted. The
-/// binding shim's retired-name response ECHOES the name it is refusing (<c>housecarl_create_record is not on
-/// this surface — …</c>), so a <c>Contains("housecarl_create")</c> test of that response is satisfied by the
-/// echo alone, whatever the successor teaching says — and three of the six retired write tools collide that way.
-///
-/// The matcher was written in <see cref="CodexUmbrellaCoverageProbe"/> for the same collision and lives here so
-/// every consumer shares one implementation with one set of teeth: that probe's GUARD-SELF arm derives the
-/// colliding pairs from the real name set and asserts the matcher tells each pair apart, so it now vouches for
-/// this helper on behalf of all of them rather than for one file's private copy.
+/// The 2.0 surface renamed tools onto PREFIXES of the 1.x names they absorbed — <c>housecarl_create</c> is a
+/// prefix of <c>housecarl_create_record</c>, and the same for remove/forward — so a bare <c>Contains</c> answers
+/// "yes" for a text that names only the retired tool. The binding shim also ECHOES the retired name in its
+/// refusal, so a <c>Contains</c> check of that response is satisfied by the echo alone. Match at identifier
+/// boundaries instead.
 /// </summary>
 internal static class ToolNameMatch
 {
     /// <summary>Does <paramref name="text"/> mention <paramref name="name"/> as a WHOLE identifier — not as part
-    /// of a longer name? Both sides are checked (PR #311 round-2 review [low]: checking only the trailing side let
-    /// a suffix collision through — a future skill slug <c>record-jobs</c> would have been reported as routed by a
-    /// router that mentions only <c>bulk-record-jobs</c>).</summary>
+    /// of a longer name? Both sides must be checked: names collide by suffix as well as by prefix, so
+    /// <c>record-jobs</c> must not match a text that mentions only <c>bulk-record-jobs</c>.</summary>
     internal static bool ReferencedAtBoundary(string text, string name)
     {
         for (int i = text.IndexOf(name, StringComparison.Ordinal); i >= 0;
@@ -36,7 +28,7 @@ internal static class ToolNameMatch
     }
 
     /// <summary>The identifier alphabet these names are written in: tool names are snake_case, skill slugs are
-    /// kebab-case, so a letter, digit, <c>_</c> or <c>-</c> continues a name rather than ending it. Without the
-    /// hyphen the boundary in <c>bulk-record-jobs</c> would read as a word break and re-open that hole.</summary>
+    /// kebab-case, so a letter, digit, <c>_</c> or <c>-</c> continues a name rather than ending it. Dropping the
+    /// hyphen would make <c>bulk-record-jobs</c> read as three words and re-open the suffix collision.</summary>
     internal static bool IsNamePart(char c) => char.IsLetterOrDigit(c) || c == '_' || c == '-';
 }

--- a/src/housecarl-generator/WriteCensus.cs
+++ b/src/housecarl-generator/WriteCensus.cs
@@ -5,19 +5,16 @@ using Mutagen.Bethesda.Skyrim;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// The write-surface CENSUS (step 7) — the cornerstone-completeness scoreboard.
+/// The write-surface CENSUS — the cornerstone-completeness scoreboard.
 ///
-/// Replaces the originally-planned "breadth sweep" (plan §5.2), which a pre-build audit
-/// (<c>dev/review/STEP7_SWEEP_AUDIT_2026-05-30.md</c>) proved would false-green: iterating the 133
-/// record roots and picking one field per type silently never touches the ~5k writable leaves that
-/// live behind a collection element, on a nested-group record, or on a polymorphic arm — yet would
-/// still report green. That is the exact Q3 failure (a silently degraded mode) the project exists to
-/// prevent.
+/// It must walk EVERY writable non-identity leaf by construction. A sweep that iterates the 133 record
+/// roots and picks one field per type never touches the ~5k writable leaves living behind a collection
+/// element, on a nested-group record, or on a polymorphic arm, and would still report green — a
+/// silently degraded answer, which this census exists to make impossible.
 ///
-/// Instead — the same discipline <c>coerce-audit</c> already proves for the VALUE surface, applied to
-/// the REACHABILITY surface: walk EVERY writable non-identity leaf by construction, classify each by
-/// the EARLIEST engine capability that makes it writable, and loud-list every deferred leaf with a
-/// per-bucket WIRE-WHEN trigger — surfaced every run, never silently skipped.
+/// So: classify each leaf by the EARLIEST engine capability that makes it writable, and loud-list every
+/// deferred leaf with a per-bucket WIRE-WHEN trigger, surfaced every run and never silently skipped.
+/// It is the same discipline <c>coerce-audit</c> applies to the VALUE surface, applied to reachability.
 ///
 /// Classification is by construction, on two axes the live engine code imposes today:
 ///   - record resolution: <see cref="WriteEngine.EnumerateFlatGroups"/> — only flat SkyrimGroup&lt;T&gt;
@@ -72,13 +69,11 @@ public static class WriteCensus
             {
                 switch (f.Cardinality)
                 {
-                    // …and the same rule on the SUBSTRUCT axis (#335). A substruct TypeRef could not be a record until
-                    // the classifier stopped calling Cell.Landscape / Worldspace.TopCell FormLinks; without this guard
-                    // the walk crosses Worldspace -> TopCell -> Cell and counts the whole nested-group world as
-                    // reachable today (+87 leaves, and Cell's 44 fields leaving the deferred bucket while axis 1 still
-                    // prints them as deferred — a scoreboard contradicting itself, which is the Q3 failure this census
-                    // exists to prevent). Descending INTO a present child record is not the same capability as
-                    // resolving the ~60k CELLs that need the nested-group wave.
+                    // …and the same rule on the SUBSTRUCT axis. A substruct TypeRef CAN be a record (Cell.Landscape,
+                    // Worldspace.TopCell), and without this guard the walk crosses Worldspace -> TopCell -> Cell and
+                    // counts the whole nested-group world as reachable today, while axis 1 still prints those same
+                    // fields as deferred — a scoreboard contradicting itself. Descending INTO a present child record
+                    // is not the same capability as resolving the ~60k CELLs the nested-group wave needs.
                     case "substruct" when f.TypeRef is { } tr && !IsRecord(tr):
                         subAdj[t.Name].Add(tr); navAdj[t.Name].Add(tr); break;
                     // A collection element that is itself a RECORD is NOT unlocked by collection navigation —
@@ -130,12 +125,12 @@ public static class WriteCensus
         // Unifies the two completeness instruments: a leaf that is REACHABLE today but whose value type the
         // engine cannot yet coerce (the coerce-audit deferred surface) must not be counted as writable-today.
         var reachableButCoercionDeferred = new List<string>();
-        // …and the leaves whose field holds an owned child record — reachable, but nothing writes AT them (#335).
+        // …and the leaves whose field holds an owned child record — reachable, but nothing writes AT them.
         var ownedChildLeaves = new List<string>();
         int totalWritable = 0;
         // Of the TODAY list/dict fields, those with a STRUCT element are only structurally writable today
-        // (Remove/Clear); ADDING a composed element is wave-1 (element composition), exactly as coerce-audit +
-        // write-proof treat them. Counted here so the "writable today" headline is faithful about that nuance.
+        // (Remove/Clear); ADDING a composed element needs element composition, exactly as coerce-audit and
+        // write-proof treat them. Counted here so the "writable today" headline is faithful about that.
         int todayStructElemColl = 0;
 
         foreach (var t in corpus.Types.Values)
@@ -158,18 +153,15 @@ public static class WriteCensus
                     reachableButCoercionDeferred.Add($"{t.Name}.{f.Name} ({Pretty(rt)})");
                     continue;
                 }
-                // The same subtraction for an OWNED CHILD RECORD leaf (#335). Every write AT the field is refused —
-                // it is not built from parts, not set from a value, and not cleared (that would delete the record) —
-                // so counting it writable-today would inflate the headline by a field nothing can write. It was
-                // already excluded while it was classified a formlink, by the coercion clause just above (a Cell
-                // does not coerce); the reclassification moved it out of "scalarish" and the exclusion has to move
-                // with it, or the correction silently buys a leaf. What IS writable is the child record itself, on
-                // its own axis, and that record's own leaves are counted under its own type.
-                // NOT gated on the TODAY bucket, unlike the coercion clause above. Bucket is a property of the leaf's
-                // OWNER (Worldspace is flat → TODAY; Cell is nested → wave_nested), and the two owned-child leaves are
-                // the same field kind in different owners. Gating on TODAY subtracted Worldspace.TopCell and left
-                // Cell.Landscape sitting in the nested-wave bucket — promised to a wave that will never make it
-                // writable, since no wave changes the answer for a field that holds a record. Same kind, same line.
+                // The same subtraction for an OWNED CHILD RECORD leaf. Every write AT the field is refused — not built
+                // from parts, not set from a value, and not cleared, since that would delete the record — so counting
+                // it writable-today would inflate the headline by a field nothing can write. What IS writable is the
+                // child record itself, on its own axis, and its leaves are counted under its own type.
+                // NOT gated on the TODAY bucket, unlike the coercion clause above: bucket is a property of the leaf's
+                // OWNER (Worldspace is flat, so TODAY; Cell is nested, so wave_nested), and the two owned-child leaves
+                // are the same field kind in different owners. Gating on TODAY would leave Cell.Landscape in the
+                // nested-wave bucket, promised to a wave that cannot make it writable — no wave changes the answer for
+                // a field that holds a record.
                 if (SchemaClassifier.IsOwnedChildRecord(f, corpus))
                 {
                     ownedChildLeaves.Add($"{t.Name}.{f.Name} ({f.TypeRef})");
@@ -183,7 +175,7 @@ public static class WriteCensus
         }
 
         // ======================================================================
-        //  REPORT — plain-English lay-of-the-land first (for Aaron), then the precise buckets.
+        //  REPORT — plain-English lay-of-the-land first, then the precise buckets.
         // ======================================================================
         Console.WriteLine("================================================================");
         Console.WriteLine(" houseCARL write-surface census");
@@ -299,8 +291,8 @@ public static class WriteCensus
         File.WriteAllText(Path.Combine(outDir, "write-census.json"),
             JsonSerializer.Serialize(summary, new JsonSerializerOptions { WriteIndented = true }));
 
-        // The census MEASURES; it does not itself prove the reachable surface byte-true (that is the proof
-        // harness, the next increment). It also never silently passes: it asserts its own partition is total.
+        // The census MEASURES; proving the reachable surface byte-true is the proof harness's job. It never
+        // silently passes: it asserts its own partition is total.
         var partitionOk = grandTotal == totalWritable;
         Console.WriteLine(partitionOk
             ? $"=== CENSUS COMPLETE: {totalWritable} writable leaves fully partitioned; {leafCount[TODAY]} writable today, {totalWritable - leafCount[TODAY]} deferred across named waves. ==="

--- a/src/housecarl-generator/WriteOracle.cs
+++ b/src/housecarl-generator/WriteOracle.cs
@@ -7,7 +7,7 @@ using Mutagen.Bethesda.Skyrim;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// The oracle (plan step 5 / build-sequence step 6) — per-kind byte-identical cells.
+/// The write oracle — per-kind byte-identical cells.
 ///
 /// Each cell performs the same logical mutation two ways: <b>Path A</b> through the generic
 /// reflection engine (<see cref="WriteEngine"/>), <b>Path B</b> via a hand-written typed Mutagen
@@ -109,7 +109,7 @@ public static class WriteOracle
                     ActorValue = actorValue,
                     Association = new FormLink<ILightGetter>(FormKey.Factory("00C2A8:Skyrim.esm")),
                 }),
-            // --- new value-type coercion kinds (step-4 coercion completion) ---
+            // --- value-type coercion kinds ---
             Cell.Generic("value Color    Activator.MarkerColor=255,128,0",
                 m => m.Activators.FirstOrDefault(),
                 new() { RecordType = "Activator", Path = ["MarkerColor"], Verb = "Set", Value = "255,128,0" },
@@ -125,9 +125,9 @@ public static class WriteOracle
             Cell.Armor("substruct-whole TranslatedString Armor.Name", ironBoots,
                 new() { RecordType = "Armor", Path = ["Name"], Verb = "Set", Value = "HC Test Boots" },
                 a => a.Name = "HC Test Boots"),
-            // --- wave 1 collection-nav: edit a sub-field INSIDE a list element (Spell.Effects[0]) ---
-            // Proves the new shape (list-element → substruct → scalar, and list-element → formlink) is byte-identical
-            // to a hand-typed Mutagen edit, exactly as the other cells prove their kinds.
+            // --- collection-nav: edit a sub-field INSIDE a list element (Spell.Effects[0]) ---
+            // Proves list-element → substruct → scalar and list-element → formlink are byte-identical to a
+            // hand-typed Mutagen edit, exactly as the other cells prove their kinds.
             Cell.Generic("collnav scalar   Spell.Effects[0].Data.Magnitude=25",
                 m => m.Spells.FirstOrDefault(s => s.Effects.Count > 0 && s.Effects[0].Data is not null),
                 new() { RecordType = "Spell", Path = ["Effects[0]", "Data", "Magnitude"], Verb = "Set", Value = "25" },
@@ -136,9 +136,9 @@ public static class WriteOracle
                 m => m.Spells.FirstOrDefault(s => s.Effects.Count > 0),
                 new() { RecordType = "Spell", Path = ["Effects[0]", "BaseEffect"], Verb = "Set", Value = "013CA9:Skyrim.esm" },
                 r => ((ISpell)r).Effects[0].BaseEffect = new FormLinkNullable<IMagicEffectGetter>(FormKey.Factory("013CA9:Skyrim.esm"))),
-            // --- wave 1 half B composition: ADD a NEW modeled struct element to a list, built FROM PARTS ---
-            // Proves the build-from-parts path (StructSpec -> recursive BuildStruct, INCL. the nested Data substruct,
-            // materialized on first write) is byte-identical to a hand-typed Mutagen Add — the composed-struct shape.
+            // --- composition: ADD a NEW modeled struct element to a list, built FROM PARTS ---
+            // Proves the build-from-parts path (StructSpec -> recursive BuildStruct, including the nested Data
+            // substruct materialized on first write) is byte-identical to a hand-typed Mutagen Add.
             Cell.Generic("struct-elem Add  LeveledItem.Entries+=Entry{Data}",
                 m => m.LeveledItems.FirstOrDefault(l => l.Entries is { Count: > 0 }),
                 new()

--- a/src/housecarl-generator/WriteProof.cs
+++ b/src/housecarl-generator/WriteProof.cs
@@ -11,14 +11,12 @@ using Mutagen.Bethesda.Skyrim;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// Wave 0 — the write-PROOF harness. Proves the census's "writable today" surface (≈2,900 leaves on
-/// flat-group records) is not merely <i>reachable</i> but actually <b>writes the intended value and disturbs
-/// nothing else</b>, across real vanilla records, by construction. The roadmap
-/// (<c>dev/plans/WRITE_SURFACE_ROADMAP_2026-05-30.md</c> §3/§6) makes this the wave that BUILDS the
-/// only-target-moved differ every later wave reuses.
+/// The write-PROOF harness. Proves the census's "writable today" surface (≈2,900 leaves on flat-group
+/// records) is not merely <i>reachable</i> but actually <b>writes the intended value and disturbs nothing
+/// else</b>, across real vanilla records, by construction. It also builds the only-target-moved differ every
+/// later phase here reuses.
 ///
-/// Two phases, both fail-loud (Q3 — never a silent skip; a silent skip is the read-side false-green the
-/// step-7 sweep audit caught):
+/// Two phases, both fail-loud — never a silent skip, because a skipped subject is a false green:
 ///
 ///   PHASE 1 — DIFFER COMPLETENESS (the load-bearing primitive).
 ///     A corpus-driven reflective <see cref="Snapshot"/> walks EVERY modeled field of a record into a flat
@@ -52,13 +50,13 @@ public static class WriteProof
 {
     // The modlist's own canonical game root — its isolated "Stock Game" instance, paired with the
     // mods/ tree — NOT the global Steam install. The full vanilla master set lives here; loading all five
-    // (vs Skyrim.esm alone) is the residual lever the wave-0 handoff named: more real Bethesda instances
+    // (vs Skyrim.esm alone) is what shrinks the no-instance gap: more real Bethesda instances
     // populate the optional paths a single master leaves empty.
     const string DefaultDataDir = @"C:\MO2\Instance\Stock Game\Data";
     static readonly string[] VanillaMasters =
         { "Skyrim.esm", "Update.esm", "Dawnguard.esm", "HearthFires.esm", "Dragonborn.esm" };
     // Beyond vanilla, the live mods/ tree. The heaviest mod plugins (Requiem, the modlist's own outputs, LOTD, the
-    // quest mods, ...) populate the optional fields no vanilla master ever fills — driving the residual toward
+    // quest mods, ...) populate the optional fields no vanilla master ever fills — driving the gap toward
     // zero AND proving the engine against real MODDED records. Loaded the same standalone way (no load-order
     // assembly: we snapshot records, never resolve cross-plugin links). Curated by record density (largest =
     // most records); the full-folder sweep (all ~3,400 plugins) is a separate, larger pass.
@@ -82,7 +80,7 @@ public static class WriteProof
         var rulebook = CorpusRulebook.Load();
 
         // Load each as a standalone binary overlay. A plugin that won't parse is surfaced LOUD, never silently
-        // dropped (Q3) — at modlist scale a real differ/format gap must show, not vanish into a skipped source.
+        // dropped — at modlist scale a real differ/format gap must show, not vanish into a skipped source.
         var sources = new List<(string label, ISkyrimModGetter overlay)>();
         var loaded = new List<string>();
         var loadFailures = new List<string>();
@@ -329,7 +327,7 @@ public static class WriteProof
         DumpList("RULEBOOK FALSE-REJECTS (engine proved it, pre-flight wrongly rejected — validator bug)", falseRejects);
         DumpList("RULEBOOK FALSE-ACCEPTS (engine could not, pre-flight wrongly accepted — validator too lax)", falseAccepts);
         Console.WriteLine();
-        // No instance to exercise these from = a master-coverage residual, not an engine defect. Surfaced, not skipped.
+        // No instance to exercise these from = a master-coverage gap, not an engine defect. Surfaced, not skipped.
         var noInstByType = noInstance
             .Select(s => s.Split('.')[0]).GroupBy(x => x).OrderByDescending(g => g.Count())
             .Select(g => $"{g.Key}({g.Count()})").ToList();
@@ -359,7 +357,7 @@ public static class WriteProof
     //  TranslatedString substruct) — the exact set Phase 2 drives as a scalar Set. Collection / dict /
     //  polymorphic leaves are set via Add / Struct, not a token; their ELEMENT values reuse the SAME
     //  EmitToken proven here, so proving the emitter on the value-leaf surface proves it for elements
-    //  too. Per-record fault isolation (Q3): a Mutagen-unparseable record is named + counted, never a
+    //  too. Per-record fault isolation: a Mutagen-unparseable record is named + counted, never a
     //  crash (the product-read-path requirement carried from the write-surface completion sweep).
     //    dotnet run --project src/housecarl-generator read-proof [<plugin> ...]
     // ======================================================================
@@ -422,7 +420,7 @@ public static class WriteProof
                     catch (Exception ex) { unreadable.Add($"{typeName} {r.FormKey}: {leaf.Display}: {Flatten(ex)}"); continue; }
                     if (probe.HasValue) { inst = r; break; }
                     // A coercible VALUE leaf must read as a token or a genuine absence. A container summary ("[…]")
-                    // means the reader did not recognise the value type — a read gap that must NOT hide as no-instance (Q3).
+                    // means the reader did not recognise the value type — a read gap that must NOT hide as no-instance.
                     if (probe.Note is { } nt && nt.StartsWith("[", StringComparison.Ordinal)) untokenizable = nt;
                 }
                 if (inst is null)
@@ -443,7 +441,7 @@ public static class WriteProof
                         // The getter probe DID read a value (that's why inst was chosen), but the override read is empty.
                         // A genuine unreadable/no-field is a defect; an absent value = Mutagen's override doesn't carry it
                         // (a write-time-managed field like Worldspace OFST), which the PRODUCT still reads off the source —
-                        // the same residual class write-proof names for Worldspace. Surface loud; not a read defect.
+                        // the same gap class write-proof names for Worldspace. Surface loud; not a read defect.
                         bool realFailure = read.Note is { } n && (n.StartsWith("(unreadable", StringComparison.Ordinal) || n.StartsWith("(no field", StringComparison.Ordinal));
                         if (realFailure) readDefects.Add($"{leaf.Display}: override read failed ({read.Note})");
                         else overrideNotCarried.Add($"{leaf.Display}: readable off source, Mutagen's override does not carry it (write-time-managed) — round-trip via override N/A");
@@ -554,8 +552,8 @@ public static class WriteProof
         // -> rebuild its fields via the engine, where the first write triggers MaterializeSubstruct) serializes
         // BYTE-IDENTICALLY to native. The COMPOSITION surface (GenderedItem<T>/Array2d<T> — no parameterless ctor) is
         // derived BY CONSTRUCTION: the engine throws CompositionRequiredException, caught + tallied as a wave-1
-        // deferral here and printed every run, NEVER silently skipped (Q3). Non-replayable content (arms,
-        // struct-element collections, owned records) is a named residual whose byte-identity rides later waves.
+        // deferral here and printed every run, NEVER silently skipped. Non-replayable content (arms,
+        // struct-element collections, owned records) is a named gap whose byte-identity rides later waves.
         Console.WriteLine("---- PHASE 4: absent-substruct materialization byte-identity (clear substruct -> engine-rebuild == native) ----");
         var ssSeen = new HashSet<string>(StringComparer.Ordinal);
         int ssChecked = 0, ssOk = 0, ssEquiv = 0, ssGetOnly = 0, ssNoInst = 0, ssMarkerResid = 0;
@@ -591,7 +589,7 @@ public static class WriteProof
                             // Phase-1 completeness backs this: an empty value-diff means EVERY modeled value is
                             // identical, so the only possible byte difference is Mutagen's internal DataTypeState/break
                             // marker (derived parse-state, not a content field, not settable via the value write API).
-                            // Named residual, not a fail; a real VALUE divergence still fails loud.
+                            // Named gap, not a fail; a real VALUE divergence still fails loud.
                             var diff = SnapshotValueDiff(natRec, ov, sn.RecordType, ctx);
                             if (diff.Length == 0)
                             {
@@ -644,7 +642,7 @@ public static class WriteProof
         // Step INTO a list/dict struct element and edit a sub-field (Effects[0].Data.Magnitude). Reuses the wave-0
         // differ: snapshot → engine edit through the element → snapshot → assert the value LANDED at the bracketed
         // target AND nothing outside that subtree moved. Polymorphic (arm) sub-leaves behind collnav are excluded
-        // (wave 4); a collnav leaf with no populated element in any source is a surfaced residual, never a skip (Q3).
+        // (wave 4); a collnav leaf with no populated element in any source is a surfaced gap, never a skip.
         Console.WriteLine("---- PHASE 5: collection-nav (wave 1) — edit a sub-field inside a list/dict element; value-landed + only-target-moved ----");
         var cnByCard = new SortedDictionary<string, int[]>(StringComparer.Ordinal);   // sub-leaf card -> [proven, attempted]
         var cnProvenKeys = new HashSet<string>(StringComparer.Ordinal);
@@ -729,8 +727,8 @@ public static class WriteProof
         // list via the engine (clear -> Add each element, each built from a spec EXTRACTED from the native element by
         // the same WalkReplay recursion) serializes BYTE-IDENTICALLY to native. The element-build reuses the verb
         // engine (BuildStruct), so a faithful rebuild IS the byte-identity test. An element CONTAINING a polymorphic
-        // arm (conditions, script properties, …) is a NAMED residual — its byte-identity rides the wave-4 arm proof,
-        // never silently skipped (Q3); the Add CAPABILITY still works, only the BYTE-proof of arm-bearing elements defers.
+        // arm (conditions, script properties, …) is a NAMED gap — its byte-identity rides the wave-4 arm proof,
+        // never silently skipped; the Add CAPABILITY still works, only the BYTE-proof of arm-bearing elements defers.
         Console.WriteLine("---- PHASE 6: struct-element composition byte-identity (clear -> engine-Add-from-parts == native) ----");
         var seSeen = new HashSet<string>(StringComparer.Ordinal);
         int seChecked = 0, seOk = 0, seEquiv = 0, seNoInst = 0;
@@ -747,7 +745,7 @@ public static class WriteProof
                 if (!seSeen.Add(leaf.LeafKey)) continue;                          // one byte-check per distinct leaf-key
 
                 // Upfront structural guards — each is a struct-element collection the wave-1 Add-from-parts proof
-                // does NOT close here; surfaced as a NAMED deferral (Q3), never a silent skip or a false failure.
+                // does NOT close here; surfaced as a NAMED deferral, never a silent skip or a false failure.
                 if (leaf.Cardinality != "list")                                  // a non-arm struct-valued dict — Phase 6 proves lists
                 { Defer($"struct-valued {leaf.Cardinality} (Phase 6 proves lists)"); continue; }
                 var collAq = leaf.Field.MutableTypeAssemblyQualified ?? leaf.Field.GetterTypeAssemblyQualified;
@@ -788,7 +786,7 @@ public static class WriteProof
                         // (a Mutagen getter/concrete-settability quirk; the corpus marks it writable via the mutable
                         // interface). An UNREPLACEABLE collection cannot be clear-rebuilt — the proof METHOD is N/A here,
                         // NOT an engine defect (the Add capability is proven by the settable leaves + the oracle). Named
-                        // deferral, never a silent skip or a false failure (Q3).
+                        // deferral, never a silent skip or a false failure.
                         Defer("runtime get-only collection (clear-rebuild byte-proof N/A; Add capability proven elsewhere)");
                         continue;
                     }
@@ -802,7 +800,7 @@ public static class WriteProof
                         {
                             // Value-identical but byte-different => a Mutagen internal DataTypeState/break marker only
                             // (e.g. the ScenePhase Unused2 marker), exactly like Phase 4's Scene.Unused2: Phase-1 differ
-                            // completeness guarantees an empty value-diff means no modeled content field differs. Named residual.
+                            // completeness guarantees an empty value-diff means no modeled content field differs. Named gap.
                             var diff = SnapshotValueDiff(natRec, ov, leaf.RecordType, ctx);
                             if (diff.Length == 0)
                                 seMarkerList.Add($"{leaf.Display}: {Math.Abs((long)na.bytes.Length - rbz.bytes.Length)}B DataTypeState/break marker (all modeled values identical)");
@@ -841,7 +839,7 @@ public static class WriteProof
     // subtree-scoping is automatic. A byte-write per type then proves serialization: single-master + source SHA
     // untouched. The 6 placed subtypes with 0 vanilla instances (Arrow/Barrier/Beam/Cone/Flame/Missile) share the
     // exact APlaced + cell-child resolution path as the proven placed types; they are LOUD-LISTED as a named
-    // residual (Q3), byte-true deferred to a source that contains them — never silently treated as covered.
+    // gap, byte-true deferred to a source that contains them — never silently treated as covered.
     static Phase7Result Phase7_NestedGroup(
         List<(string label, ISkyrimModGetter overlay)> sources, WalkContext ctx, CorpusRulebook rulebook, ISkyrimModGetter[] allMasters)
     {
@@ -946,10 +944,10 @@ public static class WriteProof
         Console.WriteLine();
         Console.WriteLine("   by cardinality (proven/attempted):");
         foreach (var (card, t) in byCard) Console.WriteLine($"        {card,-12} {t[0]}/{t[1]}");
-        // LOUD-LIST the absent placed types — named residual, byte-true deferred to a source that contains them (Q3).
+        // LOUD-LIST the absent placed types — named gap, byte-true deferred to a source that contains them.
         Console.WriteLine($"   ABSENT nested types (0 instances in any loaded source; resolution path is identical — surfaced, never silently covered): {absent.Count}");
         if (absent.Count > 0) Console.WriteLine($"        {string.Join(", ", absent)}");
-        // finding 4 (parity): Phase 7 per-sample residuals surfaced, not silently continued (like Phase 2/5 no-instance lines).
+        // Phase 7 per-sample gaps are surfaced, not silently continued — the same as Phase 2/5's no-instance lines.
         Console.WriteLine($"   NESTED residual — leaf-sites not populated on the sampled instance (no-instance, surfaced not skipped): {p7NoInst}; whole-value/composition leaves (not a differ-tracked value-leaf here): {p7WholeValue}.");
         DumpList("NESTED-GROUP violations (value didn't land / moved outside the target record)", violations);
         DumpList("NESTED-GROUP throws (engine could not perform a nested edit)", throwsList);
@@ -1004,7 +1002,7 @@ public static class WriteProof
 
     // ============ PHASE 8 — NESTED-GROUP FAIL-CLOSED (wave 3 guard) ============
     // The wave-3 resolver has two guard clauses that must fail LOUD, never silently resolve to the wrong record
-    // (Q3): (A) a nested record routed WITHOUT the source link cache (WriteEngine NestedGetOrAddAsOverride guard 1),
+    // (A) a nested record routed WITHOUT the source link cache (WriteEngine NestedGetOrAddAsOverride guard 1),
     // and (B) a nested record ABSENT from the provided cache (guard 2). Phase 7 proves the HAPPY path byte-true;
     // Phase 8 proves the SAD path throws. It drives each real instance-bearing nested record through both negatives
     // and asserts an exception is raised — a return WITHOUT throwing is the silent-failure we are guarding against.
@@ -1050,7 +1048,7 @@ public static class WriteProof
             Console.WriteLine($"   {cat,-16} {rec0.FormKey}  no-cache: {aNote}; empty-cache: {bNote}");
         }
 
-        // The absent placed types share this EXACT path (no per-type branch) — fail-closed covered transitively (Q3).
+        // The absent placed types share this EXACT path (no per-type branch) — fail-closed covered transitively.
         Console.WriteLine($"   absent nested types share this exact resolution path (no per-type branch) — fail-closed covered transitively: {absent.Count}{(absent.Count > 0 ? " (" + string.Join(", ", absent) + ")" : "")}");
         DumpList("NESTED FAIL-CLOSED gaps (a missing/uncacheable nested record did NOT fail loud)", failures);
         var pass = failures.Count == 0 && casesRun > 0;
@@ -1173,7 +1171,7 @@ public static class WriteProof
 
     // ============ PHASE 10 — ARM / FLOI FAIL-CLOSED (wave 4 guard) ============
     // Mirrors Phase 8: the wave-4 SetFloi value-classifier must throw LOUD on a malformed condition target, never
-    // write the wrong four bytes (Q3). Each malformed value is driven through the REAL engine path (ApplyVerb ->
+    // write the wrong four bytes. Each malformed value is driven through the REAL engine path (ApplyVerb ->
     // SetFloi) on a real condition arm AND through the pre-flight (rulebook.Validate, which routes to the shared
     // TryClassifyFloiValue — the same classifier the engine uses); BOTH must fail closed (engine throws + rulebook
     // rejects) or the case is a gap. The non-flag-bearing-parent guard in
@@ -1240,9 +1238,9 @@ public static class WriteProof
     //
     // The PEX half of the orphan bucket stays LOUD-DEFERRED: the Mutagen PEX read->write round-trip GATE did NOT clear
     // (pex-probe — a rewritten .pex diverges from the source bytes), so binary-PEX write is not faithful enough to wire.
-    // That is the cornerstone's ONE legitimate residual (a Mutagen-vs-source delta), surfaced here every run + by the
+    // That is the cornerstone's ONE legitimate gap (a Mutagen-vs-source delta), surfaced here every run + by the
     // census orphan bucket; houseCARL PREFERS .psc source + Papyrus compile (project_pex_prefer_source_policy). Wave 5
-    // closes the ModHeader proof slice; the PEX residual reconciles at the final completion sweep's fail-loud delta report.
+    // closes the ModHeader proof slice; the PEX gap reconciles at the final completion sweep's fail-loud delta report.
     static Phase11Result Phase11_ModHeader(
         List<(string label, ISkyrimModGetter overlay)> sources, WalkContext ctx, CorpusRulebook rulebook, ISkyrimModGetter[] allMasters)
     {
@@ -1393,7 +1391,7 @@ public static class WriteProof
     /// <summary>The FLOI site universe BY CONSTRUCTION (every (concrete *ConditionData arm, FormLinkOrIndex prop)
     /// pair — the same 156 the scout + coerce-audit derive) + one POPULATED sample per site from the sources, its
     /// native value expressed by mode (read off the arm flags — independent of the engine). Shared by Phase 9 +
-    /// Phase 10 so the site predicate lives in ONE place (no forked predicate — baseline review S2). Recognition uses
+    /// Phase 10 so the site predicate lives in ONE place rather than forking. Recognition uses
     /// the engine's shared <see cref="WriteEngine.IsFormLinkOrIndex"/> (no drift). Stops scanning once every site has
     /// a sample; if some are absent it sweeps all sources (the Phase 7 SampleNestedTypes shape).</summary>
     static (Dictionary<string, FloiSiteSample> samples, List<string> allSites, List<string> allTargets) SampleFloiSites(
@@ -1832,8 +1830,8 @@ public static class WriteProof
     /// <see cref="TodaySettableLeaves"/> but with a <c>throughColl</c> gate so it emits ONLY leaves behind ≥1 collection
     /// element (the substruct-only leaves are Phase 2's today surface, proven there). Excluded by design:
     ///   - POLYMORPHIC sub-leaves behind a collection (arm-set, e.g. <c>Condition.Data</c>) — the arm-breadth wave
-    ///     (wave 4); the census's wave_collnav bucket holds these "doubly-blocked" leaves (collnav AND arm), per the
-    ///     roadmap §3 note, so wave 1 does NOT zero that bucket — it closes the navigate-into slice only;
+    ///     (wave 4); the census's wave_collnav bucket holds these "doubly-blocked" leaves (collnav AND arm), so
+    ///     wave 1 does NOT zero that bucket — it closes the navigate-into slice only;
     ///   - record-element collections (nested-group wave) and arm-element collections (arm wave) — only Kind=="struct"
     ///     elements are collnav edges, matching the census navAdj definition;
     ///   - ADDING a composed element (composition, half B) — a different operation, tallied by Phase 2.
@@ -2072,7 +2070,7 @@ public static class WriteProof
         if (leaf.Cardinality is "list" or "dict")
         {
             // Absent (null) collections ARE reachable now — the engine materializes them on Add/Set, so
-            // "add to an absent collection" is a proven today operation, not a skipped residual. Require only
+            // "add to an absent collection" is a proven today operation, not a skipped gap. Require only
             // that the property is readable (a genuinely unreadable property is a real reach failure).
             try { GetValueByName(cur, leaf.FieldPath[^1]); return true; } catch { return false; }
         }
@@ -2081,7 +2079,7 @@ public static class WriteProof
 
     /// <summary>Bracket-aware navigability for a collnav leaf (Phase 5): every intermediate hop resolvable + non-null,
     /// and each collection-element hop (<c>[0]</c>) actually POPULATED on this instance. Checked on the getter, whose
-    /// nullness/population matches the override (a deep copy). A no-instance result is a surfaced residual, never a skip.</summary>
+    /// nullness/population matches the override (a deep copy). A no-instance result is a surfaced gap, never a skip.</summary>
     static bool CollnavNavigable(IMajorRecordGetter rec, TodayLeaf leaf)
     {
         object? cur = rec;
@@ -2413,7 +2411,7 @@ public static class WriteProof
     /// leaf to its native value, Add every coercible-collection element). Sets <paramref name="rebuildable"/> false
     /// (with a reason) if the substruct's content is not faithfully replayable here — a polymorphic arm, a
     /// struct-element collection, an owned record, or a value the engine cannot round-trip from a string. Those are
-    /// NAMED residuals (their byte-identity rides the composition/arm waves), never a silent skip.</summary>
+    /// NAMED gaps (their byte-identity rides the composition/arm waves), never a silent skip.</summary>
     static List<WriteRequest> ExtractSubstructReplay(object ov, SubstructNode sn, WalkContext ctx, out bool rebuildable, out string? reason)
     {
         var reqs = new List<WriteRequest>();
@@ -2527,7 +2525,7 @@ public static class WriteProof
     /// <c>BuildStruct</c>. Type = the element's declared catalog type; Sets = element-rooted writes that rebuild it,
     /// produced by the same <see cref="WalkReplay"/> recursion (so nested sub-structs AND nested struct-element lists
     /// are captured). On an un-replayable element (a polymorphic arm inside — wave 4; an owned record — wave 3; or an
-    /// unstringifiable value) it sets rb/rs false, so the whole rebuild becomes a NAMED residual, never a silent skip.</summary>
+    /// unstringifiable value) it sets rb/rs false, so the whole rebuild becomes a NAMED gap, never a silent skip.</summary>
     static StructSpec ExtractStructSpec(object element, string elementCatalog, WalkContext ctx, ref bool rb, ref string? rs, int depth)
     {
         var sets = new List<WriteRequest>();
@@ -2537,7 +2535,7 @@ public static class WriteProof
 
     /// <summary>Stringify a scalar/enum/value/formlink leaf into the Set-string the engine's Coerce round-trips to
     /// the SAME value (so a rebuilt field is byte-identical). Returns null for a value kind not safely round-trippable
-    /// here — the caller then marks the whole substruct a named residual rather than risk a false byte-divergence.</summary>
+    /// here — the caller then marks the whole substruct a named gap rather than risk a false byte-divergence.</summary>
     static string? LeafSetString(object? v)
     {
         switch (v)
@@ -2586,7 +2584,7 @@ public static class WriteProof
     /// <summary>Snapshot-diff two override records, returning the first differing MODELED field values (or "" when
     /// every modeled value is identical). DataTypeState keys are excluded (Mutagen derived parse-state). Backed by
     /// Phase-1 differ completeness: "" guarantees the only possible byte difference is a *DataTypeState/break marker,
-    /// never an unread content field — so classifying a no-value-diff byte difference as a marker residual is sound.</summary>
+    /// never an unread content field — so classifying a no-value-diff byte difference as a marker gap is sound.</summary>
     static string SnapshotValueDiff(object a, object b, string typeName, WalkContext ctx)
     {
         var sa = Snapshot(a, typeName, ctx); var sb = Snapshot(b, typeName, ctx);

--- a/src/housecarl-generator/WriteProof.cs
+++ b/src/housecarl-generator/WriteProof.cs
@@ -394,7 +394,7 @@ public static class WriteProof
         var readDefects = new List<string>();       // a getter-readable value the reader genuinely could not emit (a real defect)
         var overrideNotCarried = new List<string>();// getter-readable but Mutagen's override doesn't carry it (write-time-managed; same residual class write-proof names for Worldspace) — NOT a defect
         var noReadInstance = new List<string>();    // no populated instance to read (coverage residual, not a defect)
-        var unreadable = new List<string>();        // Mutagen-unparseable record, fault-isolated + named (Q3)
+        var unreadable = new List<string>();        // Mutagen-unparseable record, fault-isolated and named, never skipped
 
         foreach (var (typeName, pool) in pools)
         {


### PR DESCRIPTION
Comments only, no behaviour change. The 26 non-probe files under `src/housecarl-generator` carried a lot of how-we-got-here in their comments — plan and spec section citations, PR and issue numbers, dated audits and reviews, wave/beat/step labels, `Q3`, `Aaron-go` — mixed in with the constraints the code cannot express. This drops the narrative and keeps every constraint, restated in plain words: why the two literal readers must share no tokenization, why the hole-end lookup is memoized (it is what makes the lexer terminate), why raw and verbatim literals must be told apart, why `class-parents` cannot be regenerated on CI, why the localized-strings fixture needs a real `Skyrim.esm`, why an unknown mode is refused rather than read as an output directory, and what each proof harness needs a live MO2 instance for. The 148 probe files are untouched.

Every changed line in the diff is a comment line — checked mechanically: stripping the comments leaves the two revisions byte-identical.

Verification:

- `dotnet build housecarl.sln -c Release` — 0 errors
- `dotnet test src/housecarl-mcp-tests -c Release --no-build --filter "tier!=bridge"` — 984 passed, 0 failed
- `dotnet src/housecarl-generator/bin/Release/net9.0/housecarl-generator.dll ci-all` — 128/128 passed

No CHANGELOG line: a user notices nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)