### PR TITLE
Accept and print the runtime FormID the game and the logs use

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,17 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **A FormID from the game, a log or a crash log now works as an input, and comes back as an output.**
+  Everywhere houseCARL takes a FormID it also takes the runtime form the game, the console, Papyrus logs,
+  SKSE logs and crash logs print: eight hex digits and no plugin name — `FExxxYYY` for a light plugin,
+  `XX######` for a full one, with or without a leading `0x`. It is resolved against the load order as it
+  stands at the call (the light index moves whenever the order does, so nothing is cached), and the answer
+  names the plugin it resolved to. Every rendered record now carries its runtime FormID beside the
+  `XXXXXX:Plugin.esp` form — `runtime=` in the text lanes, `runtime_formid` in json — so a record read here
+  can be carried straight back to the console or xEdit. An index no active plugin occupies is refused by
+  name, and so is an `FF` dynamic form, which exists only in a save game. The `XXXXXX:Plugin.esp` form is
+  unchanged, and stays the way to read a plugin that is not active.
+
 - **`THIRD-PARTY-NOTICES.txt` lists what the plugin actually bundles.** The component tables are now written
   by the build from the publish output, so the names and versions in the file are the ones in `server/`. The
   file no longer lists five packages that do not ship (`System.Threading.Tasks.Extensions`,

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -19,8 +19,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
   `XX######` for a full one, with or without a leading `0x`. It is resolved against the load order as it
   stands at the call (the light index moves whenever the order does, so nothing is cached), and the answer
   names the plugin it resolved to. Every rendered record now carries its runtime FormID beside the
-  `XXXXXX:Plugin.esp` form — `runtime=` in the text lanes, `runtime_formid` in json — so a record read here
-  can be carried straight back to the console or xEdit. An index no active plugin occupies is refused by
+  `XXXXXX:Plugin.esp` form — `runtime=` in the text lanes, `runtime_formid` in json and in the scan's dense
+  columns and spilled artifacts — so a record read here can be carried straight back to the console or xEdit.
+  A record in a plugin flagged light but never compacted, whose object ID is above the ESL window, gets a
+  sentence saying so where the form would have been rather than a form that names its in-window neighbour
+  too. An index no active plugin occupies is refused by
   name, and so is an `FF` dynamic form, which exists only in a save game. The `XXXXXX:Plugin.esp` form is
   unchanged, and stays the way to read a plugin that is not active. A `where=` operand compared against a field
   holds numbers and enum names too, so it takes the plugin-qualified form only; the `formid in [...]` list takes

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -14,15 +14,17 @@ saying it sets an expectation their install may contradict. Say what is known, a
 ## Unreleased
 
 - **A FormID from the game, a log or a crash log now works as an input, and comes back as an output.**
-  Everywhere houseCARL takes a FormID it also takes the runtime form the game, the console, Papyrus logs,
-  SKSE logs and crash logs print: eight hex digits and no plugin name — `FExxxYYY` for a light plugin,
+  Wherever a parameter holds nothing but FormIDs, houseCARL now also takes the runtime form the game, the
+  console, Papyrus logs, SKSE logs and crash logs print: eight hex digits and no plugin name — `FExxxYYY` for a light plugin,
   `XX######` for a full one, with or without a leading `0x`. It is resolved against the load order as it
   stands at the call (the light index moves whenever the order does, so nothing is cached), and the answer
   names the plugin it resolved to. Every rendered record now carries its runtime FormID beside the
   `XXXXXX:Plugin.esp` form — `runtime=` in the text lanes, `runtime_formid` in json — so a record read here
   can be carried straight back to the console or xEdit. An index no active plugin occupies is refused by
   name, and so is an `FF` dynamic form, which exists only in a save game. The `XXXXXX:Plugin.esp` form is
-  unchanged, and stays the way to read a plugin that is not active.
+  unchanged, and stays the way to read a plugin that is not active. A `where=` operand compared against a field
+  holds numbers and enum names too, so it takes the plugin-qualified form only; the `formid in [...]` list takes
+  both.
 
 - **`THIRD-PARTY-NOTICES.txt` lists what the plugin actually bundles.** The component tables are now written
   by the build from the publish output, so the names and versions in the file are the ones in `server/`. The

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -159,12 +159,15 @@ public sealed class FieldPredicateSet
     /// <summary>Parse the wire <c>where</c> list into an evaluable set, or return the FIRST parse error, so a
     /// malformed predicate refuses the whole call before scanning. An empty list is a parse error: a caller
     /// passing <c>where</c> at all means to filter.</summary>
-    public static (FieldPredicateSet? Set, string? Error) Parse(IReadOnlyList<string> where)
+    /// <param name="parseFormId">How a <c>formid in [...]</c> entry becomes a FormKey — pass the load order's own
+    /// door (<c>IndexView.ParseFormId</c>) so the runtime notation is accepted here too. Null where no load order is
+    /// in hand, which leaves only the plugin-qualified form.</param>
+    public static (FieldPredicateSet? Set, string? Error) Parse(IReadOnlyList<string> where, Func<string?, FormKey>? parseFormId = null)
     {
         var list = new List<Predicate>(where.Count);
         foreach (var raw in where)
         {
-            var (p, err) = ParseOne(raw);
+            var (p, err) = ParseOne(raw, parseFormId);
             if (err is not null) return (null, err);
             list.Add(p!);
         }
@@ -172,7 +175,7 @@ public sealed class FieldPredicateSet
         return (new FieldPredicateSet(list), null);
     }
 
-    static (Predicate?, string?) ParseOne(string raw)
+    static (Predicate?, string?) ParseOne(string raw, Func<string?, FormKey>? parseFormId)
     {
         var text = (raw ?? "").Trim();
         if (text.Length == 0) return (null, "empty predicate in where= (expected \"<path> <op> <value>\").");
@@ -306,7 +309,7 @@ public sealed class FieldPredicateSet
                 return (null, $"predicate '{raw}': 'winner {OpStr(op)} <list>' is not supported (yet) — AND/OR the '=' form per plugin, e.g. \"winner = A.esp\".");
             if (pseudo == PseudoPath.FormId)
             {
-                var (set, artifact, lerr) = ParseFormIdList(text, operand);
+                var (set, artifact, lerr) = ParseFormIdList(text, operand, parseFormId);
                 if (lerr is not null) return (null, lerr);
                 return (new Predicate(text, segs, path, op, operand, 0, set, artifact, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo), null);
             }
@@ -386,8 +389,9 @@ public sealed class FieldPredicateSet
     /// <para>An <c>@file</c> whose target is a result ARTIFACT (line 1 = manifest) yields its IDENTITY column as
     /// the list instead of raw tokens, and hands back the artifact's epoch obligation. A plain list file carries
     /// no manifest and no epoch claim.</para></summary>
-    static (HashSet<FormKey>?, ArtifactDemand?, string?) ParseFormIdList(string raw, string operand)
+    static (HashSet<FormKey>?, ArtifactDemand?, string?) ParseFormIdList(string raw, string operand, Func<string?, FormKey>? parseFormId)
     {
+        var toKey = parseFormId ?? (t => FormKey.Factory((t ?? "").Trim()));
         string content;
         bool fromFile = operand[0] == '@';
         if (fromFile)
@@ -413,7 +417,7 @@ public sealed class FieldPredicateSet
                     // ReadIdentity already excludes error rows (they carry raw failed inputs, not record
                     // identities), so a non-FormID here is a genuine mismatch: server-written success rows always
                     // carry valid formids.
-                    try { aset.Add(FormKey.Factory(tok)); }
+                    try { aset.Add(toKey(tok)); }
                     catch (Exception ex)
                     {
                         return (null, null, $"predicate '{raw}': artifact '{path}' identity value '{tok}' is not a FormID ({ex.Message}) — " +
@@ -432,7 +436,7 @@ public sealed class FieldPredicateSet
             // style) strips clean; a chained Trim().Trim('[',…) stops at the inner space and leaves a quote behind.
             var tok = t.Trim('[', ']', '"', '\'', ' ', '\t');
             if (tok.Length == 0) continue;
-            try { set.Add(FormKey.Factory(tok)); }
+            try { set.Add(toKey(tok)); }
             catch (Exception ex)
             {
                 // A plugin filename can legally CONTAIN a comma ('Foo, Bar.esp') — unrepresentable in this grammar

--- a/src/housecarl-core/FormIdRange.cs
+++ b/src/housecarl-core/FormIdRange.cs
@@ -46,6 +46,29 @@ public static class FormIdRange
     /// copy flow), only the ceiling comparison is single-sourced here.</summary>
     public static bool ObjectIdSpaceExhausted(uint nextFormId) => nextFormId > ObjectIdMax;
 
+    /// <summary>The high-byte mask (0xFF000000) that isolates a FormID's INDEX byte — the load-order master index on a
+    /// full FormID, and the block signature (0xFE light, 0xFF dynamic) on a runtime one. Every prefix test masks with
+    /// this rather than restating the hex.</summary>
+    public const uint IndexByteMask = 0xFF000000;
+
+    /// <summary>The high-byte signature of a DYNAMIC runtime FormID (0xFF000000) — a form the game creates while
+    /// playing, which lives only in a save game, so no plugin defines one. The counterpart of
+    /// <see cref="LightMasterIndexPrefix"/> at the top of the index-byte space.</summary>
+    public const uint DynamicIndexPrefix = 0xFF000000;
+
+    /// <summary>How far a light plugin's 12-bit index sits above the record's local id in a runtime FormID
+    /// (<c>FExxxYYY</c>): the local id occupies the low 12 bits, so the index starts at bit 12.</summary>
+    public const int LightIndexShift = 12;
+
+    /// <summary>The 12-bit mask over a light plugin's ORDER index, once shifted down by
+    /// <see cref="LightIndexShift"/>. Same width as <see cref="LightObjectIdMask"/> — the two halves of the light
+    /// block are both 12 bits — but a different quantity, so a call site reads which half it means.</summary>
+    public const uint LightIndexMask = 0xFFF;
+
+    /// <summary>How far a full plugin's load index sits above its 24-bit object id in a FormID
+    /// (<c>XX######</c>): the object id occupies the low 3 bytes (<see cref="ObjectIdMask"/>), so the index is bit 24.</summary>
+    public const int FullIndexShift = 24;
+
     /// <summary>The high-byte signature of a light-master (ESL) RUNTIME FormID (0xFE000000). At load the engine gives every
     /// light master the shared <c>0xFE</c> index and packs a 12-bit light-order index into the next 12 bits, leaving the
     /// record its low 12 bits (<see cref="LightObjectIdMask"/>). A full plugin never loads at 0xFE (that slot is reserved
@@ -58,6 +81,11 @@ public static class FormIdRange
     /// <see cref="EslWindowCeiling"/> (the ESL window is 0x000–0xFFF); named for the masking use so a call site reads
     /// "mask off to the light local id", not "compare against the window ceiling".</summary>
     public const uint LightObjectIdMask = EslWindowCeiling;
+
+    /// <summary>Does this object ID sit ABOVE the light-master (ESL) window ceiling? True for a record in a
+    /// light-FLAGGED plugin that was never compacted: the engine masks it into the 12-bit window like any other, so
+    /// two of its records can share one runtime FormID and neither can be addressed unambiguously by that form.</summary>
+    public static bool AboveEslWindow(uint objectId) => objectId > EslWindowCeiling;
 
     /// <summary>Strip a config-token / runtime FormID down to the record's LOCAL object ID relative to its named plugin —
     /// the low 12 bits for a light-prefixed (<see cref="LightMasterIndexPrefix"/>) token (the light index is not part of the
@@ -74,7 +102,7 @@ public static class FormIdRange
     /// but no 0xFE prefix (e.g. <c>800123</c>): DSD masks it to 0x123 via the flag, this rule keeps 0x800123. DSD never
     /// EMITS that shape (its export trims ESL to ≤0xFFF), so it can only arise from a hand-authored config.</para></summary>
     public static uint LocalObjectId(uint runtimeFormId) =>
-        (runtimeFormId & 0xFF000000) == LightMasterIndexPrefix
+        (runtimeFormId & IndexByteMask) == LightMasterIndexPrefix
             ? runtimeFormId & LightObjectIdMask       // FExxxYYY light runtime FormID → the 12-bit local id (YYY)
             : runtimeFormId & ObjectIdMask;           // else the high byte is the master index → keep the low 24 bits
 }

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -144,10 +144,71 @@ public sealed class LoadOrderResolver : IDisposable
         public readonly int MaxDepth;
         public readonly string Epoch;                                         // this build's fingerprint — immutable with the snapshot
 
+        /// <summary>Per plugin index: is it a LIGHT plugin? Read off the header while the build already had the
+        /// overlay open (the .esl extension counts too — the engine force-treats it as light). This is what decides
+        /// whether the game addresses the plugin through the shared 0xFE light block or through its own load
+        /// index, so it is the only extra fact the runtime-FormID tables need.</summary>
+        public readonly bool[] Light;
+
+        /// <summary>Active plugins whose light flag could NOT be read, because the file could not be opened at all.
+        /// Their kind decides every runtime index AFTER them, so a runtime FormID cannot be answered while one is in
+        /// the order — named here so the refusal can say which plugin, rather than guessing from the extension.</summary>
+        public readonly IReadOnlyList<string> LightFlagUnknown;
+
+        /// <summary>The runtime address tables, built on first use (a load order that never sees a runtime FormID
+        /// never pays for them) and thrown away with this snapshot, so they refresh with the index.</summary>
+        public readonly Lazy<RuntimeSlots> Slots;
+
         public IndexSnapshot(Dictionary<FormKey, (int winner, int count)> index, Dictionary<FormKey, int[]> overriders,
                              List<string> loadFailures, HashSet<int> excluded, HashSet<int> unopenable,
-                             Dictionary<string, string> excludedPlugins, int maxDepth, string epoch)
-        { Index = index; Overriders = overriders; LoadFailures = loadFailures; Excluded = excluded; Unopenable = unopenable; ExcludedPlugins = excludedPlugins; MaxDepth = maxDepth; Epoch = epoch; }
+                             Dictionary<string, string> excludedPlugins, int maxDepth, string epoch,
+                             bool[] light, IReadOnlyList<string> lightFlagUnknown)
+        {
+            Index = index; Overriders = overriders; LoadFailures = loadFailures; Excluded = excluded; Unopenable = unopenable;
+            ExcludedPlugins = excludedPlugins; MaxDepth = maxDepth; Epoch = epoch; Light = light; LightFlagUnknown = lightFlagUnknown;
+            Slots = new Lazy<RuntimeSlots>(() => RuntimeSlots.Build(light));
+        }
+    }
+
+    /// <summary>The runtime address tables for ONE index build: which plugin the game loads at each load index and at
+    /// each light index. The engine numbers the two kinds separately — full plugins take 0x00, 0x01, … in order,
+    /// light plugins all share the 0xFE index and take 0x000, 0x001, … in order among themselves — so a runtime
+    /// FormID's high byte says which table to read.</summary>
+    internal sealed class RuntimeSlots
+    {
+        /// <summary>Load index → plugin index; -1 where no active plugin occupies the slot.</summary>
+        public readonly int[] FullToPlugin;
+        /// <summary>Light index → plugin index; -1 where no active plugin occupies the slot.</summary>
+        public readonly int[] LightToPlugin;
+        /// <summary>Plugin index → its own runtime slot; -1 for a plugin past the end of its block.</summary>
+        public readonly int[] SlotOfPlugin;
+        public readonly int FullCount;
+        public readonly int LightCount;
+
+        RuntimeSlots(int[] fullToPlugin, int[] lightToPlugin, int[] slotOfPlugin, int fullCount, int lightCount)
+        { FullToPlugin = fullToPlugin; LightToPlugin = lightToPlugin; SlotOfPlugin = slotOfPlugin; FullCount = fullCount; LightCount = lightCount; }
+
+        /// <summary>0xFE is the light block and 0xFF the runtime-dynamic block, so a full plugin can only load at
+        /// 0x00–0xFD.</summary>
+        public const int MaxFullSlots = 0xFE;
+        /// <summary>The light index is 12 bits.</summary>
+        public const int MaxLightSlots = 0x1000;
+
+        public static RuntimeSlots Build(bool[] light)
+        {
+            var full = new int[MaxFullSlots];
+            var lite = new int[MaxLightSlots];
+            Array.Fill(full, -1);
+            Array.Fill(lite, -1);
+            var slotOf = new int[light.Length];
+            int nFull = 0, nLight = 0;
+            for (int i = 0; i < light.Length; i++)
+            {
+                if (light[i]) { slotOf[i] = nLight < MaxLightSlots ? nLight : -1; if (nLight < MaxLightSlots) lite[nLight] = i; nLight++; }
+                else { slotOf[i] = nFull < MaxFullSlots ? nFull : -1; if (nFull < MaxFullSlots) full[nFull] = i; nFull++; }
+            }
+            return new RuntimeSlots(full, lite, slotOf, nFull, nLight);
+        }
     }
 
     volatile IndexSnapshot _snap;
@@ -477,6 +538,8 @@ public sealed class LoadOrderResolver : IDisposable
         var excluded = new HashSet<int>();
         var unopenable = new HashSet<int>();                          // the could-not-be-OPENED subset
         var excludedPlugins = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var light = new bool[_paths.Length];
+        var lightUnknown = new List<string>();
         int maxDepth = 0;
 
         for (int i = 0; i < _paths.Length; i++)
@@ -487,8 +550,13 @@ public sealed class LoadOrderResolver : IDisposable
             {
                 Exclude(i, $"could not be opened — {Concise(ex)}", failures, excluded, excludedPlugins);
                 unopenable.Add(i);   // cannot serve as a master overlay either; the write path must skip it
+                lightUnknown.Add(_names[i]);   // its kind decides every runtime index after it, and we cannot read it
                 continue;
             }
+
+            // Both ways, like the merge report reads it: the engine force-treats the .esl extension as light
+            // whatever the header bit says, and an esp-fe carries the bit without the extension.
+            light[i] = ov.IsSmallMaster || ov.ModKey.Type == ModType.Light;
 
             // Buffer the WHOLE plugin's keys first (plugin-atomic). EnumerateMajorRecords() constructs each record
             // body as it advances, so a record Mutagen rejects (e.g. a malformed PKCU data-count) throws HERE. The
@@ -528,7 +596,8 @@ public sealed class LoadOrderResolver : IDisposable
         return new IndexSnapshot(
             index,
             overriders.ToDictionary(kv => kv.Key, kv => kv.Value.ToArray()),  // trim List overhead → int[]
-            failures, excluded, unopenable, excludedPlugins, maxDepth, ComputeEpoch(_names, _paths, _mtimes, excludedPlugins));
+            failures, excluded, unopenable, excludedPlugins, maxDepth, ComputeEpoch(_names, _paths, _mtimes, excludedPlugins),
+            light, lightUnknown);
     }
 
     /// <summary>The epoch fingerprint: a compact, deterministic identity for ONE index build, derived from the
@@ -601,6 +670,62 @@ public sealed class LoadOrderResolver : IDisposable
     /// the operation reports. Pure data over the immutable snapshot — no handles, safe to hold for a call.</summary>
     public IndexView Capture() => new(this, _snap);
 
+    // ---- runtime FormIDs: the eight-hex form the game, the console and the logs print --------------------
+
+    /// <summary>Single-shot <see cref="IndexView.ParseFormId"/> for a caller holding the resolver rather than a
+    /// captured view. A door parsing a LIST should capture once and parse off the view.</summary>
+    public FormKey ParseFormId(string? raw) => Capture().ParseFormId(raw);
+
+    /// <summary>Turn a runtime FormID into the FormKey it names in THIS build, or throw one plain sentence saying
+    /// which index was not found and what to try instead. The high byte picks the table: 0xFE is the light block,
+    /// 0xFF is a dynamic form that no plugin defines, anything else is a load index.</summary>
+    FormKey RuntimeToFormKey(IndexSnapshot s, uint value)
+    {
+        if (RuntimeFormId.IsDynamic(value))
+            throw new FormatException(
+                $"{RuntimeFormId.Format(value)} is a dynamic form — the game creates FF...... FormIDs while playing and " +
+                "they exist only in a save game, so no plugin defines one.");
+
+        if (s.LightFlagUnknown.Count > 0)
+            throw new FormatException(
+                $"a runtime FormID cannot be resolved this session: '{s.LightFlagUnknown[0]}' could not be opened, so " +
+                "whether it is light — and therefore every index after it — is unknown; address the record as " +
+                "'XXXXXX:Plugin.esp' instead.");
+
+        var slots = s.Slots.Value;
+        if (RuntimeFormId.IsLight(value))
+        {
+            int slot = (int)RuntimeFormId.LightIndex(value);
+            int p = slot < slots.LightToPlugin.Length ? slots.LightToPlugin[slot] : -1;
+            if (p < 0)
+                throw new FormatException(
+                    $"{RuntimeFormId.Format(value)} names light index 0x{slot:X3}, which no active plugin occupies " +
+                    $"(the load order has {slots.LightCount} light plugin(s)) — the plugin may be inactive; read an " +
+                    "inactive plugin with 'XXXXXX:Plugin.esp'.");
+            return FormKey.Factory($"{value & FormIdRange.LightObjectIdMask:X6}:{_names[p]}");
+        }
+
+        int idx = (int)RuntimeFormId.LoadIndex(value);
+        int fp = idx < slots.FullToPlugin.Length ? slots.FullToPlugin[idx] : -1;
+        if (fp < 0)
+            throw new FormatException(
+                $"{RuntimeFormId.Format(value)} names load index 0x{idx:X2}, which no active plugin occupies " +
+                $"(the load order has {slots.FullCount} full plugin(s); light plugins are addressed as FExxxYYY) — " +
+                "the plugin may be inactive; read an inactive plugin with 'XXXXXX:Plugin.esp'.");
+        return FormKey.Factory($"{value & FormIdRange.ObjectIdMask:X6}:{_names[fp]}");
+    }
+
+    /// <summary>The runtime FormID the game, the console and the logs print for this record, or null when its plugin
+    /// is not active in this build (nothing in the order addresses it) or its kind could not be read.</summary>
+    string? RuntimeFormIdFor(IndexSnapshot s, FormKey fk)
+    {
+        if (fk.IsNull || s.LightFlagUnknown.Count > 0) return null;
+        if (!_nameToIdx.TryGetValue(fk.ModKey.FileName.ToString(), out int p)) return null;
+        int slot = s.Slots.Value.SlotOfPlugin[p];
+        if (slot < 0) return null;
+        return RuntimeFormId.Format(RuntimeFormId.Compose(s.Light[p], slot, fk.ID));
+    }
+
     /// <summary>A read view pinned to ONE captured index build (see <see cref="Capture"/>). Every member answers
     /// from the SAME build — winner, touching list, counters, and the scan streams can never disagree about which
     /// build they describe. Bodies are still fetched from the files on disk (none are held), so a
@@ -627,6 +752,18 @@ public sealed class LoadOrderResolver : IDisposable
         /// <summary>THIS captured build's epoch fingerprint — the stamp a bulk response computed off this view
         /// must carry. Immutable with the snapshot: a concurrent rebuild changes nothing here.</summary>
         public string Epoch => _s.Epoch;
+
+        /// <summary>The one FormID door: parse a caller's token into a FormKey. An eight-hex token with no colon is a
+        /// RUNTIME FormID (<c>FExxxYYY</c> or <c>XX######</c>, with or without <c>0x</c>) and is resolved against this
+        /// build's runtime address tables; anything else is the <c>XXXXXX:Plugin.esp</c> form and is unchanged. Throws
+        /// one plain sentence either way, which every door already renders as its own "bad FormID" refusal.</summary>
+        public FormKey ParseFormId(string? raw)
+            => RuntimeFormId.TryParse(raw, out uint v) ? _r.RuntimeToFormKey(_s, v) : FormKey.Factory((raw ?? "").Trim());
+
+        /// <summary>The runtime FormID this record prints as in the game, the console and the logs, or null when its
+        /// plugin is not active in this build. Rendered beside the <c>XXXXXX:Plugin.esp</c> form so a reader can
+        /// round-trip to the console and back.</summary>
+        public string? RuntimeFormIdOf(FormKey fk) => _r.RuntimeFormIdFor(_s, fk);
 
         /// <summary>Whether a plugin filename is in the indexed load order — the same OrdinalIgnoreCase name table
         /// <see cref="LoadOrderResolver.GetRecord"/> resolves against (fixed for the resolver's lifetime, like

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -707,7 +707,7 @@ public sealed class LoadOrderResolver : IDisposable
                     $"(the load order has {slots.LightCount} light plugin(s)) — the plugin may be inactive; read an " +
                     "inactive plugin with 'XXXXXX:Plugin.esp'.");
             EnsureKindKnownUpTo(s, p, value);
