### PR TITLE
records: read the named mod folder's copy under a {file, mod} source pole

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -18,6 +18,10 @@ saying it sets an expectation their install may contradict. Say what is known, a
   and MO2 serves one of them; naming a folder addresses that folder's file. When the named copy is not the one the
   game loads, the response says so and names the mod folder that provides the served copy. A folder that does not
   carry the filename is refused as before, and the plain-filename and direct-path forms are unchanged.
+  Two copies of one filename can now sit on opposite sides of a comparison, so: `form=tree` treats a provider node
+  as the reference only when the reference resolved in the load order, and both renders name the off-order side's
+  mod folder on the delta line when the two sides share a filename. A `versus="previous_provider"` against an
+  off-order `source=` is refused once for the call, before any record is read, instead of once per record.
 
 - **A FormID from the game, a log or a crash log now works as an input, and comes back as an output.**
   Wherever a parameter holds nothing but FormIDs, houseCARL now also takes the runtime form the game, the

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **`housecarl_records` with `source={"file", "mod"}` now reads the copy in the named mod folder, even when that
+  filename is active in the load order.** Several mod folders can ship the same plugin filename (an ESP replacer),
+  and MO2 serves one of them; naming a folder addresses that folder's file. When the named copy is not the one the
+  game loads, the response says so and names the mod folder that provides the served copy. A folder that does not
+  carry the filename is refused as before, and the plain-filename and direct-path forms are unchanged.
+
 - **A FormID from the game, a log or a crash log now works as an input, and comes back as an output.**
   Wherever a parameter holds nothing but FormIDs, houseCARL now also takes the runtime form the game, the
   console, Papyrus logs, SKSE logs and crash logs print: eight hex digits and no plugin name — `FExxxYYY` for a light plugin,

--- a/src/housecarl-mcp-tests/RecordsPluginFileSourceTests.cs
+++ b/src/housecarl-mcp-tests/RecordsPluginFileSourceTests.cs
@@ -191,3 +191,127 @@ public sealed class RecordsExcludedPluginSourceTests : IClassFixture<ExcludedPlu
         Assert.Contains("winner=" + _w.CleanName, r);
     }
 }
