### PR TITLE
Test the bsa_repack header read-back against a real archive

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -24,6 +24,15 @@ saying it sets an expectation their install may contradict. Say what is known, a
   Reading by a runtime FormID is unchanged, and the doors that refuse are the ones the write verbs parse their
   targets through — see `FormIdDoor.ForWrite`.
 
+- **`housecarl_bsa_repack` now refuses when BSArch exits with an error, and no longer fails a fast pack for no
+  stated reason.** BSArch can abort partway and still leave a scratch archive behind; if that scratch happened to
+  declare the same file count the source offered, the repack placed it over the existing archive and reported
+  success. A non-zero exit is now a failed pack whatever it left on disk, and the refusal names the exit code and
+  what BSArch printed. Separately, the check that the scratch came from this run compared a filesystem write stamp
+  against a finer-grained clock, so a pack that finished inside one filesystem tick could be discarded with an empty
+  message; the run's own success now decides, and the scratch is still cleared before the run (a stuck one refuses
+  up front) so a previous run's bytes cannot ship as this one's.
+
 - **`housecarl_records` with `source={"file", "mod"}` now reads the copy in the named mod folder, even when that
   filename is active in the load order.** Several mod folders can ship the same plugin filename (an ESP replacer),
   and MO2 serves one of them; naming a folder addresses that folder's file. When the named copy is not the one the

--- a/src/housecarl-core/BsaArchive.cs
+++ b/src/housecarl-core/BsaArchive.cs
@@ -212,12 +212,11 @@ public static class BsaArchive
     /// <summary>Pack <paramref name="srcFolder"/> into a .bsa at <paramref name="archive"/> with the given format flag
     /// (e.g. "-sse") and optional compression, via BSArch (Mutagen has no BSA writer). NON-DESTRUCTIVE:
     /// an existing archive at the target is NEVER overwritten unless this run successfully packs a new one — BSArch writes
-    /// to a houseCARL-internal temp beside the target, and only a clean pack THIS RUN (temp exists, non-empty, AND written
-    /// at/after the run's mtime baseline) is moved over the target; a stale scratch from a previous run that cannot be
-    /// removed REFUSES up front (nothing runs, the prior .bsa untouched), and any failure (BSArch error, non-zero exit,
-    /// timeout, empty output, stale-mtime scratch) deletes the temp and leaves the prior .bsa untouched. The mtime gate
-    /// assumes an NTFS-class timestamp resolution — on a FAT-class target a same-second pack could read as stale and fail
-    /// LOUD (never falsely succeed). The source is enumerated first and the produced archive's own header count is checked against it
+    /// to a houseCARL-internal temp beside the target, and only a clean pack THIS RUN (the scratch is cleared before the
+    /// run, so the temp existing, non-empty, after a zero-exit run is this run's) is moved over the target; a stale
+    /// scratch from a previous run that cannot be removed REFUSES up front (nothing runs, the prior .bsa untouched), and
+    /// any failure (BSArch error, non-zero exit, timeout, empty
+    /// output) deletes the temp and leaves the prior .bsa untouched. The source is enumerated first and the produced archive's own header count is checked against it
     /// before the move, so a short pack refuses instead of reporting success; files at the source ROOT are counted apart
     /// because BSArch drops them, and a source that cannot be fully enumerated packs unverified rather than refusing. NOTE the caller must surface BSArch's caveat: a COMPRESSED archive breaks any
     /// sounds/voices it contains. The write itself runs through <paramref name="packer"/>, which defaults to the BSArch
@@ -246,8 +245,6 @@ public static class BsaArchive
         try { scan = ScanPackSource(srcFolder); }
         catch { scan = null; }
 
-        var baselineUtc = DateTime.UtcNow;
-
         var run = (packer ?? ShellBsArch)(bsarchExe, srcFolder, tmp, formatFlag, compress, timeoutMs);
 
         // A non-zero exit is a failed pack whatever it left behind: BSArch can abort partway and still leave a scratch
@@ -261,10 +258,10 @@ public static class BsaArchive
                 $"BSArch exited with code {run.exit} — {said}. Nothing was packed; the existing archive, if any, is untouched.", null);
         }
 
-        // Provenance: THIS run must have written the scratch (mtime at/after the pre-run baseline) —
-        // existence alone proved nothing about who made it.
-        bool packed = run.runError is null && File.Exists(tmp) && new FileInfo(tmp).Length > 0
-                      && File.GetLastWriteTimeUtc(tmp) >= baselineUtc;
+        // Provenance: the scratch was cleared before the run (a stuck one already refused), so a non-empty scratch after
+        // a zero-exit run is this run's. No mtime compare — an NTFS write stamp can read older than a precise-clock
+        // baseline taken microseconds earlier, which failed a good fast pack with no sentence saying why (#522).
+        bool packed = run.runError is null && File.Exists(tmp) && new FileInfo(tmp).Length > 0;
         if (!packed)   // BSArch couldn't run, or produced no/empty output — leave any prior archive untouched
         {
             try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* best-effort */ }

--- a/src/housecarl-core/BsaArchive.cs
+++ b/src/housecarl-core/BsaArchive.cs
@@ -39,6 +39,13 @@ public sealed record BsaPackResult(
     public bool Ran => RunError is null;
 }
 
