### PR TITLE
Give asset_status a directory and glob select form

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -61,15 +61,19 @@ saying it sets an expectation their install may contradict. Say what is known, a
   `under=` compose in one call, and a duplicate path is not resolved twice. A selector that matches nothing says so
   rather than passing as an empty sweep; a glob with no folder in front of it is refused rather than sweeping the
   whole load order; and a drive-rooted or `..`-escaping selector is refused by name, the same gate every asset path
-  passes.
+  passes. A wildcard-free selector that names a FILE the load order provides is answered as that one path, with a note
+  saying so, rather than reported as a folder nothing provides. Every path in the answer spells the selector's folder
+  one way, whether the file came from a loose mod or an archive.
 
 - **Every `housecarl_asset_status` response now ends with a structured `[accounting]` line — `total`, `rendered`,
   `skipped`, `capped`, `truncated`, `offset`, `remaining`, `notes`.** A consumer keying results by path can compare the
   numbers instead of parsing the prose cut notice. Each omission is counted once by its own cause: `skipped` is what
   `offset=` stepped over, `capped` what `limit=` left behind, `truncated` what `max_chars` cut — so the four and
   `rendered` sum to `total`. Room for the line is reserved out of `max_chars` before the paths render, so it fits
-  inside the cap instead of past it. `limit=` and `offset=` page a large sweep, and the accounting names where the
-  next page starts — counted off what was rendered, so following it shows every path exactly once.
+  inside the cap instead of past it. `limit=` and `offset=` page a large sweep, and the accounting names the next page
+  as both a `limit=` and an `offset=` — counted off what was rendered, so following it stays paged and shows every path
+  exactly once. Notes about `under=` selectors are cut at `max_chars` like the other alarm blocks, so a call carrying
+  thousands of selectors cannot write megabytes of them.
 
 - **`housecarl_asset_status` under a `max_chars` its header and alarms already fill now renders the first path's
   answer instead of cutting to none.** `housecarl_nif_inspect` already did; both tools now render through one batch

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -59,11 +59,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
   `meshes/actors/character/facegendata/facegeom/<Master>` replaces the whole path list a facegen sweep used to spell
   out. `*` matches within a path segment, `?` one character in a segment, `**` across separators; `asset_paths=` and
   `under=` compose in one call, and a duplicate path is not resolved twice. A selector that matches nothing says so
-  rather than passing as an empty sweep, and a drive-rooted or `..`-escaping selector is refused by name, the same
-  gate every asset path passes.
+  rather than passing as an empty sweep; a glob with no folder in front of it is refused rather than sweeping the
+  whole load order; and a drive-rooted or `..`-escaping selector is refused by name, the same gate every asset path
+  passes.
 
 - **Every `housecarl_asset_status` response now ends with a structured `[accounting]` line — `total`, `rendered`,
-  `capped`, `truncated`, `offset`, `notes`.** A consumer keying results by path can compare the numbers instead of
+  `capped`, `truncated`, `offset`, `remaining`, `notes`.** A consumer keying results by path can compare the numbers instead of
   parsing the prose cut notice. The line is written after the `max_chars` cut, so it is never itself truncated away.
   `limit=` and `offset=` page a large sweep, and the accounting names where the next page starts.
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -64,9 +64,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
   passes.
 
 - **Every `housecarl_asset_status` response now ends with a structured `[accounting]` line — `total`, `rendered`,
-  `capped`, `truncated`, `offset`, `remaining`, `notes`.** A consumer keying results by path can compare the numbers instead of
-  parsing the prose cut notice. The line is written after the `max_chars` cut, so it is never itself truncated away.
-  `limit=` and `offset=` page a large sweep, and the accounting names where the next page starts.
+  `skipped`, `capped`, `truncated`, `offset`, `remaining`, `notes`.** A consumer keying results by path can compare the
+  numbers instead of parsing the prose cut notice. Each omission is counted once by its own cause: `skipped` is what
+  `offset=` stepped over, `capped` what `limit=` left behind, `truncated` what `max_chars` cut — so the four and
+  `rendered` sum to `total`. Room for the line is reserved out of `max_chars` before the paths render, so it fits
+  inside the cap instead of past it. `limit=` and `offset=` page a large sweep, and the accounting names where the
+  next page starts — counted off what was rendered, so following it shows every path exactly once.
 
 - **`housecarl_asset_status` under a `max_chars` its header and alarms already fill now renders the first path's
   answer instead of cutting to none.** `housecarl_nif_inspect` already did; both tools now render through one batch

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -54,6 +54,18 @@ saying it sets an expectation their install may contradict. Say what is known, a
   `sections=strings` prints it (matching is case-sensitive) and no `texture_slot`. A string that is a shape's or
   node's name is refused there and sent to `rename_shape` / `rename_node`, which carry the rename-onto-an-existing-
   name guard. Both verification gates apply as they do to every other op.
+- **`housecarl_asset_status` now takes `under=`, a Data-relative directory or glob, and answers for every file the
+  load order provides beneath it — loose and BSA alike, with the winner and provider chain per file.** One call over
+  `meshes/actors/character/facegendata/facegeom/<Master>` replaces the whole path list a facegen sweep used to spell
+  out. `*` matches within a path segment, `?` one character in a segment, `**` across separators; `asset_paths=` and
+  `under=` compose in one call, and a duplicate path is not resolved twice. A selector that matches nothing says so
+  rather than passing as an empty sweep, and a drive-rooted or `..`-escaping selector is refused by name, the same
+  gate every asset path passes.
+
+- **Every `housecarl_asset_status` response now ends with a structured `[accounting]` line — `total`, `rendered`,
+  `capped`, `truncated`, `offset`, `notes`.** A consumer keying results by path can compare the numbers instead of
+  parsing the prose cut notice. The line is written after the `max_chars` cut, so it is never itself truncated away.
+  `limit=` and `offset=` page a large sweep, and the accounting names where the next page starts.
 
 - **`housecarl_asset_status` under a `max_chars` its header and alarms already fill now renders the first path's
   answer instead of cutting to none.** `housecarl_nif_inspect` already did; both tools now render through one batch

--- a/src/housecarl-core/AssetGlob.cs
+++ b/src/housecarl-core/AssetGlob.cs
@@ -36,8 +36,15 @@ public static class AssetGlob
     /// <summary>Every Data-relative path the selector names, sorted. Throws ArgumentException (naming the input, never
     /// a parameter) for a drive-rooted or parent-escaping selector, the same gate every other asset query passes, and
     /// for one that names no directory at all.</summary>
-    public static IReadOnlyList<string> Select(AssetResolver.AssetView view, string selector)
+    public static IReadOnlyList<string> Select(AssetResolver.AssetView view, string selector) =>
+        Select(view, selector, out _);
+
+    /// <summary>As <see cref="Select(AssetResolver.AssetView, string)"/>, and says whether the selector turned out to
+    /// name one FILE rather than a folder — the caller pasted a path, and the answer is that path. The caller renders
+    /// that as a note, so the selection and the wording agree about what happened.</summary>
+    public static IReadOnlyList<string> Select(AssetResolver.AssetView view, string selector, out bool namedOneFile)
     {
+        namedOneFile = false;
         var norm = AssetResolver.ValidateRelPath(selector).TrimEnd('\\');
         var prefix = LiteralPrefix(norm);
         // A selector with no literal directory in front of it would enumerate the whole VFS — every loose file in every
@@ -49,7 +56,17 @@ public static class AssetGlob
                 "under has to be anchored under a directory, or it sweeps the whole load order — " +
                 $"name a folder, e.g. 'meshes/actors/character' or 'meshes/actors/character/**/*.nif': '{selector}'");
 
-        if (!HasWildcard(norm)) return Sorted(view.EnumerateUnder(norm));
+        if (!HasWildcard(norm))
+        {
+            var beneath = Sorted(view.EnumerateUnder(norm));
+            if (beneath.Count > 0) return beneath;
+            // Nothing beneath it, but the string may BE a file the load order provides — a path pasted into under=
+            // instead of asset_paths=. Answer it as that one file rather than claiming no mod provides the folder,
+            // which would contradict what asset_paths= says about the very same string. One resolve, only on the
+            // empty branch, so the ordinary folder sweep pays nothing for it.
+            if (view.Resolve(norm).Exists) { namedOneFile = true; return new[] { norm }; }
+            return beneath;
+        }
 
         var rx = ToRegex(norm);                                  // compiled ONCE, not per candidate path
         return Sorted(view.EnumerateUnder(prefix).Where(p => rx.IsMatch(p)));

--- a/src/housecarl-core/AssetGlob.cs
+++ b/src/housecarl-core/AssetGlob.cs
@@ -33,20 +33,23 @@ public static class AssetGlob
     /// normalized to backslashes.</summary>
     public static bool IsMatch(string pattern, string path) => ToRegex(pattern).IsMatch(path);
 
-    /// <summary>Every Data-relative path the selector names, sorted. Throws ArgumentException (naming the input) for a
-    /// drive-rooted or parent-escaping selector, the same gate every other asset query passes.</summary>
+    /// <summary>Every Data-relative path the selector names, sorted. Throws ArgumentException (naming the input, never
+    /// a parameter) for a drive-rooted or parent-escaping selector, the same gate every other asset query passes, and
+    /// for one that names no directory at all.</summary>
     public static IReadOnlyList<string> Select(AssetResolver.AssetView view, string selector)
     {
         var norm = AssetResolver.ValidateRelPath(selector).TrimEnd('\\');
-        if (!HasWildcard(norm)) return Sorted(view.EnumerateUnder(norm));
-
         var prefix = LiteralPrefix(norm);
-        // A glob with no literal directory in front of it would enumerate the whole VFS — every loose file in every
+        // A selector with no literal directory in front of it would enumerate the whole VFS — every loose file in every
         // enabled mod and every entry of every archive — before a single path is rendered. Refused rather than paid.
+        // Tested on the PREFIX, not on the presence of a wildcard: "/", "\" and "//" all normalize to the Data root and
+        // sweep exactly as wide as an unanchored glob does.
         if (prefix.Length == 0)
             throw new ArgumentException(
-                "a glob has to be anchored under a directory, or it sweeps the whole load order — " +
-                $"put a folder in front of it, e.g. 'meshes/actors/character/**/*.nif': '{selector}'", nameof(selector));
+                "under has to be anchored under a directory, or it sweeps the whole load order — " +
+                $"name a folder, e.g. 'meshes/actors/character' or 'meshes/actors/character/**/*.nif': '{selector}'");
+
+        if (!HasWildcard(norm)) return Sorted(view.EnumerateUnder(norm));
 
         var rx = ToRegex(norm);                                  // compiled ONCE, not per candidate path
         return Sorted(view.EnumerateUnder(prefix).Where(p => rx.IsMatch(p)));

