### PR TITLE
Report a plugin the compact/merge safety scan could not read

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **`housecarl_compact_plugin` and `housecarl_merge_plugins` name a plugin they could not read.** The
+  external-reference pass that runs before a renumber used to skip a plugin it could not open while still
+  counting it as scanned, so a plugin held open by xEdit, MO2 or the running game could make the pass report
+  a coverage it did not have. Such a plugin is now named in the report, with the remedy (close the program
+  holding it and run again), and is no longer counted in the scanned total.
+
 - **`housecarl_records project={"form": "tree"}` states which plugins declare child records.** For a record
   whose type owns children — a cell's placed references, a topic's INFO lines, a worldspace's cells — the tree
   now states, per child-bearing field, which providers declare content there (naming them for a COLLECTION

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -16,8 +16,17 @@ saying it sets an expectation their install may contradict. Say what is known, a
 - **`housecarl_compact_plugin` and `housecarl_merge_plugins` name a plugin they could not read.** The
   external-reference pass that runs before a renumber used to skip a plugin it could not open while still
   counting it as scanned, so a plugin held open by xEdit, MO2 or the running game could make the pass report
-  a coverage it did not have. Such a plugin is now named in the report, with the remedy (close the program
-  holding it and run again), and is no longer counted in the scanned total.
+  a coverage it did not have. Such a plugin is now named in the report, with the reason it could not be read,
+  and is no longer counted in the scanned total. The two reasons get their own sentence: a plugin that could
+  not be OPENED gets the close-the-program-holding-it remedy; a plugin that opened and then faulted part way
+  through gets the exception it faulted with, and no advice to close programs that are holding nothing.
+
+- **`housecarl_compact_plugin` refuses the in-place lane when it could not read a plugin.** Compacting in
+  place — overwriting the target, or rewriting its referencers with `repoint_externals` — needs the
+  external-reference pass to have covered the order, and there is no backup and no review step in that lane.
+  A run whose pass could not read a plugin through is now refused, naming the plugin and the reason, before
+  anything is written and whatever `acknowledge` says; the remedy is to resolve that, or to compact into a new
+  plugin instead. The new-plugin lane is unchanged and still reports the same plugin as a note.
 
 - **`housecarl_records project={"form": "tree"}` states which plugins declare child records.** For a record
   whose type owns children — a cell's placed references, a topic's INFO lines, a worldspace's cells — the tree

--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -185,9 +185,15 @@ public static class DialogueValidate
         foreach (var (plugin, wanted) in wantedIn)
         {
             var perTopic = new Dictionary<FormKey, IReadOnlyList<InfoLine>>();
-            foreach (var (rfk, _, body, _) in view.RecordsIn(new[] { plugin }, DialTypes))
-                if (wanted.Contains(rfk) && body is IDialogTopicGetter dt)
-                    perTopic[rfk] = DialogueInfoOrder.LinesOf(dt);
+            // A plugin that cannot be read now (moved, or held open by another program) leaves its topics
+            // unread, which the absentee accounting below states — never a silently thinner merge.
+            try
+            {
+                foreach (var (rfk, _, body, _) in view.RecordsIn(new[] { plugin }, DialTypes))
+                    if (wanted.Contains(rfk) && body is IDialogTopicGetter dt)
+                        perTopic[rfk] = DialogueInfoOrder.LinesOf(dt);
+            }
+            catch (PluginUnreadableException) { perTopic.Clear(); }
             lines[plugin] = perTopic;
         }
 
@@ -204,8 +210,8 @@ public static class DialogueValidate
                     unread.Add(p);                  // the index says it TOUCHES this topic — see below
             }
 