+/// <summary>How a pack writes the archive: produce <paramref name="tmpArchive"/> from <paramref name="srcFolder"/> and
+/// report what the run said, with <c>runError</c> non-null when it never really ran. <see cref="BsaArchive.Pack"/>
+/// defaults to the BSArch shell; a test substitutes a packer that writes a known archive, so the count read-back around
+/// it can be exercised without BSArch.</summary>
+public delegate (string stdout, string stderr, string? runError) BsaPacker(
+    string bsarchExe, string srcFolder, string tmpArchive, string formatFlag, bool compress, int timeoutMs);
+
 /// <summary>
 /// The engine behind the housecarl_bsa_* tools. READS (list + extract) go through <b>Mutagen's own BSA reader</b>
 /// (<see cref="Archive.CreateReader"/> in Mutagen.Bethesda.Core — a maintained, in-process parser that handles every
@@ -213,7 +220,7 @@ public static class BsaArchive
     /// before the move, so a short pack refuses instead of reporting success; files at the source ROOT are counted apart
     /// because BSArch drops them, and a source that cannot be fully enumerated packs unverified rather than refusing. NOTE the caller must surface BSArch's caveat: a COMPRESSED archive breaks any
     /// sounds/voices it contains.</summary>
-    public static BsaPackResult Pack(string bsarchExe, string srcFolder, string archive, string formatFlag, bool compress, int timeoutMs = 600_000)
+    public static BsaPackResult Pack(string bsarchExe, string srcFolder, string archive, string formatFlag, bool compress, int timeoutMs = 600_000, BsaPacker? packer = null)
     {
         var nothing = Array.Empty<string>();
         // Pack to a scratch sibling (keeps the .bsa extension so BSArch is happy); the real target is touched only on success.
@@ -237,9 +244,7 @@ public static class BsaArchive
         catch { scan = null; }
         var baselineUtc = DateTime.UtcNow;
 
-        var args = new List<string> { "pack", srcFolder, tmp, formatFlag, "-mt" };
-        if (compress) args.Add("-z");
-        var run = Run(bsarchExe, args, timeoutMs);
+        var run = (packer ?? ShellBsArch)(bsarchExe, srcFolder, tmp, formatFlag, compress, timeoutMs);
 
         // Provenance: THIS run must have written the scratch (mtime at/after the pre-run baseline) —
         // existence alone proved nothing about who made it.
@@ -314,6 +319,16 @@ public static class BsaArchive
         "sf1dds" => "-sf1dds",
         _ => null,
     };