--- a/src/housecarl-core/AssetGlob.cs
+++ b/src/housecarl-core/AssetGlob.cs
@@ -1,0 +1,63 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace HousecarlCore;
+
+/// <summary>The directory / glob SELECT form over the VFS: turn one Data-relative selector into the set of paths it
+/// names, by enumerating the selector's literal directory prefix through <see cref="AssetResolver.EnumerateUnder(string)"/>
+/// and, when the selector carries wildcards, keeping the paths the pattern matches. A selector with no wildcard IS a
+/// directory and takes everything beneath it. Pure over the resolver's own enumeration — this class opens nothing and
+/// holds nothing.
+/// <para>Wildcards: <c>*</c> matches any run of characters within one path segment, <c>?</c> exactly one such
+/// character, and <c>**</c> matches across separators. Matching is case-insensitive and runs against the whole
+/// Data-relative path, the same spelling the enumeration returns.</para></summary>
+public static class AssetGlob
+{
+    static readonly char[] Wildcards = { '*', '?' };
+
+    /// <summary>Does this selector carry a wildcard — i.e. is it a pattern rather than a plain directory?</summary>
+    public static bool HasWildcard(string selector) => (selector ?? "").IndexOfAny(Wildcards) >= 0;
+
+    /// <summary>The literal directory prefix of a selector: everything before the separator that precedes the first
+    /// wildcard. "meshes/actors/*/x.nif" prefixes to "meshes\actors"; a wildcard in the first segment prefixes to the
+    /// Data root (""). A selector with no wildcard is its own prefix.</summary>
+    public static string LiteralPrefix(string normalized)
+    {
+        int wild = normalized.IndexOfAny(Wildcards);
+        if (wild < 0) return normalized;
+        int sep = normalized.LastIndexOf('\\', Math.Max(wild - 1, 0));
+        return wild == 0 || sep < 0 ? "" : normalized.Substring(0, sep);
+    }
+
+    /// <summary>Does <paramref name="path"/> match <paramref name="pattern"/>? Both are Data-relative and already
+    /// normalized to backslashes.</summary>
+    public static bool IsMatch(string pattern, string path) => ToRegex(pattern).IsMatch(path);
+
+    /// <summary>Every Data-relative path the selector names, sorted. Throws ArgumentException (naming the input) for a
+    /// drive-rooted or parent-escaping selector, the same gate every other asset query passes.</summary>
+    public static IReadOnlyList<string> Select(AssetResolver.AssetView view, string selector)
+    {
+        var norm = AssetResolver.ValidateRelPath(selector).TrimEnd('\\');
+        var under = view.EnumerateUnder(HasWildcard(norm) ? LiteralPrefix(norm) : norm);
+        var hits = HasWildcard(norm)
+            ? under.Where(p => IsMatch(norm, p))
+            : under;
+        return hits.OrderBy(p => p, StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    /// <summary>The glob compiled to an anchored, case-insensitive regex. Every character outside the three wildcard
+    /// spellings is escaped, so a mod author's own regex-flavoured filename cannot change what the pattern means.</summary>
+    static Regex ToRegex(string pattern)
+    {
+        var sb = new StringBuilder("^");
+        for (int i = 0; i < pattern.Length; i++)
+        {
+            var c = pattern[i];
+            if (c == '*' && i + 1 < pattern.Length && pattern[i + 1] == '*') { sb.Append(".*"); i++; }
+            else if (c == '*') sb.Append("[^\\\\]*");
+            else if (c == '?') sb.Append("[^\\\\]");
+            else sb.Append(Regex.Escape(c.ToString()));
+        }
+        return new Regex(sb.Append('$').ToString(), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    }
+}

--- a/src/housecarl-core/AssetGlob.cs
+++ b/src/housecarl-core/AssetGlob.cs
@@ -38,12 +38,22 @@ public static class AssetGlob
     public static IReadOnlyList<string> Select(AssetResolver.AssetView view, string selector)
     {
         var norm = AssetResolver.ValidateRelPath(selector).TrimEnd('\\');
-        var under = view.EnumerateUnder(HasWildcard(norm) ? LiteralPrefix(norm) : norm);
-        var hits = HasWildcard(norm)
-            ? under.Where(p => IsMatch(norm, p))
-            : under;
-        return hits.OrderBy(p => p, StringComparer.OrdinalIgnoreCase).ToList();
+        if (!HasWildcard(norm)) return Sorted(view.EnumerateUnder(norm));
+
+        var prefix = LiteralPrefix(norm);
+        // A glob with no literal directory in front of it would enumerate the whole VFS — every loose file in every
+        // enabled mod and every entry of every archive — before a single path is rendered. Refused rather than paid.
+        if (prefix.Length == 0)
+            throw new ArgumentException(
+                "a glob has to be anchored under a directory, or it sweeps the whole load order — " +
+                $"put a folder in front of it, e.g. 'meshes/actors/character/**/*.nif': '{selector}'", nameof(selector));
+
+        var rx = ToRegex(norm);                                  // compiled ONCE, not per candidate path
+        return Sorted(view.EnumerateUnder(prefix).Where(p => rx.IsMatch(p)));
     }
+
+    static IReadOnlyList<string> Sorted(IEnumerable<string> paths) =>
+        paths.OrderBy(p => p, StringComparer.OrdinalIgnoreCase).ToList();
 
     /// <summary>The glob compiled to an anchored, case-insensitive regex. Every character outside the three wildcard
     /// spellings is escaped, so a mod author's own regex-flavoured filename cannot change what the pattern means.</summary>
@@ -53,11 +63,20 @@ public static class AssetGlob
         for (int i = 0; i < pattern.Length; i++)
         {
             var c = pattern[i];
-            if (c == '*' && i + 1 < pattern.Length && pattern[i + 1] == '*') { sb.Append(".*"); i++; }
+            if (c == '*' && i + 1 < pattern.Length && pattern[i + 1] == '*')
+            {
+                // "**\" spans ZERO OR MORE whole segments, so 'a\**\x.nif' matches 'a\x.nif' as well as 'a\b\x.nif'.
+                // A trailing "**" is the plain any-run-of-characters form.
+                if (i + 2 < pattern.Length && pattern[i + 2] == '\\') { sb.Append("(?:[^\\\\]*\\\\)*"); i += 2; }
+                else { sb.Append(".*"); i++; }
+            }
             else if (c == '*') sb.Append("[^\\\\]*");
             else if (c == '?') sb.Append("[^\\\\]");
             else sb.Append(Regex.Escape(c.ToString()));
         }
-        return new Regex(sb.Append('$').ToString(), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        // NonBacktracking: the '**' spelling nests quantifiers, and a linear-time engine forecloses the pathological
+        // non-match rather than bounding it with a timeout.
+        return new Regex(sb.Append('$').ToString(),
+                         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.NonBacktracking);
     }
 }

--- a/src/housecarl-core/AssetResolver.cs
+++ b/src/housecarl-core/AssetResolver.cs
@@ -621,16 +621,25 @@ public sealed class AssetResolver : IDisposable
     /// drive-rooted path ("C:\…") or one carrying a ".." segment — both make <c>Path.Combine(root, rel)</c> ESCAPE the
     /// loose roots and resolve a file OUTSIDE the load order, a silently-wrong answer. The resolver API is
     /// general-purpose, so a caller can hand it a bad path; it fails loud naming the input rather than resolving the
-    /// wrong file. (UNC inputs aren't drive-rooted after the leading-separator trim and aren't a caller shape here.)</summary>
+    /// wrong file. (UNC inputs aren't drive-rooted after the leading-separator trim and aren't a caller shape here.)
+    /// <para>The no-op segments — "." and an empty one from a doubled separator — are COLLAPSED, so ".\meshes",
+    /// "meshes//actors" and their plain spellings are one path. Left in, they survive into the loose walk (which
+    /// tolerates them) but not into a BSA-table match (which does not), and the two lanes would then answer for
+    /// different sets of files. The exception message names the input, not a parameter: it is rendered to the modder
+    /// as one plain sentence.</para></summary>
     static string NormalizeQueryPath(string relPath)
     {
         var rel = Normalize(relPath);
         if (Path.IsPathRooted(rel))
-            throw new ArgumentException($"expected a Data-relative asset path, got a drive-rooted path: '{relPath}'", nameof(relPath));
+            throw new ArgumentException($"expected a Data-relative asset path, got a drive-rooted path: '{relPath}'");
+        var kept = new List<string>();
         foreach (var seg in rel.Split('\\'))
+        {
             if (seg == "..")
-                throw new ArgumentException($"expected a Data-relative asset path, got a parent-escaping ('..') path: '{relPath}'", nameof(relPath));
-        return rel;
+                throw new ArgumentException($"expected a Data-relative asset path, got a parent-escaping ('..') path: '{relPath}'");
+            if (seg.Length > 0 && seg != ".") kept.Add(seg);
+        }
+        return string.Join('\\', kept);
     }
 
     static DateTime SafeMtime(string path)

--- a/src/housecarl-core/AssetResolver.cs
+++ b/src/housecarl-core/AssetResolver.cs
@@ -459,7 +459,10 @@ public sealed class AssetResolver : IDisposable
     /// what's there). The winner per path is left to <see cref="ResolveForPlacement"/>; here we only need
     /// the set of paths that exist in ANY source. Reuses the <see cref="NormalizeQueryPath"/> escape guard. Pure read of the
     /// snapshot's BSA tables + a bounded recursive loose walk under the prefix; holds nothing. A loose root that won't
-    /// enumerate contributes nothing (its absence flows through <see cref="ReadIncomplete"/>, never a silent half-answer).</summary>
+    /// enumerate contributes nothing (its absence flows through <see cref="ReadIncomplete"/>, never a silent half-answer).
+    /// <para>Every returned path is re-rooted on the NORMALIZED prefix, so one enumeration spells the prefix one way
+    /// across both lanes: the loose walk otherwise echoes back the caller's own casing and the archive tables their
+    /// author's, and a single answer would then carry two spellings of one folder.</para></summary>
     public IReadOnlyCollection<string> EnumerateUnder(string prefix) => EnumerateUnder(prefix, _snap);
 
     IReadOnlyCollection<string> EnumerateUnder(string prefix, Snapshot snap)
@@ -478,7 +481,9 @@ public sealed class AssetResolver : IDisposable
             try
             {
                 foreach (var f in Directory.EnumerateFiles(baseDir, "*", SearchOption.AllDirectories))
-                    found.Add(Normalize(f.Substring(rootDir.Length)));       // f starts with rootDir → the remainder is Data-relative
+                    // Re-rooted on the NORMALIZED prefix, not sliced off rootDir: the walk echoes back the directory
+                    // string it was handed, so slicing carries whatever case the caller typed into every loose row.
+                    found.Add(withSep + Normalize(f.Substring(baseDir.Length)));
             }
             catch { /* a root that won't enumerate contributes nothing; not silently trusted (see the summary) */ }
         }
@@ -487,7 +492,9 @@ public sealed class AssetResolver : IDisposable
         foreach (var t in snap.Tables.Values)
             foreach (var entry in t)
                 if (entry.StartsWith(withSep, StringComparison.OrdinalIgnoreCase))
-                    found.Add(entry);
+                    // Re-rooted on the same prefix as the loose lane. Left as the ARCHIVE spelt it, one answer mixes
+                    // two spellings of the same folder — loose rows one way, archive rows the other.
+                    found.Add(withSep + entry.Substring(withSep.Length));
 
         return found;
     }

--- a/src/housecarl-core/AssetResolver.cs
+++ b/src/housecarl-core/AssetResolver.cs
@@ -464,8 +464,10 @@ public sealed class AssetResolver : IDisposable
 
     IReadOnlyCollection<string> EnumerateUnder(string prefix, Snapshot snap)
     {
-        var pre = NormalizeQueryPath(prefix);                    // drive-root / '..' rejected loud, backslash-normalized
-        var withSep = pre + "\\";                                // match a SUBTREE, not a sibling whose name starts with 'pre'
+        var pre = NormalizeQueryPath(prefix).TrimEnd('\\');      // drive-root / '..' rejected loud, backslash-normalized
+        // Match a SUBTREE, not a sibling whose name starts with 'pre'. An empty prefix is the Data root, where every
+        // entry is under it and the separator test would exclude them all.
+        var withSep = pre.Length == 0 ? "" : pre + "\\";
         var found = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         // loose: recurse each root's copy of the prefix dir (set-UNION across roots — the per-path winner is decided later).

--- a/src/housecarl-mcp-tests/AssetSelectTests.cs
+++ b/src/housecarl-mcp-tests/AssetSelectTests.cs
@@ -81,6 +81,27 @@ public sealed class AssetSelectTests : IClassFixture<AssetSelectWorld>
         Assert.Empty(shallow.Results);
     }
 
+    /// <summary>'**' spans zero segments as well as many, so a sweep written with it does not quietly skip the files
+    /// sitting directly in the anchor folder.</summary>
+    [Fact]
+    public void ADoubleStarMatchesTheAnchorFolderItselfAndNotOnlyItsSubfolders()
+    {
+        var deep = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { AssetSelectWorld.FaceGeomDir + @"\**\*.nif" });
+
+        Assert.Equal(AssetSelectWorld.FaceGeomFiles, deep.Selected);
+    }
+
+    /// <summary>A glob with no directory in front of it would enumerate every loose file and every archive entry in
+    /// the order before rendering anything, so it is refused instead of paid.</summary>
+    [Fact]
+    public void AnUnanchoredGlobIsRefusedRatherThanSweepingTheWholeLoadOrder()
+    {
+        var d = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { @"**\*.nif" });
+
+        Assert.Empty(d.Results);
+        Assert.Contains(d.SelectorNotes!, n => n.Contains("anchored under a directory", StringComparison.Ordinal));
+    }
+
     /// <summary>Explicit paths and a directory compose in one call: the paths keep their place and their order, and the
     /// sweep does not repeat one it already named.</summary>
     [Fact]