-            // RecordsIn swallows an overlay it cannot open, so a plugin moved or locked by MO2/xEdit mid-call
-            // vanishes silently — and if that drop leaves one contributor the render would claim "single plugin,
+            // A plugin moved or locked by MO2/xEdit mid-call contributes no lines — and if that drop leaves
+            // one contributor the render would claim "single plugin,
             // nothing merges here" for a genuinely contested topic, hiding the very reorder this exists to
             // surface. Carry the absentees so the note can state it.
             // Built UNCONDITIONALLY, including when nothing read: gating on groups.Count > 0 would leave

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -61,6 +61,19 @@ public readonly record struct WinnerInfo(FormKey FormKey, string WinnerPlugin, i
 public readonly record struct RecordStatus(
     FormKey FormKey, string RecordType, bool PluginWins, int OverrideDepth, IReadOnlyList<string> TouchingPlugins);
 
+/// <summary>A plugin in the load order could not be opened during a scan, although it opened when the index was
+/// built — it was moved, or another program (xEdit, MO2, the running game) is holding it. Thrown from the
+/// plugin-scoped record stream so a scan reports the plugin it could not read rather than skipping it silently.</summary>
+public sealed class PluginUnreadableException : Exception
+{
+    public string PluginName { get; }
+    public PluginUnreadableException(string pluginName, Exception inner)
+        : base($"could not read '{pluginName}': it opened when the load order was indexed but not now — another " +
+               "program is probably holding it open. Close that program and run this again. " +
+               $"({inner.GetType().Name}: {inner.Message})", inner)
+        => PluginName = pluginName;
+}
+
 /// <summary>A BASELINE master (Skyrim.esm / Update.esm) is active but cannot be opened. Every written plugin
 /// force-includes the baselines, and that force-include is derived from the known-master list, so quietly omitting one
 /// would emit a plugin missing a mandatory master. Thrown from the master-set builders — the single point every write
@@ -857,8 +870,10 @@ public sealed class LoadOrderResolver : IDisposable
         foreach (int i in ScopeIndices(plugins, s))
         {
             ISkyrimModGetter ov;
+            // A plugin that opened at build time but not now became unreadable after it — moved, or held open by
+            // another program. Surfaced with the name so a caller reports a partial scan instead of a clean one.
             try { ov = OpenOverlay(_paths[i], _dataDir); }
-            catch { continue; }
+            catch (Exception ex) { throw new PluginUnreadableException(_names[i], ex); }
             try
             {
                 IEnumerable<IMajorRecordGetter> recs = getterTypes is null

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -859,7 +859,10 @@ public sealed class LoadOrderResolver : IDisposable
     /// with that PLUGIN'S body in hand — the plugin-scoped path behind a plugin dump or content audit. A FormKey
     /// touched by more than one scoped plugin is yielded once per scoped plugin; the SERVICE de-dupes.
     /// Yields (FormKey, whole-order override-depth, the scoped plugin's body, the scoped plugin's
-    /// filename — so a caller can DISPLAY from the same body it filtered, not the winner). Holds nothing.</summary>
+    /// filename — so a caller can DISPLAY from the same body it filtered, not the winner). Holds nothing.
+    /// Throws <see cref="PluginUnreadableException"/> on a scoped plugin that opened at index-build time but cannot be
+    /// opened now, ending the stream — a caller must report that plugin rather than treat the scan as complete. With a
+    /// multi-plugin scope the throw ends the whole stream, so the plugins after it are unread too.</summary>
     public IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body, string source)> RecordsIn(
         IReadOnlyList<string> plugins, IReadOnlyList<Type>? getterTypes)
         => RecordsIn(plugins, getterTypes, _snap);                         // ONE build for the whole scan (captured here, at the call)

--- a/src/housecarl-core/RemapEngine.cs
+++ b/src/housecarl-core/RemapEngine.cs
@@ -60,11 +60,23 @@ public static class RemapEngine
     /// the repoint path, which would report a false success. <paramref name="Record"/> is the overridden FormKey.</summary>
     public sealed record ExternalOverride(string Plugin, FormKey Record, string RecordType);
 
+    /// <summary>Why the identify pass could not read a plugin through. Two causes with two different remedies:
+    /// <see cref="Unopenable"/> is a file that would not open at all — almost always another program holding it, and
+    /// closing that program fixes the run; <see cref="EnumerationFault"/> is a file that opened and then threw part
+    /// way through, which no amount of closing programs changes. Telling a modder to close xEdit for the second
+    /// sends them round a loop that never ends, so the cause is carried, never assumed.</summary>
+    public enum UnscannableCause { Unopenable, EnumerationFault }
+
+    /// <summary>One plugin the identify pass could not read through: its name, which of the two causes, and the
+    /// underlying reason. The reason is recorded here unconditionally — it never competes for the per-record sample
+    /// budget, because this is the fault that decides whether an in-place compaction may proceed at all.</summary>
+    public sealed record UnscannablePlugin(string Plugin, UnscannableCause Cause, string Reason);
+
     /// <summary>The identify-pass result: every external reference found, the DISTINCT referencing plugins in load
     /// order (the opt-in-rewrite set), the external OVERRIDERS (detect and warn, not repointable), how many plugins
     /// were scanned THROUGH (a plugin whose scan faulted is not one of them), and the fault accounting — a record
-    /// whose link walk threw is counted and sampled, and a plugin that could not be read at all is named in
-    /// <see cref="UnscannablePlugins"/>; neither is ever silently skipped.</summary>
+    /// whose link walk threw is counted and sampled, and a plugin that could not be read through is named, with its
+    /// cause and reason, in <see cref="UnscannablePlugins"/>; neither is ever silently skipped.</summary>
     public sealed record IdentifyResult(
         IReadOnlyList<ExternalRef> Refs,
         IReadOnlyList<string> ExternalPlugins,
@@ -73,7 +85,7 @@ public static class RemapEngine
         IReadOnlyList<string> UnscannableSamples,
         IReadOnlyList<ExternalOverride> Overrides,
         IReadOnlyList<string> ExternalOverriders,
-        IReadOnlyList<string>? UnscannablePlugins = null)
+        IReadOnlyList<UnscannablePlugin>? UnscannablePlugins = null)
     {
         /// <summary>True when at least one plugin OUTSIDE the transform set references a remapped FormKey — the
         /// signal the default new-plugin path must not pass silently: fail loud and offer the opt-in rewrite.</summary>
@@ -105,7 +117,7 @@ public static class RemapEngine
         var externalOverriders = new List<string>();      // distinct overriding plugins, load-order order
         int scanned = 0, unscannable = 0;
         var unscannableSamples = new List<string>();
-        var unscannablePlugins = new List<string>();     // plugins whose scan faulted — NOT counted as scanned
+        var unscannablePlugins = new List<UnscannablePlugin>();   // plugins whose scan faulted — NOT counted as scanned
         // PluginNames CAN list a filename more than once in a degenerate order; scanning a name twice would
         // double-count + double-list it. A real MO2 VFS yields unique filenames, so this is belt-and-braces — but
         // it keeps the result correct regardless (the listing is, by contract, DISTINCT).
@@ -163,14 +175,25 @@ public static class RemapEngine
                 }
                 scanned++;                                               // counted only once the whole plugin has been read through
             }
-            // The plugin enumeration itself faulting — a record that throws on top-level enumeration, or a file that
-            // cannot be opened at all — is counted per-plugin and the pass continues, never an opaque whole-pass
-            // abort. The plugin is NOT counted as scanned: its coverage is what the caller has to know about.
+            // The file could not be OPENED at all — the held-open case. Split from the enumeration fault below
+            // because the remedy differs: closing xEdit, MO2 or Skyrim fixes this one and nothing else.
+            // The reason is the INNER exception, since PluginUnreadableException's own message is the prose the
+            // renders write for themselves.
+            catch (PluginUnreadableException ex)
+            {
+                unscannable++;
+                var inner = ex.InnerException ?? ex;
+                unscannablePlugins.Add(new UnscannablePlugin(plugin, UnscannableCause.Unopenable, $"{inner.GetType().Name}: {inner.Message}"));
+            }
+            // The plugin opened and a record threw on TOP-LEVEL enumeration. Counted per-plugin and the pass
+            // continues, never an opaque whole-pass abort. The plugin is NOT counted as scanned: its coverage is
+            // what the caller has to know about. The reason is recorded unconditionally — a plugin-level fault
+            // never shares the per-record sample budget, so it can never be named without its reason.
             catch (Exception ex)
             {
                 unscannable++;
-                unscannablePlugins.Add(plugin);
-                if (unscannableSamples.Count < 5) unscannableSamples.Add($"{plugin} — record enumeration aborted: {ex.GetType().Name}: {ex.Message}");
+                unscannablePlugins.Add(new UnscannablePlugin(plugin, UnscannableCause.EnumerationFault,
+                                                             $"record enumeration aborted: {ex.GetType().Name}: {ex.Message}"));
             }
         }
 

