### PR TITLE
Report a plugin the whole-order winner scan could not read

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -29,7 +29,9 @@ saying it sets an expectation their install may contradict. Say what is known, a
   game, with its last-write time unchanged so nothing rebuilds — used to be skipped without a word, and every
   record it wins was missing from an answer that read as a complete scan. Each of those tools now names the
   plugin and the reason, and states that records it wins are missing; the scan still covers the rest of the
-  order.
+  order. A SkyPatcher post-state read (`source={"overlay": "skypatcher", "state": "post"}`) of a record whose
+  replay resolves an EditorID against such a plugin now refuses by name rather than replaying against a lookup
+  table it knows is short; a record the layer addresses by FormID is unaffected.
 
 - **`housecarl_compact_plugin` and `housecarl_merge_plugins` name a plugin they could not read.** The
   external-reference pass that runs before a renumber used to skip a plugin it could not open while still

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -29,7 +29,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
   game, with its last-write time unchanged so nothing rebuilds — used to be skipped without a word, and every
   record it wins was missing from an answer that read as a complete scan. Each of those tools now names the
   plugin and the reason, and states that records it wins are missing; the scan still covers the rest of the
-  order. A SkyPatcher post-state read (`source={"overlay": "skypatcher", "state": "post"}`) of a record whose
+  order. The sentences that would contradict that — "this quest owns NO dialogue topics", "applied by no
+  SPEL/ENCH/ALCH/SCRL/INGR in the active order", and the paged header's "NO records match at any offset; check
+  the filter, not the paging" — are replaced with what the scan can actually claim, which is what it found in
+  the plugins it could read. A file lock is also no longer reported as a quest CK-parity finding: it has its
+  own line in the text response and its own `scan_gaps` key in the json one, so a quest whose ANAM and
+  objective FNAMs are correct still gets its parity verdict. A SkyPatcher post-state read (`source={"overlay": "skypatcher", "state": "post"}`) of a record whose
   replay resolves an EditorID against such a plugin now refuses by name rather than replaying against a lookup
   table it knows is short; a record the layer addresses by FormID is unaffected.
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -22,6 +22,15 @@ saying it sets an expectation their install may contradict. Say what is known, a
   recorded for it in `packaging/notices-mutagen-commits.json`, so it cannot name a release the plugin does
   not bundle. The licence texts stay hand-authored; see the markers in the file for which parts are which.
 
+- **A whole-order scan names a plugin it could not read.** `housecarl_records` and
+  `housecarl_cross_plugin_query` scanning by type, `housecarl_effect_chain`, `housecarl_validate_dialogue` on a
+  quest, and the `housecarl_skypatcher_layer` no-op scan all stream the load order's winning records. A plugin
+  that opened when the order was indexed but cannot be opened now — held open by xEdit, MO2 or the running
+  game, with its last-write time unchanged so nothing rebuilds — used to be skipped without a word, and every
+  record it wins was missing from an answer that read as a complete scan. Each of those tools now names the
+  plugin and the reason, and states that records it wins are missing; the scan still covers the rest of the
+  order.
+
 - **`housecarl_compact_plugin` and `housecarl_merge_plugins` name a plugin they could not read.** The
   external-reference pass that runs before a renumber used to skip a plugin it could not open while still
   counting it as scanned, so a plugin held open by xEdit, MO2 or the running game could make the pass report

--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -106,6 +106,12 @@ public sealed record DialogueValidationReport(
     /// for those input kinds). Empty for a DIAL input and for a gap-free record.</summary>
     public IReadOnlyList<DialogueIssue> InputIssues { get; init; } = Array.Empty<DialogueIssue>();
 
+    /// <summary>Plugins the topic fan-out could not read, one sentence each. NOT a finding about the input record,
+    /// so deliberately not in <see cref="InputIssues"/>: that is the CK-parity channel, and a file lock is not a
+    /// parity failure. It bounds what the report covers — a report carrying one lists fewer topics than the order
+    /// really holds, so no render may state "owns none" over it.</summary>
+    public IReadOnlyList<string> ScanGaps { get; init; } = Array.Empty<string>();
+
     /// <summary>The SEQ staleness/coverage lint, set only for a Start-Game-Enabled QUEST input; null otherwise
     /// (a non-SGE quest, or a DIAL input — a topic isn't a quest, so a .seq isn't its concern).</summary>
     public SeqLintFinding? SeqLint { get; init; }
@@ -331,13 +337,13 @@ public static class DialogueValidate
                 var questGaps = DialogueCkParity.MissingQuestDefaults(quest)
                     .Select(g => GapIssue("Quest", fk, g)).ToList();
                 // A plugin the fan-out could not read may own topics of this quest, so the topic list below it is
-                // incomplete — a Problem, because a clean pass over a short list is the misleading answer here.
-                foreach (var u in unreadable)
-                    questGaps.Add(new DialogueIssue(DialogueIssueSeverity.Problem,
-                        $"{u.Message} Any topic of this quest that plugin owns is missing from this report."));
+                // incomplete. Its own carrier, not the parity channel: a file lock is not a CK-parity failure.
+                var scanGaps = unreadable
+                    .Select(u => $"{u.Message} Any topic of this quest that plugin owns is missing from this report.")
+                    .ToList();
 
                 return new DialogueValidationReport(fk, "quest", quest.EditorID ?? "", win.Value.WinnerPlugin, topics)
-                    { ReadIncomplete = av.ReadIncomplete, SeqLint = seqLint, InputIssues = questGaps };
+                    { ReadIncomplete = av.ReadIncomplete, SeqLint = seqLint, InputIssues = questGaps, ScanGaps = scanGaps };
             }
 
             // DLVW / DLBR inputs: a RECORD-LEVEL CK-parity check — these carry no INFO list, so there is no topic

--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -302,7 +302,11 @@ public static class DialogueValidate
                 var seqLint = CheckSeq(view, av, fk, quest, win.Value.WinnerPlugin);
 
                 var topics = new List<TopicValidation>();