+
+    /// <summary>Run BSArch's pack for real: the shipped packer, and <see cref="Pack"/>'s default.</summary>
+    static (string stdout, string stderr, string? runError) ShellBsArch(
+        string bsarchExe, string srcFolder, string tmpArchive, string formatFlag, bool compress, int timeoutMs)
+    {
+        var args = new List<string> { "pack", srcFolder, tmpArchive, formatFlag, "-mt" };
+        if (compress) args.Add("-z");
+        var run = Run(bsarchExe, args, timeoutMs);
+        return (run.stdout, run.stderr, run.runError);
+    }
 
     static (bool ran, int exit, string stdout, string stderr, string? runError) Run(string exe, IReadOnlyList<string> args, int timeoutMs)
     {

--- a/src/housecarl-core/BsaArchive.cs
+++ b/src/housecarl-core/BsaArchive.cs
@@ -26,8 +26,8 @@ public sealed record BsaResult(bool Success, string Raw, string? RunError)
 /// source root, which BSArch silently drops — the full root listing, not just the ones BSArch would have taken.</summary>
 public sealed record BsaSourceScan(int Archivable, IReadOnlyList<string> RootFiles);
 
-/// <summary>The result of a pack (BSArch). <see cref="RunError"/> non-null ⇒ the pack never really ran (BSArch couldn't
-/// be launched / a stuck stale scratch refused up front); <see cref="CountError"/> non-null ⇒ it
+/// <summary>The result of a pack (BSArch). <see cref="RunError"/> non-null ⇒ the pack produced nothing usable (BSArch
+/// couldn't be launched, exited non-zero, or a stuck stale scratch refused up front); <see cref="CountError"/> non-null ⇒ it
 /// ran but the produced archive's header count disagreed with the source, so nothing was placed. <see cref="Packed"/> is
 /// the produced archive's own file count, or null when it could not be read — the header oracle reads .bsa only, so a
 /// BA2 (fo4/sf1) or Morrowind archive packs unverified. <see cref="Expected"/> is what the source offered, or null when
@@ -40,10 +40,11 @@ public sealed record BsaPackResult(
 }
 
 /// <summary>How a pack writes the archive: produce <paramref name="tmpArchive"/> from <paramref name="srcFolder"/> and
-/// report what the run said, with <c>runError</c> non-null when it never really ran. <see cref="BsaArchive.Pack"/>
+/// report what the run said, with <c>runError</c> non-null when it never really ran and <c>exit</c> the packer's own
+/// exit code (0 = clean; anything else is a failed pack, whatever it left on disk). <see cref="BsaArchive.Pack"/>
 /// defaults to the BSArch shell; a test substitutes a packer that writes a known archive, so the count read-back around
 /// it can be exercised without BSArch.</summary>
-public delegate (string stdout, string stderr, string? runError) BsaPacker(
+public delegate (int exit, string stdout, string stderr, string? runError) BsaPacker(
     string bsarchExe, string srcFolder, string tmpArchive, string formatFlag, bool compress, int timeoutMs);
 
 /// <summary>
@@ -213,13 +214,15 @@ public static class BsaArchive
     /// an existing archive at the target is NEVER overwritten unless this run successfully packs a new one — BSArch writes
     /// to a houseCARL-internal temp beside the target, and only a clean pack THIS RUN (temp exists, non-empty, AND written
     /// at/after the run's mtime baseline) is moved over the target; a stale scratch from a previous run that cannot be
-    /// removed REFUSES up front (nothing runs, the prior .bsa untouched), and any failure (BSArch error, timeout, empty
-    /// output, stale-mtime scratch) deletes the temp and leaves the prior .bsa untouched. The mtime gate assumes an
-    /// NTFS-class timestamp resolution — on a FAT-class target a same-second pack could read as stale and fail LOUD (never
-    /// falsely succeed). The source is enumerated first and the produced archive's own header count is checked against it
+    /// removed REFUSES up front (nothing runs, the prior .bsa untouched), and any failure (BSArch error, non-zero exit,
+    /// timeout, empty output, stale-mtime scratch) deletes the temp and leaves the prior .bsa untouched. The mtime gate
+    /// assumes an NTFS-class timestamp resolution — on a FAT-class target a same-second pack could read as stale and fail
+    /// LOUD (never falsely succeed). The source is enumerated first and the produced archive's own header count is checked against it
     /// before the move, so a short pack refuses instead of reporting success; files at the source ROOT are counted apart
     /// because BSArch drops them, and a source that cannot be fully enumerated packs unverified rather than refusing. NOTE the caller must surface BSArch's caveat: a COMPRESSED archive breaks any
-    /// sounds/voices it contains.</summary>
+    /// sounds/voices it contains. The write itself runs through <paramref name="packer"/>, which defaults to the BSArch
+    /// shell — everything above about "BSArch" is that default; a test substitutes a packer to drive the checks around
+    /// the write without BSArch.</summary>
     public static BsaPackResult Pack(string bsarchExe, string srcFolder, string archive, string formatFlag, bool compress, int timeoutMs = 600_000, BsaPacker? packer = null)
     {
         var nothing = Array.Empty<string>();
@@ -242,9 +245,21 @@ public static class BsaArchive
         BsaSourceScan? scan;
         try { scan = ScanPackSource(srcFolder); }
         catch { scan = null; }
+
         var baselineUtc = DateTime.UtcNow;
 
         var run = (packer ?? ShellBsArch)(bsarchExe, srcFolder, tmp, formatFlag, compress, timeoutMs);
+
+        // A non-zero exit is a failed pack whatever it left behind: BSArch can abort partway and still leave a scratch
+        // whose header count happens to agree with the source, which would otherwise ship over the user's archive.
+        if (run.runError is null && run.exit != 0)
+        {
+            try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* best-effort */ }
+            var said = string.IsNullOrWhiteSpace(run.stderr) ? "it printed no error output" : run.stderr.Trim();
+            return new BsaPackResult(false, null, scan?.Archivable, scan?.RootFiles ?? nothing,
+                (run.stdout + "\n" + run.stderr).Trim(),
+                $"BSArch exited with code {run.exit} — {said}. Nothing was packed; the existing archive, if any, is untouched.", null);
+        }
 
         // Provenance: THIS run must have written the scratch (mtime at/after the pre-run baseline) —
         // existence alone proved nothing about who made it.
@@ -321,13 +336,13 @@ public static class BsaArchive
     };
 
     /// <summary>Run BSArch's pack for real: the shipped packer, and <see cref="Pack"/>'s default.</summary>
-    static (string stdout, string stderr, string? runError) ShellBsArch(
+    static (int exit, string stdout, string stderr, string? runError) ShellBsArch(
         string bsarchExe, string srcFolder, string tmpArchive, string formatFlag, bool compress, int timeoutMs)
     {
         var args = new List<string> { "pack", srcFolder, tmpArchive, formatFlag, "-mt" };
         if (compress) args.Add("-z");
         var run = Run(bsarchExe, args, timeoutMs);
-        return (run.stdout, run.stderr, run.runError);
+        return (run.exit, run.stdout, run.stderr, run.runError);
     }
 
     static (bool ran, int exit, string stdout, string stderr, string? runError) Run(string exe, IReadOnlyList<string> args, int timeoutMs)

--- a/src/housecarl-generator/BsaBuilder.cs
+++ b/src/housecarl-generator/BsaBuilder.cs
@@ -1,0 +1,93 @@
+using System.Text;
+
+namespace HousecarlGenerator;
+
+/// <summary>Authors byte-exact uncompressed BSA archives in memory, so a probe or a test can exercise the real read
+/// path without BSArch and without a checked-in binary. Shared by bsa-extract-guard and the pack read-back tests.</summary>
+public static class BsaBuilder
+{
+    public const uint HasFolderNames = 0x0001;
+    public const uint HasFileNames = 0x0002;
+
+    /// <summary>Deterministic per-file body (varying content + length), so a mis-mapped name/offset is caught.</summary>
+    public static byte[] Bytes(string tag, int len)
+    {
+        var seed = Encoding.ASCII.GetBytes(tag);
+        var b = new byte[len];
+        for (int i = 0; i < len; i++) b[i] = (byte)(seed[i % seed.Length] ^ (i * 31 + 7));
+        return b;
+    }
+
+    /// <summary>Author a byte-exact uncompressed BSA (folder+file names present, little-endian) — the standard
+    /// header -> folder records -> folder blocks -> file-name block -> file data layout Mutagen's reader parses.</summary>
+    public static byte[] Build(uint version, uint archiveFlags, (string Folder, (string Name, byte[] Data)[] Files)[] folders)
+    {
+        int frSize = version == 105 ? 24 : 16;
+        uint folderCount = (uint)folders.Length;
+        uint fileCount = (uint)folders.Sum(f => f.Files.Length);
+        uint totalFolderNameLen = (uint)folders.Sum(f => f.Folder.Length + 1);
+        uint totalFileNameLen = (uint)folders.SelectMany(f => f.Files).Sum(x => x.Name.Length + 1);
+
+        long folderRecordsEnd = 36 + (long)folderCount * frSize;
+        var blockSizes = folders.Select(f => 1L + (f.Folder.Length + 1) + f.Files.Length * 16L).ToArray();
+        long nameBlockStart = folderRecordsEnd + blockSizes.Sum();
+        long fileDataStart = nameBlockStart + totalFileNameLen;
+
+        using var ms = new MemoryStream();
+        using var bw = new BinaryWriter(ms, Encoding.ASCII);
+
+        bw.Write(0x00415342u);          // "BSA\0"
+        bw.Write(version);
+        bw.Write(36u);                  // folder-records offset
+        bw.Write(archiveFlags);
+        bw.Write(folderCount);
+        bw.Write(fileCount);
+        bw.Write(totalFolderNameLen);
+        bw.Write(totalFileNameLen);
+        bw.Write(0u);                   // file (content-type) flags
+
+        long blockOffset = folderRecordsEnd;
+        for (int i = 0; i < folders.Length; i++)
+        {
+            bw.Write(0UL);                                           // hash
+            bw.Write((uint)folders[i].Files.Length);
+            if (frSize == 24) { bw.Write(0u); bw.Write((ulong)(blockOffset + totalFileNameLen)); }
+            else bw.Write((uint)(blockOffset + totalFileNameLen));
+            blockOffset += blockSizes[i];
+        }
+
+        long dataCursor = fileDataStart;
+        var dataOrder = new List<byte[]>();
+        foreach (var (folder, files) in folders)
+        {
+            var fn = Encoding.ASCII.GetBytes(folder);
+            bw.Write((byte)(fn.Length + 1));   // bzstring length INCLUDING the null
+            bw.Write(fn);
+            bw.Write((byte)0);
+            foreach (var (_, data) in files)
+            {
+                bw.Write(0UL);                 // file name hash
+                bw.Write((uint)data.Length);   // size field — uncompressed, no toggle bit
+                bw.Write((uint)dataCursor);    // absolute data offset
+                dataCursor += data.Length;
+                dataOrder.Add(data);
+            }
+        }
+
+        foreach (var (_, files) in folders)
+            foreach (var (name, _) in files) { bw.Write(Encoding.ASCII.GetBytes(name)); bw.Write((byte)0); }
+
+        foreach (var d in dataOrder) bw.Write(d);
+
+        bw.Flush();
+        return ms.ToArray();
+    }
+
+    /// <summary>Rewrite the header's declared file count (offset 20) so an archive can be made to lie about itself.</summary>
+    public static byte[] WithDeclaredFileCount(byte[] archive, uint fileCount)
+    {
+        var copy = (byte[])archive.Clone();
+        BitConverter.GetBytes(fileCount).CopyTo(copy, 20);
+        return copy;
+    }
+}

--- a/src/housecarl-generator/BsaContractProbe.cs
+++ b/src/housecarl-generator/BsaContractProbe.cs
@@ -12,7 +12,7 @@ namespace HousecarlGenerator;
 /// What it locks:
 ///   1. PACK PROVENANCE — "tmp exists and is non-empty" proved nothing about WHO made it: a stale scratch from a previous
 ///      run could ship as this run's archive. A stuck (undeletable) stale scratch now REFUSES loud before running; a
-///      fresh-run mtime baseline gates the move; a failing pack leaves any prior archive byte-untouched.
+///      pre-run clear plus a zero-exit run gates the move; a failing pack leaves any prior archive byte-untouched.
 ///   2. FORMAT REFUSAL — an unknown format token used to coerce silently to -sse; TryFormatFlag now returns null for
 ///      refusal (legal tokens keep their flags; the sse family defaults).
 /// </summary>
@@ -51,9 +51,10 @@ internal static class BsaContractProbe
                       "stuck stale scratch → loud refusal naming it (nothing packed)");
             }
             Check(File.ReadAllText(target) == "PRIOR ARCHIVE — must survive", "the prior archive is byte-untouched");