--- a/src/housecarl-core/RemapEngine.cs
+++ b/src/housecarl-core/RemapEngine.cs
@@ -62,8 +62,9 @@ public static class RemapEngine
 
     /// <summary>The identify-pass result: every external reference found, the DISTINCT referencing plugins in load
     /// order (the opt-in-rewrite set), the external OVERRIDERS (detect and warn, not repointable), how many plugins
-    /// were scanned, and the per-record fault accounting — a record whose link walk threw is counted and sampled,
-    /// never silently skipped.</summary>
+    /// were scanned THROUGH (a plugin whose scan faulted is not one of them), and the fault accounting — a record
+    /// whose link walk threw is counted and sampled, and a plugin that could not be read at all is named in
+    /// <see cref="UnscannablePlugins"/>; neither is ever silently skipped.</summary>
     public sealed record IdentifyResult(
         IReadOnlyList<ExternalRef> Refs,
         IReadOnlyList<string> ExternalPlugins,
@@ -71,7 +72,8 @@ public static class RemapEngine
         int UnscannableRecords,
         IReadOnlyList<string> UnscannableSamples,
         IReadOnlyList<ExternalOverride> Overrides,
-        IReadOnlyList<string> ExternalOverriders)
+        IReadOnlyList<string> ExternalOverriders,
+        IReadOnlyList<string>? UnscannablePlugins = null)
     {
         /// <summary>True when at least one plugin OUTSIDE the transform set references a remapped FormKey — the
         /// signal the default new-plugin path must not pass silently: fail loud and offer the opt-in rewrite.</summary>
@@ -103,6 +105,7 @@ public static class RemapEngine
         var externalOverriders = new List<string>();      // distinct overriding plugins, load-order order
         int scanned = 0, unscannable = 0;
         var unscannableSamples = new List<string>();
+        var unscannablePlugins = new List<string>();     // plugins whose scan faulted — NOT counted as scanned
         // PluginNames CAN list a filename more than once in a degenerate order; scanning a name twice would
         // double-count + double-list it. A real MO2 VFS yields unique filenames, so this is belt-and-braces — but
         // it keeps the result correct regardless (the listing is, by contract, DISTINCT).
@@ -113,7 +116,6 @@ public static class RemapEngine
             if (transformSet.Contains(plugin)) continue;                 // inside the set → its refs are INTERNAL (RemapLinks handles them)
             if (view.ExcludedPlugins.ContainsKey(plugin)) continue;      // unparseable at build — already surfaced by the resolver
             if (!scannedNames.Add(plugin)) continue;                     // a duplicate name in the order — scan and list it once, never double-count
-            scanned++;
             bool pluginListed = false;
             bool pluginListedOverride = false;
 
@@ -159,17 +161,20 @@ public static class RemapEngine
                         if (unscannableSamples.Count < 5) unscannableSamples.Add($"{plugin} {fk} — {ex.GetType().Name}: {ex.Message}");
                     }
                 }
+                scanned++;                                               // counted only once the whole plugin has been read through
             }
-            // The plugin enumeration itself faulting (a record that throws on top-level enumeration rather than on a
-            // link walk) is counted per-plugin and the pass continues — never an opaque whole-pass abort.
+            // The plugin enumeration itself faulting — a record that throws on top-level enumeration, or a file that
+            // cannot be opened at all — is counted per-plugin and the pass continues, never an opaque whole-pass
+            // abort. The plugin is NOT counted as scanned: its coverage is what the caller has to know about.
             catch (Exception ex)
             {
                 unscannable++;
+                unscannablePlugins.Add(plugin);
                 if (unscannableSamples.Count < 5) unscannableSamples.Add($"{plugin} — record enumeration aborted: {ex.GetType().Name}: {ex.Message}");
             }
         }
 
-        return new IdentifyResult(refs, externalPlugins, scanned, unscannable, unscannableSamples, overrides, externalOverriders);
+        return new IdentifyResult(refs, externalPlugins, scanned, unscannable, unscannableSamples, overrides, externalOverriders, unscannablePlugins);
     }
 
     // ======================================================================

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -2072,7 +2072,7 @@ public static class WritePatchBuilder
         int PluginsScanned, int UnscannableRecords, IReadOnlyList<string> UnscannableSamples, string? Note = null,
         AssetRenameOutcome? AssetRename = null, IReadOnlyList<string>? ExternalOverriders = null,
         VoiceCarryOutcome? VoiceRename = null, SeqRegenOutcome? SeqRegen = null,