@@ -129,7 +150,7 @@ public sealed class AssetSelectTests : IClassFixture<AssetSelectWorld>
         Assert.Equal(2, page.Results.Count);
 
         var text = AssetWire.Render(page, 80_000);
-        Assert.Contains("[accounting] total=5 rendered=2 capped=3 truncated=0 offset=1", text);
+        Assert.Contains("[accounting] total=5 rendered=2 capped=3 truncated=0 offset=1 remaining=2", text);
         Assert.Contains("offset=3 for the next page", text);
 
         // The pages tile the selection: page 2 continues where page 1 stopped.
@@ -151,6 +172,31 @@ public sealed class AssetSelectTests : IClassFixture<AssetSelectWorld>
         Assert.Contains("max_chars cut", text);
     }
 
+    /// <summary>The last page says it is the last, and an offset past the end says THAT rather than pointing back at
+    /// the offset it was just called with — a caller following the line's own advice must not loop.</summary>
+    [Fact]
+    public void TheLastPageOffersNoNextPageAndAnOffsetPastTheEndSaysSo()
+    {
+        var last = AssetWire.Render(
+            _w.Svc.AssetStatus(Array.Empty<string>(), new[] { AssetSelectWorld.FaceGeomDir }, limit: 2, offset: 3), 80_000);
+        Assert.Contains("remaining=0", last);
+        Assert.DoesNotContain("for the next page", last);
+
+        var past = AssetWire.Render(
+            _w.Svc.AssetStatus(Array.Empty<string>(), new[] { AssetSelectWorld.FaceGeomDir }, limit: 2, offset: 9), 80_000);
+        Assert.Contains("offset=9 is past the end of the selection (5 path(s))", past);
+        Assert.DoesNotContain("for the next page", past);
+    }
+
+    /// <summary>A negative window is refused by name rather than reinterpreted as "no limit".</summary>
+    [Fact]
+    public void ANegativeLimitOrOffsetIsRefusedByName()
+    {
+        var text = AssetTools.AssetStatus(_w.Svc, new[] { _w.Rel("0001.nif") }, limit: -1);
+
+        Assert.Contains("neither can be negative", text);
+    }
+
     /// <summary>An unpaged, uncut explicit-path call reports itself whole — the accounting is on every response, not
     /// only the ones that lost something.</summary>
     [Fact]
@@ -158,7 +204,7 @@ public sealed class AssetSelectTests : IClassFixture<AssetSelectWorld>
     {
         var text = AssetTools.AssetStatus(_w.Svc, new[] { _w.Rel("0001.nif") });
 
-        Assert.Contains("[accounting] total=1 rendered=1 capped=0 truncated=0 offset=0 notes=0", text);
+        Assert.Contains("[accounting] total=1 rendered=1 capped=0 truncated=0 offset=0 remaining=0 notes=0", text);
     }
 
     /// <summary>Both select forms empty is a refusal that names both, since either one alone is a legal call.</summary>

--- a/src/housecarl-mcp-tests/AssetSelectTests.cs
+++ b/src/housecarl-mcp-tests/AssetSelectTests.cs
@@ -126,6 +126,26 @@ public sealed class AssetSelectTests : IClassFixture<AssetSelectWorld>
         Assert.Contains("notes=1", AssetWire.Render(d, 80_000));
     }
 
+    /// <summary>A wildcard-free selector that names an existing FILE is answered as that one path. Enumerating a file
+    /// finds nothing beneath it, and saying "nothing provides that folder" would contradict what asset_paths= answers
+    /// for the very same string — which is what a modder pasting a path into under= would read.</summary>
+    [Fact]
+    public void AWildcardFreeSelectorThatNamesAFileIsAnsweredAsThatFile()
+    {
+        var rel = _w.Rel("0001.nif");
+
+        var d = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { rel });
+
+        var r = Assert.Single(d.Results);
+        Assert.Equal(rel, r.RelPath);
+        Assert.True(r.Hit!.Exists);
+        // The same string through asset_paths= agrees, winner and all.
+        Assert.Equal(_w.Svc.AssetStatus(new[] { rel }).Results[0].Hit!.Winner!.Source, r.Hit.Winner!.Source);
+        // And the note says what under= did with it, rather than claiming nothing provides the folder.
+        Assert.Contains(d.SelectorNotes!, n => n.Contains("names a file", StringComparison.Ordinal));
+        Assert.DoesNotContain(d.SelectorNotes!, n => n.Contains("matched no file", StringComparison.Ordinal));
+    }
+
     /// <summary>The escape guard covers the selector too — a drive-rooted or '..'-escaping directory is refused by
     /// name, never enumerated outside the load order.</summary>
     [Fact]

--- a/src/housecarl-mcp-tests/AssetSelectTests.cs
+++ b/src/housecarl-mcp-tests/AssetSelectTests.cs
@@ -139,6 +139,48 @@ public sealed class AssetSelectTests : IClassFixture<AssetSelectWorld>
         Assert.Contains(d.SelectorNotes, n => n.Contains("parent-escaping", StringComparison.Ordinal));
     }
 
+    /// <summary>A selector that normalizes to nothing — "/", "\", "//" — names the Data root, and enumerating it
+    /// sweeps every loose file and every archive table in the order. It is refused for the same reason an unanchored
+    /// glob is, in one plain sentence.</summary>
+    [Fact]
+    public void ASelectorThatNamesNoDirectoryIsRefusedTheSameWayAnUnanchoredGlobIs()
+    {
+        foreach (var root in new[] { "/", @"\", "//" })
+        {
+            var d = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { root });
+
+            Assert.Empty(d.Results);
+            var note = Assert.Single(d.SelectorNotes!);
+            Assert.Contains("anchored under a directory", note, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>"./meshes" and "meshes" are the same folder. Left in, a "." segment survives into the loose walk but
+    /// never matches a BSA table entry, so the archive-only files drop out of the sweep without a word.</summary>
+    [Fact]
+    public void ADotSegmentSelectsTheSameSetAsThePlainSpellingIncludingArchiveOnlyFiles()
+    {
+        var plain = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { "meshes" });
+        var dotted = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { "./meshes" });
+
+        Assert.Equal(AssetSelectWorld.FaceGeomFiles, plain.Selected);
+        Assert.Equal(Paths(plain), Paths(dotted));
+        // The BSA-only file is in both, not just the loose lane's answer.
+        Assert.Contains(Paths(dotted), p => Leaf(p) == "0005.nif");
+        Assert.Empty(dotted.SelectorNotes ?? Array.Empty<string>());
+    }
+
+    /// <summary>A refusal reads as one plain sentence — no .NET exception furniture trailing off the end of it.</summary>
+    [Fact]
+    public void ARefusedSelectorReadsAsOnePlainSentenceWithNoParameterSuffix()
+    {
+        var d = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { @"**\*.nif", @"C:\Windows", @"meshes\..\secrets" });
+
+        var text = AssetWire.Render(d, 80_000);
+        Assert.DoesNotContain("(Parameter", text, StringComparison.Ordinal);
+        Assert.All(d.SelectorNotes!, n => Assert.DoesNotContain("(Parameter", n, StringComparison.Ordinal));
+    }
+
     /// <summary>The window pages, and the accounting says how much of the selection it left behind and where the next
     /// page starts.</summary>
     [Fact]

--- a/src/housecarl-mcp-tests/AssetSelectTests.cs
+++ b/src/housecarl-mcp-tests/AssetSelectTests.cs
@@ -172,11 +172,27 @@ public sealed class AssetSelectTests : IClassFixture<AssetSelectWorld>
         var text = AssetWire.Render(page, 80_000);
         // skipped= is what offset stepped over, capped= what limit left behind: two different causes, counted apart.
         Assert.Contains("[accounting] total=5 rendered=2 skipped=1 capped=2 truncated=0 offset=1 remaining=2", text);
-        Assert.Contains("offset=3 for the next page", text);
+        Assert.Contains("limit=2 offset=3 for the next page", text);
 
         // The pages tile the selection: page 2 continues where page 1 stopped.
         var whole = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { AssetSelectWorld.FaceGeomDir });
         Assert.Equal(Paths(whole).Skip(1).Take(2), Paths(page));
+    }
+
+    /// <summary>The next-page advice names limit= as well as offset=. Without it a caller following the line calls
+    /// back with limit=0 and resolves the whole remainder on every page — the paging is only cheap if the advice
+    /// keeps it paged.</summary>
+    [Fact]
+    public void TheNextPageAdviceCarriesTheLimitSoFollowingItStaysPaged()
+    {
+        var paged = AssetWire.Render(
+            _w.Svc.AssetStatus(Array.Empty<string>(), new[] { AssetSelectWorld.FaceGeomDir }, limit: 2), 80_000);
+        Assert.Contains("re-call with limit=2 offset=2 for the next page", paged);
+
+        // No limit passed: the advice still names one, so the follow-up call is a page and not the whole remainder.
+        var unlimited = AssetWire.Render(
+            _w.Svc.AssetStatus(Array.Empty<string>(), new[] { AssetSelectWorld.FaceGeomDir }), 500);
+        Assert.Matches(@"re-call with limit=[1-9]\d* offset=\d+ for the next page", unlimited);
     }
 
     /// <summary>The secondary half of #246: a render cut by max_chars is counted in the structured accounting line,
@@ -246,7 +262,7 @@ public sealed class AssetSelectTests : IClassFixture<AssetSelectWorld>
                 _w.Svc.AssetStatus(Array.Empty<string>(), new[] { AssetSelectWorld.FaceGeomDir }, limit: 3, offset: offset), 500);
             foreach (var p in all) if (text.Contains(p, StringComparison.Ordinal)) seen[p]++;
 
-            var next = System.Text.RegularExpressions.Regex.Match(text, @"re-call with offset=(\d+)");
+            var next = System.Text.RegularExpressions.Regex.Match(text, @"re-call with limit=\d+ offset=(\d+)");
             if (!next.Success) break;
             var advanced = int.Parse(next.Groups[1].Value);
             Assert.True(advanced > offset, $"the advice must move forward, got offset={advanced} from offset={offset}");

--- a/src/housecarl-mcp-tests/AssetSelectTests.cs
+++ b/src/housecarl-mcp-tests/AssetSelectTests.cs
@@ -337,6 +337,21 @@ public sealed class AssetSelectTests : IClassFixture<AssetSelectWorld>
         Assert.True(AssetWire.Render(d, 2_000).Length <= 2_000);
     }
 
+    /// <summary>The selector-notes block is capped like its two sibling alarm blocks. One note per selector is bounded
+    /// by the call's own input, but that input can be thousands of selectors, which would write megabytes before the
+    /// per-path loop ever checks the budget.</summary>
+    [Fact]
+    public void ThousandsOfBadSelectorsAreCutAtMaxCharsRatherThanWrittenWhole()
+    {
+        var many = Enumerable.Range(0, 2_000).Select(i => @"meshes\nosuchfolder" + i).ToArray();
+
+        var text = AssetWire.Render(_w.Svc.AssetStatus(Array.Empty<string>(), many), 2_000);
+
+        Assert.True(text.Length < 10_000, $"max_chars=2000 wrote {text.Length} chars of selector notes");
+        Assert.Contains("more selector(s) omitted at max_chars=2000", text);
+        Assert.Contains("notes=2000", text);                  // the count is still stated in full
+    }
+
     /// <summary>Both select forms empty is a refusal that names both, since either one alone is a legal call.</summary>
     [Fact]
     public void ACallThatSelectsNothingRefusesNamingBothSelectForms()

--- a/src/housecarl-mcp-tests/AssetSelectTests.cs
+++ b/src/housecarl-mcp-tests/AssetSelectTests.cs
@@ -139,48 +139,6 @@ public sealed class AssetSelectTests : IClassFixture<AssetSelectWorld>
         Assert.Contains(d.SelectorNotes, n => n.Contains("parent-escaping", StringComparison.Ordinal));
     }
 
