### PR TITLE
Generate the third-party notices component table from the publish output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,18 @@ jobs:
       - name: Build the whole solution (Release)
         run: dotnet build housecarl.sln --configuration Release
 
+      # The two tracked THIRD-PARTY-NOTICES.txt copies are generated from the server publish output, so a
+      # dependency bump changes what they should say. Nothing else in CI publishes the server, so this step
+      # does it (Release, win-x64, framework-dependent - the same shape build-plugin.ps1 publishes) and
+      # regenerates into memory. The step goes red if either tracked copy differs from what now ships.
+      # It publishes into dist/, which the plugin-tree assembly step below wipes on its way past.
+      - name: Notices — the tracked copies match what ships
+        if: ${{ !cancelled() }}
+        shell: pwsh
+        run: |
+          dotnet publish src/housecarl-mcp -c Release -r win-x64 --self-contained false -o dist/notices-check/server
+          ./scripts/generate-notices.ps1 -PublishDir dist/notices-check/server -Check
+
       # Nearly all CI probes run IN ONE PROCESS via `ci-all` (CI optimization Phase 2A+2B): the big Mutagen
       # assembly loads + JITs once and the schema corpus is reflected once (memoized) instead of ~21x —
       # collapsing ~12 min of per-probe cold starts. The runner runs EVERY probe even if one fails and emits a

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -29,25 +29,31 @@ The plugin bundles the third-party components below in server/ — compiled .NET
 assemblies from a framework-dependent .NET 9 publish (the .NET runtime itself is
 NOT bundled; the user installs it). Components are grouped by license.
 
+The component tables between the "--- generated ---" markers below are written by
+the build from that publish output (scripts/generate-notices.ps1), so the names and
+versions are what actually ships. Everything else here is hand-authored.
+
 
 ===============================================================================
 GPL-3.0-only   (copyleft — the same license as houseCARL; see the LICENSE file)
 ===============================================================================
 
-  Mutagen.Bethesda.Skyrim          0.54.4   github.com/Mutagen-Modding/Mutagen
-  Mutagen.Bethesda.Core            0.54.4   github.com/Mutagen-Modding/Mutagen
-  Mutagen.Bethesda.Kernel          0.54.4   github.com/Mutagen-Modding/Mutagen
-  Loqui                            3.7.0    github.com/Noggog/Loqui
-  Noggog.CSharpExt                 4.3.0    github.com/Noggog/CSharpExt
-  NexusMods.Paths                  0.19.1   github.com/Nexus-Mods/NexusMods.Paths
-  Reloaded.Memory                  9.4.2    github.com/Reloaded-Project/Reloaded.Memory
+  --- generated: GPL-3.0-only components ---
   GameFinder.Common                4.9.0    github.com/erri120/GameFinder
   GameFinder.RegistryUtils         4.9.0    github.com/erri120/GameFinder
   GameFinder.StoreHandlers.GOG     4.9.0    github.com/erri120/GameFinder
   GameFinder.StoreHandlers.Steam   4.9.0    github.com/erri120/GameFinder
   GameFinder.StoreHandlers.Xbox    4.9.0    github.com/erri120/GameFinder
   GameFinder.Wine                  4.9.0    github.com/erri120/GameFinder
+  Loqui                            3.7.0    github.com/Noggog/Loqui
+  Mutagen.Bethesda.Core            0.54.4   github.com/Mutagen-Modding/Mutagen
+  Mutagen.Bethesda.Kernel          0.54.4   github.com/Mutagen-Modding/Mutagen
+  Mutagen.Bethesda.Skyrim          0.54.4   github.com/Mutagen-Modding/Mutagen
+  NexusMods.Paths                  0.19.1   github.com/Nexus-Mods/NexusMods.Paths
   NiflySharp                       1.1.0    github.com/ousnius/NiflySharp
+  Noggog.CSharpExt                 4.3.0    github.com/Noggog/CSharpExt
+  Reloaded.Memory                  9.4.2    github.com/Reloaded-Project/Reloaded.Memory
+  --- end generated ---
 
   NiflySharp (NuGet package "Nifly", by ousnius / the nifly project) is the
   asset-internal mesh reader the NIF layer is built on — pure C#, source-generated
@@ -61,13 +67,15 @@ GPL-3.0-only   (copyleft — the same license as houseCARL; see the LICENSE file
 Apache License 2.0
 ===============================================================================
 
-  ModelContextProtocol             2.2.0    github.com/modelcontextprotocol/csharp-sdk
-  ModelContextProtocol.Core        2.2.0    github.com/modelcontextprotocol/csharp-sdk
-  ModelContextProtocol.AspNetCore  2.2.0    github.com/modelcontextprotocol/csharp-sdk
+  --- generated: Apache-2.0 components ---
+  miniball                          1.0.4
+  ModelContextProtocol              2.2.0
+  ModelContextProtocol.AspNetCore   2.2.0
+  ModelContextProtocol.Core         2.2.0
+  --- end generated ---
 
-  miniball                         1.0.4    github.com/SearchAThing-forks/miniball
-
-  ModelContextProtocol*: Copyright (c) the Model Context Protocol authors.
+  ModelContextProtocol*: Copyright (c) the Model Context Protocol authors, from
+  github.com/modelcontextprotocol/csharp-sdk.
   miniball (NuGet package "miniball-devel0"): Copyright (c) Lorenzo Delana, per
   the package metadata, which also records it as a fork of Kaspar Fischer's
   github.com/hbf/miniball. The Apache-2.0 grant above is the fork's own declaration;
@@ -97,50 +105,44 @@ MIT License
   here so the determination does not have to be re-derived. It reaches the package
   as a dependency of GameFinder and NexusMods.Paths.
 
-  DynamicData                                  9.4.31
-  FluentResults                                3.15.2
-  K4os.Compression.LZ4                         1.3.8
-  K4os.Compression.LZ4.Streams                 1.3.8
-  K4os.Hash.xxHash                             1.0.8
-  ini-parser-netstandard                       2.5.3
-  OneOf                                        3.0.271
-  SharpZipLib                                  1.4.2
-  StrongInject                                 1.4.4
-  System.IO.Abstractions                       22.1.1
-  TestableIO.System.IO.Abstractions            22.1.1
-  TestableIO.System.IO.Abstractions.Wrappers   22.1.1
-  Testably.Abstractions.FileSystem.Interface   10.1.0
-  ValveKeyValue                                0.13.1.398
-  System.Interactive.Async                     7.0.1
-  System.Linq.Async                            7.0.1
-  System.Linq.AsyncEnumerable                  10.0.6
-  System.Reactive                              6.1.0
-  System.Text.Encoding.CodePages               10.0.9
-  TransparentValueObjects.Abstractions         1.1.0
-  Microsoft.Extensions.AI.Abstractions         10.8.3
-  Microsoft.Extensions.Caching.Abstractions    10.0.10
-  Microsoft.Extensions.Configuration.Abstractions        10.0.10
-  Microsoft.Extensions.DependencyInjection.Abstractions  10.0.10
-  Microsoft.Extensions.Diagnostics.Abstractions          10.0.10
-  Microsoft.Extensions.FileProviders.Abstractions        10.0.10
-  Microsoft.Extensions.Hosting.Abstractions    10.0.10
-  Microsoft.Extensions.Logging.Abstractions    10.0.10
-  Microsoft.Extensions.Options                 10.0.10
-  Microsoft.Extensions.Primitives              10.0.10
-  System.Diagnostics.DiagnosticSource          10.0.10
-  System.IO.Pipelines                          10.0.10
-  System.Net.ServerSentEvents                  10.0.10
-  System.Text.Encodings.Web                    10.0.10
-  System.Text.Json                             10.0.10
-  System.Threading.Tasks.Extensions            4.5.4
-  Microsoft.Win32.Registry                     5.0.0
-  Microsoft.NETCore.Platforms                  5.0.0
-  System.Collections.Immutable                 10.0.9
-  System.Security.AccessControl                5.0.0
-  System.Security.Principal.Windows            5.0.0
-
-  (Some of the trailing packages are provided by the .NET shared framework and
-  may not emit a private DLL on every publish; they are MIT either way.)
+  --- generated: MIT components ---
+  DynamicData                                             9.4.31
+  FluentResults                                           3.15.2
+  ini-parser-netstandard                                  2.5.3
+  K4os.Compression.LZ4                                    1.3.8
+  K4os.Compression.LZ4.Streams                            1.3.8
+  K4os.Hash.xxHash                                        1.0.8
+  Microsoft.Extensions.AI.Abstractions                    10.8.3
+  Microsoft.Extensions.Caching.Abstractions               10.0.10
+  Microsoft.Extensions.Configuration.Abstractions         10.0.10
+  Microsoft.Extensions.DependencyInjection.Abstractions   10.0.10
+  Microsoft.Extensions.Diagnostics.Abstractions           10.0.10
+  Microsoft.Extensions.FileProviders.Abstractions         10.0.10
+  Microsoft.Extensions.Hosting.Abstractions               10.0.10
+  Microsoft.Extensions.Logging.Abstractions               10.0.10
+  Microsoft.Extensions.Options                            10.0.10
+  Microsoft.Extensions.Primitives                         10.0.10
+  OneOf                                                   3.0.271
+  SharpZipLib                                             1.4.2
+  StrongInject                                            1.4.4
+  System.Collections.Immutable                            10.0.9
+  System.Diagnostics.DiagnosticSource                     10.0.10
+  System.Interactive.Async                                7.0.1
+  System.IO.Abstractions                                  22.1.1
+  System.IO.Pipelines                                     10.0.10
+  System.Linq.Async                                       7.0.1
+  System.Linq.AsyncEnumerable                             10.0.6
+  System.Net.ServerSentEvents                             10.0.10
+  System.Reactive                                         6.1.0
+  System.Text.Encoding.CodePages                          10.0.9
+  System.Text.Encodings.Web                               10.0.10
+  System.Text.Json                                        10.0.10
+  TestableIO.System.IO.Abstractions                       22.1.1
+  TestableIO.System.IO.Abstractions.Wrappers              22.1.1
+  Testably.Abstractions.FileSystem.Interface              10.1.0
+  TransparentValueObjects.Abstractions                    1.1.0
+  ValveKeyValue                                           0.13.1.398
+  --- end generated ---
 
 
 ===============================================================================

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -20,7 +20,9 @@ The complete source for houseCARL is published at:
     https://github.com/Avick3110/houseCARL
 The corresponding source for the bundled Mutagen libraries is at:
     https://github.com/Mutagen-Modding/Mutagen
+  --- generated: Mutagen release ---
     (release 0.54.4; repository commit 0188012c607ce8bb283d2704400d37737f089134)
+  --- end generated ---
 The other GPL components' sources are linked beside each entry below.
 
 WHAT SHIPS
@@ -29,9 +31,10 @@ The plugin bundles the third-party components below in server/ — compiled .NET
 assemblies from a framework-dependent .NET 9 publish (the .NET runtime itself is
 NOT bundled; the user installs it). Components are grouped by license.
 
-The component tables between the "--- generated ---" markers below are written by
-the build from that publish output (scripts/generate-notices.ps1), so the names and
-versions are what actually ships. Everything else here is hand-authored.
+The regions between the "--- generated ---" markers — the component tables below and
+the Mutagen release and commit above — are written by the build from that publish
+output (scripts/generate-notices.ps1), so the names and versions are what actually
+ships. Everything else here is hand-authored.
 
 
 ===============================================================================

--- a/packaging/notices-display-names.json
+++ b/packaging/notices-display-names.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "NuGet package id -> the name THIRD-PARTY-NOTICES.txt lists the component under, where the two differ. Read by scripts/generate-notices.ps1; a package absent from this map is listed under its own id. Two more components have a DLL name that matches neither (SharpZipLib ships ICSharpCode.SharpZipLib.dll, ini-parser-netstandard ships INIFileParser.dll) but their package id is already the listed name, so they need no entry.",
+
+  "Nifly": "NiflySharp",
+  "miniball-devel0": "miniball"
+}

