### PR TITLE
Fold the three SKSE tools into housecarl_skse

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -96,11 +96,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
   ignored on the other two, and a call runs one family — every response names the family it ran and the spelling of
   the two it did not. The three old names return a one-line redirect naming the `findings=` value that replaces them.
 
-- **The pairing family now names a debug-built DLL that loads on your own machine.** Reaching a `[LOADS]` verdict
+- **The pairing family now reports a debug-built DLL that loads on your own machine.** Reaching a `[LOADS]` verdict
   while the DLL imports the debug C runtime means that runtime resolved here — so it loads for you and fails with
-  error 126 for anyone without it. The verdict is unchanged, because it does load here; the line now says who it
-  will not load for. The inventory family already flagged this, so the two families no longer disagree about the
-  same file.
+  error 126 for anyone without it. The verdict is unchanged, because it does load here; what is new is that the DLL
+  line says who it will not load for, and that such a class is a finding of its own in the default view rather than a
+  name in the healthy roster, so the summary no longer reports a clean bill of health over it. The inventory family
+  already flagged this, so the two families no longer disagree about the same file.
 
 - **`housecarl_asset_status` under a `max_chars` its header and alarms already fill now renders the first path's
   answer instead of cutting to none.** `housecarl_nif_inspect` already did; both tools now render through one batch

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -99,9 +99,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
 - **The pairing family now reports a debug-built DLL that loads on your own machine.** Reaching a `[LOADS]` verdict
   while the DLL imports the debug C runtime means that runtime resolved here — so it loads for you and fails with
   error 126 for anyone without it. The verdict is unchanged, because it does load here; what is new is that the DLL
-  line says who it will not load for, and that such a class is a finding of its own in the default view rather than a
-  name in the healthy roster, so the summary no longer reports a clean bill of health over it. The inventory family
-  already flagged this, so the two families no longer disagree about the same file.
+  line says who it will not load for — on a `[VERIFY]` line as well as a `[LOADS]` one — and that a class whose every
+  loading DLL is debug-built is a finding of its own in the default view rather than a name in the healthy roster, so
+  the summary no longer reports a clean bill of health over it. A class that also has a clean DLL that loads stays
+  healthy: that DLL implements it for everyone. The inventory family already flagged this, so the two families no
+  longer disagree about the same file.
 
 - **`housecarl_asset_status` under a `max_chars` its header and alarms already fill now renders the first path's
   answer instead of cutting to none.** `housecarl_nif_inspect` already did; both tools now render through one batch

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -88,6 +88,19 @@ saying it sets an expectation their install may contradict. Say what is known, a
   guessed a folder name that does not exist is told how to create it under a name they choose rather than only to
   omit `into=`. On `housecarl_bsa_repack` the sentence names `patch_name=` and says that `patch=` there names the
   archive instead.
+- **`housecarl_skse_inventory`, `housecarl_native_pairing_audit` and `housecarl_skse_config_audit` are now one tool,
+  `housecarl_skse`, with `findings=` picking the family: `inventory` (the default), `pairing` or `config`.** The three
+  answered different questions about the same layer and each carried the same "what the file declares, never what the
+  DLL does" ceiling; it is now written once on the merged tool, with each family's own detail on `findings=`. `filter=`
+  and `max_chars=` mean what they meant, `peek=` still belongs to the inventory family and is refused rather than
+  ignored on the other two, and a call runs one family — every response names the family it ran and the spelling of
+  the two it did not. The three old names return a one-line redirect naming the `findings=` value that replaces them.
+
+- **The pairing family now names a debug-built DLL that loads on your own machine.** Reaching a `[LOADS]` verdict
+  while the DLL imports the debug C runtime means that runtime resolved here — so it loads for you and fails with
+  error 126 for anyone without it. The verdict is unchanged, because it does load here; the line now says who it
+  will not load for. The inventory family already flagged this, so the two families no longer disagree about the
+  same file.
 
 - **`housecarl_asset_status` under a `max_chars` its header and alarms already fill now renders the first path's
   answer instead of cutting to none.** `housecarl_nif_inspect` already did; both tools now render through one batch

--- a/plugin/codex/housecarl/SKILL.md
+++ b/plugin/codex/housecarl/SKILL.md
@@ -40,7 +40,7 @@ Beyond the core workflow, reach for the right group. Depth for the specialist ar
 
 **Runtime layers (what xEdit can't see)**
 - `housecarl_skypatcher_read` — a record's true state after the SkyPatcher INI layer replays; `housecarl_skypatcher_layer` — the INIs, apply order, conflicts.
-- `housecarl_skse_inventory` — SKSE-plugin DLLs, configs, provider/metadata; `housecarl_skse_config_audit` — config references vs the load order; `housecarl_native_pairing_audit` — native Papyrus declarations vs the DLLs implementing them.
+- `housecarl_skse` — the SKSE layer, one family per call via `findings=`: `inventory` (SKSE-plugin DLLs, configs, provider/metadata — the default), `pairing` (native Papyrus declarations vs the DLLs implementing them), `config` (config references vs the load order).
 
 **Write / author**
 - `housecarl_apply` — the consolidated 2.0 field-write surface (one or many edits × the lane × the read-back in one call): `ops=` for field edits, `bundle=`+`assignments=` to copy a field bundle from one record onto another, and one lane spelling — a new patch, `into=` an existing one, or `in_place="X.esp"` naming the file you intend to overwrite. The 1.x write tools below keep working through the 2.0 build.

--- a/src/housecarl-core/NativePairing.cs
+++ b/src/housecarl-core/NativePairing.cs
@@ -4,7 +4,7 @@ namespace HousecarlCore;
 
 // ======================================================================
 //  NativePairing — the PURE half of the native-function pairing audit
-//  (housecarl_native_pairing_audit).
+//  (housecarl_skse findings='pairing').
 //
 //  A native Papyrus function is ONE thing declared in TWO places: a .pex script class carrying a
 //  native-flagged function (what quests/MCMs/effects compile against) and a DLL that registers the

--- a/src/housecarl-core/SksePeek.cs
+++ b/src/housecarl-core/SksePeek.cs
@@ -2,7 +2,7 @@ using System.Text;
 
 namespace HousecarlCore;
 
-// SksePeek — the string half of the SKSE static peek (skse_inventory peek=true). It answers "what does this
+// SksePeek — the string half of the SKSE static peek (housecarl_skse findings='inventory' peek=true). It answers "what does this
 // unfamiliar DLL's image statically contain": imports ride the manifest read in SksePluginReader because they
 // are free there, while the embedded strings live here because scanning a whole image is not free and stays
 // opt-in per DLL.

--- a/src/housecarl-core/ToolNames.cs
+++ b/src/housecarl-core/ToolNames.cs
@@ -31,7 +31,6 @@ public static class ToolNames
     public const string Forward = "housecarl_forward";
     public const string LoadOrderStatus = "housecarl_load_order_status";
     public const string MergePlugins = "housecarl_merge_plugins";
-    public const string NativePairingAudit = "housecarl_native_pairing_audit";
     public const string NexusCheckUpdates = "housecarl_nexus_check_updates";
     public const string NexusGraphql = "housecarl_nexus_graphql";
     public const string NexusIdentify = "housecarl_nexus_identify";
@@ -44,8 +43,7 @@ public static class ToolNames
     public const string Remove = "housecarl_remove";
     public const string SetMo2Instance = "housecarl_set_mo2_instance";
     public const string SetToolPath = "housecarl_set_tool_path";
-    public const string SkseConfigAudit = "housecarl_skse_config_audit";
-    public const string SkseInventory = "housecarl_skse_inventory";
+    public const string Skse = "housecarl_skse";
     public const string SkypatcherLayer = "housecarl_skypatcher_layer";
     public const string UpdateStatus = "housecarl_update_status";
     public const string WriteSeq = "housecarl_write_seq";

--- a/src/housecarl-generator/NativePairingProbe.cs
+++ b/src/housecarl-generator/NativePairingProbe.cs
@@ -254,12 +254,22 @@ public static class NativePairingProbe
                 s.Contains("[LOADS]") && !s.Contains("[DEAD]"));
             Check("A3c: …and the line now names the debug CRT and error 126 for everyone else (#417)",
                 s.Contains("vcruntime140d.dll") && s.Contains("error 126") && s.Contains("debug CRT"));
+            // The DEFAULT view is the one the author runs first, and it prints no DLL lines for a loading class — so
+            // the finding has to reach it as its own section, or #417's whole scenario survives the fix.
+            var whole = Render(data);
+            Check("A3e: the default (unfiltered) view names the debug build as a finding, not only under filter=",
+                whole.Contains("DEBUG BUILD") && whole.Contains("vcruntime140d.dll") && whole.Contains("error 126"));
+            Check("A3f: …and it no longer claims the clean bill of health over that same file",
+                !whole.Contains("nothing dead, nothing unpaired") && !whole.Contains("paired healthy (1 class"));
             // The healthy roster must not gain the sentence: it lists class names, not DLL lines, so a leak there would
             // mean the note escaped Judge into the summary.