-    /// <summary>A selector that normalizes to nothing — "/", "\", "//" — names the Data root, and enumerating it
-    /// sweeps every loose file and every archive table in the order. It is refused for the same reason an unanchored
-    /// glob is, in one plain sentence.</summary>
-    [Fact]
-    public void ASelectorThatNamesNoDirectoryIsRefusedTheSameWayAnUnanchoredGlobIs()
-    {
-        foreach (var root in new[] { "/", @"\", "//" })
-        {
-            var d = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { root });
-
-            Assert.Empty(d.Results);
-            var note = Assert.Single(d.SelectorNotes!);
-            Assert.Contains("anchored under a directory", note, StringComparison.Ordinal);
-        }
-    }
-
-    /// <summary>"./meshes" and "meshes" are the same folder. Left in, a "." segment survives into the loose walk but
-    /// never matches a BSA table entry, so the archive-only files drop out of the sweep without a word.</summary>
-    [Fact]
-    public void ADotSegmentSelectsTheSameSetAsThePlainSpellingIncludingArchiveOnlyFiles()
-    {
-        var plain = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { "meshes" });
-        var dotted = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { "./meshes" });
-
-        Assert.Equal(AssetSelectWorld.FaceGeomFiles, plain.Selected);
-        Assert.Equal(Paths(plain), Paths(dotted));
-        // The BSA-only file is in both, not just the loose lane's answer.
-        Assert.Contains(Paths(dotted), p => Leaf(p) == "0005.nif");
-        Assert.Empty(dotted.SelectorNotes ?? Array.Empty<string>());
-    }
-
-    /// <summary>A refusal reads as one plain sentence — no .NET exception furniture trailing off the end of it.</summary>
-    [Fact]
-    public void ARefusedSelectorReadsAsOnePlainSentenceWithNoParameterSuffix()
-    {
-        var d = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { @"**\*.nif", @"C:\Windows", @"meshes\..\secrets" });
-
-        var text = AssetWire.Render(d, 80_000);
-        Assert.DoesNotContain("(Parameter", text, StringComparison.Ordinal);
-        Assert.All(d.SelectorNotes!, n => Assert.DoesNotContain("(Parameter", n, StringComparison.Ordinal));
-    }
-
     /// <summary>The window pages, and the accounting says how much of the selection it left behind and where the next
     /// page starts.</summary>
     [Fact]
@@ -192,7 +150,8 @@ public sealed class AssetSelectTests : IClassFixture<AssetSelectWorld>
         Assert.Equal(2, page.Results.Count);
 
         var text = AssetWire.Render(page, 80_000);
-        Assert.Contains("[accounting] total=5 rendered=2 capped=3 truncated=0 offset=1 remaining=2", text);
+        // skipped= is what offset stepped over, capped= what limit left behind: two different causes, counted apart.
+        Assert.Contains("[accounting] total=5 rendered=2 skipped=1 capped=2 truncated=0 offset=1 remaining=2", text);
         Assert.Contains("offset=3 for the next page", text);
 
         // The pages tile the selection: page 2 continues where page 1 stopped.
@@ -246,7 +205,100 @@ public sealed class AssetSelectTests : IClassFixture<AssetSelectWorld>
     {
         var text = AssetTools.AssetStatus(_w.Svc, new[] { _w.Rel("0001.nif") });
 
-        Assert.Contains("[accounting] total=1 rendered=1 capped=0 truncated=0 offset=0 remaining=0 notes=0", text);
+        Assert.Contains("[accounting] total=1 rendered=1 skipped=0 capped=0 truncated=0 offset=0 remaining=0 notes=0", text);
+    }
+
+    /// <summary>A caller that walks the sweep by the accounting line's OWN advice sees every path exactly once. The
+    /// next offset has to count what was RENDERED, not what was resolved: under a max_chars cut the two differ, and
+    /// counting the resolved window steps the caller straight over the paths the cap never showed it.</summary>
+    [Fact]
+    public void WalkingBySuccessiveNextPageOffsetsRendersEveryPathExactlyOnce()
+    {
+        var all = Paths(_w.Svc.AssetStatus(Array.Empty<string>(), new[] { AssetSelectWorld.FaceGeomDir }));
+        var seen = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var p in all) seen[p] = 0;
+
+        // limit=3 resolves three paths a page; max_chars=500 renders fewer than three of them.
+        int offset = 0;
+        for (int page = 0; page < 20; page++)
+        {
+            var text = AssetWire.Render(
+                _w.Svc.AssetStatus(Array.Empty<string>(), new[] { AssetSelectWorld.FaceGeomDir }, limit: 3, offset: offset), 500);
+            foreach (var p in all) if (text.Contains(p, StringComparison.Ordinal)) seen[p]++;
+
+            var next = System.Text.RegularExpressions.Regex.Match(text, @"re-call with offset=(\d+)");
+            if (!next.Success) break;
+            var advanced = int.Parse(next.Groups[1].Value);
+            Assert.True(advanced > offset, $"the advice must move forward, got offset={advanced} from offset={offset}");
+            offset = advanced;
+        }
+
+        Assert.All(all, p => Assert.Equal(1, seen[p]));
+    }
+
+    /// <summary>A selector that normalizes to nothing — "/", "\", "//" — names the Data root, and enumerating it
+    /// sweeps every loose file and every archive table in the order. It is refused for the same reason an unanchored
+    /// glob is, in one plain sentence.</summary>
+    [Fact]
+    public void ASelectorThatNamesNoDirectoryIsRefusedTheSameWayAnUnanchoredGlobIs()
+    {
+        foreach (var root in new[] { "/", @"\", "//" })
+        {
+            var d = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { root });
+
+            Assert.Empty(d.Results);
+            var note = Assert.Single(d.SelectorNotes!);
+            Assert.Contains("anchored under a directory", note, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>"./meshes" and "meshes" are the same folder. Left in, a "." segment survives into the loose walk but
+    /// never matches a BSA table entry, so the archive-only files drop out of the sweep without a word.</summary>
+    [Fact]
+    public void ADotSegmentSelectsTheSameSetAsThePlainSpellingIncludingArchiveOnlyFiles()
+    {
+        var plain = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { "meshes" });
+        var dotted = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { "./meshes" });
+
+        Assert.Equal(AssetSelectWorld.FaceGeomFiles, plain.Selected);
+        Assert.Equal(Paths(plain), Paths(dotted));
+        // The BSA-only file is in both, not just the loose lane's answer.
+        Assert.Contains(Paths(dotted), p => Leaf(p) == "0005.nif");
+        Assert.Empty(dotted.SelectorNotes ?? Array.Empty<string>());
+    }
+
+    /// <summary>A refusal reads as one plain sentence — no ".NET" exception furniture trailing off the end of it.</summary>
+    [Fact]
+    public void ARefusedSelectorReadsAsOnePlainSentenceWithNoParameterSuffix()
+    {
+        var d = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { @"**\*.nif", @"C:\Windows", @"meshes\..\secrets" });
+
+        var text = AssetWire.Render(d, 80_000);
+        Assert.DoesNotContain("(Parameter", text, StringComparison.Ordinal);
+        Assert.All(d.SelectorNotes!, n => Assert.DoesNotContain("(Parameter", n, StringComparison.Ordinal));
+    }
+
+    /// <summary>The accounting block is priced INSIDE max_chars: room for its widest spelling is held back before the
+    /// paths render, rather than appended past the cap once they have used all of it.</summary>
+    [Fact]
+    public void TheAccountingBlockIsPricedInsideMaxCharsRatherThanAppendedPastIt()
+    {
+        var d = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { AssetSelectWorld.FaceGeomDir });
+        int reserve = AssetWire.AccountingReserve(d);
+
+        foreach (var cap in new[] { 400, 900, 1200, 1600, 80_000 })
+        {
+            var text = AssetWire.Render(d, cap);
+            int at = text.IndexOf("\n\n[accounting]", StringComparison.Ordinal);
+            Assert.True(at >= 0, $"max_chars={cap} dropped the accounting block");
+            // What the block actually writes fits the room reserved for it, so subtracting that room from max_chars
+            // before the body renders is enough to hold the whole response inside the cap.
+            Assert.True(text.Length - at <= reserve,
+                        $"max_chars={cap} wrote {text.Length - at} chars through a reserve of {reserve}");
+        }
+
+        // A cap that can hold the whole answer holds the accounting too, block and all.
+        Assert.True(AssetWire.Render(d, 2_000).Length <= 2_000);
     }
 
     /// <summary>Both select forms empty is a refusal that names both, since either one alone is a legal call.</summary>