-            return FormKey.Factory($"{value & FormIdRange.LightObjectIdMask:X6}:{_names[p]}");
+            return FormKey.Factory($"{FormIdRange.LocalObjectId(value):X6}:{_names[p]}");
         }
 
         int idx = (int)RuntimeFormId.LoadIndex(value);
@@ -718,7 +718,7 @@ public sealed class LoadOrderResolver : IDisposable
                 $"(the load order has {slots.FullCount} full plugin(s); light plugins are addressed as FExxxYYY) — " +
                 "the plugin may be inactive; read an inactive plugin with 'XXXXXX:Plugin.esp'.");
         EnsureKindKnownUpTo(s, fp, value);
-        return FormKey.Factory($"{value & FormIdRange.ObjectIdMask:X6}:{_names[fp]}");
+        return FormKey.Factory($"{FormIdRange.LocalObjectId(value):X6}:{_names[fp]}");
     }
 
     /// <summary>Refuse when a plugin whose kind could not be read sits at or before the slot just resolved: its kind
@@ -733,17 +733,23 @@ public sealed class LoadOrderResolver : IDisposable
             "sits — is unknown; address the record as 'XXXXXX:Plugin.esp' instead.");
     }
 
-    /// <summary>The runtime FormID the game, the console and the logs print for this record, or null when the order
-    /// gives it no address: its plugin is not active, a plugin whose kind could not be read sits at or before it (see
-    /// <see cref="IndexSnapshot.FirstUnknownKind"/>), or it sits past the last runtime slot.</summary>
-    string? RuntimeFormIdFor(IndexSnapshot s, FormKey fk)
+    /// <summary>The runtime FormID the game, the console and the logs print for this record. Both halves are null
+    /// when the order gives it no address at all: its plugin is not active, a plugin whose kind could not be read
+    /// sits at or before it (see <see cref="IndexSnapshot.FirstUnknownKind"/>), or it sits past the last runtime
+    /// slot. The plugin IS addressable but this record is not when it sits above the ESL window in a light-flagged,
+    /// uncompacted plugin: then the form is null and the note says so, rather than an eight-hex answer that names
+    /// another record too.</summary>
+    RuntimeAddress RuntimeAddressFor(IndexSnapshot s, FormKey fk)
     {
-        if (fk.IsNull) return null;
-        if (!_nameToIdx.TryGetValue(fk.ModKey.FileName.ToString(), out int p)) return null;
-        if (s.FirstUnknownKind >= 0 && p >= s.FirstUnknownKind) return null;
+        if (fk.IsNull) return default;
+        var name = fk.ModKey.FileName.ToString();
+        if (!_nameToIdx.TryGetValue(name, out int p)) return default;
+        if (s.FirstUnknownKind >= 0 && p >= s.FirstUnknownKind) return default;
         int slot = s.Slots.Value.SlotOfPlugin[p];
-        if (slot < 0) return null;
-        return RuntimeFormId.Format(RuntimeFormId.Compose(s.Light[p], slot, fk.ID));
+        if (slot < 0) return default;
+        return RuntimeFormId.TryCompose(s.Light[p], slot, fk.ID, out uint value)
+            ? new RuntimeAddress(RuntimeFormId.Format(value), null)
+            : new RuntimeAddress(null, RuntimeFormId.OutOfWindowNote(name, fk.ID));
     }
 
     /// <summary>A read view pinned to ONE captured index build (see <see cref="Capture"/>). Every member answers
@@ -780,10 +786,10 @@ public sealed class LoadOrderResolver : IDisposable
         public FormKey ParseFormId(string? raw)
             => RuntimeFormId.TryParse(raw, out uint v) ? _r.RuntimeToFormKey(_s, v) : FormKey.Factory((raw ?? "").Trim());
 
-        /// <summary>The runtime FormID this record prints as in the game, the console and the logs, or null when its
-        /// plugin is not active in this build. Rendered beside the <c>XXXXXX:Plugin.esp</c> form so a reader can
-        /// round-trip to the console and back.</summary>
-        public string? RuntimeFormIdOf(FormKey fk) => _r.RuntimeFormIdFor(_s, fk);
+        /// <summary>The runtime FormID this record prints as in the game, the console and the logs — or, when there
+        /// is no unambiguous one, the sentence saying why. Rendered beside the <c>XXXXXX:Plugin.esp</c> form so a
+        /// reader can round-trip to the console and back.</summary>
+        public RuntimeAddress RuntimeAddressOf(FormKey fk) => _r.RuntimeAddressFor(_s, fk);
 
         /// <summary>Whether a plugin filename is in the indexed load order — the same OrdinalIgnoreCase name table
         /// <see cref="LoadOrderResolver.GetRecord"/> resolves against (fixed for the resolver's lifetime, like

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -150,10 +150,15 @@ public sealed class LoadOrderResolver : IDisposable
         /// index, so it is the only extra fact the runtime-FormID tables need.</summary>
         public readonly bool[] Light;
 
-        /// <summary>Active plugins whose light flag could NOT be read, because the file could not be opened at all.
-        /// Their kind decides every runtime index AFTER them, so a runtime FormID cannot be answered while one is in
-        /// the order — named here so the refusal can say which plugin, rather than guessing from the extension.</summary>
-        public readonly IReadOnlyList<string> LightFlagUnknown;
+        /// <summary>The FIRST active plugin whose kind could not be read, because the file could not be opened and
+        /// its extension does not settle it (a .esl is light whatever the header says). Its kind decides every runtime
+        /// slot from its own position onward, so a runtime FormID landing there or later cannot be answered — but one
+        /// landing BEFORE it is unaffected, which is why the position is kept rather than a bare flag. -1 when every
+        /// plugin's kind is known.</summary>
+        public readonly int FirstUnknownKind;
+
+        /// <summary>That plugin's filename, so a refusal can name it. Null when <see cref="FirstUnknownKind"/> is -1.</summary>
+        public readonly string? FirstUnknownKindName;
 
         /// <summary>The runtime address tables, built on first use (a load order that never sees a runtime FormID
         /// never pays for them) and thrown away with this snapshot, so they refresh with the index.</summary>
@@ -162,10 +167,11 @@ public sealed class LoadOrderResolver : IDisposable
         public IndexSnapshot(Dictionary<FormKey, (int winner, int count)> index, Dictionary<FormKey, int[]> overriders,
                              List<string> loadFailures, HashSet<int> excluded, HashSet<int> unopenable,
                              Dictionary<string, string> excludedPlugins, int maxDepth, string epoch,
-                             bool[] light, IReadOnlyList<string> lightFlagUnknown)
+                             bool[] light, int firstUnknownKind, string? firstUnknownKindName)
         {
             Index = index; Overriders = overriders; LoadFailures = loadFailures; Excluded = excluded; Unopenable = unopenable;
-            ExcludedPlugins = excludedPlugins; MaxDepth = maxDepth; Epoch = epoch; Light = light; LightFlagUnknown = lightFlagUnknown;
+            ExcludedPlugins = excludedPlugins; MaxDepth = maxDepth; Epoch = epoch; Light = light;
+            FirstUnknownKind = firstUnknownKind; FirstUnknownKindName = firstUnknownKindName;
             Slots = new Lazy<RuntimeSlots>(() => RuntimeSlots.Build(light));
         }
     }
@@ -539,7 +545,8 @@ public sealed class LoadOrderResolver : IDisposable
         var unopenable = new HashSet<int>();                          // the could-not-be-OPENED subset
         var excludedPlugins = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         var light = new bool[_paths.Length];
-        var lightUnknown = new List<string>();
+        int firstUnknownKind = -1;
+        string? firstUnknownKindName = null;
         int maxDepth = 0;
 
         for (int i = 0; i < _paths.Length; i++)
@@ -550,7 +557,10 @@ public sealed class LoadOrderResolver : IDisposable
             {
                 Exclude(i, $"could not be opened — {Concise(ex)}", failures, excluded, excludedPlugins);
                 unopenable.Add(i);   // cannot serve as a master overlay either; the write path must skip it
-                lightUnknown.Add(_names[i]);   // its kind decides every runtime index after it, and we cannot read it
+                // The header is unreadable, so only the extension can settle whether the game loads this one into
+                // the light block. A .esl always does; anything else is unknown, and the runtime tables say so.
+                light[i] = ModKey.FromFileName(_names[i]).Type == ModType.Light;
+                if (!light[i] && firstUnknownKind < 0) { firstUnknownKind = i; firstUnknownKindName = _names[i]; }
                 continue;
             }
 
@@ -597,7 +607,7 @@ public sealed class LoadOrderResolver : IDisposable
             index,
             overriders.ToDictionary(kv => kv.Key, kv => kv.Value.ToArray()),  // trim List overhead → int[]
             failures, excluded, unopenable, excludedPlugins, maxDepth, ComputeEpoch(_names, _paths, _mtimes, excludedPlugins),
-            light, lightUnknown);
+            light, firstUnknownKind, firstUnknownKindName);
     }
 
     /// <summary>The epoch fingerprint: a compact, deterministic identity for ONE index build, derived from the
@@ -686,12 +696,6 @@ public sealed class LoadOrderResolver : IDisposable
                 $"{RuntimeFormId.Format(value)} is a dynamic form — the game creates FF...... FormIDs while playing and " +
                 "they exist only in a save game, so no plugin defines one.");
 
-        if (s.LightFlagUnknown.Count > 0)
-            throw new FormatException(
-                $"a runtime FormID cannot be resolved this session: '{s.LightFlagUnknown[0]}' could not be opened, so " +
-                "whether it is light — and therefore every index after it — is unknown; address the record as " +
-                "'XXXXXX:Plugin.esp' instead.");
-
         var slots = s.Slots.Value;
         if (RuntimeFormId.IsLight(value))
         {
@@ -702,6 +706,7 @@ public sealed class LoadOrderResolver : IDisposable
                     $"{RuntimeFormId.Format(value)} names light index 0x{slot:X3}, which no active plugin occupies " +
                     $"(the load order has {slots.LightCount} light plugin(s)) — the plugin may be inactive; read an " +
                     "inactive plugin with 'XXXXXX:Plugin.esp'.");
+            EnsureKindKnownUpTo(s, p, value);
             return FormKey.Factory($"{value & FormIdRange.LightObjectIdMask:X6}:{_names[p]}");
         }
 
@@ -712,15 +717,30 @@ public sealed class LoadOrderResolver : IDisposable
                 $"{RuntimeFormId.Format(value)} names load index 0x{idx:X2}, which no active plugin occupies " +
                 $"(the load order has {slots.FullCount} full plugin(s); light plugins are addressed as FExxxYYY) — " +
                 "the plugin may be inactive; read an inactive plugin with 'XXXXXX:Plugin.esp'.");
+        EnsureKindKnownUpTo(s, fp, value);
         return FormKey.Factory($"{value & FormIdRange.ObjectIdMask:X6}:{_names[fp]}");
     }
 
