### PR TITLE
Report how many files bsa_repack packed, and what it skipped

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -38,6 +38,14 @@ saying it sets an expectation their install may contradict. Say what is known, a
   replay resolves an EditorID against such a plugin now refuses by name rather than replaying against a lookup
   table it knows is short; a record the layer addresses by FormID is unaffected.
 
+- **`housecarl_bsa_repack` reports how many files it packed, and says which it left out.** BSArch archives
+  only files under a subfolder, so loose files sitting at the source folder's root were dropped and the tool
+  still reported a plain "packed <name>". The source is now counted before the pack: the success line says
+  "packed N file(s) into <name>", and root-level files get a sentence naming how many were left out and what
+  to do about them. The produced archive's own file count is checked against the source the same way
+  `housecarl_bsa_list` and `housecarl_bsa_extract` check theirs; a disagreement refuses with both numbers and
+  leaves any existing archive untouched.
+
 - **`housecarl_compact_plugin` and `housecarl_merge_plugins` name a plugin they could not read.** The
   external-reference pass that runs before a renumber used to skip a plugin it could not open while still
   counting it as scanned, so a plugin held open by xEdit, MO2 or the running game could make the pass report

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -42,9 +42,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
   only files under a subfolder, so loose files sitting at the source folder's root were dropped and the tool
   still reported a plain "packed <name>". The source is now counted before the pack: the success line says
   "packed N file(s) into <name>", and root-level files get a sentence naming how many were left out and what
-  to do about them. The produced archive's own file count is checked against the source the same way
-  `housecarl_bsa_list` and `housecarl_bsa_extract` check theirs; a disagreement refuses with both numbers and
-  leaves any existing archive untouched.
+  to do about them, on the failed pack as well as the successful one. The produced archive's own file count is
+  read back and checked against the source the same way `housecarl_bsa_list` and `housecarl_bsa_extract` check
+  theirs; a disagreement refuses with both numbers and leaves any existing archive untouched. That read-back
+  works on `.bsa` headers, so the `fo4`, `fo4dds`, `sf1`, `sf1dds` and `tes3` formats write an archive whose
+  contents houseCARL cannot count — those packs report no count and say so instead of claiming one.
 
 - **`housecarl_compact_plugin` and `housecarl_merge_plugins` name a plugin they could not read.** The
   external-reference pass that runs before a renumber used to skip a plugin it could not open while still

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -46,7 +46,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
   read back and checked against the source the same way `housecarl_bsa_list` and `housecarl_bsa_extract` check
   theirs; a disagreement refuses with both numbers and leaves any existing archive untouched. That read-back
   works on `.bsa` headers, so the `fo4`, `fo4dds`, `sf1`, `sf1dds` and `tes3` formats write an archive whose
-  contents houseCARL cannot count — those packs report no count and say so instead of claiming one.
+  contents houseCARL cannot count — those packs report no count and say so instead of claiming one. A `.bsa`
+  whose header could not be read is placed with a WARNING that its contents were not checked, rather than the
+  format sentence. The count leaves out what BSArch itself drops — every `*.db` file (a `Thumbs.db` in a
+  textures folder, say) and every file with no extension — so a source holding those still packs. A source
+  folder that cannot be fully listed (a subfolder the process may not read) packs unchecked with a sentence
+  saying so, instead of refusing the pack.
 
 - **`housecarl_compact_plugin` and `housecarl_merge_plugins` name a plugin they could not read.** The
   external-reference pass that runs before a renumber used to skip a plugin it could not open while still

--- a/src/housecarl-core/BsaArchive.cs
+++ b/src/housecarl-core/BsaArchive.cs
@@ -22,17 +22,19 @@ public sealed record BsaResult(bool Success, string Raw, string? RunError)
 }
 
 /// <summary>What a pack source folder holds: <see cref="Archivable"/> is the files BSArch will archive (anything under a
-/// subfolder) and <see cref="RootFiles"/> names the loose files sitting at the source root, which BSArch silently drops.</summary>
+/// subfolder that BSArch does not drop for its name) and <see cref="RootFiles"/> names the loose files sitting at the
+/// source root, which BSArch silently drops — the full root listing, not just the ones BSArch would have taken.</summary>
 public sealed record BsaSourceScan(int Archivable, IReadOnlyList<string> RootFiles);
 
 /// <summary>The result of a pack (BSArch). <see cref="RunError"/> non-null ⇒ the pack never really ran (BSArch couldn't
-/// be launched / a stuck stale scratch or an unreadable source refused up front); <see cref="CountError"/> non-null ⇒ it
+/// be launched / a stuck stale scratch refused up front); <see cref="CountError"/> non-null ⇒ it
 /// ran but the produced archive's header count disagreed with the source, so nothing was placed. <see cref="Packed"/> is
 /// the produced archive's own file count, or null when it could not be read — the header oracle reads .bsa only, so a
-/// BA2 (fo4/sf1) or Morrowind archive packs unverified. <see cref="Expected"/> is what the source offered and
-/// <see cref="RootSkipped"/> the root-level files BSArch dropped.</summary>
+/// BA2 (fo4/sf1) or Morrowind archive packs unverified. <see cref="Expected"/> is what the source offered, or null when
+/// the source could not be fully scanned (so nothing was cross-checked), and <see cref="RootSkipped"/> the root-level
+/// files BSArch dropped.</summary>
 public sealed record BsaPackResult(
-    bool Success, int? Packed, int Expected, IReadOnlyList<string> RootSkipped, string Raw, string? RunError, string? CountError)
+    bool Success, int? Packed, int? Expected, IReadOnlyList<string> RootSkipped, string Raw, string? RunError, string? CountError)
 {
     public bool Ran => RunError is null;
 }