-                foreach (var (tfk, _, tbody) in view.WinnerRecordsOfType(DialTypes))
+                // A plugin that cannot be read now contributes no topics to the fan-out. Collected so the sweep
+                // covers the rest of the order, and named below — the same never-a-silently-thinner-answer rule the
+                // per-topic unread accounting follows.
+                var unreadable = new List<PluginUnreadableException>();
+                foreach (var (tfk, _, tbody) in view.WinnerRecordsOfType(DialTypes, unreadable))
                 {
                     if (tbody is not IDialogTopicGetter dt) continue;
                     if (NonNull(dt.Quest.FormKeyNullable) is not { } qk || qk != fk) continue;
@@ -326,6 +330,11 @@ public static class DialogueValidate
                 // never judges the ANAM VALUE (an edited quest's ANAM is a legitimate CK high-water mark).
                 var questGaps = DialogueCkParity.MissingQuestDefaults(quest)
                     .Select(g => GapIssue("Quest", fk, g)).ToList();
+                // A plugin the fan-out could not read may own topics of this quest, so the topic list below it is
+                // incomplete — a Problem, because a clean pass over a short list is the misleading answer here.
+                foreach (var u in unreadable)
+                    questGaps.Add(new DialogueIssue(DialogueIssueSeverity.Problem,
+                        $"{u.Message} Any topic of this quest that plugin owns is missing from this report."));
 
                 return new DialogueValidationReport(fk, "quest", quest.EditorID ?? "", win.Value.WinnerPlugin, topics)
                     { ReadIncomplete = av.ReadIncomplete, SeqLint = seqLint, InputIssues = questGaps };

--- a/src/housecarl-core/EffectChain.cs
+++ b/src/housecarl-core/EffectChain.cs
@@ -114,9 +114,12 @@ public static class EffectChain
         var rows = new List<EffectChainRow>();
         int total = 0, unscannable = 0;
         var samples = new List<string>();
+        // A plugin that cannot be opened now wins carriers this scan cannot see. Collected so the scan covers the
+        // rest of the order and the note names the gap, rather than the whole call ending at the bad plugin.
+        var unreadable = new List<PluginUnreadableException>();
         try
         {
-            foreach (var (fk, _, body) in view.WinnerRecordsOfType(scope))
+            foreach (var (fk, _, body) in view.WinnerRecordsOfType(scope, unreadable))
             {
                 // PER-RECORD FAULT ISOLATION (twin of the cross_plugin_query scan): Match lazily parses subrecord
                 // content, so ONE record Mutagen can't parse is excluded + accounted, not an opaque whole-call abort.
@@ -149,6 +152,13 @@ public static class EffectChain
               + string.Join("; ", samples)
               + (unscannable > samples.Count ? $"; and {unscannable - samples.Count} more" : "")
               + $". Inspect one with {ToolNames.Records} formids=[the FormID] (per-field fault isolation applies).";
+
+        string? coverageNote = unreadable.Count == 0 ? null
+            : $"coverage gap: {unreadable.Count} plugin(s) could not be read, so any carrier they win is missing from this chain: "
+              + string.Join("; ", unreadable.Select(u => u.Message));
+        scanNote = scanNote is null ? coverageNote
+                 : coverageNote is null ? scanNote
+                 : scanNote + " " + coverageNote;
 
         return new EffectChainResult(mgef, mgefEid, rows, total, total > rows.Count, null, scanNote, view.Epoch);
     }

--- a/src/housecarl-core/EffectChain.cs
+++ b/src/housecarl-core/EffectChain.cs
@@ -160,7 +160,8 @@ public static class EffectChain
                  : coverageNote is null ? scanNote
                  : scanNote + " " + coverageNote;
 
-        return new EffectChainResult(mgef, mgefEid, rows, total, total > rows.Count, null, scanNote, view.Epoch);
+        return new EffectChainResult(mgef, mgefEid, rows, total, total > rows.Count, null, scanNote, view.Epoch)
+            { UnreadPlugins = unreadable.Select(u => u.PluginName).ToList() };
     }
 }
 
@@ -179,6 +180,11 @@ public sealed record EffectChainResult(
     int Total, bool Capped, string? Error, string? ScanNote,
     string? Epoch = null)   // the build's fingerprint — set on success and on every post-capture refusal; null only on the service's pre-capture type-narrow gate
 {
+    /// <summary>Plugins the carrier scan could not open, by filename. The scan covered the rest of the order, so a
+    /// zero here is a real "nothing carries it" and a non-empty one bounds the answer — the render may not state a
+    /// whole-order negative over it.</summary>
+    public IReadOnlyList<string> UnreadPlugins { get; init; } = Array.Empty<string>();
+
     public bool Success => Error is null;
     public static EffectChainResult Fail(string error) =>
         new(default, "", Array.Empty<EffectChainRow>(), 0, false, error, null);

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -681,10 +681,11 @@ public sealed class LoadOrderResolver : IDisposable
             return Array.ConvertAll(_s.Overriders[fk], i => names[i]);
         }
 
-        /// <summary>The winner-body scan stream (<see cref="LoadOrderResolver.WinnerRecordsOfType(IReadOnlyList{Type})"/>),
+        /// <summary>The winner-body scan stream (<see cref="LoadOrderResolver.WinnerRecordsOfType(IReadOnlyList{Type}, ICollection{PluginUnreadableException}?)"/>),
         /// pinned to THIS view's build — so a caller's per-match winner/depth fills agree with the scan by construction.</summary>
-        public IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body)> WinnerRecordsOfType(IReadOnlyList<Type> getterTypes)
-            => _r.WinnerRecordsOfType(getterTypes, _s);
+        public IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body)> WinnerRecordsOfType(
+            IReadOnlyList<Type> getterTypes, ICollection<PluginUnreadableException>? unreadable = null)
+            => _r.WinnerRecordsOfType(getterTypes, _s, unreadable);
 
         /// <summary>The plugin-scoped scan stream (<see cref="LoadOrderResolver.RecordsIn(IReadOnlyList{string}, IReadOnlyList{Type})"/>),
         /// pinned to THIS view's build.</summary>
@@ -832,18 +833,35 @@ public sealed class LoadOrderResolver : IDisposable
     /// — i.e. the WINNER body, in hand, for each distinct typed FormKey (no re-fetch). Typed group enumeration
     /// (Mutagen seeks the GRUP). Multiple types (GMST → 4 GameSetting variants) are unioned. Yields
     /// (FormKey, override-depth, winner body). throwIfUnknown is belt-and-braces — resolved types are always
-    /// real.</summary>
-    public IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body)> WinnerRecordsOfType(IReadOnlyList<Type> getterTypes)
-        => WinnerRecordsOfType(getterTypes, _snap);                        // ONE build for the whole scan (captured here, at the call)
+    /// real.
+    ///
+    /// A plugin that opened at index-build time but cannot be opened now wins records this scan would otherwise drop
+    /// without a word. Pass <paramref name="unreadable"/> to collect such a plugin's
+    /// <see cref="PluginUnreadableException"/> and have the scan carry on to the plugins after it — the shape every
+    /// whole-order caller wants, since a throw mid-stream would lose them. With no collector the stream THROWS
+    /// instead, so a caller that has nowhere to report the gap fails loudly rather than returning a partial scan as a
+    /// clean one.</summary>
+    public IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body)> WinnerRecordsOfType(
+        IReadOnlyList<Type> getterTypes, ICollection<PluginUnreadableException>? unreadable = null)
+        => WinnerRecordsOfType(getterTypes, _snap, unreadable);            // ONE build for the whole scan (captured here, at the call)
 