-        IReadOnlyList<string>? UnscannablePlugins = null)
+        IReadOnlyList<RemapEngine.UnscannablePlugin>? UnscannablePlugins = null)
     {
         public static CompactOutcome Fail(string error) =>
             new(false, error, false, "", "", false, false, Array.Empty<string>(), 0, 0, 0,
@@ -2100,7 +2100,7 @@ public static class WritePatchBuilder
         long Bytes, string? Note = null,
         AssetRenameOutcome? AssetRename = null, VoiceCarryOutcome? VoiceRename = null, SeqRegenOutcome? SeqRegen = null,
         IReadOnlyList<string>? LightDonors = null, IReadOnlyList<string>? HeaderMetaDonors = null,
-        IReadOnlyList<string>? MasterDonors = null, IReadOnlyList<string>? UnscannablePlugins = null)
+        IReadOnlyList<string>? MasterDonors = null, IReadOnlyList<RemapEngine.UnscannablePlugin>? UnscannablePlugins = null)
     {
         public static MergeOutcome Fail(string error) =>
             new(false, error, "", "", Array.Empty<string>(), Array.Empty<string>(), 0, 0,

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -2071,7 +2071,8 @@ public static class WritePatchBuilder
         IReadOnlyList<string> ExternalPlugins, IReadOnlyList<RepointReport> Repointed,
         int PluginsScanned, int UnscannableRecords, IReadOnlyList<string> UnscannableSamples, string? Note = null,
         AssetRenameOutcome? AssetRename = null, IReadOnlyList<string>? ExternalOverriders = null,
-        VoiceCarryOutcome? VoiceRename = null, SeqRegenOutcome? SeqRegen = null)
+        VoiceCarryOutcome? VoiceRename = null, SeqRegenOutcome? SeqRegen = null,
+        IReadOnlyList<string>? UnscannablePlugins = null)
     {
         public static CompactOutcome Fail(string error) =>
             new(false, error, false, "", "", false, false, Array.Empty<string>(), 0, 0, 0,
@@ -2099,7 +2100,7 @@ public static class WritePatchBuilder
         long Bytes, string? Note = null,
         AssetRenameOutcome? AssetRename = null, VoiceCarryOutcome? VoiceRename = null, SeqRegenOutcome? SeqRegen = null,
         IReadOnlyList<string>? LightDonors = null, IReadOnlyList<string>? HeaderMetaDonors = null,
-        IReadOnlyList<string>? MasterDonors = null)
+        IReadOnlyList<string>? MasterDonors = null, IReadOnlyList<string>? UnscannablePlugins = null)
     {
         public static MergeOutcome Fail(string error) =>
             new(false, error, "", "", Array.Empty<string>(), Array.Empty<string>(), 0, 0,

--- a/src/housecarl-mcp-tests/IdentifyScanCoverageTests.cs
+++ b/src/housecarl-mcp-tests/IdentifyScanCoverageTests.cs
@@ -1,0 +1,83 @@
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>The compact/merge external-referencer scan against a referencer that becomes unreadable AFTER the
+/// index was built — a plugin held open by xEdit, MO2 or the running game. The file lock mechanism:
+/// <c>docs/architecture/test-project-fixtures.md</c>.</summary>
+[Trait("tier", "integration")]
+public sealed class IdentifyScanCoverageTests
+{
+    /// <summary>A throwaway two-plugin world this test owns outright: a target holding one weapon, and a
+    /// second plugin whose form list references that weapon.</summary>
+    sealed class ReferencerWorld : IDisposable
+    {
+        public string Root { get; }
+        public string TargetPath { get; }
+        public string ReferencerPath { get; }
+        public ModKey TargetKey { get; } = new("HcScanTarget", ModType.Plugin);
+        public ModKey ReferencerKey { get; } = new("HcScanRef", ModType.Plugin);
+        public string TargetName => TargetKey.FileName.String;
+        public string ReferencerName => ReferencerKey.FileName.String;
+        public FormKey WeaponKey { get; }
+
+        public ReferencerWorld()
+        {
+            Root = Path.Combine(Path.GetTempPath(), "hc-scan-coverage-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Root);
+
+            WeaponKey = new FormKey(TargetKey, 0x800);
+            var target = new SkyrimMod(TargetKey, SkyrimRelease.SkyrimSE);
+            target.Weapons.Add(new Weapon(WeaponKey, SkyrimRelease.SkyrimSE) { EditorID = "HcScanWeapon" });
+            target.ModHeader.Stats.NextFormID = 0x801;
+            TargetPath = Path.Combine(Root, TargetName);
+            target.BeginWrite.ToPath(TargetPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write();
+
+            using var targetOverlay = SkyrimMod.CreateFromBinaryOverlay(TargetPath, SkyrimRelease.SkyrimSE);
+            var referencer = new SkyrimMod(ReferencerKey, SkyrimRelease.SkyrimSE);
+            var list = new FormList(new FormKey(ReferencerKey, 0x800), SkyrimRelease.SkyrimSE) { EditorID = "HcScanList" };
+            list.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(WeaponKey));
+            referencer.FormLists.Add(list);
+            referencer.ModHeader.Stats.NextFormID = 0x801;
+            ReferencerPath = Path.Combine(Root, ReferencerName);
+            referencer.BeginWrite.ToPath(ReferencerPath).WithLoadOrder(new[] { targetOverlay }).NoNextFormIDProcessing().Write();
+        }
+
+        public void Dispose() { try { Directory.Delete(Root, true); } catch { /* temp cleanup best-effort */ } }
+    }
+
+    static RemapEngine.IdentifyResult Identify(LoadOrderResolver resolver, ReferencerWorld world)
+        => RemapEngine.IdentifyExternalReferencers(
+            resolver,
+            new HashSet<FormKey> { world.WeaponKey },
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { world.TargetName });
+
+    /// <summary>Holding the referencer open across the identify call, with the index already built, is the
+    /// live shape: the hold does not change the file's last-write time, so nothing rebuilds and the scan
+    /// meets a plugin it cannot open. It must report that plugin as unscannable and must not count it as
+    /// scanned — a clean scan here would let a compaction proceed and break the referencer.</summary>
+    [Fact]
+    public void AReferencerLockedAfterTheIndexWasBuiltIsReportedUnscannable()
+    {
+        using var world = new ReferencerWorld();
+        using var resolver = LoadOrderResolver.Build(new[] { world.TargetPath, world.ReferencerPath });
+
+        // Vacuity: unheld, the same call finds the referencer — so what follows is about the lock, not about
+        // a world that never had a referencer in it.
+        var open = Identify(resolver, world);
+        Assert.Contains(world.ReferencerName, open.ExternalPlugins, StringComparer.OrdinalIgnoreCase);
+        Assert.Equal(1, open.PluginsScanned);
+        Assert.Equal(0, open.UnscannableRecords);
+
+        using var hold = HeldOpen.Hold(world.ReferencerPath);
+        var locked = Identify(resolver, world);
+
+        Assert.NotEqual(0, locked.UnscannableRecords);
+        Assert.Contains(locked.UnscannableSamples,
+                        s => s.Contains(world.ReferencerName, StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(0, locked.PluginsScanned);
+    }
+}

--- a/src/housecarl-mcp-tests/IdentifyScanCoverageTests.cs
+++ b/src/housecarl-mcp-tests/IdentifyScanCoverageTests.cs
@@ -1,6 +1,7 @@
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
+using HousecarlMcp;
 using Xunit;
 
 namespace HousecarlMcpTests;
@@ -76,8 +77,115 @@ public sealed class IdentifyScanCoverageTests
         var locked = Identify(resolver, world);
 
         Assert.NotEqual(0, locked.UnscannableRecords);
-        Assert.Contains(locked.UnscannableSamples,
-                        s => s.Contains(world.ReferencerName, StringComparison.OrdinalIgnoreCase));
         Assert.Equal(0, locked.PluginsScanned);
+
+        // The plugin is named WITH its cause and a reason: a held file is the unopenable cause, and the reason is
+        // recorded unconditionally rather than competing for the per-record sample budget.
+        var unread = Assert.Single(locked.UnscannablePlugins!);
+        Assert.Equal(world.ReferencerName, unread.Plugin, StringComparer.OrdinalIgnoreCase);
+        Assert.Equal(RemapEngine.UnscannableCause.Unopenable, unread.Cause);
+        Assert.NotEmpty(unread.Reason);
+    }
+}
+
+/// <summary>The compact verb's own answer when the external-referencer scan could not read a plugin through —
+/// driven end to end against a synthetic MO2 instance, because what changes is which lane refuses and what the
+/// caller reads, not the scan result.</summary>
+[Trait("tier", "integration")]
+public sealed class CompactUnscannableReferencerTests
+{
+    /// <summary>A throwaway MO2 instance: a target plugin holding one weapon, and a second, later plugin whose
+    /// form list references it. Both active, each in its own mod folder, so compact resolves them normally.</summary>
+    sealed class CompactWorld : IDisposable
+    {
+        public string Root { get; }
+        public string TargetPath { get; }
+        public string ReferencerPath { get; }
+        public ModKey TargetKey { get; } = new("HcCompactTarget", ModType.Plugin);
+        public ModKey ReferencerKey { get; } = new("HcCompactRef", ModType.Plugin);
+        public string TargetName => TargetKey.FileName.String;
+        public string ReferencerName => ReferencerKey.FileName.String;
+        public LoadOrderService Svc { get; }
+
+        public CompactWorld()
+        {
+            Root = Path.Combine(Path.GetTempPath(), "hc-compact-unscannable-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(Root, "game", "Data"));
+            var inst = Path.Combine(Root, "inst");
+            var modsDir = Path.Combine(inst, "mods");
+            Directory.CreateDirectory(Path.Combine(modsDir, "TargetMod"));
+            Directory.CreateDirectory(Path.Combine(modsDir, "RefMod"));
+
+            var weaponKey = new FormKey(TargetKey, 0x800);
+            var target = new SkyrimMod(TargetKey, SkyrimRelease.SkyrimSE);
+            target.Weapons.Add(new Weapon(weaponKey, SkyrimRelease.SkyrimSE) { EditorID = "HcCompactWeapon" });
+            target.ModHeader.Stats.NextFormID = 0x801;
+            TargetPath = Path.Combine(modsDir, "TargetMod", TargetName);
+            target.BeginWrite.ToPath(TargetPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write();
+
+            using (var targetOverlay = SkyrimMod.CreateFromBinaryOverlay(TargetPath, SkyrimRelease.SkyrimSE))
+            {
+                var referencer = new SkyrimMod(ReferencerKey, SkyrimRelease.SkyrimSE);
+                var list = new FormList(new FormKey(ReferencerKey, 0x800), SkyrimRelease.SkyrimSE) { EditorID = "HcCompactList" };
+                list.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(weaponKey));
+                referencer.FormLists.Add(list);
+                referencer.ModHeader.Stats.NextFormID = 0x801;
+                ReferencerPath = Path.Combine(modsDir, "RefMod", ReferencerName);
+                referencer.BeginWrite.ToPath(ReferencerPath).WithLoadOrder(new[] { targetOverlay }).NoNextFormIDProcessing().Write();
+            }
+
+            File.WriteAllText(Path.Combine(inst, "ModOrganizer.ini"),
+                "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                + Path.Combine(Root, "game").Replace(@"\", @"\\") + ")\r\n");
+            var prof = Path.Combine(inst, "profiles", "Default");
+            Directory.CreateDirectory(prof);
+            File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + TargetName + "\r\n" + ReferencerName + "\r\n");
+            File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*" + TargetName + "\r\n*" + ReferencerName + "\r\n");
+            File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n+RefMod\r\n+TargetMod\r\n");
+
+            Svc = LoadOrderService.WithInstance(inst, 0, new UserConfigStore(Path.Combine(Root, "user.json")));
+            Svc.Stats();                                  // build the index BEFORE any hold, which is the live shape
+        }
+
+        public void Dispose()
+        {
+            Svc.Dispose();
+            try { Directory.Delete(Root, true); } catch { /* temp cleanup best-effort */ }
+        }
+    }
+
+    /// <summary>The in-place lane must REFUSE a run whose referencer scan could not read a plugin, even with
+    /// acknowledge=true — which skips the confirm prompt, so a note there would never be seen. There is no backup
+    /// and no review step in place, and the unread plugin may be the very thing the renumber breaks.</summary>
+    [Fact]
+    public void InPlaceCompactRefusesWhenAReferencerCouldNotBeRead()
+    {
+        using var world = new CompactWorld();
+        using var hold = HeldOpen.Hold(world.ReferencerPath);
+        var before = new FileInfo(world.TargetPath).Length;
+
+        var o = world.Svc.CompactPlugin(world.TargetName, esl: true, inPlace: true, repointExternals: false, acknowledge: true);
+
+        Assert.False(o.Success);
+        Assert.False(o.NeedsAcknowledge);                                  // a refusal, not a prompt acknowledge could waive
+        Assert.Contains(world.ReferencerName, o.Error!, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("in_place=false", o.Error!, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(before, new FileInfo(world.TargetPath).Length);       // nothing was written
+    }
+
+    /// <summary>The new-plugin lane keeps the note, and the note says which of the two causes it met: a plugin that
+    /// could not be OPENED is the held-open case, and the remedy that fixes it is naming the programs to close.</summary>
+    [Fact]
+    public void TheReportSaysAnUnreadablePluginCouldNotBeOpened()
+    {
+        using var world = new CompactWorld();
+        using var hold = HeldOpen.Hold(world.ReferencerPath);
+
+        var text = WriteTools.RenderCompact(
+            world.Svc.CompactPlugin(world.TargetName, esl: true, inPlace: false, repointExternals: false, acknowledge: false));
+
+        Assert.Contains(world.ReferencerName, text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("could not be OPENED", text, StringComparison.Ordinal);
+        Assert.Contains("close xEdit, MO2 or Skyrim", text, StringComparison.Ordinal);
     }
 }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -5894,6 +5894,14 @@ public sealed class LoadOrderService : IDisposable
                     foreach (var pl in id.ExternalPlugins.Take(25)) c.Append($"      · {pl}\n");
                     if (id.ExternalPlugins.Count > 25) c.Append($"      · … (+{id.ExternalPlugins.Count - 25} more)\n");
                 }
+                // The referencer list is only as good as the scan behind it, and this prompt is the last point the
+                // modder can decline — so a plugin the pass could not read is named HERE, not only in the report.
+                if (id.UnscannablePlugins is { Count: > 0 } unread)
+                {
+                    c.Append($"  ! the external-reference pass could not fully read {string.Join(", ", unread.Take(25))}");
+                    if (unread.Count > 25) c.Append($" (+{unread.Count - 25} more)");
+                    c.Append(", probably held open by another program, so the list above does not cover it. Close xEdit, MO2 or Skyrim and run this again.\n");
+                }
                 c.Append("Re-call with acknowledge=true to proceed.");
                 return WritePatchBuilder.CompactOutcome.Confirm(c.ToString());
             }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -6024,7 +6024,8 @@ public sealed class LoadOrderService : IDisposable
             return new WritePatchBuilder.CompactOutcome(
                 true, null, false, outPath, name, inPlace, esl, build.Masters, build.RecordsCopied, build.RecordsRenumbered,
                 build.Bytes, id.ExternalPlugins, repointed, id.PluginsScanned, id.UnscannableRecords, id.UnscannableSamples,
-                markerNotes.Count > 0 ? string.Join(" ", markerNotes) : null, assetRename, id.ExternalOverriders, voiceRename, seqRegen);
+                markerNotes.Count > 0 ? string.Join(" ", markerNotes) : null, assetRename, id.ExternalOverriders, voiceRename, seqRegen,
+                id.UnscannablePlugins);
         }
     }
 
@@ -6319,7 +6320,8 @@ public sealed class LoadOrderService : IDisposable
                 true, null, outPath, outName, donorNames, build.Masters, build.RecordsCopied, build.RecordsRenumbered,
                 plan.Donors, build.Conflicts, id.ExternalPlugins, id.ExternalOverriders,
                 id.PluginsScanned, id.UnscannableRecords, id.UnscannableSamples, build.Bytes, note,
-                assetRename, voiceRename, seqRegen, build.LightDonors, build.HeaderMetaDonors, build.MasterDonors);
+                assetRename, voiceRename, seqRegen, build.LightDonors, build.HeaderMetaDonors, build.MasterDonors,
+                id.UnscannablePlugins);
         }
     }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -5856,6 +5856,29 @@ public sealed class LoadOrderService : IDisposable
             bool willOverwriteTarget = inPlace;
             bool willRepoint = id.HasExternalReferencers && repointExternals;
 
