### PR TITLE
Render both batch tools through one shared skeleton

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,10 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **`housecarl_asset_status` under a `max_chars` its header and alarms already fill now renders the first path's
+  answer instead of cutting to none.** `housecarl_nif_inspect` already did; both tools now render through one batch
+  skeleton, so the first item always answers and the omitted-count cut reads the same in both.
+
 - **`housecarl_records` with `source={"file", "mod"}` now reads the copy in the named mod folder, even when that
   filename is active in the load order.** Several mod folders can ship the same plugin filename (an ESP replacer),
   and MO2 serves one of them; naming a folder addresses that folder's file. When the named copy is not the one the

--- a/src/housecarl-mcp-tests/BatchRenderCapTests.cs
+++ b/src/housecarl-mcp-tests/BatchRenderCapTests.cs
@@ -1,0 +1,77 @@
+using HousecarlCore;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>The shared batch-render skeleton's cap contract, on both of its callers: a max_chars the header and
+/// alarms alone exhaust still renders the FIRST item's answer, and the omitted-count cut is named with one marker.
+/// asset_status used to cut before its first path; nif_inspect never did.</summary>
+[Trait("tier", "unit")]
+public class BatchRenderCapTests
+{
+    // Small enough that the header plus the read-failure alarm alone pass it, so the loop's cap check fires
+    // on the first item.
+    const int TightCap = 100;
+
+    static AssetStatusData ThreePaths() => new(
+        new[]
+        {
+            Absent("meshes/a/first.nif"),
+            Absent("meshes/b/second.nif"),
+            Absent("meshes/c/third.nif"),
+        },
+        new[] { "Broken - Textures.bsa (header refused)" },
+        true,
+        Array.Empty<string>(),
+        "TestProfile");
+
+    static AssetPathResult Absent(string path) =>
+        new(path, new AssetHit(path, false, null, Array.Empty<AssetProvider>(), false), null);
+
+    static NifInspectBatchData ThreeMeshes() => new(
+        new[]
+        {
+            NifInspectData.Fail("meshes/a/first.nif", "ABSENT — no active mod or BSA provides this mesh"),
+            NifInspectData.Fail("meshes/b/second.nif", "ABSENT — no active mod or BSA provides this mesh"),
+            NifInspectData.Fail("meshes/c/third.nif", "ABSENT — no active mod or BSA provides this mesh"),
+        },
+        new[] { "Broken - Textures.bsa (header refused)" },
+        Array.Empty<string>(),
+        "TestProfile");
+
+    static string RenderNif(int cap) =>
+        NifWire.Render(ThreeMeshes(), new HashSet<string>(StringComparer.OrdinalIgnoreCase), Array.Empty<string>(), cap);
+
+    [Fact]
+    public void AssetStatusUnderATightCapStillRendersItsFirstPath()
+    {
+        var text = AssetWire.Render(ThreePaths(), TightCap);
+
+        Assert.Contains("meshes/a/first.nif", text);
+        Assert.DoesNotContain("meshes/b/second.nif", text);
+        Assert.Contains("2 more path(s) omitted at max_chars=100", text);
+    }
+
+    [Fact]
+    public void NifInspectUnderATightCapStillRendersItsFirstMesh()
+    {
+        var text = RenderNif(TightCap);
+
+        Assert.Contains("meshes/a/first.nif", text);
+        Assert.DoesNotContain("meshes/b/second.nif", text);
+        Assert.Contains("2 more mesh(es) omitted at max_chars=100", text);
+    }
+
+    [Fact]
+    public void BothBatchRendersCutWithTheSameMarker()
+    {
+        var asset = AssetWire.Render(ThreePaths(), TightCap);
+        var nif = RenderNif(TightCap);
+
+        Assert.Contains("  … [", asset);
+        Assert.Contains("  … [", nif);
+        Assert.DoesNotContain("... [", asset);
+        Assert.DoesNotContain("... [", nif);
+    }
+}

--- a/src/housecarl-mcp-tests/BatchRenderCapTests.cs
+++ b/src/housecarl-mcp-tests/BatchRenderCapTests.cs
@@ -26,6 +26,22 @@ public class BatchRenderCapTests
         Array.Empty<string>(),
         "TestProfile");
 
