### PR TITLE
Run the real claude plugin validate --strict in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,3 +94,28 @@ jobs:
       - name: Probe — freshness-capture-guard (own cold process)
         if: ${{ !cancelled() }}
         run: dotnet src/housecarl-generator/bin/Release/net9.0/housecarl-generator.dll freshness-capture-guard
+
+      # The real `claude plugin validate --strict`, on the real assembled plugin tree. This is the
+      # validator the harness ships, so it is the only check that agrees with the harness by
+      # construction; the plugin-validate-guard probe above is a YAML proxy for it. The version is
+      # pinned so a CLI release cannot turn this step red on its own. `validate` reads files and
+      # exits — it needs no API key and no login.
+      - name: Set up Node 22
+        if: ${{ !cancelled() }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Install the Claude Code CLI
+        if: ${{ !cancelled() }}
+        run: npm install -g @anthropic-ai/claude-code@2.1.245
+
+      # -PluginTreeOnly assembles dist/housecarl (skills + plugin files) and skips the server
+      # publish, setup exe and zip — none of which the validator reads.
+      - name: Assemble the plugin tree
+        if: ${{ !cancelled() }}
+        run: ./scripts/build-plugin.ps1 -PluginTreeOnly
+
+      - name: Validate the plugin package (claude plugin validate --strict)
+        if: ${{ !cancelled() }}
+        run: claude plugin validate ./dist/housecarl --strict

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,9 +113,12 @@ jobs:
       # -PluginTreeOnly assembles dist/housecarl (skills + plugin files) and skips the server
       # publish, setup exe and zip — none of which the validator reads.
       - name: Assemble the plugin tree
+        id: assemble
         if: ${{ !cancelled() }}
         run: ./scripts/build-plugin.ps1 -PluginTreeOnly
 
+      # Skipped when the assembly failed: step 0 wipes dist/, so validating after a failed assemble
+      # would report a missing manifest and bury the real error.
       - name: Validate the plugin package (claude plugin validate --strict)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.assemble.outcome == 'success' }}
         run: claude plugin validate ./dist/housecarl --strict

--- a/scripts/build-plugin.ps1
+++ b/scripts/build-plugin.ps1
@@ -21,6 +21,10 @@
   After it succeeds, run the validation gate (necessary, not sufficient):
       claude plugin validate ./dist/housecarl --strict
 
+  -PluginTreeOnly assembles just dist/housecarl (skills + plugin files) and stops: no corpus,
+  no server publish, no setup exe, no zip. That is the whole tree `claude plugin validate`
+  reads, and it is what CI runs the real validator against.
+
   Reference:
       dev/plans/PLUGIN_BUILD_EXECUTION_2026-06-03.md   (the checklist this implements)
       dev/plans/PLUGIN_PACKAGING_PLAN_2026-06-03.md    (the why / layout / locked decisions)
@@ -28,6 +32,7 @@
   NOTE: keep this file ASCII-only. Windows PowerShell 5.1 misreads UTF-8 non-ASCII bytes
   (em-dashes, section signs) as CP1252 and fails to parse.
 #>
+param([switch]$PluginTreeOnly)
 $ErrorActionPreference = 'Stop'
 
 # ---- paths -----------------------------------------------------------------
@@ -66,30 +71,35 @@ Step '0/10' 'Clean dist/ (package root)'
 if (Test-Path $PkgRoot) { Remove-Item $PkgRoot -Recurse -Force }
 New-Item -ItemType Directory -Path $DistRoot -Force | Out-Null
 