-            // unlocked stale: delete succeeds, stub packs nothing → honest failure, stale gone, target untouched
+            // unlocked stale: delete succeeds, stub exits non-zero and packs nothing → refusal naming the exit code
             var rp2 = BsaArchive.Pack(stub, packDir, target, "-sse", compress: false, timeoutMs: 30_000);
-            Check(rp2.Ran && !rp2.Success, "deletable stale + failing BSArch = honest failure (no stale shipped)");
+            Check(!rp2.Success && (rp2.RunError?.Contains("exited with code", StringComparison.OrdinalIgnoreCase) ?? false),
+                  "deletable stale + failing BSArch = refusal naming the exit code (no stale shipped)");
             Check(File.ReadAllText(target) == "PRIOR ARCHIVE — must survive", "the prior archive survives that path too");
 
             // ---- 2) format refusal ----

--- a/src/housecarl-generator/BsaExtractProbe.cs
+++ b/src/housecarl-generator/BsaExtractProbe.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using HousecarlCore;
 
 namespace HousecarlGenerator;
@@ -29,12 +28,12 @@ internal static class BsaExtractProbe
         {
             ("scripts", new[]
             {
-                ("main.pex",   Bytes("PEX-main", 40)),
-                ("helper.pex", Bytes("PEX-help", 4096)),
+                ("main.pex",   BsaBuilder.Bytes("PEX-main", 40)),
+                ("helper.pex", BsaBuilder.Bytes("PEX-help", 4096)),
             }),
             (@"sound\voice\test.esp\femalecommoner", new[]
             {
-                ("hello_000012ab_1.fuz", Bytes("FUZ-audio", 1)),   // 1-byte body — smallest edge
+                ("hello_000012ab_1.fuz", BsaBuilder.Bytes("FUZ-audio", 1)),   // 1-byte body — smallest edge
             }),
         };
 