--- a/src/housecarl-mcp-tests/AssetSelectTests.cs
+++ b/src/housecarl-mcp-tests/AssetSelectTests.cs
@@ -1,0 +1,173 @@
+using HousecarlCore;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>The directory / glob SELECT form on asset_status (#246): one call over a folder answers for every file the
+/// VFS provides beneath it, loose and archive both, with the winner and provider chain per file — and says in a
+/// structured line what it left out.</summary>
+[Trait("tier", "unit")]
+public sealed class AssetSelectTests : IClassFixture<AssetSelectWorld>
+{
+    readonly AssetSelectWorld _w;
+    public AssetSelectTests(AssetSelectWorld w) => _w = w;
+
+    static string[] Paths(AssetStatusData d) => d.Results.Select(r => r.RelPath).ToArray();
+
+    static string Leaf(string p) => Path.GetFileName(p);
+
+    /// <summary>The #246 measure: one call per defining master over its facegeom folder answers for the whole set —
+    /// the same files, the same winners, as spelling every path out. Forty path-list calls collapse to one.</summary>
+    [Fact]
+    public void OneCallOverAMastersFacegenFolderAnswersForEveryPathAPathListWouldHaveSpelled()
+    {
+        var spelled = new[] { "0001.nif", "0002.nif", "0003.nif", "0004.nif", "0005.nif" }.Select(_w.Rel).ToArray();
+
+        var swept = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { AssetSelectWorld.FaceGeomDir });
+        var listed = _w.Svc.AssetStatus(spelled);
+
+        Assert.Equal(AssetSelectWorld.FaceGeomFiles, swept.Selected);
+        Assert.Equal(spelled.OrderBy(p => p, StringComparer.OrdinalIgnoreCase),
+                     Paths(swept).OrderBy(p => p, StringComparer.OrdinalIgnoreCase));
+        Assert.All(swept.Results, r => Assert.True(r.Hit!.Exists));
+        // Winners agree file for file with the explicit-path answer.
+        Assert.Equal(listed.Results.Select(r => r.Hit!.Winner!.Source).OrderBy(s => s),
+                     swept.Results.Select(r => r.Hit!.Winner!.Source).OrderBy(s => s));
+    }
+
+    /// <summary>The sweep is VFS-scoped: a file only a BSA carries is in the set, and a contested file still reports
+    /// the priority winner with its whole provider chain.</summary>
+    [Fact]
+    public void ASweepUnionsLooseAndArchiveProvidersAndStillCallsTheWinnerPerFile()
+    {
+        var d = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { AssetSelectWorld.FaceGeomDir });
+
+        var bsaOnly = d.Results.Single(r => Leaf(r.RelPath) == "0005.nif");
+        Assert.Equal(AssetKind.Bsa, bsaOnly.Hit!.Winner!.Kind);
+        Assert.Equal("HcArch.bsa", bsaOnly.Hit.Winner.Source);
+
+        var contested = d.Results.Single(r => Leaf(r.RelPath) == "0002.nif");
+        Assert.Equal("FaceHigher", contested.Hit!.Winner!.Source);
+        Assert.Equal(new[] { "FaceHigher", "FaceBase" }, contested.Hit.Providers.Select(p => p.Source).ToArray());
+    }
+
+    /// <summary>A trailing separator is how a modder spells a folder, and the two spellings must answer alike.</summary>
+    [Fact]
+    public void ADirectorySelectorAnswersTheSameWithOrWithoutATrailingSeparator()
+    {
+        var bare = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { AssetSelectWorld.FaceGeomDir });
+        var slashed = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { AssetSelectWorld.FaceGeomDir + "/" });
+
+        Assert.Equal(Paths(bare), Paths(slashed));
+    }
+
+    /// <summary>A glob narrows within the subtree: '*' stays inside one segment, '**' crosses separators.</summary>
+    [Fact]
+    public void AGlobNarrowsTheSweepToTheFilesItMatches()
+    {
+        var nifs = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { AssetSelectWorld.FaceGeomDir + @"\000?.nif" });
+        Assert.Equal(AssetSelectWorld.FaceGeomFiles, nifs.Selected);
+
+        var one = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { AssetSelectWorld.FaceGeomDir + @"\0004.*" });
+        Assert.Equal("0004.nif", Leaf(Assert.Single(one.Results).RelPath));
+
+        // '**' crosses separators, so one selector reaches every facegen mesh from the actors root.
+        var deep = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { @"meshes\actors\**\*.nif" });
+        Assert.Equal(AssetSelectWorld.FaceGeomFiles, deep.Selected);
+
+        // '*' does NOT cross a separator, so the same shape one level up matches nothing.
+        var shallow = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { @"meshes\actors\*.nif" });
+        Assert.Empty(shallow.Results);
+    }
+
+    /// <summary>Explicit paths and a directory compose in one call: the paths keep their place and their order, and the
+    /// sweep does not repeat one it already named.</summary>
+    [Fact]
+    public void ExplicitPathsAndADirectoryComposeWithoutDuplicatingAPath()
+    {
+        var d = _w.Svc.AssetStatus(new[] { _w.Rel("0003.nif") }, new[] { AssetSelectWorld.FaceGeomDir });
+
+        Assert.Equal(AssetSelectWorld.FaceGeomFiles, d.Selected);
+        Assert.Equal(_w.Rel("0003.nif"), d.Results[0].RelPath);
+        Assert.Single(d.Results.Where(r => Leaf(r.RelPath) == "0003.nif"));
+    }
+
+    /// <summary>A selector that matches nothing says so. Read as a silent no-op it looks exactly like a clean sweep,
+    /// which is how a typo'd folder under-counts.</summary>
+    [Fact]
+    public void ASelectorThatMatchesNothingSaysSoRatherThanPassingAsAnEmptySweep()
+    {
+        var d = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { @"meshes\actors\character\facegendata\facegeom\Typo.esm" });
+
+        Assert.Empty(d.Results);
+        Assert.Contains(d.SelectorNotes!, n => n.Contains("matched no file", StringComparison.Ordinal));
+        Assert.Contains("notes=1", AssetWire.Render(d, 80_000));
+    }
+
+    /// <summary>The escape guard covers the selector too — a drive-rooted or '..'-escaping directory is refused by
+    /// name, never enumerated outside the load order.</summary>
+    [Fact]
+    public void ADriveRootedOrEscapingSelectorIsRefusedByName()
+    {
+        var d = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { @"C:\Windows", @"meshes\..\..\secrets" });
+
+        Assert.Empty(d.Results);
+        Assert.Equal(2, d.SelectorNotes!.Count);
+        Assert.Contains(d.SelectorNotes, n => n.Contains("drive-rooted", StringComparison.Ordinal));
+        Assert.Contains(d.SelectorNotes, n => n.Contains("parent-escaping", StringComparison.Ordinal));
+    }
+
+    /// <summary>The window pages, and the accounting says how much of the selection it left behind and where the next
+    /// page starts.</summary>
+    [Fact]
+    public void TheSweepPagesAndTheAccountingNamesWhatThePagingLeftOut()
+    {
+        var page = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { AssetSelectWorld.FaceGeomDir }, limit: 2, offset: 1);
+
+        Assert.Equal(AssetSelectWorld.FaceGeomFiles, page.Selected);
+        Assert.Equal(2, page.Results.Count);
+
+        var text = AssetWire.Render(page, 80_000);
+        Assert.Contains("[accounting] total=5 rendered=2 capped=3 truncated=0 offset=1", text);
+        Assert.Contains("offset=3 for the next page", text);
+
+        // The pages tile the selection: page 2 continues where page 1 stopped.
+        var whole = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { AssetSelectWorld.FaceGeomDir });
+        Assert.Equal(Paths(whole).Skip(1).Take(2), Paths(page));
+    }
+
+    /// <summary>The secondary half of #246: a render cut by max_chars is counted in the structured accounting line,
+    /// which is written after the cut and so can never itself be truncated away.</summary>
+    [Fact]
+    public void AMaxCharsCutIsCountedInTheAccountingLineAndNotOnlyInProse()
+    {
+        var d = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { AssetSelectWorld.FaceGeomDir });
+
+        var text = AssetWire.Render(d, 200);
+
+        Assert.Contains("[accounting] total=5 rendered=", text);
+        Assert.Matches(@"truncated=[1-9]", text);
+        Assert.Contains("max_chars cut", text);
+    }
+
+    /// <summary>An unpaged, uncut explicit-path call reports itself whole — the accounting is on every response, not
+    /// only the ones that lost something.</summary>
+    [Fact]
+    public void AnOrdinaryPathListStillCarriesTheAccountingLine()
+    {
+        var text = AssetTools.AssetStatus(_w.Svc, new[] { _w.Rel("0001.nif") });
+
+        Assert.Contains("[accounting] total=1 rendered=1 capped=0 truncated=0 offset=0 notes=0", text);
+    }
+
+    /// <summary>Both select forms empty is a refusal that names both, since either one alone is a legal call.</summary>
+    [Fact]
+    public void ACallThatSelectsNothingRefusesNamingBothSelectForms()
+    {
+        var text = AssetTools.AssetStatus(_w.Svc, Array.Empty<string>());
+
+        Assert.Contains("empty", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("under", text, StringComparison.Ordinal);
+    }
+}

--- a/src/housecarl-mcp-tests/AssetSelectTests.cs
+++ b/src/housecarl-mcp-tests/AssetSelectTests.cs
@@ -303,6 +303,25 @@ public sealed class AssetSelectTests : IClassFixture<AssetSelectWorld>
         Assert.Empty(dotted.SelectorNotes ?? Array.Empty<string>());
     }
 
+    /// <summary>One answer spells one folder one way. The loose walk echoes back the caller's own casing and the
+    /// archive tables their author's, so an upper-cased selector used to return loose rows and BSA rows in two
+    /// different spellings of the same directory.</summary>
+    [Fact]
+    public void AnUpperCasedSelectorAnswersInOneSpellingAcrossLooseAndArchiveRows()
+    {
+        var shouted = AssetSelectWorld.FaceGeomDir.ToUpperInvariant();
+
+        var d = _w.Svc.AssetStatus(Array.Empty<string>(), new[] { shouted });
+
+        Assert.Equal(AssetSelectWorld.FaceGeomFiles, d.Selected);
+        Assert.Contains(Paths(d), p => Leaf(p) == "0005.nif");        // the archive-only file is in the sweep
+        Assert.All(Paths(d), p => Assert.StartsWith(shouted + "\\", p, StringComparison.Ordinal));
+        // Typing does not change WHICH files come back, only how the prefix is spelt.
+        Assert.Equal(Paths(_w.Svc.AssetStatus(Array.Empty<string>(), new[] { AssetSelectWorld.FaceGeomDir }))
+                        .Select(Leaf).OrderBy(p => p),
+                     Paths(d).Select(Leaf).OrderBy(p => p));
+    }
+
     /// <summary>A refusal reads as one plain sentence — no ".NET" exception furniture trailing off the end of it.</summary>
     [Fact]
     public void ARefusedSelectorReadsAsOnePlainSentenceWithNoParameterSuffix()

--- a/src/housecarl-mcp-tests/AssetSelectWorld.cs
+++ b/src/housecarl-mcp-tests/AssetSelectWorld.cs
@@ -1,0 +1,88 @@
+using HousecarlGenerator;
+using HousecarlMcp;
+
+namespace HousecarlMcpTests;
+
+/// <summary>The synthetic MO2 instance the asset_status directory / glob tests are driven over: one master's facegen
+/// set spread across two loose mods and one BSA, which is the shape #246 is about — a sweep must union every provider
+/// the VFS loads, not just the loose ones, and must still call the winner per file.
+///
+/// <para>What it carries:</para>
+/// <list type="bullet">
+/// <item><c>FaceHigher</c> — the higher-priority loose mod: <c>0002.nif</c> (contending with FaceBase) and
+///   <c>0004.nif</c>.</item>
+/// <item><c>FaceBase</c> — the lower-priority loose mod: <c>0001.nif</c>, <c>0002.nif</c>, <c>0003.nif</c>, and one
+///   facetint <c>.dds</c> under textures\ so a glob has something to narrow away.</item>
+/// <item><c>ArchiveMod</c> — <c>HcArch.bsa</c>, authored by <see cref="BsaBuilder"/> and bound to the active
+///   <c>HcArch.esp</c>, carrying <c>0005.nif</c> — reachable only through the archive lane.</item>
+/// </list>
+///
+/// <para>No .esp is written to disk: asset resolution is decoupled from the record index, so the profile naming a
+/// plugin is all the archive binding needs.</para></summary>
+public sealed class AssetSelectWorld : IDisposable
+{
+    public string Root { get; }
+    public LoadOrderService Svc { get; }
+
+    /// <summary>The defining master whose facegen folder the sweep is aimed at.</summary>
+    public const string Master = "HcMaster.esm";
+    /// <summary>The facegen mesh folder — the #246 sweep target, one call per defining master.</summary>
+    public const string FaceGeomDir = @"meshes\actors\character\facegendata\facegeom\" + Master;
+    /// <summary>The facetint texture folder, so a sweep can be aimed at more than one root.</summary>
+    public const string FaceTintDir = @"textures\actors\character\facegendata\facetint\" + Master;
+
+    /// <summary>Distinct files the facegeom folder holds across every provider: three from FaceBase, one more from
+    /// FaceHigher, one from the BSA (FaceHigher's 0002 is a contender, not a sixth file).</summary>
+    public const int FaceGeomFiles = 5;
+
+    public string Rel(string leaf) => FaceGeomDir + "\\" + leaf;
+
+    public AssetSelectWorld()
+    {
+        Root = Path.Combine(Path.GetTempPath(), "hc-asset-select-" + Guid.NewGuid().ToString("N"));
+        var instance = Path.Combine(Root, "instance");
+        var profile = Path.Combine(instance, "profiles", "Default");
+        var mods = Path.Combine(instance, "mods");
+        var data = Path.Combine(Root, "game", "Data");
+        var faceBase = Path.Combine(mods, "FaceBase");
+        var faceHigher = Path.Combine(mods, "FaceHigher");
+        var archiveMod = Path.Combine(mods, "ArchiveMod");
+        foreach (var d in new[] { profile, data, faceBase, faceHigher, archiveMod }) Directory.CreateDirectory(d);
+
+        File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(Root, "game").Replace(@"\", @"\\") + ")\r\n");
+
+        Loose(faceBase, Rel("0001.nif"));
+        Loose(faceBase, Rel("0002.nif"));
+        Loose(faceBase, Rel("0003.nif"));
+        Loose(faceBase, FaceTintDir + @"\0001.dds");
+        Loose(faceHigher, Rel("0002.nif"));                    // contends with FaceBase and wins on priority
+        Loose(faceHigher, Rel("0004.nif"));
+
+        File.WriteAllBytes(Path.Combine(archiveMod, "HcArch.bsa"),
+            BsaBuilder.Build(105, BsaBuilder.HasFolderNames | BsaBuilder.HasFileNames,
+                new[] { (FaceGeomDir, new[] { ("0005.nif", BsaBuilder.Bytes("NIF-0005", 48)) }) }));
+
+        File.WriteAllText(Path.Combine(profile, "loadorder.txt"), "# header\r\nHcArch.esp\r\n");
+        File.WriteAllText(Path.Combine(profile, "plugins.txt"), "*HcArch.esp\r\n");
+        // Listed first = higher priority, the MO2 modlist.txt order.
+        File.WriteAllText(Path.Combine(profile, "modlist.txt"), "# header\r\n+ArchiveMod\r\n+FaceHigher\r\n+FaceBase\r\n");
+        File.WriteAllText(Path.Combine(profile, "Skyrim.ini"), "[Archive]\r\nsResourceArchiveList=\r\n");
+
+        Svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(Root, "houseCARL.user.json")));
+    }
+
+    static void Loose(string modDir, string rel)
+    {
+        var p = Path.Combine(modDir, rel);
+        Directory.CreateDirectory(Path.GetDirectoryName(p)!);
+        File.WriteAllText(p, "x");
+    }
+
+    public void Dispose()
+    {
+        Svc.Dispose();
+        try { Directory.Delete(Root, true); } catch { /* temp cleanup best-effort */ }
+    }
+}

--- a/src/housecarl-mcp/AssetTools.cs
+++ b/src/housecarl-mcp/AssetTools.cs
@@ -84,7 +84,7 @@ static class AssetWire
             {
                 BatchRender.AppendReadFailures(sb, d.BsaFailures, "an asset", cap);
                 BatchRender.AppendDiscoveryWarnings(sb, d.Warnings, cap);
-                AppendSelectorNotes(sb, d.SelectorNotes);
+                AppendSelectorNotes(sb, d.SelectorNotes, cap);
             },
             (sb, r) => { rendered++; AppendPath(sb, r, d.ReadIncomplete, d.Warnings.Count > 0); },
             // The accounting block is priced INSIDE max_chars, the way the check sweep's footer is: it is written