+
+/// <summary>Two ENABLED mod folders shipping the same plugin filename, the higher-priority one served into the
+/// active order — the ESP-replacer shape the {file, mod} source form exists for. The one weapon's Damage differs
+/// per copy, so which physical file was read is visible in the answer.</summary>
+public sealed class ShadowedCopyWorld : IDisposable
+{
+    public string Root { get; }
+    public LoadOrderService Svc { get; }
+    /// <summary>The one filename both mod folders provide.</summary>
+    public string FileName { get; }
+    public string WinnerMod => "SWinner";
+    public string LoserMod => "SLoser";
+    /// <summary>Damage in the served copy / in the shadowed copy.</summary>
+    public const int WinnerDamage = 99;
+    public const int LoserDamage = 44;
+    public string SubjectFid { get; }
+
+    public ShadowedCopyWorld()
+    {
+        Root = Path.Combine(Path.GetTempPath(), "hc-shadowed-copy-tests-" + Guid.NewGuid().ToString("N"));
+        var instance = Path.Combine(Root, "instance");
+        var profiles = Path.Combine(instance, "profiles", "Default");
+        var mods = Path.Combine(instance, "mods");
+        foreach (var d in new[] { profiles, mods, Path.Combine(Root, "game", "Data") }) Directory.CreateDirectory(d);
+        File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(Root, "game").Replace(@"\", @"\\") + ")\r\n");
+
+        var mKey = new ModKey("HcSMaster", ModType.Master);
+        var rKey = new ModKey("HcSReplacer", ModType.Plugin);
+        FileName = rKey.FileName.String;
+
+        string P(string folder, ModKey k)
+        {
+            var p = Path.Combine(mods, folder, k.FileName.String);
+            Directory.CreateDirectory(Path.GetDirectoryName(p)!);
+            return p;
+        }
+
+        var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
+        var subject = m.Weapons.AddNew();
+        subject.EditorID = "SSubject";
+        subject.BasicStats = new WeaponBasicStats { Damage = 10 };
+        SubjectFid = $"{subject.FormKey.ID:X6}:{mKey.FileName}";
+        m.BeginWrite.ToPath(P("SMaster", mKey)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+        foreach (var (folder, damage) in new[] { (WinnerMod, WinnerDamage), (LoserMod, LoserDamage) })
+        {
+            var r = new SkyrimMod(rKey, SkyrimRelease.SkyrimSE);
+            ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(r, subject)).BasicStats = new WeaponBasicStats { Damage = (ushort)damage };
+            r.BeginWrite.ToPath(P(folder, rKey)).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
+        }
+
+        File.WriteAllText(Path.Combine(profiles, "loadorder.txt"),
+            "# header\r\n" + mKey.FileName + "\r\n" + rKey.FileName + "\r\n");
+        File.WriteAllText(Path.Combine(profiles, "plugins.txt"),
+            "*" + mKey.FileName + "\r\n*" + rKey.FileName + "\r\n");
+        // modlist.txt is TOP = highest priority, so SWinner provides the copy MO2 serves.
+        File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+SWinner\r\n+SLoser\r\n+SMaster\r\n");
+
+        Svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(Root, "houseCARL.user.json")));
+        Svc.Stats();
+    }
+
+    public void Dispose()
+    {
+        Svc.Dispose();
+        try { Directory.Delete(Root, true); } catch { /* temp cleanup best-effort */ }
+    }
+}
+
+public sealed class ShadowedCopyFixture : IDisposable
+{
+    public ShadowedCopyWorld W { get; } = new();
+    public void Dispose() => W.Dispose();
+}
+
+/// <summary>The {file, mod} source form against a filename that IS active: it addresses the named folder's copy,
+/// which is the only reason the form exists.</summary>
+[Trait("tier", "integration")]
+public sealed class RecordsModFolderSourceTests : IClassFixture<ShadowedCopyFixture>
+{
+    readonly ShadowedCopyWorld _w;
+    public RecordsModFolderSourceTests(ShadowedCopyFixture f) => _w = f.W;
+
+    string Read(string mod) =>
+        RecordsTools.Records(_w.Svc, formids: new[] { _w.SubjectFid },
+                             source: JsonDocument.Parse("{\"file\": \"" + _w.FileName + "\", \"mod\": \"" + mod + "\"}").RootElement.Clone(),
+                             project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage" } });
+
+    [Fact]
+    public void NamingTheShadowedModReadsThatFoldersCopy()
+    {
+        var r = Read(_w.LoserMod);
+        Assert.False(r.StartsWith("error:", StringComparison.Ordinal), r);
+        Assert.Contains("BasicStats.Damage = " + ShadowedCopyWorld.LoserDamage, r);
+    }
+
+    [Fact]
+    public void NamingTheShadowedModSaysItIsNotTheActiveCopyAndWhichModIsActive()
+    {
+        var r = Read(_w.LoserMod);
+        Assert.Contains("OUT-OF-LOAD-ORDER", r);
+        Assert.Contains("SHADOWED", r);
+        Assert.Contains("'" + _w.WinnerMod + "'", r);
+    }
+
+    [Fact]
+    public void NamingTheServingModReadsTheActiveCopyOnTheActiveArm()
+    {
+        var r = Read(_w.WinnerMod);
+        Assert.False(r.StartsWith("error:", StringComparison.Ordinal), r);
+        Assert.Contains("BasicStats.Damage = " + ShadowedCopyWorld.WinnerDamage, r);
+        Assert.Contains("active in the load order", r);
+    }
+
+    [Fact]
+    public void AModFolderThatDoesNotCarryTheFilenameIsStillRefused()
+    {
+        var r = Read("SMaster");
+        Assert.StartsWith("error:", r);
+        Assert.Contains("does not provide", r);
+    }
+}

--- a/src/housecarl-mcp-tests/RecordsPluginFileSourceTests.cs
+++ b/src/housecarl-mcp-tests/RecordsPluginFileSourceTests.cs
@@ -207,6 +207,8 @@ public sealed class ShadowedCopyWorld : IDisposable
     public const int WinnerDamage = 99;
     public const int LoserDamage = 44;
     public string SubjectFid { get; }
+    /// <summary>The full path to one mod folder's copy.</summary>
+    public string PathIn(string mod) => Path.Combine(Root, "instance", "mods", mod, FileName);
 
     public ShadowedCopyWorld()
     {
@@ -313,5 +315,30 @@ public sealed class RecordsModFolderSourceTests : IClassFixture<ShadowedCopyFixt
         var r = Read("SMaster");
         Assert.StartsWith("error:", r);
         Assert.Contains("does not provide", r);
+    }
+
+    /// <summary>A file= that is a PATH addresses that file, and a mod= beside it does not redirect the read to
+    /// another folder's copy of the same filename.</summary>
+    [Fact]
+    public void APathFileWinsOverAModFolderBesideIt()
+    {
+        var r = RecordsTools.Records(_w.Svc, formids: new[] { _w.SubjectFid },
+                                     source: JsonDocument.Parse(JsonSerializer.Serialize(new { file = _w.PathIn(_w.WinnerMod), mod = _w.LoserMod })).RootElement.Clone(),
+                                     project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage" } });
+        Assert.False(r.StartsWith("error:", StringComparison.Ordinal), r);
+        Assert.Contains("BasicStats.Damage = " + ShadowedCopyWorld.WinnerDamage, r);
+    }
+
+    /// <summary>previous_provider is a position in the ACTIVE touching stack, which an off-order copy does not
+    /// hold — even when its filename is active as a different file. Refused, never anchored on the served copy.
+    /// </summary>
+    [Fact]
+    public void PreviousProviderAgainstTheShadowedCopyIsRefusedRatherThanAnchoredOnTheServedCopy()
+    {
+        var r = RecordsTools.Records(_w.Svc, formids: new[] { _w.SubjectFid },
+                                     source: JsonDocument.Parse("{\"file\": \"" + _w.FileName + "\", \"mod\": \"" + _w.LoserMod + "\"}").RootElement.Clone(),
+                                     versus: JsonDocument.Parse("\"previous_provider\"").RootElement.Clone(),
+                                     project: new RecordsTools.RecordsProject { form = "delta" });
+        Assert.Contains("no position in the active touching stack", r);
     }
 }

--- a/src/housecarl-mcp-tests/RecordsPluginFileSourceTests.cs
+++ b/src/housecarl-mcp-tests/RecordsPluginFileSourceTests.cs
@@ -207,6 +207,8 @@ public sealed class ShadowedCopyWorld : IDisposable
     public const int WinnerDamage = 99;
     public const int LoserDamage = 44;
     public string SubjectFid { get; }
+    /// <summary>A second record both copies override, so a batch has more than one row to refuse.</summary>
+    public string SecondFid { get; }
     /// <summary>The full path to one mod folder's copy.</summary>
     public string PathIn(string mod) => Path.Combine(Root, "instance", "mods", mod, FileName);
 
@@ -237,12 +239,17 @@ public sealed class ShadowedCopyWorld : IDisposable
         subject.EditorID = "SSubject";
         subject.BasicStats = new WeaponBasicStats { Damage = 10 };
         SubjectFid = $"{subject.FormKey.ID:X6}:{mKey.FileName}";
+        var second = m.Weapons.AddNew();
+        second.EditorID = "SSecond";
+        second.BasicStats = new WeaponBasicStats { Damage = 10 };
+        SecondFid = $"{second.FormKey.ID:X6}:{mKey.FileName}";
         m.BeginWrite.ToPath(P("SMaster", mKey)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
 
         foreach (var (folder, damage) in new[] { (WinnerMod, WinnerDamage), (LoserMod, LoserDamage) })
         {
             var r = new SkyrimMod(rKey, SkyrimRelease.SkyrimSE);
-            ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(r, subject)).BasicStats = new WeaponBasicStats { Damage = (ushort)damage };
+            foreach (var src in new[] { subject, second })
+                ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(r, src)).BasicStats = new WeaponBasicStats { Damage = (ushort)damage };
             r.BeginWrite.ToPath(P(folder, rKey)).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
         }
 