@@ -46,7 +45,7 @@ internal static class BsaExtractProbe
             Console.WriteLine("--- 1: uncompressed round-trip via BsaArchive.Unpack (Mutagen) ---");
             foreach (uint version in new uint[] { 105, 104 })
             {
-                var bsa = Write(work, $"round-{version}.bsa", BuildBsa(version, FHasFolderNames | FHasFileNames, folders));
+                var bsa = Write(work, $"round-{version}.bsa", BsaBuilder.Build(version, BsaBuilder.HasFolderNames | BsaBuilder.HasFileNames, folders));
                 var dest = Path.Combine(work, $"round-{version}");
                 var r = BsaArchive.Unpack(bsa, dest);
                 Check(r.Ran && r.Success, $"v{version}: extract Success ({r.Raw})");
@@ -61,9 +60,9 @@ internal static class BsaExtractProbe
             // ---- 3) path-traversal safety ----
             Console.WriteLine();
             Console.WriteLine("--- 3: path traversal ---");
-            var evil = BuildBsa(105, FHasFolderNames | FHasFileNames, new (string, (string, byte[])[])[]
+            var evil = BsaBuilder.Build(105, BsaBuilder.HasFolderNames | BsaBuilder.HasFileNames, new (string, (string, byte[])[])[]
             {
-                ("..", new[] { ("escape.txt", Bytes("nope", 8)) }),
+                ("..", new[] { ("escape.txt", BsaBuilder.Bytes("nope", 8)) }),
             });
             var evilDest = Path.Combine(work, "evil-dest");
             var er = BsaArchive.Unpack(Write(work, "evil.bsa", evil), evilDest);
@@ -72,9 +71,8 @@ internal static class BsaExtractProbe
             Check(!File.Exists(Path.Combine(work, "escape.txt")), "nothing written outside the destination");
 
             // ---- 3b) header/reader file-count mismatch -> loud (the #217 silent-empty/short-extract guard) ----
-            var good = BuildBsa(105, FHasFolderNames | FHasFileNames, folders);   // 3 real files
-            var lie = (byte[])good.Clone();
-            BitConverter.GetBytes(1u).CopyTo(lie, 20);                            // header @20 now lies: "1 file"
+            var good = BsaBuilder.Build(105, BsaBuilder.HasFolderNames | BsaBuilder.HasFileNames, folders);   // 3 real files
+            var lie = BsaBuilder.WithDeclaredFileCount(good, 1);                   // header @20 now lies: "1 file"
             var lr = BsaArchive.Unpack(Write(work, "count-lie.bsa", lie), Path.Combine(work, "count-out"));
             Check(!lr.Success, $"lying header count -> no silent success ({(lr.Ran ? lr.Raw : lr.RunError)})");
 
@@ -94,18 +92,6 @@ internal static class BsaExtractProbe
         return fail == 0 ? 0 : 1;
     }
 
-    const uint FHasFolderNames = 0x0001;
-    const uint FHasFileNames = 0x0002;
-
-    /// <summary>Deterministic per-file body (varying content + length), so a mis-mapped name/offset is caught.</summary>
-    static byte[] Bytes(string tag, int len)
-    {
-        var seed = Encoding.ASCII.GetBytes(tag);
-        var b = new byte[len];
-        for (int i = 0; i < len; i++) b[i] = (byte)(seed[i % seed.Length] ^ (i * 31 + 7));
-        return b;
-    }
-
     static string Write(string dir, string name, byte[] bytes) { var p = Path.Combine(dir, name); File.WriteAllBytes(p, bytes); return p; }
 
     static bool AllBytesCorrect(string dest, (string Folder, (string Name, byte[] Data)[] Files)[] folders)
@@ -120,68 +106,4 @@ internal static class BsaExtractProbe
         return true;
     }
 