@@ -96,13 +96,14 @@ static class AssetWire
     }
 
     /// <summary>What each under= selector had to say for itself — a selector that matched nothing, or was rejected.
-    /// Above the per-path list, with the other alarms, so a truncated sweep cannot cut it away. Uncapped, and bounded
-    /// by the call's own input: there is at most one note per selector the caller wrote.</summary>
-    static void AppendSelectorNotes(StringBuilder sb, IReadOnlyList<string>? notes)
+    /// Above the per-path list, with the other alarms, so a truncated sweep cannot cut it away. Capped like its two
+    /// sibling alarm blocks: one note per selector is bounded by the call's own input, but that input can be thousands
+    /// of selectors, which would write megabytes before the per-path loop ever checks the budget.</summary>
+    static void AppendSelectorNotes(StringBuilder sb, IReadOnlyList<string>? notes, int cap)
     {
         if (notes is not { Count: > 0 }) return;
         sb.Append("\n[!] under (").Append(notes.Count).Append("):\n");
-        foreach (var n in notes) sb.Append("  - ").Append(n).Append('\n');
+        BatchRender.AppendLines(sb, notes, "selector(s)", cap);
     }
 
     /// <summary>The numbers one accounting line states. A record so the real line and the widest-case line the reserve

--- a/src/housecarl-mcp/AssetTools.cs
+++ b/src/housecarl-mcp/AssetTools.cs
@@ -22,22 +22,40 @@ public static class AssetTools
          "who is this asset coming from / is this texture loose or in a BSA / is this asset even present / why isn't my " +
          "override applying' for ANY mesh, texture, script, sound, interface, or other Data-relative path. Pass " +
          "asset_paths = one or more paths RELATIVE to the Data folder (forward or back slashes both fine; a drive-rooted " +
-         "or '..'-escaping path is rejected per-path). An archive that cannot be read, or a Skyrim.ini base-archive list " +
-         "that cannot be found, is reported LOUD — so an 'absent' answer is never silently trusted when the scan was " +
-         "incomplete. Read-only: resolves nothing to disk, writes nothing, changes no load order.")]
+         "or '..'-escaping path is rejected per-path), and/or under = a Data-relative DIRECTORY or glob, which resolves " +
+         "every file the VFS provides beneath it — one call over " +
+         "'meshes/actors/character/facegendata/facegeom/Skyrim.esm' answers for every facegen mesh a master defines, " +
+         "with no path list at all. The two select forms compose in one call. An archive that cannot be read, or a " +
+         "Skyrim.ini base-archive list that cannot be found, is reported LOUD — so an 'absent' answer is never silently " +
+         "trusted when the scan was incomplete. Read-only: resolves nothing to disk, writes nothing, changes no load order.")]
     public static string AssetStatus(
         LoadOrderService svc,
         [Description("The Data-relative asset path(s) to resolve, e.g. " +
                      "'textures/armor/iron/cuirass_1.dds' or 'meshes/clutter/common/tankard01.nif'. One or many; resolved " +
-                     "in order, results returned in the same order. Paths are relative to the game's Data folder.")]
-            string[] asset_paths,
+                     "in order, results returned in the same order. Paths are relative to the game's Data folder. " +
+                     "Optional when under= is given.")]
+            string[]? asset_paths = null,
+        [Description("Optional. Data-relative DIRECTORY or glob selector(s): every file the load order provides beneath " +
+                     "it (loose and BSA both) is resolved, e.g. " +
+                     "'meshes/actors/character/facegendata/facegeom/Skyrim.esm' for one master's whole facegen set. " +
+                     "Wildcards: '*' matches within one path segment, '?' one character in a segment, '**' across " +
+                     "separators — 'textures/actors/character/**/*.dds'. Matches are added after any asset_paths, " +
+                     "sorted, with duplicates dropped. A selector that matches nothing says so rather than passing as " +
+                     "an empty sweep.")]
+            string[]? under = null,
+        [Description("Optional. Max paths to resolve and render from the selection. 0 = no limit.")]
+            int limit = 0,
+        [Description("Optional. Where in the selection the rendered window starts, for paging a large under= sweep. 0 = the beginning.")]
+            int offset = 0,
         [Description("Optional. Max characters before the per-path list is cut with an explicit notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool(ToolNames.AssetStatus, () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        if (asset_paths is null || asset_paths.Length == 0)
-            return "error: asset_paths is empty. Pass one or more Data-relative asset paths (e.g. 'textures/armor/iron/cuirass_1.dds').";
-        var data = svc.AssetStatus(asset_paths);
+        if ((asset_paths is null || asset_paths.Length == 0) && (under is null || under.Length == 0))
+            return "error: asset_paths and under are both empty. Pass Data-relative asset path(s) in asset_paths " +
+                   "(e.g. 'textures/armor/iron/cuirass_1.dds'), or a Data-relative directory or glob in under " +
+                   "(e.g. 'meshes/actors/character/facegendata/facegeom/Skyrim.esm').";
+        var data = svc.AssetStatus(asset_paths ?? Array.Empty<string>(), under, limit, offset);
         return AssetWire.Render(data, max_chars > 0 ? max_chars : 80_000);
     });
 }
@@ -52,18 +70,52 @@ static class AssetWire
     {
         var header = new StringBuilder("asset status — profile '")
             .Append(d.ProfileName.Length > 0 ? d.ProfileName : "(unconfigured)")
-            .Append("'  (").Append(d.Results.Count).Append(" path").Append(d.Results.Count == 1 ? "" : "s")
-            .Append(" queried)").ToString();
+            .Append("'  (").Append(d.Selected).Append(" path").Append(d.Selected == 1 ? "" : "s")
+            .Append(" selected)").ToString();
 
-        return BatchRender.Render(
+        int rendered = 0;
+        var body = BatchRender.Render(
             header, d.Results, "path(s)", cap,
             // Alarms come before the per-path list so a long batch cannot truncate them away.
             sb =>
             {
                 BatchRender.AppendReadFailures(sb, d.BsaFailures, "an asset", cap);
                 BatchRender.AppendDiscoveryWarnings(sb, d.Warnings, cap);
+                AppendSelectorNotes(sb, d.SelectorNotes);
             },
-            (sb, r) => AppendPath(sb, r, d.ReadIncomplete, d.Warnings.Count > 0));
+            (sb, r) => { rendered++; AppendPath(sb, r, d.ReadIncomplete, d.Warnings.Count > 0); });
+
+        return body + Accounting(d, rendered);
+    }
+
+    /// <summary>What each under= selector had to say for itself — a selector that matched nothing, or was rejected.
+    /// Above the per-path list, with the other alarms, so a truncated sweep cannot cut it away.</summary>
+    static void AppendSelectorNotes(StringBuilder sb, IReadOnlyList<string>? notes)
+    {
+        if (notes is not { Count: > 0 }) return;
+        sb.Append("\n[!] under (").Append(notes.Count).Append("):\n");
+        foreach (var n in notes) sb.Append("  - ").Append(n).Append('\n');
+    }
+
+    /// <summary>The one machine-readable accounting line, always last and never subject to the cap: how many paths the
+    /// selection named, how many rendered, how many the paging window left out, and how many max_chars cut. A bulk
+    /// consumer keying results by path checks these numbers instead of counting prose it might miss (#246).</summary>
+    static string Accounting(AssetStatusData d, int rendered)
+    {
+        int capped = Math.Max(d.Selected - d.Results.Count, 0);       // left out by limit/offset
+        int truncated = Math.Max(d.Results.Count - rendered, 0);      // left out by max_chars
+        var sb = new StringBuilder("\n\n[accounting] total=").Append(d.Selected)
+            .Append(" rendered=").Append(rendered)
+            .Append(" capped=").Append(capped)
+            .Append(" truncated=").Append(truncated)
+            .Append(" offset=").Append(d.Offset)
+            .Append(" notes=").Append(d.SelectorNotes?.Count ?? 0);
+        if (capped > 0)
+            sb.Append("\nthe selection is longer than this window: re-call with offset=")
+              .Append(d.Offset + d.Results.Count).Append(" for the next page.");
+        if (truncated > 0)
+            sb.Append("\nmax_chars cut ").Append(truncated).Append(" resolved path(s) from the render: raise max_chars, or page with limit=/offset=.");
+        return sb.ToString();
     }
 
     static void AppendPath(StringBuilder sb, AssetPathResult r, bool readIncomplete, bool discoveryIncomplete)

--- a/src/housecarl-mcp/AssetTools.cs
+++ b/src/housecarl-mcp/AssetTools.cs
@@ -109,7 +109,12 @@ static class AssetWire
     /// measures go through ONE composer — a second formatter would be a second spelling, and the reserve would stop
     /// bounding what is written.</summary>
     readonly record struct Counts(int Total, int Rendered, int Skipped, int Capped, int Truncated, int Offset,
-                                  int Remaining, int Notes);
+                                  int Remaining, int Notes, int NextLimit);
+
+    /// <summary>The window the next-page advice names when the caller passed none. Without a limit= in the advice a
+    /// caller following it calls back with limit=0, which resolves the WHOLE remainder on every page — the paging is
+    /// only cheap if the advice keeps it paged.</summary>
+    internal const int DefaultPageLimit = 200;
 
     /// <summary>What this response actually did. The four omissions have four distinct causes and each is counted
     /// once, so <c>skipped + rendered + truncated + capped == total</c>: <c>skipped</c> is what offset= stepped over
@@ -125,7 +130,8 @@ static class AssetWire
         Truncated: Math.Max(d.Results.Count - rendered, 0),
         Offset: d.Offset,
         Remaining: Math.Max(d.Selected - (d.Offset + rendered), 0),
-        Notes: d.SelectorNotes?.Count ?? 0);
+        Notes: d.SelectorNotes?.Count ?? 0,
+        NextLimit: d.Limit > 0 ? d.Limit : DefaultPageLimit);
 
     /// <summary>The chars held back from max_chars so the accounting block is always affordable — measured by
     /// composing the WIDEST line this response could write, so no rendering of it can outgrow its own room.</summary>
@@ -138,7 +144,7 @@ static class AssetWire
     {
         int most = Math.Max(d.Selected, d.Results.Count);
         return new Counts(most, d.Results.Count, most, most, d.Results.Count, d.Offset, most,
-                          d.SelectorNotes?.Count ?? 0);
+                          d.SelectorNotes?.Count ?? 0, Math.Max(d.Limit, DefaultPageLimit));
     }
 
     /// <summary>The one machine-readable accounting line, always last: how many paths the selection named, how many
@@ -156,10 +162,11 @@ static class AssetWire
             .Append(" remaining=").Append(c.Remaining)
             .Append(" notes=").Append(c.Notes);
         // Only what is still AHEAD of what was rendered earns a next page, and the next offset starts at the first
-        // path this response did not show — so a caller following the advice sees every path exactly once.
+        // path this response did not show — so a caller following the advice sees every path exactly once. The advice
+        // carries limit= as well: without it the next call resolves the whole remainder instead of one page.
         if (everySentence || c.Remaining > 0)
-            sb.Append("\nthe selection is longer than this window: re-call with offset=")
-              .Append(c.Offset + c.Rendered).Append(" for the next page.");
+            sb.Append("\nthe selection is longer than this window: re-call with limit=").Append(c.NextLimit)
+              .Append(" offset=").Append(c.Offset + c.Rendered).Append(" for the next page.");
         // An offset past the end would otherwise be told to re-call at the offset it already used.
         if (everySentence || (c.Remaining == 0 && c.Total > 0 && c.Offset >= c.Total))
             sb.Append("\noffset=").Append(c.Offset).Append(" is past the end of the selection (")

--- a/src/housecarl-mcp/AssetTools.cs
+++ b/src/housecarl-mcp/AssetTools.cs
@@ -86,9 +86,13 @@ static class AssetWire
                 BatchRender.AppendDiscoveryWarnings(sb, d.Warnings, cap);
                 AppendSelectorNotes(sb, d.SelectorNotes);
             },