--- a/packaging/notices-licence-exceptions.json
+++ b/packaging/notices-licence-exceptions.json
@@ -1,0 +1,40 @@
+{
+  "_comment": "Shipped packages whose NuGet metadata carries no SPDX licence expression, with the licence determined by hand and how. Read by scripts/generate-notices.ps1: a package that ships with no expression and no entry here stops the build. Keep the reason with the entry so no determination has to be made twice.",
+
+  "Loqui": {
+    "licence": "GPL-3.0-only",
+    "why": "No licence element of any kind in the nuspec. github.com/Noggog/Loqui is GPL-3.0-only, as is the rest of the Mutagen first-party ecosystem it belongs to."
+  },
+  "Noggog.CSharpExt": {
+    "licence": "GPL-3.0-only",
+    "why": "No licence element of any kind in the nuspec. github.com/Noggog/CSharpExt is GPL-3.0-only, as is the rest of the Mutagen first-party ecosystem it belongs to."
+  },
+  "Nifly": {
+    "licence": "GPL-3.0-only",
+    "why": "The nuspec embeds the licence as a file rather than an expression. The bundled LICENSE and github.com/ousnius/NiflySharp are GPL-3.0-only."
+  },
+  "Reloaded.Memory": {
+    "licence": "GPL-3.0-only",
+    "why": "The nuspec embeds the licence as a file rather than an expression. The bundled LICENSE.md is GPL-3.0-only. It reaches the package as a dependency of NexusMods.Paths."
+  },
+  "K4os.Compression.LZ4": {
+    "licence": "MIT",
+    "why": "The nuspec uses the deprecated licenseUrl form, pointing at the MIT LICENSE in github.com/MiloszKrajewski/K4os.Compression.LZ4."
+  },
+  "K4os.Compression.LZ4.Streams": {
+    "licence": "MIT",
+    "why": "The nuspec uses the deprecated licenseUrl form, pointing at the MIT LICENSE in github.com/MiloszKrajewski/K4os.Compression.LZ4."
+  },
+  "K4os.Hash.xxHash": {
+    "licence": "MIT",
+    "why": "The nuspec uses the deprecated licenseUrl form, pointing at the MIT LICENSE in github.com/MiloszKrajewski/K4os.Hash.xxHash."
+  },
+  "OneOf": {
+    "licence": "MIT",
+    "why": "The nuspec uses the deprecated licenseUrl form, pointing at the MIT licence.md in github.com/mcintyre321/OneOf."
+  },
+  "TransparentValueObjects.Abstractions": {
+    "licence": "MIT",
+    "why": "No licence element, no licenseUrl and no projectUrl in the nuspec. The package owner on nuget.org is erri120, the upstream github.com/erri120/TransparentValueObjects is MIT, and the repository commit the nuspec itself records - ff32127019b0f53480f5e9c1867924b14138999c - resolves in that repository. It reaches the package as a dependency of GameFinder and NexusMods.Paths."
+  }
+}

--- a/packaging/notices-licence-exceptions.json
+++ b/packaging/notices-licence-exceptions.json
@@ -1,39 +1,48 @@
 {
-  "_comment": "Shipped packages whose NuGet metadata carries no SPDX licence expression, with the licence determined by hand and how. Read by scripts/generate-notices.ps1: a package that ships with no expression and no entry here stops the build. Keep the reason with the entry so no determination has to be made twice.",
+  "_comment": "Shipped packages whose NuGet metadata carries no SPDX licence expression, with the licence determined by hand and how. Read by scripts/generate-notices.ps1: a package that ships with no expression and no entry here stops the build, and so does an entry whose version is not the version that ships - a package can relicense across versions, so each determination is recorded against the version it was made against. Keep the reason with the entry so no determination has to be made twice.",
 
   "Loqui": {
+    "version": "3.7.0",
     "licence": "GPL-3.0-only",
     "why": "No licence element of any kind in the nuspec. github.com/Noggog/Loqui is GPL-3.0-only, as is the rest of the Mutagen first-party ecosystem it belongs to."
   },
   "Noggog.CSharpExt": {
+    "version": "4.3.0",
     "licence": "GPL-3.0-only",
     "why": "No licence element of any kind in the nuspec. github.com/Noggog/CSharpExt is GPL-3.0-only, as is the rest of the Mutagen first-party ecosystem it belongs to."
   },
   "Nifly": {
+    "version": "1.1.0",
     "licence": "GPL-3.0-only",
     "why": "The nuspec embeds the licence as a file rather than an expression. The bundled LICENSE and github.com/ousnius/NiflySharp are GPL-3.0-only."
   },
   "Reloaded.Memory": {
+    "version": "9.4.2",
     "licence": "GPL-3.0-only",
-    "why": "The nuspec embeds the licence as a file rather than an expression. The bundled LICENSE.md is GPL-3.0-only. It reaches the package as a dependency of NexusMods.Paths."
+    "why": "The nuspec embeds the licence as a file rather than an expression. The bundled LICENSE.md is GPL-3.0-only, and says the project was LGPLv3 before May 2023 - so this determination is version-specific. It reaches the package as a dependency of NexusMods.Paths."
   },
   "K4os.Compression.LZ4": {
+    "version": "1.3.8",
     "licence": "MIT",
     "why": "The nuspec uses the deprecated licenseUrl form, pointing at the MIT LICENSE in github.com/MiloszKrajewski/K4os.Compression.LZ4."
   },
   "K4os.Compression.LZ4.Streams": {
+    "version": "1.3.8",
     "licence": "MIT",
     "why": "The nuspec uses the deprecated licenseUrl form, pointing at the MIT LICENSE in github.com/MiloszKrajewski/K4os.Compression.LZ4."
   },
   "K4os.Hash.xxHash": {
+    "version": "1.0.8",
     "licence": "MIT",
     "why": "The nuspec uses the deprecated licenseUrl form, pointing at the MIT LICENSE in github.com/MiloszKrajewski/K4os.Hash.xxHash."
   },
   "OneOf": {
+    "version": "3.0.271",
     "licence": "MIT",
     "why": "The nuspec uses the deprecated licenseUrl form, pointing at the MIT licence.md in github.com/mcintyre321/OneOf."
   },
   "TransparentValueObjects.Abstractions": {
+    "version": "1.1.0",
     "licence": "MIT",
     "why": "No licence element, no licenseUrl and no projectUrl in the nuspec. The package owner on nuget.org is erri120, the upstream github.com/erri120/TransparentValueObjects is MIT, and the repository commit the nuspec itself records - ff32127019b0f53480f5e9c1867924b14138999c - resolves in that repository. It reaches the package as a dependency of GameFinder and NexusMods.Paths."
   }

--- a/packaging/notices-mutagen-commits.json
+++ b/packaging/notices-mutagen-commits.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "Mutagen release version -> the repository commit that release is tagged at, for the GPLv3 section 6 corresponding-source line in THIRD-PARTY-NOTICES.txt. Read by scripts/generate-notices.ps1: the line is written from the Mutagen version the publish output actually ships, and a shipped version with no entry here stops the build. Take the commit from the tag for that release, github.com/Mutagen-Modding/Mutagen/releases/tag/<version>.",
+
+  "0.54.4": "0188012c607ce8bb283d2704400d37737f089134"
+}

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -17,9 +17,10 @@ saying it sets an expectation their install may contradict. Say what is known, a
   by the build from the publish output, so the names and versions in the file are the ones in `server/`. The
   file no longer lists five packages that do not ship (`System.Threading.Tasks.Extensions`,
   `Microsoft.Win32.Registry`, `Microsoft.NETCore.Platforms`, `System.Security.AccessControl`,
-  `System.Security.Principal.Windows`), and the entries are ordered by name. The licence texts and the
-  corresponding-source release and commit stay hand-authored; see the markers in the file for which parts
-  are which.
+  `System.Security.Principal.Windows`), and the entries are ordered by name. The GPLv3 section 6
+  corresponding-source line is written the same way, from the Mutagen version that ships and the commit
+  recorded for it in `packaging/notices-mutagen-commits.json`, so it cannot name a release the plugin does
+  not bundle. The licence texts stay hand-authored; see the markers in the file for which parts are which.
 
 - **`housecarl_compact_plugin` and `housecarl_merge_plugins` name a plugin they could not read.** The
   external-reference pass that runs before a renumber used to skip a plugin it could not open while still

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,14 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **`THIRD-PARTY-NOTICES.txt` lists what the plugin actually bundles.** The component tables are now written
+  by the build from the publish output, so the names and versions in the file are the ones in `server/`. The
+  file no longer lists five packages that do not ship (`System.Threading.Tasks.Extensions`,
+  `Microsoft.Win32.Registry`, `Microsoft.NETCore.Platforms`, `System.Security.AccessControl`,
+  `System.Security.Principal.Windows`), and the entries are ordered by name. The licence texts and the
+  corresponding-source release and commit stay hand-authored; see the markers in the file for which parts
+  are which.
+
 - **`housecarl_compact_plugin` and `housecarl_merge_plugins` name a plugin they could not read.** The
   external-reference pass that runs before a renumber used to skip a plugin it could not open while still
   counting it as scanned, so a plugin held open by xEdit, MO2 or the running game could make the pass report