-# ---- 1. regenerate the rulebook (corpus.json + mutagen-reference shards, in sync by construction)
-Step '1/10' 'Regenerate corpus.json (generator)'
-# Explicit absolute args make this CWD-independent (Program.cs defaults are relative to CWD).
-dotnet run --project $GenProj -c Release -- $GeneratedDir $RefDir
-if ($LASTEXITCODE -ne 0) { throw "generator failed (exit $LASTEXITCODE)" }
-if (-not (Test-Path $CorpusSrc)) { throw "corpus not produced at $CorpusSrc" }
-Write-Host ("corpus.json: {0:N1} MB" -f ((Get-Item $CorpusSrc).Length / 1MB))
+# Steps 1-3 build the SERVER half of the tree. -PluginTreeOnly skips them: nothing the plugin
+# validator reads comes out of them, and they are the slow part (corpus reflection + two publishes).
+if (-not $PluginTreeOnly) {
 
-# ---- 2. publish the server (framework-dependent; trimming OFF) -------------
-# -p:Version stamps the plugin.json version into the exe, which ServerInfo reports over MCP
-# (one version home; an unstamped dev build says 0.0.0-dev).
-Step '2/10' 'Publish server (Release, win-x64, framework-dependent)'
-dotnet publish $McpProj -c Release -r win-x64 --self-contained false -p:Version=$Version -o $ServerDir
-if ($LASTEXITCODE -ne 0) { throw "publish failed (exit $LASTEXITCODE)" }
-$Exe = Join-Path $ServerDir 'housecarl-mcp.exe'
-if (-not (Test-Path $Exe)) { throw "server exe not produced at $Exe" }
+  # ---- 1. regenerate the rulebook (corpus.json + mutagen-reference shards, in sync by construction)
+  Step '1/10' 'Regenerate corpus.json (generator)'
+  # Explicit absolute args make this CWD-independent (Program.cs defaults are relative to CWD).
+  dotnet run --project $GenProj -c Release -- $GeneratedDir $RefDir
+  if ($LASTEXITCODE -ne 0) { throw "generator failed (exit $LASTEXITCODE)" }
+  if (-not (Test-Path $CorpusSrc)) { throw "corpus not produced at $CorpusSrc" }
+  Write-Host ("corpus.json: {0:N1} MB" -f ((Get-Item $CorpusSrc).Length / 1MB))
 
-# strip dev-only appsettings.json (carries absolute dev paths - must not ship)
-Get-ChildItem $ServerDir -Filter 'appsettings*.json' -ErrorAction SilentlyContinue | Remove-Item -Force
+  # ---- 2. publish the server (framework-dependent; trimming OFF) -------------
+  # -p:Version stamps the plugin.json version into the exe, which ServerInfo reports over MCP
+  # (one version home; an unstamped dev build says 0.0.0-dev).
+  Step '2/10' 'Publish server (Release, win-x64, framework-dependent)'
+  dotnet publish $McpProj -c Release -r win-x64 --self-contained false -p:Version=$Version -o $ServerDir
+  if ($LASTEXITCODE -ne 0) { throw "publish failed (exit $LASTEXITCODE)" }
+  $Exe = Join-Path $ServerDir 'housecarl-mcp.exe'
+  if (-not (Test-Path $Exe)) { throw "server exe not produced at $Exe" }
 
-# ---- 3. corpus beside the exe (the proven #1 requirement) ------------------
-# Reads survive without it via a reflection fallback, but writes + type-filtered queries need it.
-Step '3/10' 'Copy corpus.json beside the exe'
-Copy-Item $CorpusSrc (Join-Path $ServerDir 'corpus.json') -Force
+  # strip dev-only appsettings.json (carries absolute dev paths - must not ship)
+  Get-ChildItem $ServerDir -Filter 'appsettings*.json' -ErrorAction SilentlyContinue | Remove-Item -Force
+
+  # ---- 3. corpus beside the exe (the proven #1 requirement) ------------------
+  # Reads survive without it via a reflection fallback, but writes + type-filtered queries need it.
+  Step '3/10' 'Copy corpus.json beside the exe'
+  Copy-Item $CorpusSrc (Join-Path $ServerDir 'corpus.json') -Force
+}
 
 # ---- 4. bundle the 13 skills (exclude evals/ + _CORPUS_STATUS.md; KEEP all .jsonl) ----
 Step '4/10' 'Bundle skills'
@@ -108,6 +118,14 @@ Step '5/10' 'Copy plugin files'
 Copy-Item (Join-Path $PluginSrc '.claude-plugin') $DistRoot -Recurse -Force   # -> dist/housecarl/.claude-plugin/plugin.json
 foreach ($f in @('.mcp.json','LICENSE','THIRD-PARTY-NOTICES.txt','README.md','CHANGELOG.md')) {
   Copy-Item (Join-Path $PluginSrc $f) (Join-Path $DistRoot $f) -Force
+}
+
+# The validator's whole input is assembled now. Stop here when only that was asked for.
+if ($PluginTreeOnly) {
+  $skillCount = (Get-ChildItem $SkillsDir -Directory).Count
+  Write-Host ("`nPlugin tree assembled: {0}   skills: {1}" -f $DistRoot, $skillCount) -ForegroundColor Green
+  Write-Host "Server, setup utility and zip were skipped (-PluginTreeOnly)."
+  return
 }
 
 # ---- 6. package-root extras (START-HERE note + local marketplace.json) -----

