### PR TITLE
Refuse a runtime FormID at every write door

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -35,7 +35,7 @@ saying it sets an expectation their install may contradict. Say what is known, a
   off-order `source=` is refused once for the call, before any record is read, instead of once per record.
 
 - **A FormID from the game, a log or a crash log now works as an input, and comes back as an output.**
-  Wherever a parameter holds nothing but FormIDs, houseCARL now also takes the runtime form the game, the
+  Wherever a FormID is read, houseCARL now also takes the runtime form the game, the
   console, Papyrus logs, SKSE logs and crash logs print: eight hex digits and no plugin name — `FExxxYYY` for a light plugin,
   `XX######` for a full one, with or without a leading `0x`. It is resolved against the load order as it
   stands at the call (the light index moves whenever the order does, so nothing is cached), and the answer

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -17,6 +17,13 @@ saying it sets an expectation their install may contradict. Say what is known, a
   answer instead of cutting to none.** `housecarl_nif_inspect` already did; both tools now render through one batch
   skeleton, so the first item always answers and the omitted-count cut reads the same in both.
 
+- **A runtime FormID (`FExxxYYY` / `XX######`) is now read-only: the write verbs refuse one and hand back the
+  `XXXXXX:Plugin.esp` form to use in its place.** A runtime FormID names a slot in the load order as it stands, so
+  a re-sort between the parse and the write would point the same eight digits at a different record; the plugin form
+  cannot move that way. The refusal names the translated form, so it can be pasted straight back into the call.
+  Reading by a runtime FormID is unchanged, and the doors that refuse are the ones the write verbs parse their
+  targets through — see `FormIdDoor.ForWrite`.
+
 - **`housecarl_records` with `source={"file", "mod"}` now reads the copy in the named mod folder, even when that
   filename is active in the load order.** Several mod folders can ship the same plugin filename (an ESP replacer),
   and MO2 serves one of them; naming a folder addresses that folder's file. When the named copy is not the one the

--- a/src/housecarl-mcp-tests/RuntimeFormIdTests.cs
+++ b/src/housecarl-mcp-tests/RuntimeFormIdTests.cs
@@ -248,6 +248,17 @@ public sealed class RuntimeFormIdTests
         RefusedNothingWritten(w, outcome.Error);
     }
 
+    /// <summary>The same door parses the target too — a well-formed token there is declined in the refusal's own
+    /// words, not wrapped in the "bad target formid" sentence a malformed one gets.</summary>
+    [Fact]
+    public void CopyNpcAppearanceRefusesARuntimeTargetFormIdAndNamesThePluginForm()
+    {
+        using var w = new World();
+        var outcome = w.Svc.CopyNpcAppearance(World.Fid(w.FullWeapon), null, null, Runtime(w), null, null, null, null);
+        RefusedNothingWritten(w, outcome.Error);
+        Assert.DoesNotContain("bad target formid", outcome.Error);
+    }
+
     [Fact]
     public void PlaceAssetRefusesARuntimeFormIdAndNamesThePluginForm()
     {

--- a/src/housecarl-mcp-tests/RuntimeFormIdTests.cs
+++ b/src/housecarl-mcp-tests/RuntimeFormIdTests.cs
@@ -159,7 +159,90 @@ public sealed class RuntimeFormIdTests
         Served(Read(w, World.LightRuntime(1, w.LightWeapon)), "HcRtLightWeapon", World.LightName);
     }
 
