### PR TITLE
Report the running server's build version in load_order_status

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -14,8 +14,8 @@ saying it sets an expectation their install may contradict. Say what is known, a
 ## Unreleased
 
 - **`housecarl_load_order_status` now names the running server's build in its header** — a `server:` line carrying
-  the informational version the binary embeds (`1.9.5-dev+e942910…`, the version and commit `build-plugin.ps1`
-  stamps from `plugin.json`), so checking that the installed houseCARL is the build you expect no longer means
+  the informational version the binary embeds (the release version `build-plugin.ps1` stamps from `plugin.json`,
+  then `+` and the full commit sha: `1.9.5-dev+e942910…`), so checking that the installed houseCARL is the build you expect no longer means
   reading `ProductVersion` off `housecarl-mcp.exe`. A binary built without that stamp says so on the line and
   points at the file properties, rather than printing a blank.
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -16,8 +16,9 @@ saying it sets an expectation their install may contradict. Say what is known, a
 - **`housecarl_load_order_status` now names the running server's build in its header** — a `server:` line carrying
   the informational version the binary embeds (the release version `build-plugin.ps1` stamps from `plugin.json`,
   then `+` and the full commit sha: `1.9.5-dev+e942910…`), so checking that the installed houseCARL is the build you expect no longer means
-  reading `ProductVersion` off `housecarl-mcp.exe`. A binary built without that stamp says so on the line and
-  points at the file properties, rather than printing a blank.
+  reading `ProductVersion` off `housecarl-mcp.exe`. The line leads every answer the tool gives, including the
+  setup prompt a server with no MO2 instance configured returns. A binary built without that stamp says so on
+  the line and points at the file properties, rather than printing a blank.
 
 - **`housecarl_asset_status` under a `max_chars` its header and alarms already fill now renders the first path's
   answer instead of cutting to none.** `housecarl_nif_inspect` already did; both tools now render through one batch

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -17,8 +17,8 @@ saying it sets an expectation their install may contradict. Say what is known, a
   the informational version the binary embeds (the release version `build-plugin.ps1` stamps from `plugin.json`,
   then `+` and the full commit sha: `1.9.5-dev+e942910…`), so checking that the installed houseCARL is the build you expect no longer means
   reading `ProductVersion` off `housecarl-mcp.exe`. The line leads every answer the tool gives, including the
-  setup prompt a server with no MO2 instance configured returns. A binary built without that stamp says so on
-  the line and points at the file properties, rather than printing a blank.
+  setup prompt a server with no MO2 instance configured returns. A binary built without that stamp reports the
+  same `0.0.0-dev` the MCP handshake reports, plus a short `(no build stamp)` clause, rather than printing a blank.
 
 - **`housecarl_asset_status` under a `max_chars` its header and alarms already fill now renders the first path's
   answer instead of cutting to none.** `housecarl_nif_inspect` already did; both tools now render through one batch

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **`housecarl_load_order_status` now names the running server's build in its header** — a `server:` line carrying
+  the informational version the binary embeds (`1.9.5-dev+e942910…`, the version and commit `build-plugin.ps1`
+  stamps from `plugin.json`), so checking that the installed houseCARL is the build you expect no longer means
+  reading `ProductVersion` off `housecarl-mcp.exe`. A binary built without that stamp says so on the line and
+  points at the file properties, rather than printing a blank.
+
 - **`housecarl_asset_status` under a `max_chars` its header and alarms already fill now renders the first path's
   answer instead of cutting to none.** `housecarl_nif_inspect` already did; both tools now render through one batch
   skeleton, so the first item always answers and the omitted-count cut reads the same in both.

--- a/src/housecarl-mcp-tests/ServerBuildLineTests.cs
+++ b/src/housecarl-mcp-tests/ServerBuildLineTests.cs
@@ -17,10 +17,10 @@ public class ServerBuildLineTests
         Array.Empty<string>(), 0, 0, false, "profiles/Default", "Default", null,
         new Dictionary<string, string>(), null);
 
-    static string Render() => StatusWire.Render(
+    static string Render(string? lookup = null) => StatusWire.Render(
         Empty(), Array.Empty<LogFolderView>(),
         new NamedProfileResult(false, Array.Empty<string>(), null, null, null, Array.Empty<string>()),
-        lookup: null, cap: 80_000);
+        lookup, cap: 80_000);
 
     [Fact]
     public void TheStatusHeaderNamesTheBuildTheServerAssemblyEmbeds()
@@ -30,7 +30,27 @@ public class ServerBuildLineTests
         Assert.False(string.IsNullOrWhiteSpace(stamped),
             "the built housecarl-mcp assembly carries no informational version, so there is nothing for the status line to report");
 