+    // Tighter than the header plus the read-failure heading, so only the alarm loop's first-line exemption keeps any
+    // failure from being cut.
+    const int AlarmCap = 60;
+
+    static AssetStatusData ThreeReadFailures() => new(
+        new[] { Absent("meshes/a/first.nif") },
+        new[]
+        {
+            "Broken - Textures.bsa (header refused)",
+            "Broken - Meshes.bsa (header refused)",
+            "Broken - Sounds.bsa (header refused)",
+        },
+        true,
+        Array.Empty<string>(),
+        "TestProfile");
+
     static AssetPathResult Absent(string path) =>
         new(path, new AssetHit(path, false, null, Array.Empty<AssetProvider>(), false), null);
 
@@ -51,6 +67,18 @@ public class BatchRenderCapTests
         Assert.Contains("meshes/a/first.nif", text);
         Assert.DoesNotContain("meshes/b/second.nif", text);
         Assert.Contains("2 more path(s) omitted at max_chars=100", text);
+    }
+
+    /// <summary>The alarm list keeps its first entry too: a cap the header and the alarm heading alone exhaust still
+    /// names one failed archive, then counts the rest as omitted.</summary>
+    [Fact]
+    public void AReadFailureListUnderATightCapStillRendersItsFirstEntry()
+    {
+        var text = AssetWire.Render(ThreeReadFailures(), AlarmCap);
+
+        Assert.Contains("Broken - Textures.bsa (header refused)", text);
+        Assert.DoesNotContain("Broken - Meshes.bsa", text);
+        Assert.Contains("2 more archive(s) omitted at max_chars=60", text);
     }
 
     /// <summary>The two callers agree under the same cap: each keeps its first item, and each names the cut with the