+            // A plugin the identify pass could not read through REFUSES the in-place lane, before anything is
+            // written and whatever acknowledge says. The referencer list is only as good as the scan behind it: an
+            // unread plugin may reference records about to be renumbered, and nothing downstream would catch it —
+            // the repoint pre-flight is fed only the referencers the scan DID find. In place there is no backup and
+            // no review step, so a note in a prompt is the wrong instrument (and acknowledge=true on the first call
+            // skips the prompt entirely). This matches the existing refusal for a referencer houseCARL cannot
+            // rewrite: the better-known case already refuses, and this is the strictly less-known one.
+            // The new-plugin lane keeps the note — its output is reviewed before it replaces anything.
+            if ((willOverwriteTarget || willRepoint) && id.UnscannablePlugins is { Count: > 0 } unread)
+            {
+                var c = new System.Text.StringBuilder();
+                c.Append($"refused — this is an IN-PLACE rewrite (no houseCARL backup or undo) and the external-reference pass could not read ")
+                 .Append(unread.Count).Append(unread.Count == 1 ? " plugin, so houseCARL cannot tell whether it references records "
+                                                               : " plugins, so houseCARL cannot tell whether they reference records ")
+                 .Append($"'{name}' is about to renumber: ");
+                c.Append(string.Join("; ", unread.Take(25).Select(WriteSentences.UnscannablePlugin)));
+                if (unread.Count > 25) c.Append($"; … (+{unread.Count - 25} more)");
+                c.Append(". NOTHING was written — ").Append($"'{name}' is untouched. ")
+                 .Append("Either resolve that and run this again, or compact into a NEW plugin (in_place=false), which renumbers the same records into a ")
+                 .Append("file you review and swap in yourself, leaving the original and its referencers alone.");
+                return WritePatchBuilder.CompactOutcome.Fail(c.ToString());
+            }
+
             // Before the consent gate, not after it: houseCARL cannot re-serialize a localized plugin without
             // scrambling its text, so a run whose referencer rewrites include one can never happen, and the gate
             // below would otherwise ask the modder to authorize an irreversible rewrite of their originals. Also