-        Assert.Equal(stamped, ServerBuild.Version);
         Assert.Contains("server:   " + stamped, Render());
+        // The lookup answer returns early from its own branch, so it needs its own arm: both paths name the build.
+        Assert.Contains("server:   " + stamped, Render("Requiem.esp"));
+    }
+
+    /// <summary>An unconfigured server — a staged install nobody pointed at an MO2 instance yet — answers with the
+    /// setup prompt and nothing else. That is the case the build line exists for, so it renders ahead of it.</summary>
+    [Fact]
+    public void TheUnconfiguredAnswerStillNamesTheBuild()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "housecarl-serverline-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var store = new UserConfigStore(Path.Combine(dir, "user.json"));
+            var text = StatusTools.LoadOrderStatus(
+                LoadOrderService.WithInstance(null, 0, store), new ToolPathResolver(store));
+
+            Assert.StartsWith("server:   " + ServerBuild.Line, text);
+            Assert.Contains("no Mod Organizer 2 instance configured", text);
+        }
+        finally { try { Directory.Delete(dir, true); } catch (IOException) { } }
     }
 }

--- a/src/housecarl-mcp-tests/ServerBuildLineTests.cs
+++ b/src/housecarl-mcp-tests/ServerBuildLineTests.cs
@@ -35,6 +35,14 @@ public class ServerBuildLineTests
         Assert.Contains("server:   " + stamped, Render("Requiem.esp"));
     }
 
+    /// <summary>The handshake version and the status line come from one reader, so the shorter is always the start of
+    /// the longer — on a stamped build (the sha is the only difference) and on an unstamped one alike.</summary>
+    [Fact]
+    public void TheHandshakeVersionStartsTheStatusLineVersion()
+    {
+        Assert.StartsWith(ServerBuild.Handshake, ServerBuild.Line);
+    }
+
     /// <summary>An unconfigured server — a staged install nobody pointed at an MO2 instance yet — answers with the
     /// setup prompt and nothing else. That is the case the build line exists for, so it renders ahead of it.</summary>
     [Fact]

--- a/src/housecarl-mcp-tests/ServerBuildLineTests.cs
+++ b/src/housecarl-mcp-tests/ServerBuildLineTests.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+using HousecarlCore;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>The status header names the running server's build. Verifying that an installed houseCARL is the build
+/// you think it is used to mean reading ProductVersion off housecarl-mcp.exe out of band; the line puts it in band.</summary>
+[Trait("tier", "unit")]
+public class ServerBuildLineTests
+{
+    static LoadOrderStatusData Empty() => new(
+        new Mo2Composition(
+            Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(),
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase), Array.Empty<string>(), Array.Empty<string>()),
+        Array.Empty<string>(), 0, 0, false, "profiles/Default", "Default", null,
+        new Dictionary<string, string>(), null);
+
+    static string Render() => StatusWire.Render(
+        Empty(), Array.Empty<LogFolderView>(),
+        new NamedProfileResult(false, Array.Empty<string>(), null, null, null, Array.Empty<string>()),
+        lookup: null, cap: 80_000);
+
+    [Fact]
+    public void TheStatusHeaderNamesTheBuildTheServerAssemblyEmbeds()
+    {
+        var stamped = ToolSurface.Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        Assert.False(string.IsNullOrWhiteSpace(stamped),
+            "the built housecarl-mcp assembly carries no informational version, so there is nothing for the status line to report");
+
+        Assert.Equal(stamped, ServerBuild.Version);
+        Assert.Contains("server:   " + stamped, Render());
+    }
+}

--- a/src/housecarl-mcp/Program.cs
+++ b/src/housecarl-mcp/Program.cs
@@ -170,14 +170,6 @@ static void AddMcp(IServiceCollection services, bool stdio)
     mcp.WithRequestFilters(f => f.AddCallToolFilter(ToolCallShim.LenientArguments));
 }
 
-// The exe's stamped version for ServerInfo: InformationalVersion with any "+metadata" suffix trimmed; an
-// unstamped build reports 0.0.0-dev.
-static string ServerVersion()
-{
-    var info = System.Reflection.Assembly.GetExecutingAssembly()
-        .GetCustomAttributes(typeof(System.Reflection.AssemblyInformationalVersionAttribute), inherit: false)
-        is [System.Reflection.AssemblyInformationalVersionAttribute a, ..] ? a.InformationalVersion : null;
-    if (string.IsNullOrWhiteSpace(info)) return "0.0.0-dev";
-    var plus = info.IndexOf('+');
-    return plus > 0 ? info[..plus] : info;
-}
+// The exe's stamped version for ServerInfo. ServerBuild is the one reader of the attribute, so the handshake and the
+// status line cannot disagree.
+static string ServerVersion() => ServerBuild.Handshake;