-    /// <summary>Author a byte-exact uncompressed BSA (folder+file names present, little-endian) — the standard
-    /// header -> folder records -> folder blocks -> file-name block -> file data layout Mutagen's reader parses.</summary>
-    static byte[] BuildBsa(uint version, uint archiveFlags, (string Folder, (string Name, byte[] Data)[] Files)[] folders)
-    {
-        int frSize = version == 105 ? 24 : 16;
-        uint folderCount = (uint)folders.Length;
-        uint fileCount = (uint)folders.Sum(f => f.Files.Length);
-        uint totalFolderNameLen = (uint)folders.Sum(f => f.Folder.Length + 1);
-        uint totalFileNameLen = (uint)folders.SelectMany(f => f.Files).Sum(x => x.Name.Length + 1);
-
-        long folderRecordsEnd = 36 + (long)folderCount * frSize;
-        var blockSizes = folders.Select(f => 1L + (f.Folder.Length + 1) + f.Files.Length * 16L).ToArray();
-        long nameBlockStart = folderRecordsEnd + blockSizes.Sum();
-        long fileDataStart = nameBlockStart + totalFileNameLen;
-
-        using var ms = new MemoryStream();
-        using var bw = new BinaryWriter(ms, Encoding.ASCII);
-
-        bw.Write(0x00415342u);          // "BSA\0"
-        bw.Write(version);
-        bw.Write(36u);                  // folder-records offset
-        bw.Write(archiveFlags);
-        bw.Write(folderCount);
-        bw.Write(fileCount);
-        bw.Write(totalFolderNameLen);
-        bw.Write(totalFileNameLen);
-        bw.Write(0u);                   // file (content-type) flags
-
-        long blockOffset = folderRecordsEnd;
-        for (int i = 0; i < folders.Length; i++)
-        {
-            bw.Write(0UL);                                           // hash
-            bw.Write((uint)folders[i].Files.Length);
-            if (frSize == 24) { bw.Write(0u); bw.Write((ulong)(blockOffset + totalFileNameLen)); }
-            else bw.Write((uint)(blockOffset + totalFileNameLen));
-            blockOffset += blockSizes[i];
-        }
-
-        long dataCursor = fileDataStart;
-        var dataOrder = new List<byte[]>();
-        foreach (var (folder, files) in folders)
-        {
-            var fn = Encoding.ASCII.GetBytes(folder);
-            bw.Write((byte)(fn.Length + 1));   // bzstring length INCLUDING the null
-            bw.Write(fn);
-            bw.Write((byte)0);
-            foreach (var (_, data) in files)
-            {
-                bw.Write(0UL);                 // file name hash
-                bw.Write((uint)data.Length);   // size field — uncompressed, no toggle bit
-                bw.Write((uint)dataCursor);    // absolute data offset
-                dataCursor += data.Length;
-                dataOrder.Add(data);
-            }
-        }
-
-        foreach (var (_, files) in folders)
-            foreach (var (name, _) in files) { bw.Write(Encoding.ASCII.GetBytes(name)); bw.Write((byte)0); }
-
-        foreach (var d in dataOrder) bw.Write(d);
-
-        bw.Flush();
-        return ms.ToArray();
-    }
 }

--- a/src/housecarl-mcp-tests/BsaPackReadBackTests.cs
+++ b/src/housecarl-mcp-tests/BsaPackReadBackTests.cs
@@ -39,8 +39,9 @@ public sealed class BsaPackReadBackTests : IDisposable
     }
 
     /// <summary>A packer that ignores BSArch and writes <paramref name="archive"/> at the scratch path. The write time is
-    /// stamped explicitly: a pack only ships a scratch written at or after its own start, and NTFS records a last-write
-    /// time coarser than the clock the baseline is read from, so an instant write can otherwise read as stale.</summary>
+    /// stamped explicitly to get past the pack's own provenance gate: NTFS records a last-write time coarser than the
+    /// clock that gate's baseline is read from, so an instant write reads as stale (#522). Drop the stamp once that is
+    /// fixed — these tests are about the count read-back, not the gate.</summary>
     static BsaPacker Writes(byte[] archive) => (_, _, tmpArchive, _, _, _) =>
     {
         File.WriteAllBytes(tmpArchive, archive);

--- a/src/housecarl-mcp-tests/BsaPackReadBackTests.cs
+++ b/src/housecarl-mcp-tests/BsaPackReadBackTests.cs
@@ -39,12 +39,10 @@ public sealed class BsaPackReadBackTests : IDisposable
     }
 
     /// <summary>A packer that ignores BSArch and writes <paramref name="archive"/> at the scratch path, reporting
-    /// <paramref name="exit"/> as the run's exit code. The write time is stamped explicitly to get past the pack's own
-    /// provenance gate, which an instant write reads as stale (#522); drop the stamp once that is fixed.</summary>
+    /// <paramref name="exit"/> as the run's exit code.</summary>
     static BsaPacker Writes(byte[] archive, int exit = 0, string stderr = "") => (_, _, tmpArchive, _, _, _) =>
     {
         File.WriteAllBytes(tmpArchive, archive);
-        File.SetLastWriteTimeUtc(tmpArchive, DateTime.UtcNow);
         return (exit, "", stderr, null);
     };
 
@@ -102,5 +100,22 @@ public sealed class BsaPackReadBackTests : IDisposable
         Assert.Contains("code 1", refusal);
         Assert.Contains("aborted at meshes/b.nif", refusal);
         Assert.Equal("PRIOR ARCHIVE", File.ReadAllText(target));