+    // ---- a runtime FormID is read-only: every write door refuses it ---------------------------------
+
+    [Fact]
+    public void ApplyRefusesARuntimeFormIdAndNamesThePluginForm()
+    {
+        using var w = new World();
+        var outcome = w.Svc.ApplyEdits(
+            new[] { new BulkOp { Formid = Runtime(w), FieldPath = "BasicStats.Damage", Verb = "Set", Value = "99" } },
+            "HcRtPatch", null);
+        RefusedNothingWritten(w, outcome.Error);
+    }
+
+    [Fact]
+    public void RemoveRefusesARuntimeFormIdAndNamesThePluginForm()
+    {
+        using var w = new World();
+        var outcome = w.Svc.RemoveRecords(new[] { Runtime(w) }, patch: "HcRtPatch.esp");
+        RefusedNothingWritten(w, outcome.Error);
+    }
+
+    [Fact]
+    public void ForwardRefusesARuntimeFormIdAndNamesThePluginForm()
+    {
+        using var w = new World();
+        var outcome = w.Svc.ForwardRecords(new[] { Runtime(w) }, World.MasterName, "HcRtPatch", null);
+        RefusedNothingWritten(w, outcome.Error);
+    }
+
+    [Fact]
+    public void CopyRefusesARuntimeFormIdAndNamesThePluginForm()
+    {
+        using var w = new World();
+        var response = CopyTools.Copy(w.Svc, from: Runtime(w), seed_paths: new[] { "BasicStats" },
+                                      new_editorid: "HcRtCopyClone");
+        RefusedNothingWritten(w, response);
+    }
+
+    [Fact]
+    public void CopyNpcAppearanceRefusesARuntimeFormIdAndNamesThePluginForm()
+    {
+        using var w = new World();
+        var outcome = w.Svc.CopyNpcAppearance(Runtime(w), null, null, null, "HcRtNpcClone", null, null, null);
+        RefusedNothingWritten(w, outcome.Error);
+    }
+
+    [Fact]
+    public void PlaceAssetRefusesARuntimeFormIdAndNamesThePluginForm()
+    {
+        using var w = new World();
+        var response = PlaceAssetTools.PlaceAsset(w.Svc, formid: Runtime(w), kind: "mesh");
+        RefusedNothingWritten(w, response);
+    }
+
+    [Fact]
+    public void BulkPlaceAssetRefusesARuntimeFormIdAndNamesThePluginForm()
+    {
+        using var w = new World();
+        var response = PlaceAssetTools.BulkPlaceAsset(
+            w.Svc, new[] { new PlaceAssetSpec { Formid = Runtime(w), Kind = "mesh" } });
+        RefusedNothingWritten(w, response);
+    }
+
+    /// <summary>The token every write door above refuses still reads — the ruling is read-only, not banned.</summary>
+    [Fact]
+    public void TheTokenTheWriteDoorsRefuseStillReads()
+    {
+        using var w = new World();
+        Served(Read(w, Runtime(w)), "HcRtLightWeapon", World.LightName);
+    }
+
     // ---- helpers ----------------------------------------------------------------------------------
+
+    /// <summary>The runtime FormID of the light plugin's weapon — the token the write doors are given.</summary>
+    static string Runtime(World w) => World.LightRuntime(0, w.LightWeapon);
+
+    /// <summary>A write refusal that hands back the plugin form to paste in the token's place, having written
+    /// nothing: no mod folder was created for the patch.</summary>
+    static void RefusedNothingWritten(World w, string? message)
+    {
+        Assert.NotNull(message);
+        Assert.Contains("runtime FormID", message);
+        Assert.Contains(World.Fid(w.LightWeapon), message);
+        Assert.Equal(w.ModFolders, Directory.GetDirectories(w.ModsDir).Length);
+    }
 
     static string Read(World w, string formid)
         => RecordsTools.Records(w.Svc, formids: new[] { formid });
@@ -201,6 +284,12 @@ public sealed class RuntimeFormIdTests
         readonly string _priorCorpusPath;
 
         public LoadOrderService Svc { get; }
+
+        /// <summary>The instance's mods folder, and how many folders it held before any test ran — a write that
+        /// should have been refused shows up here as a new patch folder.</summary>
+        public string ModsDir { get; }
+        public int ModFolders { get; }
+
         public FormKey FullWeapon { get; }
         public FormKey LightWeapon { get; }
 
@@ -291,6 +380,8 @@ public sealed class RuntimeFormIdTests
             CorpusGenerator.GenerateAll(genDir, Path.Combine(_root, "corpus-ref"));
             CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json");
 
+            ModsDir = mods;
+            ModFolders = Directory.GetDirectories(mods).Length;
             Svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(_root, "user.json")));
         }
 

--- a/src/housecarl-mcp-tests/RuntimeFormIdTests.cs
+++ b/src/housecarl-mcp-tests/RuntimeFormIdTests.cs
@@ -183,6 +183,38 @@ public sealed class RuntimeFormIdTests
         RefusedNothingWritten(w, outcome.Error);
     }
 