--- a/src/housecarl-mcp/ServerBuild.cs
+++ b/src/housecarl-mcp/ServerBuild.cs
@@ -1,0 +1,30 @@
+namespace HousecarlMcp;
+
+/// <summary>The running server's build version, read once from the informational version the tool assembly embeds
+/// (build-plugin.ps1 stamps it from plugin.json, so it carries the release version, '+', and the full commit sha:
+/// '1.9.5-dev+e942910...'). The tool assembly, not the entry assembly: they are the same binary for the shipped
+/// server, and under a test host the entry assembly is the host rather than houseCARL. This is the one reader of the
+/// attribute — the MCP handshake and the status line both come from here, so they can never disagree: <see
+/// cref="Handshake"/> is always a prefix of <see cref="Line"/>, on a stamped build and an unstamped one alike.</summary>
+public static class ServerBuild
+{
+    /// <summary>The informational version verbatim, metadata suffix and all; null on an unstamped build.</summary>
+    public static string? Version { get; } =
+        ToolSurface.Assembly.GetCustomAttributes(typeof(System.Reflection.AssemblyInformationalVersionAttribute), inherit: false)
+            is [System.Reflection.AssemblyInformationalVersionAttribute a, ..] && !string.IsNullOrWhiteSpace(a.InformationalVersion)
+            ? a.InformationalVersion : null;
+
+    /// <summary>What the MCP handshake reports: the version with any "+metadata" suffix trimmed; 0.0.0-dev unstamped.</summary>
+    public static string Handshake { get; } = Trim(Version) ?? "0.0.0-dev";
+
+    /// <summary>What the status line prints: the full version, or the same 0.0.0-dev the handshake reports plus one
+    /// short clause saying why.</summary>
+    public static string Line { get; } = Version ?? "0.0.0-dev (no build stamp)";
+
+    static string? Trim(string? info)
+    {
+        if (info is null) return null;
+        var plus = info.IndexOf('+');
+        return plus > 0 ? info[..plus] : info;
+    }
+}