--- a/src/housecarl-mcp-tests/BatchRenderCapTests.cs
+++ b/src/housecarl-mcp-tests/BatchRenderCapTests.cs
@@ -10,8 +10,8 @@ namespace HousecarlMcpTests;
 [Trait("tier", "unit")]
 public class BatchRenderCapTests
 {
-    // Small enough that the header plus the read-failure alarm alone pass it, so the loop's cap check fires
-    // on the first item.
+    // Small enough that the header plus the read-failure alarm alone exceed it, so only the skeleton's first-item
+    // exemption keeps any item from being cut.
     const int TightCap = 100;
 
     static AssetStatusData ThreePaths() => new(
@@ -53,22 +53,17 @@ public class BatchRenderCapTests
         Assert.Contains("2 more path(s) omitted at max_chars=100", text);
     }
 
+    /// <summary>The two callers agree under the same cap: each keeps its first item, and each names the cut with the
+    /// same marker. nif_inspect's own first-mesh contract is the nif-inspect-batch-guard probe's arm 6; this pins the
+    /// parity between the two, which is what the shared skeleton buys.</summary>
     [Fact]
-    public void NifInspectUnderATightCapStillRendersItsFirstMesh()
-    {
-        var text = RenderNif(TightCap);
-
-        Assert.Contains("meshes/a/first.nif", text);
-        Assert.DoesNotContain("meshes/b/second.nif", text);
-        Assert.Contains("2 more mesh(es) omitted at max_chars=100", text);
-    }
-
-    [Fact]
-    public void BothBatchRendersCutWithTheSameMarker()
+    public void BothBatchRendersKeepTheirFirstItemAndCutWithTheSameMarker()
     {
         var asset = AssetWire.Render(ThreePaths(), TightCap);
         var nif = RenderNif(TightCap);
 
+        Assert.Contains("meshes/a/first.nif", nif);
+        Assert.Contains("2 more mesh(es) omitted at max_chars=100", nif);
         Assert.Contains("  … [", asset);
         Assert.Contains("  … [", nif);
         Assert.DoesNotContain("... [", asset);

--- a/src/housecarl-mcp/AssetTools.cs
+++ b/src/housecarl-mcp/AssetTools.cs
@@ -50,27 +50,20 @@ static class AssetWire
 {
     public static string Render(AssetStatusData d, int cap)
     {
-        var sb = new StringBuilder();
-        sb.Append("asset status — profile '").Append(d.ProfileName.Length > 0 ? d.ProfileName : "(unconfigured)")
-          .Append("'  (").Append(d.Results.Count).Append(" path").Append(d.Results.Count == 1 ? "" : "s").Append(" queried)\n");
+        var header = new StringBuilder("asset status — profile '")
+            .Append(d.ProfileName.Length > 0 ? d.ProfileName : "(unconfigured)")
+            .Append("'  (").Append(d.Results.Count).Append(" path").Append(d.Results.Count == 1 ? "" : "s")
+            .Append(" queried)").ToString();
 
-        // Alarms come before the per-path list so a long batch cannot truncate them away.
-        AppendReadFailures(sb, d.BsaFailures, cap);
-        AppendDiscoveryWarnings(sb, d.Warnings, cap);
-
-        int shown = 0;
-        foreach (var r in d.Results)
-        {
-            if (sb.Length >= cap)
+        return BatchRender.Render(
+            header, d.Results, "path(s)", cap,
+            // Alarms come before the per-path list so a long batch cannot truncate them away.
+            sb =>
             {
-                sb.Append("\n  ... [").Append(d.Results.Count - shown)
-                  .Append(" more path(s) omitted at max_chars=").Append(cap).Append("; raise max_chars to see all]\n");
-                break;
-            }
-            AppendPath(sb, r, d.ReadIncomplete, d.Warnings.Count > 0);
-            shown++;
-        }
-        return sb.ToString().TrimEnd('\n');
+                BatchRender.AppendReadFailures(sb, d.BsaFailures, "an asset", cap);
+                BatchRender.AppendDiscoveryWarnings(sb, d.Warnings, cap);
+            },
+            (sb, r) => AppendPath(sb, r, d.ReadIncomplete, d.Warnings.Count > 0));
     }
 
     static void AppendPath(StringBuilder sb, AssetPathResult r, bool readIncomplete, bool discoveryIncomplete)
@@ -116,36 +109,6 @@ static class AssetWire
         if (hit.Ambiguous)
             sb.Append("  note: more than one source provides this — the winner above is the precedence call (loose " +
                       "beats BSA; among BSAs the latest-loaded plugin wins). Verify only if that's unexpected.\n");
-    }
-
-    /// <summary>The BSAs that could not be read this build, each named with its owning plugin and the reason. An asset
-    /// present only in one of these is indistinguishable from a truly absent one, so an "ABSENT" below is
-    /// authoritative only when this list is empty.</summary>
-    static void AppendReadFailures(StringBuilder sb, IReadOnlyList<string> failures, int cap)
-    {
-        if (failures.Count == 0) return;
-        sb.Append("\n[!] ").Append(failures.Count).Append(" archive(s) could NOT be read this build — an asset present " +
-                  "only in these may read as ABSENT below:\n");
-        int shown = 0;
-        foreach (var f in failures)
-        {
-            if (sb.Length >= cap) { sb.Append("  ... [").Append(failures.Count - shown).Append(" more omitted at max_chars=").Append(cap).Append("]\n"); break; }
-            sb.Append("  - ").Append(f).Append('\n'); shown++;
-        }
-    }
-
-    /// <summary>Archive-discovery warnings, e.g. a Skyrim.ini whose [Archive] base-archive list could not be found, so
-    /// the vanilla base BSAs are not in the scan and an "ABSENT" for a base-game asset must not be over-trusted.</summary>
-    static void AppendDiscoveryWarnings(StringBuilder sb, IReadOnlyList<string> warnings, int cap)
-    {
-        if (warnings.Count == 0) return;
-        sb.Append("\n[!] discovery (").Append(warnings.Count).Append("):\n");
-        int shown = 0;
-        foreach (var w in warnings)
-        {
-            if (sb.Length >= cap) { sb.Append("  ... [").Append(warnings.Count - shown).Append(" more omitted at max_chars=").Append(cap).Append("]\n"); break; }
-            sb.Append("  - ").Append(w).Append('\n'); shown++;
-        }
     }
 
     static string Kind(HousecarlCore.AssetKind k) => k == HousecarlCore.AssetKind.Bsa ? "BSA" : "loose";

--- a/src/housecarl-mcp/BatchRender.cs
+++ b/src/housecarl-mcp/BatchRender.cs
@@ -2,7 +2,7 @@ using System.Text;
 
 namespace HousecarlMcp;
 
-/// <summary>The one batch-render skeleton every multi-item tool renders through: a header count line, the batch-level
+/// <summary>The shared batch-render skeleton behind housecarl_asset_status and housecarl_nif_inspect: a header count line, the batch-level
 /// alarms once and first (so a long batch cannot truncate them away), a cap-checked per-item loop whose FIRST item
 /// always renders its core answer, and an explicit omitted-count cut. max_chars bounds the batch tail, never a
 /// single-item call's own answer, and a cut is always named — never a silent truncation. Callers supply the header,
@@ -58,7 +58,7 @@ static class BatchRender
         if (failures.Count == 0) return;
         sb.Append("\n[!] ").Append(failures.Count).Append(" archive(s) could NOT be read this build — ")
           .Append(subjectPhrase).Append(" present only in these may read as ABSENT below:\n");
-        AppendLines(sb, failures, cap);
+        AppendLines(sb, failures, "archive(s)", cap);
     }
 
     /// <summary>Archive-discovery warnings, e.g. a Skyrim.ini whose [Archive] base-archive list could not be found, so