-            (sb, r) => { rendered++; AppendPath(sb, r, d.ReadIncomplete, d.Warnings.Count > 0); });
+            (sb, r) => { rendered++; AppendPath(sb, r, d.ReadIncomplete, d.Warnings.Count > 0); },
+            // The accounting block is priced INSIDE max_chars, the way the check sweep's footer is: it is written
+            // after the body, so room for its longest spelling is held back before the paths render rather than
+            // appended past the cap. max_chars then means the same on this tool as on every other.
+            reserve: AccountingReserve(d));
 
-        return body + Accounting(d, rendered);
+        return body + Compose(Tally(d, rendered), everySentence: false);
     }
 
     /// <summary>What each under= selector had to say for itself — a selector that matched nothing, or was rejected.
@@ -101,31 +105,67 @@ static class AssetWire
         foreach (var n in notes) sb.Append("  - ").Append(n).Append('\n');
     }
 
-    /// <summary>The one machine-readable accounting line, always last and never subject to the cap: how many paths the
-    /// selection named, how many rendered, how many the paging window left out, and how many max_chars cut. A bulk
-    /// consumer keying results by path checks these numbers instead of counting prose it might miss (#246).</summary>
-    static string Accounting(AssetStatusData d, int rendered)
+    /// <summary>The numbers one accounting line states. A record so the real line and the widest-case line the reserve
+    /// measures go through ONE composer — a second formatter would be a second spelling, and the reserve would stop
+    /// bounding what is written.</summary>
+    readonly record struct Counts(int Total, int Rendered, int Skipped, int Capped, int Truncated, int Offset,
+                                  int Remaining, int Notes);
+
+    /// <summary>What this response actually did. The four omissions have four distinct causes and each is counted
+    /// once, so <c>skipped + rendered + truncated + capped == total</c>: <c>skipped</c> is what offset= stepped over
+    /// BEFORE the window, <c>capped</c> what limit= left AFTER it, <c>truncated</c> what max_chars cut out of the
+    /// resolved window. <c>remaining</c> and the next page are measured off what was RENDERED, not off the resolved
+    /// window: a caller walking by this line's own advice must land on the first path it has not seen, and paths the
+    /// cap cut were resolved but never shown.</summary>
+    static Counts Tally(AssetStatusData d, int rendered) => new(
+        Total: d.Selected,
+        Rendered: rendered,
+        Skipped: Math.Min(d.Offset, d.Selected),
+        Capped: Math.Max(d.Selected - d.Offset - d.Results.Count, 0),
+        Truncated: Math.Max(d.Results.Count - rendered, 0),
+        Offset: d.Offset,
+        Remaining: Math.Max(d.Selected - (d.Offset + rendered), 0),
+        Notes: d.SelectorNotes?.Count ?? 0);
+
+    /// <summary>The chars held back from max_chars so the accounting block is always affordable — measured by
+    /// composing the WIDEST line this response could write, so no rendering of it can outgrow its own room.</summary>
+    internal static int AccountingReserve(AssetStatusData d) => Compose(Widest(d), everySentence: true).Length;
+
+    /// <summary>The widest line this response could produce: every count at its largest (so every digit slot is at its
+    /// real width) and, with <c>everySentence</c>, every optional sentence present. An upper bound, which is what a
+    /// reserve has to be.</summary>
+    static Counts Widest(AssetStatusData d)
     {
-        int capped = Math.Max(d.Selected - d.Results.Count, 0);       // left out of this window by limit/offset
-        int truncated = Math.Max(d.Results.Count - rendered, 0);      // left out of the render by max_chars
-        int remaining = d.Selected - (d.Offset + d.Results.Count);    // still AHEAD of the window — what pages on
-        var sb = new StringBuilder("\n\n[accounting] total=").Append(d.Selected)
-            .Append(" rendered=").Append(rendered)
-            .Append(" capped=").Append(capped)
-            .Append(" truncated=").Append(truncated)
-            .Append(" offset=").Append(d.Offset)
-            .Append(" remaining=").Append(Math.Max(remaining, 0))
-            .Append(" notes=").Append(d.SelectorNotes?.Count ?? 0);
-        // Only what is still AHEAD earns a next page: on the last page there is nothing to advance to, and an offset
-        // past the end would otherwise be told to re-call at the offset it already used.
-        if (remaining > 0)
+        int most = Math.Max(d.Selected, d.Results.Count);
+        return new Counts(most, d.Results.Count, most, most, d.Results.Count, d.Offset, most,
+                          d.SelectorNotes?.Count ?? 0);
+    }
+
+    /// <summary>The one machine-readable accounting line, always last: how many paths the selection named, how many
+    /// rendered, how many the paging window stepped over or left behind, and how many max_chars cut. A bulk consumer
+    /// keying results by path checks these numbers instead of counting prose it might miss (#246). Room for it is
+    /// reserved out of max_chars by <see cref="Render"/>, so it fits inside the cap rather than past it.</summary>
+    static string Compose(Counts c, bool everySentence)
+    {
+        var sb = new StringBuilder("\n\n[accounting] total=").Append(c.Total)
+            .Append(" rendered=").Append(c.Rendered)
+            .Append(" skipped=").Append(c.Skipped)
+            .Append(" capped=").Append(c.Capped)
+            .Append(" truncated=").Append(c.Truncated)
+            .Append(" offset=").Append(c.Offset)
+            .Append(" remaining=").Append(c.Remaining)
+            .Append(" notes=").Append(c.Notes);
+        // Only what is still AHEAD of what was rendered earns a next page, and the next offset starts at the first
+        // path this response did not show — so a caller following the advice sees every path exactly once.
+        if (everySentence || c.Remaining > 0)
             sb.Append("\nthe selection is longer than this window: re-call with offset=")
-              .Append(d.Offset + d.Results.Count).Append(" for the next page.");
-        else if (d.Selected > 0 && d.Offset >= d.Selected)
-            sb.Append("\noffset=").Append(d.Offset).Append(" is past the end of the selection (")
-              .Append(d.Selected).Append(" path(s)) — the last page starts before it.");
-        if (truncated > 0)
-            sb.Append("\nmax_chars cut ").Append(truncated).Append(" resolved path(s) from the render: raise max_chars, or page with limit=/offset=.");
+              .Append(c.Offset + c.Rendered).Append(" for the next page.");
+        // An offset past the end would otherwise be told to re-call at the offset it already used.
+        if (everySentence || (c.Remaining == 0 && c.Total > 0 && c.Offset >= c.Total))
+            sb.Append("\noffset=").Append(c.Offset).Append(" is past the end of the selection (")
+              .Append(c.Total).Append(" path(s)) — the last page starts before it.");
+        if (everySentence || c.Truncated > 0)
+            sb.Append("\nmax_chars cut ").Append(c.Truncated).Append(" resolved path(s) from the render: raise max_chars, or page with limit=/offset=.");
         return sb.ToString();
     }
 

--- a/src/housecarl-mcp/AssetTools.cs
+++ b/src/housecarl-mcp/AssetTools.cs
@@ -55,6 +55,9 @@ public static class AssetTools
             return "error: asset_paths and under are both empty. Pass Data-relative asset path(s) in asset_paths " +
                    "(e.g. 'textures/armor/iron/cuirass_1.dds'), or a Data-relative directory or glob in under " +
                    "(e.g. 'meshes/actors/character/facegendata/facegeom/Skyrim.esm').";
+        if (limit < 0 || offset < 0)
+            return $"error: limit={limit} offset={offset} — neither can be negative. Pass limit=0 for no limit and " +
+                   "offset=0 to start at the beginning of the selection.";
         var data = svc.AssetStatus(asset_paths ?? Array.Empty<string>(), under, limit, offset);
         return AssetWire.Render(data, max_chars > 0 ? max_chars : 80_000);
     });
@@ -89,7 +92,8 @@ static class AssetWire
     }
 
     /// <summary>What each under= selector had to say for itself — a selector that matched nothing, or was rejected.