-    /// <summary>The runtime FormID the game, the console and the logs print for this record, or null when its plugin
-    /// is not active in this build (nothing in the order addresses it) or its kind could not be read.</summary>
+    /// <summary>Refuse when a plugin whose kind could not be read sits at or before the slot just resolved: its kind
+    /// decides where everything from its own position onward lands, so the answer would be a guess. A slot before it
+    /// is unaffected and answers normally.</summary>
+    static void EnsureKindKnownUpTo(IndexSnapshot s, int pluginIndex, uint value)
+    {
+        if (s.FirstUnknownKind < 0 || pluginIndex < s.FirstUnknownKind) return;
+        throw new FormatException(
+            $"{RuntimeFormId.Format(value)} cannot be resolved this session: '{s.FirstUnknownKindName}' could not be " +
+            "opened, so whether the game loads it as a light plugin — and therefore where everything from it onward " +
+            "sits — is unknown; address the record as 'XXXXXX:Plugin.esp' instead.");
+    }
+
+    /// <summary>The runtime FormID the game, the console and the logs print for this record, or null when the order
+    /// gives it no address: its plugin is not active, a plugin whose kind could not be read sits at or before it (see
+    /// <see cref="IndexSnapshot.FirstUnknownKind"/>), or it sits past the last runtime slot.</summary>
     string? RuntimeFormIdFor(IndexSnapshot s, FormKey fk)
     {
-        if (fk.IsNull || s.LightFlagUnknown.Count > 0) return null;
+        if (fk.IsNull) return null;
         if (!_nameToIdx.TryGetValue(fk.ModKey.FileName.ToString(), out int p)) return null;
+        if (s.FirstUnknownKind >= 0 && p >= s.FirstUnknownKind) return null;
         int slot = s.Slots.Value.SlotOfPlugin[p];
         if (slot < 0) return null;
         return RuntimeFormId.Format(RuntimeFormId.Compose(s.Light[p], slot, fk.ID));

--- a/src/housecarl-core/RuntimeFormId.cs
+++ b/src/housecarl-core/RuntimeFormId.cs
@@ -1,0 +1,60 @@
+using System.Globalization;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// The runtime FormID notation — the eight-hex form the game, Papyrus logs, the console, SKSE logs and crash logs
+/// print, with no plugin name in it: <c>FExxxYYY</c> for a light plugin (the shared <c>FE</c> index, a 3-hex light
+/// index, a 3-hex local id) and <c>XX######</c> for a full one (a 2-hex load index, a 6-hex local id).
+///
+/// <para>This class is pure text — splitting a token into its index and local id, and putting one back together.
+/// Turning a runtime FormID into a FormKey needs the active order's index tables, which live on
+/// <see cref="LoadOrderResolver"/>; every tool door goes through <c>IndexView.ParseFormId</c> rather than doing
+/// its own arithmetic.</para>
+/// </summary>
+public static class RuntimeFormId
+{
+    /// <summary>The high-byte signature of a DYNAMIC runtime FormID (0xFF000000). The game creates these while
+    /// playing and they live only in a save game, so no plugin defines one.</summary>
+    public const uint DynamicPrefix = 0xFF000000;
+
+    /// <summary>The high-byte mask that isolates a runtime FormID's index byte.</summary>
+    public const uint IndexByteMask = 0xFF000000;
+
+    /// <summary>How many hex digits a runtime FormID has, once an optional <c>0x</c> is stripped.</summary>
+    public const int Digits = 8;
+
+    /// <summary>True when <paramref name="text"/> is a runtime FormID: eight hex digits, optionally prefixed
+    /// <c>0x</c>. A <c>XXXXXX:Plugin.esp</c> token always carries a colon and a plugin name, so it never lands
+    /// here — that is the whole ambiguity rule between the two notations.</summary>
+    public static bool TryParse(string? text, out uint value)
+    {
+        value = 0;
+        var s = text?.Trim();
+        if (string.IsNullOrEmpty(s) || s.Contains(':')) return false;
+        if (s.Length > 2 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) s = s[2..];
+        if (s.Length != Digits) return false;
+        return uint.TryParse(s, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out value);
+    }
+
+    /// <summary>Is this token addressed to the light block (the shared <c>FE</c> index)?</summary>
+    public static bool IsLight(uint value) => (value & IndexByteMask) == FormIdRange.LightMasterIndexPrefix;
+
+    /// <summary>Is this token a dynamic form the game made at runtime (<c>FF</c>)?</summary>
+    public static bool IsDynamic(uint value) => (value & IndexByteMask) == DynamicPrefix;
+
+    /// <summary>The 12-bit light index of an <see cref="IsLight"/> token — which light plugin it addresses.</summary>
+    public static uint LightIndex(uint value) => (value >> 12) & 0xFFF;
+
+    /// <summary>The load index of a full-plugin token — which non-light plugin it addresses.</summary>
+    public static uint LoadIndex(uint value) => value >> 24;
+
+    /// <summary>The eight-hex spelling, the way the console and the logs print it.</summary>
+    public static string Format(uint value) => value.ToString("X8", CultureInfo.InvariantCulture);
+
+    /// <summary>Build the runtime FormID of a record: its plugin's runtime slot plus the record's local id.</summary>
+    public static uint Compose(bool light, int slot, uint localId)
+        => light
+            ? FormIdRange.LightMasterIndexPrefix | ((uint)slot << 12) | (localId & FormIdRange.LightObjectIdMask)
+            : ((uint)slot << 24) | (localId & FormIdRange.ObjectIdMask);
+}

--- a/src/housecarl-core/RuntimeFormId.cs
+++ b/src/housecarl-core/RuntimeFormId.cs
@@ -12,14 +12,20 @@ namespace HousecarlCore;
 /// <see cref="LoadOrderResolver"/>; every tool door goes through <c>IndexView.ParseFormId</c> rather than doing
 /// its own arithmetic.</para>
 /// </summary>
+/// <summary>What the order can say about one record's runtime address: the eight-hex <see cref="FormId"/> the game
+/// prints, or — when there is no unambiguous one — a <see cref="Note"/> saying why. Both null means the order gives
+/// the record no runtime address at all (its plugin is not active in this build), which lanes render as nothing.</summary>
+public readonly record struct RuntimeAddress(string? FormId, string? Note);
+
 public static class RuntimeFormId
 {
-    /// <summary>The high-byte signature of a DYNAMIC runtime FormID (0xFF000000). The game creates these while
-    /// playing and they live only in a save game, so no plugin defines one.</summary>
-    public const uint DynamicPrefix = 0xFF000000;
+    /// <summary>The high-byte signature of a DYNAMIC runtime FormID. The game creates these while playing and they
+    /// live only in a save game, so no plugin defines one. The number lives in <see cref="FormIdRange"/>.</summary>
+    public const uint DynamicPrefix = FormIdRange.DynamicIndexPrefix;
 
-    /// <summary>The high-byte mask that isolates a runtime FormID's index byte.</summary>
-    public const uint IndexByteMask = 0xFF000000;
+    /// <summary>The high-byte mask that isolates a runtime FormID's index byte — from
+    /// <see cref="FormIdRange.IndexByteMask"/>, the one home for the split.</summary>
+    public const uint IndexByteMask = FormIdRange.IndexByteMask;
 
     /// <summary>How many hex digits a runtime FormID has, once an optional <c>0x</c> is stripped.</summary>
     public const int Digits = 8;
@@ -44,17 +50,32 @@ public static class RuntimeFormId
     public static bool IsDynamic(uint value) => (value & IndexByteMask) == DynamicPrefix;
 
     /// <summary>The 12-bit light index of an <see cref="IsLight"/> token — which light plugin it addresses.</summary>
-    public static uint LightIndex(uint value) => (value >> 12) & 0xFFF;
+    public static uint LightIndex(uint value) => (value >> FormIdRange.LightIndexShift) & FormIdRange.LightIndexMask;
 
     /// <summary>The load index of a full-plugin token — which non-light plugin it addresses.</summary>
-    public static uint LoadIndex(uint value) => value >> 24;
+    public static uint LoadIndex(uint value) => value >> FormIdRange.FullIndexShift;
 
     /// <summary>The eight-hex spelling, the way the console and the logs print it.</summary>
     public static string Format(uint value) => value.ToString("X8", CultureInfo.InvariantCulture);
 
-    /// <summary>Build the runtime FormID of a record: its plugin's runtime slot plus the record's local id.</summary>
-    public static uint Compose(bool light, int slot, uint localId)
-        => light
-            ? FormIdRange.LightMasterIndexPrefix | ((uint)slot << 12) | (localId & FormIdRange.LightObjectIdMask)
-            : ((uint)slot << 24) | (localId & FormIdRange.ObjectIdMask);
+    /// <summary>Build the runtime FormID of a record: its plugin's runtime slot plus the record's local id. False
+    /// when a LIGHT plugin's record sits above the ESL window (<see cref="FormIdRange.AboveEslWindow"/>) — the
+    /// plugin was flagged light but never compacted, so masking it into the 12-bit window would print the same
+    /// eight digits as its in-window neighbour and read back to that other record. There is no unambiguous answer,
+    /// so there is no composed value; the caller says why instead (<see cref="OutOfWindowNote"/>).</summary>
+    public static bool TryCompose(bool light, int slot, uint localId, out uint value)
+    {
+        if (light && FormIdRange.AboveEslWindow(localId)) { value = 0; return false; }
+        value = light
+            ? FormIdRange.LightMasterIndexPrefix | ((uint)slot << FormIdRange.LightIndexShift) | (localId & FormIdRange.LightObjectIdMask)
+            : ((uint)slot << FormIdRange.FullIndexShift) | (localId & FormIdRange.ObjectIdMask);
+        return true;
+    }
+
+    /// <summary>The one sentence a lane prints where the runtime FormID would have gone, when
+    /// <see cref="TryCompose"/> refused it.</summary>
+    public static string OutOfWindowNote(string plugin, uint localId) =>
+        $"no runtime FormID: '{plugin}' is flagged light but not compacted, and this record's object ID " +
+        $"0x{localId:X6} is above the ESL window ceiling 0x{FormIdRange.EslWindowCeiling:X3}, so the form the " +
+        "game prints for it names another record too — address it as 'XXXXXX:Plugin.esp'.";
 }

--- a/src/housecarl-generator/CheckMergeProbe.cs
+++ b/src/housecarl-generator/CheckMergeProbe.cs
@@ -1639,14 +1639,14 @@ public static class CheckMergeProbe
     static DialogueCheckResult DialogueSweep_Run(IReadOnlyList<string>? seeds, int limit)
         => DialogueSweep.Run(fk => fk.ID == 0x000A01 || fk.ModKey.Name == "A" ? QuestReport(fk)
                                  : DialogueValidationReport.ForError(fk, "no DIAL, QUST, DLVW or DLBR with this FormID is in the active order"),
-                             seeds, limit);
+                             PluginQualified, seeds, limit);
 
     /// <summary>A sweep whose every reached seed is a RECORD-LEVEL kind — a DLVW and a DLBR, both passing. Neither
     /// owns an INFO list, so neither runs any of the graph, voice, script or condition checks; what the response
     /// says about them, and what its boundary claims on their behalf, is round-3 finding A1's subject.</summary>
     static DialogueCheckResult RecordLevelFixture()
         => DialogueSweep.Run(fk => RecordLevelReport(fk, fk.ID == 0x000E01 ? "view" : "branch", Array.Empty<DialogueIssue>()),
-                             new[] { "000E01:HcCm.esp", "000E02:HcCm.esp" }, 1000);
+                             PluginQualified, new[] { "000E01:HcCm.esp", "000E02:HcCm.esp" }, 1000);
 
     /// <summary>The same two kinds, both FAILING their parity — the other side of the OK line, so an arm asking for
     /// the verdict cannot pass by finding a sentence that is printed either way.</summary>
@@ -1654,7 +1654,7 @@ public static class CheckMergeProbe
         => DialogueSweep.Run(fk => RecordLevelReport(fk, fk.ID == 0x000E01 ? "view" : "branch",
                                        new[] { new DialogueIssue(DialogueIssueSeverity.Problem,
                                                    "the DNAM byte subrecord the Creation Kit always writes is absent") }),
-                             new[] { "000E01:HcCm.esp", "000E02:HcCm.esp" }, 1000);
+                             PluginQualified, new[] { "000E01:HcCm.esp", "000E02:HcCm.esp" }, 1000);
 
     /// <summary>A MIXED sweep: one quest that owns topics, one passing DLVW. The family's boundary can take only
     /// one arm and takes the wide one here — true of the response, and not of the view seed, which is why that seed
@@ -1662,7 +1662,11 @@ public static class CheckMergeProbe
     static DialogueCheckResult MixedKindFixture()
         => DialogueSweep.Run(fk => fk.ID == 0x000A01 ? QuestReport(fk)
                                  : RecordLevelReport(fk, "view", Array.Empty<DialogueIssue>()),
-                             new[] { "000A01:HcCm.esp", "000E01:HcCm.esp" }, 1000);
+                             PluginQualified, new[] { "000A01:HcCm.esp", "000E01:HcCm.esp" }, 1000);
+
+    /// <summary>The seed parse these probes drive the sweep with: the plugin-qualified form only, since there is no
+    /// load order here to resolve a runtime FormID against.</summary>
+    static FormKey PluginQualified(string? token) => FormKey.Factory((token ?? "").Trim());
 
     /// <summary>One DLVW or DLBR report: no topics at all, and its whole finding set in <c>InputIssues</c>.</summary>
     static DialogueValidationReport RecordLevelReport(FormKey seed, string kind, IReadOnlyList<DialogueIssue> issues)

--- a/src/housecarl-mcp-tests/RecordsBulkSelectTests.cs
+++ b/src/housecarl-mcp-tests/RecordsBulkSelectTests.cs
@@ -133,7 +133,7 @@ public sealed class RecordsBulkSelectTests : BulkRecordsTestBase
     /// let one through.</summary>
     [Fact]
     public void TheRecordObjectCarriesExactlyTheContractedIdentityAndBodyKeys() =>
-        Assert.Equal(new[] { "formid", "type", "editorid", "winner", "override_depth", "source", "fields" },
+        Assert.Equal(new[] { "formid", "runtime_formid", "type", "editorid", "winner", "override_depth", "source", "fields" },
                      FieldsRecord().EnumerateObject().Select(p => p.Name).ToArray());
 
     [Fact]

--- a/src/housecarl-mcp-tests/RecordsScanProjectionTests.cs
+++ b/src/housecarl-mcp-tests/RecordsScanProjectionTests.cs
@@ -110,8 +110,8 @@ public sealed class RecordsScanProjectionTests : BulkRecordsTestBase
     JsonElement DenseScoped() => Doc(RecordsTools.Records(Svc, plugins: BothScope, format: "dense", project: Fields(DamagePath)));
 
     [Fact]
-    public void TheDenseSummarysColumnsAreTheFiveIdentityColumnsInOrder() =>
-        Assert.Equal(new[] { "formid", "type", "editorid", "winner", "override_depth" }, DenseColumns(DenseSummary()));
+    public void TheDenseSummarysColumnsAreTheSixIdentityColumnsInOrder() =>
+        Assert.Equal(new[] { "formid", "runtime_formid", "type", "editorid", "winner", "override_depth" }, DenseColumns(DenseSummary()));
 
     [Fact]
     public void EveryDenseSummaryRowIsAPositionalArrayOfExactlyOneCellPerColumn()
@@ -128,21 +128,21 @@ public sealed class RecordsScanProjectionTests : BulkRecordsTestBase
     public void ADenseSummaryRowsWinnerCellNamesTheOverridingPlugin()
     {
         var row = DenseRow(DenseSummary(), Fid(W.W1));
-        Assert.Equal("Weapon", row[1].GetString());
-        Assert.Equal(W.ReplName, row[3].GetString());
+        Assert.Equal("Weapon", row[2].GetString());
+        Assert.Equal(W.ReplName, row[4].GetString());
     }
 
     [Fact]
-    public void TheDenseDetailColumnsAreFormidEditoridThenTheRequestedPaths() =>
-        Assert.Equal(new[] { "formid", "editorid", DamagePath }, DenseColumns(DenseDetail()));
+    public void TheDenseDetailColumnsAreFormidRuntimeEditoridThenTheRequestedPaths() =>
+        Assert.Equal(new[] { "formid", "runtime_formid", "editorid", DamagePath }, DenseColumns(DenseDetail()));
 
     [Fact]
     public void TheDenseDetailValueCellsCarryTheWinnersValuesUnderATypeScope()
     {
         var doc = DenseDetail();
-        Assert.Equal("15", DenseRow(doc, Fid(W.W1))[2].GetString());   // the override, not the master's 10
-        Assert.Equal("20", DenseRow(doc, Fid(W.W2))[2].GetString());
-        Assert.Equal("30", DenseRow(doc, Fid(W.W3))[2].GetString());
+        Assert.Equal("15", DenseRow(doc, Fid(W.W1))[3].GetString());   // the override, not the master's 10
+        Assert.Equal("20", DenseRow(doc, Fid(W.W2))[3].GetString());
+        Assert.Equal("30", DenseRow(doc, Fid(W.W3))[3].GetString());
     }
 
     /// <summary>The point of the transport: the same query, materially fewer characters than json.</summary>
@@ -156,14 +156,14 @@ public sealed class RecordsScanProjectionTests : BulkRecordsTestBase
 
     [Fact]
     public void UnderAPluginsScopeTheDenseColumnsGainASourceColumn() =>
-        Assert.Equal(new[] { "formid", "editorid", DamagePath, "source" }, DenseColumns(DenseScoped()));
+        Assert.Equal(new[] { "formid", "runtime_formid", "editorid", DamagePath, "source" }, DenseColumns(DenseScoped()));
 
     [Fact]
     public void TheScopedDenseRowCarriesTheScopedBodysValueBesideTheSourceThatProducedIt()
     {
         var row = DenseRow(DenseScoped(), Fid(W.W1));
-        Assert.Equal("10", row[2].GetString());            // the master's own body
-        Assert.Equal(W.MasterName, row[3].GetString());    // ... attributed in-row, so it cannot read as live truth
+        Assert.Equal("10", row[3].GetString());            // the master's own body
+        Assert.Equal(W.MasterName, row[4].GetString());    // ... attributed in-row, so it cannot read as live truth
     }
 
     [Fact]
@@ -265,8 +265,8 @@ public sealed class RecordsScanProjectionTests : BulkRecordsTestBase
         var doc = Doc(WinnerMatched(null));
         Assert.Equal(1, doc.GetProperty("rows").GetArrayLength());   // matched on the winner's 15...
         var row = DenseRow(doc, Fid(W.W1));
-        Assert.Equal("10", row[2].GetString());                      // ...and still shows the master's 10
-        Assert.Equal(W.MasterName, row[3].GetString());
+        Assert.Equal("10", row[3].GetString());                      // ...and still shows the master's 10
+        Assert.Equal(W.MasterName, row[4].GetString());
     }
 
     [Fact]
@@ -276,7 +276,7 @@ public sealed class RecordsScanProjectionTests : BulkRecordsTestBase
 
     [Fact]
     public void AddingTheWinnerDisplayPoleMovesTheValuesToTheWinnerToo() =>
-        Assert.Equal("15", DenseRow(Doc(WinnerMatched("winner")), Fid(W.W1))[2].GetString());
+        Assert.Equal("15", DenseRow(Doc(WinnerMatched("winner")), Fid(W.W1))[3].GetString());
 
     [Fact]
     public void TheBothPolesNoteSaysTheMatchAndTheValuesAreBothTheWinners() =>
@@ -341,5 +341,5 @@ public sealed class RecordsScanProjectionTests : BulkRecordsTestBase
     public void ADenseContainerCellHintsTheFormatHopRatherThanABlindKnob() =>
         Assert.Contains("pass project.depth=2 with format=text/json to expand",
                         DenseRow(Doc(RecordsTools.Records(Svc, types: Weap, format: "dense", project: Keywords())),
-                                 Fid(W.W1))[2].GetString());
+                                 Fid(W.W1))[3].GetString());
 }