--- a/src/housecarl-generator/PluginValidateProbe.cs
+++ b/src/housecarl-generator/PluginValidateProbe.cs
@@ -14,8 +14,10 @@ namespace HousecarlGenerator;
 /// pre-release gate: a single colon-space inside the unquoted description ("...the records themselves:
 /// distributing...") made YAML read a nested mapping, threw, and dropped name+description. It passed PR review
 /// and CI green because CI never validated the plugin PACKAGE — only `claude plugin validate --strict` (a
-/// manual, rig-time step) caught it. This guard turns that manual catch into a by-construction CI gate, so this
-/// class is caught at PR time, not at release (the manual --strict stays as belt-and-suspenders — see INV1).
+/// manual, rig-time step) caught it. CI now runs the real `claude plugin validate --strict` on the assembled
+/// dist/housecarl tree, so this guard is no longer the only cover for that class. It stays for the one thing the
+/// validator cannot see: the Codex umbrella skill ships at the package ROOT (dist/codex), outside the plugin tree
+/// the validator reads, so its frontmatter is guarded here or nowhere.
 ///
 /// Self-contained, in the corpus-hygiene-guard pattern: it reads the REAL shipped artifacts from the repo
 /// (every .claude/skills/*/SKILL.md, the Codex umbrella plugin/codex/housecarl/SKILL.md, and the manifest
@@ -29,8 +31,9 @@ namespace HousecarlGenerator;
 ///          --- ... --- fenced block parses as a YAML mapping with a non-empty `name` and `description`. The parse
 ///          uses a real YAML parser (YamlDotNet) — a FAITHFUL PROXY for, not byte-identical to, the harness's own
 ///          (JS) YAML parser: it reliably catches the colon-space class (RED-proven below), but the residual risk
-///          is a false-NEGATIVE (YamlDotNet accepts what the real loader would drop), which is why the manual
-///          --strict stays the belt-and-suspenders. (RED: the literal colon-space description that dropped
+///          is a false-NEGATIVE (YamlDotNet accepts what the real loader would drop). For the 14 bundled skills
+///          the CI `claude plugin validate --strict` step closes that residual; for the Codex umbrella skill it
+///          does not, and this is the only check. (RED: the literal colon-space description that dropped
 ///          dialogue-authoring; a frontmatter missing `description`; a file with no fence at all.)
 ///   INV2 — THE PLUGIN MANIFEST PARSES + CARRIES name/version. plugin.json is valid JSON with a non-empty
 ///          string name + version (the single source of truth the build stamps). (RED: a manifest missing


### PR DESCRIPTION
CI never ran the real `claude plugin validate --strict` on the built plugin package — only the YamlDotNet proxy inside `plugin-validate-guard`, whose own comments call it a faithful proxy rather than a byte-identical one, with a residual false-negative risk. The literal `--strict` existed solely as a line printed by `scripts/build-plugin.ps1`. This adds the real step: the job installs a pinned Claude Code CLI (`@anthropic-ai/claude-code@2.1.245`) on Node 22, assembles the plugin tree, and runs `claude plugin validate ./dist/housecarl --strict`. `validate` reads files and exits — it needs no API key and no login, so no secret is added to the workflow.

Assembling the tree reuses the build script rather than duplicating it: a new `-PluginTreeOnly` switch runs the clean, the skill bundle and the plugin-file copy, then stops before the corpus regeneration, both publishes and the zip — none of which the validator reads. So the CI step validates the tree a release build produces from the committed sources, with no second copy of the layout to drift. (One difference: a full build regenerates the mutagen-reference shards before bundling them and this does not, so CI validates the committed shards. Immaterial to the frontmatter and manifest the validator reads.)

The proxy probe stays, for one reason: the Codex umbrella skill ships at the package root (`dist/codex`), outside the plugin tree the validator reads, so its frontmatter is guarded by the probe or nowhere. Its comments now say that instead of pointing at the manual step. The printed `--strict` guidance at the end of the build script also stays — after a full local release build it validates the whole package, which is still worth doing by hand.

Local run on the built package, before and after the switch:

```
$ claude plugin validate ./dist/housecarl --strict
Validating plugin manifest: ...\dist\housecarl\.claude-plugin\plugin.json

✔ Validation passed
EXIT=0
```

Teeth check — the same validator on a copy of the tree with the colon-space description that dropped `dialogue-authoring` at the 1.3 gate:

```
Validating skill: ...\skills\oar-authoring\SKILL.md

✘ Found 1 error:

  ❯ frontmatter: YAML frontmatter failed to parse: YAML Parse error: Unexpected token. At runtime this skill loads with empty metadata (all frontmatter fields silently dropped).

✘ Validation failed
EXIT=1
```

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)