-    /// Above the per-path list, with the other alarms, so a truncated sweep cannot cut it away.</summary>
+    /// Above the per-path list, with the other alarms, so a truncated sweep cannot cut it away. Uncapped, and bounded
+    /// by the call's own input: there is at most one note per selector the caller wrote.</summary>
     static void AppendSelectorNotes(StringBuilder sb, IReadOnlyList<string>? notes)
     {
         if (notes is not { Count: > 0 }) return;
@@ -102,17 +106,24 @@ static class AssetWire
     /// consumer keying results by path checks these numbers instead of counting prose it might miss (#246).</summary>
     static string Accounting(AssetStatusData d, int rendered)
     {
-        int capped = Math.Max(d.Selected - d.Results.Count, 0);       // left out by limit/offset
-        int truncated = Math.Max(d.Results.Count - rendered, 0);      // left out by max_chars
+        int capped = Math.Max(d.Selected - d.Results.Count, 0);       // left out of this window by limit/offset
+        int truncated = Math.Max(d.Results.Count - rendered, 0);      // left out of the render by max_chars
+        int remaining = d.Selected - (d.Offset + d.Results.Count);    // still AHEAD of the window — what pages on
         var sb = new StringBuilder("\n\n[accounting] total=").Append(d.Selected)
             .Append(" rendered=").Append(rendered)
             .Append(" capped=").Append(capped)
             .Append(" truncated=").Append(truncated)
             .Append(" offset=").Append(d.Offset)
+            .Append(" remaining=").Append(Math.Max(remaining, 0))
             .Append(" notes=").Append(d.SelectorNotes?.Count ?? 0);
-        if (capped > 0)
+        // Only what is still AHEAD earns a next page: on the last page there is nothing to advance to, and an offset
+        // past the end would otherwise be told to re-call at the offset it already used.
+        if (remaining > 0)
             sb.Append("\nthe selection is longer than this window: re-call with offset=")
               .Append(d.Offset + d.Results.Count).Append(" for the next page.");
+        else if (d.Selected > 0 && d.Offset >= d.Selected)
+            sb.Append("\noffset=").Append(d.Offset).Append(" is past the end of the selection (")
+              .Append(d.Selected).Append(" path(s)) — the last page starts before it.");
         if (truncated > 0)
             sb.Append("\nmax_chars cut ").Append(truncated).Append(" resolved path(s) from the render: raise max_chars, or page with limit=/offset=.");
         return sb.ToString();

--- a/src/housecarl-mcp/BatchRender.cs
+++ b/src/housecarl-mcp/BatchRender.cs
@@ -10,15 +10,20 @@ namespace HousecarlMcp;
 static class BatchRender
 {
     /// <summary>Renders one batch. <paramref name="itemNoun"/> is the plural-ish noun the cut line counts, e.g.
-    /// "path(s)" or "mesh(es)".</summary>
+    /// "path(s)" or "mesh(es)". <paramref name="reserve"/> is room the caller will write AFTER this body — an
+    /// accounting line, a footer — held back out of <paramref name="cap"/> so what follows fits inside max_chars
+    /// rather than past it. The cut marker still names <paramref name="cap"/>: that is the number the caller passed
+    /// and the number they would raise.</summary>
     public static string Render<T>(
         string header,
         IReadOnlyList<T> items,
         string itemNoun,
         int cap,
         Action<StringBuilder> appendAlarms,
-        Action<StringBuilder, T> appendItem)
+        Action<StringBuilder, T> appendItem,
+        int reserve = 0)
     {
+        int budget = Math.Max(cap - reserve, 1);
         var sb = new StringBuilder();
         sb.Append(header).Append('\n');
         appendAlarms(sb);
@@ -28,7 +33,7 @@ static class BatchRender
         {
             // shown > 0: the first item always renders its core answer even when the header and alarms alone
             // exhausted the cap.
-            if (shown > 0 && sb.Length >= cap)
+            if (shown > 0 && sb.Length >= budget)
             {
                 sb.Append('\n');
                 AppendCut(sb, items.Count - shown, itemNoun, cap);

--- a/src/housecarl-mcp/BatchRender.cs
+++ b/src/housecarl-mcp/BatchRender.cs
@@ -76,7 +76,7 @@ static class BatchRender
     }
 
     /// <summary>A capped bullet list inside an alarm block, cut with the same named marker.</summary>
-    static void AppendLines(StringBuilder sb, IReadOnlyList<string> lines, string itemNoun, int cap)
+    public static void AppendLines(StringBuilder sb, IReadOnlyList<string> lines, string itemNoun, int cap)
     {
         int shown = 0;
         foreach (var line in lines)

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -321,13 +321,44 @@ public sealed class LoadOrderService : IDisposable
     /// <see cref="AssetResolver.Capture"/> for the whole batch, so every path and the build-level BsaFailures /
     /// ReadIncomplete caveat describe a single build. A drive-rooted or '..'-escaping path is a per-path recoverable
     /// error, never a batch failure.</summary>
-    public AssetStatusData AssetStatus(IReadOnlyList<string> relPaths)
+    public AssetStatusData AssetStatus(
+        IReadOnlyList<string> relPaths,
+        IReadOnlyList<string>? under = null,
+        int limit = 0,
+        int offset = 0)
     {
         lock (_gate)
         {
             var view = Assets.Capture();                          // reentrant gate; build/refresh the asset resolver once for the batch
-            var results = new List<AssetPathResult>(relPaths.Count);
-            foreach (var raw in relPaths)
+            var notes = new List<string>();
+            var selected = new List<string>(relPaths);            // explicit paths first, in the order given, never deduped
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var p in relPaths)
+                try { seen.Add(AssetResolver.ValidateRelPath((p ?? "").Trim())); } catch (ArgumentException) { /* a bad explicit path answers per-path below */ }
+
+            foreach (var raw in under ?? Array.Empty<string>())
+            {
+                var sel = (raw ?? "").Trim();
+                if (sel.Length == 0) { notes.Add("under: an empty selector was skipped — pass a Data-relative directory or glob."); continue; }
+                try
+                {
+                    var matched = AssetGlob.Select(view, sel);
+                    // A selector that matched nothing is said out loud: read as a silent no-op it looks identical to a
+                    // folder no enabled mod provides, and a typo would then read as a clean sweep.
+                    if (matched.Count == 0)
+                        notes.Add($"under '{sel}' matched no file in the active load order — check the spelling, or nothing enabled provides that folder.");
+                    foreach (var m in matched) if (seen.Add(m)) selected.Add(m);
+                }
+                catch (ArgumentException ex) { notes.Add($"under '{sel}': {ex.Message}"); }
+            }
+
+            // Page over the SELECTED set and resolve only the window, so a 15k-file sweep pays for what it renders.
+            var total = selected.Count;
+            var start = Math.Min(Math.Max(offset, 0), total);
+            var window = selected.Skip(start).Take(limit > 0 ? limit : int.MaxValue).ToList();
+
+            var results = new List<AssetPathResult>(window.Count);
+            foreach (var raw in window)
             {
                 var p = (raw ?? "").Trim();
                 try
@@ -343,7 +374,8 @@ public sealed class LoadOrderService : IDisposable
                 }
                 catch (ArgumentException ex) { results.Add(new AssetPathResult(p, null, ex.Message)); }   // bad path → per-path note, never a batch failure
             }
-            return new AssetStatusData(results, view.BsaFailures, view.ReadIncomplete, _assetWarnings, _profileName);
+            return new AssetStatusData(results, view.BsaFailures, view.ReadIncomplete, _assetWarnings, _profileName,
+                                       notes, total, start);
         }
     }
 
@@ -8619,13 +8651,24 @@ public sealed record AssetPathResult(string RelPath, AssetHit? Hit, string? Erro
 /// build-level caveats — <see cref="BsaFailures"/> (archives that couldn't be read) and <see cref="ReadIncomplete"/>
 /// (an Exists=false answer may be wrong because a BSA failed to read) — and <see cref="Warnings"/> from archive
 /// discovery (e.g. a Skyrim.ini that couldn't be found, so base-game BSAs weren't scanned). <see cref="ProfileName"/>
-/// names the active profile the answer describes.</summary>
+/// names the active profile the answer describes.
+/// <para><see cref="SelectorNotes"/> carries what each <c>under=</c> directory / glob selector had to say for itself
+/// (a selector that matched nothing, or was rejected), <see cref="Total"/> is how many paths the whole selection named
+/// before paging, and <see cref="Offset"/> where the rendered window starts. A negative <see cref="Total"/> means
+/// nothing paged — the results ARE the selection.</para></summary>
 public sealed record AssetStatusData(
     IReadOnlyList<AssetPathResult> Results,
     IReadOnlyList<string> BsaFailures,
     bool ReadIncomplete,
     IReadOnlyList<string> Warnings,
-    string ProfileName);
+    string ProfileName,
+    IReadOnlyList<string>? SelectorNotes = null,
+    int Total = -1,
+    int Offset = 0)
+{
+    /// <summary>How many paths the selection named — <see cref="Results"/>'s own count when nothing paged.</summary>
+    public int Selected => Total < 0 ? Results.Count : Total;
+}
 
 /// <summary>One provider of an SKSE-layer file: the mod / "overwrite" / "Data" / BSA-filename, and whether it's a "loose" file or
 /// a "BSA" entry. The winner-first-then-losers ordering lives in <see cref="SkseFileEntry.Providers"/>.</summary>

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -324,8 +324,10 @@ public sealed class LoadOrderService : IDisposable
     /// <para><paramref name="under"/> is the directory / glob SELECT form (#246): each selector names a Data-relative
     /// folder, or a glob anchored under one, and contributes every path the VFS provides beneath it
     /// (<see cref="AssetGlob"/>). Its matches follow the explicit paths, sorted, with anything already named dropped.
-    /// <paramref name="limit"/> and <paramref name="offset"/> window the SELECTION, so only the window is resolved and
-    /// a folder-wide sweep pays for what it renders.</para></summary>
+    /// <paramref name="limit"/> and <paramref name="offset"/> window the SELECTION, so only the window is RESOLVED —
+    /// the per-path winner and provider chain, which is the expensive half. The selector ENUMERATION is not memoized:
+    /// each page re-walks the loose roots and re-scans the archive tables under the prefix, so a paged sweep pays the
+    /// enumeration once per page and the resolution once per rendered path.</para></summary>
     public AssetStatusData AssetStatus(
         IReadOnlyList<string> relPaths,
         IReadOnlyList<string>? under = null,
@@ -383,7 +385,8 @@ public sealed class LoadOrderService : IDisposable
                 catch (ArgumentException ex) { results.Add(new AssetPathResult(p, null, ex.Message)); }   // bad path → per-path note, never a batch failure
             }
             return new AssetStatusData(results, view.BsaFailures, view.ReadIncomplete, _assetWarnings, _profileName,
-                                       notes, total, Math.Max(offset, 0));   // the offset ASKED for, so a past-the-end page can say so
+                                       notes, total, Math.Max(offset, 0),    // the offset ASKED for, so a past-the-end page can say so
+                                       Math.Max(limit, 0));                  // the limit ASKED for, so the next-page advice repeats it
         }
     }
 
@@ -8662,8 +8665,9 @@ public sealed record AssetPathResult(string RelPath, AssetHit? Hit, string? Erro
 /// names the active profile the answer describes.
 /// <para><see cref="SelectorNotes"/> carries what each <c>under=</c> directory / glob selector had to say for itself
 /// (a selector that matched nothing, or was rejected), <see cref="Total"/> is how many paths the whole selection named
-/// before paging, and <see cref="Offset"/> where the rendered window starts. A negative <see cref="Total"/> means
-/// nothing paged — the results ARE the selection.</para></summary>
+/// before paging, <see cref="Offset"/> where the rendered window starts, and <see cref="Limit"/> the window size the
+/// caller asked for (0 = none), which the next-page advice repeats so a caller following it keeps paging. A negative
+/// <see cref="Total"/> means nothing paged — the results ARE the selection.</para></summary>
 public sealed record AssetStatusData(
     IReadOnlyList<AssetPathResult> Results,
     IReadOnlyList<string> BsaFailures,
@@ -8672,7 +8676,8 @@ public sealed record AssetStatusData(
     string ProfileName,
     IReadOnlyList<string>? SelectorNotes = null,
     int Total = -1,
-    int Offset = 0)
+    int Offset = 0,
+    int Limit = 0)
 {
     /// <summary>How many paths the selection named — <see cref="Results"/>'s own count when nothing paged.</summary>
     public int Selected => Total < 0 ? Results.Count : Total;

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -347,10 +347,13 @@ public sealed class LoadOrderService : IDisposable
                 if (sel.Length == 0) { notes.Add("under: an empty selector was skipped — pass a Data-relative directory or glob."); continue; }
                 try
                 {
-                    var matched = AssetGlob.Select(view, sel);
+                    var matched = AssetGlob.Select(view, sel, out var namedOneFile);
+                    // A selector that named a FILE is said out loud too, so the sweep's own count is explained.
+                    if (namedOneFile)
+                        notes.Add($"under '{sel}' names a file, not a directory — it was resolved as that one path.");
                     // A selector that matched nothing is said out loud: read as a silent no-op it looks identical to a
                     // folder no enabled mod provides, and a typo would then read as a clean sweep.
-                    if (matched.Count == 0)
+                    else if (matched.Count == 0)
                         notes.Add($"under '{sel}' matched no file in the active load order — check the spelling, or nothing enabled provides that folder.");
                     foreach (var m in matched) if (seen.Add(m)) selected.Add(m);
                 }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -320,7 +320,12 @@ public sealed class LoadOrderService : IDisposable
     /// which source provides it and which copy wins (loose beats BSA; among BSAs the higher plugin rank). One
     /// <see cref="AssetResolver.Capture"/> for the whole batch, so every path and the build-level BsaFailures /
     /// ReadIncomplete caveat describe a single build. A drive-rooted or '..'-escaping path is a per-path recoverable
-    /// error, never a batch failure.</summary>
+    /// error, never a batch failure.
+    /// <para><paramref name="under"/> is the directory / glob SELECT form (#246): each selector names a Data-relative
+    /// folder, or a glob anchored under one, and contributes every path the VFS provides beneath it
+    /// (<see cref="AssetGlob"/>). Its matches follow the explicit paths, sorted, with anything already named dropped.
+    /// <paramref name="limit"/> and <paramref name="offset"/> window the SELECTION, so only the window is resolved and
+    /// a folder-wide sweep pays for what it renders.</para></summary>
     public AssetStatusData AssetStatus(
         IReadOnlyList<string> relPaths,
         IReadOnlyList<string>? under = null,
@@ -375,7 +380,7 @@ public sealed class LoadOrderService : IDisposable
                 catch (ArgumentException ex) { results.Add(new AssetPathResult(p, null, ex.Message)); }   // bad path → per-path note, never a batch failure
             }
             return new AssetStatusData(results, view.BsaFailures, view.ReadIncomplete, _assetWarnings, _profileName,
-                                       notes, total, start);
+                                       notes, total, Math.Max(offset, 0));   // the offset ASKED for, so a past-the-end page can say so
         }
     }
 


### PR DESCRIPTION
`housecarl_asset_status` gains `under=`, the directory and glob form of its SELECT axis (SPEC §2.3), so a sweep names a folder instead of a path list. A selector is a Data-relative directory — every file the VFS provides beneath it, loose and archive both — or a glob anchored under one, where `*` matches within a path segment, `?` one character, and `**` any run of whole segments including none. `AssetResolver.EnumerateUnder` already did the enumeration; this exposes it, with the trailing-separator and Data-root spellings fixed so `facegeom/Skyrim.esm/` and `facegeom/Skyrim.esm` answer alike. It is one value on the existing axis, not a mode and not a second tool: `asset_paths=` and `under=` compose in one call, explicit paths keep their order and place, and a path the sweep already named is not resolved twice. The measure from the issue is a test — one call over `meshes\actors\character\facegendata\facegeom\<Master>` returns the same files and the same winners as spelling every path out, which is what collapses the ~40-call facegen phase to one call per defining master.

The secondary half of the issue is the accounting. Every response now ends with one structured line — `[accounting] total= rendered= capped= truncated= offset= remaining= notes=` — written after the `max_chars` cut, so it can never itself be truncated away, and a consumer keying results by path compares numbers instead of parsing the prose notice. `limit=`/`offset=` page the selection and only the window is resolved, so a folder-wide sweep pays for what it renders; the line says where the next page starts, and says when there isn't one. A selector that matched nothing says so rather than passing as a clean sweep, an unanchored glob is refused rather than walking every mod root and archive table, and a drive-rooted or `..`-escaping selector goes through the same guard every asset path does.

Build, 1071 tests and `ci-all` (127/127) green. Fifteen new tests over a synthetic MO2 world whose facegen set is split across two loose mods and one authored BSA.

Closes #246