@@ -209,7 +211,7 @@ public static class BsaArchive
     /// NTFS-class timestamp resolution — on a FAT-class target a same-second pack could read as stale and fail LOUD (never
     /// falsely succeed). The source is enumerated first and the produced archive's own header count is checked against it
     /// before the move, so a short pack refuses instead of reporting success; files at the source ROOT are counted apart
-    /// because BSArch drops them. NOTE the caller must surface BSArch's caveat: a COMPRESSED archive breaks any
+    /// because BSArch drops them, and a source that cannot be fully enumerated packs unverified rather than refusing. NOTE the caller must surface BSArch's caveat: a COMPRESSED archive breaks any
     /// sounds/voices it contains.</summary>
     public static BsaPackResult Pack(string bsarchExe, string srcFolder, string archive, string formatFlag, bool compress, int timeoutMs = 600_000)
     {
@@ -223,18 +225,16 @@ public static class BsaArchive
             // "tmp exists and is non-empty" pass on the PREVIOUS run's bytes when BSArch fails this
             // run — a false success that ships wrong content over the target. Refuse loud instead;
             // nothing is packed, the prior archive is untouched.
-            return new BsaPackResult(false, 0, 0, nothing, "",
+            return new BsaPackResult(false, null, null, nothing, "",
                 $"a stale houseCARL scratch from a previous run is stuck at '{tmp}' and could not be removed " +
                 "(another process may hold it). Delete it and retry — this run packed nothing; the existing archive, if any, is untouched.", null);
 
-        // Count what the source offers before packing, so the produced archive can be cross-checked against it.
-        BsaSourceScan scan;
+        // Count what the source offers before packing, so the produced archive can be cross-checked against it. The count
+        // is a cross-check, not a precondition: a folder that cannot be fully listed (denied ACL, dangling junction) packs
+        // unverified and the caller says so, rather than refusing a pack that used to work.
+        BsaSourceScan? scan;
         try { scan = ScanPackSource(srcFolder); }
-        catch (Exception ex)
-        {
-            return new BsaPackResult(false, 0, 0, nothing, "",
-                $"could not read the source folder '{srcFolder}' ({ex.GetType().Name}: {ex.Message}) — check it exists and is readable.", null);
-        }
+        catch { scan = null; }
         var baselineUtc = DateTime.UtcNow;
 
         var args = new List<string> { "pack", srcFolder, tmp, formatFlag, "-mt" };
@@ -248,7 +248,7 @@ public static class BsaArchive
         if (!packed)   // BSArch couldn't run, or produced no/empty output — leave any prior archive untouched
         {
             try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* best-effort */ }
-            return new BsaPackResult(false, null, scan.Archivable, scan.RootFiles, (run.stdout + "\n" + run.stderr).Trim(), run.runError, null);
+            return new BsaPackResult(false, null, scan?.Archivable, scan?.RootFiles ?? nothing, (run.stdout + "\n" + run.stderr).Trim(), run.runError, null);
         }
 
         // Cross-check the produced archive's own header count against the source, the same oracle List/Unpack use. A
@@ -256,10 +256,10 @@ public static class BsaArchive
         // only, so a BA2 or Morrowind archive carries no count and is not cross-checked — the caller says so.
         var hdr = ReadBsaHeader(tmp);
         int? packedCount = hdr is { fileCount: var fc } ? (int)fc : null;
-        if (packedCount is { } read && PackCountError(read, scan.Archivable, Path.GetFileName(archive)) is { } countError)
+        if (packedCount is { } read && scan is { } src && PackCountError(read, src.Archivable, Path.GetFileName(archive)) is { } countError)
         {
             try { File.Delete(tmp); } catch { /* best-effort */ }
-            return new BsaPackResult(false, packedCount, scan.Archivable, scan.RootFiles,
+            return new BsaPackResult(false, packedCount, scan?.Archivable, scan?.RootFiles ?? nothing,
                 (run.stdout + "\n" + run.stderr).Trim(), null, countError);
         }
 
@@ -267,21 +267,25 @@ public static class BsaArchive
         catch (Exception ex)
         {
             try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* best-effort */ }
-            return new BsaPackResult(false, packedCount, scan.Archivable, scan.RootFiles,
+            return new BsaPackResult(false, packedCount, scan?.Archivable, scan?.RootFiles ?? nothing,
                 (run.stdout + "\n" + run.stderr + $"\ncould not place the packed archive at '{archive}': {ex.Message}").Trim(), null, null);
         }
-        return new BsaPackResult(File.Exists(archive) && new FileInfo(archive).Length > 0, packedCount, scan.Archivable,
-            scan.RootFiles, (run.stdout + "\n" + run.stderr).Trim(), null, null);
+        return new BsaPackResult(File.Exists(archive) && new FileInfo(archive).Length > 0, packedCount, scan?.Archivable,
+            scan?.RootFiles ?? nothing, (run.stdout + "\n" + run.stderr).Trim(), null, null);
     }
 
     /// <summary>Count what a pack of <paramref name="srcFolder"/> will archive and what it will drop: BSArch packs only
-    /// files under a subfolder, so loose files at the source root are silently left out.</summary>
+    /// files under a subfolder, so loose files at the source root are silently left out, and it drops every *.db file and
+    /// every file with no extension wherever they sit. <see cref="BsaSourceScan.RootFiles"/> is the FULL root listing —
+    /// the note is about what the user left loose, not about what BSArch would have taken.</summary>
     public static BsaSourceScan ScanPackSource(string srcFolder)
     {
         if (!Directory.Exists(srcFolder)) return new BsaSourceScan(0, Array.Empty<string>());
+        // BSArch packs nothing with a .db extension and nothing without one (checked against BSArch v0.9c).
+        static bool Packs(string p) => Path.GetExtension(p) is { Length: > 0 } e && !e.Equals(".db", StringComparison.OrdinalIgnoreCase);
         var root = Directory.GetFiles(srcFolder, "*", SearchOption.TopDirectoryOnly).Select(p => Path.GetFileName(p)).ToList();
-        int all = Directory.GetFiles(srcFolder, "*", SearchOption.AllDirectories).Length;
-        return new BsaSourceScan(all - root.Count, root);
+        int all = Directory.GetFiles(srcFolder, "*", SearchOption.AllDirectories).Count(Packs);
+        return new BsaSourceScan(all - root.Count(Packs), root);
     }
 
     /// <summary>The one-sentence refusal for a packed archive whose file count disagrees with its source, or null when

--- a/src/housecarl-core/BsaArchive.cs
+++ b/src/housecarl-core/BsaArchive.cs
@@ -28,10 +28,11 @@ public sealed record BsaSourceScan(int Archivable, IReadOnlyList<string> RootFil
 /// <summary>The result of a pack (BSArch). <see cref="RunError"/> non-null ⇒ the pack never really ran (BSArch couldn't
 /// be launched / a stuck stale scratch or an unreadable source refused up front); <see cref="CountError"/> non-null ⇒ it
 /// ran but the produced archive's header count disagreed with the source, so nothing was placed. <see cref="Packed"/> is
-/// the produced archive's file count, <see cref="Expected"/> what the source offered, and <see cref="RootSkipped"/> the
-/// root-level files BSArch dropped.</summary>
+/// the produced archive's own file count, or null when it could not be read — the header oracle reads .bsa only, so a
+/// BA2 (fo4/sf1) or Morrowind archive packs unverified. <see cref="Expected"/> is what the source offered and
+/// <see cref="RootSkipped"/> the root-level files BSArch dropped.</summary>
 public sealed record BsaPackResult(
-    bool Success, int Packed, int Expected, IReadOnlyList<string> RootSkipped, string Raw, string? RunError, string? CountError)
+    bool Success, int? Packed, int Expected, IReadOnlyList<string> RootSkipped, string Raw, string? RunError, string? CountError)
 {
     public bool Ran => RunError is null;
 }
@@ -247,14 +248,15 @@ public static class BsaArchive
         if (!packed)   // BSArch couldn't run, or produced no/empty output — leave any prior archive untouched
         {
             try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* best-effort */ }
-            return new BsaPackResult(false, 0, scan.Archivable, scan.RootFiles, (run.stdout + "\n" + run.stderr).Trim(), run.runError, null);
+            return new BsaPackResult(false, null, scan.Archivable, scan.RootFiles, (run.stdout + "\n" + run.stderr).Trim(), run.runError, null);
         }
 
         // Cross-check the produced archive's own header count against the source, the same oracle List/Unpack use. A