@@ -5894,14 +5917,8 @@ public sealed class LoadOrderService : IDisposable
                     foreach (var pl in id.ExternalPlugins.Take(25)) c.Append($"      · {pl}\n");
                     if (id.ExternalPlugins.Count > 25) c.Append($"      · … (+{id.ExternalPlugins.Count - 25} more)\n");
                 }
-                // The referencer list is only as good as the scan behind it, and this prompt is the last point the
-                // modder can decline — so a plugin the pass could not read is named HERE, not only in the report.
-                if (id.UnscannablePlugins is { Count: > 0 } unread)
-                {
-                    c.Append($"  ! the external-reference pass could not fully read {string.Join(", ", unread.Take(25))}");
-                    if (unread.Count > 25) c.Append($" (+{unread.Count - 25} more)");
-                    c.Append(", probably held open by another program, so the list above does not cover it. Close xEdit, MO2 or Skyrim and run this again.\n");
-                }
+                // No unread-plugin note here: this lane refuses above when the scan could not read a plugin
+                // through, so by the time the prompt is composed the referencer list is the whole story.
                 c.Append("Re-call with acknowledge=true to proceed.");
                 return WritePatchBuilder.CompactOutcome.Confirm(c.ToString());
             }

--- a/src/housecarl-mcp/WriteSentences.cs
+++ b/src/housecarl-mcp/WriteSentences.cs
@@ -95,6 +95,17 @@ internal static class WriteSentences
     internal static string InPlaceModFolder(string modFolder) =>
         $"mod folder: {modFolder}  — already active in your load order; re-sort only if a winner changed\n";
 