@@ -340,5 +347,49 @@ public sealed class RecordsModFolderSourceTests : IClassFixture<ShadowedCopyFixt
                                      versus: JsonDocument.Parse("\"previous_provider\"").RootElement.Clone(),
                                      project: new RecordsTools.RecordsProject { form = "delta" });
         Assert.Contains("no position in the active touching stack", r);
+    }
+
+    /// <summary>The previous_provider refusal is uniform for the whole call — the subject's arm decides it — so a
+    /// batch is refused ONCE, before any record is read, rather than per row.</summary>
+    [Fact]
+    public void PreviousProviderAgainstAnOffOrderSubjectIsRefusedOncePerCallNotOncePerRecord()
+    {
+        var r = RecordsTools.Records(_w.Svc, formids: new[] { _w.SubjectFid, _w.SecondFid },
+                                     source: JsonDocument.Parse("{\"file\": \"" + _w.FileName + "\", \"mod\": \"" + _w.LoserMod + "\"}").RootElement.Clone(),
+                                     versus: JsonDocument.Parse("\"previous_provider\"").RootElement.Clone(),
+                                     project: new RecordsTools.RecordsProject { form = "delta" });
+        Assert.StartsWith("error:", r);
+        Assert.Equal(1, Occurrences(r, "no position in the active touching stack"));
+    }
+
+    /// <summary>The tree form's reference is an off-order copy whose FILENAME is also active. The active copy is a
+    /// different file, so it is a provider node with a real delta, never the reference itself.</summary>
+    [Fact]
+    public void ATreeAgainstTheShadowedCopyShowsTheActiveCopysDeltaRatherThanCallingItTheReference()
+    {
+        var r = RecordsTools.Records(_w.Svc, formids: new[] { _w.SubjectFid },
+                                     versus: JsonDocument.Parse("{\"file\": \"" + _w.FileName + "\", \"mod\": \"" + _w.LoserMod + "\"}").RootElement.Clone(),
+                                     project: new RecordsTools.RecordsProject { form = "tree" });
+        Assert.Contains("BasicStats.Damage=" + ShadowedCopyWorld.WinnerDamage, r);
+    }
+
+    /// <summary>Two copies of one filename on opposite arms: the delta line itself says which side is which,
+    /// without leaning on the pole lines above it.</summary>
+    [Fact]
+    public void ADeltaBetweenTwoCopiesOfOneFilenameQualifiesTheOffOrderSideOnTheDeltaLine()
+    {
+        var r = RecordsTools.Records(_w.Svc, formids: new[] { _w.SubjectFid },
+                                     source: JsonDocument.Parse("\"" + _w.FileName + "\"").RootElement.Clone(),
+                                     versus: JsonDocument.Parse("{\"file\": \"" + _w.FileName + "\", \"mod\": \"" + _w.LoserMod + "\"}").RootElement.Clone(),
+                                     project: new RecordsTools.RecordsProject { form = "delta" });
+        var line = Assert.Single(r.Split('\n'), l => l.Contains("- BasicStats.Damage=", StringComparison.Ordinal));
+        Assert.Contains(_w.LoserMod, line);
+    }
+
+    static int Occurrences(string haystack, string needle)
+    {
+        int n = 0, i = 0;
+        while ((i = haystack.IndexOf(needle, i, StringComparison.Ordinal)) >= 0) { n++; i += needle.Length; }
+        return n;
     }
 }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2583,31 +2583,45 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>Resolve a `records` source= pole against ONE captured view: active in the order, else located on disk
     /// across the whole install. A non-null error means it was found in neither place (naming both), or is ambiguous