@@ -67,16 +67,16 @@ static class BatchRender
     {
         if (warnings.Count == 0) return;
         sb.Append("\n[!] discovery (").Append(warnings.Count).Append("):\n");
-        AppendLines(sb, warnings, cap);
+        AppendLines(sb, warnings, "warning(s)", cap);
     }
 
     /// <summary>A capped bullet list inside an alarm block, cut with the same named marker.</summary>
-    static void AppendLines(StringBuilder sb, IReadOnlyList<string> lines, int cap)
+    static void AppendLines(StringBuilder sb, IReadOnlyList<string> lines, string itemNoun, int cap)
     {
         int shown = 0;
         foreach (var line in lines)
         {
-            if (sb.Length >= cap) { AppendCut(sb, lines.Count - shown, "", cap); break; }
+            if (sb.Length >= cap) { AppendCut(sb, lines.Count - shown, itemNoun, cap); break; }
             sb.Append("  - ").Append(line).Append('\n'); shown++;
         }
     }

--- a/src/housecarl-mcp/BatchRender.cs
+++ b/src/housecarl-mcp/BatchRender.cs
@@ -76,7 +76,8 @@ static class BatchRender
         int shown = 0;
         foreach (var line in lines)
         {
-            if (sb.Length >= cap) { AppendCut(sb, lines.Count - shown, itemNoun, cap); break; }
+            // shown > 0: the first line always renders even when the header and the alarm heading alone exhausted the cap.
+            if (shown > 0 && sb.Length >= cap) { AppendCut(sb, lines.Count - shown, itemNoun, cap); break; }
             sb.Append("  - ").Append(line).Append('\n'); shown++;
         }
     }

