### PR TITLE
Strings and localization: the redirect gate, and what merge and compact do not say

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -104,6 +104,37 @@ saying it sets an expectation their install may contradict. Say what is known, a
   the summary no longer reports a clean bill of health over it. A class that also has a clean DLL that loads stays
   healthy: that DLL implements it for everyone. The inventory family already flagged this, so the two families no
   longer disagree about the same file.
+- **A localized plugin whose text lives in the game's `Data` folder now reads its names and descriptions even when a
+  `.bsa` sits beside it.** houseCARL pointed the strings lookup at game-Data only when the plugin's own folder carried
+  no strings source, and it answered that with "is there a `Strings\` folder" plus "is there any `.bsa`" — so an
+  archive holding only meshes and textures, and a shared `Strings\` folder holding only a neighbouring plugin's tables,
+  both suppressed the lookup and every localized value read back empty. The question is now asked about the named
+  plugin: a loose table matching its name, or an archive beside it that embeds one. This reaches every read houseCARL
+  does, including the copies `housecarl_merge_plugins` and `housecarl_compact_plugin` write.
+
+- **`housecarl_merge_plugins` and `housecarl_compact_plugin` now refuse a localized plugin whose `.STRINGS` houseCARL
+  cannot find anywhere.** Such a plugin reads every name, description and message as empty, and both verbs wrote those
+  blanks into the output and reported an ordinary success. The refusal names the plugin, says what reads empty, and
+  says the tables may be somewhere it cannot see from the plugin's own folder — a translation mod that is not enabled,
+  or content whose archive is in another mod folder. Nothing is written. A plugin whose strings do resolve is
+  unaffected.
+
+- **`housecarl_merge_plugins` now states that it de-localizes a localized donor.** The merged plugin is never flagged
+  localized, so a donor's text is written into it inline: the donor's `.STRINGS` files no longer describe the output,
+  and any language they shipped that this read did not resolve is not in it. The report names each donor houseCARL
+  read and found flagged. `housecarl_compact_plugin`'s new-file lane already said this.
+
+- **`housecarl_merge_plugins` now finds plugins that only DECLARE a donor as a master.** The safety scan read record
+  links and record identity and never opened a header, so a compat patch that lists a donor as a master while
+  referencing none of its records was reported as no dependent at all — and stopped loading, for want of a master, as
+  soon as the donor was deactivated. Those plugins are now named with what they declare and what to do about it, and
+  the pass line says what the scan does and does not read. `housecarl_compact_plugin` does not report them: its output
+  keeps the source's basename, so a declarer's master is still there.
+
+- **`housecarl_merge_plugins`'s `.esl` refusal no longer states a reason that is false for a light donor.** It said a
+  merge keeps the donors' object ids in the full range; renaming an already-light plugin — a single-donor merge — has
+  ids that are all inside the light window. The refusal now says what the merge does not do (it never renumbers into
+  the light range) and points at `housecarl_compact_plugin`, which does.
 
 - **`housecarl_asset_status` under a `max_chars` its header and alarms already fill now renders the first path's
   answer instead of cutting to none.** `housecarl_nif_inspect` already did; both tools now render through one batch

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -139,9 +139,10 @@ saying it sets an expectation their install may contradict. Say what is known, a
   unchanged in outcome; what changed is that it no longer claims an absence nothing checked.
 
 - **`housecarl_merge_plugins`'s `.esl` refusal no longer states a reason that is false for a light donor.** It said a
-  merge keeps the donors' object ids in the full range; renaming an already-light plugin — a single-donor merge — has
-  ids that are all inside the light window. The refusal now says what the merge does not do (it never renumbers into
-  the light range) and points at `housecarl_compact_plugin`, which does.
+  merge keeps the donors' object ids where they already are; a merge renumbers cross-donor collisions and ids below
+  the write floor, and renaming an already-light plugin — a single-donor merge — has ids that are all inside the light
+  window anyway. The refusal now says what the merge does not do (it never constrains object ids to the light window)
+  and points at `housecarl_compact_plugin`, which does.
 
 - **`housecarl_asset_status` under a `max_chars` its header and alarms already fill now renders the first path's
   answer instead of cutting to none.** `housecarl_nif_inspect` already did; both tools now render through one batch

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -131,6 +131,13 @@ saying it sets an expectation their install may contradict. Say what is known, a
   the pass line says what the scan does and does not read. `housecarl_compact_plugin` does not report them: its output
   keeps the source's basename, so a declarer's master is still there.
 
+- **A localized plugin in a mod folder houseCARL cannot list is no longer described as having no strings anywhere.**
+  The folder's "could not be listed" answer was read and then dropped, so a plugin whose tables sit in a `.bsa` in
+  that folder was refused with a sentence saying there is no archive beside it, and a remedy telling the modder to go
+  and find the tables. Such a plugin now classifies as its own shape: the refusal says the folder could not be read,
+  and the remedy names that folder — close whatever holds it open, or fix its permissions. The refusal itself is
+  unchanged in outcome; what changed is that it no longer claims an absence nothing checked.
+
 - **`housecarl_merge_plugins`'s `.esl` refusal no longer states a reason that is false for a light donor.** It said a
   merge keeps the donors' object ids in the full range; renaming an already-light plugin — a single-donor merge — has
   ids that are all inside the light window. The refusal now says what the merge does not do (it never renumbers into

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -454,9 +454,11 @@ public sealed class LoadOrderResolver : IDisposable
     /// — the near-universal "Cleaned Base Game Masters" pattern, whose <c>.STRINGS</c> live in the game-Data BSAs beside
     /// Skyrim.esm — otherwise reads every localized field EMPTY: <see cref="ReadEngine.EmitToken"/> turns the
     /// unresolved <c>TranslatedString</c> into a blank token, so a name filter silently matches nothing. When the
-    /// plugin's own folder carries NO strings source, point the lookup at the real game-Data
+    /// plugin's own folder carries NO strings source FOR THIS PLUGIN, point the lookup at the real game-Data
     /// folder so those archived strings resolve; otherwise leave the folder-adjacent default UNTOUCHED, so a mod whose
-    /// strings sit in its own folder (loose OR in its own BSA) is never redirected away from them — no regression. A
+    /// strings sit in its own folder (loose OR in its own BSA) is never redirected away from them — no regression.
+    /// The gate asks about THIS plugin, not about the folder: an asset-only <c>.bsa</c> beside a plugin whose tables
+    /// live in game-Data used to suppress the redirect and blank every value it read (#369). A
     /// non-localized plugin needs no strings at all, so the override is simply never consulted.
     ///
     /// <para>Public because it is also the open path for a raw, out-of-load-order read of an inactive or arbitrary
@@ -480,21 +482,12 @@ public sealed class LoadOrderResolver : IDisposable
         return SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
     }
 
-    /// <summary>True if the plugin's OWN folder carries a strings source Mutagen's folder-adjacent default would find —
-    /// a loose <c>Strings\</c> subfolder or any <c>.bsa</c> (which may embed strings). Cheap (one dir stat + a lazy,
-    /// short-circuited <c>.bsa</c> scan; negligible beside the per-plugin overlay open it precedes). Defensive: any IO
-    /// fault answers "has its own", keeping the unchanged default open — we only ever REDIRECT on a clean, empty read.</summary>
-    internal static bool FolderHasOwnStrings(string path)
-    {
-        try
-        {
-            var folder = Path.GetDirectoryName(path);
-            if (folder is null) return true;
-            if (Directory.Exists(Path.Combine(folder, "Strings"))) return true;
-            return Directory.EnumerateFiles(folder, "*.bsa").Any();
-        }
-        catch { return true; }
-    }
+    /// <summary>True if the plugin's OWN folder carries a strings source FOR THIS PLUGIN — a loose table matching its
+    /// name, or a <c>.bsa</c> beside it that embeds one. One home, <see cref="LocalizedStrings.OwnFolderCarriesStringsFor"/>:
+    /// the same question the strings classifier answers, so the read side and the refusal side cannot disagree about
+    /// whether a source exists. Defensive there too: any IO fault answers "has its own", keeping the unchanged default
+    /// open — we only ever REDIRECT on a clean, empty read.</summary>
+    internal static bool FolderHasOwnStrings(string path) => LocalizedStrings.OwnFolderCarriesStringsFor(path);
 
     /// <summary>Take the plugin paths already in priority order and build the index, without holding any plugin open.
     /// Names and mtimes come from the path list plus a stat (no parse, no handle); the index build

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -954,8 +954,11 @@ public sealed class LoadOrderResolver : IDisposable
 
     /// <summary>The master filenames a plugin declares in its header (the master TABLE). Opens the overlay, reads
     /// <c>ModHeader.MasterReferences</c>, disposes — the header parses without enumerating records. Throws
-    /// on a name not in the order or excluded this build, mirroring <see cref="PluginRecordStatus"/>. The
-    /// integrity sweep (housecarl_check_errors) diffs this against the masters a plugin's records actually reference.</summary>
+    /// on a name not in the order or excluded this build, mirroring <see cref="PluginRecordStatus"/>, and throws
+    /// <see cref="PluginUnreadableException"/> on a plugin that opened at index-build time but cannot be opened now —
+    /// the same fault, in the same words, as the record stream's, so a caller that classifies the two reads of one
+    /// plugin cannot give the same held-open file two different causes. The integrity sweep
+    /// (housecarl_check_errors) diffs this against the masters a plugin's records actually reference.</summary>
     public IReadOnlyList<string> DeclaredMasters(string pluginName) => DeclaredMasters(pluginName, _snap);
 
     IReadOnlyList<string> DeclaredMasters(string pluginName, IndexSnapshot s)
@@ -964,7 +967,11 @@ public sealed class LoadOrderResolver : IDisposable
             throw new ArgumentException($"plugin not in the load order: {pluginName}.{AbsenceClause(pluginName)}");
         if (s.Excluded.Contains(idx))
             throw new ArgumentException($"plugin '{pluginName}' was excluded from this session: {s.ExcludedPlugins[pluginName]}");
-        var ov = OpenOverlay(_paths[idx], _dataDir);
+        ISkyrimModGetter ov;
+        // Named as unopenable, exactly as RecordsIn names it: the header read and the record walk open the same file
+        // the same way, so a plugin held open by another program must arrive at both callers as one fault.
+        try { ov = OpenOverlay(_paths[idx], _dataDir); }
+        catch (Exception ex) { throw new PluginUnreadableException(_names[idx], ex); }
         try { return ov.ModHeader.MasterReferences.Select(m => m.Master.FileName.ToString()).ToList(); }
         finally { (ov as IDisposable)?.Dispose(); }
     }

--- a/src/housecarl-core/LocalizedStrings.cs
+++ b/src/housecarl-core/LocalizedStrings.cs
@@ -287,6 +287,53 @@ public static class LocalizedStrings
         return (a.Shape, LocalizedTargetUnsupportedException.ShapeBody(a));
     }
 
+    /// <summary>Does the plugin's OWN folder carry a strings source FOR THIS PLUGIN — a loose table beside it, or a
+    /// <c>.bsa</c> there that embeds one? The read side's redirect gate (<see cref="LoadOrderResolver.OpenOverlay"/>):
+    /// false means the folder-adjacent lookup would resolve nothing for this plugin, so the open points at game-Data
+    /// instead.
+    ///
+    /// <para>Answers for the NAMED plugin, never for the folder in general. A <c>Strings\</c> folder holding only a
+    /// NEIGHBOUR's tables, and an asset-only <c>.bsa</c> (meshes/textures — the common case), are not this plugin's
+    /// source; counting either suppressed the redirect for a whole population of localized plugins whose text was
+    /// reachable in game-Data and read back blank everywhere (#369).</para>
+    ///
+    /// <para>Cost: the loose look is one directory listing, and the archive look is the folder-keyed
+    /// <see cref="ArchiveStrings"/> cache the classifier already builds — so a mod folder's archives are enumerated
+    /// once per server process rather than once per open. Any IO fault answers TRUE, keeping the unchanged
+    /// folder-adjacent open: we only ever redirect on a clean, empty read.</para></summary>
+    public static bool OwnFolderCarriesStringsFor(string pluginPath)
+    {
+        try
+        {
+            var folder = Path.GetDirectoryName(pluginPath);
+            if (folder is null) return true;
+            var stem = Path.GetFileNameWithoutExtension(pluginPath);
+            var loose = ReadStringsFolder(Path.Combine(folder, "Strings"), stem);
+            // A folder that is there and could not be LISTED tells us nothing about what is in it — keep the default.
+            if (loose.Read == StringsFolderRead.Unlistable) return true;
+            if (loose.Languages.Count > 0) return true;
+            // BsaEmbedding returns the archive's path both when it embeds this plugin's tables and when it could not
+            // be parsed at all, so a non-null answer covers "found it" and "cannot see in there" alike — and the
+            // second keeps the unchanged open rather than redirecting past an archive that may hold the strings.
+            return BsaEmbedding(folder, stem).Path is not null;
+        }
+        catch { return true; }
+    }
+
+    /// <summary>Could houseCARL find NO strings source at all for a plugin it read and found flagged localized? True
+    /// for the two shapes where a read resolves nothing: nothing found anywhere, and a <c>Strings\</c> folder beside
+    /// the plugin that could not be listed. Every value such a plugin carries reads EMPTY, so a lane that would bake
+    /// that read into a new file refuses rather than writing blanks (#371).
+    ///
+    /// <para><see cref="LocalizedShape.Unreadable"/> is deliberately NOT here: the plugin's own header was never
+    /// read, so nothing is known about its strings, and a lane that must act on that answers it as unreadable in its
+    /// own words.</para></summary>
+    public static bool ResolvesNowhere(LocalizedShape shape) => shape switch
+    {
+        LocalizedShape.Nowhere or LocalizedShape.StringsFolderUnreadable => true,
+        _ => false,
+    };
+
     /// <summary>The loose table files this plugin's own folder carries — what a read resolves against, and what a
     /// refusal has to leave byte-identical.</summary>
     public static IReadOnlyList<string> OwnTableFiles(string pluginPath)

--- a/src/housecarl-core/LocalizedStrings.cs
+++ b/src/housecarl-core/LocalizedStrings.cs
@@ -306,7 +306,9 @@ public static class LocalizedStrings
         try
         {
             var folder = Path.GetDirectoryName(pluginPath);
-            if (folder is null) return true;
+            // A folder that is not there is not a clean, empty read — it is a bad one, and the redirect is only ever
+            // taken on a clean one.
+            if (folder is null || !Directory.Exists(folder)) return true;
             var stem = Path.GetFileNameWithoutExtension(pluginPath);
             var loose = ReadStringsFolder(Path.Combine(folder, "Strings"), stem);
             // A folder that is there and could not be LISTED tells us nothing about what is in it — keep the default.

--- a/src/housecarl-core/LocalizedStrings.cs
+++ b/src/housecarl-core/LocalizedStrings.cs
@@ -182,7 +182,11 @@ public static class LocalizedStrings
         // An archive the write cannot rewrite decides the shape regardless of what else is on disk — a loose set beside
         // a BSA that also embeds this plugin's strings is an ambiguous source, and which one Mutagen prefers is not
         // something this classifier should be guessing at when the answer is "refuse either way".
-        var (bsaPath, bsaUnreadable) = BsaEmbedding(folder, stem);
+        // The folder-unlistable answer is not consumed here: a mod folder that will not list also hides its
+        // Strings\ folder, so this classification falls through to the shapes that resolve NOWHERE and every lane
+        // reading it refuses. Fail-CLOSED is the right default for a write; the read side's gate takes the third
+        // answer, because its default is to leave the open unchanged.
+        var (bsaPath, bsaUnreadable, _) = BsaEmbedding(folder, stem);
         if (bsaPath is not null)
             return new LocalizedAssessment(LocalizedShape.BsaEmbedded, Names(own), Incomplete(own), Names(gameData),
                                            bsaPath, bsaUnreadable, dataDir is null, UnmatchedTables: unmatched);
@@ -215,7 +219,7 @@ public static class LocalizedStrings
         // nothing nearer was found, so an ordinary plugin never pays for it.
         if (dataDir is not null)
         {
-            var (gdBsa, gdUnreadable) = BsaEmbedding(dataDir, stem);
+            var (gdBsa, gdUnreadable, _) = BsaEmbedding(dataDir, stem);
             if (gdBsa is not null)
                 return new LocalizedAssessment(LocalizedShape.BsaEmbedded, Array.Empty<string>(), NoneIncomplete,
                                                Array.Empty<string>(), gdBsa, gdUnreadable, false, BsaInGameData: true,
@@ -317,7 +321,11 @@ public static class LocalizedStrings
             // BsaEmbedding returns the archive's path both when it embeds this plugin's tables and when it could not
             // be parsed at all, so a non-null answer covers "found it" and "cannot see in there" alike — and the
             // second keeps the unchanged open rather than redirecting past an archive that may hold the strings.
-            return BsaEmbedding(folder, stem).Path is not null;
+            var bsa = BsaEmbedding(folder, stem);
+            // The mod folder itself would not list — the same fact as the unlistable Strings\ folder above, and the
+            // same answer: nothing is known about what is beside the plugin, so the default open stands.
+            if (bsa.FolderUnlistable) return true;
+            return bsa.Path is not null;
         }
         catch { return true; }
     }
@@ -447,19 +455,25 @@ public static class LocalizedStrings
     /// when the archive could not be parsed at all — an archive we cannot see into is refused rather than assumed
     /// harmless (a malformed one is not merely opaque: it takes the plugin's own open down with an ArchiveException).
     /// No archive is opened unless one is present, which is the common case at ~0.06 ms.</summary>
-    static (string? Path, bool Unreadable) BsaEmbedding(string folder, string stem)
+    static (string? Path, bool Unreadable, bool FolderUnlistable) BsaEmbedding(string folder, string stem)
     {
+        var (folderUnlistable, entries) = ArchiveStrings(folder);
+        // The folder would not list, so which archives are in it — and whether any carries this stem — was never
+        // established. Reported as its own answer rather than as "no archive": there is no archive to name, and a
+        // caller that must not conclude an absence needs to be told it cannot.
+        if (folderUnlistable) return (null, false, true);
+
         // A POSITIVE hit wins over an unreadable one: returning on the first unreadable archive would let a single
         // unparseable .bsa anywhere in game-Data answer for every plugin that searched there, naming an archive that
         // neither sits beside the plugin nor carries its tables. An archive we cannot see into still refuses, but only
         // once no archive has actually claimed the stem.
         string? unreadable = null;
-        foreach (var e in ArchiveStrings(folder))
+        foreach (var e in entries)
         {
             if (e.Unreadable) { unreadable ??= e.Archive; continue; }
-            if (e.Stems.Contains(stem)) return (e.Archive, false);
+            if (e.Stems.Contains(stem)) return (e.Archive, false, false);
         }
-        return unreadable is null ? (null, false) : (unreadable, true);
+        return unreadable is null ? (null, false, false) : (unreadable, true, false);
     }
 
     /// <summary>Per archive in a folder: which plugin stems it embeds strings for. Cached by folder, because game-Data
@@ -502,17 +516,20 @@ public static class LocalizedStrings
         return string.Join(" ", parts);
     }
 
-    static List<ArchiveEntry> ArchiveStrings(string folder)
+    static (bool Unlistable, List<ArchiveEntry> Entries) ArchiveStrings(string folder)
     {
         string[] archives;
+        // THE SAME THREE ANSWERS the loose look has, for the same reason: a folder that could not be listed is not a
+        // folder found to hold no archives, and returning the empty list for both made the read side's gate conclude
+        // an absence it never checked.
         try { archives = Directory.GetFiles(folder, "*.bsa"); }
-        catch (IOException) { return NoArchives; }
-        catch (UnauthorizedAccessException) { return NoArchives; }
-        if (archives.Length == 0) return NoArchives;
+        catch (IOException) { return (true, NoArchives); }
+        catch (UnauthorizedAccessException) { return (true, NoArchives); }
+        if (archives.Length == 0) return (false, NoArchives);
         var stamp = ArchiveStamp(archives);
 
         lock (ArchiveCache)
-            if (ArchiveCache.TryGetValue(folder, out var hit) && hit.Stamp == stamp) return hit.Entries;
+            if (ArchiveCache.TryGetValue(folder, out var hit) && hit.Stamp == stamp) return (false, hit.Entries);
 
         var entries = new List<ArchiveEntry>();
         foreach (var a in archives)
@@ -538,7 +555,7 @@ public static class LocalizedStrings
         }
 
         lock (ArchiveCache) ArchiveCache[folder] = (stamp, entries);
-        return entries;
+        return (false, entries);
     }
 
     static IReadOnlyList<string> Names(Dictionary<string, List<string>> m) => m.Keys.OrderBy(x => x).ToList();

--- a/src/housecarl-core/LocalizedStrings.cs
+++ b/src/housecarl-core/LocalizedStrings.cs
@@ -65,6 +65,17 @@ public enum LocalizedShape
     /// beside a plugin whose folder is full — an absence claim nothing checked.</para></summary>
     StringsFolderUnreadable,
 
+    /// <summary>Flagged localized, and the MOD FOLDER holding the plugin could not be listed — a deny ACE, a share
+    /// that refuses enumeration, a path the filesystem will not walk.
+    ///
+    /// <para>Its own shape for the same reason <see cref="StringsFolderUnreadable"/> is, one level up: nothing may be
+    /// concluded about what sits beside the plugin, and an archive there carrying its tables is invisible. On Windows
+    /// listing a directory is a separate right from traversing it, so the <c>Strings\</c> subfolder can enumerate
+    /// perfectly well while the archive look at the folder itself throws — which is how this arrived at
+    /// <see cref="Nowhere"/>, whose sentence then says there is "no archive beside it" about a folder nothing could
+    /// read.</para></summary>
+    ModFolderUnreadable,
+
     /// <summary>Flagged localized, and houseCARL can find no strings source for it — the residual case.
     ///
     /// <para>This says what houseCARL could FIND, not what exists: MO2's VFS merges mod folders at runtime, so a
@@ -182,11 +193,10 @@ public static class LocalizedStrings
         // An archive the write cannot rewrite decides the shape regardless of what else is on disk — a loose set beside
         // a BSA that also embeds this plugin's strings is an ambiguous source, and which one Mutagen prefers is not
         // something this classifier should be guessing at when the answer is "refuse either way".
-        // The folder-unlistable answer is not consumed here: a mod folder that will not list also hides its
-        // Strings\ folder, so this classification falls through to the shapes that resolve NOWHERE and every lane
-        // reading it refuses. Fail-CLOSED is the right default for a write; the read side's gate takes the third
-        // answer, because its default is to leave the open unchanged.
-        var (bsaPath, bsaUnreadable, _) = BsaEmbedding(folder, stem);
+        // The folder's third answer is carried, not dropped: a mod folder that will not list may hold an archive with
+        // this plugin's tables in it, so nothing found below is an absence. It decides the shape only where nothing
+        // was found anywhere — see the ModFolderUnreadable return at the end.
+        var (bsaPath, bsaUnreadable, folderUnlistable) = BsaEmbedding(folder, stem);
         if (bsaPath is not null)
             return new LocalizedAssessment(LocalizedShape.BsaEmbedded, Names(own), Incomplete(own), Names(gameData),
                                            bsaPath, bsaUnreadable, dataDir is null, UnmatchedTables: unmatched);
@@ -226,6 +236,14 @@ public static class LocalizedStrings
                                                UnmatchedTables: unmatched);
         }
 
+        // NOTHING FOUND ANYWHERE, and the mod folder itself would not list — so the reason nothing was found may be
+        // that nothing could be looked at. Its own shape rather than Nowhere, whose sentence asserts there is no
+        // archive beside the plugin: on Windows the Strings\ subfolder can still enumerate while the archive look at
+        // the folder throws, so this is reachable with a complete .bsa sitting right there. It still REFUSES — the
+        // lanes reading it are fail-closed — but it claims no absence.
+        if (folderUnlistable)
+            return Plain(LocalizedShape.ModFolderUnreadable, dataDir is null) with { UnmatchedTables = unmatched };
+
         return Plain(LocalizedShape.Nowhere, dataDir is null) with { UnmatchedTables = unmatched };
     }
 
@@ -262,7 +280,7 @@ public static class LocalizedStrings
         // The header was read and the flag is set. Where the text lives varies; that it is localized does not.
         LocalizedShape.LooseComplete or LocalizedShape.LoosePartial or LocalizedShape.LooseWithGameDataDuplicate
             or LocalizedShape.BsaEmbedded or LocalizedShape.GameDataOnly or LocalizedShape.StringsFolderUnreadable
-            or LocalizedShape.Nowhere => true,
+            or LocalizedShape.ModFolderUnreadable or LocalizedShape.Nowhere => true,
 
         // Read it, flag clear.
         LocalizedShape.NotLocalized => false,
@@ -331,16 +349,17 @@ public static class LocalizedStrings
     }
 
     /// <summary>Could houseCARL find NO strings source at all for a plugin it read and found flagged localized? True
-    /// for the two shapes where a read resolves nothing: nothing found anywhere, and a <c>Strings\</c> folder beside
-    /// the plugin that could not be listed. Every value such a plugin carries reads EMPTY, so a lane that would bake
-    /// that read into a new file refuses rather than writing blanks (#371).
+    /// for the three shapes where a read resolves nothing houseCARL can see: nothing found anywhere, a
+    /// <c>Strings\</c> folder beside the plugin that could not be listed, and a mod folder that could not be listed.
+    /// Every value such a plugin carries reads EMPTY (or, for the two unlistable folders, cannot be told from empty),
+    /// so a lane that would bake that read into a new file refuses rather than writing blanks (#371).
     ///
     /// <para><see cref="LocalizedShape.Unreadable"/> is deliberately NOT here: the plugin's own header was never
     /// read, so nothing is known about its strings, and a lane that must act on that answers it as unreadable in its
     /// own words.</para></summary>
     public static bool ResolvesNowhere(LocalizedShape shape) => shape switch
     {
-        LocalizedShape.Nowhere or LocalizedShape.StringsFolderUnreadable => true,
+        LocalizedShape.Nowhere or LocalizedShape.StringsFolderUnreadable or LocalizedShape.ModFolderUnreadable => true,
         _ => false,
     };
 
@@ -513,7 +532,7 @@ public static class LocalizedStrings
             catch (IOException) { parts.Add(Path.GetFileName(a) + "|?"); }
             catch (UnauthorizedAccessException) { parts.Add(Path.GetFileName(a) + "|?"); }
         }
-        return string.Join(" ", parts);
+        return string.Join(" ", parts);
     }
 
     static (bool Unlistable, List<ArchiveEntry> Entries) ArchiveStrings(string folder)

--- a/src/housecarl-core/RemapEngine.cs
+++ b/src/housecarl-core/RemapEngine.cs
@@ -60,6 +60,17 @@ public static class RemapEngine
     /// the repoint path, which would report a false success. <paramref name="Record"/> is the overridden FormKey.</summary>
     public sealed record ExternalOverride(string Plugin, FormKey Record, string RecordType);
 
+    /// <summary>One plugin OUTSIDE the transform set that DECLARES a plugin in it as a master while referencing and
+    /// overriding none of its records — a third kind of dependent, found in the header rather than in the records.
+    ///
+    /// <para>A normal shape for a compat patch that exists to be load-ordered, or one whose overrides were trimmed
+    /// later. It is invisible to a walk over record links and record identity, and it breaks the moment the donor is
+    /// deactivated: the game refuses to load a plugin missing a master. Reported ONLY when the plugin is neither a
+    /// referencer nor an overrider — every referencer declares the donor as a master too, so listing them all would
+    /// just repeat the referencer list under a new heading.</para></summary>
+    /// <param name="Declared">Which plugins of the transform set it lists as masters.</param>
+    public sealed record MasterDeclarer(string Plugin, IReadOnlyList<string> Declared);
+
     /// <summary>Why the identify pass could not read a plugin through. Two causes with two different remedies:
     /// <see cref="Unopenable"/> is a file that would not open at all — almost always another program holding it, and
     /// closing that program fixes the run; <see cref="EnumerationFault"/> is a file that opened and then threw part
@@ -76,7 +87,11 @@ public static class RemapEngine
     /// order (the opt-in-rewrite set), the external OVERRIDERS (detect and warn, not repointable), how many plugins
     /// were scanned THROUGH (a plugin whose scan faulted is not one of them), and the fault accounting — a record
     /// whose link walk threw is counted and sampled, and a plugin that could not be read through is named, with its
-    /// cause and reason, in <see cref="UnscannablePlugins"/>; neither is ever silently skipped.</summary>
+    /// cause and reason, in <see cref="UnscannablePlugins"/>; neither is ever silently skipped.
+    ///
+    /// <para><see cref="MasterDeclarers"/> is the third dependent kind, read from headers rather than records: plugins
+    /// that DECLARE a transform-set plugin as a master while referencing and overriding none of its records. Only
+    /// those the record walk did not already find are listed — see <see cref="MasterDeclarer"/>.</para></summary>
     public sealed record IdentifyResult(
         IReadOnlyList<ExternalRef> Refs,
         IReadOnlyList<string> ExternalPlugins,
@@ -85,7 +100,8 @@ public static class RemapEngine
         IReadOnlyList<string> UnscannableSamples,
         IReadOnlyList<ExternalOverride> Overrides,
         IReadOnlyList<string> ExternalOverriders,
-        IReadOnlyList<UnscannablePlugin>? UnscannablePlugins = null)
+        IReadOnlyList<UnscannablePlugin>? UnscannablePlugins = null,
+        IReadOnlyList<MasterDeclarer>? MasterDeclarers = null)
     {
         /// <summary>True when at least one plugin OUTSIDE the transform set references a remapped FormKey — the
         /// signal the default new-plugin path must not pass silently: fail loud and offer the opt-in rewrite.</summary>
@@ -118,6 +134,7 @@ public static class RemapEngine
         int scanned = 0, unscannable = 0;
         var unscannableSamples = new List<string>();
         var unscannablePlugins = new List<UnscannablePlugin>();   // plugins whose scan faulted — NOT counted as scanned
+        var declarers = new List<MasterDeclarer>();               // plugins declaring a transform-set plugin as a master
         // PluginNames CAN list a filename more than once in a degenerate order; scanning a name twice would
         // double-count + double-list it. A real MO2 VFS yields unique filenames, so this is belt-and-braces — but
         // it keeps the result correct regardless (the listing is, by contract, DISTINCT).
@@ -130,6 +147,23 @@ public static class RemapEngine
             if (!scannedNames.Add(plugin)) continue;                     // a duplicate name in the order — scan and list it once, never double-count
             bool pluginListed = false;
             bool pluginListedOverride = false;
+
+            // The HEADER read, before the records: a plugin that merely LISTS a plugin in the transform set as a
+            // master is a dependent no walk over links and identity can see, and it loses a master the moment the
+            // donor is deactivated. Its own try, because a header that will not read means the file will not open at
+            // all — the record scan would fail the same way, and the plugin is named as unopenable rather than
+            // silently counted as declaring nothing.
+            List<string> declares;
+            try { declares = view.DeclaredMasters(plugin).Where(transformSet.Contains).ToList(); }
+            catch (Exception ex)
+            {
+                unscannable++;
+                var headerInner = (ex as PluginUnreadableException)?.InnerException ?? ex;
+                unscannablePlugins.Add(new UnscannablePlugin(plugin, UnscannableCause.Unopenable,
+                                                             $"{headerInner.GetType().Name}: {headerInner.Message}"));
+                continue;
+            }
+            if (declares.Count > 0) declarers.Add(new MasterDeclarer(plugin, declares));
 
             try
             {
@@ -197,7 +231,14 @@ public static class RemapEngine
             }
         }
 
-        return new IdentifyResult(refs, externalPlugins, scanned, unscannable, unscannableSamples, overrides, externalOverriders, unscannablePlugins);
+        // DECLARER-ONLY: a referencer or an overrider necessarily declares the donor as a master too, so the new
+        // category is the plugins the record walk did NOT already find — the dependents that were invisible.
+        var alreadyFound = new HashSet<string>(externalPlugins, StringComparer.OrdinalIgnoreCase);
+        alreadyFound.UnionWith(externalOverriders);
+        var declarerOnly = declarers.Where(d => !alreadyFound.Contains(d.Plugin)).ToList();
+
+        return new IdentifyResult(refs, externalPlugins, scanned, unscannable, unscannableSamples, overrides, externalOverriders,
+                                  unscannablePlugins, declarerOnly);
     }
 
     // ======================================================================

--- a/src/housecarl-core/RemapEngine.cs
+++ b/src/housecarl-core/RemapEngine.cs
@@ -123,8 +123,13 @@ public static class RemapEngine
     /// Mutagen can't parse is counted and sampled, never an opaque whole-call abort and never a silent skip. One
     /// <see cref="LoadOrderResolver.Capture"/> pins the whole pass; the resolver streams one plugin at a time.
     /// </summary>
+    /// <param name="readDeclaredMasters">Also read each candidate's HEADER and report the declarer-only dependents
+    /// (<see cref="MasterDeclarer"/>). Opt-in because it costs one extra open per plugin on a whole-order walk, and
+    /// only a caller that RENAMES the transform set has anything to report: compact's output keeps the source's
+    /// basename, so a declarer's master is still there afterwards.</param>
     public static IdentifyResult IdentifyExternalReferencers(
-        LoadOrderResolver resolver, IReadOnlySet<FormKey> targets, IReadOnlySet<string> transformSet)
+        LoadOrderResolver resolver, IReadOnlySet<FormKey> targets, IReadOnlySet<string> transformSet,
+        bool readDeclaredMasters = false)
     {
         var view = resolver.Capture();
         var refs = new List<ExternalRef>();
@@ -153,17 +158,31 @@ public static class RemapEngine
             // donor is deactivated. Its own try, because a header that will not read means the file will not open at
             // all — the record scan would fail the same way, and the plugin is named as unopenable rather than
             // silently counted as declaring nothing.
-            List<string> declares;
-            try { declares = view.DeclaredMasters(plugin).Where(transformSet.Contains).ToList(); }
-            catch (Exception ex)
+            if (readDeclaredMasters)
             {
-                unscannable++;
-                var headerInner = (ex as PluginUnreadableException)?.InnerException ?? ex;
-                unscannablePlugins.Add(new UnscannablePlugin(plugin, UnscannableCause.Unopenable,
-                                                             $"{headerInner.GetType().Name}: {headerInner.Message}"));
-                continue;
+                List<string> declares;
+                try { declares = view.DeclaredMasters(plugin).Where(transformSet.Contains).ToList(); }
+                catch (PluginUnreadableException ex)
+                {
+                    // The file would not open — closing whatever holds it fixes this one, and the record scan below
+                    // would fail the same way, so the plugin is named and skipped rather than counted as declaring
+                    // nothing.
+                    unscannable++;
+                    var inner = ex.InnerException ?? ex;
+                    unscannablePlugins.Add(new UnscannablePlugin(plugin, UnscannableCause.Unopenable, $"{inner.GetType().Name}: {inner.Message}"));
+                    continue;
+                }
+                catch (Exception ex)
+                {
+                    // It opened and the master table would not parse. Closing programs does not fix that, so it
+                    // takes the other cause, exactly as a record enumeration that throws part way does.
+                    unscannable++;
+                    unscannablePlugins.Add(new UnscannablePlugin(plugin, UnscannableCause.EnumerationFault,
+                                                                 $"master table unreadable: {ex.GetType().Name}: {ex.Message}"));
+                    continue;
+                }
+                if (declares.Count > 0) declarers.Add(new MasterDeclarer(plugin, declares));
             }
-            if (declares.Count > 0) declarers.Add(new MasterDeclarer(plugin, declares));
 
             try
             {
@@ -231,10 +250,16 @@ public static class RemapEngine
             }
         }
 
-        // DECLARER-ONLY: a referencer or an overrider necessarily declares the donor as a master too, so the new
-        // category is the plugins the record walk did NOT already find — the dependents that were invisible.
+        // DECLARER-ONLY: a referencer or an overrider necessarily declares the transform set as a master too — true
+        // wherever `targets` covers every record the set originates, which is the merge caller's case — so the new
+        // category is the plugins the record walk did NOT already find: the dependents that were invisible.
+        //
+        // A plugin whose record walk FAULTED is dropped from it too. The category's claim is "declares it and
+        // references none of its records", and nothing walked that plugin's records; it is already named, with its
+        // reason, in the unscannable accounting.
         var alreadyFound = new HashSet<string>(externalPlugins, StringComparer.OrdinalIgnoreCase);
         alreadyFound.UnionWith(externalOverriders);
+        alreadyFound.UnionWith(unscannablePlugins.Select(u => u.Plugin));
         var declarerOnly = declarers.Where(d => !alreadyFound.Contains(d.Plugin)).ToList();
 
         return new IdentifyResult(refs, externalPlugins, scanned, unscannable, unscannableSamples, overrides, externalOverriders,

--- a/src/housecarl-core/RemapEngine.cs
+++ b/src/housecarl-core/RemapEngine.cs
@@ -152,6 +152,10 @@ public static class RemapEngine
             if (!scannedNames.Add(plugin)) continue;                     // a duplicate name in the order — scan and list it once, never double-count
             bool pluginListed = false;
             bool pluginListedOverride = false;
+            // The header read faulted, so this plugin is already named in the unscannable accounting: the record walk
+            // below still runs, and whatever it finds is reported, but the plugin is neither counted as scanned
+            // through nor named a second time by the catches at the bottom.
+            bool headerFaulted = false;
 
             // The HEADER read, before the records: a plugin that merely LISTS a plugin in the transform set as a
             // master is a dependent no walk over links and identity can see, and it loses a master the moment the
@@ -176,10 +180,21 @@ public static class RemapEngine
                 {
                     // It opened and the master table would not parse. Closing programs does not fix that, so it
                     // takes the other cause, exactly as a record enumeration that throws part way does.
+                    //
+                    // The fault is recorded and the walk FALLS THROUGH to the records rather than skipping them: this
+                    // arm is reached only once the file has OPENED, and the record stream is a different read that
+                    // may well succeed. Continuing here made the one caller that opts in — merge — report "external
+                    // referencers: none" for a plugin whose records the pass could have walked.
+                    //
+                    // Measured on a corrupted TES4 master table (2026-09-05): Mutagen parses the master list while
+                    // OPENING the file, so that corruption never reaches this arm — the resolver excludes the plugin
+                    // at build and the pass skips it before either header branch, identically for both callers. What
+                    // is left for this arm is a fault the header read meets after a successful open.
                     unscannable++;
                     unscannablePlugins.Add(new UnscannablePlugin(plugin, UnscannableCause.EnumerationFault,
                                                                  $"master table unreadable: {ex.GetType().Name}: {ex.Message}"));
-                    continue;
+                    headerFaulted = true;
+                    declares = new List<string>();
                 }
                 if (declares.Count > 0) declarers.Add(new MasterDeclarer(plugin, declares));
             }
@@ -226,7 +241,7 @@ public static class RemapEngine
                         if (unscannableSamples.Count < 5) unscannableSamples.Add($"{plugin} {fk} — {ex.GetType().Name}: {ex.Message}");
                     }
                 }
-                scanned++;                                               // counted only once the whole plugin has been read through
+                if (!headerFaulted) scanned++;                           // counted only once the whole plugin has been read through, header included
             }
             // The file could not be OPENED at all — the held-open case. Split from the enumeration fault below
             // because the remedy differs: closing xEdit, MO2 or Skyrim fixes this one and nothing else.
@@ -234,6 +249,9 @@ public static class RemapEngine
             // renders write for themselves.
             catch (PluginUnreadableException ex)
             {
+                // A plugin whose header already faulted is named once, with the first fault's reason — a second entry
+                // would count one plugin twice and list it twice.
+                if (headerFaulted) continue;
                 unscannable++;
                 var inner = ex.InnerException ?? ex;
                 unscannablePlugins.Add(new UnscannablePlugin(plugin, UnscannableCause.Unopenable, $"{inner.GetType().Name}: {inner.Message}"));
@@ -244,6 +262,7 @@ public static class RemapEngine
             // never shares the per-record sample budget, so it can never be named without its reason.
             catch (Exception ex)
             {
+                if (headerFaulted) continue;                             // already named, for the fault that came first
                 unscannable++;
                 unscannablePlugins.Add(new UnscannablePlugin(plugin, UnscannableCause.EnumerationFault,
                                                              $"record enumeration aborted: {ex.GetType().Name}: {ex.Message}"));

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -3648,7 +3648,7 @@ public sealed class LocalizedTargetUnsupportedException : InvalidOperationExcept
         LocalizedShape.NotLocalized
             or LocalizedShape.LooseComplete or LocalizedShape.LoosePartial or LocalizedShape.LooseWithGameDataDuplicate
             or LocalizedShape.BsaEmbedded or LocalizedShape.GameDataOnly or LocalizedShape.StringsFolderUnreadable
-            or LocalizedShape.Nowhere
+            or LocalizedShape.ModFolderUnreadable or LocalizedShape.Nowhere
             => WhereTheTextIs(a) + " " + WhyNotInPlace(a),
 
         // Enumerated above one by one, so a shape added later lands HERE and says nothing rather than inheriting
@@ -3741,6 +3741,14 @@ public sealed class LocalizedTargetUnsupportedException : InvalidOperationExcept
             + "to see what is in there. Rewriting the plugin renumbers the indices its text is looked up by, and "
             + "houseCARL cannot tell whether the files written beside it would replace a set that is already there or "
             + "land next to one it never saw." + Settled,
+
+        // The same as the arm above, one level up: the folder holding the plugin would not list, so what is beside it
+        // — a loose set, an archive carrying its tables — was never established.
+        LocalizedShape.ModFolderUnreadable =>
+            "A localized plugin's text is not in the plugin, and houseCARL could not read the folder the plugin sits "
+            + "in to see what is beside it. Rewriting the plugin renumbers the indices its text is looked up by, and "
+            + "houseCARL cannot tell whether the files written beside it would replace a set that is already there, "
+            + "shadow one it never saw, or sit next to an archive it could not look in." + Settled,
 
         // houseCARL cannot see the source, so it cannot name a hazard it has verified. Saying which one it cannot
         // rule out is the honest form.
@@ -3846,6 +3854,13 @@ public sealed class LocalizedTargetUnsupportedException : InvalidOperationExcept
                 "It is flagged LOCALIZED and there is a Strings folder beside it that houseCARL could not read, so "
                 + "whether its text is in there — and in which languages — is unknown" + AlsoLoose(a) + ".",
 
+            // The MOD folder is the one that would not list, so nothing beside the plugin was established — not a
+            // loose set, and not an archive there. It asserts no absence, which is the whole reason it is not Nowhere:
+            // that sentence says there is "no archive beside it", about a folder nothing could read.
+            LocalizedShape.ModFolderUnreadable =>
+                "It is flagged LOCALIZED and houseCARL could not read the folder the plugin sits in, so whether its "
+                + "text is beside it — loose, or inside an archive there — is unknown" + AlsoLoose(a) + ".",
+
             // Says what was SEARCHED and what was FOUND, never what exists. It asserts no absence: a Strings folder
             // beside the plugin may hold a neighbour's tables, or this plugin's in a language Mutagen does not model
             // (ptbr), and neither is "nothing is there". NothingMatched describes the folder as it is, and the only
@@ -3924,6 +3939,9 @@ public sealed class LocalizedTargetUnsupportedException : InvalidOperationExcept
             "It is flagged LOCALIZED and houseCARL cannot find its .STRINGS files: " + NothingMatched(a) + ".",
         LocalizedShape.StringsFolderUnreadable =>
             "It is flagged LOCALIZED and houseCARL could not read the Strings folder beside it, so where its text "
+            + "lives is unknown.",
+        LocalizedShape.ModFolderUnreadable =>
+            "It is flagged LOCALIZED and houseCARL could not read the folder the plugin sits in, so where its text "
             + "lives is unknown.",
         LocalizedShape.Unreadable =>
             "houseCARL could not read it to see whether it is localized or where its text lives.",

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -2085,8 +2085,10 @@ public static class WritePatchBuilder
     /// <summary>The merge tool's outcome: the merged plugin's identity + per-donor remap accounting + every
     /// cross-donor conflict (load-order winner, reported never silent) + the identify-pass WARN surfaces (external
     /// referencers AND overriders — merge never refuses on them, the donors stay installed and active until the user
-    /// swaps in MO2, so nothing breaks at write time; the report names each with the remedy) + the FormID-keyed asset
-    /// carry accounting (facegen/voice/SEQ — a merge renames the plugin, so EVERY donor NPC's facegen and EVERY voiced
+    /// swaps in MO2, so nothing breaks at write time; the report names each with the remedy) + <see cref="LocalizedDonors"/>
+    /// (donors houseCARL read and found flagged LOCALIZED — M is a bare mod, so their text is written into it inline and
+    /// their <c>.STRINGS</c> no longer describe the output: a changed nature the report states, never silently)
+    /// + the FormID-keyed asset carry accounting (facegen/voice/SEQ — a merge renames the plugin, so EVERY donor NPC's facegen and EVERY voiced
     /// line moves to the new-name folders, not just the collided ones). Merge has NO in-place lane and overwrites
     /// nothing, so there is no consent gate.</summary>
     public sealed record MergeOutcome(
@@ -2100,7 +2102,8 @@ public static class WritePatchBuilder
         long Bytes, string? Note = null,
         AssetRenameOutcome? AssetRename = null, VoiceCarryOutcome? VoiceRename = null, SeqRegenOutcome? SeqRegen = null,
         IReadOnlyList<string>? LightDonors = null, IReadOnlyList<string>? HeaderMetaDonors = null,
-        IReadOnlyList<string>? MasterDonors = null, IReadOnlyList<RemapEngine.UnscannablePlugin>? UnscannablePlugins = null)
+        IReadOnlyList<string>? MasterDonors = null, IReadOnlyList<RemapEngine.UnscannablePlugin>? UnscannablePlugins = null,
+        IReadOnlyList<string>? LocalizedDonors = null)
     {
         public static MergeOutcome Fail(string error) =>
             new(false, error, "", "", Array.Empty<string>(), Array.Empty<string>(), 0, 0,

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -2103,7 +2103,8 @@ public static class WritePatchBuilder
         AssetRenameOutcome? AssetRename = null, VoiceCarryOutcome? VoiceRename = null, SeqRegenOutcome? SeqRegen = null,
         IReadOnlyList<string>? LightDonors = null, IReadOnlyList<string>? HeaderMetaDonors = null,
         IReadOnlyList<string>? MasterDonors = null, IReadOnlyList<RemapEngine.UnscannablePlugin>? UnscannablePlugins = null,
-        IReadOnlyList<string>? LocalizedDonors = null)
+        IReadOnlyList<string>? LocalizedDonors = null,
+        IReadOnlyList<RemapEngine.MasterDeclarer>? MasterDeclarers = null)
     {
         public static MergeOutcome Fail(string error) =>
             new(false, error, "", "", Array.Empty<string>(), Array.Empty<string>(), 0, 0,

--- a/src/housecarl-generator/CompactServiceGuardProbe.cs
+++ b/src/housecarl-generator/CompactServiceGuardProbe.cs
@@ -472,6 +472,40 @@ public static class CompactServiceGuardProbe
                     $"(refused={!og.Success} named={namedGone} nothingWritten={nothingWritten}) [{og.Error}]");
             }
 
+            // ---- FOLDER-UNREADABLE (#371): the OTHER shape that resolves nowhere — a Strings folder beside the
+            //      plugin that houseCARL could not LIST. It refuses for the same reason, and its REMEDY cannot be the
+            //      same sentence: the folder is already there, so "place them in a Strings folder beside the plugin"
+            //      tells the caller to fill the very folder nothing could open. Fixtured with a real deny ACE, and
+            //      the deny is VERIFIED to bite before anything is asserted.
+            {
+                var locked = Path.Combine(root, "locked");
+                var ls = new LocalizedStringsFixture.Spec("LockedSrc", new ModKey("HcCsLocked", ModType.Plugin),
+                    "LOCKED NAME", "LOCKED DESC", StringsBeside: true);
+                var fx = LocalizedStringsFixture.Build(locked, new[] { ls });
+                var strings = Path.Combine(fx.Mods, ls.ModFolder, "Strings");
+                if (!LocalizedWriteGuardProbe.TryDenyListing(strings))
+                    Check(false, "FOLDER-UNREADABLE fixture: the deny-listing ACE did not take on this host — the cell cannot be built, so it FAILS rather than passing");
+                else
+                {
+                    try
+                    {
+                        var lockedStore = new UserConfigStore(Path.Combine(locked, "houseCARL.user.json"));
+                        using var lockedSvc = LoadOrderService.WithInstance(fx.Instance, 0, lockedStore);
+                        lockedSvc.Stats();
+
+                        var ol = lockedSvc.CompactPlugin(ls.Key.FileName.String);
+                        bool refused = !ol.Success && ol.Error is not null;
+                        bool remedyFits = refused
+                                          && ol.Error!.Contains("fix its permissions", StringComparison.Ordinal)
+                                          && !ol.Error.Contains("place them in a Strings folder", StringComparison.Ordinal);
+                        Check(refused && remedyFits,
+                            $"FOLDER-UNREADABLE refuses with the remedy for THIS shape — free the folder, not fill it " +
+                            $"(refused={refused} remedyFits={remedyFits}) [{ol.Error}]");
+                    }
+                    finally { LocalizedWriteGuardProbe.UndenyListing(strings); }
+                }
+            }
+
             // NEWFILE-NOTE, other direction: the SAME lane over a NON-localized source says nothing about localization.
             // Without this the note could be unconditional and the arm above would not notice.
             {

--- a/src/housecarl-generator/CompactServiceGuardProbe.cs
+++ b/src/housecarl-generator/CompactServiceGuardProbe.cs
@@ -449,6 +449,29 @@ public static class CompactServiceGuardProbe
                     $"TARGET-LOC the refusal tells THIS caller the new-file output is NOT localized, and where its text is [{oip.Error}]");
             }
 
+            // ---- NOWHERE (#371): a localized source whose strings are NEITHER beside it NOR in game-Data. Nothing
+            //      resolves it, so every value reads blank — and the NEW-FILE lane, the one the refusals above send
+            //      callers to, refuses rather than writing those blanks into a plugin they keep. The arm pins the
+            //      named refusal and that nothing was written.
+            {
+                var gone = Path.Combine(root, "gone");
+                var gs = new LocalizedStringsFixture.Spec("GoneSrc", new ModKey("HcCsGone", ModType.Plugin),
+                    "GONE NAME", "GONE DESC", StringsNowhere: true);
+                var fx = LocalizedStringsFixture.Build(gone, new[] { gs });
+                var goneStore = new UserConfigStore(Path.Combine(gone, "houseCARL.user.json"));
+                using var goneSvc = LoadOrderService.WithInstance(fx.Instance, 0, goneStore);
+                goneSvc.Stats();
+
+                var og = goneSvc.CompactPlugin(gs.Key.FileName.String);
+                bool namedGone = !og.Success && og.Error is not null
+                                 && og.Error.Contains("LOCALIZED", StringComparison.Ordinal)
+                                 && og.Error.Contains(".STRINGS", StringComparison.Ordinal);
+                bool nothingWritten = string.IsNullOrEmpty(og.OutputPath) || !File.Exists(og.OutputPath);
+                Check(namedGone && nothingWritten,
+                    $"NOWHERE-resolving strings REFUSE the new-file compact, named, nothing written " +
+                    $"(refused={!og.Success} named={namedGone} nothingWritten={nothingWritten}) [{og.Error}]");
+            }
+
             // NEWFILE-NOTE, other direction: the SAME lane over a NON-localized source says nothing about localization.
             // Without this the note could be unconditional and the arm above would not notice.
             {

--- a/src/housecarl-generator/LocalizedShapeSweep.cs
+++ b/src/housecarl-generator/LocalizedShapeSweep.cs
@@ -92,6 +92,7 @@ public static class LocalizedShapeSweep
         LocalizedShape.BsaEmbedded => "  " + Path.GetFileName(a.BsaPath!) + (a.BsaUnreadable ? " (UNREADABLE)" : ""),
         LocalizedShape.GameDataOnly => $"  gameData[{string.Join(",", a.GameDataLanguages)}]",
         LocalizedShape.StringsFolderUnreadable => "  Strings folder present, could not be listed",
+        LocalizedShape.ModFolderUnreadable => "  the mod folder itself could not be listed",
         LocalizedShape.Nowhere => a.UnmatchedTables.Total > 0 ? $"  {a.UnmatchedTables.Total} unmatched table file(s) in the folder" : "",
         LocalizedShape.Unreadable => "  the plugin itself could not be opened",
         _ => "",

--- a/src/housecarl-generator/LocalizedWriteGuardProbe.cs
+++ b/src/housecarl-generator/LocalizedWriteGuardProbe.cs
@@ -631,7 +631,7 @@ public static class LocalizedWriteGuardProbe
     /// <summary>Deny LISTING on one directory for the current user, and say whether it actually bit. Deliberately not
     /// a deny-all: <c>Directory.Exists</c> reads the path's attributes, and denying that too would make the folder
     /// look ABSENT rather than unlistable — which is the wrong state to measure.</summary>
-    static bool TryDenyListing(string dir)
+    internal static bool TryDenyListing(string dir)
     {
         try
         {
@@ -654,7 +654,7 @@ public static class LocalizedWriteGuardProbe
     }
 
     /// <summary>Lift the deny again — always in a finally, or the temp tree cannot be cleaned up afterwards.</summary>
-    static void UndenyListing(string dir)
+    internal static void UndenyListing(string dir)
     {
         try
         {

--- a/src/housecarl-generator/LocalizedWriteGuardProbe.cs
+++ b/src/housecarl-generator/LocalizedWriteGuardProbe.cs
@@ -45,6 +45,8 @@ public static class LocalizedWriteGuardProbe
         Console.WriteLine();
         UnlistableStringsFolder();
         Console.WriteLine();
+        UnlistableModFolder();
+        Console.WriteLine();
         ConfirmedLocalizedIsNotTheRefusalBoolean();
         Console.WriteLine();
         Console.WriteLine(_fail == 0
@@ -555,9 +557,9 @@ public static class LocalizedWriteGuardProbe
         // do is describe an arrangement, and it does not.
         LocalizedShape.NotLocalized => true,
 
-        // The PLUGIN's flag was read and is set; only its Strings folder could not be listed. So it may be called
-        // localized — what it may not do is describe what is in that folder.
-        LocalizedShape.StringsFolderUnreadable => true,
+        // The PLUGIN's flag was read and is set; only a FOLDER could not be listed — its Strings folder, or the mod
+        // folder it sits in. So it may be called localized; what it may not do is describe what is in that folder.
+        LocalizedShape.StringsFolderUnreadable or LocalizedShape.ModFolderUnreadable => true,
 
         // Nothing was read. Nothing may be asserted.
         LocalizedShape.Unreadable => false,
@@ -625,6 +627,66 @@ public static class LocalizedWriteGuardProbe
             var msg = LocalizedStrings.RefusalFor(f.Plugin, "ZRef.esp", f.DataDir) ?? "";
             Check(a.Shape == LocalizedShape.Nowhere && msg.Contains("no .STRINGS files beside it", StringComparison.Ordinal),
                 $"a folder that really is gone still gets the checked absence (shape={a.Shape})");
+        });
+    }
+
+    // ------------------------------------------------- a MOD folder houseCARL cannot list
+
+    /// <summary>The same third answer one level up: the folder the PLUGIN sits in will not list, so what is beside it
+    /// was never established. The classifier used to drop that answer and fall through to
+    /// <see cref="LocalizedShape.Nowhere"/>, whose sentence says there is "no archive beside it" — asserted about a
+    /// folder nothing could read, and reachable with a complete <c>.bsa</c> sitting right there.
+    ///
+    /// <para>Windows makes it reachable: listing a directory is a separate right from traversing it, so the plugin
+    /// still opens, the <c>Strings\</c> subfolder still enumerates, and only the archive look at the folder itself
+    /// throws.</para></summary>
+    static void UnlistableModFolder()
+    {
+        Console.WriteLine();
+        Console.WriteLine("== a MOD folder houseCARL cannot LIST is not a folder it found empty ==");
+
+        // Nowhere's fixture — no loose set beside the plugin — plus an archive in the mod folder, which is the source
+        // the deny then hides.
+        Run(Variant.Nowhere, f =>
+        {
+            var modDir = Path.GetDirectoryName(f.Plugin)!;
+            File.WriteAllBytes(Path.Combine(modDir, "ZRef.bsa"), new byte[] { 0x42, 0x53, 0x41, 0x00 });
+
+            var listed = LocalizedStrings.Assess(f.Plugin, f.DataDir);
+            Check(listed.Shape == LocalizedShape.BsaEmbedded,
+                $"fixture: listable, the archive beside the plugin is found (shape={listed.Shape})");
+
+            if (!TryDenyListing(modDir))
+            {
+                Check(false, "fixture: the deny-listing ACE did not take on this host — the cell cannot be built, so it FAILS rather than passing");
+                return;
+            }
+            try
+            {
+                var a = LocalizedStrings.Assess(f.Plugin, f.DataDir);
+                Check(a.Shape == LocalizedShape.ModFolderUnreadable,
+                    $"an unlistable mod folder classifies as its own shape, NOT as Nowhere (shape={a.Shape})");
+
+                var msg = LocalizedStrings.RefusalFor(f.Plugin, "ZRef.esp", f.DataDir) ?? "";
+                Check(!msg.Contains("no archive beside it", StringComparison.Ordinal)
+                      && !msg.Contains("cannot find its text", StringComparison.Ordinal)
+                      && !msg.Contains("no .STRINGS files beside it", StringComparison.Ordinal),
+                    "…and its refusal asserts no absence over a folder houseCARL could not read");
+                Check(msg.Contains("could not read the folder the plugin sits in", StringComparison.Ordinal),
+                    $"…and says what actually happened — the folder is there and could not be read [{msg}]");
+                if (msg.Contains("no archive beside it")) Console.WriteLine("          got: " + msg);
+
+                // THE TWO SIDES AGREE. The read side keeps the folder-adjacent open because a source may be in there;
+                // the write side must not classify into the shape that says one is not.
+                Check(LocalizedStrings.OwnFolderCarriesStringsFor(f.Plugin) && a.Shape != LocalizedShape.Nowhere,
+                    "the read gate and the classifier agree that a strings source may exist in that folder");
+            }
+            finally { UndenyListing(modDir); }
+
+            // The other direction on the same folder: with the deny lifted the archive is found again, so the arms
+            // above cannot pass by the classifier answering ModFolderUnreadable for everything.
+            Check(LocalizedStrings.Assess(f.Plugin, f.DataDir).Shape == LocalizedShape.BsaEmbedded,
+                "with the deny lifted the same folder classifies by the archive that is in it");
         });
     }
 

--- a/src/housecarl-generator/LocalizedWriteProbe.cs
+++ b/src/housecarl-generator/LocalizedWriteProbe.cs
@@ -286,7 +286,8 @@ public static class LocalizedWriteProbe
             Row("M3-langset", null,
                 $"{langs.Count} files → {{{string.Join(", ", langs.OrderBy(x => x))}}}; {sw.Elapsed.TotalMilliseconds / 1000:F4} ms per check");
 
-            // (b) the cheap BSA presence test the read side already runs (LoadOrderResolver.FolderHasOwnStrings).
+            // (b) the cheap BSA presence test the read side USED to run as its gate — kept as the cost baseline the
+            // stem-keyed test in (d) is measured against.
             sw.Restart();
             bool anyBsa = false;
             for (int i = 0; i < 1000; i++) anyBsa = Directory.EnumerateFiles(folder, "*.bsa").Any();
@@ -294,8 +295,9 @@ public static class LocalizedWriteProbe
             Row("M3-bsa-cheap", null,
                 $"any .bsa beside the plugin = {anyBsa}; {sw.Elapsed.TotalMilliseconds / 1000:F4} ms per check (no archive opened)");
 
-            // (c) #369's interaction, measured: drop an EMPTY-of-strings .bsa beside a plugin whose strings live in
-            // game-Data. FolderHasOwnStrings answers "has its own" on the .bsa alone, so OpenOverlay does not redirect.
+            // (c) #369, measured: drop an EMPTY-of-strings .bsa beside a plugin whose strings live in game-Data. The
+            // gate now asks whether the archive embeds strings for THIS plugin, so the redirect survives it and the
+            // values resolve — this arm reads 0 blanks where it used to read all of them.
             var small = SmallRealBsa();
             if (small is null) { Row("M3-369", null, "no Skyrim install on this machine — #369 arm skipped"); return; }
             var g = BuildFixture(NewRoot(), relocate: true, secondLanguage: false, bsaBeside: small);
@@ -305,7 +307,7 @@ public static class LocalizedWriteProbe
                 var blank = without.Values.Count(v => string.IsNullOrEmpty(v));
                 Row("M3-369", null,
                     $"a .bsa beside a game-Data-strings plugin: FolderHasOwnStrings={LoadOrderResolver.FolderHasOwnStrings(g.PluginPath)}, "
-                    + $"{blank}/{without.Count} values read BLANK through OpenOverlay (#369, measured not fixed)");
+                    + $"{blank}/{without.Count} values read BLANK through OpenOverlay (#369, fixed)");
             }
             finally { Nuke(Path.GetDirectoryName(Path.GetDirectoryName(g.DataDir)!)!); }
         }

--- a/src/housecarl-generator/MergeServiceGuardProbe.cs
+++ b/src/housecarl-generator/MergeServiceGuardProbe.cs
@@ -400,6 +400,14 @@ public static class MergeServiceGuardProbe
                 Check(!r.Success && (r.Error?.Contains(".esl", StringComparison.OrdinalIgnoreCase) ?? false)
                                  && (r.Error?.Contains("compact", StringComparison.OrdinalIgnoreCase) ?? false),
                     $"REFUSE .esl output with the compact-after remedy ({r.Error?.Split('—')[0].Trim()})");
+                // The REASON, not just the refusal. It may only claim what holds on every path: a merge does not
+                // constrain ids to the light window. Saying it keeps each donor's ids where they are is false —
+                // BuildMergeRemap renumbers collisions and below-floor ids from 0x800 up, and the report prints that
+                // count — and a single already-light donor's ids are all inside the window anyway.
+                Check((r.Error?.Contains("never constrains object ids to the light window", StringComparison.Ordinal) ?? false)
+                      && !(r.Error?.Contains("keeps each donor's object ids", StringComparison.Ordinal) ?? true)
+                      && !(r.Error?.Contains("where they already are", StringComparison.Ordinal) ?? true),
+                    $"…and its reason is the claim that holds on every path [{r.Error}]");
             }
 
             // ---- RENAME: donor A ALONE into a new name (#345). Same walk, empty collision set. ----

--- a/src/housecarl-generator/MergeServiceGuardProbe.cs
+++ b/src/housecarl-generator/MergeServiceGuardProbe.cs
@@ -312,11 +312,11 @@ public static class MergeServiceGuardProbe
                 var rendered = WriteTools.RenderMerge(o);
                 Check(rendered.Contains("WARNING") && rendered.Contains("HcMgDep.esp") && rendered.Contains("HcMgOvr.esp"),
                     "WARN both warnings reach the rendered user output");
-                // The pass's own coverage, stated by the pass — a dependent that only DECLARES a donor as a master is
-                // invisible here, and the sentence has to say so whether the list came back empty or full.
-                Check(rendered.Contains("it reads record links and record identity, NOT declared masters")
-                      && rendered.Contains("only lists a donor as a master"),
-                    "WARN the identify-pass line states what the pass does NOT read");
+                // The pass's own coverage, stated by the pass. Declared masters are read now; runtime config files are
+                // not, and the sentence has to name what is left out whether the lists came back empty or full.
+                Check(rendered.Contains("it reads record links, record identity and declared masters, NOT runtime config files")
+                      && rendered.Contains("only names a donor in such a file"),
+                    "WARN the identify-pass line states what the pass does and does NOT read");
                 // "Not read" is not the same fact as "and here is what that costs" — the loss is stated as well as the
                 // gap in coverage, on every merge rather than only when the referencer list came back populated.
                 //

--- a/src/housecarl-generator/MergeServiceGuardProbe.cs
+++ b/src/housecarl-generator/MergeServiceGuardProbe.cs
@@ -659,14 +659,21 @@ public static class MergeServiceGuardProbe
                     }
                     Check(flagOk && noStringsFolder,
                         $"LOCALIZED output is written NON-localized with strings inline (flagClear={flagOk} noStringsFolder={noStringsFolder})");
+
+                    // #435 — the de-localization above is a change in the output's NATURE, and the report has to say
+                    // so. The donor must be NAMED: a generic note would not tell a caller with ten donors which of
+                    // them stopped being a translated plugin.
+                    var rendered = lo.Success ? WriteTools.RenderMerge(lo) : "";
+                    Check(rendered.Contains("flagged LOCALIZED") && rendered.Contains(la.Key.FileName.String)
+                          && rendered.Contains("is NOT localized"),
+                        "LOCALIZED de-localization is STATED in the merge report, naming the donor");
                 }
             }
 
-            // ---- RESIDUAL (#362, measured not fixed): a localized donor whose strings exist NEITHER beside it NOR in
-            //      game-Data. OpenOverlay's fallback is the game-Data folder and nothing else, so there is no dataDir
-            //      that resolves this one — the merge still succeeds and still writes blanks, with no warning. Pinned
-            //      here so the residual is a measured fact in the PR rather than a claim, and so a later change to it
-            //      is a deliberate one. Asserting the CURRENT behaviour, not endorsing it.
+            // ---- NOWHERE (#371): a localized donor whose strings exist NEITHER beside it NOR in game-Data. There is
+            //      no dataDir that resolves this one, so every value reads blank — and the merge REFUSES rather than
+            //      writing those blanks into a plugin the caller keeps. The arm pins the refusal AND that nothing was
+            //      written: a refusal that still left an output would be the worse failure.
             {
                 var resRoot = Path.Combine(root, "res");
                 var lr = new LocalizedStringsFixture.Spec("LocGone", new ModKey("HcMgLocGone", ModType.Plugin),
@@ -677,16 +684,13 @@ public static class MergeServiceGuardProbe
                 resSvc.Stats();
 
                 var lo = resSvc.MergePlugins(new[] { lr.Key.FileName.String }, "HcMgResRen.esp");
-                var rb = lo.Success && File.Exists(lo.OutputPath)
-                    ? LocalizedStringsFixture.ReadBackBare(lo.OutputPath, LocalizedStringsFixture.WeaponEdid(lr))
-                    : (Name: "unwritten", Desc: "unwritten");
-                // The record must be THERE and blank. A blank read alone is also what an ABSENT record returns, so
-                // without this the arm would report the residual as pinned even if the merge had dropped the record
-                // altogether — an arm that passes for the wrong reason is the one failure a guard cannot survive.
-                bool carried = lo.Success && File.Exists(lo.OutputPath)
-                               && LocalizedStringsFixture.CarriesWeapon(lo.OutputPath, LocalizedStringsFixture.WeaponEdid(lr));
-                Check(lo.Success && carried && string.IsNullOrEmpty(rb.Name) && string.IsNullOrEmpty(rb.Desc),
-                    $"RESIDUAL strings resolvable NOWHERE still merge to blanks, silently (success={lo.Success} carried={carried} Name='{rb.Name}' Desc='{rb.Desc}')");
+                // The refusal must NAME the cause: a generic failure would pass this arm while telling the modder
+                // nothing about where their text went.
+                bool named = !lo.Success && lo.Error is not null
+                             && lo.Error.Contains("LOCALIZED") && lo.Error.Contains(".STRINGS");
+                bool nothingWritten = string.IsNullOrEmpty(lo.OutputPath) || !File.Exists(lo.OutputPath);
+                Check(named && nothingWritten,
+                    $"NOWHERE-resolving strings REFUSE the merge, named, nothing written (success={lo.Success} named={named} nothingWritten={nothingWritten} err='{(lo.Error ?? "").Split('.')[0]}')");
             }
         }
         finally { try { Directory.Delete(root, true); } catch { } }

--- a/src/housecarl-generator/MergeServiceGuardProbe.cs
+++ b/src/housecarl-generator/MergeServiceGuardProbe.cs
@@ -50,9 +50,12 @@ namespace HousecarlGenerator;
 ///               EMPTY — without that, every arm here would pass on a fixture that was never localized. A further arm
 ///               pins that the OUTPUT is written non-localized with its strings inline, which is what makes the
 ///               read-backs a read of the written bytes.
-///   RESIDUAL  — (#362, measured not fixed) a donor whose strings are in NEITHER place: OpenOverlay's fallback is
-///               game-Data and nothing else, so no dataDir resolves it, and the merge still writes blanks and still
-///               reports success. Pinned as the current behaviour so the residual is measured rather than asserted.
+///   NOWHERE   — (#371) a donor whose strings are in NEITHER place: no dataDir resolves it, so every value reads
+///               blank — and the merge REFUSES, named, with nothing written, rather than baking those blanks into a
+///               plugin the caller keeps.
+///   DECLARER  — a plugin outside the merge that lists a donor as a master and references none of its records. Its
+///               own instance. The unit tests cover the detection; this arm covers the JOIN — the service reads it,
+///               carries it into the outcome, and the rendered report names the plugin and what it declares.
 /// Run: dotnet run --project src/housecarl-generator merge-service-guard
 /// </summary>
 public static class MergeServiceGuardProbe
@@ -691,6 +694,71 @@ public static class MergeServiceGuardProbe
                 bool nothingWritten = string.IsNullOrEmpty(lo.OutputPath) || !File.Exists(lo.OutputPath);
                 Check(named && nothingWritten,
                     $"NOWHERE-resolving strings REFUSE the merge, named, nothing written (success={lo.Success} named={named} nothingWritten={nothingWritten} err='{(lo.Error ?? "").Split('.')[0]}')");
+            }
+
+            // ---- DECLARER: a plugin OUTSIDE the merge that lists a donor as a master and references none of its
+            //      records. Its own instance, so the counts and lists every arm above asserts stay as they are. The
+            //      detection has unit coverage; what this arm owes is the JOIN — the service reads declared masters,
+            //      carries them into the outcome, and the rendered report a caller actually reads names the plugin and
+            //      what it declares. A break anywhere along that path is a warning nobody ever sees.
+            {
+                var decRoot = Path.Combine(root, "decl");
+                string decInstance = Path.Combine(decRoot, "instance");
+                string decProfiles = Path.Combine(decInstance, "profiles", "Default");
+                string decMods = Path.Combine(decInstance, "mods");
+                Directory.CreateDirectory(decProfiles); Directory.CreateDirectory(decMods);
+                Directory.CreateDirectory(Path.Combine(decRoot, "game", "Data"));
+                File.WriteAllText(Path.Combine(decInstance, "ModOrganizer.ini"),
+                    "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                    + Path.Combine(decRoot, "game").Replace(@"\", @"\\") + ")\r\n");
+
+                var donorKey = new ModKey("HcMgDeclDonor", ModType.Plugin);
+                var donorDir = Path.Combine(decMods, "DeclDonorMod"); Directory.CreateDirectory(donorDir);
+                var donorPath = Path.Combine(donorDir, donorKey.FileName.String);
+                {
+                    var m = new SkyrimMod(donorKey, SkyrimRelease.SkyrimSE);
+                    m.Weapons.Add(new Weapon(new FormKey(donorKey, 0xA01), SkyrimRelease.SkyrimSE) { EditorID = "HcMgDeclDonorWeap" });
+                    m.BeginWrite.ToPath(donorPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+                }
+
+                // The declarer: its own record, no link into the donor, and the donor carried in the master table
+                // anyway — the trimmed compat patch, which no walk over links or record identity can see.
+                var declKey = new ModKey("HcMgDeclOnly", ModType.Plugin);
+                var declDir = Path.Combine(decMods, "DeclOnlyMod"); Directory.CreateDirectory(declDir);
+                {
+                    using var donorOv = SkyrimMod.CreateFromBinaryOverlay(donorPath, SkyrimRelease.SkyrimSE);
+                    var m = new SkyrimMod(declKey, SkyrimRelease.SkyrimSE);
+                    m.Weapons.Add(new Weapon(new FormKey(declKey, 0xB01), SkyrimRelease.SkyrimSE) { EditorID = "HcMgDeclOwnWeap" });
+                    m.BeginWrite.ToPath(Path.Combine(declDir, declKey.FileName.String))
+                        .WithLoadOrder(new ISkyrimModGetter[] { donorOv }).WithExtraIncludedMasters(donorKey).Write();
+                }
+
+                File.WriteAllText(Path.Combine(decProfiles, "loadorder.txt"),
+                    "# header\r\n" + string.Join("\r\n", donorKey.FileName, declKey.FileName) + "\r\n");
+                File.WriteAllText(Path.Combine(decProfiles, "plugins.txt"),
+                    string.Join("\r\n", "*" + donorKey.FileName, "*" + declKey.FileName) + "\r\n");
+                File.WriteAllText(Path.Combine(decProfiles, "modlist.txt"),
+                    "# header\r\n" + string.Join("\r\n", "+DeclOnlyMod", "+DeclDonorMod") + "\r\n");
+
+                var decStore = new UserConfigStore(Path.Combine(decRoot, "houseCARL.user.json"));
+                using var decSvc = LoadOrderService.WithInstance(decInstance, 0, decStore);
+                decSvc.Stats();
+
+                var dm = decSvc.MergePlugins(new[] { donorKey.FileName.String }, "HcMgDeclOut.esp");
+                // In NEITHER existing list — that is what makes this a third category rather than a second heading
+                // over the same plugins, and an arm reading only the rendered text would pass on a report that had
+                // quietly folded it into the referencers.
+                bool inOutcome = dm.Success && dm.MasterDeclarers is { Count: 1 }
+                                 && string.Equals(dm.MasterDeclarers[0].Plugin, declKey.FileName.String, StringComparison.OrdinalIgnoreCase)
+                                 && !dm.ExternalPlugins.Contains(declKey.FileName.String, StringComparer.OrdinalIgnoreCase)
+                                 && !dm.ExternalOverriders.Contains(declKey.FileName.String, StringComparer.OrdinalIgnoreCase);
+                var decRendered = dm.Success ? WriteTools.RenderMerge(dm) : "";
+                bool warned = decRendered.Contains("DECLARE a donor as a MASTER")
+                              && decRendered.Contains(declKey.FileName.String)
+                              && decRendered.Contains("declares " + donorKey.FileName.String);
+                Check(inOutcome && warned,
+                    "DECLARER a real declarer-only dependent reaches the rendered merge report, named with what it "
+                    + $"declares (inOutcome={inOutcome} warned={warned}{(dm.Success ? "" : ", ERR " + dm.Error)})");
             }
         }
         finally { try { Directory.Delete(root, true); } catch { } }

--- a/src/housecarl-generator/StringsDecisionProbe.cs
+++ b/src/housecarl-generator/StringsDecisionProbe.cs
@@ -8,7 +8,8 @@ namespace HousecarlGenerator;
 /// DLC strings in the game-Data BSA once redirected) is exercised by the manual strings-resolve-probe against
 /// real DLC + Skyrim - Interface.bsa; THIS guard locks the two decision pieces most likely to silently regress
 /// under a refactor:
-///   FolderHasOwnStrings(path) — does the plugin's OWN folder carry a strings source (loose Strings\ or a .bsa)?
+///   FolderHasOwnStrings(path) — does the plugin's OWN folder carry a strings source FOR THIS PLUGIN (a loose table
+///                              matching its name, or a .bsa beside it that embeds one)?
 ///                              true ⇒ keep the unchanged folder-adjacent default open; false ⇒ redirect to game-Data.
 ///   ComputeDataDir(nameToIdx, paths) — the game-Data fallback target = the resolved Skyrim.esm's directory.
 ///
@@ -34,22 +35,39 @@ public static class StringsDecisionProbe
             fails += Check("bare folder (.esm only) → no own strings (redirect)",
                 LoadOrderResolver.FolderHasOwnStrings(Path.Combine(bare, "Cleaned.esm")) == false);
 
-            // (b) folder WITH a loose Strings\ ⇒ has own strings ⇒ keep default.
+            // (b) a loose Strings\ carrying a table for THIS plugin ⇒ has own strings ⇒ keep default.
             var loose = MkFolder(root, "loose", esp: "Mod.esp");
             Directory.CreateDirectory(Path.Combine(loose, "Strings"));
-            fails += Check("loose Strings\\ → has own strings (no redirect)",
+            File.WriteAllText(Path.Combine(loose, "Strings", "Mod_English.STRINGS"), "x");
+            fails += Check("loose Strings\\ with this plugin's table → has own strings (no redirect)",
                 LoadOrderResolver.FolderHasOwnStrings(Path.Combine(loose, "Mod.esp")) == true);
 
-            // (c) folder WITH a .bsa (may embed strings) ⇒ has own strings ⇒ keep default. The check the bug needs
-            //     most: a localized mod whose strings live in its OWN bsa must NOT be redirected away from them.
+            // (b2) #369: a Strings\ folder is shared by every plugin beside it, so an EMPTY one — and one holding only
+            //      a NEIGHBOUR's tables — is not this plugin's source and must not suppress the redirect.
+            var emptyLoose = MkFolder(root, "loose-empty", esp: "Mod.esp");
+            Directory.CreateDirectory(Path.Combine(emptyLoose, "Strings"));
+            fails += Check("empty Strings\\ → no own strings (redirect)",
+                LoadOrderResolver.FolderHasOwnStrings(Path.Combine(emptyLoose, "Mod.esp")) == false);
+
+            var neighbour = MkFolder(root, "loose-neighbour", esp: "Mod.esp");
+            Directory.CreateDirectory(Path.Combine(neighbour, "Strings"));
+            File.WriteAllText(Path.Combine(neighbour, "Strings", "Mod_extras_English.STRINGS"), "x");
+            fails += Check("Strings\\ holding only a NEIGHBOUR's table → no own strings (redirect)",
+                LoadOrderResolver.FolderHasOwnStrings(Path.Combine(neighbour, "Mod.esp")) == false);
+
+            // (c) an UNREADABLE .bsa beside the plugin ⇒ "has own" ⇒ keep default. It may hold the tables and nothing
+            //     here can rule that out, so the redirect is not taken past a source that was never ruled out. (An
+            //     archive that PARSES is asked whether it embeds this plugin's tables — see LocalizedStringsSourceTests,
+            //     which authors real archives both ways.)
             var bsa = MkFolder(root, "bsa", esp: "Mod.esp");
             File.WriteAllText(Path.Combine(bsa, "Mod.bsa"), "x");
-            fails += Check(".bsa present → has own strings (no redirect)",
+            fails += Check("unreadable .bsa present → has own strings (no redirect)",
                 LoadOrderResolver.FolderHasOwnStrings(Path.Combine(bsa, "Mod.esp")) == true);
 
             // (d) BOTH ⇒ has own strings.
             var both = MkFolder(root, "both", esp: "M.esp");
             Directory.CreateDirectory(Path.Combine(both, "Strings"));
+            File.WriteAllText(Path.Combine(both, "Strings", "M_English.STRINGS"), "x");
             File.WriteAllText(Path.Combine(both, "M.bsa"), "x");
             fails += Check("Strings\\ + .bsa → has own strings (no redirect)",
                 LoadOrderResolver.FolderHasOwnStrings(Path.Combine(both, "M.esp")) == true);

--- a/src/housecarl-mcp-tests/LocalizedModFolderUnreadableTests.cs
+++ b/src/housecarl-mcp-tests/LocalizedModFolderUnreadableTests.cs
@@ -1,0 +1,126 @@
+using System.Security.AccessControl;
+using System.Security.Principal;
+using HousecarlGenerator;
+using HousecarlMcp;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Strings;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>A localized plugin in a MOD FOLDER that will not list, with its tables in a <c>.bsa</c> sitting in that
+/// same folder. The classifier read the folder's third answer and then discarded it, so this fell through to
+/// <see cref="LocalizedShape.Nowhere"/> — whose refusal tells the modder there is "no archive beside it" and sends
+/// them off to find tables that are right there, while the read side's gate answers that a source may well exist.
+///
+/// <para>Windows is what makes it reachable: listing a directory is a separate right from traversing it, so the
+/// plugin still opens and a <c>Strings\</c> subfolder still enumerates while <c>GetFiles(folder, "*.bsa")</c>
+/// throws.</para></summary>
+[Trait("tier", "unit")]
+public sealed class LocalizedModFolderUnreadableTests : IDisposable
+{
+    readonly string _root;
+    readonly string _modDir;
+    readonly string _dataDir;
+    readonly string _plugin;
+
+    public LocalizedModFolderUnreadableTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "hc-modfolder-" + Guid.NewGuid().ToString("N"));
+        _modDir = Path.Combine(_root, "mods", "ZRefMod");
+        _dataDir = Path.Combine(_root, "game", "Data");
+        Directory.CreateDirectory(_modDir);
+        Directory.CreateDirectory(_dataDir);
+        _plugin = WriteLocalized(_modDir, "ZRef");
+        // The tables, in an archive in the mod folder — a real one, so the classifier finds it while the folder lists.
+        File.WriteAllBytes(Path.Combine(_modDir, "ZRef.bsa"), BsaBuilder.Build(
+            105, BsaBuilder.HasFolderNames | BsaBuilder.HasFileNames,
+            new[] { ("strings", new[] { ("zref_english.strings", BsaBuilder.Bytes("STR", 32)) }) }));
+    }
+
+    public void Dispose() { try { Directory.Delete(_root, recursive: true); } catch { /* temp scratch */ } }
+
+    /// <summary>A localized plugin whose text is written into its own <c>Strings\</c> tables, which the fixture then
+    /// deletes: the archive beside it is the only source left.</summary>
+    static string WriteLocalized(string modDir, string stem)
+    {
+        var key = new ModKey(stem, ModType.Plugin);
+        var path = Path.Combine(modDir, key.FileName.String);
+        var m = new SkyrimMod(key, SkyrimRelease.SkyrimSE) { UsingLocalization = true };
+        var name = new TranslatedString(Language.English, "REF NAME");
+        m.Weapons.Add(new Weapon(new FormKey(key, 0xA02), SkyrimRelease.SkyrimSE) { EditorID = stem + "Weap", Name = name });
+        m.BeginWrite.ToPath(path).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        var own = Path.Combine(modDir, "Strings");
+        if (!Directory.Exists(own))
+            throw new InvalidOperationException($"fixture: '{key.FileName}' was written localized but produced no Strings folder.");
+        Directory.Delete(own, recursive: true);
+        return path;
+    }
+
+    /// <summary>Deny LISTING (not traverse) on the mod folder, run <paramref name="body"/>, and lift it again.
+    /// Returns false when the ACE did not bite on this host, so the caller can say so rather than passing.</summary>
+    bool WithDeniedListing(Action body)
+    {
+        if (!OperatingSystem.IsWindows()) return false;
+        var dir = new DirectoryInfo(_modDir);
+        var acl = dir.GetAccessControl();
+        var deny = new FileSystemAccessRule(WindowsIdentity.GetCurrent().Name, FileSystemRights.ListDirectory, AccessControlType.Deny);
+        acl.AddAccessRule(deny);
+        dir.SetAccessControl(acl);
+        try
+        {
+            // VERIFIED to bite, and verified to leave the plugin readable — a deny that took the whole folder down
+            // would be measuring a different state.
+            try { Directory.GetFiles(_modDir, "*.bsa"); return false; }
+            catch (UnauthorizedAccessException) { }
+            catch (IOException) { }
+            body();
+            return true;
+        }
+        finally
+        {
+            acl.RemoveAccessRule(deny);
+            dir.SetAccessControl(acl);
+        }
+    }
+
+    [Fact]
+    public void AnUnlistableModFolderIsNotAFolderFoundEmpty()
+    {
+        if (!OperatingSystem.IsWindows()) return;   // the deny ACE that makes a folder unlistable is Windows-only
+
+        Assert.Equal(LocalizedShape.BsaEmbedded, LocalizedStrings.Assess(_plugin, _dataDir).Shape);
+
+        var bit = WithDeniedListing(() =>
+        {
+            var a = LocalizedStrings.Assess(_plugin, _dataDir);
+            Assert.Equal(LocalizedShape.ModFolderUnreadable, a.Shape);
+
+            // The refusal says what happened, and asserts none of the absences Nowhere's sentence asserts.
+            var msg = LocalizedStrings.RefusalFor(_plugin, "ZRef.esp", _dataDir);
+            Assert.NotNull(msg);
+            Assert.Contains("could not read the folder the plugin sits in", msg);
+            Assert.DoesNotContain("no archive beside it", msg);
+            Assert.DoesNotContain("cannot find its text", msg);
+            Assert.DoesNotContain("no .STRINGS files beside it", msg);
+
+            // The remedy points at the folder that is actually stuck, named — not at filling a Strings folder the
+            // modder does not have, and not at the Strings folder, which is not the one that would not read.
+            var refusal = LoadOrderService.UnresolvableStringsRefusal("ZRef.esp", a, "merge");
+            Assert.Contains("the folder 'ZRef.esp' sits in", refusal);
+            Assert.Contains("fix its permissions", refusal);
+            Assert.DoesNotContain("place them in a Strings folder beside the plugin", refusal);
+
+            // THE TWO SIDES AGREE: the read gate keeps the folder-adjacent open because a source may be in there, and
+            // the classifier must not answer with the shape that says one is not.
+            Assert.True(LocalizedStrings.OwnFolderCarriesStringsFor(_plugin));
+            Assert.NotEqual(LocalizedShape.Nowhere, a.Shape);
+        });
+        Assert.True(bit, "the deny-listing ACE did not take on this host — the fixture cannot be built");
+
+        // The other direction: with the deny lifted the archive is found again, so the assertions above cannot pass
+        // by the classifier answering ModFolderUnreadable for everything.
+        Assert.Equal(LocalizedShape.BsaEmbedded, LocalizedStrings.Assess(_plugin, _dataDir).Shape);
+    }
+}

--- a/src/housecarl-mcp-tests/LocalizedStringsSourceTests.cs
+++ b/src/housecarl-mcp-tests/LocalizedStringsSourceTests.cs
@@ -1,0 +1,118 @@
+using HousecarlCore;
+using HousecarlGenerator;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>The read side's strings-redirect gate: does the plugin's own folder carry a strings source FOR THIS
+/// PLUGIN? The gate used to answer yes to any <c>.bsa</c> at all and to any <c>Strings\</c> folder at all, so an
+/// asset-only archive — meshes and textures, the common case — suppressed the redirect for a localized plugin whose
+/// tables live in game-Data, and every value it read came back blank (#369).</summary>
+[Trait("tier", "unit")]
+public sealed class LocalizedStringsSourceTests : IDisposable
+{
+    readonly string _root;
+
+    public LocalizedStringsSourceTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "hc-strings-source-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose() { try { Directory.Delete(_root, recursive: true); } catch { /* temp scratch */ } }
+
+    /// <summary>A fresh mod folder holding an empty file standing in for the plugin — the gate reads the folder
+    /// around the path and the file's name, never the plugin's bytes.</summary>
+    string Folder(string name)
+    {
+        var dir = Path.Combine(_root, name);
+        Directory.CreateDirectory(dir);
+        var plugin = Path.Combine(dir, "ZRef.esp");
+        File.WriteAllBytes(plugin, Array.Empty<byte>());
+        return plugin;
+    }
+
+    static void WriteArchive(string pluginPath, string archiveName, (string Folder, (string Name, byte[] Data)[] Files)[] contents)
+        => File.WriteAllBytes(
+            Path.Combine(Path.GetDirectoryName(pluginPath)!, archiveName),
+            BsaBuilder.Build(105, BsaBuilder.HasFolderNames | BsaBuilder.HasFileNames, contents));
+
+    static void WriteTable(string pluginPath, string tableName)
+    {
+        var dir = Path.Combine(Path.GetDirectoryName(pluginPath)!, "Strings");
+        Directory.CreateDirectory(dir);
+        File.WriteAllBytes(Path.Combine(dir, tableName), new byte[] { 0 });
+    }
+
+    /// <summary>#369: an archive carrying only meshes is not a strings source, so the gate must let the redirect
+    /// through. This is the shape that blanked a whole population of localized plugins.</summary>
+    [Fact]
+    public void AnAssetOnlyArchiveIsNotAStringsSource()
+    {
+        var plugin = Folder("asset-only");
+        WriteArchive(plugin, "ZRef - Meshes.bsa", new[]
+        {
+            ("meshes", new[] { ("a.nif", BsaBuilder.Bytes("NIF-a", 64)) }),
+        });
+        Assert.False(LocalizedStrings.OwnFolderCarriesStringsFor(plugin));
+    }
+
+    /// <summary>The other half of the same question: an archive that really does embed this plugin's tables keeps
+    /// the folder-adjacent open, so a mod shipping its strings in its own .bsa is never redirected away from them.</summary>
+    [Fact]
+    public void AnArchiveEmbeddingThisPluginsTablesIsAStringsSource()
+    {
+        var plugin = Folder("bsa-strings");
+        WriteArchive(plugin, "ZRef.bsa", new[]
+        {
+            ("strings", new[] { ("zref_english.strings", BsaBuilder.Bytes("STR", 32)) }),
+        });
+        Assert.True(LocalizedStrings.OwnFolderCarriesStringsFor(plugin));
+    }
+
+    /// <summary>An archive embedding a NEIGHBOUR's tables answers for that neighbour, not for this plugin — two
+    /// plugins share a mod folder, and a prefix-loose match would hand one plugin the other's source.</summary>
+    [Fact]
+    public void AnArchiveEmbeddingANeighboursTablesIsNotThisPluginsSource()
+    {
+        var plugin = Folder("bsa-neighbour");
+        WriteArchive(plugin, "Other.bsa", new[]
+        {
+            ("strings", new[] { ("zref_shrubs_english.strings", BsaBuilder.Bytes("STR", 32)) }),
+        });
+        Assert.False(LocalizedStrings.OwnFolderCarriesStringsFor(plugin));
+    }
+
+    /// <summary>A Strings folder is shared by every plugin beside it, so its mere existence says nothing: one
+    /// holding only a neighbour's tables is not this plugin's source either.</summary>
+    [Fact]
+    public void ALooseFolderHoldingOnlyANeighboursTablesIsNotThisPluginsSource()
+    {
+        var plugin = Folder("loose-neighbour");
+        WriteTable(plugin, "ZRef_shrubs_English.STRINGS");
+        Assert.False(LocalizedStrings.OwnFolderCarriesStringsFor(plugin));
+    }
+
+    [Fact]
+    public void ALooseTableForThisPluginIsAStringsSource()
+    {
+        var plugin = Folder("loose-own");
+        WriteTable(plugin, "ZRef_English.STRINGS");
+        Assert.True(LocalizedStrings.OwnFolderCarriesStringsFor(plugin));
+    }
+
+    /// <summary>An archive houseCARL cannot parse may hold the tables, so the gate keeps the unchanged
+    /// folder-adjacent open rather than redirecting past a source it could not rule out.</summary>
+    [Fact]
+    public void AnUnreadableArchiveKeepsTheUnchangedOpen()
+    {
+        var plugin = Folder("bsa-malformed");
+        File.WriteAllBytes(Path.Combine(Path.GetDirectoryName(plugin)!, "ZRef.bsa"), new byte[] { 0x42, 0x53, 0x41, 0x00 });
+        Assert.True(LocalizedStrings.OwnFolderCarriesStringsFor(plugin));
+    }
+
+    /// <summary>A plain mod folder with nothing beside the plugin: the redirect is the whole point of the gate.</summary>
+    [Fact]
+    public void AnEmptyFolderCarriesNoStringsSource()
+        => Assert.False(LocalizedStrings.OwnFolderCarriesStringsFor(Folder("bare")));
+}

--- a/src/housecarl-mcp-tests/LocalizedStringsSourceTests.cs
+++ b/src/housecarl-mcp-tests/LocalizedStringsSourceTests.cs
@@ -1,3 +1,5 @@
+using System.Security.AccessControl;
+using System.Security.Principal;
 using HousecarlCore;
 using HousecarlGenerator;
 using Xunit;
@@ -115,4 +117,32 @@ public sealed class LocalizedStringsSourceTests : IDisposable
     [Fact]
     public void AnEmptyFolderCarriesNoStringsSource()
         => Assert.False(LocalizedStrings.OwnFolderCarriesStringsFor(Folder("bare")));
+
+    /// <summary>The mod folder itself will not list, so the archive look tells us nothing about what is beside the
+    /// plugin — the same fact as an unlistable <c>Strings\</c> folder, and it takes the same answer: keep the
+    /// unchanged folder-adjacent open. Swallowed as "no archives", the gate answers false and redirects a plugin
+    /// whose tables may be sitting right there, which is the failure #369 was about.</summary>
+    [Fact]
+    public void AModFolderThatCannotBeListedKeepsTheUnchangedOpen()
+    {
+        if (!OperatingSystem.IsWindows()) return;   // the deny ACE that makes a folder unlistable is Windows-only
+        var plugin = Folder("folder-unlistable");
+        var dir = new DirectoryInfo(Path.GetDirectoryName(plugin)!);
+        var acl = dir.GetAccessControl();
+        var deny = new FileSystemAccessRule(WindowsIdentity.GetCurrent().Name, FileSystemRights.ListDirectory, AccessControlType.Deny);
+        acl.AddAccessRule(deny);
+        dir.SetAccessControl(acl);
+        try
+        {
+            // The fixture is VERIFIED to bite: without this the arm passes on a folder that lists fine, which is
+            // exactly the shape it exists to rule out.
+            Assert.ThrowsAny<Exception>(() => Directory.GetFiles(dir.FullName, "*.bsa"));
+            Assert.True(LocalizedStrings.OwnFolderCarriesStringsFor(plugin));
+        }
+        finally
+        {
+            acl.RemoveAccessRule(deny);
+            dir.SetAccessControl(acl);
+        }
+    }
 }

--- a/src/housecarl-mcp-tests/MasterDeclarerScanTests.cs
+++ b/src/housecarl-mcp-tests/MasterDeclarerScanTests.cs
@@ -1,0 +1,126 @@
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>The identify pass against a plugin that DECLARES the transform target as a master and references none of
+/// its records — a compat patch that exists to be load-ordered, or one whose overrides were trimmed. A walk over
+/// record links and record identity cannot see it, and it loses a master the moment the donor is deactivated.</summary>
+[Trait("tier", "integration")]
+public sealed class MasterDeclarerScanTests : IDisposable
+{
+    readonly string _root;
+    readonly ModKey _targetKey = new("HcDeclTarget", ModType.Plugin);
+    readonly ModKey _declarerKey = new("HcDeclOnly", ModType.Plugin);
+    readonly ModKey _referencerKey = new("HcDeclRef", ModType.Plugin);
+    readonly string _targetPath;
+    readonly string _declarerPath;
+    readonly string _referencerPath;
+    readonly FormKey _weaponKey;
+
+    public MasterDeclarerScanTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "hc-declarer-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+
+        _weaponKey = new FormKey(_targetKey, 0x800);
+        var target = new SkyrimMod(_targetKey, SkyrimRelease.SkyrimSE);
+        target.Weapons.Add(new Weapon(_weaponKey, SkyrimRelease.SkyrimSE) { EditorID = "HcDeclWeapon" });
+        target.ModHeader.Stats.NextFormID = 0x801;
+        _targetPath = Path.Combine(_root, _targetKey.FileName.String);
+        target.BeginWrite.ToPath(_targetPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write();
+
+        using var targetOverlay = SkyrimMod.CreateFromBinaryOverlay(_targetPath, SkyrimRelease.SkyrimSE);
+
+        // The declarer: its own record, no link to anything the target defines, and the target carried in the master
+        // table anyway — what an extra included master is for, and what a trimmed compat patch looks like on disk.
+        var declarer = new SkyrimMod(_declarerKey, SkyrimRelease.SkyrimSE);
+        declarer.Weapons.Add(new Weapon(new FormKey(_declarerKey, 0x800), SkyrimRelease.SkyrimSE) { EditorID = "HcDeclOwn" });
+        declarer.ModHeader.Stats.NextFormID = 0x801;
+        _declarerPath = Path.Combine(_root, _declarerKey.FileName.String);
+        declarer.BeginWrite.ToPath(_declarerPath).WithLoadOrder(new[] { targetOverlay })
+                .WithExtraIncludedMasters(_targetKey).NoNextFormIDProcessing().Write();
+
+        // A real referencer alongside it: every referencer declares the donor as a master too, so this is what keeps
+        // the new category from simply repeating the referencer list.
+        var referencer = new SkyrimMod(_referencerKey, SkyrimRelease.SkyrimSE);
+        var list = new FormList(new FormKey(_referencerKey, 0x800), SkyrimRelease.SkyrimSE) { EditorID = "HcDeclList" };
+        list.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(_weaponKey));
+        referencer.FormLists.Add(list);
+        referencer.ModHeader.Stats.NextFormID = 0x801;
+        _referencerPath = Path.Combine(_root, _referencerKey.FileName.String);
+        referencer.BeginWrite.ToPath(_referencerPath).WithLoadOrder(new[] { targetOverlay }).NoNextFormIDProcessing().Write();
+    }
+
+    public void Dispose() { try { Directory.Delete(_root, true); } catch { /* temp cleanup best-effort */ } }
+
+    RemapEngine.IdentifyResult Identify(LoadOrderResolver resolver)
+        => RemapEngine.IdentifyExternalReferencers(
+            resolver,
+            new HashSet<FormKey> { _weaponKey },
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { _targetKey.FileName.String });
+
+    /// <summary>The declarer must be found, named with what it declares, and must not be mistaken for a referencer:
+    /// the pass reported "external referencers: none" for this plugin and the user lost a master at the swap.</summary>
+    [Fact]
+    public void ADeclarerOnlyDependentIsFoundAndNamed()
+    {
+        using var resolver = LoadOrderResolver.Build(new[] { _targetPath, _declarerPath, _referencerPath });
+        var id = Identify(resolver);
+
+        var found = Assert.Single(id.MasterDeclarers!);
+        Assert.Equal(_declarerKey.FileName.String, found.Plugin, StringComparer.OrdinalIgnoreCase);
+        Assert.Equal(_targetKey.FileName.String, Assert.Single(found.Declared), StringComparer.OrdinalIgnoreCase);
+
+        // It links to nothing and overrides nothing, so the two existing categories are right to leave it out.
+        Assert.DoesNotContain(_declarerKey.FileName.String, id.ExternalPlugins, StringComparer.OrdinalIgnoreCase);
+        Assert.DoesNotContain(_declarerKey.FileName.String, id.ExternalOverriders, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>A referencer declares the donor as a master by construction, so listing every declarer would repeat
+    /// the referencer list under a new heading. Only the dependents the record walk did NOT find are reported.</summary>
+    [Fact]
+    public void AReferencerIsNotAlsoListedAsADeclarer()
+    {
+        using var resolver = LoadOrderResolver.Build(new[] { _targetPath, _declarerPath, _referencerPath });
+        var id = Identify(resolver);
+
+        Assert.Contains(_referencerKey.FileName.String, id.ExternalPlugins, StringComparer.OrdinalIgnoreCase);
+        Assert.DoesNotContain(id.MasterDeclarers!, d => string.Equals(d.Plugin, _referencerKey.FileName.String, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>Detection is only half of it: the merge report has to NAME the plugin and what it declares, because
+    /// the remedy — add the merged plugin as a master, or include it in the merge — is per plugin.</summary>
+    [Fact]
+    public void TheMergeReportNamesADeclarerAndWhatItDeclares()
+    {
+        var outcome = new WritePatchBuilder.MergeOutcome(
+            true, null, Path.Combine(_root, "Merged.esp"), "Merged.esp",
+            new[] { _targetKey.FileName.String }, Array.Empty<string>(), 1, 1,
+            Array.Empty<RemapEngine.MergeDonorRemap>(), Array.Empty<RemapEngine.MergeConflict>(),
+            Array.Empty<string>(), Array.Empty<string>(), 3, 0, Array.Empty<string>(), 1024,
+            MasterDeclarers: new[] { new RemapEngine.MasterDeclarer(_declarerKey.FileName.String, new[] { _targetKey.FileName.String }) });
+
+        var rendered = HousecarlMcp.WriteTools.RenderMerge(outcome);
+        Assert.Contains("DECLARE a donor as a MASTER", rendered);
+        Assert.Contains(_declarerKey.FileName.String, rendered);
+        Assert.Contains("declares " + _targetKey.FileName.String, rendered);
+        // The pass line may no longer claim declared masters are unread — it reads them now.
+        Assert.Contains("record identity and declared masters", rendered);
+    }
+
+    /// <summary>A plugin declaring nothing in the transform set is not a dependent of it at all.</summary>
+    [Fact]
+    public void AnUnrelatedPluginIsNotADeclarer()
+    {
+        using var resolver = LoadOrderResolver.Build(new[] { _targetPath, _declarerPath });
+        var id = RemapEngine.IdentifyExternalReferencers(
+            resolver, new HashSet<FormKey> { _weaponKey },
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { _declarerKey.FileName.String });
+
+        Assert.Empty(id.MasterDeclarers!);
+    }
+}

--- a/src/housecarl-mcp-tests/MasterDeclarerScanTests.cs
+++ b/src/housecarl-mcp-tests/MasterDeclarerScanTests.cs
@@ -113,6 +113,42 @@ public sealed class MasterDeclarerScanTests : IDisposable
         Assert.Equal(RemapEngine.UnscannableCause.Unopenable, bad.Cause);
     }
 
+    /// <summary>A plugin whose TES4 MASTER TABLE is corrupt: the two callers must agree about it. Merge reads headers
+    /// and compact does not, so a header fault that skipped the record walk would let merge report "external
+    /// referencers: none" for a plugin compact reports as a referencer.
+    ///
+    /// <para>What actually happens is measured here rather than assumed: Mutagen parses the master list while OPENING
+    /// the file, so a corrupt table takes the open down, the resolver excludes the plugin at build, and the pass skips
+    /// it before either header branch — the same answer with headers read and with them not. The referencer it
+    /// carries is NOT reported by either lane, and the exclusion is where the caller is told why.</para></summary>
+    [Fact]
+    public void ACorruptMasterTableReadsTheSameForBothCallers()
+    {
+        // The MAST subrecord claims a length that overruns the header record — the whole table is unparseable.
+        var bytes = File.ReadAllBytes(_referencerPath);
+        int mast = System.Text.Encoding.ASCII.GetString(bytes, 0, Math.Min(bytes.Length, 512)).IndexOf("MAST", StringComparison.Ordinal);
+        Assert.True(mast > 0, "fixture: the referencer declares a master, so its header holds a MAST subrecord");
+        bytes[mast + 4] = 0xFF; bytes[mast + 5] = 0x00;
+        var corruptPath = Path.Combine(_root, "HcDeclCorrupt.esp");
+        File.WriteAllBytes(corruptPath, bytes);
+
+        using var resolver = LoadOrderResolver.Build(new[] { _targetPath, corruptPath });
+        Assert.Contains("HcDeclCorrupt.esp", resolver.Capture().ExcludedPlugins.Keys, StringComparer.OrdinalIgnoreCase);
+
+        var withHeaders = Identify(resolver);
+        var withoutHeaders = RemapEngine.IdentifyExternalReferencers(
+            resolver, new HashSet<FormKey> { _weaponKey },
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { _targetKey.FileName.String },
+            readDeclaredMasters: false);
+
+        // The two lanes agree, which is the property that matters: the header read may not change what the record
+        // walk reports.
+        Assert.Equal(withoutHeaders.ExternalPlugins, withHeaders.ExternalPlugins);
+        Assert.Equal(withoutHeaders.UnscannablePlugins!.Count, withHeaders.UnscannablePlugins!.Count);
+        Assert.Equal(withoutHeaders.PluginsScanned, withHeaders.PluginsScanned);
+        Assert.Empty(withHeaders.MasterDeclarers!);
+    }
+
     /// <summary>Detection is only half of it: the merge report has to NAME the plugin and what it declares, because
     /// the remedy — remove the stale master, or include it in the merge — is per plugin.</summary>
     [Fact]

--- a/src/housecarl-mcp-tests/MasterDeclarerScanTests.cs
+++ b/src/housecarl-mcp-tests/MasterDeclarerScanTests.cs
@@ -95,7 +95,11 @@ public sealed class MasterDeclarerScanTests : IDisposable
 
     /// <summary>The category's claim is "declares a donor and references none of its records". A plugin the pass
     /// could not read through had no records walked, so it may not be put in that list — it is named, with its
-    /// reason, in the unscannable accounting instead.</summary>
+    /// reason, in the unscannable accounting instead.
+    ///
+    /// <para>The CAUSE is asserted, not merely the presence of an entry: a held-open file is a file that will not
+    /// open, and the report's remedy for that cause is "close the program holding it". Reported as an enumeration
+    /// fault instead, the same plugin is told that closing programs will not help.</para></summary>
     [Fact]
     public void APluginThePassCouldNotReadIsNotCalledADeclarer()
     {
@@ -104,7 +108,9 @@ public sealed class MasterDeclarerScanTests : IDisposable
         var id = Identify(resolver);
 
         Assert.Empty(id.MasterDeclarers!);
-        Assert.NotEmpty(id.UnscannablePlugins!);
+        var bad = Assert.Single(id.UnscannablePlugins!);
+        Assert.Equal(_declarerKey.FileName.String, bad.Plugin, StringComparer.OrdinalIgnoreCase);
+        Assert.Equal(RemapEngine.UnscannableCause.Unopenable, bad.Cause);
     }
 
     /// <summary>Detection is only half of it: the merge report has to NAME the plugin and what it declares, because

--- a/src/housecarl-mcp-tests/MasterDeclarerScanTests.cs
+++ b/src/housecarl-mcp-tests/MasterDeclarerScanTests.cs
@@ -61,7 +61,8 @@ public sealed class MasterDeclarerScanTests : IDisposable
         => RemapEngine.IdentifyExternalReferencers(
             resolver,
             new HashSet<FormKey> { _weaponKey },
-            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { _targetKey.FileName.String });
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { _targetKey.FileName.String },
+            readDeclaredMasters: true);
 
     /// <summary>The declarer must be found, named with what it declares, and must not be mistaken for a referencer:
     /// the pass reported "external referencers: none" for this plugin and the user lost a master at the swap.</summary>
@@ -92,8 +93,22 @@ public sealed class MasterDeclarerScanTests : IDisposable
         Assert.DoesNotContain(id.MasterDeclarers!, d => string.Equals(d.Plugin, _referencerKey.FileName.String, StringComparison.OrdinalIgnoreCase));
     }
 
+    /// <summary>The category's claim is "declares a donor and references none of its records". A plugin the pass
+    /// could not read through had no records walked, so it may not be put in that list — it is named, with its
+    /// reason, in the unscannable accounting instead.</summary>
+    [Fact]
+    public void APluginThePassCouldNotReadIsNotCalledADeclarer()
+    {
+        using var resolver = LoadOrderResolver.Build(new[] { _targetPath, _declarerPath });
+        using var hold = HeldOpen.Hold(_declarerPath);
+        var id = Identify(resolver);
+
+        Assert.Empty(id.MasterDeclarers!);
+        Assert.NotEmpty(id.UnscannablePlugins!);
+    }
+
     /// <summary>Detection is only half of it: the merge report has to NAME the plugin and what it declares, because
-    /// the remedy — add the merged plugin as a master, or include it in the merge — is per plugin.</summary>
+    /// the remedy — remove the stale master, or include it in the merge — is per plugin.</summary>
     [Fact]
     public void TheMergeReportNamesADeclarerAndWhatItDeclares()
     {
@@ -119,7 +134,8 @@ public sealed class MasterDeclarerScanTests : IDisposable
         using var resolver = LoadOrderResolver.Build(new[] { _targetPath, _declarerPath });
         var id = RemapEngine.IdentifyExternalReferencers(
             resolver, new HashSet<FormKey> { _weaponKey },
-            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { _declarerKey.FileName.String });
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { _declarerKey.FileName.String },
+            readDeclaredMasters: true);
 
         Assert.Empty(id.MasterDeclarers!);
     }

--- a/src/housecarl-mcp-tests/MasterDeclarerScanTests.cs
+++ b/src/housecarl-mcp-tests/MasterDeclarerScanTests.cs
@@ -133,14 +133,17 @@ public sealed class MasterDeclarerScanTests : IDisposable
         Assert.Contains("record identity and declared masters", rendered);
     }
 
-    /// <summary>A plugin declaring nothing in the transform set is not a dependent of it at all.</summary>
+    /// <summary>A plugin declaring nothing IN THE TRANSFORM SET is not a dependent of it at all — the filter over the
+    /// declared master list, not the empty-header case. The scanned plugin here declares a real master
+    /// (HcDeclTarget.esp) that the transform set does not contain, so a pass that reported every declared master
+    /// would name it and this arm would fail; a plugin declaring nothing at all cannot tell the two apart.</summary>
     [Fact]
-    public void AnUnrelatedPluginIsNotADeclarer()
+    public void APluginDeclaringAMasterOutsideTheTransformSetIsNotADeclarer()
     {
-        using var resolver = LoadOrderResolver.Build(new[] { _targetPath, _declarerPath });
+        using var resolver = LoadOrderResolver.Build(new[] { _targetPath, _declarerPath, _referencerPath });
         var id = RemapEngine.IdentifyExternalReferencers(
             resolver, new HashSet<FormKey> { _weaponKey },
-            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { _declarerKey.FileName.String },
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { _referencerKey.FileName.String },
             readDeclaredMasters: true);
 
         Assert.Empty(id.MasterDeclarers!);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1,4 +1,4 @@
-﻿using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Aspects;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -6340,12 +6340,12 @@ public sealed class LoadOrderService : IDisposable
     /// at runtime, so a plugin's strings can sit in an archive in another mod folder that no path walked here can
     /// see.</para>
     ///
-    /// <para>Two shapes arrive here and the words differ per shape — what the read WILL be, and what to do about it.
-    /// Nothing found anywhere is fixed by putting the tables somewhere houseCARL can see; a Strings folder that is
-    /// there and would not list is fixed by freeing that folder, and telling its caller to place tables in it
-    /// describes a folder they already have.</para></summary>
+    /// <para>Three shapes arrive here and the words differ per shape — what the read WILL be, and what to do about it.
+    /// Nothing found anywhere is fixed by putting the tables somewhere houseCARL can see; a folder that is there and
+    /// would not list — the plugin's <c>Strings\</c> folder, or the mod folder itself — is fixed by freeing THAT
+    /// folder, and telling its caller to place tables in it describes a folder they already have.</para></summary>
     /// <param name="verb">The operation, as the report names it — "compact", "merge".</param>
-    static string UnresolvableStringsRefusal(string name, LocalizedAssessment a, string verb)
+    internal static string UnresolvableStringsRefusal(string name, LocalizedAssessment a, string verb)
     {
         // WHERE the text is comes from the one renderer that already gets it right for both shapes: it names what
         // the Strings folder beside the plugin actually holds rather than claiming it is empty, and it drops the
@@ -6354,16 +6354,21 @@ public sealed class LoadOrderService : IDisposable
         // What the READ will be is per shape, and neither claim may be made for the other: nothing resolves a
         // plugin whose text is nowhere, so its values are empty; a folder that could not be listed was never read,
         // so what comes back from it is unknown.
-        var consequence = a.Shape == LocalizedShape.StringsFolderUnreadable
+        var unlistable = a.Shape is LocalizedShape.StringsFolderUnreadable or LocalizedShape.ModFolderUnreadable;
+        var consequence = unlistable
             ? "houseCARL cannot tell what its text reads as, or an empty value from a real one"
             : "every name, description and message it carries reads back EMPTY";
 
         // And so is the REMEDY. "Put the tables where houseCARL can see them" is the answer when nothing was found
-        // anywhere; told to a plugin whose Strings folder is already sitting there unreadable, it sends the caller to
-        // fill the one folder nothing could open. That shape needs the folder freed, not populated.
-        var remedy = a.Shape == LocalizedShape.StringsFolderUnreadable
-            ? $"Let houseCARL read the Strings folder beside '{name}' — close whatever is holding it open, or fix its "
-              + "permissions — and run this again."
+        // anywhere; told to a plugin whose folder is already sitting there unreadable, it sends the caller to fill a
+        // folder nothing could open. Those shapes need the folder freed, not populated — and the sentence names WHICH
+        // folder, because the two are different places on disk and only one of them is the one to fix.
+        var folder = a.Shape == LocalizedShape.StringsFolderUnreadable
+            ? $"the Strings folder beside '{name}'"
+            : $"the folder '{name}' sits in";
+        var remedy = unlistable
+            ? $"Let houseCARL read {folder} — close whatever is holding it open, or fix its permissions — and run "
+              + "this again."
             : "Put this plugin's .STRINGS where houseCARL can see them — enable the mod that provides them, or place "
               + "them in a Strings folder beside the plugin — and run this again.";
         return $"refused — houseCARL did not {verb} '{name}'. "
@@ -6393,7 +6398,8 @@ public sealed class LoadOrderService : IDisposable
 
             LocalizedShape.LooseComplete or LocalizedShape.LoosePartial or LocalizedShape.LooseWithGameDataDuplicate
                 or LocalizedShape.BsaEmbedded or LocalizedShape.GameDataOnly
-                or LocalizedShape.StringsFolderUnreadable or LocalizedShape.Nowhere =>
+                or LocalizedShape.StringsFolderUnreadable or LocalizedShape.ModFolderUnreadable
+                or LocalizedShape.Nowhere =>
                 head + "A compaction does not re-serialize your plugin, it builds a NEW one and writes that over the "
                      + "original, and houseCARL will not replace a translated plugin's .STRINGS files on your own copy: "
                      + "it cannot swap the plugin and its tables as one operation, and the file the game loads would "

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -6620,7 +6620,7 @@ public sealed class LoadOrderService : IDisposable
                 plan.Donors, build.Conflicts, id.ExternalPlugins, id.ExternalOverriders,
                 id.PluginsScanned, id.UnscannableRecords, id.UnscannableSamples, build.Bytes, note,
                 assetRename, voiceRename, seqRegen, build.LightDonors, build.HeaderMetaDonors, build.MasterDonors,
-                id.UnscannablePlugins, localizedDonors);
+                id.UnscannablePlugins, localizedDonors, id.MasterDeclarers);
         }
     }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -5998,6 +5998,13 @@ public sealed class LoadOrderService : IDisposable
             if (inPlace && srcLocalized)
                 return WritePatchBuilder.CompactOutcome.Fail(CompactInPlaceRefusal(name, srcShape));
 
+            // The NEW-FILE lane's own refusal: a localized source whose strings houseCARL can find NOWHERE reads
+            // every value EMPTY, and this lane copies that read into a plugin the caller keeps. The in-place refusal
+            // above covers the wider flag, so this fires only for the new-file lane and only for that one shape.
+            if (LocalizedStrings.ResolvesNowhere(srcShape.Shape))
+                return WritePatchBuilder.CompactOutcome.Fail(
+                    UnresolvableStringsRefusal(name, srcShape, "compacting it"));
+
             // 1. originating record keys + the remap into the (light, by default) window.
             if (!WritePatchBuilder.TryReadOriginatingKeys(srcPath, modKey, out var keys, out var keyErr))
                 return WritePatchBuilder.CompactOutcome.Fail(keyErr!);
@@ -6324,6 +6331,32 @@ public sealed class LoadOrderService : IDisposable
         return string.Join(" ", parts);
     }
 
+    /// <summary>The refusal for a plugin that IS flagged localized and whose <c>.STRINGS</c> houseCARL can find
+    /// nowhere — the one shape where the read itself is empty, so a lane that copies the read into a new file writes
+    /// blanks. Shared by compact and merge, one wording: both bake the same read into a plugin the caller keeps, and
+    /// neither may do it silently.
+    ///
+    /// <para>It says houseCARL cannot FIND the tables, never that the plugin has none: MO2's VFS merges mod folders
+    /// at runtime, so a plugin's strings can sit in an archive in another mod folder that no path walked here can
+    /// see. The remedy is written for that case, because it is the likely one.</para></summary>
+    /// <param name="what">The operation, as the report names it — "compacting it", "merging it".</param>
+    static string UnresolvableStringsRefusal(string name, LocalizedAssessment a, string what)
+    {
+        // Two shapes reach here and they are different facts: one folder was listed and held nothing for this
+        // plugin, the other could not be listed at all. Saying the first about the second claims an absence
+        // nothing checked.
+        var found = a.Shape == LocalizedShape.StringsFolderUnreadable
+            ? $"there is a Strings folder beside '{name}' that houseCARL could not list, so it could not read the tables"
+            : "houseCARL can find no .STRINGS files for it — not beside the plugin, and not in the game's Data folder";
+        return $"refused — '{name}' is flagged LOCALIZED, so its text lives in separate .STRINGS files rather than in the "
+             + $"plugin, and {found}. Every name, description and message it carries therefore reads EMPTY, and {what} "
+             + "would write those blanks into the output with nothing left to distinguish them from a plugin that never "
+             + "had any text. The tables may still exist somewhere houseCARL cannot see from the plugin's own folder — a "
+             + "translation mod that is not enabled, or content whose archive lives in a different mod folder. Enable the "
+             + "mod that provides this plugin's .STRINGS, or put them in a Strings folder beside it, and run this again. "
+             + "Nothing was written.";
+    }
+
     /// <summary>The in-place compaction's refusal, rendered per shape. The refusal decision is one fail-closed
     /// boolean, but its words cannot be: the localized arm's clauses are all about a translated plugin's
     /// <c>.STRINGS</c> files and end on the new-file lane, and told to a source houseCARL could not open that would
@@ -6455,6 +6488,23 @@ public sealed class LoadOrderService : IDisposable
             donorInfos.Sort((a, b) => a.Order.CompareTo(b.Order));
             var donorNames = donorInfos.Select(d => d.Name).ToList();
 
+            // ---- the donors' strings, read once and used twice. A donor whose .STRINGS resolve NOWHERE reads every
+            //      value EMPTY, and the merge would copy those blanks into M — refused here, before a rider folder
+            //      exists and before anything is written. A donor that IS localized (and resolves) earns the
+            //      de-localization note the report carries: M is a bare mod, so the text comes out inline and the
+            //      donor's .STRINGS stop describing it. ----
+            var localizedDonors = new List<string>();
+            foreach (var (dName, dPath, _, _) in donorInfos)
+            {
+                var shape = LocalizedStrings.Assess(dPath, view.DataDir);
+                if (LocalizedStrings.ResolvesNowhere(shape.Shape))
+                    return WritePatchBuilder.MergeOutcome.Fail(UnresolvableStringsRefusal(dName, shape, "merging it"));
+                // ConfirmedLocalized, not "anything but NotLocalized": the note ASSERTS where a donor's text lives,
+                // and a donor houseCARL could not read gives it nothing to assert. That donor fails loudly at the
+                // open in MergeBuild instead.
+                if (LocalizedStrings.ConfirmedLocalized(shape.Shape)) localizedDonors.Add(dName);
+            }
+
             // ---- 2. originating keys per donor + the collision-only remap (first donor keeps its ids — zMerge default) ----
             var donorKeys = new List<(string Donor, IReadOnlyList<FormKey> Keys)>();
             foreach (var (dName, dPath, dKey, _) in donorInfos)
@@ -6570,7 +6620,7 @@ public sealed class LoadOrderService : IDisposable
                 plan.Donors, build.Conflicts, id.ExternalPlugins, id.ExternalOverriders,
                 id.PluginsScanned, id.UnscannableRecords, id.UnscannableSamples, build.Bytes, note,
                 assetRename, voiceRename, seqRegen, build.LightDonors, build.HeaderMetaDonors, build.MasterDonors,
-                id.UnscannablePlugins);
+                id.UnscannablePlugins, localizedDonors);
         }
     }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1,4 +1,4 @@
-using Mutagen.Bethesda.Plugins;
+﻿using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Aspects;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
@@ -6003,7 +6003,7 @@ public sealed class LoadOrderService : IDisposable
             // above covers the wider flag, so this fires only for the new-file lane and only for that one shape.
             if (LocalizedStrings.ResolvesNowhere(srcShape.Shape))
                 return WritePatchBuilder.CompactOutcome.Fail(
-                    UnresolvableStringsRefusal(name, srcShape, "compacting it"));
+                    UnresolvableStringsRefusal(name, srcShape, "compact"));
 
             // 1. originating record keys + the remap into the (light, by default) window.
             if (!WritePatchBuilder.TryReadOriginatingKeys(srcPath, modKey, out var keys, out var keyErr))
@@ -6339,22 +6339,25 @@ public sealed class LoadOrderService : IDisposable
     /// <para>It says houseCARL cannot FIND the tables, never that the plugin has none: MO2's VFS merges mod folders
     /// at runtime, so a plugin's strings can sit in an archive in another mod folder that no path walked here can
     /// see. The remedy is written for that case, because it is the likely one.</para></summary>
-    /// <param name="what">The operation, as the report names it — "compacting it", "merging it".</param>
-    static string UnresolvableStringsRefusal(string name, LocalizedAssessment a, string what)
+    /// <param name="verb">The operation, as the report names it — "compact", "merge".</param>
+    static string UnresolvableStringsRefusal(string name, LocalizedAssessment a, string verb)
     {
-        // Two shapes reach here and they are different facts: one folder was listed and held nothing for this
-        // plugin, the other could not be listed at all. Saying the first about the second claims an absence
-        // nothing checked.
-        var found = a.Shape == LocalizedShape.StringsFolderUnreadable
-            ? $"there is a Strings folder beside '{name}' that houseCARL could not list, so it could not read the tables"
-            : "houseCARL can find no .STRINGS files for it — not beside the plugin, and not in the game's Data folder";
-        return $"refused — '{name}' is flagged LOCALIZED, so its text lives in separate .STRINGS files rather than in the "
-             + $"plugin, and {found}. Every name, description and message it carries therefore reads EMPTY, and {what} "
-             + "would write those blanks into the output with nothing left to distinguish them from a plugin that never "
-             + "had any text. The tables may still exist somewhere houseCARL cannot see from the plugin's own folder — a "
-             + "translation mod that is not enabled, or content whose archive lives in a different mod folder. Enable the "
-             + "mod that provides this plugin's .STRINGS, or put them in a Strings folder beside it, and run this again. "
-             + "Nothing was written.";
+        // WHERE the text is comes from the one renderer that already gets it right for both shapes: it names what
+        // the Strings folder beside the plugin actually holds rather than claiming it is empty, and it drops the
+        // game-Data clause when there was no Data folder to search. Hand-rolling it here asserted both.
+        //
+        // What the READ will be is per shape, and neither claim may be made for the other: nothing resolves a
+        // plugin whose text is nowhere, so its values are empty; a folder that could not be listed was never read,
+        // so what comes back from it is unknown.
+        var consequence = a.Shape == LocalizedShape.StringsFolderUnreadable
+            ? "houseCARL cannot tell what its text reads as, or an empty value from a real one"
+            : "every name, description and message it carries reads back EMPTY";
+        return $"refused — houseCARL did not {verb} '{name}'. "
+             + LocalizedTargetUnsupportedException.WhereTheTextIs(a) + " "
+             + $"So {consequence}, and a {verb} writes whatever this read produced into a NEW plugin you keep, with "
+             + "nothing left in it to tell that text from a plugin that never had any. Put this plugin's .STRINGS "
+             + "where houseCARL can see them — enable the mod that provides them, or place them in a Strings folder "
+             + "beside the plugin — and run this again. Nothing was written.";
     }
 
     /// <summary>The in-place compaction's refusal, rendered per shape. The refusal decision is one fail-closed
@@ -6502,7 +6505,7 @@ public sealed class LoadOrderService : IDisposable
             {
                 var shape = LocalizedStrings.Assess(dPath, view.DataDir);
                 if (LocalizedStrings.ResolvesNowhere(shape.Shape))
-                    return WritePatchBuilder.MergeOutcome.Fail(UnresolvableStringsRefusal(dName, shape, "merging it"));
+                    return WritePatchBuilder.MergeOutcome.Fail(UnresolvableStringsRefusal(dName, shape, "merge"));
                 // ConfirmedLocalized, not "anything but NotLocalized": the note ASSERTS where a donor's text lives,
                 // and a donor houseCARL could not read gives it nothing to assert. That donor fails loudly at the
                 // open in MergeBuild instead.
@@ -6525,7 +6528,11 @@ public sealed class LoadOrderService : IDisposable
             //      affected plugin with the remedy — include it in the merge set, or handle it before disabling the donors.) ----
             var targets = plan.Dict.Keys.ToHashSet();
             var transformSet = new HashSet<string>(donorNames, StringComparer.OrdinalIgnoreCase);
-            var id = RemapEngine.IdentifyExternalReferencers(resolver, targets, transformSet);
+            // readDeclaredMasters: a merge RENAMES the donors' records into a new plugin, so a dependent that only
+            // lists a donor as a master loses it at the swap. Sound here because BuildMergeRemap enters every
+            // originating key of every donor into the dict, so a referencer is always a declarer too and the
+            // declarer-only filter cannot hide one.
+            var id = RemapEngine.IdentifyExternalReferencers(resolver, targets, transformSet, readDeclaredMasters: true);
 
             // ---- 4. masters = union(donor declared masters) − donors, load-order sorted (each donor's own header order
             //      is already load-order-consistent; the union sorts by the active order so the merged header is too) ----

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -6457,13 +6457,15 @@ public sealed class LoadOrderService : IDisposable
         catch (Exception ex) { return WritePatchBuilder.MergeOutcome.Fail($"'{outName}' is not a valid plugin filename ({ex.Message})."); }
         if (outKey.Type == ModType.Light)
             return WritePatchBuilder.MergeOutcome.Fail(
-                // The reason is what the merge does NOT do, not a claim about where the donors' ids are. A single
-                // already-light donor's ids are all inside the window by definition, so "a merge keeps the ids in the
-                // full range" was false on exactly the path a rename made ordinary.
+                // The reason is what the merge does NOT do, and only that. Neither "the donors' ids stay in the full
+                // range" nor "it keeps each donor's object ids where they already are" is true on every path: an
+                // already-light donor's ids are all inside the window by definition, and BuildMergeRemap renumbers
+                // collisions and below-floor ids from 0x800 up — a count the report prints.
                 $"refused — '{outName}' has the .esl extension, which the game engine force-treats as a LIGHT master regardless " +
-                "of the header flag, but a merge does not renumber into the light range: it keeps each donor's object ids where " +
-                "they already are, and an id above 0xFFF would be misread in game. Merge to a '.esp' instead, then run " +
-                ToolNames.CompactPlugin + " on it to make it light — that renumbers the ids into the light window (the tools compose). Nothing was written.");
+                "of the header flag, but a merge never constrains object ids to the light window: it renumbers only what it must " +
+                "(cross-donor collisions, and ids below the write floor), so an id above 0xFFF would be misread in game. Merge to " +
+                "a '.esp' instead, then run " + ToolNames.CompactPlugin + " on it to make it light — that renumbers every id into " +
+                "the light window (the tools compose). Nothing was written.");
         if (donorsRaw.Any(d => string.Equals(d, outName, StringComparison.OrdinalIgnoreCase)))
             return WritePatchBuilder.MergeOutcome.Fail($"the output '{outName}' cannot also be a donor — name a NEW plugin file.");
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -6338,7 +6338,12 @@ public sealed class LoadOrderService : IDisposable
     ///
     /// <para>It says houseCARL cannot FIND the tables, never that the plugin has none: MO2's VFS merges mod folders
     /// at runtime, so a plugin's strings can sit in an archive in another mod folder that no path walked here can
-    /// see. The remedy is written for that case, because it is the likely one.</para></summary>
+    /// see.</para>
+    ///
+    /// <para>Two shapes arrive here and the words differ per shape — what the read WILL be, and what to do about it.
+    /// Nothing found anywhere is fixed by putting the tables somewhere houseCARL can see; a Strings folder that is
+    /// there and would not list is fixed by freeing that folder, and telling its caller to place tables in it
+    /// describes a folder they already have.</para></summary>
     /// <param name="verb">The operation, as the report names it — "compact", "merge".</param>
     static string UnresolvableStringsRefusal(string name, LocalizedAssessment a, string verb)
     {
@@ -6352,12 +6357,20 @@ public sealed class LoadOrderService : IDisposable
         var consequence = a.Shape == LocalizedShape.StringsFolderUnreadable
             ? "houseCARL cannot tell what its text reads as, or an empty value from a real one"
             : "every name, description and message it carries reads back EMPTY";
+
+        // And so is the REMEDY. "Put the tables where houseCARL can see them" is the answer when nothing was found
+        // anywhere; told to a plugin whose Strings folder is already sitting there unreadable, it sends the caller to
+        // fill the one folder nothing could open. That shape needs the folder freed, not populated.
+        var remedy = a.Shape == LocalizedShape.StringsFolderUnreadable
+            ? $"Let houseCARL read the Strings folder beside '{name}' — close whatever is holding it open, or fix its "
+              + "permissions — and run this again."
+            : "Put this plugin's .STRINGS where houseCARL can see them — enable the mod that provides them, or place "
+              + "them in a Strings folder beside the plugin — and run this again.";
         return $"refused — houseCARL did not {verb} '{name}'. "
              + LocalizedTargetUnsupportedException.WhereTheTextIs(a) + " "
              + $"So {consequence}, and a {verb} writes whatever this read produced into a NEW plugin you keep, with "
-             + "nothing left in it to tell that text from a plugin that never had any. Put this plugin's .STRINGS "
-             + "where houseCARL can see them — enable the mod that provides them, or place them in a Strings folder "
-             + "beside the plugin — and run this again. Nothing was written.";
+             + "nothing left in it to tell that text from a plugin that never had any. "
+             + remedy + " Nothing was written.";
     }
 
     /// <summary>The in-place compaction's refusal, rendered per shape. The refusal decision is one fail-closed

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -6435,9 +6435,13 @@ public sealed class LoadOrderService : IDisposable
         catch (Exception ex) { return WritePatchBuilder.MergeOutcome.Fail($"'{outName}' is not a valid plugin filename ({ex.Message})."); }
         if (outKey.Type == ModType.Light)
             return WritePatchBuilder.MergeOutcome.Fail(
+                // The reason is what the merge does NOT do, not a claim about where the donors' ids are. A single
+                // already-light donor's ids are all inside the window by definition, so "a merge keeps the ids in the
+                // full range" was false on exactly the path a rename made ordinary.
                 $"refused — '{outName}' has the .esl extension, which the game engine force-treats as a LIGHT master regardless " +
-                "of the header flag, but a merge keeps the donors' object ids in the full range (ids above 0xFFF would be misread " +
-                "in game). Merge to a '.esp' instead, then run " + ToolNames.CompactPlugin + " on it to make it light (the tools compose). Nothing was written.");
+                "of the header flag, but a merge does not renumber into the light range: it keeps each donor's object ids where " +
+                "they already are, and an id above 0xFFF would be misread in game. Merge to a '.esp' instead, then run " +
+                ToolNames.CompactPlugin + " on it to make it light — that renumbers the ids into the light window (the tools compose). Nothing was written.");
         if (donorsRaw.Any(d => string.Equals(d, outName, StringComparison.OrdinalIgnoreCase)))
             return WritePatchBuilder.MergeOutcome.Fail($"the output '{outName}' cannot also be a donor — name a NEW plugin file.");
 

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -748,17 +748,31 @@ public static class WriteTools
             foreach (var pl in o.ExternalOverriders.Take(25)) sb.Append("  ! ").Append(pl).Append('\n');
             if (o.ExternalOverriders.Count > 25) sb.Append("  ! … (+").Append(o.ExternalOverriders.Count - 25).Append(" more)\n");
         }
+        // The third dependent kind, and the one a merge breaks hardest: a plugin that lists a donor as a master while
+        // referencing none of its records keeps loading only while the donor does. The game refuses to load a plugin
+        // missing a master, so this is a WARN with the same standing as the two above — nothing breaks until the swap.
+        if (o.MasterDeclarers is { Count: > 0 } declarers)
+        {
+            sb.Append("WARNING — ").Append(declarers.Count).Append(" plugin(s) OUTSIDE the merge DECLARE a donor as a MASTER ")
+              .Append("without referencing any of its records. They are not in the lists above (nothing links to a donor ")
+              .Append("record), but a plugin missing a master does not load at all, so each one breaks the moment you ")
+              .Append(isRename ? "deactivate the donor plugin" : "deactivate the donor plugins")
+              .Append(". Add '").Append(o.OutputName).Append("' as a master in xEdit and remove the donor, or include them ")
+              .Append("in the merge set:\n");
+            foreach (var d in declarers.Take(25))
+                sb.Append("  ! ").Append(d.Plugin).Append("  — declares ").Append(string.Join(", ", d.Declared)).Append('\n');
+            if (declarers.Count > 25) sb.Append("  ! … (+").Append(declarers.Count - 25).Append(" more)\n");
+        }
         if (o.UnscannableRecords > 0)
             sb.Append("note: ").Append(o.UnscannableRecords).Append(" record(s) couldn't be scanned in the external-reference pass, so a ")
               .Append("'none' above may be incomplete — verify in xEdit. Samples: ").Append(string.Join("; ", o.UnscannableSamples)).Append('\n');
         AppendUnscannablePlugins(sb, o.UnscannablePlugins);
         // The coverage caveat belongs to the PASS, not to either outcome: a "none" and a populated list are incomplete
-        // the same way. The pass reads record links and record identity, never a plugin header, so a dependent that
-        // merely DECLARES a donor as a master is invisible to it and loses a master at the swap.
-        sb.Append("identify-pass scanned ").Append(o.PluginsScanned).Append(" plugin(s) — it reads record links and ")
-          .Append("record identity, NOT declared masters or runtime config files (SPID, KID, SkyPatcher, Open Animation ")
-          .Append("Replacer), so a plugin that only lists a donor as a master, or only names one in such a file, is not ")
-          .Append("counted above.\n");
+        // the same way. Declared masters ARE read now; runtime config files still are not, and naming what is left out
+        // is what keeps the pass from claiming more than it measured.
+        sb.Append("identify-pass scanned ").Append(o.PluginsScanned).Append(" plugin(s) — it reads record links, record ")
+          .Append("identity and declared masters, NOT runtime config files (SPID, KID, SkyPatcher, Open Animation ")
+          .Append("Replacer), so a plugin that only names a donor in such a file is not counted above.\n");
         // The caveat above says those files are not READ; this says what that costs, which a caller cannot derive from
         // "not counted". Both are bounded by the claim rule at WriteSentences.MergeRuntimeConfigs: this tool's own
         // behaviour, plus a break entailed by the swap this same report instructs.

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -757,8 +757,12 @@ public static class WriteTools
               .Append("without referencing any of its records. They are not in the lists above (nothing links to a donor ")
               .Append("record), but a plugin missing a master does not load at all, so each one breaks the moment you ")
               .Append(isRename ? "deactivate the donor plugin" : "deactivate the donor plugins")
-              .Append(". Add '").Append(o.OutputName).Append("' as a master in xEdit and remove the donor, or include them ")
-              .Append("in the merge set:\n");
+              // The fix is the stale master reference, not a new one: these plugins reference nothing in the donor,
+              // so adding the merged plugin as a master would buy them nothing. Combining is offered second for a
+              // rename, as in the two warnings above, because it stops being a rename.
+              .Append(". Remove that master in xEdit (nothing in them references it)")
+              .Append(isRename ? " — or, to combine them instead, re-run with them added as donors" : ", or include them in the merge set")
+              .Append(":\n");
             foreach (var d in declarers.Take(25))
                 sb.Append("  ! ").Append(d.Plugin).Append("  — declares ").Append(string.Join(", ", d.Declared)).Append('\n');
             if (declarers.Count > 25) sb.Append("  ! … (+").Append(declarers.Count - 25).Append(" more)\n");

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -791,6 +791,21 @@ public static class WriteTools
               .Append(" is NOT flagged as a master — it loads as a plain plugin, in the plugin block rather than the ")
               .Append("master block, so anything depending on that ordering will see it move.\n");
         }
+        // The donors' text is the other thing the bare output does not carry across as it was. The merged plugin is
+        // never flagged localized, so a localized donor's values are written INTO it and its .STRINGS stop describing
+        // it — the plugin's nature changed, and a report that called that an ordinary success said nothing about it.
+        // Keyed on donors houseCARL READ and found flagged, so nothing is asserted about a donor it could not read.
+        if (o.LocalizedDonors is { Count: > 0 } localized)
+        {
+            sb.Append("NOTE — ").Append(string.Join(", ", localized.Take(10)));
+            if (localized.Count > 10) sb.Append(" (+").Append(localized.Count - 10).Append(" more)");
+            sb.Append(localized.Count == 1 ? " is flagged LOCALIZED — its text lives" : " are flagged LOCALIZED — their text lives")
+              .Append(" in separate .STRINGS files rather than in the plugin. ").Append(o.OutputName)
+              .Append(" is NOT localized: it carries whatever this read of the donors produced, written into the plugin ")
+              .Append("itself and with no .STRINGS files of its own — so the donors' .STRINGS no longer describe it, and ")
+              .Append("any language they shipped that this read did not resolve is not in the output. Read the output ")
+              .Append("before you swap it in.\n");
+        }
         if (o.HeaderMetaDonors is { Count: > 0 } meta)
         {
             // No remedy is named because none exists on the surface: author=/description= belong to create_plugin, and


### PR DESCRIPTION
Six issues that share one detection: whether a plugin's strings actually resolve, and what merge and compact leave behind when they do not.

The shared piece is `LocalizedStrings.OwnFolderCarriesStringsFor` — "does this plugin's own folder carry a strings source FOR THIS PLUGIN". The overlay open's redirect gate now delegates to it instead of answering on the existence of any `Strings\` folder or any `.bsa`, so an asset-only archive no longer suppresses the game-Data lookup for a localized plugin (#369). Its sibling `ResolvesNowhere` reads the shape classifier that was already there, and merge and compact consume it: a localized source whose `.STRINGS` houseCARL can find nowhere is refused instead of having its blanks written into a plugin the caller keeps (#371). Merge also states the de-localization it performs on a donor whose strings do resolve — the compact lane already did (#435). The identify pass now reads each candidate's declared masters as well as its records, so a plugin that only lists a donor as a master is reported instead of counting as no dependent at all (#367); merge names those, compact does not, because a compaction keeps the source's basename and a declarer's master survives it. The `.esl` merge refusal no longer gives a reason that is false for the light single donor a rename makes ordinary (#363, the wording half).

Tests: 1071 pass (13 new — eight on the redirect gate against real authored archives, five on the declarer detection and its render). `ci-all` is ALL PASS (127/127); `strings-decision-guard` was updated to the fixed contract, the merge and compact guards gained arms for the refusal and the de-localization note (the merge guard's old RESIDUAL arm, which pinned the silent blanks, now pins the refusal), the merge guard gained an arm driving a real declarer plugin through `MergePlugins` to the rendered warning, and the compact guard one on the refusal's remedy for a `Strings\` folder that will not list.

Not done here, and why:

- **#376 (no tool reports the localized header flag)** is untouched. Its only home is `housecarl_load_order_status` — the tool and its render both live in `StatusTools.cs`, which this session was told not to edit. Nothing else on the surface walks the order per plugin. It needs a session that owns that file.
- **#363's carry decision** stays open. What remains after the wording fix is whether a single-donor merge should CARRY the donor's ESL/ESM flag, which forks on the recorded no-ESL-in-v1 scope call at PR #158 — a ruling, not a fold. The report already names the dropped flag.

One cost worth naming: the redirect gate can now open a `.bsa` beside a plugin to ask whether it embeds that plugin's tables. It is the folder-keyed archive cache the strings classifier already builds, so it is one walk per mod folder per process rather than per open — cheaper across a session than re-reading each plugin's header would be, but it is a real first-index cost on an order with many archives.

Closes #369
Closes #371
Closes #435
Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)