-    /// across mod folders (naming them and the {file, mod} disambiguator).</summary>
+    /// across mod folders (naming them and the {file, mod} disambiguator).
+    /// <para>The {file, mod} form addresses ONE on-disk copy, which is the whole reason it exists: several mod
+    /// folders ship the same filename and MO2 serves one. So it does NOT short-circuit to the active copy of the
+    /// filename — the locate runs first, and the named copy resolves to the active arm only when it IS the copy the
+    /// game loads. A plain filename and a direct path are unchanged.</para></summary>
     (PoleInfo? Pole, string? Error) ResolvePoleArm(LoadOrderResolver.IndexView view, string plugin, string? mod)
     {
         // A pole addressed by path that IS the active order's file resolves back to its plugin name.
         if (LooksLikePath(plugin) && ActiveNameForPath(view, plugin) is { } activeName) plugin = activeName;
 
-        if (view.ContainsPlugin(plugin))
+        bool namesMod = !string.IsNullOrWhiteSpace(mod) && !LooksLikePath(plugin);
+        bool activeFilename = view.ContainsPlugin(plugin);
+        if (!namesMod && activeFilename)
             return (new PoleInfo(plugin, "active in the load order", InOrder: true, EpochCoversPole: true), null);
 
         string modsDir, dataDir, overwriteDir, profileDir;
         try { lock (_gate) { EnsurePathsDerived(); modsDir = _modsDir; dataDir = _dataDir; overwriteDir = _overwriteDir; profileDir = _profileDir; } }
         catch (Exception ex)
         {
-            return (null, $"source '{plugin}' is not active in the load order, and the MO2 roots couldn't be derived to search for it on disk: {ex.Message}");
+            return (null, activeFilename
+                ? $"source '{plugin}' names a mod folder, and the MO2 roots couldn't be derived to read that folder's copy: {ex.Message}"
+                : $"source '{plugin}' is not active in the load order, and the MO2 roots couldn't be derived to search for it on disk: {ex.Message}");
         }
         var comp = Mo2LoadOrder.ReadComposition(profileDir);
         var loc = LocatePluginFileOnDisk(comp, modsDir, dataDir, overwriteDir, plugin, mod);
         if (loc.Error is not null)
-            // A pole found in neither place names both places searched.
-            return (null, $"source '{plugin}' resolves in NEITHER place the one-pole rule searches: it is not ACTIVE in " +
-                          $"the load order ({view.PluginCount} plugins), and on disk {loc.Error}");
+            // A pole found in neither place names both places searched. When the filename IS active, the named mod
+            // folder is the only place searched, so the sentence says that instead of claiming it is not active.
+            return (null, activeFilename
+                ? $"source '{plugin}': {loc.Error} The filename IS active in the load order — drop mod= to read the copy the game loads."
+                : $"source '{plugin}' resolves in NEITHER place the one-pole rule searches: it is not ACTIVE in " +
+                  $"the load order ({view.PluginCount} plugins), and on disk {loc.Error}");
         if (loc.Ambiguous is not null)
             return (null, $"source '{plugin}' is not active in the load order and its filename is provided by SEVERAL mod " +
                           $"folders on disk: {string.Join(", ", loc.Ambiguous.Select(h => $"'{h.Where}'"))} — disambiguate " +
                           "with source={\"file\": \"" + plugin + "\", \"mod\": \"<mod folder>\"}.");
+        // The named copy IS the copy the game loads, so it is read out of the order like any other active pole.
+        if (activeFilename && loc.Enabled)
+            return (new PoleInfo(plugin, "active in the load order", InOrder: true, EpochCoversPole: true), null);
         var poleWhere = $"OUT-OF-LOAD-ORDER ({loc.Where}{(loc.WhyNotActive is { } why ? $"; NOT active — {why}" : "")})";
         return (new PoleInfo(plugin, poleWhere, InOrder: false, EpochCoversPole: false) { Path = loc.Path }, null);
     }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2518,7 +2518,19 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>One side of a housecarl_diff_record comparison: the plugin named, WHERE its version was found (active
     /// order, or OUT-OF-LOAD-ORDER on disk), whether it's in the active order, and the record identity it carries.</summary>
-    public sealed record DiffPole(string Plugin, string Where, bool InOrder, string? RecordType, string? EditorId);
+    public sealed record DiffPole(string Plugin, string Where, bool InOrder, string? RecordType, string? EditorId)
+    {
+        /// <summary>What tells this pole apart from a same-named one on the other arm — the mod folder it was read
+        /// out of, or "off-order" when the layer names nothing. Set on the off-order arm only: two poles can share a
+        /// filename and be different files, and the active one is then the unqualified side.</summary>
+        internal string? Qualifier { get; init; }
+
+        /// <summary>The pole's label for a render that shows both sides. Qualified only when the other side carries
+        /// the same filename, so the ordinary one-pole-per-name case reads unchanged.</summary>
+        public string LabelVersus(string? otherPlugin) =>
+            Qualifier is { } q && string.Equals(Plugin, otherPlugin, StringComparison.OrdinalIgnoreCase)
+                ? $"{Plugin} ({q})" : Plugin;
+    }
 
     // ---- batch ------------------------------------------------------------------------------------------
 
@@ -2575,6 +2587,11 @@ public sealed class LoadOrderService : IDisposable
         /// consuming lane can open the file without re-running the locate.</summary>
         internal string? Path { get; init; }
 
+        /// <summary>The layer the off-order copy came from ("mod 'X'", the overwrite folder), when the locate's own
+        /// label names one — carried as a fact rather than re-derived from <see cref="Where"/>, so a render that has
+        /// to tell two same-named copies apart names the folder instead of parsing a sentence.</summary>
+        internal string? Layer { get; init; }
+
         /// <summary>The epoch of the build the arm was judged against. The caller compares it against its dispatch's
         /// own stamp, so a load-order change between probe and dispatch surfaces as a loud retry refusal instead of
         /// an arm statement about a different build.</summary>
@@ -2626,7 +2643,8 @@ public sealed class LoadOrderService : IDisposable
         if (activeFilename && loc.Enabled)
             return (new PoleInfo(plugin, "active in the load order", InOrder: true, EpochCoversPole: true), null);
         var poleWhere = $"OUT-OF-LOAD-ORDER ({loc.Where}{(loc.WhyNotActive is { } why ? $"; NOT active — {why}" : "")})";
-        return (new PoleInfo(plugin, poleWhere, InOrder: false, EpochCoversPole: false) { Path = loc.Path }, null);
+        return (new PoleInfo(plugin, poleWhere, InOrder: false, EpochCoversPole: false)
+                { Path = loc.Path, Layer = loc.WhereNamesLayer ? loc.Where : null }, null);
     }
 
     /// <summary>The tool-layer probe: WHICH arm would this source= pole resolve to (active / off-order / neither)?