--- a/src/housecarl-mcp/BatchRender.cs
+++ b/src/housecarl-mcp/BatchRender.cs
@@ -1,0 +1,83 @@
+using System.Text;
+
+namespace HousecarlMcp;
+
+/// <summary>The one batch-render skeleton every multi-item tool renders through: a header count line, the batch-level
+/// alarms once and first (so a long batch cannot truncate them away), a cap-checked per-item loop whose FIRST item
+/// always renders its core answer, and an explicit omitted-count cut. max_chars bounds the batch tail, never a
+/// single-item call's own answer, and a cut is always named — never a silent truncation. Callers supply the header,
+/// the alarms block, the per-item renderer, the cap, and the noun the omitted-count line counts in.</summary>
+static class BatchRender
+{
+    /// <summary>Renders one batch. <paramref name="itemNoun"/> is the plural-ish noun the cut line counts, e.g.
+    /// "path(s)" or "mesh(es)".</summary>
+    public static string Render<T>(
+        string header,
+        IReadOnlyList<T> items,
+        string itemNoun,
+        int cap,
+        Action<StringBuilder> appendAlarms,
+        Action<StringBuilder, T> appendItem)
+    {
+        var sb = new StringBuilder();
+        sb.Append(header).Append('\n');
+        appendAlarms(sb);
+
+        int shown = 0;
+        foreach (var item in items)
+        {
+            // shown > 0: the first item always renders its core answer even when the header and alarms alone
+            // exhausted the cap.
+            if (shown > 0 && sb.Length >= cap)
+            {
+                sb.Append('\n');
+                AppendCut(sb, items.Count - shown, itemNoun, cap);
+                break;
+            }
+            appendItem(sb, item);
+            shown++;
+        }
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    /// <summary>The one cut marker: how many items were left out, and the max_chars that left them out. An empty
+    /// <paramref name="itemNoun"/> counts unnamed items ("3 more omitted").</summary>
+    public static void AppendCut(StringBuilder sb, int remaining, string itemNoun, int cap)
+    {
+        sb.Append("  … [").Append(Math.Max(remaining, 0)).Append(" more ");
+        if (itemNoun.Length > 0) sb.Append(itemNoun).Append(' ');
+        sb.Append("omitted at max_chars=").Append(cap).Append("; raise max_chars to see all]\n");
+    }
+
+    /// <summary>The BSAs that could not be read this build, each named with its owning plugin and the reason. An item
+    /// present only in one of these is indistinguishable from a truly absent one, so an "ABSENT" below is
+    /// authoritative only when this list is empty. <paramref name="subjectPhrase"/> names the thing with its article,
+    /// e.g. "an asset" or "a mesh".</summary>
+    public static void AppendReadFailures(StringBuilder sb, IReadOnlyList<string> failures, string subjectPhrase, int cap)
+    {
+        if (failures.Count == 0) return;
+        sb.Append("\n[!] ").Append(failures.Count).Append(" archive(s) could NOT be read this build — ")
+          .Append(subjectPhrase).Append(" present only in these may read as ABSENT below:\n");
+        AppendLines(sb, failures, cap);
+    }
+
+    /// <summary>Archive-discovery warnings, e.g. a Skyrim.ini whose [Archive] base-archive list could not be found, so
+    /// the vanilla base BSAs are not in the scan and an "ABSENT" for a base-game asset must not be over-trusted.</summary>
+    public static void AppendDiscoveryWarnings(StringBuilder sb, IReadOnlyList<string> warnings, int cap)
+    {
+        if (warnings.Count == 0) return;
+        sb.Append("\n[!] discovery (").Append(warnings.Count).Append("):\n");
+        AppendLines(sb, warnings, cap);
+    }
+
+    /// <summary>A capped bullet list inside an alarm block, cut with the same named marker.</summary>
+    static void AppendLines(StringBuilder sb, IReadOnlyList<string> lines, int cap)
+    {
+        int shown = 0;
+        foreach (var line in lines)
+        {
+            if (sb.Length >= cap) { AppendCut(sb, lines.Count - shown, "", cap); break; }
+            sb.Append("  - ").Append(line).Append('\n'); shown++;
+        }
+    }
+}

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -266,33 +266,24 @@ static class NifWire
 {
     public static string Render(NifInspectBatchData d, HashSet<string> want, IReadOnlyList<string> unknownSections, int cap)
     {
-        var sb = new StringBuilder();
-        sb.Append("nif inspect — profile '").Append(d.ProfileName.Length > 0 ? d.ProfileName : "(unconfigured)")
-          .Append("'  (").Append(d.Results.Count).Append(" mesh").Append(d.Results.Count == 1 ? "" : "es").Append(")\n");
-
-        // The alarms come first and once, at batch level, so a long batch cannot truncate them away.
-        AppendReadFailures(sb, d.BsaFailures, cap);
-        AppendDiscoveryWarnings(sb, d.Warnings, cap);
-        if (unknownSections.Count > 0)
-            sb.Append("\n[!] unrecognized section(s) ignored: ").Append(string.Join(", ", unknownSections))
-              .Append("  (").Append(NifTools.KnownSectionsHint).Append(")\n");
+        var header = new StringBuilder("nif inspect — profile '")
+            .Append(d.ProfileName.Length > 0 ? d.ProfileName : "(unconfigured)")
+            .Append("'  (").Append(d.Results.Count).Append(" mesh").Append(d.Results.Count == 1 ? "" : "es")
+            .Append(')').ToString();
 
         bool readIncomplete = d.BsaFailures.Count > 0, discoveryIncomplete = d.Warnings.Count > 0;
-        int shown = 0;
-        foreach (var r in d.Results)
-        {
-            // shown > 0: the first mesh always renders its core answer even when the alarms alone exhausted the cap.
-            // max_chars bounds the batch tail and detail lists, never a single-path call's own answer.
-            if (shown > 0 && sb.Length >= cap)
+        return BatchRender.Render(
+            header, d.Results, "mesh(es)", cap,
+            // The alarms come first and once, at batch level, so a long batch cannot truncate them away.
+            sb =>
             {
-                sb.Append("\n… [").Append(d.Results.Count - shown)
-                  .Append(" more mesh(es) omitted at max_chars=").Append(cap).Append("; raise max_chars to see all]\n");
-                break;
-            }
-            AppendMesh(sb, r, want, cap, readIncomplete, discoveryIncomplete);
-            shown++;
-        }
-        return sb.ToString().TrimEnd('\n');
+                BatchRender.AppendReadFailures(sb, d.BsaFailures, "a mesh", cap);
+                BatchRender.AppendDiscoveryWarnings(sb, d.Warnings, cap);
+                if (unknownSections.Count > 0)
+                    sb.Append("\n[!] unrecognized section(s) ignored: ").Append(string.Join(", ", unknownSections))
+                      .Append("  (").Append(NifTools.KnownSectionsHint).Append(")\n");
+            },
+            (sb, r) => AppendMesh(sb, r, want, cap, readIncomplete, discoveryIncomplete));
     }
 
     /// <summary>One mesh's block: the path line, then either its named error with the provider chain where there is
@@ -638,37 +629,12 @@ static class NifWire
     static bool Cut(StringBuilder sb, int cap, int remaining)
     {
         if (sb.Length < cap) return false;
-        sb.Append("  … [").Append(Math.Max(remaining, 0)).Append(" more omitted at max_chars=").Append(cap).Append("; raise max_chars to see all]\n");
+        BatchRender.AppendCut(sb, remaining, "", cap);
         return true;
     }
 
     static string Fmt(float f) => f.ToString("0.#######", System.Globalization.CultureInfo.InvariantCulture);
 
-    /// <summary>The BSAs that could not be read this build. A mesh present only in one of these is indistinguishable
-    /// from a truly absent one, so this is surfaced before the answer.</summary>
-    static void AppendReadFailures(StringBuilder sb, IReadOnlyList<string> failures, int cap)
-    {
-        if (failures.Count == 0) return;
-        sb.Append("\n[!] ").Append(failures.Count).Append(" archive(s) could NOT be read this build — a mesh present only in these may read as ABSENT:\n");
-        int shown = 0;
-        foreach (var f in failures)
-        {
-            if (sb.Length >= cap) { sb.Append("  ... [").Append(failures.Count - shown).Append(" more omitted]\n"); break; }
-            sb.Append("  - ").Append(f).Append('\n'); shown++;
-        }
-    }
-
-    static void AppendDiscoveryWarnings(StringBuilder sb, IReadOnlyList<string> warnings, int cap)
-    {
-        if (warnings.Count == 0) return;
-        sb.Append("\n[!] discovery (").Append(warnings.Count).Append("):\n");
-        int shown = 0;
-        foreach (var w in warnings)
-        {
-            if (sb.Length >= cap) { sb.Append("  ... [").Append(warnings.Count - shown).Append(" more omitted]\n"); break; }
-            sb.Append("  - ").Append(w).Append('\n'); shown++;
-        }
-    }
 }
 
 /// <summary>Renders <see cref="NifSetResult"/>: the resolution — which copy was edited, and the provider chain — then