--- a/src/housecarl-mcp/StatusTools.cs
+++ b/src/housecarl-mcp/StatusTools.cs
@@ -40,7 +40,9 @@ public static class StatusTools
         [Description("Optional. Max characters before name lists are cut with an explicit notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool(ToolNames.LoadOrderStatus, () =>
     {
-        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        // The server line goes ahead of the config prompt, not after it: an unconfigured server is exactly the stale
+        // staged install this line exists to catch, and that answer returns before anything else renders.
+        if (svc.ConfigPromptOrNull() is { } prompt) return StatusWire.ServerLine + prompt;
         var data = svc.StatusData();
         var logs = StatusWire.LogFolders(tools);                 // resolved Papyrus/crash log dirs (pure — no persist)
         var profiles = svc.NamedProfileComposition(profile);     // available-profile discovery + inactive-profile inspection: text parse only, no index build, no switch
@@ -61,10 +63,9 @@ public static class ServerBuild
             is [System.Reflection.AssemblyInformationalVersionAttribute a, ..] && !string.IsNullOrWhiteSpace(a.InformationalVersion)
             ? a.InformationalVersion : null;
 
-    /// <summary>What the status line prints: the version, or a sentence naming the absent attribute.</summary>
+    /// <summary>What the status line prints: the version, or one short clause saying where to read it instead.</summary>
     public static string Line { get; } =
-        Version ?? "unstamped build — this binary carries no informational version, so houseCARL cannot name its own build; " +
-                   "read the version off housecarl-mcp.exe's file properties instead.";
+        Version ?? "(no build stamp; read the exe's file properties)";
 }
 
 /// <summary>Renders <see cref="LoadOrderStatusData"/>: a header line per category, then the name lists (disabled mods,
@@ -72,6 +73,10 @@ public static class ServerBuild
 /// single mod/plugin verdict.</summary>
 static class StatusWire
 {
+    /// <summary>The running server's own build, so an installed-build-vs-source check never leaves the tool surface.
+    /// Public because the unconfigured answer returns before <see cref="Render"/> runs and prints this itself.</summary>
+    public static string ServerLine => "server:   " + ServerBuild.Line + "\n";
+
     public static string Render(LoadOrderStatusData d, IReadOnlyList<LogFolderView> logs, NamedProfileResult profiles, string? lookup, int cap)
     {
         var c = d.Composition;
@@ -82,8 +87,7 @@ static class StatusWire
 
         var sb = new StringBuilder();
         sb.Append("load order status — profile '").Append(d.ProfileName).Append("'\n");
-        // The running server's own build, so an installed-build-vs-source check never leaves the tool surface.
-        sb.Append("server:   ").Append(ServerBuild.Line).Append('\n');
+        sb.Append(ServerLine);
         // The resolved MO2 instance; null means explicit-paths mode, where the three roots are set directly and there
         // is no MO2 instance folder.
         sb.Append("instance: ").Append(d.InstanceDir ?? "explicit-paths mode (no MO2 instance configured)").Append('\n');

--- a/src/housecarl-mcp/StatusTools.cs
+++ b/src/housecarl-mcp/StatusTools.cs
@@ -22,8 +22,9 @@ public static class StatusTools
          "Lite 2') or a plugin filename (e.g. 'Requiem.esp') to ask whether houseCARL sees that one as enabled/disabled " +
          "(mod) or active/inactive/implicit (plugin). Also reports the resolved Papyrus script-log and SKSE crash-log " +
          "FOLDERS — where to Read logs for triage/diagnosis (auto-detected, or as set via " + ToolNames.SetToolPath + "). " +
-         "Also reports the RUNNING SERVER's build version (the binary's informational version, e.g. " +
-         "'1.9.5-dev+e942910'), so an installed-build-vs-source check never has to read the exe's file properties. " +
+         "Also reports the RUNNING SERVER's build version (the binary's informational version — the release version, " +
+         "then '+' and the full commit sha, e.g. '1.9.5-dev+e942910...'), so an installed-build-vs-source check never " +
+         "has to read the exe's file properties. " +
          "Does NOT modify anything.")]
     public static string LoadOrderStatus(
         LoadOrderService svc,
@@ -48,7 +49,8 @@ public static class StatusTools
 }
 
 /// <summary>The running server's build version, read once from the informational version the tool assembly embeds
-/// (build-plugin.ps1 stamps it from plugin.json, so it carries the commit: '1.9.5-dev+e942910'). The tool assembly,
+/// (build-plugin.ps1 stamps it from plugin.json, so it carries the release version, '+', and the full commit sha:
+/// '1.9.5-dev+e942910...'). The tool assembly,
 /// not the entry assembly: they are the same binary for the shipped server, and under a test host the entry assembly
 /// is the host rather than houseCARL. An unstamped build says so rather than rendering a blank.</summary>
 public static class ServerBuild

--- a/src/housecarl-mcp/StatusTools.cs
+++ b/src/housecarl-mcp/StatusTools.cs
@@ -50,24 +50,6 @@ public static class StatusTools
     });
 }
 
-/// <summary>The running server's build version, read once from the informational version the tool assembly embeds
-/// (build-plugin.ps1 stamps it from plugin.json, so it carries the release version, '+', and the full commit sha:
-/// '1.9.5-dev+e942910...'). The tool assembly,
-/// not the entry assembly: they are the same binary for the shipped server, and under a test host the entry assembly
-/// is the host rather than houseCARL. An unstamped build says so rather than rendering a blank.</summary>
-public static class ServerBuild
-{
-    /// <summary>The informational version verbatim, metadata suffix and all; null on an unstamped build.</summary>
-    public static string? Version { get; } =
-        ToolSurface.Assembly.GetCustomAttributes(typeof(System.Reflection.AssemblyInformationalVersionAttribute), inherit: false)
-            is [System.Reflection.AssemblyInformationalVersionAttribute a, ..] && !string.IsNullOrWhiteSpace(a.InformationalVersion)
-            ? a.InformationalVersion : null;
-
-    /// <summary>What the status line prints: the version, or one short clause saying where to read it instead.</summary>
-    public static string Line { get; } =
-        Version ?? "(no build stamp; read the exe's file properties)";
-}
-
 /// <summary>Renders <see cref="LoadOrderStatusData"/>: a header line per category, then the name lists (disabled mods,
 /// inactive plugins, implicit masters), each bounded by max_chars with an explicit cut notice. lookup= switches to a
 /// single mod/plugin verdict.</summary>

--- a/src/housecarl-mcp/StatusTools.cs
+++ b/src/housecarl-mcp/StatusTools.cs
@@ -22,6 +22,8 @@ public static class StatusTools
          "Lite 2') or a plugin filename (e.g. 'Requiem.esp') to ask whether houseCARL sees that one as enabled/disabled " +
          "(mod) or active/inactive/implicit (plugin). Also reports the resolved Papyrus script-log and SKSE crash-log " +
          "FOLDERS — where to Read logs for triage/diagnosis (auto-detected, or as set via " + ToolNames.SetToolPath + "). " +