-    IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body)> WinnerRecordsOfType(IReadOnlyList<Type> getterTypes, IndexSnapshot s)
+    IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body)> WinnerRecordsOfType(
+        IReadOnlyList<Type> getterTypes, IndexSnapshot s, ICollection<PluginUnreadableException>? unreadable)
     {
         for (int i = 0; i < _paths.Length; i++)
         {
             if (s.Excluded.Contains(i)) continue;                          // excluded at build (unparseable/unopenable) — wins nothing; never re-touch (would re-throw)
             ISkyrimModGetter ov;
             try { ov = OpenOverlay(_paths[i], _dataDir); }
-            catch { continue; }                                            // an unopenable plugin wins nothing (surfaced at build)
+            catch (Exception ex)
+            {
+                // It opened when the index was built, so it became unreadable after that — moved, or held open by
+                // another program. Collected and skipped when the caller can report the gap; thrown otherwise.
+                var fault = new PluginUnreadableException(_names[i], ex);
+                if (unreadable is null) throw fault;
+                unreadable.Add(fault);
+                continue;
+            }
             try
             {
                 foreach (var t in getterTypes)

--- a/src/housecarl-mcp-tests/WinnerScanCoverageTests.cs
+++ b/src/housecarl-mcp-tests/WinnerScanCoverageTests.cs
@@ -1,0 +1,150 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlGenerator;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>The whole-order winner scan against a plugin that becomes unreadable AFTER the index was built — held
+/// open by xEdit, MO2 or the running game, with an unchanged last-write time so nothing rebuilds. Each tool that
+/// scans the order that way must name the plugin, never render a clean scan over the rest. The file lock mechanism:
+/// <c>docs/architecture/test-project-fixtures.md</c>.</summary>
+[Trait("tier", "integration")]
+public sealed class WinnerScanCoverageTests
+{
+    /// <summary>A throwaway MO2 instance a test owns outright, because a held file is unreadable to everything else
+    /// in the process. A base plugin holds the magic effect and the quest; a second, later plugin — the one the tests
+    /// hold open — holds a weapon, a spell carrying that effect, and a topic owned by that quest, so each of the
+    /// three scans loses something it would otherwise report.</summary>
+    sealed class ScanWorld : IDisposable
+    {
+        public const string BaseName = "HcWsBase.esp";
+        public const string HeldName = "HcWsHeld.esp";
+
+        public string Root { get; }
+        public string HeldPath { get; }
+        public FormKey Mgef { get; }
+        public FormKey Quest { get; }
+        public LoadOrderService Svc { get; }
+
+        /// <summary>What <c>CorpusRulebook.CorpusPath</c> named before this world repointed it — restored on
+        /// Dispose, which deletes the directory the repointed path names.</summary>
+        readonly string _priorCorpusPath;
+
+        public ScanWorld()
+        {
+            _priorCorpusPath = CorpusRulebook.CorpusPath;
+            Root = Path.Combine(Path.GetTempPath(), "hc-winner-scan-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(Root, "game", "Data"));
+            var inst = Path.Combine(Root, "inst");
+            var mods = Path.Combine(inst, "mods");
+            Directory.CreateDirectory(Path.Combine(mods, "BaseMod"));
+            Directory.CreateDirectory(Path.Combine(mods, "HeldMod"));
+
+            var baseKey = ModKey.FromNameAndExtension(BaseName);
+            var heldKey = ModKey.FromNameAndExtension(HeldName);
+
+            var baseMod = new SkyrimMod(baseKey, SkyrimRelease.SkyrimSE);
+            var mgef = baseMod.MagicEffects.AddNew(); mgef.EditorID = "HcWsEffect";
+            Mgef = mgef.FormKey;
+            var quest = baseMod.Quests.AddNew(); quest.EditorID = "HcWsQuest";
+            Quest = quest.FormKey;
+            var basePath = Path.Combine(mods, "BaseMod", BaseName);
+            baseMod.BeginWrite.ToPath(basePath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            var held = new SkyrimMod(heldKey, SkyrimRelease.SkyrimSE);
+            var weapon = held.Weapons.AddNew(); weapon.EditorID = "HcWsHeldWeapon";
+            var spell = held.Spells.AddNew(); spell.EditorID = "HcWsHeldSpell";
+            var effect = new Effect();
+            effect.BaseEffect.SetTo(Mgef);
+            spell.Effects.Add(effect);
+            var topic = held.DialogTopics.AddNew(); topic.EditorID = "HcWsHeldTopic";
+            topic.Quest.SetTo(Quest);
+            HeldPath = Path.Combine(mods, "HeldMod", HeldName);
+            held.BeginWrite.ToPath(HeldPath).WithLoadOrder(new ISkyrimModGetter[] { baseMod }).Write();
+
+            var genDir = Path.Combine(Root, "corpus-gen");
+            CorpusGenerator.GenerateAll(genDir, Path.Combine(Root, "corpus-ref"));
+            CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json");
+
+            File.WriteAllText(Path.Combine(inst, "ModOrganizer.ini"),
+                "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                + Path.Combine(Root, "game").Replace(@"\", @"\\") + ")\r\n");
+            var prof = Path.Combine(inst, "profiles", "Default");
+            Directory.CreateDirectory(prof);
+            File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + BaseName + "\r\n" + HeldName + "\r\n");
+            File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*" + BaseName + "\r\n*" + HeldName + "\r\n");
+            File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n+HeldMod\r\n+BaseMod\r\n");
+
+            Svc = LoadOrderService.WithInstance(inst, 0, new UserConfigStore(Path.Combine(Root, "user.json")));
+            Svc.Stats();                                  // build the index BEFORE any hold, which is the live shape
+        }
+
+        public void Dispose()
+        {
+            Svc.Dispose();
+            CorpusRulebook.CorpusPath = _priorCorpusPath;
+            try { Directory.Delete(Root, true); } catch { /* temp cleanup best-effort */ }
+        }
+    }
+
+    /// <summary>The type= scan streams winner bodies over the whole order, so a plugin it cannot open takes every
+    /// record that plugin wins out of the answer. Zero matches with no note reads as "no such weapon exists".</summary>
+    [Fact]
+    public void TheCrossQueryScanNamesAPluginItCouldNotRead()
+    {
+        using var world = new ScanWorld();
+
+        // Vacuity: unheld, the same call finds the weapon — so what follows is about the lock.
+        var open = world.Svc.CrossQuery("Weapon", null, null, false, null, null, 50);
+        Assert.Equal(1, open.Total);
+        Assert.Null(open.ScanNote);
+
+        using var hold = HeldOpen.Hold(world.HeldPath);
+        var locked = world.Svc.CrossQuery("Weapon", null, null, false, null, null, 50);
+
+        Assert.Equal(0, locked.Total);
+        Assert.NotNull(locked.ScanNote);
+        Assert.Contains(ScanWorld.HeldName, locked.ScanNote!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>The effect chain scans the same winner stream for carriers, so a plugin it cannot open drops that
+    /// plugin's carriers. A carrier-free chain is a real answer, which is exactly why the gap must be named.</summary>
+    [Fact]
+    public void TheEffectChainNamesAPluginItCouldNotRead()
+    {
+        using var world = new ScanWorld();
+
+        var open = world.Svc.ResolveEffectChain(world.Mgef, null, 50);
+        Assert.Equal(1, open.Total);
+        Assert.Null(open.ScanNote);
+
+        using var hold = HeldOpen.Hold(world.HeldPath);
+        var locked = world.Svc.ResolveEffectChain(world.Mgef, null, 50);
+
+        Assert.Equal(0, locked.Total);
+        Assert.NotNull(locked.ScanNote);
+        Assert.Contains(ScanWorld.HeldName, locked.ScanNote!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>A quest input fans out over the winning topics, so a plugin the sweep cannot open takes its topics
+    /// out of the report. A quest that validates clean on a short list is the misleading answer.</summary>
+    [Fact]
+    public void TheQuestFanOutNamesAPluginItCouldNotRead()
+    {
+        using var world = new ScanWorld();
+
+        var open = world.Svc.ValidateDialogue(world.Quest);
+        Assert.Single(open.Topics);
+        Assert.DoesNotContain(open.InputIssues, i => i.Message.Contains(ScanWorld.HeldName, StringComparison.OrdinalIgnoreCase));
+
+        using var hold = HeldOpen.Hold(world.HeldPath);
+        var locked = world.Svc.ValidateDialogue(world.Quest);
+
+        Assert.Empty(locked.Topics);
+        Assert.Contains(locked.InputIssues, i => i.Message.Contains(ScanWorld.HeldName, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/housecarl-mcp-tests/WinnerScanCoverageTests.cs
+++ b/src/housecarl-mcp-tests/WinnerScanCoverageTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Skyrim;
@@ -50,7 +51,9 @@ public sealed class WinnerScanCoverageTests
             var baseMod = new SkyrimMod(baseKey, SkyrimRelease.SkyrimSE);
             var mgef = baseMod.MagicEffects.AddNew(); mgef.EditorID = "HcWsEffect";
             Mgef = mgef.FormKey;
-            var quest = baseMod.Quests.AddNew(); quest.EditorID = "HcWsQuest";
+            // ANAM present, no objectives: the quest's own CK parity passes, so a missing parity verdict in these
+            // tests can only be the file lock leaking into the parity channel.
+            var quest = baseMod.Quests.AddNew(); quest.EditorID = "HcWsQuest"; quest.NextAliasID = 0;
             Quest = quest.FormKey;
             var basePath = Path.Combine(mods, "BaseMod", BaseName);
             baseMod.BeginWrite.ToPath(basePath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
@@ -163,12 +166,107 @@ public sealed class WinnerScanCoverageTests
 
         var open = world.Svc.ValidateDialogue(world.Quest);
         Assert.Single(open.Topics);
-        Assert.DoesNotContain(open.InputIssues, i => i.Message.Contains(ScanWorld.HeldName, StringComparison.OrdinalIgnoreCase));
+        Assert.Empty(open.ScanGaps);
 
         using var hold = HeldOpen.Hold(world.HeldPath);
         var locked = world.Svc.ValidateDialogue(world.Quest);
 
         Assert.Empty(locked.Topics);
-        Assert.Contains(locked.InputIssues, i => i.Message.Contains(ScanWorld.HeldName, StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(locked.ScanGaps, g => g.Contains(ScanWorld.HeldName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ---- the renders one line above each note, which must not assert a definitive negative ----------
+
+    static string Fid(FormKey fk) => $"{fk.ID:X6}:{fk.ModKey.FileName}";
+
+    static SweepFamilySelection DialogueSel()
+    {
+        Assert.True(SweepFamilySelection.TryParse(new[] { "dialogue" }, out var sel, out var err), err);
+        return sel!;
+    }
+
+    /// <summary>Paging over a scan that lost a plugin to a lock: the header must not tell the caller their filter
+    /// matches nothing at any offset, because the lock is why the total is zero.</summary>
+    [Fact]
+    public void ThePagedHeaderDoesNotBlameTheFilterWhenAPluginWasUnread()
+    {
+        using var world = new ScanWorld();
+        using var hold = HeldOpen.Hold(world.HeldPath);
+
+        var locked = world.Svc.CrossQuery("Weapon", null, null, false, null, null, 50, offset: 10);
+        string header = Wire.RenderCrossQuery(world.Svc, locked, null, 40_000, false, false, 0, null, out _)
+                            .Split('\n')[0];
+
+        Assert.Equal(0, locked.Total);
+        Assert.DoesNotContain("check the filter", header);
+        Assert.Contains(ScanWorld.HeldName, header, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>The chain render must not say the effect is carried by nothing when the carrier it would have found
+    /// is in the plugin it could not read.</summary>
+    [Fact]
+    public void TheEffectChainRenderDoesNotClaimNoCarrierWhenAPluginWasUnread()
+    {
+        using var world = new ScanWorld();
+        using var hold = HeldOpen.Hold(world.HeldPath);
+
+        string text = Wire.RenderEffectChain(world.Svc.ResolveEffectChain(world.Mgef, null, 50), 40_000);
+
+        Assert.DoesNotContain("is applied by no SPEL/ENCH/ALCH/SCRL/INGR in the active order", text);
+        Assert.Contains("could read", text);
+        Assert.Contains(ScanWorld.HeldName, text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>The seed render must not say the quest owns no topics when a plugin it could not read owns one.</summary>
+    [Fact]
+    public void TheQuestSeedRenderDoesNotClaimTheQuestOwnsNoTopics()
+    {
+        using var world = new ScanWorld();
+        using var hold = HeldOpen.Hold(world.HeldPath);
+
+        var sweep = new CheckSweep(DialogueSel(), Dialogue: world.Svc.CheckDialogue(new[] { Fid(world.Quest) }, 1000));
+        string text = Wire.RenderCheck(sweep, 40_000);
+
+        Assert.DoesNotContain("owns NO dialogue topics", text);
+        Assert.Contains("could read", text);
+        Assert.Contains(ScanWorld.HeldName, text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>The file lock is not a CK-parity failure: it must stay out of the parity channel, so a quest whose
+    /// ANAM and objective FNAMs are fine still gets its parity verdict in both transports.</summary>
+    [Fact]
+    public void TheQuestParityVerdictSurvivesAPluginItCouldNotRead()
+    {
+        using var world = new ScanWorld();
+        using var hold = HeldOpen.Hold(world.HeldPath);
+
+        var locked = world.Svc.ValidateDialogue(world.Quest);
+        Assert.Empty(locked.InputIssues);
+        Assert.Contains(locked.ScanGaps, g => g.Contains(ScanWorld.HeldName, StringComparison.OrdinalIgnoreCase));
+
+        var sweep = new CheckSweep(DialogueSel(), Dialogue: world.Svc.CheckDialogue(new[] { Fid(world.Quest) }, 1000));
+        Assert.Contains("quest CK-parity: OK", Wire.RenderCheck(sweep, 40_000));
+        using var doc = JsonDocument.Parse(JsonWire.RenderCheck(sweep, 40_000));
+        var seedObj = FindSeed(doc.RootElement);
+        Assert.Empty(seedObj.GetProperty("input_issues").EnumerateArray());
+        Assert.Contains(seedObj.GetProperty("scan_gaps").EnumerateArray(),
+                        g => g.GetString()!.Contains(ScanWorld.HeldName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>The first object in the json response that carries a seed's findings.</summary>
+    static JsonElement FindSeed(JsonElement e)
+    {
+        if (e.ValueKind == JsonValueKind.Object)
+        {
+            if (e.TryGetProperty("input_issues", out _)) return e;
+            foreach (var p in e.EnumerateObject())
+                if (FindSeed(p.Value) is { ValueKind: JsonValueKind.Object } hit) return hit;
+        }
+        else if (e.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in e.EnumerateArray())
+                if (FindSeed(item) is { ValueKind: JsonValueKind.Object } hit) return hit;
+        }
+        return default;
     }
 }

--- a/src/housecarl-mcp-tests/WinnerScanCoverageTests.cs
+++ b/src/housecarl-mcp-tests/WinnerScanCoverageTests.cs
@@ -66,6 +66,13 @@ public sealed class WinnerScanCoverageTests
             HeldPath = Path.Combine(mods, "HeldMod", HeldName);
             held.BeginWrite.ToPath(HeldPath).WithLoadOrder(new ISkyrimModGetter[] { baseMod }).Write();
 
+            // One SkyPatcher line targeting the held plugin's weapon BY EDITORID, so the layer's no-op scan has to
+            // sweep the order's weapon winners to resolve it. The INI lives in the OTHER mod, so holding the plugin
+            // affects the lookup and nothing else.
+            var iniDir = Path.Combine(mods, "BaseMod", "SKSE", "Plugins", "SkyPatcher", "weapon");
+            Directory.CreateDirectory(iniDir);
+            File.WriteAllText(Path.Combine(iniDir, "hcws.ini"), "filterByWeapons=HcWsHeldWeapon:attackDamage=20\r\n");
+
             var genDir = Path.Combine(Root, "corpus-gen");
             CorpusGenerator.GenerateAll(genDir, Path.Combine(Root, "corpus-ref"));
             CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json");
@@ -128,6 +135,23 @@ public sealed class WinnerScanCoverageTests
         Assert.Equal(0, locked.Total);
         Assert.NotNull(locked.ScanNote);
         Assert.Contains(ScanWorld.HeldName, locked.ScanNote!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>The layer's no-op scan resolves a line's EditorID target by sweeping the order's winners, so a
+    /// plugin it cannot open leaves that target unresolved. Counting it with the ordinary unresolved targets would
+    /// blame the INI for a file lock.</summary>
+    [Fact]
+    public void TheSkyPatcherNoOpScanNamesAPluginItCouldNotRead()
+    {
+        using var world = new ScanWorld();
+
+        var open = world.Svc.SkyPatcherLayer();
+        Assert.DoesNotContain(open.NoOpNotes, n => n.Contains(ScanWorld.HeldName, StringComparison.OrdinalIgnoreCase));
+
+        using var hold = HeldOpen.Hold(world.HeldPath);
+        var locked = world.Svc.SkyPatcherLayer();
+
+        Assert.Contains(locked.NoOpNotes, n => n.Contains(ScanWorld.HeldName, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>A quest input fans out over the winning topics, so a plugin the sweep cannot open takes its topics

--- a/src/housecarl-mcp/DialogueSweep.cs
+++ b/src/housecarl-mcp/DialogueSweep.cs
@@ -74,7 +74,9 @@ internal static class DialogueSweep
     /// rendered, because the accounting subtracts from these totals.</summary>
     static int Problems(DialogueValidationReport r)
     {
-        int n = r.InputIssues.Count;
+        // The coverage gaps count too: they are not parity findings, but a response headlining "0 findings" over a
+        // report that lost a plugin reads as a clean pass.
+        int n = r.InputIssues.Count + r.ScanGaps.Count;
         if (r.SeqLint is { QuestIsSge: true } s && !(s.SeqExists && s.SeqContainsQuest == true && s.SeqNewerThanPlugin == true))
             n++;
         foreach (var t in r.Topics)

--- a/src/housecarl-mcp/DialogueSweepRender.cs
+++ b/src/housecarl-mcp/DialogueSweepRender.cs
@@ -99,7 +99,11 @@ internal static class DialogueSweepRender
     {
         var sb = new StringBuilder();
         var checks = DialogueKindChecks.For(r.InputKind);
-        if (r.InputKind == "quest" && r.Topics.Count == 0) sb.Append(ReadSentences.DialogueSeedNoTopics);
+        // "owns none" is a claim about the load order, and a fan-out that lost a plugin cannot make it — it says what
+        // it covered instead, and the gap lines below name what it did not.
+        if (r.InputKind == "quest" && r.Topics.Count == 0)
+            sb.Append(r.ScanGaps.Count > 0 ? ReadSentences.DialogueSeedNoTopicsRead : ReadSentences.DialogueSeedNoTopics);
+        foreach (var gap in r.ScanGaps) sb.Append(string.Format(ReadSentences.DialogueSeedScanGap, gap));
         DialogueWire.AppendSeq(sb, r.SeqLint);
         // The seed record's own CK parity, stated both when it passes and when it fails, for every kind that has one.
         // Which kinds those are, and what each verdict says, comes from DialogueKindChecks rather than a literal
@@ -229,6 +233,11 @@ internal static class DialogueSweepRender
         foreach (var name in DialogueKindChecks.Names(DialogueKindChecks.For(r.InputKind))) w.WriteStringValue(name);
         w.WriteEndArray();
         WriteIssues(w, "input_issues", r.InputIssues);
+        // Its own key for the same reason the text lane gives it its own line: a consumer reading input_issues as the
+        // parity result must not find a file lock in it, and must still be able to see the report is bounded.
+        w.WriteStartArray("scan_gaps");
+        foreach (var gap in r.ScanGaps) w.WriteStringValue(gap);
+        w.WriteEndArray();
         if (r.SeqLint is { QuestIsSge: true } seq)
         {
             w.WriteStartObject("seq");

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -941,6 +941,11 @@ public sealed class LoadOrderService : IDisposable
                 $"Could not materialize a mutable copy of {fk} ({typeName}) for the replay — {ex.GetType().Name}: {ex.Message}", null);
         }
 
+        // Watch this record's own EditorID lookups: only a replay that actually read from a table missing a
+        // plugin's records is affected, so a record addressed purely by FormID answers normally.
+        var spr = formResolver as SkyPatcherServiceResolver;
+        spr?.WatchLookups();
+
         var folders = new List<SkyPatcherFolderOutcome>();
         foreach (var m in maps)
         {
@@ -964,11 +969,11 @@ public sealed class LoadOrderService : IDisposable
         }
 
         // An EditorID sweep that could not read a plugin leaves that plugin's EditorIDs out of the lookup table, so a
-        // line naming one resolves to nothing and the replay would report a state the layer does not actually
-        // produce. Named as the record's error rather than answered wrong.
-        if (formResolver is SkyPatcherServiceResolver spr && spr.Unreadable.Count > 0)
+        // line naming one resolves to nothing and this replay would report a state the layer does not produce.
+        // Named as the record's error rather than answered wrong.
+        if (spr is { ConsumedIncompleteTable: true })
             return (typeName, winner.Value.WinnerPlugin, body.EditorID, none,
-                $"the SkyPatcher replay of {fk} resolves EditorIDs against the load order, and "
+                $"the SkyPatcher replay of {fk} resolved an EditorID against the load order, and "
                 + string.Join(" ", spr.Unreadable.Select(u => u.Message).Distinct()), null);
 
         return (typeName, winner.Value.WinnerPlugin, body.EditorID, folders, null, copy);
@@ -1040,10 +1045,6 @@ public sealed class LoadOrderService : IDisposable
                     if (rfk is not null) targets.Add(rfk.Value); else unresolvedTargets++;
                 }
             }
-            // A plugin the EditorID sweep could not open keeps its records out of the lookup, so a target naming one
-            // counts as unresolved for a reason that has nothing to do with the INI. Say which plugin.
-            foreach (var msg in formResolver.Unreadable.Select(u => u.Message).Distinct())
-                noOpNotes.Add($"no-op scan: {msg} Targets naming a record it defines could not be resolved.");
             foreach (var fk in targets)
             {
                 var r = ReplaySkyPatcher(view, session, scan, catalog, fieldMap, scratch, formResolver, fk, linesCache);
@@ -1069,7 +1070,11 @@ public sealed class LoadOrderService : IDisposable
             });
             if (broadLines > 0) noOpNotes.Add($"no-op scan: {broadLines} broad (type-wide) line(s) were evaluated only against the explicitly-targeted records, not every record of their type.");
             if (unresolvedTargets > 0) noOpNotes.Add($"no-op scan: {unresolvedTargets} explicit target(s) did not resolve (the overlay's per-record warnings name them; read one with {ToolNames.Records} formids=[\"<FormID>\"] source={{\"overlay\": \"skypatcher\", \"state\": \"post\"}}).");
-            if (failedReplays > 0) noOpNotes.Add($"no-op scan: {failedReplays} targeted record(s) could not be replayed (not in the order / unpatchable type / copy failure).");
+            if (failedReplays > 0) noOpNotes.Add($"no-op scan: {failedReplays} targeted record(s) could not be replayed (not in the order / unpatchable type / copy failure / an EditorID lookup that could not be completed).");
+            // Emitted AFTER the replays: a plugin can first turn out unreadable in a sweep the replay itself runs
+            // (a value operand naming a donor by EditorID), not only in the target-collection sweep above.
+            foreach (var msg in formResolver.Unreadable.Select(u => u.Message).Distinct())
+                noOpNotes.Add($"no-op scan: {msg} Lines naming a record it defines could not be resolved.");
         }
 
         return new SkyPatcherLayerData(scan, conflicts, itms, duplicates, noOps, noOpNotes,
@@ -1088,11 +1093,21 @@ public sealed class LoadOrderService : IDisposable
         readonly LoadOrderResolver.OverlaySession _session;
         readonly Dictionary<string, Dictionary<string, FormKey>> _eidsByType = new(StringComparer.OrdinalIgnoreCase);
         readonly List<PluginUnreadableException> _unreadable = new();
+        readonly HashSet<string> _incompleteTypes = new(StringComparer.OrdinalIgnoreCase);   // types whose sweep missed a plugin
+        bool _consumedIncomplete;
 
         /// <summary>Plugins an EditorID sweep could not open. Their EditorIDs are absent from the table, so a miss
         /// here is not proof the name does not exist — the callers state the gap rather than let a lookup answer
         /// "no such record" on a plugin they never read.</summary>
         public IReadOnlyList<PluginUnreadableException> Unreadable => _unreadable;
+
+        /// <summary>Whether a lookup since the last <see cref="WatchLookups"/> was answered from a table a plugin is
+        /// missing from. The table is memoized across records, so the count of unreadable plugins does not grow on
+        /// the second record that consults it — this flag is what tells a caller its OWN answer is affected.</summary>
+        public bool ConsumedIncompleteTable => _consumedIncomplete;
+
+        /// <summary>Start watching lookups for a single record's replay.</summary>
+        public void WatchLookups() => _consumedIncomplete = false;
 
         public SkyPatcherServiceResolver(LoadOrderService svc, LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session)
         { _svc = svc; _view = view; _session = session; }
@@ -1105,11 +1120,16 @@ public sealed class LoadOrderService : IDisposable
                 eids = new Dictionary<string, FormKey>(StringComparer.OrdinalIgnoreCase);
                 var types = _svc.ResolveFormScope(mutagenType);
                 if (types is not null)
+                {
+                    int before = _unreadable.Count;
                     foreach (var (candidate, _, cBody) in _view.WinnerRecordsOfType(types, _unreadable))
                         if (cBody.EditorID is { Length: > 0 } eid && !eids.ContainsKey(eid))   // first winner keeps the slot
                             eids[eid] = candidate;
+                    if (_unreadable.Count > before) _incompleteTypes.Add(mutagenType);
+                }
                 _eidsByType[mutagenType] = eids;
             }
+            if (_incompleteTypes.Contains(mutagenType)) _consumedIncomplete = true;
             return eids.TryGetValue(editorId, out var fk) ? fk : null;
         }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -963,6 +963,14 @@ public sealed class LoadOrderService : IDisposable
                 folder.PatchingEnabled));
         }
 
+        // An EditorID sweep that could not read a plugin leaves that plugin's EditorIDs out of the lookup table, so a
+        // line naming one resolves to nothing and the replay would report a state the layer does not actually
+        // produce. Named as the record's error rather than answered wrong.
+        if (formResolver is SkyPatcherServiceResolver spr && spr.Unreadable.Count > 0)
+            return (typeName, winner.Value.WinnerPlugin, body.EditorID, none,
+                $"the SkyPatcher replay of {fk} resolves EditorIDs against the load order, and "
+                + string.Join(" ", spr.Unreadable.Select(u => u.Message).Distinct()), null);
+
         return (typeName, winner.Value.WinnerPlugin, body.EditorID, folders, null, copy);
     }
 
@@ -1032,6 +1040,10 @@ public sealed class LoadOrderService : IDisposable
                     if (rfk is not null) targets.Add(rfk.Value); else unresolvedTargets++;
                 }
             }
+            // A plugin the EditorID sweep could not open keeps its records out of the lookup, so a target naming one
+            // counts as unresolved for a reason that has nothing to do with the INI. Say which plugin.
+            foreach (var msg in formResolver.Unreadable.Select(u => u.Message).Distinct())
+                noOpNotes.Add($"no-op scan: {msg} Targets naming a record it defines could not be resolved.");
             foreach (var fk in targets)
             {
                 var r = ReplaySkyPatcher(view, session, scan, catalog, fieldMap, scratch, formResolver, fk, linesCache);
@@ -1075,6 +1087,12 @@ public sealed class LoadOrderService : IDisposable
         readonly LoadOrderResolver.IndexView _view;
         readonly LoadOrderResolver.OverlaySession _session;
         readonly Dictionary<string, Dictionary<string, FormKey>> _eidsByType = new(StringComparer.OrdinalIgnoreCase);
+        readonly List<PluginUnreadableException> _unreadable = new();
+
+        /// <summary>Plugins an EditorID sweep could not open. Their EditorIDs are absent from the table, so a miss
+        /// here is not proof the name does not exist — the callers state the gap rather than let a lookup answer
+        /// "no such record" on a plugin they never read.</summary>
+        public IReadOnlyList<PluginUnreadableException> Unreadable => _unreadable;
 
         public SkyPatcherServiceResolver(LoadOrderService svc, LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session)
         { _svc = svc; _view = view; _session = session; }
@@ -1087,7 +1105,7 @@ public sealed class LoadOrderService : IDisposable
                 eids = new Dictionary<string, FormKey>(StringComparer.OrdinalIgnoreCase);
                 var types = _svc.ResolveFormScope(mutagenType);
                 if (types is not null)
-                    foreach (var (candidate, _, cBody) in _view.WinnerRecordsOfType(types))
+                    foreach (var (candidate, _, cBody) in _view.WinnerRecordsOfType(types, _unreadable))
                         if (cBody.EditorID is { Length: > 0 } eid && !eids.ContainsKey(eid))   // first winner keeps the slot
                             eids[eid] = candidate;
                 _eidsByType[mutagenType] = eids;
@@ -3733,6 +3751,9 @@ public sealed class LoadOrderService : IDisposable
         int total = 0;
         int unscannable = 0;                                                  // records whose body tests threw (Mutagen-unparseable content) — excluded and accounted, never silent
         var unscannableSamples = new List<string>();
+        // Plugins the winner scan could not open at all — a whole-plugin coverage gap, named in the response rather
+        // than left to read as a clean whole-order scan.
+        var unreadablePlugins = new List<PluginUnreadableException>();
 
         HashSet<FormKey>? setFilter = hasFormidSet ? new HashSet<FormKey>(formidSet!) : null;
         // The set-alone branch also owns conflicts_only combined with formidSet, via its in-loop touching-count
@@ -3847,7 +3868,7 @@ public sealed class LoadOrderService : IDisposable
                 // winner: plugins= gives the scoped plugin's filename, type= gives null, meaning the winner.
                 IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body, string? source)> stream =
                     hasPlugins ? view.RecordsIn(plugins!, types).Select(x => (fk: x.fk, depth: x.depth, body: x.body, source: (string?)x.source))  // the scoped plugin's own body
-                               : view.WinnerRecordsOfType(types!).Select(x => (fk: x.fk, depth: x.depth, body: x.body, source: (string?)null));    // the load-order winner's body
+                               : view.WinnerRecordsOfType(types!, unreadablePlugins).Select(x => (fk: x.fk, depth: x.depth, body: x.body, source: (string?)null));    // the load-order winner's body
                 foreach (var (fk, depth, body, source) in stream)
                 {
                     if (setFilter is not null && !setFilter.Contains(fk)) continue;   // the identity intersection, cheapest first
@@ -3984,6 +4005,14 @@ public sealed class LoadOrderService : IDisposable
               + string.Join("; ", unscannableSamples)
               + (unscannable > unscannableSamples.Count ? $"; and {unscannable - unscannableSamples.Count} more" : "")
               + $". Inspect one with {ToolNames.Records} formids=[the FormID] (per-field fault isolation applies).";
+        // Whole-plugin coverage gap: the scan carried on past a plugin it could not open, so the answer covers the
+        // rest of the order but not that plugin's winners. Named here so the result never reads as a clean scan.
+        if (unreadablePlugins.Count > 0)
+        {
+            string gap = $"coverage gap: {unreadablePlugins.Count} plugin(s) could not be read, so any record they win is missing from this answer: "
+                       + string.Join("; ", unreadablePlugins.Select(u => u.Message));
+            scanNote = scanNote is null ? gap : scanNote + " " + gap;
+        }
         // group_by= aggregation is not limit-capped, so Capped is a match-line concern only.
         var groupRows = groups?.Select(kv => new GroupCount(kv.Key, kv.Value))
                               .OrderByDescending(g => g.Count).ThenBy(g => g.Key, StringComparer.Ordinal).ToList();

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4042,7 +4042,8 @@ public sealed class LoadOrderService : IDisposable
                                      predicate?.AccountingNote(), sources, scanNote,
                                      matched, groupRows, groupBy, definedIn ? string.Join(", ", plugins!) : null, offset,
                                      whereWinner, whereSourceNote)
-               { Epoch = view.Epoch, Pin = new ViewPin(resolver, view) };
+               { Epoch = view.Epoch, Pin = new ViewPin(resolver, view),
+                 UnreadPlugins = unreadablePlugins.Select(u => u.PluginName).ToList() };
     }
 
     // ---- the off-order scan ----------------------------------------------------------------------------
@@ -8501,6 +8502,10 @@ public sealed record CrossQueryOutcome(
     /// <summary>The captured build the scan ran over. The render stamps it into the in-band accounting so paged
     /// windows are checkably from the same build. Null on the pre-scan refusals.</summary>
     public string? Epoch { get; init; }
+
+    /// <summary>Plugins the winner scan could not open, by filename. A zero-match answer with one of these is bounded
+    /// by the lock, not by the filter, and the render must not tell the caller otherwise.</summary>
+    public IReadOnlyList<string> UnreadPlugins { get; init; } = Array.Empty<string>();
 
     /// <summary>The scan's pinned resolver and view, carried so the render's per-match fills — detail bodies,
     /// summaries, conflict trees — read off the same build the scan matched and <see cref="Epoch"/> names. Without

--- a/src/housecarl-mcp/ReadSentences.cs
+++ b/src/housecarl-mcp/ReadSentences.cs
@@ -571,6 +571,18 @@ internal static class ReadSentences
         "  this quest owns NO dialogue topics in the active load order — nothing to validate. If you expected some, " +
         "check those topics set DialogTopic.Quest to this quest and that their plugin is enabled.\n";
 
+    /// <summary>The same seed, where the fan-out could not read a plugin: what it found is bounded by what it could
+    /// open, so the answer is about the plugins read, never about the quest.</summary>
+    [MustState("could read", "not the whole load order")]
+    internal const string DialogueSeedNoTopicsRead =
+        "  no dialogue topics of this quest were found in the plugins this sweep could read — that is not the whole " +
+        "load order: the coverage gap below names the plugin(s) left out, and any topic they own is missing here.\n";
+
+    /// <summary>A plugin the fan-out could not read, printed as what bounds the report rather than as a finding
+    /// against the quest.</summary>
+    [NoClaims("a label around the core's own gap sentence; that sentence carries the claim")]
+    internal const string DialogueSeedScanGap = "  coverage gap: {0}\n";
+
     /// <summary>A quest seed whose CK-parity subrecords are present and correct. Stated rather than left silent,
     /// for the reason the per-topic "graph: OK" line exists: a sub-check that ran and passed is a different answer
     /// from one nobody ran, and an absence cannot tell them apart.</summary>

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -238,7 +238,12 @@ static class Wire
         if (q.ScopeLabel is not null) sb.Append(" DEFINED IN ").Append(q.ScopeLabel);   // explicit scope — NOT the 'touches' default
         if (q.Offset > 0)                                                              // name the window, and the next offset while paging
         {
-            if (q.Total == 0) sb.Append(" (offset=").Append(q.Offset).Append(" had nothing to skip — NO records match at any offset; check the filter, not the paging)");
+            // "no records match at any offset" is a claim over the whole order; a scan that lost a plugin names the
+            // lock instead, because the filter is the one thing that is not the cause.
+            if (q.Total == 0 && q.UnreadPlugins.Count > 0)
+                sb.Append(" (offset=").Append(q.Offset).Append(" had nothing to skip — no records match in the plugins this scan could read, and it could not read ")
+                  .Append(string.Join(", ", q.UnreadPlugins)).Append("; the note below names why)");
+            else if (q.Total == 0) sb.Append(" (offset=").Append(q.Offset).Append(" had nothing to skip — NO records match at any offset; check the filter, not the paging)");
             else if (q.Keys.Count == 0) sb.Append(" (offset=").Append(q.Offset).Append(" skipped past the last match — nothing to show; lower offset=)");
             else
             {

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -357,9 +357,15 @@ static class Wire
         if (r.Capped) sb.Append(" (showing first ").Append(r.Rows.Count).Append("; raise limit= or narrow to see more)");
         if (r.Epoch is not null) sb.Append("  epoch=").Append(r.Epoch);
         sb.Append('\n');
-        if (r.Total == 0)
+        // The whole-order negative is only the scan's to make when the scan read the whole order; with a plugin left
+        // out it states the scope it covered and leaves the note below to name what it missed.
+        if (r.Total == 0 && r.UnreadPlugins.Count == 0)
             sb.Append("  none — ").Append(r.MgefEditorId)
               .Append(" is a valid MagicEffect but is applied by no SPEL/ENCH/ALCH/SCRL/INGR in the active order.\n");
+        else if (r.Total == 0)
+            sb.Append("  none in the plugins this scan could read — ").Append(r.MgefEditorId)
+              .Append(" is a valid MagicEffect, and no SPEL/ENCH/ALCH/SCRL/INGR of the plugins read applies it; ")
+              .Append(string.Join(", ", r.UnreadPlugins)).Append(" could not be read, so this is not the whole order.\n");
         if (r.ScanNote is not null) sb.Append(r.ScanNote).Append('\n');
 
         int rendered = 0;


### PR DESCRIPTION
`LoadOrderResolver.WinnerRecordsOfType` swallowed a plugin that opened when the index was built but cannot be opened now — held open by xEdit, MO2 or the running game, with its last-write time unchanged so nothing rebuilds. Every record that plugin wins was simply absent, and each caller rendered a clean scan of the whole order: `housecarl_records` / `housecarl_cross_plugin_query` scanning by type, `housecarl_effect_chain`, the dialogue quest fan-out, and the SkyPatcher EditorID sweep behind the layer's no-op scan and the post-state read. All four now name the plugin and say what is missing.

**Iterator shape.** #509 made `RecordsIn` throw, because its caller wraps each plugin. This stream spans the whole order, so a throw mid-stream would lose every plugin after the bad one — trading a silent gap for a bigger one. `WinnerRecordsOfType` instead takes an optional collector: a caller that passes one gets the fault recorded and the scan carried on past that plugin, and a caller that passes none gets the throw. That keeps one primitive rather than a per-caller special case, and keeps the default loud: nothing can drop a plugin silently, whether or not it has somewhere to report it.

What each caller does with the gap: the cross-query scan and the effect chain append a named coverage gap to the scan note beside the existing per-record accounting, and keep scanning; the dialogue quest fan-out carries it on the quest report's own `ScanGaps` list; the SkyPatcher EditorID sweep marks the types whose sweep came up short, so a replay is refused by name only when its own lookups read one of those tables — a record the layer addresses by FormID is unaffected — and the layer's no-op scan names the plugin in its notes.

**Naming the gap is not enough if the line above it says the opposite.** Four renders asserted a definitive negative off a zero count alone, one line above the new note, so the note never retracted them. Each is now gated on the gap:

- The quest seed body no longer says the quest owns NO dialogue topics; with a gap it says none were found in the plugins the sweep could read, and prints a `coverage gap:` line per unread plugin.
- The unread-plugin gap left `InputIssues`, which is the CK-parity channel — the seed render gates the parity verdict on it and a json consumer reads it as the parity result. It has its own `ScanGaps` carrier and its own `scan_gaps` json key now, so a locked file no longer reads as a parity failure and the parity verdict still prints.
- The effect chain no longer says the effect is applied by no SPEL/ENCH/ALCH/SCRL/INGR in the active order; with a gap it names the scope it covered and the plugins it could not read.
- The paged scan header no longer says NO records match at any offset and to check the filter; with a gap it names the unread plugin instead, which is the one thing that is not the filter.

Closes #510

Tests are in `WinnerScanCoverageTests`, each holding the plugin open across the call with the index already built. One per caller for the gap itself: `TheCrossQueryScanNamesAPluginItCouldNotRead`, `TheEffectChainNamesAPluginItCouldNotRead`, `TheSkyPatcherNoOpScanNamesAPluginItCouldNotRead`, `TheQuestFanOutNamesAPluginItCouldNotRead`; each first asserts the unheld call finds the record, so it is about the lock and not an empty world. One per render for the false negative, asserting the definitive sentence is absent and the truthful one present: `ThePagedHeaderDoesNotBlameTheFilterWhenAPluginWasUnread`, `TheEffectChainRenderDoesNotClaimNoCarrierWhenAPluginWasUnread`, `TheQuestSeedRenderDoesNotClaimTheQuestOwnsNoTopics`, `TheQuestParityVerdictSurvivesAPluginItCouldNotRead`. All eight fail against `origin/main` and pass here. Build clean, 995/995 tests, ci-all 128/128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