### PR DESCRIPTION
`AssetWire.Render` and `NifWire.Render` were two hand-rolled copies of the same batch shape — header count line, alarms first and once, cap-checked per-item loop, omitted-count cut — and they had drifted. The first-item-always-renders guard from PR #243 existed only in `NifWire`, so a tight `max_chars` on `asset_status` could render zero items where `nif_inspect` guaranteed one; the cut markers and the `AppendReadFailures` / `AppendDiscoveryWarnings` helpers were duplicated too. Both tools now render through one `BatchRender` skeleton (`src/housecarl-mcp/BatchRender.cs`): the caller supplies a header, an alarms block, an item renderer, a cap, and the noun the omitted-count line counts, and the skeleton owns the first-item guard and the single cut marker. `asset_status` gets the fix by construction, and the W4 `place` tool lands as the third caller without a fourth copy. The only behaviour changes are that fix and the marker unification (`asset_status` now cuts with the same `  … [` marker `nif_inspect` uses); `NifTools`'s own detail cut delegates to the same marker rather than repeating it.

The alarm list had the same gap and is fixed here too: `AppendLines` now carries the same `shown > 0` exemption as the item loop, so at a very tight `max_chars` the read-failure block always names at least one archive before the omitted-count cut, instead of naming zero while a per-path hedge points at it.

New tests in `src/housecarl-mcp-tests/BatchRenderCapTests.cs` (tier `unit`): `AssetStatusUnderATightCapStillRendersItsFirstPath` is red on the unfixed renderer (verified by reverting both tool files — it cuts to zero paths) and green now; `BothBatchRendersKeepTheirFirstItemAndCutWithTheSameMarker` pins the parity the skeleton buys; `AReadFailureListUnderATightCapStillRendersItsFirstEntry` covers the alarm-list fix, and was red before it. `nif_inspect`'s own first-mesh contract stays where it already lives, arm 6 of `nif-inspect-batch-guard`. No probe pinned the old ASCII marker, so no probe needed updating.

Verified: `dotnet build -c Release` 0 errors, `dotnet test --filter tier!=bridge` 1042 passed / 0 failed, `ci-all` all pass.

Closes #414
Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)