--- a/plugin/THIRD-PARTY-NOTICES.txt
+++ b/plugin/THIRD-PARTY-NOTICES.txt
@@ -29,25 +29,31 @@ The plugin bundles the third-party components below in server/ — compiled .NET
 assemblies from a framework-dependent .NET 9 publish (the .NET runtime itself is
 NOT bundled; the user installs it). Components are grouped by license.
 
+The component tables between the "--- generated ---" markers below are written by
+the build from that publish output (scripts/generate-notices.ps1), so the names and
+versions are what actually ships. Everything else here is hand-authored.
+
 
 ===============================================================================
 GPL-3.0-only   (copyleft — the same license as houseCARL; see the LICENSE file)
 ===============================================================================
 
-  Mutagen.Bethesda.Skyrim          0.54.4   github.com/Mutagen-Modding/Mutagen
-  Mutagen.Bethesda.Core            0.54.4   github.com/Mutagen-Modding/Mutagen
-  Mutagen.Bethesda.Kernel          0.54.4   github.com/Mutagen-Modding/Mutagen
-  Loqui                            3.7.0    github.com/Noggog/Loqui
-  Noggog.CSharpExt                 4.3.0    github.com/Noggog/CSharpExt
-  NexusMods.Paths                  0.19.1   github.com/Nexus-Mods/NexusMods.Paths
-  Reloaded.Memory                  9.4.2    github.com/Reloaded-Project/Reloaded.Memory
+  --- generated: GPL-3.0-only components ---
   GameFinder.Common                4.9.0    github.com/erri120/GameFinder
   GameFinder.RegistryUtils         4.9.0    github.com/erri120/GameFinder
   GameFinder.StoreHandlers.GOG     4.9.0    github.com/erri120/GameFinder
   GameFinder.StoreHandlers.Steam   4.9.0    github.com/erri120/GameFinder
   GameFinder.StoreHandlers.Xbox    4.9.0    github.com/erri120/GameFinder
   GameFinder.Wine                  4.9.0    github.com/erri120/GameFinder
+  Loqui                            3.7.0    github.com/Noggog/Loqui
+  Mutagen.Bethesda.Core            0.54.4   github.com/Mutagen-Modding/Mutagen
+  Mutagen.Bethesda.Kernel          0.54.4   github.com/Mutagen-Modding/Mutagen
+  Mutagen.Bethesda.Skyrim          0.54.4   github.com/Mutagen-Modding/Mutagen
+  NexusMods.Paths                  0.19.1   github.com/Nexus-Mods/NexusMods.Paths
   NiflySharp                       1.1.0    github.com/ousnius/NiflySharp
+  Noggog.CSharpExt                 4.3.0    github.com/Noggog/CSharpExt
+  Reloaded.Memory                  9.4.2    github.com/Reloaded-Project/Reloaded.Memory
+  --- end generated ---
 
   NiflySharp (NuGet package "Nifly", by ousnius / the nifly project) is the
   asset-internal mesh reader the NIF layer is built on — pure C#, source-generated