+            var cleanData = Data(new[] { Cls("CleanUtil", NativeProvenance.ThirdParty, NativePairingRung.SameMod, "CleanMod",
+                new[] { new NativePairedDll(@"SKSE\Plugins\PapyrusUtil.dll", "PapyrusUtil.dll", "", "CleanMod", indepInfo, null) }) }, "1.6.1170.0");
             Check("A3d: a clean version-independent DLL gets no debug note",
-                !Render(Data(new[] { Cls("CleanUtil", NativeProvenance.ThirdParty, NativePairingRung.SameMod, "CleanMod",
-                    new[] { new NativePairedDll(@"SKSE\Plugins\PapyrusUtil.dll", "PapyrusUtil.dll", "", "CleanMod", indepInfo, null) }) }, "1.6.1170.0"),
-                    filter: "CleanUtil").Contains("debug CRT"));
+                !Render(cleanData, filter: "CleanUtil").Contains("debug CRT"));
+            Check("A3g: …and it still earns the clean bill of health in the default view",
+                Render(cleanData).Contains("nothing dead, nothing unpaired")
+                && !Render(cleanData).Contains("DEBUG BUILD"));
         }
         {
             // Arm C: a static blocker (BSA-only) is dead regardless of runtime knowledge.

--- a/src/housecarl-generator/NativePairingProbe.cs
+++ b/src/housecarl-generator/NativePairingProbe.cs
@@ -215,7 +215,7 @@ public static class NativePairingProbe
         {
             // Arm A2 (tier D, Aaron-go 2026-07-17): the DEBUG-build blocker — the audit's 7th, and the one that used to
             // read as healthy. This DLL is loose, top-level, x64, readable and version-INDEPENDENT: every other check
-            // passes it, so before this the audit rendered [LOADS] while skse_inventory called the same DLL broken.
+            // passes it, so before this the audit rendered [LOADS] while the inventory family called the same DLL broken.
             // The blocker rides LoadBlocker, so it lands in PAIRED-BUT-DEAD by construction — no Judge arm needed.
             // Drives the REAL service chain (LoadOrderService.LooseDllBlocker), not a hand-built blocker — the wiring is
             // the one link no live gate can reach here (ARR has zero debug plugins; the dev box HAS the debug runtime,
@@ -237,6 +237,29 @@ public static class NativePairingProbe
             Check("A2: a DEBUG-built version-INDEPENDENT DLL → 'PAIRED BUT DEAD', not healthy (the tier-D blind spot)",
                 s.Contains("PAIRED BUT DEAD") && s.Contains("DEBUG build") && s.Contains("error 126")
                 && !s.Contains("paired healthy (1"));
+        }
+        {
+            // Arm A3 (#417): the SAME debug build on the AUTHOR's own box, where the debug runtime resolves — so
+            // LooseDllBlocker returns null and every other check passes it. The verdict is right (it does load here) and
+            // stays LOADS; what used to be missing is any mention of the debug build, leaving the author who ships one
+            // told everything is healthy. The filter= view is the one that renders a healthy class's DLL line.
+            var dbgInfo = new SksePluginReader.SksePluginInfo("Dbg.dll", SksePluginReader.SksePluginKind.Modern, true,
+                Ver(independent: true, compat: Array.Empty<string>()), null, new[] { "kernel32.dll", "vcruntime140d.dll" });
+            Check("A3a: on a box WITH the debug runtime the DLL has no blocker (the author's own machine)",
+                LoadOrderService.LooseDllBlocker(dbgInfo, _ => true) is null);
+            var dbgDll = new NativePairedDll(@"SKSE\Plugins\Dbg.dll", "Dbg.dll", "", "DbgMod", dbgInfo, null);
+            var data = Data(new[] { Cls("DbgUtil", NativeProvenance.ThirdParty, NativePairingRung.SameMod, "DbgMod", new[] { dbgDll }) }, "1.6.1170.0");
+            var s = Render(data, filter: "DbgUtil");
+            Check("A3b: it still renders [LOADS] — the verdict is untouched, because it does load here",
+                s.Contains("[LOADS]") && !s.Contains("[DEAD]"));
+            Check("A3c: …and the line now names the debug CRT and error 126 for everyone else (#417)",
+                s.Contains("vcruntime140d.dll") && s.Contains("error 126") && s.Contains("debug CRT"));
+            // The healthy roster must not gain the sentence: it lists class names, not DLL lines, so a leak there would
+            // mean the note escaped Judge into the summary.
+            Check("A3d: a clean version-independent DLL gets no debug note",
+                !Render(Data(new[] { Cls("CleanUtil", NativeProvenance.ThirdParty, NativePairingRung.SameMod, "CleanMod",
+                    new[] { new NativePairedDll(@"SKSE\Plugins\PapyrusUtil.dll", "PapyrusUtil.dll", "", "CleanMod", indepInfo, null) }) }, "1.6.1170.0"),
+                    filter: "CleanUtil").Contains("debug CRT"));
         }
         {
             // Arm C: a static blocker (BSA-only) is dead regardless of runtime knowledge.

--- a/src/housecarl-generator/NativePairingProbe.cs
+++ b/src/housecarl-generator/NativePairingProbe.cs
@@ -286,6 +286,22 @@ public static class NativePairingProbe
                 Render(mixedData, filter: "MixedUtil").Contains("debug CRT"));
         }
         {
+            // Arm A4 (review finding): a version-LOCKED debug build with the runtime unknown lands on VERIFY, and the
+            // debug CRT is just as fatal for everyone else there as on LOADS — the inventory family flags the same file
+            // regardless of the version question, so this render must not go quiet about it.
+            var lockedDbgInfo = new SksePluginReader.SksePluginInfo("LockedDbg.dll", SksePluginReader.SksePluginKind.Modern, true,
+                Ver(independent: false, compat: new[] { "1.5.97" }), null, new[] { "kernel32.dll", "vcruntime140d.dll" });
+            var lockedDbgDll = new NativePairedDll(@"SKSE\Plugins\LockedDbg.dll", "LockedDbg.dll", "", "LockedDbgMod", lockedDbgInfo, null);
+            var data = Data(new[] { Cls("LockedDbgUtil", NativeProvenance.ThirdParty, NativePairingRung.SameMod, "LockedDbgMod", new[] { lockedDbgDll }) }, runtime: null);
+            var s = Render(data);
+            Check("A4a: a version-locked debug build still reads [VERIFY] — the verdict is untouched by the note",
+                s.Contains("[VERIFY]") && s.Contains("need a version check") && !s.Contains("[DEAD]"));
+            Check("A4b: …and the VERIFY line names the debug CRT and error 126, as the LOADS line does",
+                s.Contains("vcruntime140d.dll") && s.Contains("debug CRT") && s.Contains("error 126"));
+            Check("A4c: …in the filter= view too, from the same Judge",
+                Render(data, filter: "LockedDbgUtil").Contains("debug CRT"));
+        }
+        {
             // Arm C: a static blocker (BSA-only) is dead regardless of runtime knowledge.
             var bsaDll = new NativePairedDll(@"SKSE\Plugins\X.dll", "X.dll", "", "XMod", null,
                 "provided only inside a BSA — the SKSE loader scans loose DLLs only, so it will not load");

--- a/src/housecarl-generator/NativePairingProbe.cs
+++ b/src/housecarl-generator/NativePairingProbe.cs
@@ -1,4 +1,4 @@
-using Mutagen.Bethesda;
+﻿using Mutagen.Bethesda;
 using Mutagen.Bethesda.Pex;
 using Mutagen.Bethesda.Plugins;
 using HousecarlCore;
@@ -270,6 +270,20 @@ public static class NativePairingProbe
             Check("A3g: …and it still earns the clean bill of health in the default view",
                 Render(cleanData).Contains("nothing dead, nothing unpaired")
                 && !Render(cleanData).Contains("DEBUG BUILD"));
+            // A3h (review finding): a class with TWO candidates — a clean release DLL that loads plus a debug sibling.
+            // The clean DLL implements the class for everyone, so the class is healthy; only a class whose EVERY loading
+            // candidate is debug-built is the #417 finding. The sibling's own line keeps the clause under filter=.
+            var mixedData = Data(new[] { Cls("MixedUtil", NativeProvenance.ThirdParty, NativePairingRung.SameMod, "MixedMod", new[]
+            {
+                new NativePairedDll(@"SKSE\Plugins\PapyrusUtil.dll", "PapyrusUtil.dll", "", "MixedMod", indepInfo, null),
+                new NativePairedDll(@"SKSE\Plugins\Dbg.dll", "Dbg.dll", "", "MixedMod", dbgInfo, null),
+            }) }, "1.6.1170.0");
+            var mixed = Render(mixedData);
+            Check("A3h: a class with a clean LOADING DLL beside a debug sibling stays healthy, not debug-only",
+                mixed.Contains("paired healthy (1 class(es))") && mixed.Contains("MixedMod: MixedUtil")
+                && !mixed.Contains("paired only to a DEBUG BUILD") && !mixed.Contains("DEBUG BUILD —"));
+            Check("A3i: …and the debug sibling's own line still carries the debug-CRT clause under filter=",
+                Render(mixedData, filter: "MixedUtil").Contains("debug CRT"));
         }
         {
             // Arm C: a static blocker (BSA-only) is dead regardless of runtime knowledge.

--- a/src/housecarl-generator/NativePairingProbe.cs
+++ b/src/housecarl-generator/NativePairingProbe.cs
@@ -284,6 +284,23 @@ public static class NativePairingProbe
                 && !mixed.Contains("paired only to a DEBUG BUILD") && !mixed.Contains("DEBUG BUILD —"));
             Check("A3i: …and the debug sibling's own line still carries the debug-CRT clause under filter=",
                 Render(mixedData, filter: "MixedUtil").Contains("debug CRT"));
+            // A3j (review finding): the same mix with the clean sibling version-LOCKED and the runtime UNKNOWN, so that
+            // sibling reads VERIFY rather than LOADS. It still implements the class on every machine matching its lock,
+            // so calling the class debug-only would print "loads on THIS machine and nowhere else" over a file that is
+            // simply unresolved — a claim the data does not support.
+            var lockedCleanInfo = new SksePluginReader.SksePluginInfo("Clean.dll", SksePluginReader.SksePluginKind.Modern, true,
+                Ver(independent: false, compat: new[] { "1.5.97" }), null);
+            var lockedMixedData = Data(new[] { Cls("LockedMixedUtil", NativeProvenance.ThirdParty, NativePairingRung.SameMod, "MixedMod", new[]
+            {
+                new NativePairedDll(@"SKSE\Plugins\Dbg.dll", "Dbg.dll", "", "MixedMod", dbgInfo, null),
+                new NativePairedDll(@"SKSE\Plugins\Clean.dll", "Clean.dll", "", "MixedMod", lockedCleanInfo, null),
+            }) }, runtime: null);
+            var lockedMixed = Render(lockedMixedData);
+            Check("A3j: a clean version-LOCKED sibling on VERIFY also keeps the class off the debug-only finding",
+                lockedMixed.Contains("paired healthy (1 class(es))") && lockedMixed.Contains("MixedMod: LockedMixedUtil")
+                && !lockedMixed.Contains("paired only to a DEBUG BUILD") && !lockedMixed.Contains("DEBUG BUILD —"));
+            Check("A3k: …and that sibling's debug line still carries the clause under filter=",
+                Render(lockedMixedData, filter: "LockedMixedUtil").Contains("debug CRT"));
         }
         {
             // Arm A4 (review finding): a version-LOCKED debug build with the runtime unknown lands on VERIFY, and the

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -236,7 +236,7 @@ if (args.Length > 0 && args[0] == "remap-wave1-real") return RemapWave1Probe.Run
 // IMajorRecordGetterEnumerable is the recurse discriminator.
 if (args.Length > 0 && args[0] == "remap-wave2-nested-mech") return RemapWave2NestedMechProbe.RunMechanism(args[1..]);
 
-// MANUAL real-data harness: run housecarl_skse_inventory against a live MO2 instance and print the render and
+// MANUAL real-data harness: run the housecarl_skse inventory family against a live MO2 instance and print the render and
 // timing. The CI skse-reader-guard pins the decode; this covers the full inventory.
 if (args.Length > 0 && args[0] == "skse-inventory-real") return SkseInventoryProbe.RunReal(args[1..]);
 

--- a/src/housecarl-generator/SkseConfigAuditProbe.cs
+++ b/src/housecarl-generator/SkseConfigAuditProbe.cs
@@ -286,7 +286,7 @@ public static class SkseConfigAuditProbe
         => new(files, files.Length, Array.Empty<string>(), false, Array.Empty<string>(), "TestProfile");
 
     /// <summary>MANUAL real-data harness (the tier-B LIVE GATE): run the WHOLE audit against a live MO2 instance and print
-    /// exactly what housecarl_skse_config_audit would return, plus a timing line — the empirical re-check Aaron drives (the
+    /// exactly what housecarl_skse findings='config' would return, plus a timing line — the empirical re-check Aaron drives (the
     /// CI guard pins the extractor + verdict logic; this proves the full scan over real configs). NOT in ci-all (needs a
     /// real instance + game install). Read-only; touches nothing but a temp user.json.
     /// Usage: dotnet run --project src/housecarl-generator -- skse-config-audit-real --mo2 "&lt;MO2 instance&gt;" [--filter &lt;substr&gt;]</summary>

--- a/src/housecarl-generator/SkseInventoryProbe.cs
+++ b/src/housecarl-generator/SkseInventoryProbe.cs
@@ -5,7 +5,7 @@ using HousecarlMcp;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// MANUAL real-data harness for housecarl_skse_inventory (SKSE-plugin-layer visibility, gap 2026-06-08). Runs the REAL
+/// MANUAL real-data harness for housecarl_skse findings='inventory' (SKSE-plugin-layer visibility, gap 2026-06-08). Runs the REAL
 /// service + renderer against a live MO2 instance and prints exactly what the tool would return, plus a timing line —
 /// the empirical re-check Aaron drives (the CI skse-reader-guard pins the DECODE; this proves the whole inventory over
 /// real DLLs). NOT in ci-all (needs a real instance + game install). Read-only; touches nothing but a temp user.json.

--- a/src/housecarl-mcp-tests/AliasActivationTests.cs
+++ b/src/housecarl-mcp-tests/AliasActivationTests.cs
@@ -183,7 +183,7 @@ public sealed class AliasActivationTests
 
         // A change here is either a real surface change (update the number; the listing above names the row)
         // or a row that went dead.
-        Assert.Equal(91, renames.Length);
+        Assert.Equal(89, renames.Length);
         Assert.Equal(23, hints.Length);
     }
 }

--- a/src/housecarl-mcp-tests/SkseFamilyBindingTests.cs
+++ b/src/housecarl-mcp-tests/SkseFamilyBindingTests.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// The BIND-a-family half of <c>housecarl_skse</c>: each <c>findings=</c> value reaching its own service call and its
+/// own wire class, driven through the published tool method against a configured instance.
+///
+/// <para><see cref="SkseFamilySelectionTests"/> pins the switch behind a recording seam, which cannot see two arms of
+/// <c>ServiceRenders</c> swapped: the seam would still report the right family while the caller read another family's
+/// answer. So these go through the real renders on the shared <see cref="RecordsWorld"/> — a synthetic MO2 instance
+/// with no SKSE layer at all, which is enough, because what is asserted is WHICH render answered, not what it
+/// found.</para>
+/// </summary>
+[Collection("records")]
+[Trait("tier", "integration")]
+public sealed class SkseFamilyBindingTests
+{
+    readonly RecordsWorld W;
+    public SkseFamilyBindingTests(RecordsFixture f) => W = f.W;
+
+    /// <summary>Each family's own header — the first line its wire class writes, and no other one does.</summary>
+    const string InventoryHeader = "SKSE plugin layer — profile '";
+    const string PairingHeader = "native pairing audit — profile '";
+    const string ConfigHeader = "SKSE config audit — profile '";
+
+    static readonly string[] AllHeaders = { InventoryHeader, PairingHeader, ConfigHeader };
+
+    static JsonElement Str(string s) => JsonSerializer.SerializeToElement(s);
+
+    [Theory]
+    [InlineData("inventory", InventoryHeader)]
+    [InlineData("pairing", PairingHeader)]
+    [InlineData("config", ConfigHeader)]
+    public void EachFamilyAnswersWithItsOwnWireClassHeaderAndItsOwnFooter(string findings, string header)
+    {
+        Assert.True(SkseTools.TryParseFamily(findings, out var family, out var parseError), parseError);
+
+        var text = SkseTools.Skse(W.Svc, findings: Str(findings));
+
+        Assert.DoesNotContain("error: ", text, StringComparison.Ordinal);
+        Assert.StartsWith(header, text, StringComparison.Ordinal);
+        Assert.EndsWith(SkseTools.FamilyFooter(family), text, StringComparison.Ordinal);
+
+        // The two families that did NOT run must not have written a line into this answer.
+        foreach (var other in AllHeaders)
+            if (other != header) Assert.DoesNotContain(other, text, StringComparison.Ordinal);
+    }
+
+    /// <summary>The omitted default binds to the inventory RENDER, not merely to the inventory enum value.</summary>
+    [Fact]
+    public void FindingsOmittedAnswersWithTheInventoryRender()
+    {
+        var text = SkseTools.Skse(W.Svc);
+
+        Assert.StartsWith(InventoryHeader, text, StringComparison.Ordinal);
+        Assert.EndsWith(SkseTools.FamilyFooter(SkseTools.SkseFamily.Inventory), text, StringComparison.Ordinal);
+    }
+
+}