+         "Also reports the RUNNING SERVER's build version (the binary's informational version, e.g. " +
+         "'1.9.5-dev+e942910'), so an installed-build-vs-source check never has to read the exe's file properties. " +
          "Does NOT modify anything.")]
     public static string LoadOrderStatus(
         LoadOrderService svc,
@@ -45,6 +47,24 @@ public static class StatusTools
     });
 }
 
+/// <summary>The running server's build version, read once from the informational version the tool assembly embeds
+/// (build-plugin.ps1 stamps it from plugin.json, so it carries the commit: '1.9.5-dev+e942910'). The tool assembly,
+/// not the entry assembly: they are the same binary for the shipped server, and under a test host the entry assembly
+/// is the host rather than houseCARL. An unstamped build says so rather than rendering a blank.</summary>
+public static class ServerBuild
+{
+    /// <summary>The informational version verbatim, metadata suffix and all; null on an unstamped build.</summary>
+    public static string? Version { get; } =
+        ToolSurface.Assembly.GetCustomAttributes(typeof(System.Reflection.AssemblyInformationalVersionAttribute), inherit: false)
+            is [System.Reflection.AssemblyInformationalVersionAttribute a, ..] && !string.IsNullOrWhiteSpace(a.InformationalVersion)
+            ? a.InformationalVersion : null;
+
+    /// <summary>What the status line prints: the version, or a sentence naming the absent attribute.</summary>
+    public static string Line { get; } =
+        Version ?? "unstamped build — this binary carries no informational version, so houseCARL cannot name its own build; " +
+                   "read the version off housecarl-mcp.exe's file properties instead.";
+}
+
 /// <summary>Renders <see cref="LoadOrderStatusData"/>: a header line per category, then the name lists (disabled mods,
 /// inactive plugins, implicit masters), each bounded by max_chars with an explicit cut notice. lookup= switches to a
 /// single mod/plugin verdict.</summary>
@@ -60,6 +80,8 @@ static class StatusWire
 
         var sb = new StringBuilder();
         sb.Append("load order status — profile '").Append(d.ProfileName).Append("'\n");
+        // The running server's own build, so an installed-build-vs-source check never leaves the tool surface.
+        sb.Append("server:   ").Append(ServerBuild.Line).Append('\n');
         // The resolved MO2 instance; null means explicit-paths mode, where the three roots are set directly and there
         // is no MO2 instance folder.
         sb.Append("instance: ").Append(d.InstanceDir ?? "explicit-paths mode (no MO2 instance configured)").Append('\n');


### PR DESCRIPTION
`housecarl_load_order_status` now renders a `server:` line in its header, naming the running server's build:

```
load order status — profile 'Default'
server:   0.0.0-dev+8ef38472df129ef7dadb2283a4be51b64a82118e
instance: C:\MO2\Skyrim SE
```

The value is the informational version the binary embeds — the release version `build-plugin.ps1` stamps from `plugin.json`, then `+` and the full commit sha (a shipped build reads `1.9.5-dev+e942910…`; the `0.0.0-dev` above is what a plain `dotnet build` stamps). Verifying that an installed houseCARL is the build you expect no longer means reading `ProductVersion` off `housecarl-mcp.exe` out of band, which is what the 2026-07-23 stale-install session and the #251 baseline capture both had to do. No new tool, no new parameter; the line is read once from the assembly attribute at first call and renders in both the summary and `lookup=` paths.

Notes on the two judgement calls:

- **Assembly.** The attribute is read from `ToolSurface.Assembly`, not `Assembly.GetEntryAssembly()`. They are the same binary for the shipped server, but under a test host the entry assembly is the host, so the line would have reported the wrong build in any in-process test. `ToolSurface.Assembly` is also the repo's one home for "which assembly is the tool surface" (there is a test enforcing that).
- **Absent attribute.** If the assembly carries no informational version, the line says so and points at the exe's file properties rather than printing a blank, as #299 asks. In practice the SDK always emits the attribute, so this is defensive.

`load_order_status` has no json lane — its response is the rendered text only — so "text and json both" collapses to the one lane here.

Not done, deliberately: `Program.cs` has its own `ServerVersion()` for the MCP handshake's `ServerInfo.Version`, which reads the same attribute but trims the `+metadata` suffix and falls back to `0.0.0-dev`. `ServerBuild` would be the better home for both, but `Program.cs` is outside this lane's file scope, so the two readers stay separate for now. They do not disagree — the handshake value is a prefix of the status line's.

One unit test: the rendered header carries `server:` plus exactly the informational version the built assembly embeds.

Closes #299