--- a/src/housecarl-mcp-tests/RuntimeFormIdTests.cs
+++ b/src/housecarl-mcp-tests/RuntimeFormIdTests.cs
@@ -1,0 +1,243 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// Reading a record by the FormID a log, the console or a crash log printed, and printing that form back.
+///
+/// <para>The world is built per test because two of these change the load order, which is the whole point: the
+/// light index moves when the order does, so a cached answer would be wrong the next day.</para>
+/// </summary>
+[Trait("tier", "integration")]
+public sealed class RuntimeFormIdTests
+{
+    // ---- the parser, no world needed --------------------------------------------------------------
+
+    [Theory]
+    [InlineData("FE028B19")]
+    [InlineData("0xFE028B19")]
+    [InlineData("fe028b19")]
+    public void ALightRuntimeFormIdParsesWithOrWithoutTheHexPrefix(string token)
+    {
+        Assert.True(RuntimeFormId.TryParse(token, out uint v));
+        Assert.Equal(0xFE028B19u, v);
+        Assert.True(RuntimeFormId.IsLight(v));
+        Assert.Equal(0x028u, RuntimeFormId.LightIndex(v));
+    }
+
+    [Theory]
+    [InlineData("0A00B19C")]
+    [InlineData("0x0A00B19C")]
+    public void AFullRuntimeFormIdParsesWithOrWithoutTheHexPrefix(string token)
+    {
+        Assert.True(RuntimeFormId.TryParse(token, out uint v));
+        Assert.Equal(0x0A00B19Cu, v);
+        Assert.False(RuntimeFormId.IsLight(v));
+        Assert.Equal(0x0Au, RuntimeFormId.LoadIndex(v));
+    }
+
+    [Theory]
+    [InlineData("000800:Skyrim.esm")]      // the plugin-qualified form is never a runtime FormID
+    [InlineData("FE028B1")]                // seven digits
+    [InlineData("FE028B199")]              // nine digits
+    [InlineData("not-a-formid")]
+    public void OnlyAnEightHexTokenWithNoPluginIsARuntimeFormId(string token)
+        => Assert.False(RuntimeFormId.TryParse(token, out _));
+
+    // ---- reading by a runtime FormID --------------------------------------------------------------
+
+    [Fact]
+    public void ALightPluginsRecordReadsByItsRuntimeFormId()
+    {
+        using var w = new World();
+        Served(Read(w, World.LightRuntime(0, w.LightWeapon)), "HcRtLightWeapon", World.LightName);
+    }
+
+    [Fact]
+    public void AFullPluginsRecordReadsByItsLoadIndex()
+    {
+        using var w = new World();
+        Served(Read(w, World.FullRuntime(1, w.FullWeapon)), "HcRtFullWeapon", World.FullName);
+    }
+
+    [Fact]
+    public void ALightIndexNoActivePluginOccupiesIsRefused()
+    {
+        using var w = new World();
+        var response = Read(w, "FE0FF800");
+        Assert.Contains("light index 0x0FF", response);
+        Assert.Contains("XXXXXX:Plugin.esp", response);
+    }
+
+    [Fact]
+    public void ALoadIndexNoActivePluginOccupiesIsRefused()
+    {
+        using var w = new World();
+        var response = Read(w, "5A000800");
+        Assert.Contains("load index 0x5A", response);
+        Assert.Contains("XXXXXX:Plugin.esp", response);
+    }
+
+    [Fact]
+    public void ADynamicFormIdIsRefusedAsBelongingToNoPlugin()
+    {
+        using var w = new World();
+        Assert.Contains("save game", Read(w, "FF000800"));
+    }
+
+    // ---- printing it back -------------------------------------------------------------------------
+
+    [Fact]
+    public void TheRuntimeFormIdIsPrintedBesideTheRecordsOwnFormId()
+    {
+        using var w = new World();
+        Served(Read(w, World.Fid(w.LightWeapon)), "runtime=" + World.LightRuntime(0, w.LightWeapon));
+    }
+
+    [Fact]
+    public void ThePrintedRuntimeFormIdReadsBackTheSameRecord()
+    {
+        using var w = new World();
+        var printed = Token(Read(w, World.Fid(w.LightWeapon)), "runtime=");
+        Served(Read(w, printed), "HcRtLightWeapon", World.LightName);
+    }
+
+    // ---- the tables follow the order --------------------------------------------------------------
+
+    [Fact]
+    public void TheLightIndexMovesWhenTheLoadOrderDoes()
+    {
+        using var w = new World();
+        Served(Read(w, World.Fid(w.LightWeapon)), "runtime=" + World.LightRuntime(0, w.LightWeapon));
+
+        w.ActivateSecondLightPluginFirst();
+
+        Served(Read(w, World.Fid(w.LightWeapon)), "runtime=" + World.LightRuntime(1, w.LightWeapon));
+        Served(Read(w, World.LightRuntime(1, w.LightWeapon)), "HcRtLightWeapon", World.LightName);
+    }
+
+    // ---- helpers ----------------------------------------------------------------------------------
+
+    static string Read(World w, string formid)
+        => RecordsTools.Records(w.Svc, formids: new[] { formid });
+
+    static void Served(string response, params string[] mustName)
+    {
+        Assert.False(response.StartsWith("error:", StringComparison.Ordinal), "refused: " + response);
+        Assert.DoesNotContain("error=", response);
+        foreach (var s in mustName) Assert.Contains(s, response);
+    }
+
+    /// <summary>The value of a "key=value" token in a rendered line.</summary>
+    static string Token(string response, string key)
+    {
+        int i = response.IndexOf(key, StringComparison.Ordinal);
+        Assert.True(i >= 0, $"'{key}' is not in the response: {response}");
+        return new string(response[(i + key.Length)..].TakeWhile(c => !char.IsWhiteSpace(c)).ToArray());
+    }
+
+    /// <summary>
+    /// A master, a full plugin, and two light plugins — the second one inactive until a test activates it, which
+    /// pushes the first light plugin's index up by one.
+    /// </summary>
+    sealed class World : IDisposable
+    {
+        public const string MasterName = "HcRtMaster.esm";
+        public const string FullName = "HcRtFull.esp";
+        public const string LightName = "HcRtLight.esp";
+        public const string SpareLightName = "HcRtSpare.esp";
+
+        readonly string _root;
+        readonly string _profileDir;
+
+        public LoadOrderService Svc { get; }
+        public FormKey FullWeapon { get; }
+        public FormKey LightWeapon { get; }
+
+        public static string Fid(FormKey fk) => $"{fk.ID:X6}:{fk.ModKey.FileName}";
+
+        /// <summary>What the game prints for a record in the light plugin at <paramref name="lightIndex"/>: the
+        /// shared FE index, the light index, and the record's own low 12 bits.</summary>
+        public static string LightRuntime(int lightIndex, FormKey fk) => $"FE{lightIndex:X3}{fk.ID:X3}";
+
+        /// <summary>What the game prints for a record in the full plugin at <paramref name="loadIndex"/>.</summary>
+        public static string FullRuntime(int loadIndex, FormKey fk) => $"{loadIndex:X2}{fk.ID:X6}";
+
+        public World()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "hc-runtime-formid-tests-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(_root, "game", "Data"));
+
+            var masterKey = new ModKey("HcRtMaster", ModType.Master);
+            var master = new SkyrimMod(masterKey, SkyrimRelease.SkyrimSE);
+            var mw = master.Weapons.AddNew(); mw.EditorID = "HcRtMasterWeapon";
+            mw.BasicStats = new WeaponBasicStats { Damage = 10, Weight = 1 };
+
+            var full = new SkyrimMod(new ModKey("HcRtFull", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            var fw = full.Weapons.AddNew(); fw.EditorID = "HcRtFullWeapon";
+            fw.BasicStats = new WeaponBasicStats { Damage = 20, Weight = 1 };
+            FullWeapon = fw.FormKey;
+
+            // An esp-fe: the .esp extension with the light flag set in the header, which is how most light
+            // plugins ship. The tables must read the FLAG, not the filename.
+            var light = new SkyrimMod(new ModKey("HcRtLight", ModType.Plugin), SkyrimRelease.SkyrimSE) { IsSmallMaster = true };
+
+            var lw = light.Weapons.AddNew(); lw.EditorID = "HcRtLightWeapon";
+            lw.BasicStats = new WeaponBasicStats { Damage = 30, Weight = 1 };
+            LightWeapon = lw.FormKey;
+
+            var spare = new SkyrimMod(new ModKey("HcRtSpare", ModType.Plugin), SkyrimRelease.SkyrimSE) { IsSmallMaster = true };
+
+            var sw = spare.Weapons.AddNew(); sw.EditorID = "HcRtSpareWeapon";
+            sw.BasicStats = new WeaponBasicStats { Damage = 40, Weight = 1 };
+
+            var instance = Path.Combine(_root, "inst");
+            var mods = Path.Combine(instance, "mods");
+            foreach (var d in new[] { "MasterMod", "FullMod", "LightMod", "SpareMod" })
+                Directory.CreateDirectory(Path.Combine(mods, d));
+            master.BeginWrite.ToPath(Path.Combine(mods, "MasterMod", MasterName))
+                  .WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            full.BeginWrite.ToPath(Path.Combine(mods, "FullMod", FullName))
+                .WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            light.BeginWrite.ToPath(Path.Combine(mods, "LightMod", LightName))
+                 .WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            spare.BeginWrite.ToPath(Path.Combine(mods, "SpareMod", SpareLightName))
+                 .WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+                "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                + Path.Combine(_root, "game").Replace(@"\", @"\\") + ")\r\n");
+            _profileDir = Path.Combine(instance, "profiles", "Default");
+            Directory.CreateDirectory(_profileDir);
+            WriteOrder(spareFirst: false);
+            File.WriteAllText(Path.Combine(_profileDir, "modlist.txt"),
+                "# header\r\n+SpareMod\r\n+LightMod\r\n+FullMod\r\n+MasterMod\r\n");
+
+            Svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(_root, "user.json")));
+        }
+
+        /// <summary>Tick the spare light plugin ahead of the other one — the ordinary load-order movement that
+        /// renumbers every light index below it.</summary>
+        public void ActivateSecondLightPluginFirst() => WriteOrder(spareFirst: true);
+
+        void WriteOrder(bool spareFirst)
+        {
+            var names = spareFirst
+                ? new[] { MasterName, FullName, SpareLightName, LightName }
+                : new[] { MasterName, FullName, LightName };
+            File.WriteAllText(Path.Combine(_profileDir, "loadorder.txt"), "# header\r\n" + string.Join("\r\n", names) + "\r\n");
+            File.WriteAllText(Path.Combine(_profileDir, "plugins.txt"), string.Join("\r\n", names.Select(n => "*" + n)) + "\r\n");
+        }
+
+        public void Dispose()
+        {
+            Svc.Dispose();
+            try { Directory.Delete(_root, true); } catch { /* temp cleanup best-effort */ }
+        }
+    }
+}

--- a/src/housecarl-mcp-tests/RuntimeFormIdTests.cs
+++ b/src/housecarl-mcp-tests/RuntimeFormIdTests.cs
@@ -2,6 +2,7 @@ using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Skyrim;
 using HousecarlCore;
+using HousecarlGenerator;
 using HousecarlMcp;
 using Xunit;
 
@@ -107,6 +108,43 @@ public sealed class RuntimeFormIdTests
         Served(Read(w, printed), "HcRtLightWeapon", World.LightName);
     }
 
+    [Fact]
+    public void TheScanSummaryRowCarriesTheRuntimeFormId()
+    {
+        using var w = new World();
+        Served(Scan(w, World.LightName), "runtime=" + World.LightRuntime(0, w.LightWeapon));
+    }
+
+    [Fact]
+    public void TheDenseScanLaneCarriesTheRuntimeFormIdColumn()
+    {
+        using var w = new World();
+        var response = Scan(w, World.LightName, format: "dense");
+        Assert.Contains("runtime_formid", response);
+        Assert.Contains(World.LightRuntime(0, w.LightWeapon), response);
+    }
+
+    // ---- a light plugin whose records sit outside the ESL window -----------------------------------
+
+    /// <summary>An esp-fe flagged light but never compacted: masking its 0x001801 record down to 0x801 would
+    /// print the same eight digits as the plugin's own 0x000801 record, and reading that back returns the
+    /// other one. The answer must say the plugin is out of window instead of stating a form that lies.</summary>
+    [Fact]
+    public void ARecordOutsideTheEslWindowGetsNoRuntimeFormIdButAReason()
+    {
+        using var w = new World();
+        var response = Read(w, World.Fid(w.WideWeapon));
+        Assert.DoesNotContain("runtime=FE", response);
+        Assert.Contains("ESL window", response);
+    }
+
+    [Fact]
+    public void TheInWindowRecordOfTheSameUncompactedPluginStillPrintsItsRuntimeFormId()
+    {
+        using var w = new World();
+        Served(Read(w, World.Fid(w.NarrowWeapon)), "runtime=" + World.LightRuntime(1, w.NarrowWeapon));
+    }
+
     // ---- the tables follow the order --------------------------------------------------------------
 
     [Fact]
@@ -125,6 +163,11 @@ public sealed class RuntimeFormIdTests
 
     static string Read(World w, string formid)
         => RecordsTools.Records(w.Svc, formids: new[] { formid });
+
+    /// <summary>The cross-plugin scan lane over one plugin's weapons — the summary rows, not a formids= read.</summary>
+    static string Scan(World w, string plugin, string? format = null)
+        => RecordsTools.Records(w.Svc, types: new[] { "WEAP" },
+                                plugins: new RecordsTools.RecordsScope { names = new[] { plugin } }, format: format);
 
     static void Served(string response, params string[] mustName)
     {
@@ -151,13 +194,21 @@ public sealed class RuntimeFormIdTests
         public const string FullName = "HcRtFull.esp";
         public const string LightName = "HcRtLight.esp";
         public const string SpareLightName = "HcRtSpare.esp";
+        public const string WideName = "HcRtWide.esp";
 
         readonly string _root;
         readonly string _profileDir;
+        readonly string _priorCorpusPath;
 
         public LoadOrderService Svc { get; }
         public FormKey FullWeapon { get; }
         public FormKey LightWeapon { get; }
+
+        /// <summary>The 0x001801 record in the light-flagged, never-compacted plugin — outside the ESL window.</summary>
+        public FormKey WideWeapon { get; }
+
+        /// <summary>Its 0x000801 neighbour in the SAME plugin — the record a masked 0x001801 would collide with.</summary>
+        public FormKey NarrowWeapon { get; }
 
         public static string Fid(FormKey fk) => $"{fk.ID:X6}:{fk.ModKey.FileName}";
 
@@ -170,6 +221,8 @@ public sealed class RuntimeFormIdTests
 
         public World()
         {
+            // CorpusRulebook.CorpusPath is a process-global: capture before repointing, restore on dispose.
+            _priorCorpusPath = CorpusRulebook.CorpusPath;
             _root = Path.Combine(Path.GetTempPath(), "hc-runtime-formid-tests-" + Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(Path.Combine(_root, "game", "Data"));
 
@@ -196,9 +249,21 @@ public sealed class RuntimeFormIdTests
             var sw = spare.Weapons.AddNew(); sw.EditorID = "HcRtSpareWeapon";
             sw.BasicStats = new WeaponBasicStats { Damage = 40, Weight = 1 };
 
+            // The light-flagged but NEVER COMPACTED plugin: one record inside the ESL window and one above it.
+            // It is written as a full plugin because Mutagen refuses to write an out-of-window record into a
+            // light one; the header flag is flipped on disk afterwards, which is how such a plugin is made.
+            var wideKey = new ModKey("HcRtWide", ModType.Plugin);
+            var wide = new SkyrimMod(wideKey, SkyrimRelease.SkyrimSE);
+            NarrowWeapon = new FormKey(wideKey, 0x000801);
+            WideWeapon = new FormKey(wideKey, 0x001801);
+            wide.Weapons.Add(new Weapon(NarrowWeapon, SkyrimRelease.SkyrimSE)
+                { EditorID = "HcRtNarrowWeapon", BasicStats = new WeaponBasicStats { Damage = 50, Weight = 1 } });
+            wide.Weapons.Add(new Weapon(WideWeapon, SkyrimRelease.SkyrimSE)
+                { EditorID = "HcRtWideWeapon", BasicStats = new WeaponBasicStats { Damage = 60, Weight = 1 } });
+
             var instance = Path.Combine(_root, "inst");
             var mods = Path.Combine(instance, "mods");
-            foreach (var d in new[] { "MasterMod", "FullMod", "LightMod", "SpareMod" })
+            foreach (var d in new[] { "MasterMod", "FullMod", "LightMod", "SpareMod", "WideMod" })
                 Directory.CreateDirectory(Path.Combine(mods, d));
             master.BeginWrite.ToPath(Path.Combine(mods, "MasterMod", MasterName))
                   .WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
@@ -208,6 +273,10 @@ public sealed class RuntimeFormIdTests
                  .WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
             spare.BeginWrite.ToPath(Path.Combine(mods, "SpareMod", SpareLightName))
                  .WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            var widePath = Path.Combine(mods, "WideMod", WideName);
+            wide.BeginWrite.ToPath(widePath)
+                .WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write();
+            SetLightFlag(widePath);
 
             File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
                 "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
@@ -216,7 +285,11 @@ public sealed class RuntimeFormIdTests
             Directory.CreateDirectory(_profileDir);
             WriteOrder(spareFirst: false);
             File.WriteAllText(Path.Combine(_profileDir, "modlist.txt"),
-                "# header\r\n+SpareMod\r\n+LightMod\r\n+FullMod\r\n+MasterMod\r\n");
+                "# header\r\n+WideMod\r\n+SpareMod\r\n+LightMod\r\n+FullMod\r\n+MasterMod\r\n");
+
+            var genDir = Path.Combine(_root, "corpus-gen");
+            CorpusGenerator.GenerateAll(genDir, Path.Combine(_root, "corpus-ref"));
+            CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json");
 
             Svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(_root, "user.json")));
         }
@@ -225,17 +298,27 @@ public sealed class RuntimeFormIdTests
         /// renumbers every light index below it.</summary>
         public void ActivateSecondLightPluginFirst() => WriteOrder(spareFirst: true);
 
+        /// <summary>Set the light (ESL) flag in a written plugin's TES4 header — the record flags are the four
+        /// bytes at offset 8, and 0x00000200 is the light bit.</summary>
+        static void SetLightFlag(string path)
+        {
+            var bytes = File.ReadAllBytes(path);
+            bytes[9] |= 0x02;
+            File.WriteAllBytes(path, bytes);
+        }
+
         void WriteOrder(bool spareFirst)
         {
             var names = spareFirst
-                ? new[] { MasterName, FullName, SpareLightName, LightName }
-                : new[] { MasterName, FullName, LightName };
+                ? new[] { MasterName, FullName, SpareLightName, LightName, WideName }
+                : new[] { MasterName, FullName, LightName, WideName };
             File.WriteAllText(Path.Combine(_profileDir, "loadorder.txt"), "# header\r\n" + string.Join("\r\n", names) + "\r\n");
             File.WriteAllText(Path.Combine(_profileDir, "plugins.txt"), string.Join("\r\n", names.Select(n => "*" + n)) + "\r\n");
         }
 
         public void Dispose()
         {
+            CorpusRulebook.CorpusPath = _priorCorpusPath;
             Svc.Dispose();
             try { Directory.Delete(_root, true); } catch { /* temp cleanup best-effort */ }
         }

--- a/src/housecarl-mcp/ApplyTools.cs
+++ b/src/housecarl-mcp/ApplyTools.cs
@@ -21,10 +21,11 @@ public static class ApplyTools
          "Edit fields on one or many records and write the result to a NEW patch plugin (originals untouched by " +
          "default). ONE surface: what to change (ops=, or the bundle=/assignments= copy zip) x WHERE it lands (the " +
          "LANE: a new patch | into= an existing one | in_place=\"X.esp\" | dry_run) x how it reads back (TRANSPORT).\n\n" +
-         "A FormID is 'XXXXXX:Plugin.esp' — 6 hex digits, a colon, the defining master's filename. The RUNTIME " +
-         "form the game, the console and the logs print is accepted too: eight hex digits and no plugin name, " +
-         "'FExxxYYY' for a light plugin or 'XX######' for a full one, with or without a leading 0x, resolved " +
-         "against the CURRENT load order. Every edit " +
+         "A FormID is 'XXXXXX:Plugin.esp' — 6 hex digits, a colon, the defining master's filename. On ops[].formid " +
+         "(and from=) the RUNTIME form the game, the console and the logs print is accepted too: eight hex digits " +
+         "and no plugin name, 'FExxxYYY' for a light plugin or 'XX######' for a full one, with or without a leading " +
+         "0x, resolved against the CURRENT load order. A field VALUE takes the 'XXXXXX:Plugin.esp' form only. " +
+         "Every edit " +
          "resolves the record's load-order WINNER and overrides it into the patch; all edits land in ONE reviewable " +
          ".esp, whose master header spans every plugin the edits reference (cross-master merge, derived not declared).\n\n" +
          "OPS. ops= is the edit list — {formid, field_path, op?, value?, values?, key?, entries?, compose?, " +