@@ -2834,11 +2852,21 @@ public sealed class LoadOrderService : IDisposable
         }
 
         // Resolve the uniform arms once (named poles; winner/overlay are per-record but uniform in statement).
-        var sReader = MakePoleReader(view, session, subject, fields, wanted, out subjectArm, out var sCovers, out var sErr);
+        var sReader = MakePoleReader(view, session, subject, fields, wanted, out subjectArm, out var sCovers, out var sErr, out var sOffOrder);
         if (sErr is not null) { refusal = "source: " + sErr; return Array.Empty<DeltaRow>(); }
-        var rReader = MakePoleReader(view, session, reference, fields, wanted, out referenceArm, out var rCovers, out var rErr);
+        var rReader = MakePoleReader(view, session, reference, fields, wanted, out referenceArm, out var rCovers, out var rErr, out _);
         if (rErr is not null) { refusal = "versus: " + rErr; return Array.Empty<DeltaRow>(); }
         epochCoversAll = sCovers && rCovers;
+
+        // previous_provider is measured from the SUBJECT's position in the active touching stack, which an off-order
+        // subject holds in no record — and its filename can be active as a DIFFERENT file. That is a fact about the
+        // arm, not about any record, so it refuses the whole call here rather than deep-reading every match first.
+        if (reference.Kind == PoleKind.PreviousProvider && sOffOrder is not null)
+        {
+            refusal = $"versus: the subject is the off-order file '{sOffOrder.Plugin}' ({sOffOrder.Where}), which holds no position in the " +
+                      "active touching stack previous_provider is measured in. Name an active plugin as source=, or compare against a named versus= plugin.";
+            return Array.Empty<DeltaRow>();
+        }
 
         var rows = new List<DeltaRow>(formids.Count);
         foreach (var (raw, fkOpt, parseError) in parsed)