+    }
+
+    /// <summary>A scratch written the instant the packer is called passes the pack's provenance gate. The gate used to
+    /// compare an NTFS write stamp against a precise-clock baseline, so an immediate write read as stale better than
+    /// half the time (#522) — hence the loop.</summary>
+    [Fact]
+    public void PackAcceptsAScratchWrittenImmediately()
+    {
+        var src = ThreeFileSource();
+        var archive = BsaBuilder.Build(105, BsaBuilder.HasFolderNames | BsaBuilder.HasFileNames, Contents);
+
+        for (var i = 0; i < 20; i++)
+        {
+            var target = Path.Combine(_root, $"Loop{i}.bsa");
+            var result = BsaArchive.Pack("bsarch.exe", src, target, "-sse", compress: false, packer: Writes(archive));
+            Assert.True(result.Success, $"run {i} was refused: {result.RunError ?? result.Raw}");
+        }
     }
 }

--- a/src/housecarl-mcp-tests/BsaPackReadBackTests.cs
+++ b/src/housecarl-mcp-tests/BsaPackReadBackTests.cs
@@ -1,0 +1,86 @@
+using HousecarlCore;
+using HousecarlGenerator;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>The repack read-back, against a real archive: a pack reads the produced .bsa's own header count and refuses
+/// when it disagrees with the source. The suite has no BSArch, so a substituted packer writes an archive authored by
+/// <see cref="BsaBuilder"/> — the header the read-back parses is a real one.</summary>
+[Trait("tier", "unit")]
+public sealed class BsaPackReadBackTests : IDisposable
+{
+    readonly string _root;
+
+    public BsaPackReadBackTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "hc-bsa-readback-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose() { try { Directory.Delete(_root, recursive: true); } catch { /* temp scratch */ } }
+
+    static readonly (string Folder, (string Name, byte[] Data)[] Files)[] Contents =
+    {
+        ("meshes", new[] { ("a.nif", BsaBuilder.Bytes("NIF-a", 64)), ("b.nif", BsaBuilder.Bytes("NIF-b", 12)) }),
+        ("scripts", new[] { ("c.pex", BsaBuilder.Bytes("PEX-c", 300)) }),
+    };
+
+    /// <summary>A source folder holding the same three files the authored archive carries.</summary>
+    string ThreeFileSource()
+    {
+        var src = Path.Combine(_root, "src");
+        foreach (var (folder, files) in Contents)
+        {
+            Directory.CreateDirectory(Path.Combine(src, folder));
+            foreach (var (name, data) in files) File.WriteAllBytes(Path.Combine(src, folder, name), data);
+        }
+        return src;
+    }
+
+    /// <summary>A packer that ignores BSArch and writes <paramref name="archive"/> at the scratch path. The write time is
+    /// stamped explicitly: a pack only ships a scratch written at or after its own start, and NTFS records a last-write
+    /// time coarser than the clock the baseline is read from, so an instant write can otherwise read as stale.</summary>
+    static BsaPacker Writes(byte[] archive) => (_, _, tmpArchive, _, _, _) =>
+    {
+        File.WriteAllBytes(tmpArchive, archive);
+        File.SetLastWriteTimeUtc(tmpArchive, DateTime.UtcNow);
+        return ("", "", null);
+    };
+
+    [Fact]
+    public void PackReadsTheProducedArchiveCountBack()
+    {
+        var src = ThreeFileSource();
+        var target = Path.Combine(_root, "Out.bsa");
+        var archive = BsaBuilder.Build(105, BsaBuilder.HasFolderNames | BsaBuilder.HasFileNames, Contents);
+
+        var result = BsaArchive.Pack("bsarch.exe", src, target, "-sse", compress: false, packer: Writes(archive));
+
+        Assert.True(result.Success);
+        Assert.Null(result.CountError);
+        Assert.Equal(3, result.Packed);
+        Assert.Equal(3, result.Expected);
+        Assert.True(File.Exists(target));
+    }
+
+    [Fact]
+    public void PackRefusesAnArchiveThatCountsShort()
+    {
+        var src = ThreeFileSource();
+        var target = Path.Combine(_root, "Out.bsa");
+        File.WriteAllText(target, "PRIOR ARCHIVE");
+        var archive = BsaBuilder.WithDeclaredFileCount(
+            BsaBuilder.Build(105, BsaBuilder.HasFolderNames | BsaBuilder.HasFileNames, Contents), 2);
+
+        var result = BsaArchive.Pack("bsarch.exe", src, target, "-sse", compress: false, packer: Writes(archive));
+
+        Assert.False(result.Success);
+        Assert.Equal(2, result.Packed);
+        Assert.Equal(3, result.Expected);
+        var refusal = Assert.IsType<string>(result.CountError);
+        Assert.Contains("2 file(s)", refusal);
+        Assert.Contains("offers 3", refusal);
+        Assert.Equal("PRIOR ARCHIVE", File.ReadAllText(target));
+    }
+}

--- a/src/housecarl-mcp-tests/BsaPackReadBackTests.cs
+++ b/src/housecarl-mcp-tests/BsaPackReadBackTests.cs
@@ -38,15 +38,14 @@ public sealed class BsaPackReadBackTests : IDisposable
         return src;
     }
 