-        // disagreement means files went missing, so refuse before the target is touched.
+        // disagreement means files went missing, so refuse before the target is touched. The header oracle reads .bsa
+        // only, so a BA2 or Morrowind archive carries no count and is not cross-checked — the caller says so.
         var hdr = ReadBsaHeader(tmp);
-        int packedCount = hdr is { fileCount: var fc } ? (int)fc : scan.Archivable;
-        if (hdr is not null && PackCountError(packedCount, scan.Archivable, Path.GetFileName(archive)) is { } countError)
+        int? packedCount = hdr is { fileCount: var fc } ? (int)fc : null;
+        if (packedCount is { } read && PackCountError(read, scan.Archivable, Path.GetFileName(archive)) is { } countError)
         {
             try { File.Delete(tmp); } catch { /* best-effort */ }
             return new BsaPackResult(false, packedCount, scan.Archivable, scan.RootFiles,

--- a/src/housecarl-core/BsaArchive.cs
+++ b/src/housecarl-core/BsaArchive.cs
@@ -14,10 +14,24 @@ public sealed record BsaListResult(
     public bool Ran => RunError is null;
 }
 
-/// <summary>The result of an unpack (Mutagen) or pack (BSArch). <see cref="RunError"/> non-null ⇒ the operation never
-/// really ran (archive couldn't be opened / BSArch couldn't be launched / a stuck stale scratch refused up front);
-/// otherwise <see cref="Success"/> reflects what was actually written this run.</summary>
+/// <summary>The result of an unpack (Mutagen). <see cref="RunError"/> non-null ⇒ the operation never really ran (the
+/// archive couldn't be opened); otherwise <see cref="Success"/> reflects what was actually written this run.</summary>
 public sealed record BsaResult(bool Success, string Raw, string? RunError)
+{
+    public bool Ran => RunError is null;
+}
+
+/// <summary>What a pack source folder holds: <see cref="Archivable"/> is the files BSArch will archive (anything under a
+/// subfolder) and <see cref="RootFiles"/> names the loose files sitting at the source root, which BSArch silently drops.</summary>
+public sealed record BsaSourceScan(int Archivable, IReadOnlyList<string> RootFiles);
+
+/// <summary>The result of a pack (BSArch). <see cref="RunError"/> non-null ⇒ the pack never really ran (BSArch couldn't
+/// be launched / a stuck stale scratch or an unreadable source refused up front); <see cref="CountError"/> non-null ⇒ it
+/// ran but the produced archive's header count disagreed with the source, so nothing was placed. <see cref="Packed"/> is
+/// the produced archive's file count, <see cref="Expected"/> what the source offered, and <see cref="RootSkipped"/> the
+/// root-level files BSArch dropped.</summary>
+public sealed record BsaPackResult(
+    bool Success, int Packed, int Expected, IReadOnlyList<string> RootSkipped, string Raw, string? RunError, string? CountError)
 {
     public bool Ran => RunError is null;
 }
@@ -192,10 +206,13 @@ public static class BsaArchive
     /// removed REFUSES up front (nothing runs, the prior .bsa untouched), and any failure (BSArch error, timeout, empty
     /// output, stale-mtime scratch) deletes the temp and leaves the prior .bsa untouched. The mtime gate assumes an
     /// NTFS-class timestamp resolution — on a FAT-class target a same-second pack could read as stale and fail LOUD (never
-    /// falsely succeed). NOTE the caller must surface BSArch's caveat: a COMPRESSED archive breaks any sounds/voices it
-    /// contains.</summary>
-    public static BsaResult Pack(string bsarchExe, string srcFolder, string archive, string formatFlag, bool compress, int timeoutMs = 600_000)
+    /// falsely succeed). The source is enumerated first and the produced archive's own header count is checked against it
+    /// before the move, so a short pack refuses instead of reporting success; files at the source ROOT are counted apart
+    /// because BSArch drops them. NOTE the caller must surface BSArch's caveat: a COMPRESSED archive breaks any
+    /// sounds/voices it contains.</summary>
+    public static BsaPackResult Pack(string bsarchExe, string srcFolder, string archive, string formatFlag, bool compress, int timeoutMs = 600_000)
     {
+        var nothing = Array.Empty<string>();
         // Pack to a scratch sibling (keeps the .bsa extension so BSArch is happy); the real target is touched only on success.
         var dir = Path.GetDirectoryName(archive) ?? Environment.CurrentDirectory;
         var tmp = Path.Combine(dir, Path.GetFileNameWithoutExtension(archive) + ".houseCARL-tmp.bsa");
@@ -205,9 +222,18 @@ public static class BsaArchive
             // "tmp exists and is non-empty" pass on the PREVIOUS run's bytes when BSArch fails this
             // run — a false success that ships wrong content over the target. Refuse loud instead;
             // nothing is packed, the prior archive is untouched.
-            return new BsaResult(false, "",
+            return new BsaPackResult(false, 0, 0, nothing, "",
                 $"a stale houseCARL scratch from a previous run is stuck at '{tmp}' and could not be removed " +
-                "(another process may hold it). Delete it and retry — this run packed nothing; the existing archive, if any, is untouched.");
+                "(another process may hold it). Delete it and retry — this run packed nothing; the existing archive, if any, is untouched.", null);
+
+        // Count what the source offers before packing, so the produced archive can be cross-checked against it.
+        BsaSourceScan scan;
+        try { scan = ScanPackSource(srcFolder); }
+        catch (Exception ex)
+        {
+            return new BsaPackResult(false, 0, 0, nothing, "",
+                $"could not read the source folder '{srcFolder}' ({ex.GetType().Name}: {ex.Message}) — check it exists and is readable.", null);
+        }
         var baselineUtc = DateTime.UtcNow;
 
         var args = new List<string> { "pack", srcFolder, tmp, formatFlag, "-mt" };
@@ -221,17 +247,46 @@ public static class BsaArchive
         if (!packed)   // BSArch couldn't run, or produced no/empty output — leave any prior archive untouched
         {
             try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* best-effort */ }
-            return new BsaResult(false, (run.stdout + "\n" + run.stderr).Trim(), run.runError);
+            return new BsaPackResult(false, 0, scan.Archivable, scan.RootFiles, (run.stdout + "\n" + run.stderr).Trim(), run.runError, null);
+        }
+
+        // Cross-check the produced archive's own header count against the source, the same oracle List/Unpack use. A
+        // disagreement means files went missing, so refuse before the target is touched.
+        var hdr = ReadBsaHeader(tmp);
+        int packedCount = hdr is { fileCount: var fc } ? (int)fc : scan.Archivable;
+        if (hdr is not null && PackCountError(packedCount, scan.Archivable, Path.GetFileName(archive)) is { } countError)
+        {
+            try { File.Delete(tmp); } catch { /* best-effort */ }
+            return new BsaPackResult(false, packedCount, scan.Archivable, scan.RootFiles,
+                (run.stdout + "\n" + run.stderr).Trim(), null, countError);
         }
 
         try { AtomicFile.Commit(tmp, archive); }   // success → crash-atomically swap the target (File.Replace / rename, same volume)
         catch (Exception ex)
         {
             try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* best-effort */ }
-            return new BsaResult(false, (run.stdout + "\n" + run.stderr + $"\ncould not place the packed archive at '{archive}': {ex.Message}").Trim(), null);
+            return new BsaPackResult(false, packedCount, scan.Archivable, scan.RootFiles,
+                (run.stdout + "\n" + run.stderr + $"\ncould not place the packed archive at '{archive}': {ex.Message}").Trim(), null, null);
         }
-        return new BsaResult(File.Exists(archive) && new FileInfo(archive).Length > 0, (run.stdout + "\n" + run.stderr).Trim(), null);
+        return new BsaPackResult(File.Exists(archive) && new FileInfo(archive).Length > 0, packedCount, scan.Archivable,
+            scan.RootFiles, (run.stdout + "\n" + run.stderr).Trim(), null, null);
     }