+    /// <summary>One plugin the external-referencer pass could not read through, in the words its own cause earns.
+    /// A file that would not OPEN is almost always held by another program and closing it fixes the run; a file
+    /// that opened and threw part way through is held by nothing, and repeating the close-your-programs advice
+    /// there sends the modder round a loop. One home so the report, the prompt and the refusal cannot drift.</summary>
+    internal static string UnscannablePlugin(RemapEngine.UnscannablePlugin p) => p.Cause switch
+    {
+        RemapEngine.UnscannableCause.Unopenable =>
+            $"{p.Plugin} — could not be OPENED, probably held open by another program; close xEdit, MO2 or Skyrim and run this again ({p.Reason})",
+        _ => $"could not fully read {p.Plugin}: {p.Reason}",
+    };
+
     /// <summary>The header + mod-folder pair for a write to a NEW patch or an EXTENDED one — the default lane's
     /// "here is the artifact and what to do with it", rendered identically by apply / create / forward.</summary>
     internal static string NewOrExtendedArtifact(bool extended, string file, long bytes, string modFolder) =>

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -589,15 +589,18 @@ public static class WriteTools
     }
 
     // A plugin the external-reference pass could not read through — shared by compact and merge, one render home.
-    // "Not fully" rather than "not at all": the pass lands a plugin here whether it could not be opened or faulted
-    // partway, and a plugin that faulted partway can already be in the referencer list above.
-    static void AppendUnscannablePlugins(StringBuilder sb, IReadOnlyList<string>? plugins)
+    // Each plugin gets the sentence its own cause earns (WriteSentences.UnscannablePlugin): a file that would not
+    // open is held by another program, a file that faulted mid-enumeration is not, and one blanket claim would be
+    // wrong for half of them. "The external-referencer check", not "the list above": the referencer list prints
+    // only on some shapes, and a plugin that faulted partway can already be in it.
+    static void AppendUnscannablePlugins(StringBuilder sb, IReadOnlyList<RemapEngine.UnscannablePlugin>? plugins)
     {
         if (plugins is not { Count: > 0 }) return;
-        sb.Append("note: the external-reference pass could not fully read ").Append(string.Join(", ", plugins.Take(25)))
-          .Append(plugins.Count > 25 ? $" (+{plugins.Count - 25} more)" : "")
-          .Append(" — probably held open by another program, so close xEdit, MO2 or Skyrim and run this again; ")
-          .Append("until then the referencer list above does not cover that plugin.\n");
+        sb.Append("note: the external-reference pass could not fully read ").Append(plugins.Count)
+          .Append(plugins.Count == 1 ? " plugin, so the external-referencer check does not cover it:\n"
+                                     : " plugins, so the external-referencer check does not cover them:\n");
+        foreach (var p in plugins.Take(25)) sb.Append("  ! ").Append(WriteSentences.UnscannablePlugin(p)).Append('\n');
+        if (plugins.Count > 25) sb.Append("  ! … (+").Append(plugins.Count - 25).Append(" more)\n");
     }
 
     // FormID-keyed assets carried WITH the renumber — shared by compact and merge, one render home. The renumber moves

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -572,6 +572,7 @@ public static class WriteTools
             sb.Append("note: ").Append(o.UnscannableRecords).Append(" record(s) couldn't be scanned in the external-reference pass, so an ")
               .Append("'external referencers: none' may be incomplete — verify in xEdit. Samples: ").Append(string.Join("; ", o.UnscannableSamples)).Append('\n');
         }