--- a/src/housecarl-mcp/ApplyTools.cs
+++ b/src/housecarl-mcp/ApplyTools.cs
@@ -21,7 +21,10 @@ public static class ApplyTools
          "Edit fields on one or many records and write the result to a NEW patch plugin (originals untouched by " +
          "default). ONE surface: what to change (ops=, or the bundle=/assignments= copy zip) x WHERE it lands (the " +
          "LANE: a new patch | into= an existing one | in_place=\"X.esp\" | dry_run) x how it reads back (TRANSPORT).\n\n" +
-         "A FormID is 'XXXXXX:Plugin.esp' — 6 hex digits, a colon, the defining master's filename. Every edit " +
+         "A FormID is 'XXXXXX:Plugin.esp' — 6 hex digits, a colon, the defining master's filename. The RUNTIME " +
+         "form the game, the console and the logs print is accepted too: eight hex digits and no plugin name, " +
+         "'FExxxYYY' for a light plugin or 'XX######' for a full one, with or without a leading 0x, resolved " +
+         "against the CURRENT load order. Every edit " +
          "resolves the record's load-order WINNER and overrides it into the patch; all edits land in ONE reviewable " +
          ".esp, whose master header spans every plugin the edits reference (cross-master merge, derived not declared).\n\n" +
          "OPS. ops= is the edit list — {formid, field_path, op?, value?, values?, key?, entries?, compose?, " +

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -138,7 +138,7 @@ internal static class Artifacts
         else if (fields is { Count: > 0 })                                    // detail rows — full record objects
         {
             identity = "formid";
-            schema = new[] { "formid", "type", "editorid", "winner", "override_depth", "source", "matches?", "fields" };
+            schema = new[] { "formid", "runtime_formid", "type", "editorid", "winner", "override_depth", "source", "matches?", "fields" };
             sort = "load-order scan order (deterministic within one epoch)";
             var linkMemo = resolveNames ? new Dictionary<FormKey, ResolvedRef>() : null;
             for (int i = 0; i < q.Keys.Count; i++)
@@ -166,7 +166,7 @@ internal static class Artifacts
         else                                                                  // summary rows
         {
             identity = "formid";
-            schema = new[] { "formid", "type", "editorid", "winner", "override_depth", "matches?" };
+            schema = new[] { "formid", "runtime_formid", "type", "editorid", "winner", "override_depth", "matches?" };
             sort = "load-order scan order (deterministic within one epoch)";
             for (int i = 0; i < q.Keys.Count; i++)
             {
@@ -228,7 +228,7 @@ internal static class Artifacts
         var epoch = outcomes.FirstOrDefault(o => o.Epoch is not null)?.Epoch ?? "";
         // The manifest's tool stamp; see WriteResolve.
         var (manifest, err) = writer.Save(path, ToolNames.Records, query, "formid",
-                                          new[] { "formid", "type", "editorid", "winner", "override_depth", "source", "fields" },
+                                          new[] { "formid", "runtime_formid", "type", "editorid", "winner", "override_depth", "source", "fields" },
                                           "input order", outcomes.Count, epoch, OwnedChildNotes(AnnotatedFields(outcomes)));
         return err is not null ? (null, err) : (new SpillInfo(path, manifest!, reason), null);
     }

--- a/src/housecarl-mcp/CopyTools.cs
+++ b/src/housecarl-mcp/CopyTools.cs
@@ -88,7 +88,7 @@ public static class CopyTools
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
 
         FormKey fromKey;
-        try { fromKey = svc.ParseFormId(from); }
+        try { fromKey = svc.OpenFormIdDoor().Parse(from); }
         catch (Exception ex) { return $"error: bad from '{from}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }
 
         bool hasTarget = !string.IsNullOrWhiteSpace(target);
@@ -100,7 +100,7 @@ public static class CopyTools
         FormKey? targetKey = null;
         if (hasTarget)
         {
-            try { targetKey = svc.ParseFormId(target); }
+            try { targetKey = svc.OpenFormIdDoor().Parse(target); }
             catch (Exception ex) { return $"error: bad target '{target}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }
         }
 

--- a/src/housecarl-mcp/CopyTools.cs
+++ b/src/housecarl-mcp/CopyTools.cs
@@ -88,7 +88,7 @@ public static class CopyTools
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
 
         FormKey fromKey;
-        try { fromKey = FormKey.Factory((from ?? "").Trim()); }
+        try { fromKey = svc.ParseFormId(from); }
         catch (Exception ex) { return $"error: bad from '{from}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }
 
         bool hasTarget = !string.IsNullOrWhiteSpace(target);
@@ -100,7 +100,7 @@ public static class CopyTools
         FormKey? targetKey = null;
         if (hasTarget)
         {
-            try { targetKey = FormKey.Factory(target!.Trim()); }
+            try { targetKey = svc.ParseFormId(target); }
             catch (Exception ex) { return $"error: bad target '{target}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }
         }
 

--- a/src/housecarl-mcp/CopyTools.cs
+++ b/src/housecarl-mcp/CopyTools.cs
@@ -87,8 +87,10 @@ public static class CopyTools
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
 
+        // One door for every token in the call, so the source and the target resolve against one index build.
+        var door = svc.OpenFormIdDoor();
         FormKey fromKey;
-        try { fromKey = svc.OpenFormIdDoor().Parse(from); }
+        try { fromKey = door.Parse(from); }
         catch (Exception ex) { return $"error: bad from '{from}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }
 
         bool hasTarget = !string.IsNullOrWhiteSpace(target);
@@ -100,7 +102,7 @@ public static class CopyTools
         FormKey? targetKey = null;
         if (hasTarget)
         {
-            try { targetKey = svc.OpenFormIdDoor().Parse(target); }
+            try { targetKey = door.Parse(target); }
             catch (Exception ex) { return $"error: bad target '{target}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }
         }
 

--- a/src/housecarl-mcp/DialogueSweep.cs
+++ b/src/housecarl-mcp/DialogueSweep.cs
@@ -18,6 +18,7 @@ internal static class DialogueSweep
     /// response states how many and which knob moves them.</param>
     /// <param name="countsOnly">carry the totals and the unreachable-seed roster, and no topic blocks.</param>
     internal static DialogueCheckResult Run(Func<FormKey, DialogueValidationReport> validate,
+                                            Func<string?, FormKey> parseFormId,
                                             IReadOnlyList<string>? seeds, int limit, bool countsOnly = false)
     {
         var named = (seeds ?? Array.Empty<string>()).Where(s => !string.IsNullOrWhiteSpace(s)).ToArray();
@@ -33,7 +34,7 @@ internal static class DialogueSweep
             if (results.Count >= limit) break;    // the seed budget; the accounting states the rest
 
             FormKey fk;
-            try { fk = FormKey.Factory(seed); }
+            try { fk = parseFormId(seed); }
             catch (Exception ex)
             {
                 // A malformed seed is named and carried, never dropped: the scope is the seed list, so a discarded

--- a/src/housecarl-mcp/FormIdDoor.cs
+++ b/src/housecarl-mcp/FormIdDoor.cs
@@ -26,6 +26,11 @@ internal sealed class FormIdDoor
     /// <summary>A door that captures a build on the first runtime FormID, and never if none arrives.</summary>
     public static FormIdDoor For(LoadOrderService svc) => new(svc, null);
 
+    /// <summary>The build this door captured, or null when no runtime FormID arrived and it never reached for one.
+    /// A caller that goes on to scan passes it down, so the tokens it parsed and the records it matches come from
+    /// the same index build rather than two adjacent ones.</summary>
+    public LoadOrderResolver.IndexView? CapturedView => _view;
+
     /// <summary>Parse one token — see <see cref="LoadOrderResolver.IndexView.ParseFormId"/>. Throws one plain
     /// sentence on anything it cannot answer.</summary>
     public FormKey Parse(string? raw)

--- a/src/housecarl-mcp/FormIdDoor.cs
+++ b/src/housecarl-mcp/FormIdDoor.cs
@@ -1,0 +1,37 @@
+using Mutagen.Bethesda.Plugins;
+using HousecarlCore;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// The FormID door a tool body parses a LIST of tokens through. It answers the plugin-qualified
+/// <c>XXXXXX:Plugin.esp</c> form without touching the load order at all, and reaches for the index only when a
+/// RUNTIME FormID actually arrives — then once, holding that one build for every remaining token.
+///
+/// <para>Both halves of that matter. Reaching for the resolver per token re-stats every plugin in the order on
+/// every one, and lets the index rebuild mid-list so two tokens in one call resolve against different builds.
+/// Reaching for it at all would break the lanes that read a plugin from disk with no active order.</para>
+/// </summary>
+internal sealed class FormIdDoor
+{
+    readonly LoadOrderService? _svc;
+    LoadOrderResolver.IndexView? _view;
+
+    FormIdDoor(LoadOrderService? svc, LoadOrderResolver.IndexView? view) { _svc = svc; _view = view; }
+
+    /// <summary>A door pinned to a build the caller already captured, so its FormIDs and its records describe the
+    /// same index.</summary>
+    public static FormIdDoor On(LoadOrderResolver.IndexView view) => new(null, view);
+
+    /// <summary>A door that captures a build on the first runtime FormID, and never if none arrives.</summary>
+    public static FormIdDoor For(LoadOrderService svc) => new(svc, null);
+
+    /// <summary>Parse one token — see <see cref="LoadOrderResolver.IndexView.ParseFormId"/>. Throws one plain
+    /// sentence on anything it cannot answer.</summary>
+    public FormKey Parse(string? raw)
+    {
+        if (!RuntimeFormId.TryParse(raw, out _)) return FormKey.Factory((raw ?? "").Trim());
+        _view ??= _svc!.CaptureView();
+        return _view.Value.ParseFormId(raw);
+    }
+}

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -284,6 +284,7 @@ static class JsonWire
         w.WriteStartObject();
         if (epoch is not null) w.WriteString("epoch", epoch);   // single-read top level ONLY
         w.WriteString("formid", r.FormKey);
+        WriteNullable(w, "runtime_formid", o.RuntimeFormId);
         w.WriteString("type", r.Type);
         WriteNullable(w, "editorid", r.EditorId);
         WriteNullable(w, "winner", o.WinnerPlugin);
@@ -423,6 +424,7 @@ static class JsonWire
                 if (ms.Length >= cap) { rowsTruncated = true; break; }
                 w.WriteStartObject();
                 w.WriteString("formid", o.FormKey.ToString());
+                WriteNullable(w, "runtime_formid", o.RuntimeFormId);
                 if (o.Error is not null) w.WriteString("error", o.Error);
                 else
                 {

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -29,6 +29,15 @@ static class JsonWire
         if (v is null) w.WriteNull(name); else w.WriteString(name, v);
     }
 
+    /// <summary>A record's runtime address on the json lanes: <c>runtime_formid</c> always present (null when the
+    /// order gives the record none), plus <c>runtime_formid_note</c> written ONLY when there is a reason to state —
+    /// a consumer reading the form gets a token or a null, never a sentence where a FormID belongs.</summary>
+    static void WriteRuntime(Utf8JsonWriter w, string? runtime, string? note)
+    {
+        WriteNullable(w, "runtime_formid", runtime);
+        if (note is not null) w.WriteString("runtime_formid_note", note);
+    }
+
     /// <summary>The array twin of <see cref="WriteNullable"/>, for a member whose null carries meaning: null says
     /// the value was NOT COMPUTED, an empty array says it was computed and came back empty. Writing <c>[]</c> for
     /// both leaves the consumer nothing to tell them apart.</summary>
@@ -284,7 +293,7 @@ static class JsonWire
         w.WriteStartObject();
         if (epoch is not null) w.WriteString("epoch", epoch);   // single-read top level ONLY
         w.WriteString("formid", r.FormKey);
-        WriteNullable(w, "runtime_formid", o.RuntimeFormId);
+        WriteRuntime(w, o.RuntimeFormId, o.RuntimeFormIdNote);
         w.WriteString("type", r.Type);
         WriteNullable(w, "editorid", r.EditorId);
         WriteNullable(w, "winner", o.WinnerPlugin);
@@ -424,7 +433,7 @@ static class JsonWire
                 if (ms.Length >= cap) { rowsTruncated = true; break; }
                 w.WriteStartObject();
                 w.WriteString("formid", o.FormKey.ToString());
-                WriteNullable(w, "runtime_formid", o.RuntimeFormId);
+                WriteRuntime(w, o.RuntimeFormId, o.RuntimeFormIdNote);
                 if (o.Error is not null) w.WriteString("error", o.Error);
                 else
                 {
@@ -1084,7 +1093,7 @@ static class JsonWire
                 w.WriteStartArray("columns");
                 if (detail)
                 {
-                    w.WriteStringValue("formid"); w.WriteStringValue("editorid");
+                    w.WriteStringValue("formid"); w.WriteStringValue("runtime_formid"); w.WriteStringValue("editorid");
                     foreach (var f in fields!) w.WriteStringValue(f);         // cells align positionally: ReadFields returns exactly one value per requested path, in order
                     // Under a plugins= scope each row's values are SOME scoped plugin's own body, and with 2+ scoped
                     // plugins the caller cannot reconstruct WHICH from the row alone — a defining esp's stale value
@@ -1093,7 +1102,7 @@ static class JsonWire
                     if (anyScoped) w.WriteStringValue("source");
                 }
                 else
-                    foreach (var c in new[] { "formid", "type", "editorid", "winner", "override_depth" }) w.WriteStringValue(c);
+                    foreach (var c in new[] { "formid", "runtime_formid", "type", "editorid", "winner", "override_depth" }) w.WriteStringValue(c);
                 if (hasMatches) w.WriteStringValue("matches");
                 w.WriteEndArray();
 
@@ -1116,6 +1125,7 @@ static class JsonWire
                         var r = o.Record!;
                         w.WriteStartArray();
                         w.WriteStringValue(r.FormKey);
+                        WriteCell(w, RuntimeCell(o.RuntimeFormId, o.RuntimeFormIdNote));
                         WriteCell(w, r.EditorId);
                         foreach (var f in r.Fields)
                         {
@@ -1134,6 +1144,7 @@ static class JsonWire
                         if (m.Error is not null) { (errors ??= new()).Add((m.FormKey.ToString(), m.Error)); rendered++; continue; }
                         w.WriteStartArray();
                         w.WriteStringValue(m.FormKey.ToString());
+                        WriteCell(w, RuntimeCell(m.RuntimeFormId, m.RuntimeFormIdNote));
                         w.WriteStringValue(m.Type);
                         WriteCell(w, m.EditorId);
                         w.WriteStringValue(m.Winner);
@@ -1173,6 +1184,10 @@ static class JsonWire
         return s;
     }
 
+    /// <summary>The runtime-FormID cell in a dense row: the eight-hex form, else the reason in the parenthetical
+    /// vocabulary every other dense cell uses for a value that is not a round-trip token, else null.</summary>
+    static string? RuntimeCell(string? runtime, string? note) => runtime ?? (note is null ? null : $"({note})");
+
     static void WriteCell(Utf8JsonWriter w, string? v)
     {
         if (v is null) w.WriteNullValue(); else w.WriteStringValue(v);
@@ -1182,6 +1197,7 @@ static class JsonWire
     {
         w.WriteStartObject();
         w.WriteString("formid", m.FormKey.ToString());
+        WriteRuntime(w, m.RuntimeFormId, m.RuntimeFormIdNote);
         if (m.Error is not null) w.WriteString("error", m.Error);
         else
         {

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -97,6 +97,12 @@ public sealed class LoadOrderService : IDisposable
     /// this resolves regardless of the MO2-launched process's working directory.</summary>
     CorpusRulebook Rulebook => _rulebook ??= CorpusRulebook.Load();
 
+    /// <summary>The FormID door for a tool body with no captured view in hand — see
+    /// <see cref="LoadOrderResolver.IndexView.ParseFormId"/>. The load order is consulted ONLY for a runtime FormID:
+    /// the <c>XXXXXX:Plugin.esp</c> form names its own plugin, so the off-order lanes keep parsing without one.</summary>
+    internal FormKey ParseFormId(string? raw)
+        => RuntimeFormId.TryParse(raw, out _) ? Resolver.ParseFormId(raw) : FormKey.Factory((raw ?? "").Trim());
+
     /// <summary>The resolver, built on first access and kept fresh on every subsequent access. Throws loudly if the
     /// configured roots yield no plugins.</summary>
     LoadOrderResolver Resolver
@@ -2147,7 +2153,7 @@ public sealed class LoadOrderService : IDisposable
     /// tallied for one section of a merged response. Deliberately thin — the family's own grammar (seed parse,
     /// cost refusal, seed budget, tally) lives in <see cref="DialogueSweep"/> rather than in this file.</summary>
     public DialogueCheckResult CheckDialogue(IReadOnlyList<string>? seeds, int limit, bool countsOnly = false)
-        => DialogueSweep.Run(ValidateDialogue, seeds, limit, countsOnly);
+        => DialogueSweep.Run(ValidateDialogue, ParseFormId, seeds, limit, countsOnly);
 
     /// <summary>The read body, answered entirely off ONE captured view: the excluded-check, the winner and the
     /// touching-plugin list all describe the same build, so a freshness rebuild landing mid-read cannot make a
@@ -2492,7 +2498,7 @@ public sealed class LoadOrderService : IDisposable
         {
             var t = raw?.Trim() ?? "";
             FormKey fk;
-            try { fk = FormKey.Factory(t); }
+            try { fk = view.ParseFormId(t); }
             catch (Exception ex) { results.Add(new ResolvedRef(t, Resolved: false, Error: $"bad FormID: {ex.Message}. Expected 'XXXXXX:Plugin.esp'.")); continue; }
             results.Add(ResolveRefOne(view, session, fk, memo));
         }
@@ -2561,7 +2567,7 @@ public sealed class LoadOrderService : IDisposable
         foreach (var raw in formids)
         {
             FormKey fk;
-            try { fk = FormKey.Factory(raw.Trim()); }
+            try { fk = view.ParseFormId(raw); }
             catch (Exception ex) { outcomes.Add(ReadOutcome.Fail(default, $"bad FormID '{raw}': {ex.Message}")); continue; }
             outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint)
                          with { Epoch = view.Epoch, Pin = pin });   // the batch's one build, stamped and pinned per item
@@ -2672,7 +2678,7 @@ public sealed class LoadOrderService : IDisposable
             foreach (var raw in formids)
             {
                 FormKey fk;
-                try { fk = FormKey.Factory(raw.Trim()); }
+                try { fk = view.ParseFormId(raw); }
                 catch (Exception ex) { outcomes.Add(ReadOutcome.Fail(default, $"bad FormID '{raw}': {ex.Message}")); continue; }
                 outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, false, depth, resolveNames, linkMemo, containerHint)
                              with { Epoch = view.Epoch, Pin = pin });
@@ -2697,7 +2703,7 @@ public sealed class LoadOrderService : IDisposable
         var results = new ReadOutcome?[formids.Count];
         for (int i = 0; i < formids.Count; i++)
         {
-            try { parsed.Add((i, FormKey.Factory(formids[i].Trim()))); }
+            try { parsed.Add((i, view.ParseFormId(formids[i]))); }
             catch (Exception ex) { results[i] = ReadOutcome.Fail(default, $"bad FormID '{formids[i]}': {ex.Message}"); }
         }
 
@@ -2817,7 +2823,7 @@ public sealed class LoadOrderService : IDisposable
         var wanted = new HashSet<FormKey>();
         foreach (var raw in formids)
         {
-            try { var fk0 = FormKey.Factory(raw.Trim()); parsed.Add((raw, fk0, null)); wanted.Add(fk0); }
+            try { var fk0 = view.ParseFormId(raw); parsed.Add((raw, fk0, null)); wanted.Add(fk0); }
             catch (Exception ex) { parsed.Add((raw, null, $"bad FormID '{raw}': {ex.Message}")); }
         }
 
@@ -3166,7 +3172,7 @@ public sealed class LoadOrderService : IDisposable
         foreach (var raw in formids)
         {
             FormKey fk;
-            try { fk = FormKey.Factory(raw.Trim()); }
+            try { fk = view.ParseFormId(raw); }
             catch (Exception ex) { outcomes.Add(ReadOutcome.Fail(default, $"bad FormID '{raw}': {ex.Message}")); continue; }
             if (replayMemo.TryGetValue(fk, out var memoized)) { outcomes.Add(memoized); continue; }
             var winner = view.ResolveWinner(fk);
@@ -3244,7 +3250,7 @@ public sealed class LoadOrderService : IDisposable
         var wantedT = new HashSet<FormKey>();
         foreach (var raw in formids)
         {
-            try { var fk0 = FormKey.Factory(raw.Trim()); parsedT.Add((raw, fk0, null)); wantedT.Add(fk0); }
+            try { var fk0 = view.ParseFormId(raw); parsedT.Add((raw, fk0, null)); wantedT.Add(fk0); }
             catch (Exception ex) { parsedT.Add((raw, null, $"bad FormID '{raw}': {ex.Message}")); }
         }
 
@@ -3400,7 +3406,7 @@ public sealed class LoadOrderService : IDisposable
         foreach (var raw in seeds)
         {
             FormKey seedFk;
-            try { seedFk = FormKey.Factory(raw.Trim()); }
+            try { seedFk = view.ParseFormId(raw); }
             catch (Exception ex) { results.Add(new WalkSeedResult(raw?.Trim() ?? "", null, null, Array.Empty<WalkNodeRow>(), Array.Empty<string>(), null, null, $"bad FormID '{raw}': {ex.Message}")); continue; }
             var seedBody = Fetch(seedFk);
             if (seedBody is null)
@@ -3576,7 +3582,7 @@ public sealed class LoadOrderService : IDisposable
         foreach (var raw in formids)
         {
             FormKey fk;
-            try { fk = FormKey.Factory(raw.Trim()); }
+            try { fk = view.ParseFormId(raw); }
             catch (Exception ex) { rows.Add(new InfoOrderRow(raw?.Trim() ?? "", null, null, null, null, $"bad FormID '{raw}': {ex.Message}")); continue; }
             var win = view.ResolveWinner(fk);
             if (win is null)
@@ -3729,7 +3735,7 @@ public sealed class LoadOrderService : IDisposable
         FieldPredicateSet? predicate = null;
         if (hasWhere)
         {
-            var (set, perr) = FieldPredicateSet.Parse(where!);
+            var (set, perr) = FieldPredicateSet.Parse(where!, ParseFormId);
             if (perr is not null) return CrossQueryOutcome.Fail(perr);
             predicate = set;
         }
@@ -4077,7 +4083,7 @@ public sealed class LoadOrderService : IDisposable
         FieldPredicateSet? predicate = null;
         if (where is { Count: > 0 })
         {
-            var (set, perr) = FieldPredicateSet.Parse(where);
+            var (set, perr) = FieldPredicateSet.Parse(where, ParseFormId);
             if (perr is not null) return CrossQueryOutcome.Fail(perr);
             predicate = set;
         }
@@ -4417,7 +4423,7 @@ public sealed class LoadOrderService : IDisposable
             {
                 var t = raw?.Trim() ?? "";
                 if (t.Length == 0) return (null, "a blank entry in formids= — pass FormID tokens (e.g. '0BCC84:Skyrim.esm').");
-                try { keys.Add(FormKey.Factory(t)); }
+                try { keys.Add(ParseFormId(t)); }
                 catch (Exception ex) { return (null, $"bad FormID '{raw}' in formids=: {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '0BCC84:Skyrim.esm'."); }
             }
         }
@@ -5419,7 +5425,7 @@ public sealed class LoadOrderService : IDisposable
         {
             var raw = formids[i];
             if (string.IsNullOrWhiteSpace(raw)) { problems.Add($"formid[{i}]: empty."); continue; }
-            try { keys.Add(FormKey.Factory(raw.Trim())); }
+            try { keys.Add(ParseFormId(raw)); }
             catch (Exception ex) { problems.Add($"formid[{i}] '{raw}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
         }
         if (problems.Count > 0)
@@ -5552,7 +5558,7 @@ public sealed class LoadOrderService : IDisposable
         {
             var raw = formids[i];
             if (string.IsNullOrWhiteSpace(raw)) { problems.Add($"formid[{i}]: empty."); continue; }
-            try { specs.Add(new WritePatchBuilder.ForwardSpec { Target = FormKey.Factory(raw.Trim()), FromPlugin = fp }); }
+            try { specs.Add(new WritePatchBuilder.ForwardSpec { Target = ParseFormId(raw), FromPlugin = fp }); }
             catch (Exception ex) { problems.Add($"formid[{i}] '{raw}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
         }
         if (problems.Count > 0)
@@ -6417,7 +6423,7 @@ public sealed class LoadOrderService : IDisposable
     {
         // ---- argument shape: exactly one target mode ----
         FormKey donorFk;
-        try { donorFk = FormKey.Factory((sourceFormid ?? "").Trim()); }
+        try { donorFk = ParseFormId(sourceFormid); }
         catch (Exception ex) { return NpcCopyOutcome.Fail($"bad source formid '{sourceFormid}': {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '000D62:Vivace.esp'."); }
 
         bool apply = !string.IsNullOrWhiteSpace(targetFormid);
@@ -6429,7 +6435,7 @@ public sealed class LoadOrderService : IDisposable
         FormKey targetFk = default;
         if (apply)
         {
-            try { targetFk = FormKey.Factory(targetFormid!.Trim()); }
+            try { targetFk = ParseFormId(targetFormid); }
             catch (Exception ex) { return NpcCopyOutcome.Fail($"bad target formid '{targetFormid}': {ex.Message}."); }
         }
 
@@ -7003,7 +7009,7 @@ public sealed class LoadOrderService : IDisposable
         var where = origin ?? $"op[{index}]";
         if (string.IsNullOrWhiteSpace(op.Formid)) { error = $"{where}: formid is required."; return null; }
         FormKey fk;
-        try { fk = FormKey.Factory(op.Formid.Trim()); }
+        try { fk = ParseFormId(op.Formid); }
         catch (Exception ex) { error = $"{where}: bad formid '{op.Formid}' ({ex.Message}). Expected 'XXXXXX:Plugin.esp'."; return null; }
         if (string.IsNullOrWhiteSpace(op.FieldPath)) { error = $"{where} ({op.Formid}): field_path is required."; return null; }
         var path = SplitPath(op.FieldPath);
@@ -7027,7 +7033,7 @@ public sealed class LoadOrderService : IDisposable
         FormKey? fromKey = null;
         if (!string.IsNullOrWhiteSpace(fromRecord))
         {
-            try { fromKey = FormKey.Factory(fromRecord.Trim()); }
+            try { fromKey = ParseFormId(fromRecord); }
             catch (Exception ex) { error = $"{where} ({op.Formid}): bad from '{fromRecord}' ({ex.Message}). Expected 'XXXXXX:Plugin.esp'."; return null; }
             if (fromKey == fk)
             { error = $"{where} ({op.Formid}): from names the SAME record as formid — copying a record's field onto itself is a no-op. Drop from=, and name the plugin whose version to copy in from_source=."; return null; }
@@ -7993,7 +7999,7 @@ public sealed class LoadOrderService : IDisposable
         FormKey fk = default;
         if (hasFormid)
         {
-            try { fk = FormKey.Factory(formid!.Trim()); }
+            try { fk = ParseFormId(formid); }
             catch (Exception ex) { return PluginFileOutcome.Fail(plugin, $"bad FormID '{formid}': {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '000D62:Vivace.esp'."); }
         }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2234,7 +2234,7 @@ public sealed class LoadOrderService : IDisposable
         if (resolveNames) record = AnnotateLinks(record, view, session, linkMemo ?? new());   // identity of every FormLink token, display-only, on the same open session
         var touching = conflictTree ? view.TouchingPlugins(fk) : null;
         return new ReadOutcome(fk, record, source, winner.Value.WinnerPlugin, winner.Value.OverrideDepth, touching, null)
-               { OwnedChildFields = childFields, RuntimeFormId = view.RuntimeFormIdOf(fk) };
+               { OwnedChildFields = childFields }.WithRuntime(view.RuntimeAddressOf(fk));
     }
 
     /// <summary>resolve_names (P7): annotate every field whose <see cref="FieldValue.Token"/> is a form reference (a
@@ -2353,7 +2353,8 @@ public sealed class LoadOrderService : IDisposable
             return new RecordSummary(fk, "?", null, w.Value.WinnerPlugin, w.Value.OverrideDepth,
                 $"winner '{w.Value.WinnerPlugin}' did not yield {fk} on fetch");
         return new RecordSummary(fk, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID,
-                                 w.Value.WinnerPlugin, w.Value.OverrideDepth, null);
+                                 w.Value.WinnerPlugin, w.Value.OverrideDepth, null)
+               .WithRuntime(view.RuntimeAddressOf(fk));
     }
 
     // ---- pinned per-match fills ------------------------------------------------------------------------
@@ -3199,9 +3200,9 @@ public sealed class LoadOrderService : IDisposable
             }
             var record = ReadEngine.ReadFields(bodyToRead!, fields, depth, containerHint);
             if (resolveNames) record = AnnotateLinks(record, view, session, overlayLinkMemo ??= new Dictionary<FormKey, ResolvedRef>());
-            var ok = new ReadOutcome(fk, record, winner.Value.WinnerPlugin, winner.Value.WinnerPlugin,
-                                     winner.Value.OverrideDepth, null, null)
-                     with { Epoch = view.Epoch, Pin = pin, RuntimeFormId = view.RuntimeFormIdOf(fk) };
+            var ok = (new ReadOutcome(fk, record, winner.Value.WinnerPlugin, winner.Value.WinnerPlugin,
+                                      winner.Value.OverrideDepth, null, null)
+                      with { Epoch = view.Epoch, Pin = pin }).WithRuntime(view.RuntimeAddressOf(fk));
             replayMemo[fk] = ok; outcomes.Add(ok);
         }
         return outcomes;
@@ -3851,7 +3852,8 @@ public sealed class LoadOrderService : IDisposable
                             sources.Add(null);                                // the winner body is what matched and displays
                             matched?.Add(hitTargets is not null ? string.Join(", ", hitTargets) : null);
                             prefilled?.Add(new RecordSummary(fk, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID,
-                                                             w.Value.WinnerPlugin, w.Value.OverrideDepth, null));
+                                                             w.Value.WinnerPlugin, w.Value.OverrideDepth, null)
+                                           .WithRuntime(view.RuntimeAddressOf(fk)));
                         }
                     }
                     catch (Exception ex)
@@ -3982,7 +3984,8 @@ public sealed class LoadOrderService : IDisposable
                             // cannot make a row's winner reflect a newer build than the depth beside it. Type and
                             // editorid come from the body that MATCHED.
                             prefilled!.Add(new RecordSummary(fk, RecordNaming.StripOverlay(filterBody.GetType().Name), filterBody.EditorID,
-                                                             view.ResolveWinner(fk)?.WinnerPlugin ?? "?", depth, null));
+                                                             view.ResolveWinner(fk)?.WinnerPlugin ?? "?", depth, null)
+                                           .WithRuntime(view.RuntimeAddressOf(fk)));
                         }
                     }
                     catch (Exception ex)
@@ -4207,7 +4210,8 @@ public sealed class LoadOrderService : IDisposable
                         sources.Add(pole.Plugin);
                         matched?.Add(hitTargets is not null ? string.Join(", ", hitTargets) : null);
                         prefilled.Add(new RecordSummary(fk, RecordNaming.StripOverlay(rec.GetType().Name), rec.EditorID,
-                                                        w?.WinnerPlugin ?? "(not in the active order)", w?.OverrideDepth ?? 0, null));
+                                                        w?.WinnerPlugin ?? "(not in the active order)", w?.OverrideDepth ?? 0, null)
+                                      .WithRuntime(view.RuntimeAddressOf(fk)));
                     }
                 }
                 catch (Exception ex)
@@ -8485,6 +8489,15 @@ public sealed record ReadOutcome(
     /// when). Carried per outcome because the light index moves whenever the order does.</summary>
     public string? RuntimeFormId { get; init; }
 
+    /// <summary>Why this record has no runtime FormID, when the order can address the plugin but not the record —
+    /// today, a light-flagged plugin that was never compacted. Rendered where the form would have gone, so the
+    /// answer is never a silently missing field.</summary>
+    public string? RuntimeFormIdNote { get; init; }
+
+    /// <summary>Carry a resolved runtime address onto this outcome — the one place the two halves are set, so a
+    /// lane cannot keep one and drop the other.</summary>
+    public ReadOutcome WithRuntime(RuntimeAddress a) => this with { RuntimeFormId = a.FormId, RuntimeFormIdNote = a.Note };
+
     /// <summary>The resolver and view this outcome was answered from, carried beside <see cref="Epoch"/> so the
     /// render's conflict-tree fill reads the same build the stamp names. Internal render plumbing.</summary>
     internal LoadOrderService.ViewPin? Pin { get; init; }
@@ -8542,7 +8555,18 @@ public sealed record GroupCount(string Key, int Count);
 
 /// <summary>A compact, header-only record summary (no field dump) — the per-match line cross_plugin_query emits
 /// by default. <see cref="Error"/> non-null ⇒ the winner couldn't be summarised (named, recoverable).</summary>
-public sealed record RecordSummary(FormKey FormKey, string Type, string? EditorId, string Winner, int OverrideDepth, string? Error);
+public sealed record RecordSummary(FormKey FormKey, string Type, string? EditorId, string Winner, int OverrideDepth, string? Error)
+{
+    /// <summary>The runtime FormID of this row's record in the build that answered — the same identity the detail
+    /// lanes print, so a scan row a modder takes to the console carries the form the console wants.</summary>
+    public string? RuntimeFormId { get; init; }
+
+    /// <summary>Why the row has no runtime FormID — see <see cref="ReadOutcome.RuntimeFormIdNote"/>.</summary>
+    public string? RuntimeFormIdNote { get; init; }
+
+    /// <summary>Carry a resolved runtime address onto this row; the one place the two halves are set.</summary>
+    public RecordSummary WithRuntime(RuntimeAddress a) => this with { RuntimeFormId = a.FormId, RuntimeFormIdNote = a.Note };
+}
 
 /// <summary>One enumerate/read row from a raw plugin-file read: a record the file DEFINES or OVERRIDES, as its
 /// FormKey + type + EditorID. NOT a load-order winner — the FILE's own record.</summary>

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2233,7 +2233,7 @@ public sealed class LoadOrderService : IDisposable
         if (resolveNames) record = AnnotateLinks(record, view, session, linkMemo ?? new());   // identity of every FormLink token, display-only, on the same open session
         var touching = conflictTree ? view.TouchingPlugins(fk) : null;
         return new ReadOutcome(fk, record, source, winner.Value.WinnerPlugin, winner.Value.OverrideDepth, touching, null)
-               { OwnedChildFields = childFields };
+               { OwnedChildFields = childFields, RuntimeFormId = view.RuntimeFormIdOf(fk) };
     }
 
     /// <summary>resolve_names (P7): annotate every field whose <see cref="FieldValue.Token"/> is a form reference (a
@@ -8470,6 +8470,12 @@ public sealed record ReadOutcome(
     /// it too: a "not present" is an answer ABOUT a build. Null only where no view was ever consulted, such as a
     /// malformed-FormID parse failure.</summary>
     public string? Epoch { get; init; }
+
+    /// <summary>The RUNTIME FormID of this record in the build that answered — the eight-hex form the game, the
+    /// console, Papyrus logs and crash logs print. Rendered beside the FormKey so a reader can carry the record
+    /// either way. Null when the record's plugin is not active, which is the only way it has no runtime address.
+    /// Carried per outcome because the light index moves whenever the order does.</summary>
+    public string? RuntimeFormId { get; init; }
 
     /// <summary>The resolver and view this outcome was answered from, carried beside <see cref="Epoch"/> so the
     /// render's conflict-tree fill reads the same build the stamp names. Internal render plumbing.</summary>

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -97,11 +97,12 @@ public sealed class LoadOrderService : IDisposable
     /// this resolves regardless of the MO2-launched process's working directory.</summary>
     CorpusRulebook Rulebook => _rulebook ??= CorpusRulebook.Load();
 
-    /// <summary>The FormID door for a tool body with no captured view in hand — see
-    /// <see cref="LoadOrderResolver.IndexView.ParseFormId"/>. The load order is consulted ONLY for a runtime FormID:
-    /// the <c>XXXXXX:Plugin.esp</c> form names its own plugin, so the off-order lanes keep parsing without one.</summary>
-    internal FormKey ParseFormId(string? raw)
-        => RuntimeFormId.TryParse(raw, out _) ? Resolver.ParseFormId(raw) : FormKey.Factory((raw ?? "").Trim());
+    /// <summary>One captured index build, for a <see cref="FormIdDoor"/> that has found a runtime FormID to
+    /// resolve.</summary>
+    internal LoadOrderResolver.IndexView CaptureView() => Resolver.Capture();
+
+    /// <summary>A FormID door for a tool body with no captured view of its own — see <see cref="FormIdDoor"/>.</summary>
+    internal FormIdDoor OpenFormIdDoor() => FormIdDoor.For(this);
 
     /// <summary>The resolver, built on first access and kept fresh on every subsequent access. Throws loudly if the
     /// configured roots yield no plugins.</summary>
@@ -2153,7 +2154,7 @@ public sealed class LoadOrderService : IDisposable
     /// tallied for one section of a merged response. Deliberately thin — the family's own grammar (seed parse,
     /// cost refusal, seed budget, tally) lives in <see cref="DialogueSweep"/> rather than in this file.</summary>
     public DialogueCheckResult CheckDialogue(IReadOnlyList<string>? seeds, int limit, bool countsOnly = false)
-        => DialogueSweep.Run(ValidateDialogue, ParseFormId, seeds, limit, countsOnly);
+        => DialogueSweep.Run(ValidateDialogue, OpenFormIdDoor().Parse, seeds, limit, countsOnly);
 
     /// <summary>The read body, answered entirely off ONE captured view: the excluded-check, the winner and the
     /// touching-plugin list all describe the same build, so a freshness rebuild landing mid-read cannot make a
@@ -3200,7 +3201,7 @@ public sealed class LoadOrderService : IDisposable
             if (resolveNames) record = AnnotateLinks(record, view, session, overlayLinkMemo ??= new Dictionary<FormKey, ResolvedRef>());
             var ok = new ReadOutcome(fk, record, winner.Value.WinnerPlugin, winner.Value.WinnerPlugin,
                                      winner.Value.OverrideDepth, null, null)
-                     with { Epoch = view.Epoch, Pin = pin };
+                     with { Epoch = view.Epoch, Pin = pin, RuntimeFormId = view.RuntimeFormIdOf(fk) };
             replayMemo[fk] = ok; outcomes.Add(ok);
         }
         return outcomes;
@@ -3735,7 +3736,7 @@ public sealed class LoadOrderService : IDisposable
         FieldPredicateSet? predicate = null;
         if (hasWhere)
         {
-            var (set, perr) = FieldPredicateSet.Parse(where!, ParseFormId);
+            var (set, perr) = FieldPredicateSet.Parse(where!, FormIdDoor.On(view).Parse);
             if (perr is not null) return CrossQueryOutcome.Fail(perr);
             predicate = set;
         }
@@ -4083,7 +4084,7 @@ public sealed class LoadOrderService : IDisposable
         FieldPredicateSet? predicate = null;
         if (where is { Count: > 0 })
         {
-            var (set, perr) = FieldPredicateSet.Parse(where, ParseFormId);
+            var (set, perr) = FieldPredicateSet.Parse(where, FormIdDoor.On(view).Parse);
             if (perr is not null) return CrossQueryOutcome.Fail(perr);
             predicate = set;
         }
@@ -4419,11 +4420,12 @@ public sealed class LoadOrderService : IDisposable
         if (formids is { Count: > 0 })
         {
             keys = new HashSet<FormKey>();
+            var door = OpenFormIdDoor();
             foreach (var raw in formids)
             {
                 var t = raw?.Trim() ?? "";
                 if (t.Length == 0) return (null, "a blank entry in formids= — pass FormID tokens (e.g. '0BCC84:Skyrim.esm').");
-                try { keys.Add(ParseFormId(t)); }
+                try { keys.Add(door.Parse(t)); }
                 catch (Exception ex) { return (null, $"bad FormID '{raw}' in formids=: {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '0BCC84:Skyrim.esm'."); }
             }
         }
@@ -4510,14 +4512,16 @@ public sealed class LoadOrderService : IDisposable
                 "target= is only meaningful with in_place=true (it names the plugin to edit in place). For the default patch lane omit target=; use into= to extend an existing houseCARL patch.");
 
         // Map every op to a core PatchEdit, collecting ALL parse problems first (all-or-nothing, like the cleave).
-        // Pure parsing — runs outside the write gate so a malformed call never queues behind a real write.
+        // Runs outside the write gate so a malformed call never queues behind a real write. A runtime FormID here
+        // resolves against the order as it stands at the call, the same way a read of one does.
         var edits = new List<WritePatchBuilder.PatchEdit>(ops.Count);
         var problems = new List<string>();
+        var editDoor = OpenFormIdDoor();
         for (int i = 0; i < ops.Count; i++)
         {
             // fromRecords[i] is the zip's per-op source record, carried parallel to the op list because the
             // published wire shape deliberately gains no new member.
-            var edit = MapEdit(ops[i], i, out var err,
+            var edit = MapEdit(editDoor, ops[i], i, out var err,
                 fromRecords is not null && i < fromRecords.Count ? fromRecords[i] : null,
                 opOrigins is not null && i < opOrigins.Count ? opOrigins[i] : null);
             if (err is not null) problems.Add(err); else edits.Add(edit!);
@@ -5421,11 +5425,12 @@ public sealed class LoadOrderService : IDisposable
         // Parse every formid first, collecting ALL problems (all-or-nothing, like the edit path). Pure — outside the gate.
         var keys = new List<FormKey>(formids.Count);
         var problems = new List<string>();
+        var door = OpenFormIdDoor();
         for (int i = 0; i < formids.Count; i++)
         {
             var raw = formids[i];
             if (string.IsNullOrWhiteSpace(raw)) { problems.Add($"formid[{i}]: empty."); continue; }
-            try { keys.Add(ParseFormId(raw)); }
+            try { keys.Add(door.Parse(raw)); }
             catch (Exception ex) { problems.Add($"formid[{i}] '{raw}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
         }
         if (problems.Count > 0)
@@ -5554,11 +5559,12 @@ public sealed class LoadOrderService : IDisposable
         var fp = fromPlugin.Trim();
         var specs = new List<WritePatchBuilder.ForwardSpec>(formids.Count);
         var problems = new List<string>();
+        var door = OpenFormIdDoor();
         for (int i = 0; i < formids.Count; i++)
         {
             var raw = formids[i];
             if (string.IsNullOrWhiteSpace(raw)) { problems.Add($"formid[{i}]: empty."); continue; }
-            try { specs.Add(new WritePatchBuilder.ForwardSpec { Target = ParseFormId(raw), FromPlugin = fp }); }
+            try { specs.Add(new WritePatchBuilder.ForwardSpec { Target = door.Parse(raw), FromPlugin = fp }); }
             catch (Exception ex) { problems.Add($"formid[{i}] '{raw}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
         }
         if (problems.Count > 0)
@@ -6423,7 +6429,7 @@ public sealed class LoadOrderService : IDisposable
     {
         // ---- argument shape: exactly one target mode ----
         FormKey donorFk;
-        try { donorFk = ParseFormId(sourceFormid); }
+        try { donorFk = OpenFormIdDoor().Parse(sourceFormid); }
         catch (Exception ex) { return NpcCopyOutcome.Fail($"bad source formid '{sourceFormid}': {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '000D62:Vivace.esp'."); }
 
         bool apply = !string.IsNullOrWhiteSpace(targetFormid);
@@ -6435,7 +6441,7 @@ public sealed class LoadOrderService : IDisposable
         FormKey targetFk = default;
         if (apply)
         {
-            try { targetFk = ParseFormId(targetFormid); }
+            try { targetFk = OpenFormIdDoor().Parse(targetFormid); }
             catch (Exception ex) { return NpcCopyOutcome.Fail($"bad target formid '{targetFormid}': {ex.Message}."); }
         }
 
@@ -7000,7 +7006,8 @@ public sealed class LoadOrderService : IDisposable
     /// field path, and build the composition <see cref="StructSpec"/> when present. RecordType is deliberately not
     /// taken from the wire — the engine derives it from the resolved winner. Returns null and a named error on any
     /// malformed input.</summary>
-    WritePatchBuilder.PatchEdit? MapEdit(BulkOp op, int index, out string? error, string? fromRecord = null, string? origin = null)
+    WritePatchBuilder.PatchEdit? MapEdit(FormIdDoor door, BulkOp op, int index, out string? error,
+                                         string? fromRecord = null, string? origin = null)
     {
         error = null;
         // The caller's own spelling for this edit: inline ops are op[i], while zip-generated ops are named by the
@@ -7009,7 +7016,7 @@ public sealed class LoadOrderService : IDisposable
         var where = origin ?? $"op[{index}]";
         if (string.IsNullOrWhiteSpace(op.Formid)) { error = $"{where}: formid is required."; return null; }
         FormKey fk;
-        try { fk = ParseFormId(op.Formid); }
+        try { fk = door.Parse(op.Formid); }
         catch (Exception ex) { error = $"{where}: bad formid '{op.Formid}' ({ex.Message}). Expected 'XXXXXX:Plugin.esp'."; return null; }
         if (string.IsNullOrWhiteSpace(op.FieldPath)) { error = $"{where} ({op.Formid}): field_path is required."; return null; }
         var path = SplitPath(op.FieldPath);
@@ -7033,7 +7040,7 @@ public sealed class LoadOrderService : IDisposable
         FormKey? fromKey = null;
         if (!string.IsNullOrWhiteSpace(fromRecord))
         {
-            try { fromKey = ParseFormId(fromRecord); }
+            try { fromKey = door.Parse(fromRecord); }
             catch (Exception ex) { error = $"{where} ({op.Formid}): bad from '{fromRecord}' ({ex.Message}). Expected 'XXXXXX:Plugin.esp'."; return null; }
             if (fromKey == fk)
             { error = $"{where} ({op.Formid}): from names the SAME record as formid — copying a record's field onto itself is a no-op. Drop from=, and name the plugin whose version to copy in from_source=."; return null; }
@@ -7999,7 +8006,7 @@ public sealed class LoadOrderService : IDisposable
         FormKey fk = default;
         if (hasFormid)
         {
-            try { fk = ParseFormId(formid); }
+            try { fk = OpenFormIdDoor().Parse(formid); }
             catch (Exception ex) { return PluginFileOutcome.Fail(plugin, $"bad FormID '{formid}': {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '000D62:Vivace.esp'."); }
         }
 
@@ -8473,8 +8480,9 @@ public sealed record ReadOutcome(
 
     /// <summary>The RUNTIME FormID of this record in the build that answered — the eight-hex form the game, the
     /// console, Papyrus logs and crash logs print. Rendered beside the FormKey so a reader can carry the record
-    /// either way. Null when the record's plugin is not active, which is the only way it has no runtime address.
-    /// Carried per outcome because the light index moves whenever the order does.</summary>
+    /// either way. Null when the order gives the record no runtime address — the read came from a plugin outside the
+    /// active order, or the tables could not be built (<see cref="LoadOrderResolver.IndexView.RuntimeFormIdOf"/> says
+    /// when). Carried per outcome because the light index moves whenever the order does.</summary>
     public string? RuntimeFormId { get; init; }
 
     /// <summary>The resolver and view this outcome was answered from, carried beside <see cref="Epoch"/> so the

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -3655,10 +3655,13 @@ public sealed class LoadOrderService : IDisposable
                                         bool conflictsOnly, IReadOnlyList<string>? plugins, IReadOnlyList<string>? where, int limit,
                                         bool definedIn = false, string? groupBy = null, int offset = 0, string? whereSource = null,
                                         IReadOnlyList<ArtifactDemand>? artifactDemands = null,
-                                        IReadOnlyList<FormKey>? formidSet = null)
+                                        IReadOnlyList<FormKey>? formidSet = null,
+                                        LoadOrderResolver.IndexView? pinnedView = null)
     {
         var resolver = Resolver;
-        var view = resolver.Capture();          // one build for the scan and every per-match fill it makes
+        // The caller's own build when its FormID door already captured one, so the tokens it parsed and the
+        // records this scan matches come from ONE build; otherwise one build for the scan and every fill it makes.
+        var view = pinnedView ?? resolver.Capture();
         bool hasPlugins = plugins is { Count: > 0 };
         bool hasType = typeSet is { Count: > 0 };
         bool hasWhere = where is { Count: > 0 };
@@ -4068,10 +4071,11 @@ public sealed class LoadOrderService : IDisposable
     public CrossQueryOutcome OffOrderQuery(PoleInfo pole, IReadOnlyList<string>? typeSet,
         IReadOnlyList<FormKey>? references, string? editoridContains, IReadOnlyList<string>? scopePlugins,
         bool definedIn, IReadOnlyList<string>? where, int limit, string? groupBy, int offset,
-        IReadOnlyList<FormKey>? formidSet, IReadOnlyList<ArtifactDemand>? artifactDemands)
+        IReadOnlyList<FormKey>? formidSet, IReadOnlyList<ArtifactDemand>? artifactDemands,
+        LoadOrderResolver.IndexView? pinnedView = null)
     {
         var resolver = Resolver;
-        var view = resolver.Capture();
+        var view = pinnedView ?? resolver.Capture();   // the caller's door build when it captured one — see CrossQuery
 
         if (groupBy is not null)
         {
@@ -6432,8 +6436,11 @@ public sealed class LoadOrderService : IDisposable
         string? patchName, string? into)
     {
         // ---- argument shape: exactly one target mode ----
+        // ONE door for both tokens: two doors would each capture their own build, and a re-sort between them
+        // would read the donor off one order and the target off another.
+        var door = OpenFormIdDoor();
         FormKey donorFk;
-        try { donorFk = OpenFormIdDoor().Parse(sourceFormid); }
+        try { donorFk = door.Parse(sourceFormid); }
         catch (Exception ex) { return NpcCopyOutcome.Fail($"bad source formid '{sourceFormid}': {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '000D62:Vivace.esp'."); }
 
         bool apply = !string.IsNullOrWhiteSpace(targetFormid);
@@ -6445,7 +6452,7 @@ public sealed class LoadOrderService : IDisposable
         FormKey targetFk = default;
         if (apply)
         {
-            try { targetFk = OpenFormIdDoor().Parse(targetFormid); }
+            try { targetFk = door.Parse(targetFormid); }
             catch (Exception ex) { return NpcCopyOutcome.Fail($"bad target formid '{targetFormid}': {ex.Message}."); }
         }
 

--- a/src/housecarl-mcp/PlaceAssetTools.cs
+++ b/src/housecarl-mcp/PlaceAssetTools.cs
@@ -68,7 +68,7 @@ public static class PlaceAssetTools
             string? into = null) => Guard.Tool(ToolNames.PlaceAsset, () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        var reqs = MapSpec(formid, kind, asset_path, source, source_provider, allowExpand: false, where: "", out var err);
+        var reqs = MapSpec(svc.ParseFormId, formid, kind, asset_path, source, source_provider, allowExpand: false, where: "", out var err);
         if (err is not null) return "error: " + err;
         return PlaceWire.Render(svc.PlaceAssets(reqs!, patch_name, into));
     });
@@ -110,7 +110,7 @@ public static class PlaceAssetTools
         for (int i = 0; i < assets.Length; i++)
         {
             var a = assets[i];
-            var reqs = MapSpec(a.Formid, a.Kind, a.AssetPath, a.Source, a.SourceProvider, allowExpand: true, where: $"assets[{i}]: ", out var err);
+            var reqs = MapSpec(svc.ParseFormId, a.Formid, a.Kind, a.AssetPath, a.Source, a.SourceProvider, allowExpand: true, where: $"assets[{i}]: ", out var err);
             if (err is not null) problems.Add(err); else all.AddRange(reqs!);
         }
         if (problems.Count > 0)
@@ -124,7 +124,7 @@ public static class PlaceAssetTools
     /// tool). Exactly one of formid/asset_path is required. A both-expansion forbids a single loose/entry source (it can't
     /// serve two different files) — only a FULLY-QUALIFIED '.bsa' source (entry derived per slot) or auto-resolve. Every
     /// bad input is a NAMED error returned via <paramref name="error"/>, never a silent skip.</summary>
-    static List<PlaceRequest>? MapSpec(string? formid, string? kind, string? assetPath, string? source, string? sourceProvider, bool allowExpand, string where, out string? error)
+    static List<PlaceRequest>? MapSpec(Func<string?, FormKey> parseFormId, string? formid, string? kind, string? assetPath, string? source, string? sourceProvider, bool allowExpand, string where, out string? error)
     {
         error = null;
         bool hasFormid = !string.IsNullOrWhiteSpace(formid);
@@ -138,7 +138,7 @@ public static class PlaceAssetTools
             return new List<PlaceRequest> { new(assetPath!.Trim(), src, prov) };
 
         FormKey fk;
-        try { fk = FormKey.Factory(formid!.Trim()); }
+        try { fk = parseFormId(formid); }
         catch (Exception ex) { error = $"{where}bad formid '{formid}' ({ex.Message}). Expected 'XXXXXX:Plugin.esp'."; return null; }
 
         var slot = ParseSlot(kind, out var slotErr);

--- a/src/housecarl-mcp/PlaceAssetTools.cs
+++ b/src/housecarl-mcp/PlaceAssetTools.cs
@@ -68,7 +68,7 @@ public static class PlaceAssetTools
             string? into = null) => Guard.Tool(ToolNames.PlaceAsset, () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        var reqs = MapSpec(svc.ParseFormId, formid, kind, asset_path, source, source_provider, allowExpand: false, where: "", out var err);
+        var reqs = MapSpec(svc.OpenFormIdDoor().Parse, formid, kind, asset_path, source, source_provider, allowExpand: false, where: "", out var err);
         if (err is not null) return "error: " + err;
         return PlaceWire.Render(svc.PlaceAssets(reqs!, patch_name, into));
     });
@@ -107,10 +107,11 @@ public static class PlaceAssetTools
         // (ambiguous/absent/unreadable source) are per-asset (the resolver isn't consulted until the place loop).
         var all = new List<PlaceRequest>();
         var problems = new List<string>();
+        var door = svc.OpenFormIdDoor();
         for (int i = 0; i < assets.Length; i++)
         {
             var a = assets[i];
-            var reqs = MapSpec(svc.ParseFormId, a.Formid, a.Kind, a.AssetPath, a.Source, a.SourceProvider, allowExpand: true, where: $"assets[{i}]: ", out var err);
+            var reqs = MapSpec(door.Parse, a.Formid, a.Kind, a.AssetPath, a.Source, a.SourceProvider, allowExpand: true, where: $"assets[{i}]: ", out var err);
             if (err is not null) problems.Add(err); else all.AddRange(reqs!);
         }
         if (problems.Count > 0)

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -301,6 +301,7 @@ static class Wire
                 if (m.Error is not null) sb.Append("  error=").Append(m.Error).Append('\n');
                 else
                 {
+                    AppendRuntime(sb, m.RuntimeFormId, m.RuntimeFormIdNote);
                     sb.Append("  type=").Append(m.Type).Append("  editorid=").Append(m.EditorId ?? "<none>")
                       .Append("  winner=").Append(m.Winner).Append("  override_depth=").Append(m.OverrideDepth);
                     if (matches is not null) sb.Append("  matches=").Append(matches);
@@ -918,6 +919,15 @@ static class Wire
 
     // ---- shared building blocks ---------------------------------------------------------------------
 
+    /// <summary>The runtime-FormID token every text lane prints beside a record's identity: the eight-hex form, or
+    /// the parenthetical sentence saying why there is none. Nothing when the order gives the record no runtime
+    /// address at all.</summary>
+    internal static void AppendRuntime(StringBuilder sb, string? runtime, string? note)
+    {
+        if (runtime is not null) sb.Append("  runtime=").Append(runtime);
+        else if (note is not null) sb.Append("  runtime=(").Append(note).Append(')');
+    }
+
     /// <summary><paramref name="notes"/> registers the owned-child clause as each annotated field line is written,
     /// so a field the cap truncates away earns nothing. Null on the lanes that render a record outside an
     /// annotated response, such as readback and verify.</summary>
@@ -930,7 +940,7 @@ static class Wire
         var r = o.Record!;
         sb.Append("type=").Append(r.Type)
           .Append("  formid=").Append(r.FormKey);
-        if (o.RuntimeFormId is { } runtime) sb.Append("  runtime=").Append(runtime);   // what the console and the logs print
+        AppendRuntime(sb, o.RuntimeFormId, o.RuntimeFormIdNote);   // what the console and the logs print, or why there is none
         sb.Append("  editorid=").Append(r.EditorId ?? "<none>")
           .Append("  winner=").Append(o.WinnerPlugin)
           .Append("  override_depth=").Append(o.OverrideDepth).Append('\n');

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -929,8 +929,9 @@ static class Wire
         var lv = levers ?? LeverNames.Legacy;
         var r = o.Record!;
         sb.Append("type=").Append(r.Type)
-          .Append("  formid=").Append(r.FormKey)
-          .Append("  editorid=").Append(r.EditorId ?? "<none>")
+          .Append("  formid=").Append(r.FormKey);
+        if (o.RuntimeFormId is { } runtime) sb.Append("  runtime=").Append(runtime);   // what the console and the logs print
+        sb.Append("  editorid=").Append(r.EditorId ?? "<none>")
           .Append("  winner=").Append(o.WinnerPlugin)
           .Append("  override_depth=").Append(o.OverrideDepth).Append('\n');
         sb.Append("fields (from ").Append(o.SourcePlugin).Append("):\n");

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -1925,7 +1925,7 @@ public static class RecordsTools
             else
             {
                 sb.Append(o.FormKey);
-                if (o.RuntimeFormId is { } runtime) sb.Append("  runtime=").Append(runtime);
+                Wire.AppendRuntime(sb, o.RuntimeFormId, o.RuntimeFormIdNote);
                 sb.Append("  ").Append(o.Record!.Type)
                   .Append("  ").Append(o.Record.EditorId ?? "<no editorid>")
                   .Append("  source=").Append(o.SourcePlugin ?? "?");

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -84,7 +84,11 @@ public static class RecordsTools
      Description(
          "Read Bethesda records from the load order — ONE read surface: which records (SELECT) x whose version " +
          "(SOURCE) x what shape of answer (PROJECT) compose in a single call.\n\n" +
-         "A FormID is 'XXXXXX:Plugin.esp' — 6 hex digits, a colon, the defining master's filename. Every " +
+         "A FormID is 'XXXXXX:Plugin.esp' — 6 hex digits, a colon, the defining master's filename. The RUNTIME " +
+         "form the game, the console, Papyrus logs, SKSE logs and crash logs print is accepted too: eight hex " +
+         "digits and no plugin name, 'FExxxYYY' for a light plugin or 'XX######' for a full one, with or without " +
+         "a leading 0x, resolved against the CURRENT load order — the response names the plugin it resolved to, " +
+         "and prints each record's runtime FormID beside its own. Every " +
          "list-valued parameter is set-valued (one item is a set of one), and formids=/references= accept a single " +
          "\"@<absolute path>\" element to read the list from a file — including a spilled result artifact from an " +
          "earlier call (its identity column becomes the list, epoch-checked against the then-current build).\n\n" +
@@ -141,7 +145,7 @@ public static class RecordsTools
          ToolNames.Remove + " / " + ToolNames.Forward + ").")]
     public static string Records(
         LoadOrderService svc,
-        [Description("SELECT: records by FormID ('XXXXXX:Plugin.esp'), or [\"@<absolute path>\"] to read the list from a file / spilled artifact. Results return in input order; a bad or absent FormID is a per-item error, never a failed batch.")]
+        [Description("SELECT: records by FormID ('XXXXXX:Plugin.esp', or the runtime form a log or the console prints — 'FExxxYYY' / 'XX######'), or [\"@<absolute path>\"] to read the list from a file / spilled artifact. Results return in input order; a bad or absent FormID is a per-item error, never a failed batch.")]
             string[]? formids = null,
         [Description("SELECT: record types — signatures ('WEAP') or catalog names ('Weapon'); the scan streams the UNION. types alone enumerates every record of those types in whatever the SOURCE names.")]
             string[]? types = null,

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -1912,7 +1912,9 @@ public static class RecordsTools
             if (o.Error is not null) sb.Append(o.FormKey).Append("  error=").Append(o.Error).Append('\n');
             else
             {
-                sb.Append(o.FormKey).Append("  ").Append(o.Record!.Type)
+                sb.Append(o.FormKey);
+                if (o.RuntimeFormId is { } runtime) sb.Append("  runtime=").Append(runtime);
+                sb.Append("  ").Append(o.Record!.Type)
                   .Append("  ").Append(o.Record.EditorId ?? "<no editorid>")
                   .Append("  source=").Append(o.SourcePlugin ?? "?");
                 if (o.WinnerPlugin is not null) sb.Append("  winner=").Append(o.WinnerPlugin).Append("  depth=").Append(o.OverrideDepth);

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -193,6 +193,11 @@ public static class RecordsTools
         bool json = fmt is Wire.QueryFormat.Json;
         bool dense = fmt is Wire.QueryFormat.Dense;
 
+        // ONE FormID door for the whole call, shared by every lane below: formids=, references= and the walk seeds
+        // all resolve against one index build, and the scan then runs on that same build. A door per list would let
+        // a freshness rebuild land between two lists, so a call's own tokens could name records in different orders.
+        var door = svc.OpenFormIdDoor();
+
         // ---- PROJECT: form + form-scoping ---------------------------------------------------------------
         var form = project?.form?.Trim().ToLowerInvariant() ?? "summary";
         switch (form)
@@ -616,11 +621,10 @@ public static class RecordsTools
                 // The typed MGEF lane: each seed must resolve to a MagicEffect, and a non-MGEF seed fails loud
                 // per item rather than reading as '0 carriers'.
                 var results = new List<(string Seed, EffectChainResult Result)>(ids.Length);
-                var seedDoor = svc.OpenFormIdDoor();
                 foreach (var raw in ids)
                 {
                     FormKey fk;
-                    try { fk = seedDoor.Parse(raw); }
+                    try { fk = door.Parse(raw); }
                     catch (Exception ex) { results.Add((raw?.Trim() ?? "", EffectChainResult.Fail($"bad FormID '{raw}': {ex.Message}"))); continue; }
                     // The per-seed carrier bound is the walk's own reach budget; limit=/offset= stay the SEED
                     // window, never a second silent cut on the carrier axis.
@@ -950,11 +954,10 @@ public static class RecordsTools
                 if (fxerr is not null) return Wire.Refuse(json, fxerr);
                 fidDemand = fdemand; fidEcho = fecho;
                 var fkList = new List<FormKey>();
-                var fidDoor = svc.OpenFormIdDoor();
                 foreach (var t in ftoks!)
                 {
                     if (string.IsNullOrWhiteSpace(t)) continue;
-                    try { fkList.Add(fidDoor.Parse(t)); }
+                    try { fkList.Add(door.Parse(t)); }
                     catch (Exception ex) { return Wire.Refuse(json, $"error: bad formids entry '{t}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
                 }
                 if (fkList.Count == 0) return Wire.Refuse(json, "error: formids= expanded to an empty list — nothing to intersect the scan with.");
@@ -1009,11 +1012,10 @@ public static class RecordsTools
             if (refs is { Length: > 0 })
             {
                 var list = new List<FormKey>();
-                var refDoor = svc.OpenFormIdDoor();
                 foreach (var r in refs)
                 {
                     if (string.IsNullOrWhiteSpace(r)) continue;
-                    try { list.Add(refDoor.Parse(r)); }
+                    try { list.Add(door.Parse(r)); }
                     catch (Exception ex) { return Wire.Refuse(json, $"error: bad references FormID '{r}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
                 }
                 if (list.Count > 0) refFks = list.Distinct().ToList();
@@ -1035,7 +1037,7 @@ public static class RecordsTools
             if (fidDemand is not null) demandsList.Add(fidDemand);
             var outcome = svc.CrossQuery(types, refFks, null, conflicts_only, scanPlugins, where,
                                          effLimit, definedIn, groupBy, offset, where_source,
-                                         demandsList.Count > 0 ? demandsList : null, formidSet);
+                                         demandsList.Count > 0 ? demandsList : null, formidSet, door.CapturedView);
             // The probe-to-scan seam is epoch-compared: the source statement must describe the same build the
             // rows were scanned from.
             if (probeEpoch is not null && outcome.Error is null && outcome.Epoch is not null && outcome.Epoch != probeEpoch)
@@ -1308,11 +1310,10 @@ public static class RecordsTools
             if (refs is { Length: > 0 })
             {
                 var list = new List<FormKey>();
-                var refDoor = svc.OpenFormIdDoor();
                 foreach (var r in refs)
                 {
                     if (string.IsNullOrWhiteSpace(r)) continue;
-                    try { list.Add(refDoor.Parse(r)); }
+                    try { list.Add(door.Parse(r)); }
                     catch (Exception ex) { return Wire.Refuse(json, $"error: bad references FormID '{r}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
                 }
                 if (list.Count > 0) refFks = list.Distinct().ToList();
@@ -1325,11 +1326,10 @@ public static class RecordsTools
                 if (fxerr is not null) return Wire.Refuse(json, fxerr);
                 fidDemand = fdemand; fidEcho = fecho;
                 var fkList = new List<FormKey>();
-                var fidDoor = svc.OpenFormIdDoor();
                 foreach (var t in ftoks!)
                 {
                     if (string.IsNullOrWhiteSpace(t)) continue;
-                    try { fkList.Add(fidDoor.Parse(t)); }
+                    try { fkList.Add(door.Parse(t)); }
                     catch (Exception ex) { return Wire.Refuse(json, $"error: bad formids entry '{t}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
                 }
                 if (fkList.Count == 0) return Wire.Refuse(json, "error: formids= expanded to an empty list — nothing to intersect the scan with.");
@@ -1344,7 +1344,7 @@ public static class RecordsTools
 
             var outcome = svc.OffOrderQuery(pole, types, refFks, null, plugins?.names,
                                             plugins?.defined_in ?? false, where, offLimit, offGroupBy, offset,
-                                            formidSet, offDemands.Count > 0 ? offDemands : null);
+                                            formidSet, offDemands.Count > 0 ? offDemands : null, door.CapturedView);
 
             List<KeyValuePair<string, string>> Echo()
             {

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -88,7 +88,10 @@ public static class RecordsTools
          "form the game, the console, Papyrus logs, SKSE logs and crash logs print is accepted too: eight hex " +
          "digits and no plugin name, 'FExxxYYY' for a light plugin or 'XX######' for a full one, with or without " +
          "a leading 0x, resolved against the CURRENT load order — the response names the plugin it resolved to, " +
-         "and prints each record's runtime FormID beside its own. Every " +
+         "and prints each record's runtime FormID beside its own. It is taken wherever a parameter holds nothing " +
+         "but FormIDs (formids=, references=, walk seeds, and a where= 'formid in [...]' list); a where= operand " +
+         "compared against a field also holds numbers and enum names, so it takes the plugin-qualified form only. " +
+         "Every " +
          "list-valued parameter is set-valued (one item is a set of one), and formids=/references= accept a single " +
          "\"@<absolute path>\" element to read the list from a file — including a spilled result artifact from an " +
          "earlier call (its identity column becomes the list, epoch-checked against the then-current build).\n\n" +
@@ -613,10 +616,11 @@ public static class RecordsTools
                 // The typed MGEF lane: each seed must resolve to a MagicEffect, and a non-MGEF seed fails loud
                 // per item rather than reading as '0 carriers'.
                 var results = new List<(string Seed, EffectChainResult Result)>(ids.Length);
+                var seedDoor = svc.OpenFormIdDoor();
                 foreach (var raw in ids)
                 {
                     FormKey fk;
-                    try { fk = svc.ParseFormId(raw); }
+                    try { fk = seedDoor.Parse(raw); }
                     catch (Exception ex) { results.Add((raw?.Trim() ?? "", EffectChainResult.Fail($"bad FormID '{raw}': {ex.Message}"))); continue; }
                     // The per-seed carrier bound is the walk's own reach budget; limit=/offset= stay the SEED
                     // window, never a second silent cut on the carrier axis.
@@ -946,10 +950,11 @@ public static class RecordsTools
                 if (fxerr is not null) return Wire.Refuse(json, fxerr);
                 fidDemand = fdemand; fidEcho = fecho;
                 var fkList = new List<FormKey>();
+                var fidDoor = svc.OpenFormIdDoor();
                 foreach (var t in ftoks!)
                 {
                     if (string.IsNullOrWhiteSpace(t)) continue;
-                    try { fkList.Add(svc.ParseFormId(t)); }
+                    try { fkList.Add(fidDoor.Parse(t)); }
                     catch (Exception ex) { return Wire.Refuse(json, $"error: bad formids entry '{t}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
                 }
                 if (fkList.Count == 0) return Wire.Refuse(json, "error: formids= expanded to an empty list — nothing to intersect the scan with.");
@@ -1004,10 +1009,11 @@ public static class RecordsTools
             if (refs is { Length: > 0 })
             {
                 var list = new List<FormKey>();
+                var refDoor = svc.OpenFormIdDoor();
                 foreach (var r in refs)
                 {
                     if (string.IsNullOrWhiteSpace(r)) continue;
-                    try { list.Add(svc.ParseFormId(r)); }
+                    try { list.Add(refDoor.Parse(r)); }
                     catch (Exception ex) { return Wire.Refuse(json, $"error: bad references FormID '{r}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
                 }
                 if (list.Count > 0) refFks = list.Distinct().ToList();
@@ -1302,10 +1308,11 @@ public static class RecordsTools
             if (refs is { Length: > 0 })
             {
                 var list = new List<FormKey>();
+                var refDoor = svc.OpenFormIdDoor();
                 foreach (var r in refs)
                 {
                     if (string.IsNullOrWhiteSpace(r)) continue;
-                    try { list.Add(svc.ParseFormId(r)); }
+                    try { list.Add(refDoor.Parse(r)); }
                     catch (Exception ex) { return Wire.Refuse(json, $"error: bad references FormID '{r}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
                 }
                 if (list.Count > 0) refFks = list.Distinct().ToList();
@@ -1318,10 +1325,11 @@ public static class RecordsTools
                 if (fxerr is not null) return Wire.Refuse(json, fxerr);
                 fidDemand = fdemand; fidEcho = fecho;
                 var fkList = new List<FormKey>();
+                var fidDoor = svc.OpenFormIdDoor();
                 foreach (var t in ftoks!)
                 {
                     if (string.IsNullOrWhiteSpace(t)) continue;
-                    try { fkList.Add(svc.ParseFormId(t)); }
+                    try { fkList.Add(fidDoor.Parse(t)); }
                     catch (Exception ex) { return Wire.Refuse(json, $"error: bad formids entry '{t}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
                 }
                 if (fkList.Count == 0) return Wire.Refuse(json, "error: formids= expanded to an empty list — nothing to intersect the scan with.");

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -612,7 +612,7 @@ public static class RecordsTools
                 foreach (var raw in ids)
                 {
                     FormKey fk;
-                    try { fk = FormKey.Factory(raw.Trim()); }
+                    try { fk = svc.ParseFormId(raw); }
                     catch (Exception ex) { results.Add((raw?.Trim() ?? "", EffectChainResult.Fail($"bad FormID '{raw}': {ex.Message}"))); continue; }
                     // The per-seed carrier bound is the walk's own reach budget; limit=/offset= stay the SEED
                     // window, never a second silent cut on the carrier axis.
@@ -945,7 +945,7 @@ public static class RecordsTools
                 foreach (var t in ftoks!)
                 {
                     if (string.IsNullOrWhiteSpace(t)) continue;
-                    try { fkList.Add(FormKey.Factory(t.Trim())); }
+                    try { fkList.Add(svc.ParseFormId(t)); }
                     catch (Exception ex) { return Wire.Refuse(json, $"error: bad formids entry '{t}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
                 }
                 if (fkList.Count == 0) return Wire.Refuse(json, "error: formids= expanded to an empty list — nothing to intersect the scan with.");
@@ -1003,7 +1003,7 @@ public static class RecordsTools
                 foreach (var r in refs)
                 {
                     if (string.IsNullOrWhiteSpace(r)) continue;
-                    try { list.Add(FormKey.Factory(r.Trim())); }
+                    try { list.Add(svc.ParseFormId(r)); }
                     catch (Exception ex) { return Wire.Refuse(json, $"error: bad references FormID '{r}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
                 }
                 if (list.Count > 0) refFks = list.Distinct().ToList();
@@ -1301,7 +1301,7 @@ public static class RecordsTools
                 foreach (var r in refs)
                 {
                     if (string.IsNullOrWhiteSpace(r)) continue;
-                    try { list.Add(FormKey.Factory(r.Trim())); }
+                    try { list.Add(svc.ParseFormId(r)); }
                     catch (Exception ex) { return Wire.Refuse(json, $"error: bad references FormID '{r}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
                 }
                 if (list.Count > 0) refFks = list.Distinct().ToList();
@@ -1317,7 +1317,7 @@ public static class RecordsTools
                 foreach (var t in ftoks!)
                 {
                     if (string.IsNullOrWhiteSpace(t)) continue;
-                    try { fkList.Add(FormKey.Factory(t.Trim())); }
+                    try { fkList.Add(svc.ParseFormId(t)); }
                     catch (Exception ex) { return Wire.Refuse(json, $"error: bad formids entry '{t}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
                 }
                 if (fkList.Count == 0) return Wire.Refuse(json, "error: formids= expanded to an empty list — nothing to intersect the scan with.");


### PR DESCRIPTION
houseCARL now takes the FormID the game itself uses. A modder reading a crash log, a Papyrus log, an SKSE log or the in-game console has eight hex digits and no plugin name — `FExxxYYY` for a light plugin, `XX######` for a full one — and until now had to translate that by hand before they could ask about the record. Every parameter that holds nothing but FormIDs accepts that form, resolved against the load order as it stands at the call: the resolver builds the light and full runtime index tables from the order's own plugin kinds, so nothing is cached and the light index moves when the order does. The `XXXXXX:Plugin.esp` form is unchanged and stays the way to read a plugin that is not active.

It comes back out too. Every rendered record carries its runtime FormID beside its FormKey — `runtime=` in the text lanes, `runtime_formid` in json, in the scan's dense columns and in spilled artifacts — so a record found here can be carried straight to the console or xEdit. An index no active plugin occupies is refused by name, an `FF` dynamic form is refused as belonging to no plugin, and a plugin whose kind could not be read blocks only the slots at or after its own position.

Two cases where the honest answer is not an eight-hex form:

- **A light-flagged plugin that was never compacted.** Its record at `0x001801` masks into the same runtime form as its neighbour at `0x000801`, and reading that form back returns the other record. Those records get one sentence saying the plugin is above the ESL window and to address it by plugin, rather than a form that lies.
- **A plugin outside the active order.** No runtime address exists, and none is printed.

One `FormIdDoor` per call parses every token in that call: it answers the plugin-qualified form without touching the load order at all, reaches for the index only when a runtime FormID actually arrives, and then once — so a call's own tokens cannot resolve against two adjacent index builds. The records tool hands that build to the scan it then runs, so the tokens it parsed and the records it matches come from one build.

All numeric FormID window facts — the ESL window, the index-byte mask, the light and full index shifts, the dynamic prefix — live in `FormIdRange`, and the resolver's local-id split goes through `FormIdRange.LocalObjectId` rather than restating the hex.

Verification:

```
dotnet build housecarl.sln -c Release                                    0 errors, 89 warnings (unchanged)
dotnet test src/housecarl-mcp-tests -c Release --no-build \
    --filter "tier!=bridge"                                             1029 passed, 0 failed
dotnet src/housecarl-generator/bin/Release/net9.0/housecarl-generator.dll ci-all
                                                                        128/128 passed
```

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)