+
+    /// <summary>Count what a pack of <paramref name="srcFolder"/> will archive and what it will drop: BSArch packs only
+    /// files under a subfolder, so loose files at the source root are silently left out.</summary>
+    public static BsaSourceScan ScanPackSource(string srcFolder)
+    {
+        if (!Directory.Exists(srcFolder)) return new BsaSourceScan(0, Array.Empty<string>());
+        var root = Directory.GetFiles(srcFolder, "*", SearchOption.TopDirectoryOnly).Select(p => Path.GetFileName(p)).ToList();
+        int all = Directory.GetFiles(srcFolder, "*", SearchOption.AllDirectories).Length;
+        return new BsaSourceScan(all - root.Count, root);
+    }
+
+    /// <summary>The one-sentence refusal for a packed archive whose file count disagrees with its source, or null when
+    /// the two agree.</summary>
+    public static string? PackCountError(int packed, int expected, string archiveName) =>
+        packed == expected ? null
+            : $"'{archiveName}' packed {packed} file(s) but the source folder offers {expected} — refusing to place it; check the source folder for unreadable or locked files and repack.";
 
     /// <summary>The legal format tokens, for refusal messages.</summary>
     public const string FormatTokens = "sse (default), tes3/morrowind, tes4/oblivion, fo3, fnv, tes5/le/skyrimle, fo4, fo4dds, sf1/starfield, sf1dds";