@@ -2849,20 +2877,17 @@ public sealed class LoadOrderService : IDisposable
             var s = sReader(fk, null);
             if (s.Error is not null) { rows.Add(new DeltaRow(fk.ToString(), s.Pole, null, null, null, null, "subject: " + s.Error)); continue; }
             // previous_provider is measured from the SUBJECT, so hand the reference reader the subject's resolved
-            // plugin for this record and it anchors on the right stack position. An off-order subject holds no
-            // position in that stack — and its filename can be active as a DIFFERENT file — so it is refused rather
-            // than anchored by name on whatever the order serves.
-            var r = reference.Kind == PoleKind.PreviousProvider && !s.Pole!.InOrder
-                ? new PoleReading(null, null, null,
-                    $"the subject is the off-order file '{s.Pole.Plugin}' ({s.Pole.Where}), which holds no position in the " +
-                    "active touching stack previous_provider is measured in. Name an active plugin as source=, or compare against a named versus= plugin.")
-                : rReader(fk, s.Pole!.Plugin);
+            // plugin for this record and it anchors on the right stack position. The off-order subject is already
+            // refused for the whole call above.
+            var r = rReader(fk, s.Pole!.Plugin);
             if (r.Error is not null) { rows.Add(new DeltaRow(fk.ToString(), s.Pole, r.Pole, null, r.StackAbove, null, "versus: " + r.Error)); continue; }
 
             string? note = string.Equals(s.Pole.Plugin, r.Pole!.Plugin, StringComparison.OrdinalIgnoreCase) && s.Pole.Where == r.Pole.Where
                 ? "the two poles resolved to the SAME provider — the diff is trivially empty by construction"
                 : null;
-            var diff = FieldsDiff.Compare(s.Fields!, r.Fields!, referenceLabel: r.Pole.Plugin);
+            // Two copies of one filename on opposite arms: the delta line names the off-order side's mod folder, or
+            // the reader cannot tell which side a value came from without the pole lines above.
+            var diff = FieldsDiff.Compare(s.Fields!, r.Fields!, referenceLabel: r.Pole.LabelVersus(s.Pole.Plugin));
             rows.Add(new DeltaRow(fk.ToString(), s.Pole, r.Pole, diff, r.StackAbove, note, null));
         }
         return rows;
@@ -2879,12 +2904,13 @@ public sealed class LoadOrderService : IDisposable
     /// resolution — a named plugin's active-versus-off-order arm, or an off-order file opened and swept lazily on
     /// first use — happens here once; per-record work stays in the returned reader. <paramref name="covers"/> is
     /// false when the pole reads content outside the epoch fingerprint, such as an off-order file or the overlay's
-    /// INIs.</summary>
+    /// INIs. <paramref name="offOrderArm"/> is the resolved arm when it is an on-disk file outside the order, and
+    /// null otherwise — a uniform fact about the whole call, so a caller can judge it once instead of per record.</summary>
     PoleReader MakePoleReader(LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session,
                               PoleSpec spec, IReadOnlyList<string>? fields, IReadOnlyCollection<FormKey>? wanted,
-                              out string? armStatement, out bool covers, out string? error)
+                              out string? armStatement, out bool covers, out string? error, out PoleInfo? offOrderArm)
     {
-        error = null; covers = true;
+        error = null; covers = true; offOrderArm = null;
         switch (spec.Kind)
         {
             case PoleKind.Winner:
@@ -2968,6 +2994,7 @@ public sealed class LoadOrderService : IDisposable
                 // Off-order arm: open the overlay lazily once; per-record lookups sweep it on first use and memoise
                 // every record seen on the way, so one enumeration pass serves the whole batch.
                 covers = false;   // the file's content sits outside the epoch fingerprint
+                offOrderArm = arm;
                 var lazy = new OffOrderPoleCache(this, arm, fields, wanted);
                 return (fk, _) =>
                 {
@@ -2982,7 +3009,8 @@ public sealed class LoadOrderService : IDisposable
                                 ? $"Touched by (active order, winner last): {string.Join(", ", touchers)}."
                                 : "No active plugin touches it either."));
                     }