+        AppendUnscannablePlugins(sb, o.UnscannablePlugins);
         sb.Append("identify-pass scanned ").Append(o.PluginsScanned).Append(" plugin(s) for external references.\n");
         // The plugin NAME survives a compaction, so what moves is the object id — and only the ids this run actually
         // moved, which the accounting above states. Bounded by the claim rule at WriteSentences.CompactRuntimeConfigs.
@@ -585,6 +586,17 @@ public static class WriteTools
         sb.Append("reminder: FormIDs compiled into Papyrus (.pex hardcoded / GetFormFromFile) and any Mutagen-delta ")
           .Append("residual are NOT remappable — verify scripted records after compacting.");
         return sb.ToString();
+    }
+
+    // A plugin the external-reference pass could not read at all — shared by compact and merge, one render home. Its
+    // references into the renumbered records are unknown, so the pass's verdict does not cover it.
+    static void AppendUnscannablePlugins(StringBuilder sb, IReadOnlyList<string>? plugins)
+    {
+        if (plugins is not { Count: > 0 }) return;
+        sb.Append("note: the external-reference pass could not read ").Append(string.Join(", ", plugins.Take(25)))
+          .Append(plugins.Count > 25 ? $" (+{plugins.Count - 25} more)" : "")
+          .Append(" — probably held open by another program, so close xEdit, MO2 or Skyrim and run this again; ")
+          .Append("until then the referencer list above does not cover that plugin.\n");
     }
 
     // FormID-keyed assets carried WITH the renumber — shared by compact and merge, one render home. The renumber moves
@@ -735,6 +747,7 @@ public static class WriteTools
         if (o.UnscannableRecords > 0)
             sb.Append("note: ").Append(o.UnscannableRecords).Append(" record(s) couldn't be scanned in the external-reference pass, so a ")
               .Append("'none' above may be incomplete — verify in xEdit. Samples: ").Append(string.Join("; ", o.UnscannableSamples)).Append('\n');
+        AppendUnscannablePlugins(sb, o.UnscannablePlugins);
         // The coverage caveat belongs to the PASS, not to either outcome: a "none" and a populated list are incomplete
         // the same way. The pass reads record links and record identity, never a plugin header, so a dependent that
         // merely DECLARES a donor as a master is invisible to it and loses a master at the swap.

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -588,12 +588,13 @@ public static class WriteTools
         return sb.ToString();
     }
 
-    // A plugin the external-reference pass could not read at all — shared by compact and merge, one render home. Its
-    // references into the renumbered records are unknown, so the pass's verdict does not cover it.
+    // A plugin the external-reference pass could not read through — shared by compact and merge, one render home.
+    // "Not fully" rather than "not at all": the pass lands a plugin here whether it could not be opened or faulted
+    // partway, and a plugin that faulted partway can already be in the referencer list above.
     static void AppendUnscannablePlugins(StringBuilder sb, IReadOnlyList<string>? plugins)
     {
         if (plugins is not { Count: > 0 }) return;
-        sb.Append("note: the external-reference pass could not read ").Append(string.Join(", ", plugins.Take(25)))
+        sb.Append("note: the external-reference pass could not fully read ").Append(string.Join(", ", plugins.Take(25)))
           .Append(plugins.Count > 25 ? $" (+{plugins.Count - 25} more)" : "")
           .Append(" — probably held open by another program, so close xEdit, MO2 or Skyrim and run this again; ")
           .Append("until then the referencer list above does not cover that plugin.\n");


### PR DESCRIPTION
The external-reference pass that runs before a compact or merge renumber promises that every plugin in the order was checked for references into the target. It was not keeping that promise: `LoadOrderResolver.RecordsIn` swallowed a per-plugin open failure and simply moved on, so a plugin that opened when the index was built but is unreadable now — held open by xEdit, MO2 or the running game, with an unchanged mtime so nothing rebuilds — was skipped without a word while the identify pass still counted it as scanned. Its own unscannable count and samples never fired, and a compaction could proceed on a report of a clean scan and break that plugin's references. The stream now throws, naming the plugin; the identify pass counts it, keeps it out of the scanned total, and lists it separately with its cause and reason. The other callers of the stream were checked: `check_errors` and `validate_scripts` already turn a plugin-level fault into a named per-plugin scan error, `cross_plugin_query` already fails the call loudly with a named reason, and the dialogue merge gets a catch so its existing absentee accounting still fires.

Two things the pass reports follow from that. It has two causes, not one — a file that would not open, and a record throwing on top-level enumeration — so they are caught separately and each gets its own sentence: the first names the programs to close, the second gives the exception it faulted with and claims nothing about anything holding the file. And the plugin's reason is recorded unconditionally rather than sharing the 5-entry per-record sample budget, so a named plugin always carries its reason.

Compact's in-place lane refuses rather than warns. Overwriting the target or repointing referencers has no backup and no review step, the referencer list is only as good as the scan behind it, and `acknowledge=true` on the first call skips the confirm prompt entirely — so a run whose pass left any plugin unread is now refused, naming each plugin and its reason, before anything is written and whatever `acknowledge` says. This matches the existing refusal for a referencer houseCARL identified but cannot rewrite. The new-plugin lane keeps the note, since its output is reviewed before it replaces anything, and merge only ever writes a new file so its note stays a note.

Closes #437

`IdentifyScanCoverageTests.AReferencerLockedAfterTheIndexWasBuiltIsReportedUnscannable` builds a two-plugin world, builds the index, then holds the referencer open across the identify call. It fails on `main` at `UnscannableRecords` being 0 — the reported symptom — and passes here. `CompactUnscannableReferencerTests` drives compact end to end against a synthetic MO2 instance with the referencer held open: `InPlaceCompactRefusesWhenAReferencerCouldNotBeRead` checks the in-place refusal with `acknowledge=true` and that the target file is untouched, and `TheReportSaysAnUnreadablePluginCouldNotBeOpened` checks the new-plugin lane's report names the plugin and the open failure. Build clean, 987/987 tests, ci-all 128/128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