--- a/src/housecarl-mcp-tests/BsaPackCountTests.cs
+++ b/src/housecarl-mcp-tests/BsaPackCountTests.cs
@@ -34,8 +34,8 @@ public sealed class BsaPackCountTests : IDisposable
         File.WriteAllText(path, "x");
     }
 
-    static BsaPackResult Packed(int packed, IReadOnlyList<string> rootSkipped) =>
-        new(true, packed, packed, rootSkipped, "", null, null);
+    static BsaPackResult Packed(int? packed, IReadOnlyList<string> rootSkipped) =>
+        new(true, packed, packed ?? 0, rootSkipped, "", null, null);
 
     [Fact]
     public void SubfolderedSourceCountsEveryFileUnderAFolder()
@@ -80,6 +80,15 @@ public sealed class BsaPackCountTests : IDisposable
 
         Assert.Contains("2 file(s) at the source folder's root were NOT archived", report);
         Assert.Contains("subfolder", report);
+    }
+
+    [Fact]
+    public void AnUncountableArchiveFormatReportsNoCount()
+    {
+        var report = BsaTools.PackReport(Packed(null, Array.Empty<string>()), "Test.ba2", @"C:\mods\Test.ba2", "-fo4", compress: false);
+
+        Assert.DoesNotContain("file(s) into", report);
+        Assert.Contains("not counted or checked against the source", report);
     }
 
     [Fact]

--- a/src/housecarl-mcp-tests/BsaPackCountTests.cs
+++ b/src/housecarl-mcp-tests/BsaPackCountTests.cs
@@ -1,3 +1,5 @@
+using System.Security.AccessControl;
+using System.Security.Principal;
 using HousecarlCore;
 using HousecarlMcp;
 using Xunit;
@@ -66,6 +68,32 @@ public sealed class BsaPackCountTests : IDisposable
     }
 
     [Fact]
+    public void ADbFileIsNotArchivableBecauseBsarchDropsIt()
+    {
+        var src = Source("with-db");
+        WriteFile(src, Path.Combine("textures", "a.dds"));
+        WriteFile(src, Path.Combine("textures", "Thumbs.db"));
+
+        var scan = BsaArchive.ScanPackSource(src);
+
+        Assert.Equal(1, scan.Archivable);
+    }
+
+    [Fact]
+    public void AFileWithNoExtensionIsNotArchivableBecauseBsarchDropsIt()
+    {
+        var src = Source("with-extensionless");
+        WriteFile(src, Path.Combine("meshes", "a.nif"));
+        WriteFile(src, Path.Combine("meshes", "LICENSE"));
+        WriteFile(src, "Thumbs.db");
+
+        var scan = BsaArchive.ScanPackSource(src);
+
+        Assert.Equal(1, scan.Archivable);
+        Assert.Equal(new[] { "Thumbs.db" }, scan.RootFiles);   // the root listing stays whole — it says what was left loose
+    }
+
+    [Fact]
     public void RepackReportsTheFileCount()
     {
         var report = BsaTools.PackReport(Packed(3, Array.Empty<string>()), "Test.bsa", @"C:\mods\Test.bsa", "-sse", compress: false);
@@ -89,6 +117,27 @@ public sealed class BsaPackCountTests : IDisposable
 
         Assert.DoesNotContain("file(s) into", report);
         Assert.Contains("not counted or checked against the source", report);
+        Assert.DoesNotContain("WARNING", report);
+    }
+
+    [Fact]
+    public void ABsaWhoseHeaderCouldNotBeReadWarnsInsteadOfBlamingTheFormat()
+    {
+        var report = BsaTools.PackReport(Packed(null, Array.Empty<string>()), "Test.bsa", @"C:\mods\Test.bsa", "-sse", compress: false);
+
+        Assert.Contains("WARNING", report);
+        Assert.Contains("could not read its .bsa header", report);
+    }
+
+    [Fact]
+    public void ASourceThatCouldNotBeScannedSaysTheArchiveWasNotChecked()
+    {
+        var r = new BsaPackResult(true, 3, null, Array.Empty<string>(), "", null, null);
+
+        var report = BsaTools.PackReport(r, "Test.bsa", @"C:\mods\Test.bsa", "-sse", compress: false);
+
+        Assert.Contains("packed 3 file(s) into Test.bsa", report);
+        Assert.Contains("could not be fully scanned", report);
     }
 
     [Fact]