+    /// <summary>A runtime token the index cannot translate — an FF dynamic form — is bad input, so it comes back as
+    /// this record's own problem rather than escaping as an internal failure.</summary>
+    [Fact]
+    public void CreateReportsAnUntranslatableRuntimeParentAsThisRecordsProblem()
+    {
+        using var w = new World();
+        var outcome = w.Svc.CreateRecordsBatch(
+            new[] { new CreateOp { RecordType = "Weapon", Editorid = "HcRtDynParent", Parent = "FF001234" } },
+            "HcRtPatch", null);
+        Assert.False(outcome.Success);
+        Assert.NotNull(outcome.Error);
+        Assert.Contains("parent:", outcome.Error);
+        Assert.Contains("dynamic form", outcome.Error);
+        Assert.Equal(w.ModFolders, Directory.GetDirectories(w.ModsDir).Length);
+    }
+
+    /// <summary>parent= also takes a same-call sibling's EditorID, and modders write eight-hex ones — such a parent
+    /// is a reference, never a FormID, so the nested create still lands.</summary>
+    [Fact]
+    public void CreateTakesAnEightHexSiblingEditoridAsAParent()
+    {
+        using var w = new World();
+        var outcome = w.Svc.CreateRecordsBatch(
+            new[]
+            {
+                new CreateOp { RecordType = "DialogTopic", Editorid = "DEADBEEF" },
+                new CreateOp { RecordType = "DialogResponses", Editorid = "HcRtSiblingLine", Parent = "DEADBEEF" },
+            },
+            "HcRtSiblingPatch", null);
+        Assert.True(outcome.Success, "refused: " + outcome.Error);
+    }
+
     [Fact]
     public void RemoveRefusesARuntimeFormIdAndNamesThePluginForm()
     {

--- a/src/housecarl-mcp-tests/RuntimeFormIdTests.cs
+++ b/src/housecarl-mcp-tests/RuntimeFormIdTests.cs
@@ -171,6 +171,18 @@ public sealed class RuntimeFormIdTests
         RefusedNothingWritten(w, outcome.Error);
     }
 