-    /// <summary>A packer that ignores BSArch and writes <paramref name="archive"/> at the scratch path. The write time is
-    /// stamped explicitly to get past the pack's own provenance gate: NTFS records a last-write time coarser than the
-    /// clock that gate's baseline is read from, so an instant write reads as stale (#522). Drop the stamp once that is
-    /// fixed — these tests are about the count read-back, not the gate.</summary>
-    static BsaPacker Writes(byte[] archive) => (_, _, tmpArchive, _, _, _) =>
+    /// <summary>A packer that ignores BSArch and writes <paramref name="archive"/> at the scratch path, reporting
+    /// <paramref name="exit"/> as the run's exit code. The write time is stamped explicitly to get past the pack's own
+    /// provenance gate, which an instant write reads as stale (#522); drop the stamp once that is fixed.</summary>
+    static BsaPacker Writes(byte[] archive, int exit = 0, string stderr = "") => (_, _, tmpArchive, _, _, _) =>
     {
         File.WriteAllBytes(tmpArchive, archive);
         File.SetLastWriteTimeUtc(tmpArchive, DateTime.UtcNow);
-        return ("", "", null);
+        return (exit, "", stderr, null);
     };
 
     [Fact]
@@ -82,6 +81,26 @@ public sealed class BsaPackReadBackTests : IDisposable
         var refusal = Assert.IsType<string>(result.CountError);
         Assert.Contains("2 file(s)", refusal);
         Assert.Contains("offers 3", refusal);
+        Assert.Equal("PRIOR ARCHIVE", File.ReadAllText(target));
+    }
+
+    /// <summary>A packer that exits non-zero has failed, whatever it left on disk — even a scratch whose header count
+    /// agrees with the source. The refusal names the exit code and what the packer printed.</summary>
+    [Fact]
+    public void PackRefusesAScratchFromANonZeroExit()
+    {
+        var src = ThreeFileSource();
+        var target = Path.Combine(_root, "Out.bsa");
+        File.WriteAllText(target, "PRIOR ARCHIVE");
+        var archive = BsaBuilder.Build(105, BsaBuilder.HasFolderNames | BsaBuilder.HasFileNames, Contents);
+
+        var result = BsaArchive.Pack("bsarch.exe", src, target, "-sse", compress: false,
+            packer: Writes(archive, exit: 1, stderr: "aborted at meshes/b.nif"));
+
+        Assert.False(result.Success);
+        var refusal = Assert.IsType<string>(result.RunError);
+        Assert.Contains("code 1", refusal);
+        Assert.Contains("aborted at meshes/b.nif", refusal);
         Assert.Equal("PRIOR ARCHIVE", File.ReadAllText(target));
     }
 }


### PR DESCRIPTION
PR #514 made `bsa_repack` read the produced archive's own header count back and refuse when it disagrees with the source, but the suite has no BSArch, so nothing in CI ever produced an archive and counted it — a later break of the read-back stayed green. `BsaArchive.Pack` now takes an optional packer delegate, defaulting to the BSArch shell it already ran, so a test can substitute a packer that writes a known archive; the in-memory BSA builder that `BsaExtractProbe` hand-rolls moves to a shared `BsaBuilder` the probe and the tests both use, so the archive the read-back parses is a real one rather than a stub header. Two tests: one packs a three-file source through the seam, reads back 3 and reports success; one makes the archive claim 2 and asserts the refusal names both numbers and leaves the existing archive untouched.

Both shapes the issue offered turned out to be needed rather than alternatives — the seam is the only way to drive `Pack` without BSArch, and a substituted packer needs something real to write — so the smaller move was to take the seam and lift the builder instead of duplicating sixty lines of byte layout into the test project. The builder is a verbatim move; the probe keeps working through it.

Two review findings and one issue folded on top:

- The packer tuple now carries the run's **exit code**. It was dropped, so BSArch aborting partway while leaving a scratch whose header count happened to match the source would ship that scratch over the user's archive and report success. A non-zero exit is now a failed pack whatever it left on disk, refused in one sentence naming the code and what BSArch printed, with nothing committed over the target.
- `Pack`'s summary now says the write runs through `packer`, defaulting to the BSArch shell, so the "via BSArch" paragraph above it reads as that default.
- **#522**: the scratch freshness gate compared an NTFS write stamp against a baseline read from the precise clock, so a pack finishing inside one filesystem tick read as stale and failed with an empty message. The scratch is cleared before the run and a stuck one already refuses, so existence plus non-empty plus a clean exit now proves provenance without a timestamp. The test packer's write-time workaround comes out, so the tests exercise the real gate.

Proved red by making the read-back's `ReadBsaHeader(tmp)` return null: `PackReadsTheProducedArchiveCountBack` failed on `Packed` (expected 3, got null) and `PackRefusesAnArchiveThatCountsShort` failed on the refusal being gone. The two new tests were proved red against the old gate — with the exit check off and the mtime compare back, `PackRefusesAScratchFromANonZeroExit` and `PackAcceptsAScratchWrittenImmediately` (20 immediate writes in a loop) both failed. All green after. Full suite 1043 passed, `ci-all` 127/127. `BsaContractProbe`'s stub-BSArch check moved with the behaviour: a failing stub now returns a refusal naming the exit code rather than a bare Ran-but-not-Success.

Closes #519
Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)