--- a/src/housecarl-mcp-tests/SkseFamilySelectionTests.cs
+++ b/src/housecarl-mcp-tests/SkseFamilySelectionTests.cs
@@ -51,8 +51,14 @@ public sealed class SkseFamilySelectionTests
         Assert.Contains(token.Trim(), error);
         foreach (var family in new[] { "inventory", "pairing", "config" })
             Assert.Contains($"'{family}'", error);
-        Assert.Contains("One family per call", error);
+        Assert.Equal(1, OneFamilyPerCallCount(error!));
     }
+
+    /// <summary>How many times the refusal says the one-family rule. It is one rule, so it is said once — a second
+    /// telling is the reader's cue that they missed something the first time.</summary>
+    static int OneFamilyPerCallCount(string error) =>
+        System.Text.RegularExpressions.Regex.Matches(error, "family per call",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase).Count;
 
     /// <summary>A list-shaped value carries the housecarl_check habit, where findings= names several families at once.
     /// The refusal names the SHAPE as well as the word, so the caller knows to drop the list rather than hunt for a
@@ -64,7 +70,7 @@ public sealed class SkseFamilySelectionTests
     {
         Assert.False(SkseTools.TryParseFamily(token, out _, out var error));
         Assert.Contains("takes ONE value, not a list", error);
-        Assert.Contains("one family per call", error);
+        Assert.Equal(1, OneFamilyPerCallCount(error!));
     }
 
     /// <summary>peek= reads one DLL image, which only the inventory family looks at. Passing it with another family is

--- a/src/housecarl-mcp-tests/SkseFamilySelectionTests.cs
+++ b/src/housecarl-mcp-tests/SkseFamilySelectionTests.cs
@@ -54,6 +54,19 @@ public sealed class SkseFamilySelectionTests
         Assert.Contains("One family per call", error);
     }
 
+    /// <summary>A list-shaped value carries the housecarl_check habit, where findings= names several families at once.
+    /// The refusal names the SHAPE as well as the word, so the caller knows to drop the list rather than hunt for a
+    /// spelling that does not exist.</summary>
+    [Theory]
+    [InlineData("inventory,pairing")]
+    [InlineData("[\"inventory\"]")]
+    public void AListShapedFindingsValueIsRefusedNamingTheShape(string token)
+    {
+        Assert.False(SkseTools.TryParseFamily(token, out _, out var error));
+        Assert.Contains("takes ONE value, not a list", error);
+        Assert.Contains("one family per call", error);
+    }
+
     /// <summary>peek= reads one DLL image, which only the inventory family looks at. Passing it with another family is
     /// refused rather than ignored: a silently dropped flag reads as a peek that found nothing.</summary>
     [Fact]

--- a/src/housecarl-mcp-tests/SkseFamilySelectionTests.cs
+++ b/src/housecarl-mcp-tests/SkseFamilySelectionTests.cs
@@ -109,4 +109,59 @@ public sealed class SkseFamilySelectionTests
         foreach (var retired in new[] { "skse_inventory", "native_pairing_audit", "skse_config_audit" })
             Assert.DoesNotContain(retired, footer, StringComparison.Ordinal);
     }
+
+    /// <summary>Every refusal this one tool can return carries the same "error: " prefix, so a caller reading them
+    /// cannot take one for an answer because it happened to start with a lowercase word.</summary>
+    [Fact]
+    public void AllThreeRefusalsCarryTheErrorPrefix()
+    {
+        SkseTools.TryParseFamily("errors", out _, out var famErr);
+        Assert.StartsWith("error: ", famErr);
+        Assert.StartsWith("error: ", SkseTools.PeekFamilyError(peek: true, SkseTools.SkseFamily.Config));
+        Assert.StartsWith("error: ", SkseInventoryWire.PeekArgError(peek: true, filter: null));
+    }
+
+    /// <summary>Records which family render the dispatch called, so the findings= switch and the footer append can be
+    /// driven without a live MO2 instance.</summary>
+    sealed class RecordingRenders : SkseTools.IFamilyRenders
+    {
+        public string? Called;
+        public int Cap;
+        public string Inventory(string? filter, bool peek, int cap) { Called = "inventory"; Cap = cap; return "INVENTORY-BODY"; }
+        public string Pairing(string? filter, int cap) { Called = "pairing"; Cap = cap; return "PAIRING-BODY"; }
+        public string Config(string? filter, int cap) { Called = "config"; Cap = cap; return "CONFIG-BODY"; }
+    }
+
+    /// <summary>Each findings= value runs its OWN family's render, and the answer ends on that family's footer. Without
+    /// this, swapping two arms of the switch changes every response and breaks no test.</summary>
+    [Theory]
+    [InlineData("inventory", "INVENTORY-BODY")]
+    [InlineData("pairing", "PAIRING-BODY")]
+    [InlineData("config", "CONFIG-BODY")]
+    public void EachFamilyRunsItsOwnRenderAndTheAnswerEndsOnTheFooter(string token, string body)
+    {
+        var family = Parse(token);
+        var renders = new RecordingRenders();
+
+        var text = SkseTools.Dispatch(renders, family, filter: null, peek: false, max_chars: 0);
+
+        Assert.Equal(token, renders.Called);
+        Assert.StartsWith(body, text);
+        Assert.EndsWith(SkseTools.FamilyFooter(family), text);
+        Assert.Contains($"this call ran findings='{token}'", text);
+    }
+
+    /// <summary>The footer is paid for out of max_chars rather than appended past it, so the renders are handed a cap
+    /// already short by its length — the one part of the bound the tool itself controls.</summary>
+    [Fact]
+    public void TheFooterLengthIsSubtractedFromTheCapHandedToTheRender()
+    {
+        var renders = new RecordingRenders();
+        SkseTools.Dispatch(renders, SkseTools.SkseFamily.Pairing, filter: null, peek: false, max_chars: 5_000);
+        Assert.Equal(5_000 - SkseTools.FamilyFooter(SkseTools.SkseFamily.Pairing).Length, renders.Cap);
+
+        // A cap smaller than the footer never becomes zero or negative: the render still gets a usable bound.
+        SkseTools.Dispatch(renders, SkseTools.SkseFamily.Pairing, filter: null, peek: false, max_chars: 1);
+        Assert.True(renders.Cap >= 1);
+    }
 }

--- a/src/housecarl-mcp-tests/SkseFamilySelectionTests.cs
+++ b/src/housecarl-mcp-tests/SkseFamilySelectionTests.cs
@@ -1,0 +1,93 @@
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// The SELECT-a-family half of <c>housecarl_skse</c>: which family <c>findings=</c> picks, what a call that names
+/// none of them ran, and the two refusals. All four are pure over their inputs, so they are driven directly rather
+/// than through a live MO2 instance — the three family renders themselves are covered by the generator's
+/// skse/native-pairing/config probes against synthetic data.
+/// </summary>
+[Trait("tier", "unit")]
+public sealed class SkseFamilySelectionTests
+{
+    static SkseTools.SkseFamily Parse(string? findings)
+    {
+        Assert.True(SkseTools.TryParseFamily(findings, out var family, out var error), error);
+        Assert.Null(error);
+        return family;
+    }
+
+    [Fact]
+    public void FindingsOmitted_RunsTheInventoryFamily()
+    {
+        Assert.Equal(SkseTools.SkseFamily.Inventory, Parse(null));
+        Assert.Equal(SkseTools.SkseFamily.Inventory, Parse(""));
+        Assert.Equal(SkseTools.SkseFamily.Inventory, Parse("   "));
+    }
+
+    [Theory]
+    [InlineData("inventory", "Inventory")]
+    [InlineData("pairing", "Pairing")]
+    [InlineData("config", "Config")]
+    [InlineData("  PAIRING  ", "Pairing")]
+    [InlineData("Config", "Config")]
+    public void EachFamilyTokenSelectsItsFamily_CaseAndPaddingInsensitive(string token, string expected)
+        => Assert.Equal(expected, Parse(token).ToString());
+
+    /// <summary>An unknown value is refused naming all three spellings — never quietly defaulted to inventory, which
+    /// would answer a question the caller did not ask and call it the answer.</summary>
+    [Theory]
+    [InlineData("inventories")]
+    [InlineData("skse_inventory")]
+    [InlineData("errors")]
+    [InlineData("inventory,pairing")]
+    public void AnUnknownFindingsValueIsRefused_NamingTheThreeFamilies(string token)
+    {
+        Assert.False(SkseTools.TryParseFamily(token, out _, out var error));
+        Assert.NotNull(error);
+        Assert.StartsWith("error: ", error);
+        Assert.Contains(token.Trim(), error);
+        foreach (var family in new[] { "inventory", "pairing", "config" })
+            Assert.Contains($"'{family}'", error);
+        Assert.Contains("One family per call", error);
+    }
+
+    /// <summary>peek= reads one DLL image, which only the inventory family looks at. Passing it with another family is
+    /// refused rather than ignored: a silently dropped flag reads as a peek that found nothing.</summary>
+    [Fact]
+    public void PeekOnANonInventoryFamilyIsRefused_AndOnInventoryIsNot()
+    {
+        foreach (var family in new[] { SkseTools.SkseFamily.Pairing, SkseTools.SkseFamily.Config })
+        {
+            var error = SkseTools.PeekFamilyError(peek: true, family);
+            Assert.NotNull(error);
+            Assert.StartsWith("error: ", error);
+            Assert.Contains(family.ToString().ToLowerInvariant(), error);
+            Assert.Contains("findings='inventory'", error);
+            Assert.Null(SkseTools.PeekFamilyError(peek: false, family));
+        }
+        Assert.Null(SkseTools.PeekFamilyError(peek: true, SkseTools.SkseFamily.Inventory));
+    }
+
+    /// <summary>Every response says which family ran and how to ask for the two it did not — the only thing that keeps
+    /// the omitted-findings default from being a silent narrowing.</summary>
+    [Theory]
+    [InlineData("inventory", "pairing", "config")]
+    [InlineData("pairing", "inventory", "config")]
+    [InlineData("config", "inventory", "pairing")]
+    public void TheFooterNamesTheFamilyThatRanAndTheSpellingOfBothThatDidNot(string mine, string first, string second)
+    {
+        var footer = SkseTools.FamilyFooter(Parse(mine));
+
+        Assert.Contains($"this call ran findings='{mine}'", footer);
+        Assert.Contains("NOT run:", footer);
+        Assert.Contains($"findings='{first}'", footer);
+        Assert.Contains($"findings='{second}'", footer);
+
+        // The three retired spellings are gone from the surface, so no response may teach one of them.
+        foreach (var retired in new[] { "skse_inventory", "native_pairing_audit", "skse_config_audit" })
+            Assert.DoesNotContain(retired, footer, StringComparison.Ordinal);
+    }
+}