+    /// <summary>create's only FormID is parent=, which also takes an EditorID — a runtime FormID there is still
+    /// refused, rather than falling through to "no sibling of that name was declared earlier".</summary>
+    [Fact]
+    public void CreateRefusesARuntimeFormIdParentAndNamesThePluginForm()
+    {
+        using var w = new World();
+        var outcome = w.Svc.CreateRecordsBatch(
+            new[] { new CreateOp { RecordType = "Weapon", Editorid = "HcRtNewWeapon", Parent = Runtime(w) } },
+            "HcRtPatch", null);
+        RefusedNothingWritten(w, outcome.Error);
+    }
+
     [Fact]
     public void RemoveRefusesARuntimeFormIdAndNamesThePluginForm()
     {

--- a/src/housecarl-mcp/ApplyTools.cs
+++ b/src/housecarl-mcp/ApplyTools.cs
@@ -21,10 +21,11 @@ public static class ApplyTools
          "Edit fields on one or many records and write the result to a NEW patch plugin (originals untouched by " +
          "default). ONE surface: what to change (ops=, or the bundle=/assignments= copy zip) x WHERE it lands (the " +
          "LANE: a new patch | into= an existing one | in_place=\"X.esp\" | dry_run) x how it reads back (TRANSPORT).\n\n" +
-         "A FormID is 'XXXXXX:Plugin.esp' — 6 hex digits, a colon, the defining master's filename. On ops[].formid " +
-         "(and from=) the RUNTIME form the game, the console and the logs print is accepted too: eight hex digits " +
-         "and no plugin name, 'FExxxYYY' for a light plugin or 'XX######' for a full one, with or without a leading " +
-         "0x, resolved against the CURRENT load order. A field VALUE takes the 'XXXXXX:Plugin.esp' form only. " +
+         "A FormID is 'XXXXXX:Plugin.esp' — 6 hex digits, a colon, the defining master's filename, and every FormID " +
+         "this tool takes (ops[].formid, from=, a field VALUE) is that form. The RUNTIME form the game, the console " +
+         "and the logs print — eight hex digits and no plugin name, 'FExxxYYY' / 'XX######' — is READ-ONLY, because " +
+         "it names a slot in the load order as it stands rather than a record: pass one here and it is refused with " +
+         "the 'XXXXXX:Plugin.esp' form to use in its place. " + ToolNames.Records + " reads by either form. " +
          "Every edit " +
          "resolves the record's load-order WINNER and overrides it into the patch; all edits land in ONE reviewable " +
          ".esp, whose master header spans every plugin the edits reference (cross-master merge, derived not declared).\n\n" +

--- a/src/housecarl-mcp/CopyTools.cs
+++ b/src/housecarl-mcp/CopyTools.cs
@@ -88,7 +88,7 @@ public static class CopyTools
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
 
         // One door for every token in the call, so the source and the target resolve against one index build.
-        var door = svc.OpenFormIdDoor();
+        var door = svc.OpenWriteFormIdDoor();
         FormKey fromKey;
         try { fromKey = door.Parse(from); }
         catch (Exception ex) { return $"error: bad from '{from}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }

--- a/src/housecarl-mcp/CopyTools.cs
+++ b/src/housecarl-mcp/CopyTools.cs
@@ -91,7 +91,7 @@ public static class CopyTools
         var door = svc.OpenWriteFormIdDoor();
         FormKey fromKey;
         try { fromKey = door.Parse(from); }
-        catch (Exception ex) { return $"error: bad from '{from}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }
+        catch (Exception ex) { return FormIdDoor.Sentence(ex, "error: ", $"error: bad from '{from}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
 
         bool hasTarget = !string.IsNullOrWhiteSpace(target);
         bool hasClone = !string.IsNullOrWhiteSpace(new_editorid);
@@ -103,7 +103,7 @@ public static class CopyTools
         if (hasTarget)
         {
             try { targetKey = door.Parse(target); }
-            catch (Exception ex) { return $"error: bad target '{target}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }
+            catch (Exception ex) { return FormIdDoor.Sentence(ex, "error: ", $"error: bad target '{target}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
         }
 
         // Blank elements are REFUSED BY INDEX, never dropped: dropping one shifts every later index, so the

--- a/src/housecarl-mcp/FormIdDoor.cs
+++ b/src/housecarl-mcp/FormIdDoor.cs
@@ -62,6 +62,9 @@ internal sealed class FormIdDoor
         if (!RuntimeFormId.TryParse(raw, out _)) return null;
         try { Parse(raw); return null; }
         catch (WriteRefusal ex) { return ex.Message; }
+        // A well-formed runtime token the index cannot translate (an FF dynamic form, an unoccupied index) is bad
+        // input, not an internal fault — hand its sentence back as this record's problem.
+        catch (FormatException ex) { return ex.Message; }
     }
 
     /// <summary>What to report for a token this door threw on. A write refusal is a WELL-FORMED token being

--- a/src/housecarl-mcp/FormIdDoor.cs
+++ b/src/housecarl-mcp/FormIdDoor.cs
@@ -15,9 +15,11 @@ namespace HousecarlMcp;
 internal sealed class FormIdDoor
 {
     readonly LoadOrderService? _svc;
+    readonly bool _write;
     LoadOrderResolver.IndexView? _view;
 
-    FormIdDoor(LoadOrderService? svc, LoadOrderResolver.IndexView? view) { _svc = svc; _view = view; }
+    FormIdDoor(LoadOrderService? svc, LoadOrderResolver.IndexView? view, bool write = false)
+    { _svc = svc; _view = view; _write = write; }
 
     /// <summary>A door pinned to a build the caller already captured, so its FormIDs and its records describe the
     /// same index.</summary>
@@ -26,17 +28,29 @@ internal sealed class FormIdDoor
     /// <summary>A door that captures a build on the first runtime FormID, and never if none arrives.</summary>
     public static FormIdDoor For(LoadOrderService svc) => new(svc, null);
 
+    /// <summary>The same door in WRITE mode: a runtime FormID is translated and then refused, because it names a
+    /// slot in the order as it stands rather than a record, and a re-sort between the parse and the write would
+    /// point the same eight digits at a different record. Reads keep taking it.</summary>
+    public static FormIdDoor ForWrite(LoadOrderService svc) => new(svc, null, write: true);
+
     /// <summary>The build this door captured, or null when no runtime FormID arrived and it never reached for one.
     /// A caller that goes on to scan passes it down, so the tokens it parsed and the records it matches come from
     /// the same index build rather than two adjacent ones.</summary>
     public LoadOrderResolver.IndexView? CapturedView => _view;
 
     /// <summary>Parse one token — see <see cref="LoadOrderResolver.IndexView.ParseFormId"/>. Throws one plain
-    /// sentence on anything it cannot answer.</summary>
+    /// sentence on anything it cannot answer, and on a runtime FormID at a <see cref="ForWrite"/> door.</summary>
     public FormKey Parse(string? raw)
     {
         if (!RuntimeFormId.TryParse(raw, out _)) return FormKey.Factory((raw ?? "").Trim());
         _view ??= _svc!.CaptureView();
-        return _view.Value.ParseFormId(raw);
+        var fk = _view.Value.ParseFormId(raw);
+        // Translate first, so the refusal can hand back the plugin form to paste in place of the token.
+        if (_write)
+            throw new FormatException(
+                $"'{(raw ?? "").Trim()}' is a runtime FormID, which houseCARL accepts for reading but not for " +
+                $"writing, because it names a slot in the load order as it stands rather than a record — write to " +
+                $"'{fk.ID:X6}:{fk.ModKey.FileName}' instead.");
+        return fk;
     }
 }

--- a/src/housecarl-mcp/FormIdDoor.cs
+++ b/src/housecarl-mcp/FormIdDoor.cs
@@ -47,10 +47,30 @@ internal sealed class FormIdDoor
         var fk = _view.Value.ParseFormId(raw);
         // Translate first, so the refusal can hand back the plugin form to paste in place of the token.
         if (_write)
-            throw new FormatException(
+            throw new WriteRefusal(
                 $"'{(raw ?? "").Trim()}' is a runtime FormID, which houseCARL accepts for reading but not for " +
                 $"writing, because it names a slot in the load order as it stands rather than a record — write to " +
                 $"'{fk.ID:X6}:{fk.ModKey.FileName}' instead.");
         return fk;
     }
+
+    /// <summary>Refuse a runtime FormID in a slot that may hold something OTHER than a FormID (a create's
+    /// <c>parent=</c> takes an EditorID too), returning the sentence or null. Anything the door cannot recognise as
+    /// a runtime FormID is left to the caller's own parser.</summary>
+    public string? RuntimeRefusal(string? raw)
+    {
+        if (!RuntimeFormId.TryParse(raw, out _)) return null;
+        try { Parse(raw); return null; }
+        catch (WriteRefusal ex) { return ex.Message; }
+    }
+
+    /// <summary>What to report for a token this door threw on. A write refusal is a WELL-FORMED token being
+    /// declined, with the form to use already in it, so it stands as its own sentence under
+    /// <paramref name="prefix"/>; anything else keeps the caller's own "bad FormID, expected …" framing.</summary>
+    public static string Sentence(Exception ex, string prefix, string ifMalformed)
+        => ex is WriteRefusal ? prefix + ex.Message : ifMalformed;
+
+    /// <summary>A runtime FormID at a <see cref="ForWrite"/> door — distinguishable so a caller does not wrap it in
+    /// its malformed-token sentence.</summary>
+    internal sealed class WriteRefusal(string message) : FormatException(message);
 }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -6761,15 +6761,21 @@ public sealed class LoadOrderService : IDisposable
         var problems = new List<string>();
         var specs = new List<WritePatchBuilder.CreateSpec>(records.Count);
         // One write door for the whole call, as the sibling verbs open: parent= is the only token here that can be
-        // a FormID, and it is a write's, so a runtime one is refused with the plugin form to use.
+        // a FormID, and it is a write's, so a runtime one that is not a sibling editorid is refused with the plugin
+        // form to use.
         var door = OpenWriteFormIdDoor();
+        // The editorids this call declares: a parent naming one of them is a sibling reference, not a FormID, even
+        // when it happens to read as eight hex characters ('DEADBEEF').
+        var siblings = new HashSet<string>(
+            records.Where(x => !string.IsNullOrWhiteSpace(x.Editorid)).Select(x => x.Editorid!.Trim()),
+            StringComparer.OrdinalIgnoreCase);
         for (int r = 0; r < records.Count; r++)
         {
             var rec = records[r];
             // origins[r] is the caller's own spelling for this spec, carried parallel to the list for the same
             // reason ApplyEdits carries opOrigins: a refusal must never name an index shape the caller did not write.
             var where = origins is not null && r < origins.Count && origins[r] is { } o ? o : $"record[{r}]";
-            var spec = BuildCreateSpec(door, rec.RecordType, rec.Editorid, rec.Operations ?? Array.Empty<BulkOp>(), rec.Parent, rec.Collection, rec.Grid, where, problems, naming ?? CreateOpNaming.Legacy);
+            var spec = BuildCreateSpec(door, rec.RecordType, rec.Editorid, rec.Operations ?? Array.Empty<BulkOp>(), rec.Parent, rec.Collection, rec.Grid, where, problems, naming ?? CreateOpNaming.Legacy, siblings);
             if (spec is not null) specs.Add(spec);
         }
         if (problems.Count > 0)
@@ -6785,14 +6791,17 @@ public sealed class LoadOrderService : IDisposable
     /// top-level record. Every problem, tagged with the optional <paramref name="where"/> label, is appended to
     /// <paramref name="problems"/>, and this returns null iff this record contributed any.</summary>
     WritePatchBuilder.CreateSpec? BuildCreateSpec(FormIdDoor door, string? recordType, string? editorid, IReadOnlyList<BulkOp> operations,
-        string? parent, string? collection, string? grid, string? where, List<string> problems, CreateOpNaming naming)
+        string? parent, string? collection, string? grid, string? where, List<string> problems, CreateOpNaming naming,
+        IReadOnlySet<string>? siblingEditorids = null)
     {
         var prefix = where is null ? "" : where + ": ";
         int before = problems.Count;
 
         // parent= takes an EditorID as well as a FormID, so only a runtime FormID is judged here; everything else
-        // is left to the core's own parse.
-        if (door.RuntimeRefusal(parent) is { } parentRefusal) problems.Add($"{prefix}parent: {parentRefusal}");
+        // is left to the core's own parse. An eight-hex EditorID this call declares is a sibling reference and is
+        // never read as a FormID, so the runtime refusal runs only once that lookup has missed.
+        bool parentIsSibling = parent is not null && siblingEditorids is not null && siblingEditorids.Contains(parent.Trim());
+        if (!parentIsSibling && door.RuntimeRefusal(parent) is { } parentRefusal) problems.Add($"{prefix}parent: {parentRefusal}");
 
         string? catalogName = null;
         if (string.IsNullOrWhiteSpace(recordType))

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -100,6 +100,10 @@ public sealed class LoadOrderService : IDisposable
     /// <summary>A FormID door for a tool body with no captured view of its own — see <see cref="FormIdDoor"/>.</summary>
     internal FormIdDoor OpenFormIdDoor() => FormIdDoor.For(this);
 
+    /// <summary>The same door for a WRITE verb's tokens, which refuses a runtime FormID — see
+    /// <see cref="FormIdDoor.ForWrite"/>.</summary>
+    internal FormIdDoor OpenWriteFormIdDoor() => FormIdDoor.ForWrite(this);
+
     /// <summary>The resolver, built on first access and kept fresh on every subsequent access. Throws loudly if the
     /// configured roots yield no plugins.</summary>
     LoadOrderResolver Resolver
@@ -4565,11 +4569,11 @@ public sealed class LoadOrderService : IDisposable
                 "target= is only meaningful with in_place=true (it names the plugin to edit in place). For the default patch lane omit target=; use into= to extend an existing houseCARL patch.");
 
         // Map every op to a core PatchEdit, collecting ALL parse problems first (all-or-nothing, like the cleave).
-        // Runs outside the write gate so a malformed call never queues behind a real write. A runtime FormID here
-        // resolves against the order as it stands at the call, the same way a read of one does.
+        // Runs outside the write gate so a malformed call never queues behind a real write. A write door, so a
+        // runtime FormID is refused with the plugin form to use instead.
         var edits = new List<WritePatchBuilder.PatchEdit>(ops.Count);
         var problems = new List<string>();
-        var editDoor = OpenFormIdDoor();
+        var editDoor = OpenWriteFormIdDoor();
         for (int i = 0; i < ops.Count; i++)
         {
             // fromRecords[i] is the zip's per-op source record, carried parallel to the op list because the
@@ -5478,7 +5482,7 @@ public sealed class LoadOrderService : IDisposable
         // Parse every formid first, collecting ALL problems (all-or-nothing, like the edit path). Pure — outside the gate.
         var keys = new List<FormKey>(formids.Count);
         var problems = new List<string>();
-        var door = OpenFormIdDoor();
+        var door = OpenWriteFormIdDoor();
         for (int i = 0; i < formids.Count; i++)
         {
             var raw = formids[i];
@@ -5612,7 +5616,7 @@ public sealed class LoadOrderService : IDisposable
         var fp = fromPlugin.Trim();
         var specs = new List<WritePatchBuilder.ForwardSpec>(formids.Count);
         var problems = new List<string>();
-        var door = OpenFormIdDoor();
+        var door = OpenWriteFormIdDoor();
         for (int i = 0; i < formids.Count; i++)
         {
             var raw = formids[i];
@@ -6483,7 +6487,7 @@ public sealed class LoadOrderService : IDisposable
         // ---- argument shape: exactly one target mode ----
         // ONE door for both tokens: two doors would each capture their own build, and a re-sort between them
         // would read the donor off one order and the target off another.
-        var door = OpenFormIdDoor();
+        var door = OpenWriteFormIdDoor();
         FormKey donorFk;
         try { donorFk = door.Parse(sourceFormid); }
         catch (Exception ex) { return NpcCopyOutcome.Fail($"bad source formid '{sourceFormid}': {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '000D62:Vivace.esp'."); }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -5488,7 +5488,7 @@ public sealed class LoadOrderService : IDisposable
             var raw = formids[i];
             if (string.IsNullOrWhiteSpace(raw)) { problems.Add($"formid[{i}]: empty."); continue; }
             try { keys.Add(door.Parse(raw)); }
-            catch (Exception ex) { problems.Add($"formid[{i}] '{raw}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
+            catch (Exception ex) { problems.Add(FormIdDoor.Sentence(ex, $"formid[{i}]: ", $"formid[{i}] '{raw}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'.")); }
         }
         if (problems.Count > 0)
             return WritePatchBuilder.RemovalOutcome.Fail(
@@ -5622,7 +5622,7 @@ public sealed class LoadOrderService : IDisposable
             var raw = formids[i];
             if (string.IsNullOrWhiteSpace(raw)) { problems.Add($"formid[{i}]: empty."); continue; }
             try { specs.Add(new WritePatchBuilder.ForwardSpec { Target = door.Parse(raw), FromPlugin = fp }); }
-            catch (Exception ex) { problems.Add($"formid[{i}] '{raw}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
+            catch (Exception ex) { problems.Add(FormIdDoor.Sentence(ex, $"formid[{i}]: ", $"formid[{i}] '{raw}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'.")); }
         }
         if (problems.Count > 0)
             return WritePatchBuilder.ForwardOutcome.Fail(
@@ -6490,7 +6490,7 @@ public sealed class LoadOrderService : IDisposable
         var door = OpenWriteFormIdDoor();
         FormKey donorFk;
         try { donorFk = door.Parse(sourceFormid); }
-        catch (Exception ex) { return NpcCopyOutcome.Fail($"bad source formid '{sourceFormid}': {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '000D62:Vivace.esp'."); }
+        catch (Exception ex) { return NpcCopyOutcome.Fail(FormIdDoor.Sentence(ex, "", $"bad source formid '{sourceFormid}': {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '000D62:Vivace.esp'.")); }
 
         bool apply = !string.IsNullOrWhiteSpace(targetFormid);
         bool clone = !string.IsNullOrWhiteSpace(newEditorid);
@@ -6760,13 +6760,16 @@ public sealed class LoadOrderService : IDisposable
 
         var problems = new List<string>();
         var specs = new List<WritePatchBuilder.CreateSpec>(records.Count);
+        // One write door for the whole call, as the sibling verbs open: parent= is the only token here that can be
+        // a FormID, and it is a write's, so a runtime one is refused with the plugin form to use.
+        var door = OpenWriteFormIdDoor();
         for (int r = 0; r < records.Count; r++)
         {
             var rec = records[r];
             // origins[r] is the caller's own spelling for this spec, carried parallel to the list for the same
             // reason ApplyEdits carries opOrigins: a refusal must never name an index shape the caller did not write.
             var where = origins is not null && r < origins.Count && origins[r] is { } o ? o : $"record[{r}]";
-            var spec = BuildCreateSpec(rec.RecordType, rec.Editorid, rec.Operations ?? Array.Empty<BulkOp>(), rec.Parent, rec.Collection, rec.Grid, where, problems, naming ?? CreateOpNaming.Legacy);
+            var spec = BuildCreateSpec(door, rec.RecordType, rec.Editorid, rec.Operations ?? Array.Empty<BulkOp>(), rec.Parent, rec.Collection, rec.Grid, where, problems, naming ?? CreateOpNaming.Legacy);
             if (spec is not null) specs.Add(spec);
         }
         if (problems.Count > 0)
@@ -6781,11 +6784,15 @@ public sealed class LoadOrderService : IDisposable
     /// <paramref name="parent"/> and <paramref name="collection"/> through for a nested child — null means a flat
     /// top-level record. Every problem, tagged with the optional <paramref name="where"/> label, is appended to
     /// <paramref name="problems"/>, and this returns null iff this record contributed any.</summary>
-    WritePatchBuilder.CreateSpec? BuildCreateSpec(string? recordType, string? editorid, IReadOnlyList<BulkOp> operations,
+    WritePatchBuilder.CreateSpec? BuildCreateSpec(FormIdDoor door, string? recordType, string? editorid, IReadOnlyList<BulkOp> operations,
         string? parent, string? collection, string? grid, string? where, List<string> problems, CreateOpNaming naming)
     {
         var prefix = where is null ? "" : where + ": ";
         int before = problems.Count;
+
+        // parent= takes an EditorID as well as a FormID, so only a runtime FormID is judged here; everything else
+        // is left to the core's own parse.
+        if (door.RuntimeRefusal(parent) is { } parentRefusal) problems.Add($"{prefix}parent: {parentRefusal}");
 
         string? catalogName = null;
         if (string.IsNullOrWhiteSpace(recordType))
@@ -7062,7 +7069,7 @@ public sealed class LoadOrderService : IDisposable
         if (string.IsNullOrWhiteSpace(op.Formid)) { error = $"{where}: formid is required."; return null; }
         FormKey fk;
         try { fk = door.Parse(op.Formid); }
-        catch (Exception ex) { error = $"{where}: bad formid '{op.Formid}' ({ex.Message}). Expected 'XXXXXX:Plugin.esp'."; return null; }
+        catch (Exception ex) { error = FormIdDoor.Sentence(ex, $"{where}: ", $"{where}: bad formid '{op.Formid}' ({ex.Message}). Expected 'XXXXXX:Plugin.esp'."); return null; }
         if (string.IsNullOrWhiteSpace(op.FieldPath)) { error = $"{where} ({op.Formid}): field_path is required."; return null; }
         var path = SplitPath(op.FieldPath);
         if (path.Length == 0) { error = $"{where} ({op.Formid}): field_path '{op.FieldPath}' is empty."; return null; }
@@ -7086,7 +7093,7 @@ public sealed class LoadOrderService : IDisposable
         if (!string.IsNullOrWhiteSpace(fromRecord))
         {
             try { fromKey = door.Parse(fromRecord); }
-            catch (Exception ex) { error = $"{where} ({op.Formid}): bad from '{fromRecord}' ({ex.Message}). Expected 'XXXXXX:Plugin.esp'."; return null; }
+            catch (Exception ex) { error = FormIdDoor.Sentence(ex, $"{where} ({op.Formid}): ", $"{where} ({op.Formid}): bad from '{fromRecord}' ({ex.Message}). Expected 'XXXXXX:Plugin.esp'."); return null; }
             if (fromKey == fk)
             { error = $"{where} ({op.Formid}): from names the SAME record as formid — copying a record's field onto itself is a no-op. Drop from=, and name the plugin whose version to copy in from_source=."; return null; }
         }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -6502,7 +6502,7 @@ public sealed class LoadOrderService : IDisposable
         if (apply)
         {
             try { targetFk = door.Parse(targetFormid); }
-            catch (Exception ex) { return NpcCopyOutcome.Fail($"bad target formid '{targetFormid}': {ex.Message}."); }
+            catch (Exception ex) { return NpcCopyOutcome.Fail(FormIdDoor.Sentence(ex, "", $"bad target formid '{targetFormid}': {ex.Message}.")); }
         }
 
         lock (_writeGate)

--- a/src/housecarl-mcp/PlaceAssetTools.cs
+++ b/src/housecarl-mcp/PlaceAssetTools.cs
@@ -68,7 +68,7 @@ public static class PlaceAssetTools
             string? into = null) => Guard.Tool(ToolNames.PlaceAsset, () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        var reqs = MapSpec(svc.OpenFormIdDoor().Parse, formid, kind, asset_path, source, source_provider, allowExpand: false, where: "", out var err);
+        var reqs = MapSpec(svc.OpenWriteFormIdDoor().Parse, formid, kind, asset_path, source, source_provider, allowExpand: false, where: "", out var err);
         if (err is not null) return "error: " + err;
         return PlaceWire.Render(svc.PlaceAssets(reqs!, patch_name, into));
     });
@@ -107,7 +107,7 @@ public static class PlaceAssetTools
         // (ambiguous/absent/unreadable source) are per-asset (the resolver isn't consulted until the place loop).
         var all = new List<PlaceRequest>();
         var problems = new List<string>();
-        var door = svc.OpenFormIdDoor();
+        var door = svc.OpenWriteFormIdDoor();
         for (int i = 0; i < assets.Length; i++)
         {
             var a = assets[i];

--- a/src/housecarl-mcp/PlaceAssetTools.cs
+++ b/src/housecarl-mcp/PlaceAssetTools.cs
@@ -140,7 +140,7 @@ public static class PlaceAssetTools
 
         FormKey fk;
         try { fk = parseFormId(formid); }
-        catch (Exception ex) { error = $"{where}bad formid '{formid}' ({ex.Message}). Expected 'XXXXXX:Plugin.esp'."; return null; }
+        catch (Exception ex) { error = FormIdDoor.Sentence(ex, where, $"{where}bad formid '{formid}' ({ex.Message}). Expected 'XXXXXX:Plugin.esp'."); return null; }
 
         var slot = ParseSlot(kind, out var slotErr);
         if (slotErr is not null) { error = $"{where}{slotErr}"; return null; }


### PR DESCRIPTION
A runtime FormID (`FExxxYYY` / `XX######`) names a slot in the load order as it stands, not a record, so a re-sort between the parse and the write could land a write on whatever the old numbering pointed at. Aaron's ruling is that they are read-only. The FormID door gains a write mode: it still translates the token, then refuses with the `XXXXXX:Plugin.esp` form to paste back in its place. `apply`, `remove`, `forward`, `copy`, `copy_npc_appearance` and both `place_asset` doors open the write door instead of the read one; `create`'s `parent=` also takes an EditorID, so it goes through a runtime-only check at the same door rather than a parse. Reads are unchanged, and the refusal is a sentence of its own rather than being wrapped in the callers' "bad FormID … expected" framing, which called a well-formed token malformed. `apply`'s tool description no longer advertises the runtime form on `ops[].formid` and `from=`.

Tests: one per write door in `RuntimeFormIdTests`, each giving the light plugin's runtime FormID, asserting the refusal names the translated plugin form and that no patch folder was written, plus one asserting the same token still reads. All eight write-door tests were red on the unfixed code (they got as far as the record's own type/field errors, so the token had been accepted); the read test passed throughout.

Verified: build clean, `dotnet test --filter "tier!=bridge"` 1048/1048, `ci-all` 127/127.

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)