-                    return new PoleReading(rec, new DiffPole(arm.Plugin, arm.Where, false, rec.Type, rec.EditorId), null, null);
+                    return new PoleReading(rec, new DiffPole(arm.Plugin, arm.Where, false, rec.Type, rec.EditorId)
+                                                { Qualifier = arm.Layer ?? "off-order" }, null, null);
                 };
         }
     }
@@ -3269,7 +3297,7 @@ public sealed class LoadOrderService : IDisposable
         PoleReader? refReader = null;
         if (reference.Kind is not PoleKind.Winner)
         {
-            refReader = MakePoleReader(view, session, reference, fields, wantedT, out referenceArm, out var rCovers, out var rErr);
+            refReader = MakePoleReader(view, session, reference, fields, wantedT, out referenceArm, out var rCovers, out var rErr, out _);
             if (rErr is not null) { refusal = "versus: " + rErr; return Array.Empty<TreeRow>(); }
             epochCoversAll = rCovers;
         }
@@ -3296,7 +3324,7 @@ public sealed class LoadOrderService : IDisposable
                 continue;
             }
 
-            RecordFields? refFields; string refPlugin;
+            RecordFields? refFields; string refPlugin; DiffPole? refPole = null;
             if (refReader is null)
             {
                 var winnerNode = tree.Winner;
@@ -3312,25 +3340,32 @@ public sealed class LoadOrderService : IDisposable
                                          Array.Empty<ChildDeclarers>()));
                     continue;
                 }
-                refFields = r.Fields; refPlugin = r.Pole!.Plugin;
+                refFields = r.Fields; refPlugin = r.Pole!.Plugin; refPole = r.Pole;
             }