--- a/src/housecarl-mcp-tests/SkseFindingsWireShapeTests.cs
+++ b/src/housecarl-mcp-tests/SkseFindingsWireShapeTests.cs
@@ -1,0 +1,95 @@
+using System.Text.Json;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// The SHAPE <c>housecarl_skse</c>'s <c>findings=</c> accepts over the wire. A real JSON array is the
+/// <c>housecarl_check</c> habit and the shape the tool's own description promises a refusal for, so it has to reach
+/// the tool: published as a string alone it was caught by the shim's type check and answered with the generic
+/// type-mismatch sentence, which teaches nothing about families.
+///
+/// <para>Driven through the built server: the string form goes nowhere near the schema or the binder, so it cannot
+/// see this at all.</para>
+/// </summary>
+[Collection("server")]
+[Trait("tier", "stdio")]
+public sealed class SkseFindingsWireShapeTests
+{
+    readonly ServerFixture _s;
+    public SkseFindingsWireShapeTests(ServerFixture s) => _s = s;
+
+    /// <summary>The published declaration the shim judges against: a string OR an array, plus null for optional.</summary>
+    [Fact]
+    public void FindingsIsPublishedAsAStringOrAnArray()
+    {
+        var types = _s.PublishedTools[ToolNames.Skse].GetProperty("inputSchema").GetProperty("properties")
+                      .GetProperty("findings").GetProperty("type")
+                      .EnumerateArray().Select(e => e.GetString()!).ToArray();
+
+        Assert.Equal(new[] { "string", "array", "null" }, types);
+    }
+
+    /// <summary>A real JSON array is answered by the TOOL, in its own words: the three family spellings and the
+    /// one-family rule — never the shim's generic "could not be bound".</summary>
+    [Theory]
+    [InlineData("""{"findings":["inventory"]}""")]
+    [InlineData("""{"findings":["inventory","pairing"]}""")]
+    public void AJsonArrayForFindingsGetsTheToolsOwnOneFamilyRefusal(string arguments)
+    {
+        var r = _s.Call(ToolNames.Skse, arguments);
+
+        Assert.DoesNotContain("could not be bound", r.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain(ServerFixture.GenericError, r.Text, StringComparison.Ordinal);
+        Assert.StartsWith("error: ", r.Text, StringComparison.Ordinal);
+        Assert.Contains("is not a family on this tool", r.Text, StringComparison.Ordinal);
+        foreach (var family in new[] { "inventory", "pairing", "config" })
+            Assert.Contains($"'{family}'", r.Text, StringComparison.Ordinal);
+        Assert.Contains("takes ONE value, not a list", r.Text, StringComparison.Ordinal);
+        Assert.Contains("One family per call.", r.Text, StringComparison.Ordinal);
+
+        // The argument is wrong whether or not an instance is configured, so the refusal outranks the config prompt:
+        // being sent to configure one, only to meet this same refusal, is a round trip that teaches nothing.
+        Assert.DoesNotContain(ServerFixture.ConfigPrompt, r.Text, StringComparison.Ordinal);
+    }
+
+    /// <summary>The control the array arm needs: a scalar findings= still binds as a SCALAR and runs. Declaring the
+    /// array shape puts the parameter in reach of the shim's bare-string-to-array coercion, which would hand the tool
+    /// <c>["pairing"]</c> — the very shape the arm above refuses — for a call that was spelled correctly.</summary>
+    [Theory]
+    [InlineData("inventory")]
+    [InlineData("pairing")]
+    [InlineData("config")]
+    public void AScalarFindingsStillBindsAsAScalarAndReachesTheBody(string family)
+    {
+        var r = _s.Call(ToolNames.Skse, $$"""{"findings":"{{family}}"}""");
+
+        Assert.False(r.IsError, r.Describe());
+        Assert.DoesNotContain("is not a family on this tool", r.Text, StringComparison.Ordinal);
+        Assert.True(r.BodyRan, r.Describe());
+    }
+
+    /// <summary>An OBJECT is neither declared shape, so it stays the SHIM's refusal — which now names both shapes the
+    /// parameter takes. The tool's own refusal is for a value it can read; a shape the schema does not declare is the
+    /// shim's to name.</summary>
+    [Fact]
+    public void AnObjectForFindingsIsRefusedNamingBothShapesTheParameterTakes()
+    {
+        var r = _s.Call(ToolNames.Skse, """{"findings":{"family":"inventory"}}""");
+
+        Assert.DoesNotContain(ServerFixture.GenericError, r.Text, StringComparison.Ordinal);
+        Assert.StartsWith("error: ", r.Text, StringComparison.Ordinal);
+        Assert.Contains("findings (expects string or array, received object)", r.Text, StringComparison.Ordinal);
+    }
+
+    /// <summary>Whatever else changes, the arguments are judged before the instance is: an unusable findings= must
+    /// never come back as the config prompt.</summary>
+    [Fact]
+    public void AnUnknownScalarFindingsIsRefusedRatherThanAnsweredWithTheConfigPrompt()
+    {
+        var r = _s.Call(ToolNames.Skse, """{"findings":"inventories"}""");
+
+        Assert.Contains("is not a family on this tool", r.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain(ServerFixture.ConfigPrompt, r.Text, StringComparison.Ordinal);
+    }
+}

--- a/src/housecarl-mcp-tests/data/tools-list-2.0.json
+++ b/src/housecarl-mcp-tests/data/tools-list-2.0.json
@@ -25,7 +25,6 @@
     "housecarl_forward",
     "housecarl_load_order_status",
     "housecarl_merge_plugins",
-    "housecarl_native_pairing_audit",
     "housecarl_nexus_check_updates",
     "housecarl_nexus_graphql",
     "housecarl_nexus_identify",
@@ -38,8 +37,7 @@
     "housecarl_remove",
     "housecarl_set_mo2_instance",
     "housecarl_set_tool_path",
-    "housecarl_skse_config_audit",
-    "housecarl_skse_inventory",
+    "housecarl_skse",
     "housecarl_skypatcher_layer",
     "housecarl_update_status",
     "housecarl_write_seq"

--- a/src/housecarl-mcp/AliasTable.cs
+++ b/src/housecarl-mcp/AliasTable.cs
@@ -206,6 +206,15 @@ internal static class AliasTable
         ("housecarl_skypatcher_read",
          "absorbed into " + ToolNames.Records + ": source={\"overlay\": \"skypatcher\", \"state\": \"post\"} reads the post-INI body; pre-vs-post is project={\"form\": \"delta\"} with the two overlay poles."),
 
+        // The SKSE layer. Three families of one substrate, so all three rows name the same tool and differ only in the
+        // findings= value; the declared-vs-runtime ceiling they each used to carry is now written once on that tool.
+        ("housecarl_skse_inventory",
+         "absorbed into " + ToolNames.Skse + ": findings=\"inventory\", which is also the DEFAULT when findings= is omitted. filter=, peek= and max_chars= are unchanged, and peek= still requires filter=."),
+        ("housecarl_native_pairing_audit",
+         "absorbed into " + ToolNames.Skse + ": findings=\"pairing\". filter= and max_chars= are unchanged; peek= belongs to findings=\"inventory\" and is refused here."),
+        ("housecarl_skse_config_audit",
+         "absorbed into " + ToolNames.Skse + ": findings=\"config\". filter= and max_chars= are unchanged; peek= belongs to findings=\"inventory\" and is refused here."),
+
         // The write side. Each redirect names the parameter migration too, since a caller arriving from old docs
         // has the old parameter habits as well as the old tool name.
         ("housecarl_set_field",

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -8715,7 +8715,7 @@ public sealed record AssetStatusData(
 /// a "BSA" entry. The winner-first-then-losers ordering lives in <see cref="SkseFileEntry.Providers"/>.</summary>
 public sealed record SkseProvider(string Name, string Kind);
 
-/// <summary>One file found under Data\SKSE\Plugins in the active load order (housecarl_skse_inventory). <see cref="Group"/> is the
+/// <summary>One file found under Data\SKSE\Plugins in the active load order (housecarl_skse findings='inventory'). <see cref="Group"/> is the
 /// immediate subfolder it sits in ("" = top level) — the derived render-grouping key. <see cref="Providers"/> is the FULL conflict
 /// chain — every mod that ships this exact file, WINNER FIRST then the losers in precedence order (the same winner→loser
 /// transparency the asset tools give), each tagged loose/BSA; empty ⇒ nothing active provides it. <see cref="Plugin"/> is the tier-C
@@ -8756,7 +8756,7 @@ public sealed record SkseFileEntry(
     public int ProviderCount => Providers.Count;
 }
 
-/// <summary>The data behind housecarl_skse_inventory: the SKSE-plugin layer of the active load order — <see cref="Dlls"/> (each a
+/// <summary>The data behind housecarl_skse findings='inventory': the SKSE-plugin layer of the active load order — <see cref="Dlls"/> (each a
 /// plugin DLL with its winning provider + static manifest) and <see cref="Configs"/> (their .ini/.toml/.json/.yaml with the
 /// winning provider), plus <see cref="OtherFileCount"/> (uncategorized files like .pdb/.txt, counted not listed). The build-level
 /// caveats <see cref="BsaFailures"/> / <see cref="ReadIncomplete"/> and discovery <see cref="Warnings"/> ride along; <see cref="ProfileName"/>
@@ -8785,7 +8785,7 @@ public sealed record SkseInventoryData(
     public bool PeekRequested { get; init; } = PeekRequested;
 }
 
-/// <summary>The load-order verdict for one reference an SKSE config declares (housecarl_skse_config_audit).</summary>
+/// <summary>The load-order verdict for one reference an SKSE config declares (housecarl_skse findings='config').</summary>
 public enum SkseRefVerdict
 {
     /// <summary>Plugin in the active order, and (for a form token) the FormID resolves to a record in it.</summary>
@@ -8815,7 +8815,7 @@ public sealed record SkseConfigFileAudit(
     IReadOnlyList<SkseAuditedRef> Refs,
     string? ReadError);
 
-/// <summary>The data behind housecarl_skse_config_audit: every SKSE-plugin config with the references it
+/// <summary>The data behind housecarl_skse findings='config': every SKSE-plugin config with the references it
 /// declares resolved to OK / PLUGIN MISSING / DANGLING / UNPARSEABLE, plus the build-level caveats
 /// (<see cref="BsaFailures"/> / <see cref="ReadIncomplete"/> / <see cref="Warnings"/>) and the active <see cref="ProfileName"/>.</summary>
 public sealed record SkseConfigAuditData(
@@ -8826,7 +8826,7 @@ public sealed record SkseConfigAuditData(
     IReadOnlyList<string> Warnings,
     string ProfileName);
 
-/// <summary>Who implements a native class's declarations (housecarl_native_pairing_audit).</summary>
+/// <summary>Who implements a native class's declarations (housecarl_skse findings='pairing').</summary>
 public enum NativeProvenance
 {
     /// <summary>The class's provider chain includes an OFFICIAL archive — implemented by the game executable. Baseline;
@@ -8894,7 +8894,7 @@ public sealed record NativeClassEntry(
 /// <summary>A .pex whose winning copy could not be parsed — a NAMED note, never a silent skip.</summary>
 public sealed record NativeUnreadablePex(string RelPath, string? WinningProvider, string Reason);
 
-/// <summary>The data behind housecarl_native_pairing_audit: every native-declaring class classified and (for third
+/// <summary>The data behind housecarl_skse findings='pairing': every native-declaring class classified and (for third
 /// parties) paired, the scan accounting (<see cref="PexScanned"/> total compiled scripts examined), the unreadable
 /// notes, whether an skse64 loader is visible (<see cref="SkseLoaderSeen"/> — the SKSE-CORE sanity note; tri-state:
 /// null = the check itself failed, "could not check", never rendered as a definite absence), the installed game

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -71,6 +71,43 @@ public static class SkseTools
         return $"\n\n(this call ran findings='{mine}'. NOT run: {a}; {b}.)";
     }
 
+    /// <summary>The three family renders, one method each. The dispatch below picks one and appends the footer; behind
+    /// this seam it can be driven without a live MO2 instance, so a test can pin which family a findings= value runs
+    /// and that the answer ends on the footer. <see cref="ServiceRenders"/> is the live implementation.</summary>
+    internal interface IFamilyRenders
+    {
+        string Inventory(string? filter, bool peek, int cap);
+        string Pairing(string? filter, int cap);
+        string Config(string? filter, int cap);
+    }
+
+    /// <summary>The live renders: each family's data read from the service, handed to its own wire class.</summary>
+    sealed class ServiceRenders(LoadOrderService svc) : IFamilyRenders
+    {
+        public string Inventory(string? filter, bool peek, int cap)
+            => SkseInventoryWire.Render(svc.SkseInventory(peek ? filter!.Trim() : null), filter, cap);
+        public string Pairing(string? filter, int cap) => NativePairingWire.Render(svc.NativePairingAudit(), filter, cap);
+        public string Config(string? filter, int cap) => SkseConfigAuditWire.Render(svc.SkseConfigAudit(), filter, cap);
+    }
+
+    /// <summary>Runs the selected family and appends the footer. The footer's length is subtracted from max_chars so it
+    /// is paid for rather than added past the cap; the renders themselves test the cap BEFORE each list item and then
+    /// append their scope note, caveats and filter hint unconditionally, so a response can still overrun a tight cap by
+    /// one item plus that tail. Under a cap too small to hold both, the footer wins: it is the line that says which
+    /// family answered.</summary>
+    internal static string Dispatch(IFamilyRenders renders, SkseFamily family, string? filter, bool peek, int max_chars)
+    {
+        var footer = FamilyFooter(family);
+        int cap = Math.Max(1, (max_chars > 0 ? max_chars : 80_000) - footer.Length);
+        var body = family switch
+        {
+            SkseFamily.Inventory => renders.Inventory(filter, peek, cap),
+            SkseFamily.Pairing => renders.Pairing(filter, cap),
+            _ => renders.Config(filter, cap),
+        };
+        return body + footer;
+    }
+
     [McpServerTool(Name = ToolNames.Skse, ReadOnly = true, Title = "The SKSE layer: DLL/config inventory, native pairing, config references"),
      Description(
          // ---- what it is, and what selects a family ------------------------------------------------
@@ -170,17 +207,7 @@ public static class SkseTools
         if (PeekFamilyError(peek, family) is { } peekErr) return peekErr;
         if (SkseInventoryWire.PeekArgError(peek, filter) is { } err) return err;
 
-        // The footer is priced into the cap rather than appended past it, so max_chars bounds the whole response. Under
-        // a cap too small to hold both, the footer wins: it is the line that says which family answered.
-        var footer = FamilyFooter(family);
-        int cap = Math.Max(1, (max_chars > 0 ? max_chars : 80_000) - footer.Length);
-        var body = family switch
-        {
-            SkseFamily.Inventory => SkseInventoryWire.Render(svc.SkseInventory(peek ? filter!.Trim() : null), filter, cap),
-            SkseFamily.Pairing => NativePairingWire.Render(svc.NativePairingAudit(), filter, cap),
-            _ => SkseConfigAuditWire.Render(svc.SkseConfigAudit(), filter, cap),
-        };
-        return body + footer;
+        return Dispatch(new ServiceRenders(svc), family, filter, peek, max_chars);
     });
 }
 

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -904,6 +904,21 @@ static class NativePairingWire
         return best;
     }
 
+    /// <summary>True when every candidate DLL that actually loads is a debug build, and at least one does — the class
+    /// whose implementation exists on the author's machine alone (#417). A class with one clean loading candidate is
+    /// healthy however many debug siblings sit beside it; those siblings still carry the note on their own line.</summary>
+    static bool IsDebugOnly(NativeClassEntry c, string? runtime)
+    {
+        bool any = false;
+        foreach (var dll in c.PairedDlls)
+        {
+            if (Judge(dll, runtime).Fate != DllFate.Loads) continue;
+            if (dll.Info is not { } i || i.DebugCrtImports.Count == 0) return false;
+            any = true;
+        }
+        return any;
+    }
+
     public static string Render(NativePairingAuditData d, string? filter, int cap)
     {
         if (filter is { Length: > 0 }) return RenderFiltered(d, filter.Trim(), cap);
@@ -921,8 +936,10 @@ static class NativePairingWire
         var loads = byFate[DllFate.Loads].ToList();
         // #417: a class whose only loadable candidate is a DEBUG build loads on THIS machine and nowhere else, so it is
         // a finding in its own right rather than a line of the healthy roster — which prints class names, not DLLs, and
-        // would have carried the clean checkmark over exactly the file the author needs to hear about.
-        var debugBuilds = loads.Where(c => c.PairedDlls.Any(x => x.Info is { } i && i.DebugCrtImports.Count > 0)).ToList();
+        // would have carried the clean checkmark over exactly the file the author needs to hear about. EVERY loading
+        // candidate must be debug-built: one clean DLL that loads keeps the class healthy, because that DLL implements
+        // the class for everyone.
+        var debugBuilds = loads.Where(c => IsDebugOnly(c, d.InstalledRuntime)).ToList();
         var healthy = loads.Except(debugBuilds).ToList();
 
         var sb = new StringBuilder();

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -36,9 +36,14 @@ public static class SkseTools
             case "pairing": family = SkseFamily.Pairing; return true;
             case "config": family = SkseFamily.Config; return true;
         }
+        // A list-shaped value is the housecarl_check habit, where findings= names several families. Naming the shape is
+        // what turns the refusal into a fix; "not a family" alone reads as the wrong word rather than the wrong shape.
+        var shape = token.Contains(',') || token.Contains('[')
+            ? " findings= here takes ONE value, not a list — this tool runs one family per call."
+            : "";
         error = $"error: findings='{token}' is not a family on this tool — pass findings='inventory' (the DLL and config " +
                 "layer), 'pairing' (native Papyrus declarations vs the DLLs that implement them) or 'config' (the form " +
-                "references SKSE configs declare vs your load order). One family per call.";
+                $"references SKSE configs declare vs your load order).{shape} One family per call.";
         return false;
     }
 
@@ -91,7 +96,9 @@ public static class SkseTools
     public static string Skse(
         LoadOrderService svc,
         [Description(
-            "Optional. WHICH FAMILY to run — exactly one; the default when omitted is 'inventory'. " +
+            "Optional. WHICH FAMILY to run — exactly one; the default when omitted is 'inventory'. ONE STRING, not a " +
+            "list: unlike " + ToolNames.Check + "'s findings=, which names several families at once, this tool runs one " +
+            "family per call, so findings=['inventory'] and findings='inventory,pairing' are both refused. " +
             // ---- family: inventory (harvested from housecarl_skse_inventory) -------------------------
             "'inventory' — the SKSE-plugin layer itself, over the FULL depth of Data\\SKSE\\Plugins: every .dll and " +
             "every .ini/.toml/.json/.yaml config beneath it, each with the MOD that wins the VFS for it. Configs are " +
@@ -163,9 +170,10 @@ public static class SkseTools
         if (PeekFamilyError(peek, family) is { } peekErr) return peekErr;
         if (SkseInventoryWire.PeekArgError(peek, filter) is { } err) return err;
 
-        // The footer is priced into the cap rather than appended past it, so max_chars stays the whole response.
+        // The footer is priced into the cap rather than appended past it, so max_chars bounds the whole response. Under
+        // a cap too small to hold both, the footer wins: it is the line that says which family answered.
         var footer = FamilyFooter(family);
-        int cap = Math.Max(1_000, (max_chars > 0 ? max_chars : 80_000) - footer.Length);
+        int cap = Math.Max(1, (max_chars > 0 ? max_chars : 80_000) - footer.Length);
         var body = family switch
         {
             SkseFamily.Inventory => SkseInventoryWire.Render(svc.SkseInventory(peek ? filter!.Trim() : null), filter, cap),
@@ -833,7 +841,8 @@ static class SkseConfigAuditWire
 /// <summary>Renders <see cref="NativePairingAuditData"/>: a health summary, then the diagnostics in full —
 /// paired-but-dead (every candidate DLL statically will not load, version-locked mismatches included where the
 /// installed runtime is known), locked-but-unverifiable pairings where the runtime is unknown, unpaired classes as a
-/// verify flag, and unreadable-.pex notes — then the accounted-for baseline of engine and skse-core counts and
+/// verify flag, debug builds that load on this machine alone, and unreadable-.pex notes — then the accounted-for
+/// baseline of engine and skse-core counts and
 /// paired-healthy classes grouped by implementing mod. Bounded by max_chars with explicit cut notices. filter= shows a
 /// class in full: native function names, pairing evidence, per-DLL manifests and load verdicts, conflict
 /// chains.</summary>
@@ -909,7 +918,12 @@ static class NativePairingWire
             .ToLookup(c => BestFate(c, d.InstalledRuntime));
         var dead = byFate[DllFate.Dead].ToList();
         var verify = byFate[DllFate.Verify].ToList();
-        var healthy = byFate[DllFate.Loads].ToList();
+        var loads = byFate[DllFate.Loads].ToList();
+        // #417: a class whose only loadable candidate is a DEBUG build loads on THIS machine and nowhere else, so it is
+        // a finding in its own right rather than a line of the healthy roster — which prints class names, not DLLs, and
+        // would have carried the clean checkmark over exactly the file the author needs to hear about.
+        var debugBuilds = loads.Where(c => c.PairedDlls.Any(x => x.Info is { } i && i.DebugCrtImports.Count > 0)).ToList();
+        var healthy = loads.Except(debugBuilds).ToList();
 
         var sb = new StringBuilder();
         sb.Append("native pairing audit — profile '").Append(d.ProfileName).Append("' — ")
@@ -918,7 +932,7 @@ static class NativePairingWire
         if (d.InstalledRuntime is { } rt) sb.Append("installed game runtime: ").Append(rt).Append('\n');
         else sb.Append("installed game runtime: could not be resolved — version-LOCKED findings degrade to 'verify'\n");
 
-        if (dead.Count == 0 && unpaired.Count == 0 && verify.Count == 0)
+        if (dead.Count == 0 && unpaired.Count == 0 && verify.Count == 0 && debugBuilds.Count == 0)
         {
             sb.Append("✓ every third-party native class pairs to a mod whose DLL statically loads — nothing dead, nothing unpaired");
             // The checkmark must not claim a universal the scan did not verify: unreadable .pex files were never
@@ -931,6 +945,8 @@ static class NativePairingWire
             if (dead.Count > 0) sb.Append(dead.Count).Append(" class(es) PAIRED BUT DEAD — scripts installed, nothing that could implement them loads");
             if (verify.Count > 0) sb.Append(dead.Count > 0 ? "   ·   " : "").Append(verify.Count).Append(" pairing(s) need a version check");
             if (unpaired.Count > 0) sb.Append(dead.Count > 0 || verify.Count > 0 ? "   ·   " : "").Append(unpaired.Count).Append(" class(es) UNPAIRED (verify)");
+            if (debugBuilds.Count > 0) sb.Append(dead.Count > 0 || verify.Count > 0 || unpaired.Count > 0 ? "   ·   " : "")
+                                         .Append(debugBuilds.Count).Append(" class(es) paired only to a DEBUG BUILD");
             sb.Append('\n');
         }
 
@@ -951,6 +967,14 @@ static class NativePairingWire
               .Append("). A VERIFY flag, not 'broken': most often a declaration copy of a framework that isn't installed — the calls will silently no-op if anything uses them:\n");
             AppendCapped(sb, unpaired, cap, c =>
                 $"  - {c.ClassName} ({c.NativeCount} native fn) ← {c.WinningProvider ?? "(no provider)"} ({c.ProviderKind})");
+        }
+        if (debugBuilds.Count > 0)
+        {
+            sb.Append("\nDEBUG BUILD — these load on THIS machine and nowhere else (").Append(debugBuilds.Count)
+              .Append("). The debug C runtime ships with Visual Studio and is not redistributable, so the DLL fails with " +
+                      "error 126 for anyone without it and every native these scripts declare is a silent no-op there. " +
+                      "If you built it, ship a Release build; if you installed it, ask its author for one:\n");
+            AppendCapped(sb, debugBuilds, cap, c => DeadLine(c, d.InstalledRuntime));
         }
         if (d.Unreadable.Count > 0)
         {

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -940,17 +940,22 @@ static class NativePairingWire
         return best;
     }
 
-    /// <summary>True when every candidate DLL that actually loads is a debug build, and at least one does — the class
-    /// whose implementation exists on the author's machine alone (#417). A class with one clean loading candidate is
-    /// healthy however many debug siblings sit beside it; those siblings still carry the note on their own line.</summary>
+    /// <summary>True when every candidate DLL that could implement the class is a debug build, and at least one of them
+    /// loads here — the class whose implementation exists on the author's machine alone (#417). A class with one clean
+    /// candidate is healthy however many debug siblings sit beside it; those siblings still carry the note on their own
+    /// line. A clean VERIFY candidate disqualifies exactly as a clean LOADS one does: it is a version question, not a
+    /// dead DLL, and it implements the class for everyone on a matching runtime — so "loads here and nowhere else"
+    /// would be a claim the data does not support. Only a DEAD candidate is passed over, because it implements the
+    /// class nowhere.</summary>
     static bool IsDebugOnly(NativeClassEntry c, string? runtime)
     {
         bool any = false;
         foreach (var dll in c.PairedDlls)
         {
-            if (Judge(dll, runtime).Fate != DllFate.Loads) continue;
+            var fate = Judge(dll, runtime).Fate;
+            if (fate == DllFate.Dead) continue;
             if (dll.Info is not { } i || i.DebugCrtImports.Count == 0) return false;
-            any = true;
+            any |= fate == DllFate.Loads;
         }
         return any;
     }

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -5,119 +5,174 @@ using ModelContextProtocol.Server;
 
 namespace HousecarlMcp;
 
-/// <summary>Read-only view of the SKSE-plugin layer, which the record and asset tools cannot see: the full depth of
-/// Data\SKSE\Plugins — the .dll plugins and every .toml, .ini and .json config beneath them grouped by real subfolder
-/// — which mod wins the VFS for each, and each plugin's statically declared manifest (name, author, version, Address
-/// Library versus version-locked, target runtimes, XSE floor). It reads what a DLL declares about itself, via the SKSE
-/// loader's own <c>SKSEPlugin_Version</c> data blob, never what it does at runtime. Compact by default with everything
-/// accounted for; <c>filter=</c> expands any group or plugin. See <see cref="SksePluginReader"/>.</summary>
+/// <summary>Read-only view of the SKSE layer of the active load order: the .dll plugins under Data\SKSE\Plugins, the
+/// configs beneath them, and the native Papyrus functions the order's compiled scripts declare. One tool, one finding
+/// family per call — <c>findings=</c> picks inventory, pairing or config, and each family's render lives in its own
+/// wire class below.
+///
+/// <para>The declared-versus-runtime ceiling is written ONCE, in the tool description, because it is the same ceiling
+/// for all three families; per-family detail lives in the <c>findings=</c> parameter text. That is the whole reason
+/// the three tools folded into one (SPEC §6.3 S7).</para>
+///
+/// <para>No response merges two families: the families answer different questions over different populations, and a
+/// merged render would have no honest summary line. See <see cref="SksePluginReader"/>.</para></summary>
 [McpServerToolType]
 public static class SkseTools
 {
-    [McpServerTool(Name = ToolNames.SkseInventory, ReadOnly = true, Title = "SKSE plugin layer (DLLs, configs, provider & static metadata)"),
+    /// <summary>The three finding families <c>findings=</c> selects between.</summary>
+    internal enum SkseFamily { Inventory, Pairing, Config }
+
+    /// <summary>Parses <c>findings=</c>. Omitted is the inventory family, which every response states; an unknown
+    /// value is refused naming the three, never quietly defaulted.</summary>
+    internal static bool TryParseFamily(string? findings, out SkseFamily family, out string? error)
+    {
+        family = SkseFamily.Inventory;
+        error = null;
+        var token = (findings ?? "").Trim();
+        if (token.Length == 0) return true;
+        switch (token.ToLowerInvariant())
+        {
+            case "inventory": family = SkseFamily.Inventory; return true;
+            case "pairing": family = SkseFamily.Pairing; return true;
+            case "config": family = SkseFamily.Config; return true;
+        }
+        error = $"error: findings='{token}' is not a family on this tool — pass findings='inventory' (the DLL and config " +
+                "layer), 'pairing' (native Papyrus declarations vs the DLLs that implement them) or 'config' (the form " +
+                "references SKSE configs declare vs your load order). One family per call.";
+        return false;
+    }
+
+    /// <summary>The <c>peek=</c> family check, or null when the call is valid. peek= reads one DLL's image, which only
+    /// the inventory family looks at, so it is refused on the other two rather than silently ignored.</summary>
+    internal static string? PeekFamilyError(bool peek, SkseFamily family) =>
+        peek && family != SkseFamily.Inventory
+            ? $"error: peek= is the inventory family's — findings='{family.ToString().ToLowerInvariant()}' never reads a " +
+              "DLL image. Drop peek=, or pass findings='inventory' with filter='<DLL/plugin/mod name>'."
+            : null;
+
+    /// <summary>The line every response ends on: which family ran, and the exact spelling for the two that did not.
+    /// The default narrows only because the response says so.</summary>
+    internal static string FamilyFooter(SkseFamily ran)
+    {
+        const string Inventory = "findings='inventory' (the DLL and config layer, with each plugin's static manifest)";
+        const string Pairing = "findings='pairing' (native Papyrus declarations vs the DLLs that implement them)";
+        const string Config = "findings='config' (the form references SKSE configs declare vs your load order)";
+        var (mine, a, b) = ran switch
+        {
+            SkseFamily.Inventory => ("inventory", Pairing, Config),
+            SkseFamily.Pairing => ("pairing", Inventory, Config),
+            _ => ("config", Inventory, Pairing),
+        };
+        return $"\n\n(this call ran findings='{mine}'. NOT run: {a}; {b}.)";
+    }
+
+    [McpServerTool(Name = ToolNames.Skse, ReadOnly = true, Title = "The SKSE layer: DLL/config inventory, native pairing, config references"),
      Description(
-         "Inventory the SKSE-plugin layer of the ACTIVE load order — the layer houseCARL's record/asset tools are otherwise " +
-         "blind to. Covers the FULL depth of Data\\SKSE\\Plugins: the .dll plugins and every .ini/.toml/.json/.yaml config " +
-         "beneath, each with the MOD that wins the VFS for it. Configs are grouped by their real subfolder (SkyPatcher, " +
-         "DynamicStringDistributor, OStim, … — derived from the actual tree, never a hardcoded list), so the default stays " +
-         "compact while accounting for everything; non-config content is counted, never dropped. For every modern plugin it " +
-         "also reads the STATIC manifest the SKSE loader itself reads — name, author, version, whether it uses Address Library " +
-         "(version-independent) or is LOCKED to specific game runtimes, and the XSE floor — by parsing the DLL's " +
-         "SKSEPlugin_Version data export WITHOUT loading or running it. Leads with the diagnostics that matter: version-LOCKED " +
-         "plugins (won't load on a mismatched game version), legacy query-only plugins (metadata set at runtime — not statically " +
-         "readable), non-plugin DLLs (bundled dependencies), subfolder DLLs (not on SKSE's loader path), and any DLL contested " +
-         "by more than one mod. Pass filter= a plugin/mod/DLL name, author, or config FOLDER (e.g. 'SkyPatcher', 'EngineFixes', " +
-         "'po3', 'OStim') to expand that group or see a plugin in full (all flags, compatible runtimes, email, providers, " +
-         "configs). Pass peek=true WITH filter= to additionally read what the matching DLL's IMAGE statically contains: the " +
-         "DLLs it imports (with derived flags — graphics/input hooks, network, and which sibling non-plugin DLL is bundled " +
-         "for it), the config paths it embeds (which folder it actually scans), and the plugin names it embeds, each " +
-         "cross-checked against your load order. Debug-build plugins are flagged WITHOUT peek — a DLL importing the debug C " +
-         "runtime fails with error 126 for anyone without Visual Studio. It does NOT read DLL behavior (that's the ceiling; " +
-         "an embedded string is what the image CONTAINS, never what the code DOES, and absence proves nothing), and it does " +
-         "NOT cover distributor INIs (SPID *_DISTR, KID *_KID) — those live in Data\\ root and are owned by the " +
-         "spid-authoring / kid-authoring skills. Read-only.")]
-    public static string SkseInventory(
+         // ---- what it is, and what selects a family ------------------------------------------------
+         "The SKSE LAYER of the ACTIVE load order — the plane houseCARL's record and asset tools are blind to: the .dll " +
+         "plugins under Data\\SKSE\\Plugins, every .ini/.toml/.json/.yaml config beneath them, and the native Papyrus " +
+         "functions the order's compiled scripts declare. Read-only; writes nothing. ONE FAMILY PER CALL, selected by " +
+         "findings= — 'inventory' (the DEFAULT when findings= is omitted), 'pairing' or 'config'. Each family's own " +
+         "detail is on the findings= parameter below, and every response states which family it ran and the exact " +
+         "spelling of the two it did not, so the default narrows only because the response says so. Two families are " +
+         "never merged into one answer: they run over different populations and would share no honest summary line. " +
+         // ---- the ceiling, once for all three -------------------------------------------------------
+         "THE CEILING, stated once because it is the same for all three families: everything here is WHAT A FILE " +
+         "DECLARES, NEVER WHAT THE DLL DOES. A version manifest, an import table, an embedded string and a config token " +
+         "are static facts about a file on disk; loading, registering, hooking and reading are runtime behavior " +
+         "houseCARL never observes, and the ABSENCE of a token proves nothing. So a finding here is a plausibility " +
+         "verdict to VERIFY rather than a claim about a running game, and 'nothing found' is never a clean bill of " +
+         "health. " +
+         // ---- shared narrowing and the one boundary that spans every family -------------------------
+         "filter= narrows whichever family ran (its match domain is that family's own — see filter= below); peek= " +
+         "belongs to the inventory family alone and is refused, not ignored, on the other two. NOT COVERED by any " +
+         "family: distributor INIs in Data\\ root (SPID *_DISTR, KID *_KID) — they live outside SKSE\\Plugins and are " +
+         "owned by the spid-authoring / kid-authoring skills.")]
+    public static string Skse(
         LoadOrderService svc,
-        [Description("Optional. A plugin name, author, DLL filename, providing-mod, or config-FOLDER substring (case-insensitive). " +
-            "Expands the matching config folder to its individual files, and shows full per-plugin detail for a matching DLL. " +
-            "Omit for the whole-layer overview.")]
+        [Description(
+            "Optional. WHICH FAMILY to run — exactly one; the default when omitted is 'inventory'. " +
+            // ---- family: inventory (harvested from housecarl_skse_inventory) -------------------------
+            "'inventory' — the SKSE-plugin layer itself, over the FULL depth of Data\\SKSE\\Plugins: every .dll and " +
+            "every .ini/.toml/.json/.yaml config beneath it, each with the MOD that wins the VFS for it. Configs are " +
+            "grouped by their real subfolder (SkyPatcher, DynamicStringDistributor, OStim, … derived from the actual " +
+            "tree, never a hardcoded list), so the default stays compact while accounting for everything; non-config " +
+            "content is counted, never dropped. For every modern plugin it also reads the STATIC manifest the SKSE " +
+            "loader itself reads — name, author, version, whether it uses Address Library (version-independent) or is " +
+            "LOCKED to specific game runtimes, and the XSE floor — by parsing the DLL's SKSEPlugin_Version data export " +
+            "WITHOUT loading or running it. Leads with the diagnostics: version-LOCKED plugins (won't load on a " +
+            "mismatched game version), legacy query-only plugins (metadata set at runtime, not statically readable), " +
+            "non-plugin DLLs (bundled dependencies), subfolder DLLs (not on SKSE's loader path), DLLs contested by more " +
+            "than one mod, and DEBUG-BUILD plugins — a DLL importing the debug C runtime fails with error 126 for " +
+            "anyone without Visual Studio, and it is flagged WITHOUT peek=. " +
+            // ---- family: pairing (harvested from housecarl_native_pairing_audit) ---------------------
+            "'pairing' — the declaration↔implementation seam, where 'a mod's scripts are installed but its DLL is " +
+            "missing, won't load on this game version, or is 32-bit/BSA-packed/subfolder-shipped' hides. A native " +
+            "function is ONE thing declared in TWO places (a .pex class with a native-flagged function, plus a DLL " +
+            "registering the implementation at runtime); the halves ship as separate files and fail INDEPENDENTLY, and " +
+            "the engine's response is a cryptic 'unable to bind' log plus calls that silently no-op. It scans the " +
+            "winning copy of EVERY compiled script (loose + BSA), keeps the baseline honest by construction (a class " +
+            "carried by an official archive is the ENGINE's — even when SKSE's loose override wins the file; skse64's " +
+            "own script additions are SKSE CORE, implemented by the game-root loader), then pairs each remaining class " +
+            "to the DLLs its provider mod — or a mod in its conflict chain, the bundling case — ships under " +
+            "SKSE\\Plugins. Leads with PAIRED-BUT-DEAD (scripts installed and every candidate DLL statically will not " +
+            "load: wrong game runtime for a version-LOCKED plugin, BSA-only, subfolder, 32-bit, unreadable, debug-built) " +
+            "and UNPAIRED (no DLL in sight — a VERIFY flag, typically a declaration copy of a framework you don't have; " +
+            "never called 'broken', because registration is runtime behavior). It answers 'is this pairing plausible and " +
+            "healthy', NEVER 'does the DLL register exactly these functions'. " +
+            // ---- family: config (harvested from housecarl_skse_config_audit) -------------------------
+            "'config' — reference VALIDITY, so a BROKEN reference (a FormID pointing at a record that doesn't exist in " +
+            "a plugin you DO have) is caught here instead of by a silent in-game failure, and kept apart from a merely " +
+            "INERT one. It reads the WINNING copy of every .ini/.toml/.json/.yaml/.yml under the full depth of " +
+            "Data\\SKSE\\Plugins (the copy the DLL actually reads) and extracts every form-shaped reference — a hex " +
+            "FormID paired with a plugin filename in EITHER order (0xFORM|Plugin.esp as DSD/CDF/po3 write it, " +
+            "Plugin.esp|0xFORM as SkyPatcher writes it, the ~ tilde form) plus plugin-named folder gates " +
+            "(DynamicStringDistributor\\Plugin.esp\\...) — and resolves each against the real records of the active " +
+            "order: OK, PLUGIN MISSING (plugin not in the order), DANGLING (plugin present but no such record) or " +
+            "UNPARSEABLE (a shape-matched token that can't be normalized), summarized as BROKEN (dangling/unparseable, " +
+            "actionable) vs INERT (plugin-missing, usually optional support for a mod you aren't running). The " +
+            "framework-AGNOSTIC twin of the SkyPatcher reader's first half: it checks whether a reference RESOLVES, " +
+            "never what it is FOR (per-framework skill territory). Extraction is a heuristic over token SHAPES, so a " +
+            "token in a comment or a disabled block still surfaces; 'no references found' is the most common per-file " +
+            "outcome and is accounted for, never a warning. Bare EditorID / name strings are NOT validated.")]
+            string? findings = null,
+        [Description(
+            "Optional. A case-insensitive substring narrowing whichever family ran; the match domain is that family's " +
+            "own. inventory: a plugin name, author, DLL filename, providing mod, or config FOLDER ('SkyPatcher', " +
+            "'EngineFixes', 'po3', 'OStim') — expands that folder to its individual files, or shows one plugin in full " +
+            "(all flags, compatible runtimes, email, providers, configs). pairing: a script CLASS name, providing mod, " +
+            "paired mod, or DLL filename — full detail per matching class: the declared native function names, the " +
+            "pairing evidence, each candidate DLL's manifest and load verdict, the conflict chains. config: a config " +
+            "FOLDER, providing mod, filename, or REFERENCED-plugin name — audits just those configs and lists EVERY " +
+            "reference with its verdict, the OKs included (positive confirmation of a patch you just authored). Omit " +
+            "for the family's whole-layer view.")]
             string? filter = null,
-        [Description("Optional. Static peek at the matching DLL's image — its imports, the config paths and plugin names it " +
-            "embeds. REQUIRES filter= (a peek is per-DLL: it reads whole images, and a whole-layer dump would be unreadable " +
-            "noise). Use it to answer 'what does this unfamiliar DLL touch'.")]
+        [Description(
+            "Optional. The INVENTORY family only, and it REQUIRES filter=. Statically peeks inside the matching DLL's " +
+            "IMAGE: the DLLs it imports (with derived flags — graphics/input hooks, network, and which sibling " +
+            "non-plugin DLL is bundled for it), the config paths it embeds (which folder it actually scans), and the " +
+            "plugin names it embeds, each cross-checked against your load order — the answer to 'what does this " +
+            "unfamiliar DLL touch'. Per-DLL by design: it reads whole images, so a whole-layer peek is refused rather " +
+            "than dumped. Passed with findings='pairing' or 'config' it is refused, never silently ignored.")]
             bool peek = false,
         [Description("Optional. Max characters before lists are cut with an explicit notice. 0 = the server default (~80k).")]
-            int max_chars = 0) => Guard.Tool(ToolNames.SkseInventory, () =>
+            int max_chars = 0) => Guard.Tool(ToolNames.Skse, () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        if (!TryParseFamily(findings, out var family, out var famErr)) return famErr!;
+        if (PeekFamilyError(peek, family) is { } peekErr) return peekErr;
         if (SkseInventoryWire.PeekArgError(peek, filter) is { } err) return err;
-        var data = svc.SkseInventory(peek ? filter!.Trim() : null);
-        return SkseInventoryWire.Render(data, filter, max_chars > 0 ? max_chars : 80_000);
-    });
 
-    [McpServerTool(Name = ToolNames.NativePairingAudit, ReadOnly = true, Title = "Native Papyrus declarations vs the DLLs that implement them (pairing audit)"),
-     Description(
-         "Cross-check the native Papyrus functions the ACTIVE order's compiled scripts declare against the SKSE DLLs that must " +
-         "implement them — the seam where 'a mod's scripts are installed but its DLL is missing, won't load on this game version, " +
-         "or is 32-bit/BSA-packed/subfolder-shipped' hides. A native function is ONE thing declared in TWO places (a .pex class " +
-         "with a native-flagged function + a DLL registering the implementation at runtime); the halves ship as separate files and " +
-         "fail INDEPENDENTLY, and the engine's response is a cryptic 'unable to bind' log + calls that silently no-op. Scans the " +
-         "winning copy of EVERY compiled script (loose + BSA), keeps the baseline honest by construction (a class carried by an " +
-         "official archive is the ENGINE's — even when SKSE's loose override wins the file; skse64's own script additions are " +
-         "SKSE CORE, implemented by the game-root loader), then pairs each remaining class to the DLLs its provider mod — or a mod " +
-         "in its conflict chain, the bundling case — ships under SKSE\\Plugins. Leads with the findings: PAIRED-BUT-DEAD (scripts " +
-         "installed, and every candidate DLL statically will not load — wrong game runtime for a version-LOCKED plugin, BSA-only, " +
-         "subfolder, 32-bit, unreadable) and UNPAIRED (no DLL in sight — a VERIFY flag, typically a declaration copy of a framework " +
-         "you don't have; never called 'broken', because registration is runtime behavior — the tier-E ceiling this tool never " +
-         "crosses). It answers 'is the declaration↔implementation pairing plausible and healthy', NEVER 'does the DLL register " +
-         "exactly these functions'. Pass filter= a class, mod, or DLL substring for full detail — the native function names, the " +
-         "pairing evidence, each candidate DLL's manifest and load verdict, the conflict chains. Read-only.")]
-    public static string NativePairingAudit(
-        LoadOrderService svc,
-        [Description("Optional. A script CLASS name, providing-mod, paired-mod, or DLL filename substring (case-insensitive). " +
-            "Shows full detail for every matching class: declared native functions, pairing rung, candidate DLL manifests and " +
-            "load verdicts, conflict chains. Omit for the whole-order audit (findings first, then the accounted-for baseline).")]
-            string? filter = null,
-        [Description("Optional. Max characters before lists are cut with an explicit notice. 0 = the server default (~80k).")]
-            int max_chars = 0) => Guard.Tool(ToolNames.NativePairingAudit, () =>
-    {
-        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        var data = svc.NativePairingAudit();
-        return NativePairingWire.Render(data, filter, max_chars > 0 ? max_chars : 80_000);
-    });
-
-    [McpServerTool(Name = ToolNames.SkseConfigAudit, ReadOnly = true, Title = "SKSE config references vs the load order (reference-validity audit)"),
-     Description(
-         "Cross-check the form references SKSE-plugin CONFIGS declare against the real records of the ACTIVE load order — so a " +
-         "BROKEN reference (a FormID pointing at a record that doesn't exist in a plugin you DO have) is caught by houseCARL " +
-         "instead of by a silent in-game failure, and kept apart from a merely INERT one (a plugin you don't have installed — " +
-         "usually optional support for a mod you aren't running). Scans the full depth of Data\\SKSE\\Plugins for .ini/.toml/.json/" +
-         ".yaml/.yml configs, reads the WINNING copy of each (the copy the DLL actually reads), and extracts every form-shaped " +
-         "reference — a hex FormID paired with a plugin filename in EITHER order (0xFORM|Plugin.esp as DSD/CDF/po3 write it, " +
-         "Plugin.esp|0xFORM as SkyPatcher writes it, the ~ tilde form) plus plugin-named folder gates (DynamicStringDistributor\\" +
-         "Plugin.esp\\...) — then resolves each to a verdict: OK, PLUGIN MISSING (plugin not in the order), DANGLING (plugin " +
-         "present but no such record), or UNPARSEABLE (a shape-matched token that can't be normalized) — the summary groups " +
-         "these as BROKEN (dangling/unparseable, actionable) vs INERT (plugin-missing, usually optional support). It is the generic, " +
-         "framework-AGNOSTIC twin of the SkyPatcher reader's first half: it checks reference VALIDITY, never what a reference is " +
-         "FOR (that's per-framework skill territory) and never what the DLL DOES with it (the honest ceiling). Extraction is a " +
-         "heuristic over token SHAPES, so a token in a comment or disabled block still surfaces — the framing is 'references this " +
-         "file DECLARES', not 'references the DLL will use'. 'No references found' is the most common per-file outcome and is " +
-         "accounted for, never a warning. Bare EditorID / name strings are NOT validated (Wave 2). Pass filter= a folder, mod, " +
-         "filename, or referenced-plugin substring to audit just that group and list EVERY reference with its verdict (the OKs " +
-         "included — positive confirmation of a patch you just authored). Distributor INIs in Data\\ root (SPID *_DISTR, KID " +
-         "*_KID) are out of scope — owned by their authoring skills. Read-only.")]
-    public static string SkseConfigAudit(
-        LoadOrderService svc,
-        [Description("Optional. A config FOLDER, providing-mod, filename, or REFERENCED-plugin substring (case-insensitive). " +
-            "Audits just the matching configs and lists every reference with its verdict, OKs included. Omit for the whole-layer " +
-            "audit (diagnostics — broken & inert references — first, then the accounted-for remainder).")]
-            string? filter = null,
-        [Description("Optional. Max characters before lists are cut with an explicit notice. 0 = the server default (~80k).")]
-            int max_chars = 0) => Guard.Tool(ToolNames.SkseConfigAudit, () =>
-    {
-        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        var data = svc.SkseConfigAudit();
-        return SkseConfigAuditWire.Render(data, filter, max_chars > 0 ? max_chars : 80_000);
+        // The footer is priced into the cap rather than appended past it, so max_chars stays the whole response.
+        var footer = FamilyFooter(family);
+        int cap = Math.Max(1_000, (max_chars > 0 ? max_chars : 80_000) - footer.Length);
+        var body = family switch
+        {
+            SkseFamily.Inventory => SkseInventoryWire.Render(svc.SkseInventory(peek ? filter!.Trim() : null), filter, cap),
+            SkseFamily.Pairing => NativePairingWire.Render(svc.NativePairingAudit(), filter, cap),
+            _ => SkseConfigAuditWire.Render(svc.SkseConfigAudit(), filter, cap),
+        };
+        return body + footer;
     });
 }
 

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -22,6 +22,20 @@ public static class SkseTools
     /// <summary>The three finding families <c>findings=</c> selects between.</summary>
     internal enum SkseFamily { Inventory, Pairing, Config }
 
+    /// <summary>Parses <c>findings=</c> as it arrives OFF THE WIRE, where the schema declares it a string or an array.
+    /// The array shape is the <c>housecarl_check</c> habit and is a real JSON array, not a string starting with '[':
+    /// it binds so that the refusal below — which names the three families and the one-family rule — is what the caller
+    /// reads, instead of the shim's generic type-mismatch sentence. Any non-string shape is refused by its own JSON
+    /// text, so a one-element array is refused too: this tool runs one family per call, and taking <c>["inventory"]</c>
+    /// as the scalar would teach a shape the tool description says is refused.</summary>
+    internal static bool TryParseFamily(System.Text.Json.JsonElement? findings, out SkseFamily family, out string? error)
+        => TryParseFamily(findings switch
+        {
+            null or { ValueKind: System.Text.Json.JsonValueKind.Null or System.Text.Json.JsonValueKind.Undefined } => null,
+            { ValueKind: System.Text.Json.JsonValueKind.String } el => el.GetString(),
+            { } el => el.GetRawText(),
+        }, out family, out error);
+
     /// <summary>Parses <c>findings=</c>. Omitted is the inventory family, which every response states; an unknown
     /// value is refused naming the three, never quietly defaulted.</summary>
     internal static bool TryParseFamily(string? findings, out SkseFamily family, out string? error)
@@ -179,7 +193,9 @@ public static class SkseTools
             "never what it is FOR (per-framework skill territory). Extraction is a heuristic over token SHAPES, so a " +
             "token in a comment or a disabled block still surfaces; 'no references found' is the most common per-file " +
             "outcome and is accounted for, never a warning. Bare EditorID / name strings are NOT validated.")]
-            string? findings = null,
+            // JsonElement, not string: the array shape must BIND so the refusal above answers it. The published type
+            // is stamped string-or-array by ToolSchemas.ShapeUnionParams.
+            System.Text.Json.JsonElement? findings = null,
         [Description(
             "Optional. A case-insensitive substring narrowing whichever family ran; the match domain is that family's " +
             "own. inventory: a plugin name, author, DLL filename, providing mod, or config FOLDER ('SkyPatcher', " +
@@ -202,10 +218,13 @@ public static class SkseTools
         [Description("Optional. Max characters before lists are cut with an explicit notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool(ToolNames.Skse, () =>
     {
-        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        // The argument checks run BEFORE the config prompt: findings= is wrong in the same way whether or not an
+        // instance is configured, and answering the prompt first would send the caller off to configure one only to
+        // meet the same refusal.
         if (!TryParseFamily(findings, out var family, out var famErr)) return famErr!;
         if (PeekFamilyError(peek, family) is { } peekErr) return peekErr;
         if (SkseInventoryWire.PeekArgError(peek, filter) is { } err) return err;
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
 
         return Dispatch(new ServiceRenders(svc), family, filter, peek, max_chars);
     });

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -39,7 +39,7 @@ public static class SkseTools
         // A list-shaped value is the housecarl_check habit, where findings= names several families. Naming the shape is
         // what turns the refusal into a fix; "not a family" alone reads as the wrong word rather than the wrong shape.
         var shape = token.Contains(',') || token.Contains('[')
-            ? " findings= here takes ONE value, not a list — this tool runs one family per call."
+            ? " findings= here takes ONE value, not a list."
             : "";
         error = $"error: findings='{token}' is not a family on this tool — pass findings='inventory' (the DLL and config " +
                 "layer), 'pairing' (native Papyrus declarations vs the DLLs that implement them) or 'config' (the form " +
@@ -195,7 +195,7 @@ static class SkseInventoryWire
     /// bare <c>peek=true</c> fails rather than ignoring the flag or peeking one arbitrary DLL.</summary>
     internal static string? PeekArgError(bool peek, string? filter) =>
         peek && string.IsNullOrWhiteSpace(filter)
-            ? "peek=true needs filter= — a peek is per-DLL, not a whole-layer dump (it reads each matching DLL's whole " +
+            ? "error: peek=true needs filter= — a peek is per-DLL, not a whole-layer dump (it reads each matching DLL's whole " +
               "image). Pass filter='<DLL/plugin/mod name>' to name the DLL to peek, e.g. filter='SkyPatcher' peek=true."
             : null;
 

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -843,7 +843,20 @@ static class NativePairingWire
     /// static blocker or a locked-runtime mismatch).</summary>
     enum DllFate { Loads, Verify, Dead }
 
+    /// <summary>The verdict a DLL line carries, with the debug-build note appended when it applies. Reaching a LOADS
+    /// fate with debug-CRT imports means the debug runtime resolved on THIS machine — the DLL loads for its author and
+    /// for nobody else, which the fate alone does not say (#417). The verdict itself is untouched: it does load here.</summary>
     static (DllFate Fate, string Detail) Judge(NativePairedDll d, string? runtime)
+    {
+        var (fate, detail) = Verdict(d, runtime);
+        if (fate == DllFate.Loads && d.Info is { } info && info.DebugCrtImports.Count > 0)
+            detail += $" — but it imports the debug CRT ({string.Join(", ", info.DebugCrtImports)}), so it loads HERE and " +
+                      "fails with error 126 for anyone without the debug runtime";
+        return (fate, detail);
+    }
+
+    /// <summary>The static load verdict alone — the blocker, the loader's era rules, and the version lock.</summary>
+    static (DllFate Fate, string Detail) Verdict(NativePairedDll d, string? runtime)
     {
         if (d.LoadBlocker is { } b) return (DllFate.Dead, b);
         if (d.Info is not { } info) return (DllFate.Verify, "no static manifest read");   // defensive: blocker-less entries carry Info by construction

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -852,15 +852,24 @@ static class NativePairingWire
     /// static blocker or a locked-runtime mismatch).</summary>
     enum DllFate { Loads, Verify, Dead }
 
-    /// <summary>The verdict a DLL line carries, with the debug-build note appended when it applies. Reaching a LOADS
-    /// fate with debug-CRT imports means the debug runtime resolved on THIS machine — the DLL loads for its author and
-    /// for nobody else, which the fate alone does not say (#417). The verdict itself is untouched: it does load here.</summary>
+    /// <summary>The verdict a DLL line carries, with the debug-build note appended when it applies. Reaching a LOADS or
+    /// VERIFY fate with debug-CRT imports means the debug runtime resolved on THIS machine — the DLL loads for its
+    /// author and for nobody else, which the fate alone does not say (#417). A DEAD verdict already names the debug
+    /// build in its blocker. The verdict itself is untouched by the note.</summary>
     static (DllFate Fate, string Detail) Judge(NativePairedDll d, string? runtime)
     {
         var (fate, detail) = Verdict(d, runtime);
-        if (fate == DllFate.Loads && d.Info is { } info && info.DebugCrtImports.Count > 0)
-            detail += $" — but it imports the debug CRT ({string.Join(", ", info.DebugCrtImports)}), so it loads HERE and " +
-                      "fails with error 126 for anyone without the debug runtime";
+        if (fate != DllFate.Dead && d.Info is { } info && info.DebugCrtImports.Count > 0)
+        {
+            var crt = string.Join(", ", info.DebugCrtImports);
+            // VERIFY is a version question, so the clause is additive there rather than a 'but': the version lock is
+            // still unresolved, AND the debug runtime is a second, independent reason it will not load elsewhere.
+            detail += fate == DllFate.Loads
+                ? $" — but it imports the debug CRT ({crt}), so it loads HERE and fails with error 126 for anyone " +
+                  "without the debug runtime"
+                : $" — and it imports the debug CRT ({crt}), so even where the version matches it loads HERE only and " +
+                  "fails with error 126 for anyone without the debug runtime";
+        }
         return (fate, detail);
     }
 

--- a/src/housecarl-mcp/ToolCallShim.cs
+++ b/src/housecarl-mcp/ToolCallShim.cs
@@ -166,7 +166,9 @@ internal static class ToolCallShim
         if (value.ValueKind == JsonValueKind.String)
         {
             var s = value.GetString() ?? "";
-            if (declared.Contains("array"))
+            // A parameter declaring BOTH string and array takes the string as it stands: wrapping it would hand the
+            // tool the very shape a caller spelled correctly as a scalar.
+            if (declared.Contains("array") && !declared.Contains("string"))
             {
                 // A string-encoded JSON array first: clients do serialize array arguments into a JSON string
                 // ("[\"a\",\"b\"]") despite the schema declaring an array. Only an unambiguous parse is taken;

--- a/src/housecarl-mcp/ToolSchemas.cs
+++ b/src/housecarl-mcp/ToolSchemas.cs
@@ -45,6 +45,21 @@ internal static class ToolSchemas
         new(ToolNames.Place, "assets", typeof(PlaceTarget[])),
     };
 
+    /// <summary>One parameter typed <see cref="JsonElement"/> so it can BIND more than one wire shape, with the JSON
+    /// types it actually accepts. "null" is added by the rewrite — every one of these is optional.</summary>
+    internal readonly record struct ShapeUnionParam(string Tool, string Parameter, string[] Types);
+
+    /// <summary>The parameters whose published type is a union of JSON kinds. Without a row the SDK publishes such a
+    /// parameter untyped, and <see cref="ToolCallShim"/> — which judges off the published type — then lets every shape
+    /// through to the binder. With one, a shape the tool means to refuse reaches the tool and is refused in the tool's
+    /// own words rather than by the shim's generic type-mismatch sentence.</summary>
+    internal static readonly ShapeUnionParam[] ShapeUnionParams =
+    {
+        // housecarl_skse takes ONE family, and the tool says so itself; the array shape is the housecarl_check habit,
+        // so it must bind and be answered by the tool, not intercepted.
+        new(ToolNames.Skse, "findings", new[] { "string", "array" }),
+    };
+
     /// <summary>How many times one pointer may be inlined along a single nesting chain before
     /// <see cref="Terminator"/> closes it. Raising it deepens every recursive branch of every published schema.</summary>
     const int MaxSelfExpansions = 1;
@@ -63,6 +78,8 @@ internal static class ToolSchemas
                 if (JsonNode.Parse(tool.ProtocolTool.InputSchema.GetRawText()) is not JsonObject root) continue;
                 var wanted = FileListParams.Where(p => p.Tool == tool.ProtocolTool.Name).ToList();
                 var changed = wanted.Count > 0 && RewriteFileListUnions(root, wanted);
+                var shapes = ShapeUnionParams.Where(p => p.Tool == tool.ProtocolTool.Name).ToList();
+                changed |= shapes.Count > 0 && RewriteShapeUnions(root, shapes);
                 changed |= FlattenRefs(root);
                 if (changed) tool.ProtocolTool.InputSchema = JsonSerializer.Deserialize<JsonElement>(root.ToJsonString());
             }
@@ -130,6 +147,26 @@ internal static class ToolSchemas
         }
 
         if (changed && defs is not null) root["$defs"] = defs;
+        return changed;
+    }
+
+    /// <summary>Stamp each listed parameter's published <c>type</c> with the JSON kinds it accepts, plus "null" for
+    /// being optional. Returns false — leaving the schema untouched — when the document is not the shape this
+    /// expects.</summary>
+    internal static bool RewriteShapeUnions(JsonObject root, IReadOnlyList<ShapeUnionParam> parameters)
+    {
+        if (root["properties"] is not JsonObject props) return false;
+
+        bool changed = false;
+        foreach (var p in parameters)
+        {
+            if (props[p.Parameter] is not JsonObject existing) continue;
+            var types = new JsonArray();
+            foreach (var t in p.Types) types.Add(t);
+            types.Add("null");
+            existing["type"] = types;
+            changed = true;
+        }
         return changed;
     }
 


### PR DESCRIPTION
`housecarl_skse_inventory`, `housecarl_native_pairing_audit` and `housecarl_skse_config_audit` were three tools over one substrate (SPEC §1 S7), each paying for the same declared-versus-runtime ceiling teaching. They are now one tool, `housecarl_skse`, with `findings=` selecting the family — `inventory` (the default), `pairing`, `config` — per SPEC §2.6 S7 and §6.3's Aaron-decided merge. The ceiling is written once in the tool description; each family's own detail (what it scans, what it leads with, where its boundary is) lives on the `findings=` parameter. SELECT is the one `filter=` the three shared, its match domain stated per family; SOURCE stays the implicit installed VFS state; ACT is return. A call runs exactly one family and every response ends on a line naming the family it ran and the exact `findings=` spelling of the two it did not, so the omitted-`findings=` default narrows only because the response says so. That footer is priced into `max_chars` rather than appended past it. `peek=` stays the inventory family's: passed with `pairing` or `config` it is refused with a sentence rather than silently ignored, and it still requires `filter=`. The three old names are deleted from `ToolNames`, from the published surface and from the Codex umbrella router, and each gets a retired-name row naming the `findings=` value that replaces it.

The PR also carries #417. `NativePairingWire.Judge` read only the load blocker, the plugin kind and the version lock, so a debug-built DLL on the author's own machine — where the debug runtime resolves, so there is no blocker and every other check passes it — rendered a clean `[LOADS] … version-independent` with no mention of the debug build. The verdict was right and is untouched: it does load there. What is new is one appended clause naming the debug CRT it imports and error 126 for anyone without that runtime. Reaching the loads path with `DebugCrtImports.Count > 0` already implies the runtime resolved here, so no machine probe is needed. The inventory family already shouted this, so the two families now agree about the same file.

Build clean, `dotnet test --filter "tier!=bridge"` 1075 passed / 0 failed, `ci-all` 127/127. New coverage: `SkseFamilySelectionTests` (the default, the three tokens, the unknown-value refusal, the `peek=` family refusal, the footer) and `native-pairing-guard` arms A3a-A3i and A4a-A4c, which pin that the loads verdict survives, that the debug clause appears, and that a clean version-independent DLL gets no such note. The `AliasActivationTests` rename pin moved 91 → 89 because the `lookup` → `filter` row now activates on one tool instead of three; the retired-name sweep is derived from the 1.9 capture, so the three redirects are covered without a new list.

**Not delivered here, and not claimed:** the §2.1 TRANSPORT remainder on this substrate. `housecarl_skse` carries `max_chars=` and nothing else — no `format='json'`, no `limit=`/`offset=`, no in-band accounting block. That is exactly what the three tools carried before the merge, so nothing regressed, but the merge does not close the §2.1 gap for S7, and doing so needs a JSON twin for each of the three family renders. Worth its own issue rather than a silent claim of compliance.

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)