@@ -114,5 +163,55 @@ public sealed class BsaPackCountTests : IDisposable
         Assert.False(r.Ran);
         Assert.Equal(1, r.Expected);
         Assert.Equal(new[] { "readme.txt" }, r.RootSkipped);
+    }
+
+    [Fact]
+    public void ARunThatPackedNothingReportsNoCountAtAll()
+    {
+        var src = Source("stuck-scratch");
+        WriteFile(src, Path.Combine("meshes", "a.nif"));
+        var archive = Path.Combine(_root, "Out.bsa");
+        var scratch = Path.Combine(_root, "Out.houseCARL-tmp.bsa");
+        File.WriteAllText(scratch, "stale");
+        using var held = new FileStream(scratch, FileMode.Open, FileAccess.Read, FileShare.None);   // undeletable, so the pack refuses up front
+
+        var r = BsaArchive.Pack(Path.Combine(_root, "no-such-bsarch.exe"), src, archive, "-sse", compress: false, timeoutMs: 5_000);
+
+        Assert.False(r.Ran);
+        Assert.Contains("stale houseCARL scratch", r.RunError);
+        Assert.Null(r.Packed);     // nothing was produced, so the count is unknown, not zero
+        Assert.Null(r.Expected);
+    }
+
+    /// <summary>A subfolder the process cannot list throws out of the scan; the pack still runs, unchecked, and says so.</summary>
+    [Fact]
+    public void ASourceThatCannotBeListedPacksUncheckedInsteadOfRefusing()
+    {
+        if (!OperatingSystem.IsWindows()) return;   // the deny ACE that makes a folder unlistable is Windows-only
+        var src = Source("unlistable");
+        WriteFile(src, Path.Combine("meshes", "a.nif"));
+        var denied = Path.Combine(src, "denied");
+        Directory.CreateDirectory(denied);
+        File.WriteAllText(Path.Combine(denied, "b.nif"), "x");
+
+        var info = new DirectoryInfo(denied);
+        var acl = info.GetAccessControl();
+        var deny = new FileSystemAccessRule(WindowsIdentity.GetCurrent().Name, FileSystemRights.ListDirectory, AccessControlType.Deny);
+        acl.AddAccessRule(deny);
+        info.SetAccessControl(acl);
+        try
+        {
+            Assert.ThrowsAny<Exception>(() => BsaArchive.ScanPackSource(src));
+
+            var r = BsaArchive.Pack(Path.Combine(_root, "no-such-bsarch.exe"), src, Path.Combine(_root, "Out.bsa"), "-sse", compress: false, timeoutMs: 5_000);
+
+            Assert.Null(r.Expected);                                   // nothing to cross-check against
+            Assert.DoesNotContain("source folder", r.RunError ?? "");  // the scan did not refuse the pack — BSArch was reached
+        }
+        finally
+        {
+            acl.RemoveAccessRule(deny);
+            info.SetAccessControl(acl);
+        }
     }
 }