@@ -61,13 +67,15 @@ GPL-3.0-only   (copyleft — the same license as houseCARL; see the LICENSE file
 Apache License 2.0
 ===============================================================================
 
-  ModelContextProtocol             2.2.0    github.com/modelcontextprotocol/csharp-sdk
-  ModelContextProtocol.Core        2.2.0    github.com/modelcontextprotocol/csharp-sdk
-  ModelContextProtocol.AspNetCore  2.2.0    github.com/modelcontextprotocol/csharp-sdk
+  --- generated: Apache-2.0 components ---
+  miniball                          1.0.4
+  ModelContextProtocol              2.2.0
+  ModelContextProtocol.AspNetCore   2.2.0
+  ModelContextProtocol.Core         2.2.0
+  --- end generated ---
 
-  miniball                         1.0.4    github.com/SearchAThing-forks/miniball
-
-  ModelContextProtocol*: Copyright (c) the Model Context Protocol authors.
+  ModelContextProtocol*: Copyright (c) the Model Context Protocol authors, from
+  github.com/modelcontextprotocol/csharp-sdk.
   miniball (NuGet package "miniball-devel0"): Copyright (c) Lorenzo Delana, per
   the package metadata, which also records it as a fork of Kaspar Fischer's
   github.com/hbf/miniball. The Apache-2.0 grant above is the fork's own declaration;
@@ -97,50 +105,44 @@ MIT License
   here so the determination does not have to be re-derived. It reaches the package
   as a dependency of GameFinder and NexusMods.Paths.
 
-  DynamicData                                  9.4.31
-  FluentResults                                3.15.2
-  K4os.Compression.LZ4                         1.3.8
-  K4os.Compression.LZ4.Streams                 1.3.8
-  K4os.Hash.xxHash                             1.0.8
-  ini-parser-netstandard                       2.5.3
-  OneOf                                        3.0.271
-  SharpZipLib                                  1.4.2
-  StrongInject                                 1.4.4
-  System.IO.Abstractions                       22.1.1
-  TestableIO.System.IO.Abstractions            22.1.1
-  TestableIO.System.IO.Abstractions.Wrappers   22.1.1
-  Testably.Abstractions.FileSystem.Interface   10.1.0
-  ValveKeyValue                                0.13.1.398
-  System.Interactive.Async                     7.0.1
-  System.Linq.Async                            7.0.1
-  System.Linq.AsyncEnumerable                  10.0.6
-  System.Reactive                              6.1.0
-  System.Text.Encoding.CodePages               10.0.9
-  TransparentValueObjects.Abstractions         1.1.0
-  Microsoft.Extensions.AI.Abstractions         10.8.3
-  Microsoft.Extensions.Caching.Abstractions    10.0.10
-  Microsoft.Extensions.Configuration.Abstractions        10.0.10
-  Microsoft.Extensions.DependencyInjection.Abstractions  10.0.10
-  Microsoft.Extensions.Diagnostics.Abstractions          10.0.10
-  Microsoft.Extensions.FileProviders.Abstractions        10.0.10
-  Microsoft.Extensions.Hosting.Abstractions    10.0.10
-  Microsoft.Extensions.Logging.Abstractions    10.0.10
-  Microsoft.Extensions.Options                 10.0.10
-  Microsoft.Extensions.Primitives              10.0.10
-  System.Diagnostics.DiagnosticSource          10.0.10
-  System.IO.Pipelines                          10.0.10
-  System.Net.ServerSentEvents                  10.0.10
-  System.Text.Encodings.Web                    10.0.10
-  System.Text.Json                             10.0.10
-  System.Threading.Tasks.Extensions            4.5.4
-  Microsoft.Win32.Registry                     5.0.0
-  Microsoft.NETCore.Platforms                  5.0.0
-  System.Collections.Immutable                 10.0.9
-  System.Security.AccessControl                5.0.0
-  System.Security.Principal.Windows            5.0.0
-
-  (Some of the trailing packages are provided by the .NET shared framework and
-  may not emit a private DLL on every publish; they are MIT either way.)
+  --- generated: MIT components ---
+  DynamicData                                             9.4.31
+  FluentResults                                           3.15.2
+  ini-parser-netstandard                                  2.5.3
+  K4os.Compression.LZ4                                    1.3.8
+  K4os.Compression.LZ4.Streams                            1.3.8
+  K4os.Hash.xxHash                                        1.0.8
+  Microsoft.Extensions.AI.Abstractions                    10.8.3
+  Microsoft.Extensions.Caching.Abstractions               10.0.10
+  Microsoft.Extensions.Configuration.Abstractions         10.0.10
+  Microsoft.Extensions.DependencyInjection.Abstractions   10.0.10
+  Microsoft.Extensions.Diagnostics.Abstractions           10.0.10
+  Microsoft.Extensions.FileProviders.Abstractions         10.0.10
+  Microsoft.Extensions.Hosting.Abstractions               10.0.10
+  Microsoft.Extensions.Logging.Abstractions               10.0.10
+  Microsoft.Extensions.Options                            10.0.10
+  Microsoft.Extensions.Primitives                         10.0.10
+  OneOf                                                   3.0.271
+  SharpZipLib                                             1.4.2
+  StrongInject                                            1.4.4
+  System.Collections.Immutable                            10.0.9
+  System.Diagnostics.DiagnosticSource                     10.0.10
+  System.Interactive.Async                                7.0.1
+  System.IO.Abstractions                                  22.1.1
+  System.IO.Pipelines                                     10.0.10
+  System.Linq.Async                                       7.0.1
+  System.Linq.AsyncEnumerable                             10.0.6
+  System.Net.ServerSentEvents                             10.0.10
+  System.Reactive                                         6.1.0
+  System.Text.Encoding.CodePages                          10.0.9
+  System.Text.Encodings.Web                               10.0.10
+  System.Text.Json                                        10.0.10
+  TestableIO.System.IO.Abstractions                       22.1.1
+  TestableIO.System.IO.Abstractions.Wrappers              22.1.1
+  Testably.Abstractions.FileSystem.Interface              10.1.0
+  TransparentValueObjects.Abstractions                    1.1.0
+  ValveKeyValue                                           0.13.1.398
+  --- end generated ---
 
 
 ===============================================================================

--- a/plugin/THIRD-PARTY-NOTICES.txt
+++ b/plugin/THIRD-PARTY-NOTICES.txt
@@ -20,7 +20,9 @@ The complete source for houseCARL is published at:
     https://github.com/Avick3110/houseCARL
 The corresponding source for the bundled Mutagen libraries is at:
     https://github.com/Mutagen-Modding/Mutagen
+  --- generated: Mutagen release ---
     (release 0.54.4; repository commit 0188012c607ce8bb283d2704400d37737f089134)
+  --- end generated ---
 The other GPL components' sources are linked beside each entry below.
 
 WHAT SHIPS
@@ -29,9 +31,10 @@ The plugin bundles the third-party components below in server/ — compiled .NET
 assemblies from a framework-dependent .NET 9 publish (the .NET runtime itself is
 NOT bundled; the user installs it). Components are grouped by license.
 
-The component tables between the "--- generated ---" markers below are written by
-the build from that publish output (scripts/generate-notices.ps1), so the names and
-versions are what actually ships. Everything else here is hand-authored.
+The regions between the "--- generated ---" markers — the component tables below and
+the Mutagen release and commit above — are written by the build from that publish
+output (scripts/generate-notices.ps1), so the names and versions are what actually
+ships. Everything else here is hand-authored.
 
 
 ===============================================================================

--- a/scripts/build-plugin.ps1
+++ b/scripts/build-plugin.ps1
@@ -67,16 +67,16 @@ Write-Host ("Building houseCARL v{0}" -f $Version) -ForegroundColor Green
 # Clean the WHOLE package root, not just dist/housecarl: stale package-root extras (codex/,
 # START-HERE.txt, a previous setup exe) would otherwise survive into the zip - a stale nested
 # codex/codex/ subtree did exactly that at the 1.2.2 build.
-Step '0/10' 'Clean dist/ (package root)'
+Step '0/11' 'Clean dist/ (package root)'
 if (Test-Path $PkgRoot) { Remove-Item $PkgRoot -Recurse -Force }
 New-Item -ItemType Directory -Path $DistRoot -Force | Out-Null
 
-# Steps 1-3 build the SERVER half of the tree. -PluginTreeOnly skips them: nothing the plugin
+# Steps 1-4 build the SERVER half of the tree. -PluginTreeOnly skips them: nothing the plugin
 # validator reads comes out of them, and they are the slow part (corpus reflection + two publishes).
 if (-not $PluginTreeOnly) {
 
   # ---- 1. regenerate the rulebook (corpus.json + mutagen-reference shards, in sync by construction)
-  Step '1/10' 'Regenerate corpus.json (generator)'
+  Step '1/11' 'Regenerate corpus.json (generator)'
   # Explicit absolute args make this CWD-independent (Program.cs defaults are relative to CWD).
   dotnet run --project $GenProj -c Release -- $GeneratedDir $RefDir
   if ($LASTEXITCODE -ne 0) { throw "generator failed (exit $LASTEXITCODE)" }
@@ -86,7 +86,7 @@ if (-not $PluginTreeOnly) {
   # ---- 2. publish the server (framework-dependent; trimming OFF) -------------
   # -p:Version stamps the plugin.json version into the exe, which ServerInfo reports over MCP
   # (one version home; an unstamped dev build says 0.0.0-dev).
-  Step '2/10' 'Publish server (Release, win-x64, framework-dependent)'
+  Step '2/11' 'Publish server (Release, win-x64, framework-dependent)'
   dotnet publish $McpProj -c Release -r win-x64 --self-contained false -p:Version=$Version -o $ServerDir
   if ($LASTEXITCODE -ne 0) { throw "publish failed (exit $LASTEXITCODE)" }
   $Exe = Join-Path $ServerDir 'housecarl-mcp.exe'
@@ -95,14 +95,22 @@ if (-not $PluginTreeOnly) {
   # strip dev-only appsettings.json (carries absolute dev paths - must not ship)
   Get-ChildItem $ServerDir -Filter 'appsettings*.json' -ErrorAction SilentlyContinue | Remove-Item -Force
 
-  # ---- 3. corpus beside the exe (the proven #1 requirement) ------------------
+  # ---- 3. generated notices regions from the publish output ------------------
+  # THIRD-PARTY-NOTICES.txt names every third-party component in server/ with its version, and names the
+  # Mutagen release its corresponding-source line points at. Both are written here from the publish just
+  # made, so neither can drift from what ships; the licence texts stay hand-authored. Both tracked copies
+  # (repo root and plugin/) are rewritten from one string, so they stay byte-identical.
+  Step '3/11' 'Write the generated notices regions from the publish output'
+  & (Join-Path $PSScriptRoot 'generate-notices.ps1') -PublishDir $ServerDir -RepoRoot $RepoRoot
+
+  # ---- 4. corpus beside the exe (the proven #1 requirement) ------------------
   # Reads survive without it via a reflection fallback, but writes + type-filtered queries need it.
-  Step '3/10' 'Copy corpus.json beside the exe'
+  Step '4/11' 'Copy corpus.json beside the exe'
   Copy-Item $CorpusSrc (Join-Path $ServerDir 'corpus.json') -Force
 }
 
-# ---- 4. bundle the 13 skills (exclude evals/ + _CORPUS_STATUS.md; KEEP all .jsonl) ----
-Step '4/10' 'Bundle skills'
+# ---- 5. bundle the 13 skills (exclude evals/ + _CORPUS_STATUS.md; KEEP all .jsonl) ----
+Step '5/11' 'Bundle skills'
 New-Item -ItemType Directory -Path $SkillsDir -Force | Out-Null
 foreach ($s in $Skills) {
   $src = Join-Path $RepoRoot ".claude\skills\$s"
@@ -113,8 +121,8 @@ foreach ($s in $Skills) {
 Get-ChildItem $SkillsDir -Directory -Recurse -Filter 'evals' | Remove-Item -Recurse -Force
 Get-ChildItem $SkillsDir -File -Recurse -Filter '_CORPUS_STATUS.md' | Remove-Item -Force
 
-# ---- 5. plugin source files ------------------------------------------------
-Step '5/10' 'Copy plugin files'
+# ---- 6. plugin source files ------------------------------------------------
+Step '6/11' 'Copy plugin files'
 Copy-Item (Join-Path $PluginSrc '.claude-plugin') $DistRoot -Recurse -Force   # -> dist/housecarl/.claude-plugin/plugin.json
 foreach ($f in @('.mcp.json','LICENSE','THIRD-PARTY-NOTICES.txt','README.md','CHANGELOG.md')) {
   Copy-Item (Join-Path $PluginSrc $f) (Join-Path $DistRoot $f) -Force
@@ -128,12 +136,12 @@ if ($PluginTreeOnly) {
   return
 }
 
-# ---- 6. package-root extras (START-HERE note + local marketplace.json) -----
+# ---- 7. package-root extras (START-HERE note + local marketplace.json) -----
 # These live in the PACKAGE ROOT (dist/), beside - not inside - dist/housecarl/, so the leak-check's
-# excluded-file scan (scoped to dist/housecarl) leaves them out, while the dev-path scan (step 8) still
+# excluded-file scan (scoped to dist/housecarl) leaves them out, while the dev-path scan (step 9) still
 # covers them. Source: packaging/ (tracked). START-HERE.txt is version-stamped from plugin.json;
 # marketplace.json is the local CLI-install descriptor (`claude plugin marketplace add <this folder>`).
-Step '6/10' 'Package-root extras (START-HERE.txt + marketplace.json + codex umbrella)'
+Step '7/11' 'Package-root extras (START-HERE.txt + marketplace.json + codex umbrella)'
 $startHere = (Get-Content (Join-Path $PackagingSrc 'START-HERE.txt') -Raw) -replace '\{\{VERSION\}\}', $Version
 if ($startHere -match '\{\{') { throw "START-HERE.txt has an unresolved {{token}} after substitution" }
 [System.IO.File]::WriteAllText((Join-Path $PkgRoot 'START-HERE.txt'), $startHere, (New-Object System.Text.UTF8Encoding($false)))
@@ -147,7 +155,7 @@ Copy-Item (Join-Path $PackagingSrc 'marketplace.json') (Join-Path $MpDir 'market
 $CodexSrc = Join-Path $PluginSrc 'codex'
 if (Test-Path $CodexSrc) { Copy-Item $CodexSrc (Join-Path $PkgRoot 'codex') -Recurse -Force }
 
-# ---- 7. publish the setup utility into dist/ (beside the plugin) -----------
+# ---- 8. publish the setup utility into dist/ (beside the plugin) -----------
 # houseCARL-Setup.exe: the no-CLI desktop installer a user double-clicks. It copies the plugin into
 # ~/.claude/skills/housecarl/ (desktop auto-loads the skills) and registers the MCP server in
 # ~/.claude.json (desktop spawns it per session). It ships in the PACKAGE ROOT (dist\), beside - not
@@ -157,15 +165,15 @@ if (Test-Path $CodexSrc) { Copy-Item $CodexSrc (Join-Path $PkgRoot 'codex') -Rec
 # framework-dependent SERVER needs (.NET Runtime + ASP.NET Core Runtime - separate installers on
 # Windows) and say exactly which is missing. Trimming is safe HERE (setup uses only the
 # System.Text.Json DOM, no reflection serialization) - the server's trimming ban is untouched.
-Step '7/10' 'Publish the setup utility (houseCARL-Setup.exe) into dist/'
+Step '8/11' 'Publish the setup utility (houseCARL-Setup.exe) into dist/'
 dotnet publish $SetupProj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=true -p:EnableCompressionInSingleFile=true -p:DebugType=None -p:DebugSymbols=false -o $PkgRoot
 if ($LASTEXITCODE -ne 0) { throw "setup-utility publish failed (exit $LASTEXITCODE)" }
 $SetupExe = Join-Path $PkgRoot 'houseCARL-Setup.exe'
 if (-not (Test-Path $SetupExe)) { throw "setup utility not produced at $SetupExe" }
 Write-Host ("houseCARL-Setup.exe: {0:N2} MB" -f ((Get-Item $SetupExe).Length / 1MB))
 
-# ---- 8. leak-check ---------------------------------------------------------
-Step '8/10' 'Leak-check assembled tree'
+# ---- 9. leak-check ---------------------------------------------------------
+Step '9/11' 'Leak-check assembled tree'
 $leaks = @()
 $leaks += Get-ChildItem $DistRoot -Recurse -Force -Filter 'appsettings*.json'
 $leaks += Get-ChildItem $DistRoot -Recurse -Force -Filter '_CORPUS_STATUS.md'
@@ -192,11 +200,11 @@ if ($pathLeaks.Count -gt 0) {
 }
 Write-Host "leak-check clean." -ForegroundColor Green
 
-# ---- 9. pack the shippable zip ---------------------------------------------
+# ---- 10. pack the shippable zip ---------------------------------------------
 # One zip, single 'houseCARL/' root (so unzipping never scatters files), built from dist/ via the
 # .NET zip API (Compress-Archive can't set a custom root). Lands in release/ - outside dist/, so it
 # never includes itself. FileMode::Create overwrites a same-version zip in place.
-Step '9/10' 'Pack release zip'
+Step '10/11' 'Pack release zip'
 New-Item -ItemType Directory -Path $ReleaseDir -Force | Out-Null
 $ZipPath = Join-Path $ReleaseDir ("houseCARL-{0}.zip" -f $Version)
 Add-Type -AssemblyName System.IO.Compression
@@ -218,8 +226,8 @@ $zipCheck.Dispose()
 $ZipMB = [math]::Round((Get-Item $ZipPath).Length / 1MB, 2)
 Write-Host ("packed {0} entries -> {1} ({2} MB)" -f $ZipEntryCount, $ZipPath, $ZipMB) -ForegroundColor Green
 
-# ---- 10. summary -----------------------------------------------------------
-Step '10/10' 'Summary'
+# ---- 11. summary -----------------------------------------------------------
+Step '11/11' 'Summary'
 $fileCount  = (Get-ChildItem $DistRoot -Recurse -Force -File).Count
 $totalMB    = (Get-ChildItem $DistRoot -Recurse -Force -File | Measure-Object Length -Sum).Sum / 1MB
 $skillCount = (Get-ChildItem $SkillsDir -Directory).Count

--- a/scripts/generate-notices.ps1
+++ b/scripts/generate-notices.ps1
@@ -1,0 +1,188 @@
+#requires -Version 5.1
+<#
+  generate-notices.ps1 - write the component table of THIRD-PARTY-NOTICES.txt from the publish output.
+
+  The notices file claims to list every third-party component the plugin bundles in server/, with an
+  exact version. That claim used to be hand-maintained and drifted three times (stale versions, missing
+  components, an unattributed Apache-2.0 component). This script derives the list instead: it reads the
+  publish output's deps.json, keeps only the packages that actually emitted a DLL beside the exe, resolves
+  each to its licence, and rewrites the marked regions of plugin/THIRD-PARTY-NOTICES.txt in place. The
+  repo-root copy is then written from the same string, so the two stay byte-identical.
+
+  Everything else in the notices file - the licence texts, the per-component prose, and the GPLv3 section 6
+  corresponding-source release and commit - stays hand-authored. Only the tables between the
+
+      --- generated: <licence> components ---
+      --- end generated ---
+
+  markers are written here.
+
+  Two data files carry what the publish output cannot say:
+
+      packaging/notices-display-names.json        package id -> the name the file lists it under
+      packaging/notices-licence-exceptions.json   packages whose NuGet metadata has no licence expression
+
+  A shipped DLL that resolves to neither a project nor a known package, a package with no licence
+  expression and no exception entry, or a licence with no section in the notices file, all stop the build
+  with the component named.
+
+  Run standalone against any publish directory:
+      pwsh scripts/generate-notices.ps1 -PublishDir dist/housecarl/server
+
+  NOTE: keep this file ASCII-only. Windows PowerShell 5.1 misreads UTF-8 non-ASCII bytes as CP1252
+  and fails to parse.
+#>
+param(
+  [Parameter(Mandatory = $true)][string] $PublishDir,
+  [string] $RepoRoot
+)
+$ErrorActionPreference = 'Stop'
+
+if (-not $RepoRoot) { $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path }
+$PublishDir = (Resolve-Path $PublishDir).Path
+
+$DepsFile     = Join-Path $PublishDir 'housecarl-mcp.deps.json'
+$PluginCopy   = Join-Path $RepoRoot 'plugin/THIRD-PARTY-NOTICES.txt'
+$RootCopy     = Join-Path $RepoRoot 'THIRD-PARTY-NOTICES.txt'
+$NamesFile    = Join-Path $RepoRoot 'packaging/notices-display-names.json'
+$ExceptFile   = Join-Path $RepoRoot 'packaging/notices-licence-exceptions.json'
+
+foreach ($f in @($DepsFile, $PluginCopy, $RootCopy, $NamesFile, $ExceptFile)) {
+  if (-not (Test-Path $f)) { throw "notices generation needs a file that is not there: $f" }
+}
+
+function Read-JsonFile($path) {
+  return [System.IO.File]::ReadAllText($path, [System.Text.Encoding]::UTF8) | ConvertFrom-Json
+}
+function Get-Prop($obj, $name) {
+  $p = $obj.PSObject.Properties[$name]
+  if ($p) { return $p.Value }
+  return $null
+}
+
+$displayNames = Read-JsonFile $NamesFile
+$exceptions   = Read-JsonFile $ExceptFile
+
+# ---- what the publish actually put beside the exe --------------------------
+$shippedDlls = @{}
+foreach ($d in (Get-ChildItem $PublishDir -File -Filter '*.dll')) { $shippedDlls[$d.Name.ToLowerInvariant()] = $true }
+if ($shippedDlls.Count -eq 0) { throw "no DLLs in the publish directory: $PublishDir" }
+
+$deps = Read-JsonFile $DepsFile
+# The RID-specific target is the one that ships; fall back to the portable one.
+$targetName = ($deps.targets.PSObject.Properties.Name | Where-Object { $_ -match '/' } | Select-Object -First 1)
+if (-not $targetName) { $targetName = ($deps.targets.PSObject.Properties.Name | Select-Object -First 1) }
+$target = Get-Prop $deps.targets $targetName
+
+# ---- the NuGet cache the nuspecs are read from -----------------------------
+$NugetCache = $env:NUGET_PACKAGES
+if (-not $NugetCache) { $NugetCache = Join-Path $env:USERPROFILE '.nuget/packages' }
+if (-not (Test-Path $NugetCache)) { throw "NuGet package cache not found at $NugetCache; set NUGET_PACKAGES" }
+
+function Get-NuspecFacts($id, $version) {
+  $dir = Join-Path $NugetCache ("{0}/{1}" -f $id.ToLowerInvariant(), $version.ToLowerInvariant())
+  $nuspec = Join-Path $dir ("{0}.nuspec" -f $id.ToLowerInvariant())
+  if (-not (Test-Path $nuspec)) { return $null }
+  $xml = [xml][System.IO.File]::ReadAllText($nuspec, [System.Text.Encoding]::UTF8)
+  $md = $xml.package.metadata
+  $expr = $null
+  if ($md.license -and $md.license.type -eq 'expression') { $expr = [string]$md.license.'#text' }
+  $url = $null
+  if ($md.repository -and $md.repository.url) { $url = [string]$md.repository.url }
+  elseif ($md.projectUrl) { $url = [string]$md.projectUrl }
+  return [pscustomobject]@{ Licence = $expr; Url = $url }
+}
+
+function Format-SourceUrl($url) {
+  if (-not $url) { return '' }
+  $u = $url -replace '^https?://', ''
+  $u = $u -replace '\.git$', ''
+  return $u.TrimEnd('/')
+}
+
+# ---- resolve every shipped DLL to a component ------------------------------
+$components = @()
+$claimed = @{}
+foreach ($p in $target.PSObject.Properties) {
+  $id, $version = $p.Name -split '/', 2
+  $runtime = Get-Prop $p.Value 'runtime'
+  $files = @()
+  if ($runtime) { $files = $runtime.PSObject.Properties.Name | ForEach-Object { Split-Path $_ -Leaf } }
+  $mine = @($files | Where-Object { $shippedDlls.ContainsKey($_.ToLowerInvariant()) })
+  if ($mine.Count -eq 0) { continue }
+  foreach ($m in $mine) { $claimed[$m.ToLowerInvariant()] = $true }
+
+  $lib = Get-Prop $deps.libraries $p.Name
+  # First-party assemblies are ours, not third-party: they belong in no notices file.
+  if ($lib -and $lib.type -eq 'project') { continue }
+
+  $facts = Get-NuspecFacts $id $version
+  $licence = $null
+  if ($facts) { $licence = $facts.Licence }
+  $exception = Get-Prop $exceptions $id
+  if (-not $licence -and $exception) { $licence = $exception.licence }
+  if (-not $licence) {
+    throw "$id $version ships but declares no licence expression in its NuGet metadata; record the determined licence in packaging/notices-licence-exceptions.json"
+  }
+  $name = Get-Prop $displayNames $id
+  if (-not $name) { $name = $id }
+
+  $sourceUrl = $null
+  if ($facts) { $sourceUrl = $facts.Url }
+
+  $components += [pscustomobject]@{
+    Name    = $name
+    Version = $version
+    Licence = $licence
+    Source  = Format-SourceUrl $sourceUrl
+  }
+}
+
+$unclaimed = @($shippedDlls.Keys | Where-Object { -not $claimed.ContainsKey($_) })
+if ($unclaimed.Count -gt 0) {
+  throw ("these DLLs ship but resolve to no package in the publish output: {0}" -f ($unclaimed -join ', '))
+}
+
+# ---- render one table per licence ------------------------------------------
+function Format-ComponentTable($rows, $withSource) {
+  $sorted = $rows | Sort-Object { $_.Name.ToLowerInvariant() }
+  $nameWidth = ($sorted | ForEach-Object { $_.Name.Length } | Measure-Object -Maximum).Maximum + 3
+  $verWidth  = ($sorted | ForEach-Object { $_.Version.Length } | Measure-Object -Maximum).Maximum + 3
+  $lines = @()
+  foreach ($r in $sorted) {
+    if ($withSource) {
+      $lines += ('  {0}{1}{2}' -f $r.Name.PadRight($nameWidth), $r.Version.PadRight($verWidth), $r.Source).TrimEnd()
+    } else {
+      $lines += ('  {0}{1}' -f $r.Name.PadRight($nameWidth), $r.Version).TrimEnd()
+    }
+  }
+  return $lines
+}
+
+$text = [System.IO.File]::ReadAllText($PluginCopy, [System.Text.Encoding]::UTF8)
+$newline = if ($text -match "`r`n") { "`r`n" } else { "`n" }
+$lines = $text -split "`r?`n"
+
+$groups = $components | Group-Object Licence
+foreach ($g in $groups) {
+  $begin = '  --- generated: {0} components ---' -f $g.Name
+  $beginIdx = [Array]::IndexOf($lines, $begin)
+  if ($beginIdx -lt 0) {
+    throw "$($g.Name) components ship but THIRD-PARTY-NOTICES.txt has no '$($g.Name)' section; add the section and its licence text, then rerun the build"
+  }
+  $endIdx = [Array]::IndexOf($lines, '  --- end generated ---', $beginIdx)
+  if ($endIdx -lt 0) { throw "the $($g.Name) generated region in THIRD-PARTY-NOTICES.txt has no end marker" }
+  # The source column is only shown for the copyleft components, whose corresponding source has to be findable.
+  $table = Format-ComponentTable $g.Group ($g.Name -like 'GPL*')
+  $head = $lines[0..$beginIdx]
+  $tail = $lines[$endIdx..($lines.Length - 1)]
+  $lines = @($head) + @($table) + @($tail)
+}
+
+$rendered = ($lines -join $newline)
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText($PluginCopy, $rendered, $utf8NoBom)
+[System.IO.File]::WriteAllText($RootCopy, $rendered, $utf8NoBom)
+
+$changed = ($rendered -ne $text)
+Write-Host ("notices: {0} components from {1}{2}" -f $components.Count, $PublishDir, $(if ($changed) { ' (component table updated)' } else { '' }))

--- a/scripts/generate-notices.ps1
+++ b/scripts/generate-notices.ps1
@@ -140,7 +140,7 @@ foreach ($p in $target.PSObject.Properties) {
   $sourceUrl = $null
   if ($facts) { $sourceUrl = Format-SourceUrl $facts.Url }
   # A copyleft component with no source pointer would leave the GPLv3 section 6 claim unbacked.
-  if ($licence -like 'GPL*' -and -not $sourceUrl) {
+  if ($licence -match 'GPL' -and -not $sourceUrl) {
     throw "$id $version is $licence but its NuGet metadata names no repository or project URL, so the notices file cannot point at its corresponding source"
   }
 
@@ -227,7 +227,7 @@ for ($k = $regions.Count - 1; $k -ge 0; $k--) {
   } else {
     $lic = $r.Tag -replace ' components$', ''
     # The source column is only shown for the copyleft components, whose corresponding source has to be findable.
-    if ($byLicence.ContainsKey($lic)) { $body = Format-ComponentTable $byLicence[$lic] ($lic -like 'GPL*') }
+    if ($byLicence.ContainsKey($lic)) { $body = Format-ComponentTable $byLicence[$lic] ($lic -match 'GPL') }
   }
   $lines = @($lines[0..$r.Begin]) + @($body) + @($lines[$r.End..($lines.Length - 1)])
 }

--- a/scripts/generate-notices.ps1
+++ b/scripts/generate-notices.ps1
@@ -9,22 +9,25 @@
   each to its licence, and rewrites the marked regions of plugin/THIRD-PARTY-NOTICES.txt in place. The
   repo-root copy is then written from the same string, so the two stay byte-identical.
 
-  Everything else in the notices file - the licence texts, the per-component prose, and the GPLv3 section 6
-  corresponding-source release and commit - stays hand-authored. Only the tables between the
+  Everything else in the notices file - the licence texts and the per-component prose - stays hand-authored.
+  Only the regions between the
 
-      --- generated: <licence> components ---
+      --- generated: <tag> ---
       --- end generated ---
 
-  markers are written here.
+  markers are written here. Two tags exist: "<licence> components" for a licence's component table, and
+  "Mutagen release" for the GPLv3 section 6 corresponding-source line, which names the Mutagen version the
+  publish output ships and the commit that release is tagged at.
 
-  Two data files carry what the publish output cannot say:
+  Three data files carry what the publish output cannot say:
 
       packaging/notices-display-names.json        package id -> the name the file lists it under
       packaging/notices-licence-exceptions.json   packages whose NuGet metadata has no licence expression
+      packaging/notices-mutagen-commits.json      Mutagen release version -> repository commit
 
   A shipped DLL that resolves to neither a project nor a known package, a package with no licence
-  expression and no exception entry, or a licence with no section in the notices file, all stop the build
-  with the component named.
+  expression and no exception entry, a licence with no section in the notices file, and a shipped Mutagen
+  version with no recorded commit, all stop the build with the component named.
 
   Run standalone against any publish directory:
       pwsh scripts/generate-notices.ps1 -PublishDir dist/housecarl/server
@@ -46,8 +49,9 @@ $PluginCopy   = Join-Path $RepoRoot 'plugin/THIRD-PARTY-NOTICES.txt'
 $RootCopy     = Join-Path $RepoRoot 'THIRD-PARTY-NOTICES.txt'
 $NamesFile    = Join-Path $RepoRoot 'packaging/notices-display-names.json'
 $ExceptFile   = Join-Path $RepoRoot 'packaging/notices-licence-exceptions.json'
+$CommitsFile  = Join-Path $RepoRoot 'packaging/notices-mutagen-commits.json'
 
-foreach ($f in @($DepsFile, $PluginCopy, $RootCopy, $NamesFile, $ExceptFile)) {
+foreach ($f in @($DepsFile, $PluginCopy, $RootCopy, $NamesFile, $ExceptFile, $CommitsFile)) {
   if (-not (Test-Path $f)) { throw "notices generation needs a file that is not there: $f" }
 }
 
@@ -60,8 +64,9 @@ function Get-Prop($obj, $name) {
   return $null
 }
 
-$displayNames = Read-JsonFile $NamesFile
-$exceptions   = Read-JsonFile $ExceptFile
+$displayNames   = Read-JsonFile $NamesFile
+$exceptions     = Read-JsonFile $ExceptFile
+$mutagenCommits = Read-JsonFile $CommitsFile
 
 # ---- what the publish actually put beside the exe --------------------------
 $shippedDlls = @{}
@@ -139,6 +144,7 @@ foreach ($p in $target.PSObject.Properties) {
   }
 
   $components += [pscustomobject]@{
+    Id      = $id
     Name    = $name
     Version = $version
     Licence = $licence
@@ -150,6 +156,21 @@ $unclaimed = @($shippedDlls.Keys | Where-Object { -not $claimed.ContainsKey($_) 
 if ($unclaimed.Count -gt 0) {
   throw ("these DLLs ship but resolve to no package in the publish output: {0}" -f ($unclaimed -join ', '))
 }
+
+# ---- the corresponding-source line, from the Mutagen version that ships -----
+$mutagenVersions = @($components | Where-Object { $_.Id -like 'Mutagen.*' } | ForEach-Object { $_.Version } | Sort-Object -Unique)
+if ($mutagenVersions.Count -eq 0) {
+  throw "no Mutagen package ships in $PublishDir, so the corresponding-source line in THIRD-PARTY-NOTICES.txt cannot name a release"
+}
+if ($mutagenVersions.Count -gt 1) {
+  throw ("the publish output ships more than one Mutagen version ({0}), so the corresponding-source line in THIRD-PARTY-NOTICES.txt cannot name one release" -f ($mutagenVersions -join ', '))
+}
+$mutagenVersion = $mutagenVersions[0]
+$mutagenCommit  = Get-Prop $mutagenCommits $mutagenVersion
+if (-not $mutagenCommit) {
+  throw "Mutagen $mutagenVersion ships but packaging/notices-mutagen-commits.json records no commit for it; add the commit the release is tagged at, from github.com/Mutagen-Modding/Mutagen/releases/tag/$mutagenVersion"
+}
+$mutagenLine = '    (release {0}; repository commit {1})' -f $mutagenVersion, $mutagenCommit
 
 # ---- render one table per licence ------------------------------------------
 function Format-ComponentTable($rows, $withSource) {
@@ -178,24 +199,36 @@ foreach ($g in ($components | Group-Object Licence)) { $byLicence[$g.Name] = $g.
 # emptied rather than left standing.
 $regions = @()
 for ($i = 0; $i -lt $lines.Length; $i++) {
-  if ($lines[$i] -match '^  --- generated: (.+) components ---$') {
+  if ($lines[$i] -match '^  --- generated: (.+) ---$') {
+    $tag = $Matches[1]
+    if ($tag -ne 'Mutagen release' -and $tag -notmatch ' components$') {
+      throw "THIRD-PARTY-NOTICES.txt marks a generated region '$tag' that this script does not know how to write"
+    }
     $endIdx = [Array]::IndexOf($lines, '  --- end generated ---', $i)
-    if ($endIdx -lt 0) { throw "the $($Matches[1]) generated region in THIRD-PARTY-NOTICES.txt has no end marker" }
-    $regions += [pscustomobject]@{ Licence = $Matches[1]; Begin = $i; End = $endIdx }
+    if ($endIdx -lt 0) { throw "the $tag generated region in THIRD-PARTY-NOTICES.txt has no end marker" }
+    $regions += [pscustomobject]@{ Tag = $tag; Begin = $i; End = $endIdx }
   }
 }
+if (@($regions | Where-Object { $_.Tag -eq 'Mutagen release' }).Count -ne 1) {
+  throw "THIRD-PARTY-NOTICES.txt needs exactly one 'Mutagen release' generated region for the corresponding-source line"
+}
 foreach ($lic in $byLicence.Keys) {
-  if (-not ($regions | Where-Object { $_.Licence -eq $lic })) {
+  if (-not ($regions | Where-Object { $_.Tag -eq "$lic components" })) {
     throw "$lic components ship but THIRD-PARTY-NOTICES.txt has no '$lic' section; add the section, its markers and its licence text, then rerun the build"
   }
 }
 # Last region first, so the earlier regions' line numbers stay valid as the file grows and shrinks.
 for ($k = $regions.Count - 1; $k -ge 0; $k--) {
   $r = $regions[$k]
-  $table = @()
-  # The source column is only shown for the copyleft components, whose corresponding source has to be findable.
-  if ($byLicence.ContainsKey($r.Licence)) { $table = Format-ComponentTable $byLicence[$r.Licence] ($r.Licence -like 'GPL*') }
-  $lines = @($lines[0..$r.Begin]) + @($table) + @($lines[$r.End..($lines.Length - 1)])
+  $body = @()
+  if ($r.Tag -eq 'Mutagen release') {
+    $body = @($mutagenLine)
+  } else {
+    $lic = $r.Tag -replace ' components$', ''
+    # The source column is only shown for the copyleft components, whose corresponding source has to be findable.
+    if ($byLicence.ContainsKey($lic)) { $body = Format-ComponentTable $byLicence[$lic] ($lic -like 'GPL*') }
+  }
+  $lines = @($lines[0..$r.Begin]) + @($body) + @($lines[$r.End..($lines.Length - 1)])
 }
 
 $rendered = ($lines -join $newline)
@@ -204,4 +237,4 @@ $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
 [System.IO.File]::WriteAllText($RootCopy, $rendered, $utf8NoBom)
 
 $changed = ($rendered -ne $text)
-Write-Host ("notices: {0} components from {1}{2}" -f $components.Count, $PublishDir, $(if ($changed) { ' (component table updated)' } else { '' }))
+Write-Host ("notices: {0} components from {1}{2}" -f $components.Count, $PublishDir, $(if ($changed) { ' (generated regions updated)' } else { '' }))

--- a/scripts/generate-notices.ps1
+++ b/scripts/generate-notices.ps1
@@ -34,12 +34,16 @@
   Run standalone against any publish directory:
       pwsh scripts/generate-notices.ps1 -PublishDir dist/housecarl/server
 
+  -Check generates into memory and writes nothing, failing if either tracked copy differs. CI runs it
+  after a publish, so a dependency bump cannot merge with a stale notices file.
+
   NOTE: keep this file ASCII-only. Windows PowerShell 5.1 misreads UTF-8 non-ASCII bytes as CP1252
   and fails to parse.
 #>
 param(
   [Parameter(Mandatory = $true)][string] $PublishDir,
-  [string] $RepoRoot
+  [string] $RepoRoot,
+  [switch] $Check
 )
 $ErrorActionPreference = 'Stop'
 
@@ -244,6 +248,28 @@ for ($k = $regions.Count - 1; $k -ge 0; $k--) {
 }
 
 $rendered = ($lines -join $newline)
+
+if ($Check) {
+  # Compare instead of writing, so CI can fail a dependency bump that leaves a tracked copy stale.
+  foreach ($copy in @($PluginCopy, $RootCopy)) {
+    $onDisk = [System.IO.File]::ReadAllText($copy, [System.Text.Encoding]::UTF8)
+    if ($onDisk -eq $rendered) { continue }
+    $want = $rendered -split "`r?`n"
+    $have = $onDisk -split "`r?`n"
+    $firstDiff = [Math]::Max($want.Length, $have.Length)
+    for ($i = 0; $i -lt $firstDiff; $i++) {
+      $w = if ($i -lt $want.Length) { $want[$i] } else { $null }
+      $h = if ($i -lt $have.Length) { $have[$i] } else { $null }
+      if ($w -ne $h) { $firstDiff = $i; break }
+    }
+    $haveLine = if ($firstDiff -lt $have.Length) { "'" + $have[$firstDiff] + "'" } else { 'nothing' }
+    $wantLine = if ($firstDiff -lt $want.Length) { "'" + $want[$firstDiff] + "'" } else { 'nothing' }
+    throw ("{0} is stale: line {1} has {2} where the publish output gives {3}; rerun scripts/build-plugin.ps1 and commit both THIRD-PARTY-NOTICES.txt copies" -f $copy, ($firstDiff + 1), $haveLine, $wantLine)
+  }
+  Write-Host ("notices: {0} components from {1} (both tracked copies match)" -f $components.Count, $PublishDir)
+  return
+}
+
 $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
 [System.IO.File]::WriteAllText($PluginCopy, $rendered, $utf8NoBom)
 [System.IO.File]::WriteAllText($RootCopy, $rendered, $utf8NoBom)

--- a/scripts/generate-notices.ps1
+++ b/scripts/generate-notices.ps1
@@ -42,6 +42,7 @@ param(
 $ErrorActionPreference = 'Stop'
 
 if (-not $RepoRoot) { $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path }
+if (-not (Test-Path $PublishDir)) { throw "notices generation needs a publish directory, and there is nothing at $PublishDir; publish the server first" }
 $PublishDir = (Resolve-Path $PublishDir).Path
 
 $DepsFile     = Join-Path $PublishDir 'housecarl-mcp.deps.json'

--- a/scripts/generate-notices.ps1
+++ b/scripts/generate-notices.ps1
@@ -75,7 +75,9 @@ if (-not $targetName) { $targetName = ($deps.targets.PSObject.Properties.Name | 
 $target = Get-Prop $deps.targets $targetName
 
 # ---- the NuGet cache the nuspecs are read from -----------------------------
-$NugetCache = $env:NUGET_PACKAGES
+# Ask the toolchain rather than guessing: a nuget.config globalPackagesFolder moves it off the default path.
+$NugetCache = ((dotnet nuget locals global-packages --list) | Where-Object { $_ -match 'global-packages:' } | Select-Object -First 1) -replace '^.*global-packages:\s*', ''
+if (-not $NugetCache -or -not (Test-Path $NugetCache)) { $NugetCache = $env:NUGET_PACKAGES }
 if (-not $NugetCache) { $NugetCache = Join-Path $env:USERPROFILE '.nuget/packages' }
 if (-not (Test-Path $NugetCache)) { throw "NuGet package cache not found at $NugetCache; set NUGET_PACKAGES" }
 
@@ -105,9 +107,11 @@ $components = @()
 $claimed = @{}
 foreach ($p in $target.PSObject.Properties) {
   $id, $version = $p.Name -split '/', 2
-  $runtime = Get-Prop $p.Value 'runtime'
   $files = @()
-  if ($runtime) { $files = $runtime.PSObject.Properties.Name | ForEach-Object { Split-Path $_ -Leaf } }
+  foreach ($kind in @('runtime', 'native')) {
+    $assets = Get-Prop $p.Value $kind
+    if ($assets) { $files += $assets.PSObject.Properties.Name | ForEach-Object { Split-Path $_ -Leaf } }
+  }
   $mine = @($files | Where-Object { $shippedDlls.ContainsKey($_.ToLowerInvariant()) })
   if ($mine.Count -eq 0) { continue }
   foreach ($m in $mine) { $claimed[$m.ToLowerInvariant()] = $true }
@@ -128,13 +132,17 @@ foreach ($p in $target.PSObject.Properties) {
   if (-not $name) { $name = $id }
 
   $sourceUrl = $null
-  if ($facts) { $sourceUrl = $facts.Url }
+  if ($facts) { $sourceUrl = Format-SourceUrl $facts.Url }
+  # A copyleft component with no source pointer would leave the GPLv3 section 6 claim unbacked.
+  if ($licence -like 'GPL*' -and -not $sourceUrl) {
+    throw "$id $version is $licence but its NuGet metadata names no repository or project URL, so the notices file cannot point at its corresponding source"
+  }
 
   $components += [pscustomobject]@{
     Name    = $name
     Version = $version
     Licence = $licence
-    Source  = Format-SourceUrl $sourceUrl
+    Source  = $sourceUrl
   }
 }
 
@@ -163,20 +171,31 @@ $text = [System.IO.File]::ReadAllText($PluginCopy, [System.Text.Encoding]::UTF8)
 $newline = if ($text -match "`r`n") { "`r`n" } else { "`n" }
 $lines = $text -split "`r?`n"
 
-$groups = $components | Group-Object Licence
-foreach ($g in $groups) {
-  $begin = '  --- generated: {0} components ---' -f $g.Name
-  $beginIdx = [Array]::IndexOf($lines, $begin)
-  if ($beginIdx -lt 0) {
-    throw "$($g.Name) components ship but THIRD-PARTY-NOTICES.txt has no '$($g.Name)' section; add the section and its licence text, then rerun the build"
+$byLicence = @{}
+foreach ($g in ($components | Group-Object Licence)) { $byLicence[$g.Name] = $g.Group }
+
+# Walk the file's markers, not the components, so a region whose components all stopped shipping is
+# emptied rather than left standing.
+$regions = @()
+for ($i = 0; $i -lt $lines.Length; $i++) {
+  if ($lines[$i] -match '^  --- generated: (.+) components ---$') {
+    $endIdx = [Array]::IndexOf($lines, '  --- end generated ---', $i)
+    if ($endIdx -lt 0) { throw "the $($Matches[1]) generated region in THIRD-PARTY-NOTICES.txt has no end marker" }
+    $regions += [pscustomobject]@{ Licence = $Matches[1]; Begin = $i; End = $endIdx }
   }
-  $endIdx = [Array]::IndexOf($lines, '  --- end generated ---', $beginIdx)
-  if ($endIdx -lt 0) { throw "the $($g.Name) generated region in THIRD-PARTY-NOTICES.txt has no end marker" }
+}
+foreach ($lic in $byLicence.Keys) {
+  if (-not ($regions | Where-Object { $_.Licence -eq $lic })) {
+    throw "$lic components ship but THIRD-PARTY-NOTICES.txt has no '$lic' section; add the section, its markers and its licence text, then rerun the build"
+  }
+}
+# Last region first, so the earlier regions' line numbers stay valid as the file grows and shrinks.
+for ($k = $regions.Count - 1; $k -ge 0; $k--) {
+  $r = $regions[$k]
+  $table = @()
   # The source column is only shown for the copyleft components, whose corresponding source has to be findable.
-  $table = Format-ComponentTable $g.Group ($g.Name -like 'GPL*')
-  $head = $lines[0..$beginIdx]
-  $tail = $lines[$endIdx..($lines.Length - 1)]
-  $lines = @($head) + @($table) + @($tail)
+  if ($byLicence.ContainsKey($r.Licence)) { $table = Format-ComponentTable $byLicence[$r.Licence] ($r.Licence -like 'GPL*') }
+  $lines = @($lines[0..$r.Begin]) + @($table) + @($lines[$r.End..($lines.Length - 1)])
 }
 
 $rendered = ($lines -join $newline)

--- a/scripts/generate-notices.ps1
+++ b/scripts/generate-notices.ps1
@@ -22,12 +22,14 @@
   Three data files carry what the publish output cannot say:
 
       packaging/notices-display-names.json        package id -> the name the file lists it under
-      packaging/notices-licence-exceptions.json   packages whose NuGet metadata has no licence expression
+      packaging/notices-licence-exceptions.json   packages whose NuGet metadata has no licence expression,
+                                                  each keyed to the version the determination was made against
       packaging/notices-mutagen-commits.json      Mutagen release version -> repository commit
 
   A shipped DLL that resolves to neither a project nor a known package, a package with no licence
-  expression and no exception entry, a licence with no section in the notices file, and a shipped Mutagen
-  version with no recorded commit, all stop the build with the component named.
+  expression and no exception entry, an exception entry recorded against a different version than ships,
+  a licence with no section in the notices file, and a shipped Mutagen version with no recorded commit,
+  all stop the build with the component named.
 
   Run standalone against any publish directory:
       pwsh scripts/generate-notices.ps1 -PublishDir dist/housecarl/server
@@ -130,7 +132,16 @@ foreach ($p in $target.PSObject.Properties) {
   $licence = $null
   if ($facts) { $licence = $facts.Licence }
   $exception = Get-Prop $exceptions $id
-  if (-not $licence -and $exception) { $licence = $exception.licence }
+  if (-not $licence -and $exception) {
+    # The determination was made against one version, and a package can relicense across versions, so a
+    # differing version stops the build rather than carrying the old determination forward.
+    $recorded = $exception.version
+    if (-not $recorded) { $recorded = '(no version recorded)' }
+    if ($recorded -ne $version) {
+      throw "$id ships as $version but packaging/notices-licence-exceptions.json records its licence against $recorded; check the licence of $version and update the entry"
+    }
+    $licence = $exception.licence
+  }
   if (-not $licence) {
     throw "$id $version ships but declares no licence expression in its NuGet metadata; record the determined licence in packaging/notices-licence-exceptions.json"
   }


### PR DESCRIPTION
`THIRD-PARTY-NOTICES.txt` claims to name every third-party component the plugin bundles in `server/`, with an exact version. Nothing derived that claim from what actually ships, and it drifted three times. This regenerates the file against a real `dotnet publish` of `housecarl-mcp` and makes the component table a build artifact rather than a hand-maintained list: `scripts/generate-notices.ps1` reads the publish output's `deps.json`, keeps only the packages that emitted a DLL beside the exe, resolves each to its NuGet licence expression, and rewrites the marked regions of both tracked copies from one string so they stay byte-identical. It runs as a new step 3 of `scripts/build-plugin.ps1`, inside the `-not $PluginTreeOnly` block right after the publish it reads, so a `-PluginTreeOnly` build never calls it with no publish. The GPLv3 section 6 corresponding-source line — the release and commit of the bundled Mutagen — is written the same way, from the Mutagen version the publish output ships; it is a second kind of generated region rather than a second mechanism. Only the licence texts and the per-component prose stay hand-authored.

Three data files carry what the publish output cannot say: `packaging/notices-display-names.json` (package id to listed name, for `Nifly` and `miniball-devel0`), `packaging/notices-licence-exceptions.json` (the nine packages whose metadata has no SPDX expression — vendored licence files, the deprecated `licenseUrl` form, and `TransparentValueObjects.Abstractions`, which declares nothing at all — each with the determined licence, how it was determined, and the version it was determined against), and `packaging/notices-mutagen-commits.json` (Mutagen release version to the repository commit that release is tagged at; the one entry, `0.54.4` to `0188012c607ce8bb283d2704400d37737f089134`, is the existing hand-written value, checked against the Mutagen GitHub tag). The script stops the build with the component named when a shipped DLL resolves to no package, when a package has neither an expression nor an exception entry, when an exception entry's version is not the version that ships (a package can relicense across versions — Reloaded.Memory was LGPLv3 before May 2023), when a copyleft component's metadata names no source URL, when a licence has no section in the file, or when the shipped Mutagen version has no recorded commit. The copyleft test matches "contains GPL", so LGPL and AGPL count.

CI keeps the tracked copies fresh. `generate-notices.ps1 -Check` generates into memory, writes nothing, and fails with one sentence naming the file, the first differing line and the fix. A new CI step publishes the server (Release, win-x64, framework-dependent — the same shape the build script uses) and runs it, so a dependency bump that leaves the notices file stale cannot merge.

Against the current graph the regenerated file gains nothing and loses five entries that do not ship: `System.Threading.Tasks.Extensions`, `Microsoft.Win32.Registry`, `Microsoft.NETCore.Platforms`, `System.Security.AccessControl` and `System.Security.Principal.Windows`, along with the caveat paragraph that covered them. All 54 shipped third-party versions were already correct — the file had been hand-swept during the Mutagen bump. Entries are now ordered by name.

Verified with `dotnet build housecarl.sln -c Release`, `dotnet test src/housecarl-mcp-tests -c Release --no-build --filter "tier!=bridge"` (987 passed), `housecarl-generator ci-all` (all pass), and a full `scripts/build-plugin.ps1` run: 54 components written, and the repo-root copy, `plugin/` copy and `dist/housecarl/THIRD-PARTY-NOTICES.txt` compare byte-identical. Re-running the generator against the same publish leaves the files unchanged. `-Check` passes on that fresh tree and fails on a one-line hand edit of either tracked copy, naming the line. Emptying the commits data file, running with a missing `-PublishDir`, and pointing an exception entry at a version that does not ship were each checked by hand and each stop with their own sentence.

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)