+
+            // A node IS the reference only when the reference resolved IN the order: an off-order pole is never one
+            // of the active providers, even when its filename is also active as a different file. Where they share
+            // that filename, the reference's label names its mod folder so the two are told apart.
+            bool refIsActiveProvider = refPole is null || refPole.InOrder;
+            string refLabel = refPole is not null && tree.Nodes.Any(n => string.Equals(n.Plugin, refPlugin, StringComparison.OrdinalIgnoreCase))
+                            ? refPole.LabelVersus(refPlugin) : refPlugin;
 
             var nodes = new List<TreeNodeDelta>(tree.Nodes.Count);
             foreach (var node in tree.Nodes)
             {
                 bool isWinner = ReferenceEquals(node, tree.Winner);
                 bool isRef = refReader is null ? isWinner
-                           : string.Equals(node.Plugin, refPlugin, StringComparison.OrdinalIgnoreCase);
+                           : refIsActiveProvider && string.Equals(node.Plugin, refPlugin, StringComparison.OrdinalIgnoreCase);
                 if (isRef)
                 {
                     nodes.Add(new TreeNodeDelta(node.Plugin, isWinner, true, Array.Empty<string>(), 0, true, null));
                     continue;
                 }
-                var d = FieldsDiff.Compare(node.Record, refFields!, referenceLabel: refPlugin);
+                var d = FieldsDiff.Compare(node.Record, refFields!, referenceLabel: refLabel);
                 nodes.Add(new TreeNodeDelta(node.Plugin, isWinner, false, d.Deltas, d.AgreedCount, d.Complete, null));
             }
             rows.Add(new TreeRow(fk.ToString(), tree.Winner.Record.Type, tree.Winner.Record.EditorId,
-                                 touchers, refPlugin, nodes, null, tree.ChildDeclarers));
+                                 touchers, refLabel, nodes, null, tree.ChildDeclarers));
         }
         return rows;
     }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2590,10 +2590,13 @@ public sealed class LoadOrderService : IDisposable
     /// game loads. A plain filename and a direct path are unchanged.</para></summary>
     (PoleInfo? Pole, string? Error) ResolvePoleArm(LoadOrderResolver.IndexView view, string plugin, string? mod)
     {
+        // Judged on the argument as given: the rewrite below turns a path into a bare filename, which would flip a
+        // path pole into the mod= lane and read a file the caller did not name.
+        bool namesMod = !string.IsNullOrWhiteSpace(mod) && !LooksLikePath(plugin);
+
         // A pole addressed by path that IS the active order's file resolves back to its plugin name.
         if (LooksLikePath(plugin) && ActiveNameForPath(view, plugin) is { } activeName) plugin = activeName;
 
-        bool namesMod = !string.IsNullOrWhiteSpace(mod) && !LooksLikePath(plugin);
         bool activeFilename = view.ContainsPlugin(plugin);
         if (!namesMod && activeFilename)
             return (new PoleInfo(plugin, "active in the load order", InOrder: true, EpochCoversPole: true), null);
@@ -2603,7 +2606,7 @@ public sealed class LoadOrderService : IDisposable
         catch (Exception ex)
         {
             return (null, activeFilename
-                ? $"source '{plugin}' names a mod folder, and the MO2 roots couldn't be derived to read that folder's copy: {ex.Message}"
+                ? $"source '{plugin}' names mod folder '{mod!.Trim()}', and the MO2 roots couldn't be derived to read that folder's copy: {ex.Message}"
                 : $"source '{plugin}' is not active in the load order, and the MO2 roots couldn't be derived to search for it on disk: {ex.Message}");
         }
         var comp = Mo2LoadOrder.ReadComposition(profileDir);
@@ -2846,8 +2849,14 @@ public sealed class LoadOrderService : IDisposable
             var s = sReader(fk, null);
             if (s.Error is not null) { rows.Add(new DeltaRow(fk.ToString(), s.Pole, null, null, null, null, "subject: " + s.Error)); continue; }
             // previous_provider is measured from the SUBJECT, so hand the reference reader the subject's resolved
-            // plugin for this record and it anchors on the right stack position.
-            var r = rReader(fk, s.Pole!.Plugin);
+            // plugin for this record and it anchors on the right stack position. An off-order subject holds no
+            // position in that stack — and its filename can be active as a DIFFERENT file — so it is refused rather
+            // than anchored by name on whatever the order serves.
+            var r = reference.Kind == PoleKind.PreviousProvider && !s.Pole!.InOrder
+                ? new PoleReading(null, null, null,
+                    $"the subject is the off-order file '{s.Pole.Plugin}' ({s.Pole.Where}), which holds no position in the " +
+                    "active touching stack previous_provider is measured in. Name an active plugin as source=, or compare against a named versus= plugin.")
+                : rReader(fk, s.Pole!.Plugin);
             if (r.Error is not null) { rows.Add(new DeltaRow(fk.ToString(), s.Pole, r.Pole, null, r.StackAbove, null, "versus: " + r.Error)); continue; }
 
             string? note = string.Equals(s.Pole.Plugin, r.Pole!.Plugin, StringComparison.OrdinalIgnoreCase) && s.Pole.Where == r.Pole.Where

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -1593,7 +1593,8 @@ public static class RecordsTools
             else
             {
                 sb.Append("  ").Append(d.Deltas.Count).Append(d.Deltas.Count == 1 ? " difference" : " differences")
-                  .Append(" — each line: ").Append(s.Plugin).Append("'s value (reference = ").Append(r.Plugin).Append("):\n");
+                  .Append(" — each line: ").Append(s.LabelVersus(r.Plugin)).Append("'s value (reference = ")
+                  .Append(r.LabelVersus(s.Plugin)).Append("):\n");
                 foreach (var delta in d.Deltas)
                 {
                     if (sb.Length >= cap)


### PR DESCRIPTION
The `{"file", "mod"}` source form on `housecarl_records` exists to read a specific on-disk copy of a plugin when several mod folders ship the same filename and MO2 serves one of them. The source pole resolved the active copy first, so when the filename was active the form read the served copy whatever folder was named — it only did its job for a filename that was not active. The pole now runs the on-disk locate first for that form: the named folder's copy is read, and when it is not the copy the game loads the response carries the existing off-order label, which names the mod folder that provides the served copy. A folder that does not carry the filename is still refused, with a sentence that says the filename is active rather than claiming it is not. The plain-filename and direct-path forms are unchanged; a `file=` that is a path still addresses that path even with a `mod=` beside it.

One knock-on from the new state: an off-order subject can now carry a filename that IS active, and `versus="previous_provider"` is a position in the active touching stack that such a copy does not hold. It is refused instead of anchoring by name on the served copy.

Tests: two enabled mods carrying one filename with different Damage per copy, the higher-priority one served. Naming the shadowed mod reads its copy and says which mod is active; naming the serving mod reads the active copy on the active arm; a folder without the filename is refused; a path beside a `mod=` reads the path; `previous_provider` against the shadowed copy is refused.

Closes #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)