--- a/src/housecarl-mcp-tests/BsaPackCountTests.cs
+++ b/src/housecarl-mcp-tests/BsaPackCountTests.cs
@@ -1,0 +1,109 @@
+using HousecarlCore;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>The repack file-count lane: BSArch archives only files under a subfolder, so a pack enumerates the source
+/// first, names the root-level files it drops, and refuses when the produced archive's count disagrees with the source.
+/// No BSArch needed — the enumeration, the refusal sentence and the tool's own render are exercised directly.</summary>
+[Trait("tier", "unit")]
+public sealed class BsaPackCountTests : IDisposable
+{
+    readonly string _root;
+
+    public BsaPackCountTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "hc-bsa-pack-count-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose() { try { Directory.Delete(_root, recursive: true); } catch { /* temp scratch */ } }
+
+    string Source(string name)
+    {
+        var dir = Path.Combine(_root, name);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    static void WriteFile(string dir, string relative)
+    {
+        var path = Path.Combine(dir, relative);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "x");
+    }
+
+    static BsaPackResult Packed(int packed, IReadOnlyList<string> rootSkipped) =>
+        new(true, packed, packed, rootSkipped, "", null, null);
+
+    [Fact]
+    public void SubfolderedSourceCountsEveryFileUnderAFolder()
+    {
+        var src = Source("subfoldered");
+        WriteFile(src, Path.Combine("meshes", "a.nif"));
+        WriteFile(src, Path.Combine("meshes", "deep", "b.nif"));
+        WriteFile(src, Path.Combine("scripts", "c.pex"));
+
+        var scan = BsaArchive.ScanPackSource(src);
+
+        Assert.Equal(3, scan.Archivable);
+        Assert.Empty(scan.RootFiles);
+    }
+
+    [Fact]
+    public void RootLevelFilesAreNotArchivableAndAreNamed()
+    {
+        var src = Source("with-root");
+        WriteFile(src, Path.Combine("meshes", "a.nif"));
+        WriteFile(src, "readme.txt");
+        WriteFile(src, "loose.nif");
+
+        var scan = BsaArchive.ScanPackSource(src);
+
+        Assert.Equal(1, scan.Archivable);
+        Assert.Equal(new[] { "loose.nif", "readme.txt" }, scan.RootFiles.OrderBy(f => f).ToArray());
+    }
+
+    [Fact]
+    public void RepackReportsTheFileCount()
+    {
+        var report = BsaTools.PackReport(Packed(3, Array.Empty<string>()), "Test.bsa", @"C:\mods\Test.bsa", "-sse", compress: false);
+
+        Assert.Contains("packed 3 file(s) into Test.bsa", report);
+    }
+
+    [Fact]
+    public void RepackReportsTheSkippedRootFiles()
+    {
+        var report = BsaTools.PackReport(Packed(1, new[] { "readme.txt", "loose.nif" }), "Test.bsa", @"C:\mods\Test.bsa", "-sse", compress: false);
+
+        Assert.Contains("2 file(s) at the source folder's root were NOT archived", report);
+        Assert.Contains("subfolder", report);
+    }
+
+    [Fact]
+    public void ACountMismatchRefusesNamingBothNumbers()
+    {
+        var refusal = BsaArchive.PackCountError(packed: 2, expected: 5, "Test.bsa");
+
+        Assert.NotNull(refusal);
+        Assert.Contains("2 file(s)", refusal);
+        Assert.Contains("5", refusal);
+        Assert.Null(BsaArchive.PackCountError(packed: 5, expected: 5, "Test.bsa"));
+    }
+
+    [Fact]
+    public void APackThatNeverRanStillReportsWhatTheSourceOffered()
+    {
+        var src = Source("never-ran");
+        WriteFile(src, Path.Combine("meshes", "a.nif"));
+        WriteFile(src, "readme.txt");
+
+        var r = BsaArchive.Pack(Path.Combine(_root, "no-such-bsarch.exe"), src, Path.Combine(_root, "Out.bsa"), "-sse", compress: false, timeoutMs: 5_000);
+
+        Assert.False(r.Ran);
+        Assert.Equal(1, r.Expected);
+        Assert.Equal(new[] { "readme.txt" }, r.RootSkipped);
+    }
+}

--- a/src/housecarl-mcp/BsaTools.cs
+++ b/src/housecarl-mcp/BsaTools.cs
@@ -163,8 +163,13 @@ public static class BsaTools
         sb.Append(name)
           .Append(" (").Append(fmtFlag.TrimStart('-')).Append(compress ? ", compressed" : ", uncompressed").Append(") → ").Append(archive).Append('\n');
         sb.Append("(a new houseCARL mod folder — enable it in MO2 to use the archive.)");
+        // A null count means the format carries no .bsa header, or the header of one that should have been read failed.
         if (r.Packed is null)
-            sb.Append("\nhouseCARL reads file counts from .bsa headers only, so this archive's contents were not counted or checked against the source.");
+            sb.Append(fmtFlag is "-fo4" or "-fo4dds" or "-sf1" or "-sf1dds" or "-tes3"
+                ? "\nhouseCARL reads file counts from .bsa headers only, so this archive's contents were not counted or checked against the source."
+                : $"\nWARNING: '{name}' was written but houseCARL could not read its .bsa header, so its contents were not counted or checked against the source — list it before relying on it.");
+        else if (r.Expected is null)
+            sb.Append("\nThe source folder could not be fully scanned, so this archive's contents were not checked against it — list it before relying on it.");
         sb.Append(RootSkipNote(r.RootSkipped));
         if (compress) sb.Append("\nNOTE: compressed — any sounds/voices in it will not work in-game (BSArch limitation).");
         return sb.ToString();

--- a/src/housecarl-mcp/BsaTools.cs
+++ b/src/housecarl-mcp/BsaTools.cs
@@ -146,13 +146,25 @@ public static class BsaTools
             return Refuse($"error: unknown format '{format}'. Legal tokens: {HousecarlCore.BsaArchive.FormatTokens}.");
         var r = HousecarlCore.BsaArchive.Pack(bsarch!, source_folder, archive, fmtFlag, compress);
         if (!r.Ran) return Refuse("error: " + r.RunError);
+        if (r.CountError is { } mismatch) return Refuse("error: " + mismatch);
         if (!r.Success)
             return Refuse($"repack FAILED: no .bsa written at '{archive}'. Raw BSArch output:\n" + r.Raw);
 
+        return PackReport(r, name, archive, fmtFlag, compress);
+    });
+
+    /// <summary>The success message for a repack: how many files the archive holds, where it landed, and any root-level
+    /// files BSArch dropped.</summary>
+    internal static string PackReport(HousecarlCore.BsaPackResult r, string name, string archive, string fmtFlag, bool compress)
+    {
         var sb = new StringBuilder();
-        sb.Append("packed ").Append(name).Append(" (").Append(fmtFlag.TrimStart('-')).Append(compress ? ", compressed" : ", uncompressed").Append(") → ").Append(archive).Append('\n');
+        sb.Append("packed ").Append(r.Packed).Append(" file(s) into ").Append(name)
+          .Append(" (").Append(fmtFlag.TrimStart('-')).Append(compress ? ", compressed" : ", uncompressed").Append(") → ").Append(archive).Append('\n');
         sb.Append("(a new houseCARL mod folder — enable it in MO2 to use the archive.)");
+        if (r.RootSkipped.Count > 0)
+            sb.Append('\n').Append(r.RootSkipped.Count)
+              .Append(" file(s) at the source folder's root were NOT archived — BSArch packs only files under a subfolder, so move them into one and repack if they belong in the archive.");
         if (compress) sb.Append("\nNOTE: compressed — any sounds/voices in it will not work in-game (BSArch limitation).");
         return sb.ToString();
-    });
+    }
 }

--- a/src/housecarl-mcp/BsaTools.cs
+++ b/src/housecarl-mcp/BsaTools.cs
@@ -148,7 +148,7 @@ public static class BsaTools
         if (!r.Ran) return Refuse("error: " + r.RunError);
         if (r.CountError is { } mismatch) return Refuse("error: " + mismatch);
         if (!r.Success)
-            return Refuse($"repack FAILED: no .bsa written at '{archive}'. Raw BSArch output:\n" + r.Raw);
+            return Refuse($"repack FAILED: no .bsa written at '{archive}'. Raw BSArch output:\n" + r.Raw + RootSkipNote(r.RootSkipped));
 
         return PackReport(r, name, archive, fmtFlag, compress);
     });
@@ -158,13 +158,21 @@ public static class BsaTools
     internal static string PackReport(HousecarlCore.BsaPackResult r, string name, string archive, string fmtFlag, bool compress)
     {
         var sb = new StringBuilder();
-        sb.Append("packed ").Append(r.Packed).Append(" file(s) into ").Append(name)
+        sb.Append("packed ");
+        if (r.Packed is { } packed) sb.Append(packed).Append(" file(s) into ");
+        sb.Append(name)
           .Append(" (").Append(fmtFlag.TrimStart('-')).Append(compress ? ", compressed" : ", uncompressed").Append(") → ").Append(archive).Append('\n');
         sb.Append("(a new houseCARL mod folder — enable it in MO2 to use the archive.)");
-        if (r.RootSkipped.Count > 0)
-            sb.Append('\n').Append(r.RootSkipped.Count)
-              .Append(" file(s) at the source folder's root were NOT archived — BSArch packs only files under a subfolder, so move them into one and repack if they belong in the archive.");
+        if (r.Packed is null)
+            sb.Append("\nhouseCARL reads file counts from .bsa headers only, so this archive's contents were not counted or checked against the source.");
+        sb.Append(RootSkipNote(r.RootSkipped));
         if (compress) sb.Append("\nNOTE: compressed — any sounds/voices in it will not work in-game (BSArch limitation).");
         return sb.ToString();
     }
+
+    /// <summary>The sentence naming the source-root files BSArch dropped, or empty when there were none.</summary>
+    static string RootSkipNote(IReadOnlyList<string> rootSkipped) =>
+        rootSkipped.Count == 0 ? ""
+            : $"\n{rootSkipped.Count} file(s) at the source folder's root were NOT archived — BSArch packs only files " +
+              "under a subfolder, so move them into one and repack if they belong in the archive.";
 }


### PR DESCRIPTION
BSArch packs only files that sit under a subfolder of the source, so loose files at the source root were silently dropped — and `housecarl_bsa_repack` reported a plain "packed <name>" with no count, so a vanished file read as success. `BsaArchive.Pack` now enumerates the source before packing, separating the files BSArch will archive from the root-level ones it will drop, and reads the produced archive's own header count back before the temp is moved over the target — the same cross-check `List` and `Unpack` already do. The success line says "packed N file(s) into <name>"; when root files exist, a sentence names how many were left out and what to do about them, on the failed pack as well as the successful one (an all-root source makes BSArch fail outright, which is where that case lands). A count that disagrees with the source refuses with both numbers and leaves any existing archive untouched. The header oracle reads `.bsa` only, so the `fo4`/`fo4dds`/`sf1`/`sf1dds`/`tes3` formats write an archive houseCARL cannot count: those packs report no count and say so rather than printing the source's number as the archive's. A `.bsa` that should have carried a header but could not be read is a different case, and gets a WARNING that the archive was placed unchecked.

The count matches what BSArch actually takes: it drops every `*.db` file (a `Thumbs.db` in a textures folder) and every file with no extension wherever they sit, so those are left out of the expected count and no longer make the cross-check refuse a correct pack. The count is a cross-check, not a precondition — a source folder that cannot be fully listed (a denied ACL, a dangling junction) packs unchecked with a sentence saying so, rather than refusing a pack that used to work. A run that produced no archive reports no count at all rather than zero.

`Pack` now returns `BsaPackResult` (counts plus the dropped root files) instead of the shared `BsaResult`; the probes that call it use only `Ran`/`Success`/`Raw`/`RunError` and are unchanged.

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)
