### PR TITLE
Add a probe measuring child-to-parent capture cost

### DIFF
--- a/src/housecarl-generator/ParentInHandProbe.cs
+++ b/src/housecarl-generator/ParentInHandProbe.cs
@@ -28,29 +28,34 @@ static class ParentInHandProbe
         if (paths is null) return 1;
         Console.WriteLine($"parent-in-hand: {label} — {paths.Count} plugin(s)\n");
 
+        // A discarded warm-up sweep runs first. Without it the first timed pass alone pays the JIT of both
+        // enumerators and the cold file cache for every plugin, which is bigger than the difference being measured.
+        Sweep(paths, dataDir, new WarmupPass(), "warm-up");
+        Console.WriteLine("warm-up sweep done and discarded; every timing below is warm.\n");
+
         // ---- pass A: the flat walk BuildIndex runs today ------------------------------------------------------
         var flat = new FlatPass();
-        var passA = Sweep(paths, dataDir, flat);
+        var passA = Sweep(paths, dataDir, flat, "A");
 
         Console.WriteLine($"A. flat pass (today's BuildIndex walk)");
         Console.WriteLine($"   records          : {flat.Records:N0}");
         Console.WriteLine($"   wall             : {passA.Wall.TotalSeconds:N2} s");
         Console.WriteLine($"   retained after   : {passA.RetainedMb:N1} MB   (FormKey buffer only, as today)");
-        Console.WriteLine($"   plugins skipped  : {passA.Skipped}\n");
+        Console.WriteLine($"   plugins excluded : {passA.Skipped}\n");
 
         // ---- pass B: flat + containment, fused into the SAME open ---------------------------------------------
         var both = new FusedPass();
-        var passB = Sweep(paths, dataDir, both);
+        var passB = Sweep(paths, dataDir, both, "B");
 
         Console.WriteLine($"B. fused pass (flat walk + containment walk, one open per plugin)");
         Console.WriteLine($"   records          : {both.Records:N0}");
         Console.WriteLine($"   parents visited  : {both.Parents:N0}");
         Console.WriteLine($"   child->parent    : {both.Map.Count:N0} distinct children");
         Console.WriteLine($"   wall             : {passB.Wall.TotalSeconds:N2} s");
-        Console.WriteLine($"   retained after   : {passB.RetainedMb:N1} MB   (includes the child->parent map)");
-        Console.WriteLine($"   plugins skipped  : {passB.Skipped}");
-        Console.WriteLine($"   MARGINAL time    : {(passB.Wall - passA.Wall).TotalSeconds:N2} s " +
-                          $"({(passA.Wall.TotalSeconds > 0 ? (passB.Wall.TotalSeconds / passA.Wall.TotalSeconds) : 0):N2}x the flat pass)");
+        Console.WriteLine($"   retained after   : {passB.RetainedMb:N1} MB   (the child->parent map)");
+        Console.WriteLine($"   plugins excluded : {passB.Skipped}");
+        Console.WriteLine($"   MARGINAL time    : {(passB.Wall - passA.Wall).TotalSeconds:N2} s more than the flat pass " +
+                          $"(B in total is {(passA.Wall.TotalSeconds > 0 ? (passB.Wall.TotalSeconds / passA.Wall.TotalSeconds) : 0):N2}x A)");
         Console.WriteLine($"   MARGINAL memory  : {(passB.RetainedMb - passA.RetainedMb):N1} MB\n");
 
         // ---- pass C: the same map, packed --------------------------------------------------------------------
@@ -58,16 +63,29 @@ static class ParentInHandProbe
         // pays for two of those per entry. The index already has a dense plugin index, so pack (modIdx, id) into
         // one ulong and measure what the SAME map costs stored that way.
         var packed = new PackedPass();
-        var passC = Sweep(paths, dataDir, packed);
-        Console.WriteLine($"C. packed map only (ulong -> ulong, (modIdx<<32|id))");
+        var passC = Sweep(paths, dataDir, packed, "C");
+        Console.WriteLine($"C. packed map (ulong -> ulong, (modIdx<<32|id)); same work as B, map stored packed");
         Console.WriteLine($"   entries          : {packed.Map.Count:N0}");
-        Console.WriteLine($"   wall             : {passC.Wall.TotalSeconds:N2} s");
-        Console.WriteLine($"   retained after   : {passC.RetainedMb:N1} MB   ({passC.RetainedMb * 1024 * 1024 / Math.Max(1, packed.Map.Count):N0} B/entry)");
-        Console.WriteLine($"   without Cell.Temporary : {both.Map.Count - both.PerProperty.GetValueOrDefault("Cell.Temporary"):N0} entries\n");
+        Console.WriteLine($"   wall             : {passC.Wall.TotalSeconds:N2} s   (flat walk + containment walk, as B)");
+        Console.WriteLine($"   retained after   : {passC.RetainedMb:N1} MB   (map plus the small ModKey index; " +
+                          $"~{passC.RetainedMb * 1024 * 1024 / Math.Max(1, packed.Map.Count):N0} B/entry)\n");
 
-        Console.WriteLine("   per child-bearing property (children reached by the containment walk):");
-        foreach (var kv in both.PerProperty.OrderByDescending(k => k.Value))
-            Console.WriteLine($"     {kv.Key,-34} {kv.Value,10:N0}");
+        // ---- the descriptive breakdown, deliberately OUTSIDE the timed passes --------------------------------
+        // Per-property distinct counts and one live sample body per property. Both would distort the figures
+        // above — the sample pins a whole overlay graph, the counts need a second set per property — so they are
+        // collected in their own sweep whose time and memory are not reported.
+        var describe = new DescribePass();
+        Sweep(paths, dataDir, describe, "describe");
+
+        var temporary = describe.PerProperty.GetValueOrDefault("Cell.Temporary")?.Count ?? 0;
+        var nonTemporary = describe.PerProperty.Where(k => k.Key != "Cell.Temporary")
+                                               .SelectMany(k => k.Value).Distinct().Count();
+        Console.WriteLine($"   Cell.Temporary children : {temporary:N0} distinct");
+        Console.WriteLine($"   children reached by any OTHER property : {nonTemporary:N0} distinct\n");
+
+        Console.WriteLine("   per child-bearing property (distinct children reached by the containment walk):");
+        foreach (var kv in describe.PerProperty.OrderByDescending(k => k.Value.Count))
+            Console.WriteLine($"     {kv.Key,-34} {kv.Value.Count,10:N0}");
         Console.WriteLine();
 
         // ---- pass E: Mutagen's own context enumeration, which carries a Parent ---------------------------------
@@ -75,7 +93,7 @@ static class ParentInHandProbe
         // IModContext<IMajorRecordGetter>, whose IModContext.Parent is the containing record's context. If that is
         // populated, the containment map needs no custom walk at all — one enumeration replaces both passes.
         var ctx = new ContextPass();
-        var passE = Sweep(paths, dataDir, ctx);
+        var passE = Sweep(paths, dataDir, ctx, "E");
         Console.WriteLine($"E. Mutagen context enumeration (EnumerateMajorRecordContexts, no link cache)");
         Console.WriteLine($"   contexts         : {ctx.Contexts:N0}");
         Console.WriteLine($"   with a Parent    : {ctx.WithParent:N0}");
@@ -84,7 +102,7 @@ static class ParentInHandProbe
         Console.WriteLine($"   re-parented      : {ctx.Reparented:N0} (a later plugin put the same child under a DIFFERENT parent)");
         Console.WriteLine($"   wall             : {passE.Wall.TotalSeconds:N2} s");
         Console.WriteLine($"   retained after   : {passE.RetainedMb:N1} MB");
-        Console.WriteLine($"   plugins skipped  : {passE.Skipped}");
+        Console.WriteLine($"   plugins excluded : {passE.Skipped}");
         Console.WriteLine($"   vs the flat pass : {(passE.Wall - passA.Wall).TotalSeconds:N2} s more");
         Console.WriteLine("   edges the context walk hands over (child -> parent, by type):");
         foreach (var kv in ctx.Edges.Where(k => !k.Key.EndsWith("(no parent)", StringComparison.Ordinal))
@@ -94,17 +112,28 @@ static class ParentInHandProbe
 
         // ---- question 1: is the parent in hand on the child body itself? ---------------------------------------
         Console.WriteLine("D. is the parent in hand during the FLAT walk? (per child-bearing property)\n");
-        ReportParentInHand(both);
+        ReportParentInHand(describe);
 
         return 0;
     }
 
     // ---------------------------------------------------------------------------------------------------------
-    // The two passes. Both open one plugin at a time and dispose it, exactly as BuildIndex does, so the timings
-    // are comparable and neither holds the order open.
+    // The passes. Each opens one plugin at a time and disposes it, exactly as BuildIndex does, so the timings are
+    // comparable and none holds the order open. Each merges a plugin's work into its totals only after that
+    // plugin has walked to the end, so a mid-plugin throw excludes the plugin instead of half-counting it.
     // ---------------------------------------------------------------------------------------------------------
 
     interface IPass { void Plugin(ISkyrimModGetter ov); }
+
+    /// <summary>Touches both enumerators on every plugin so the timed passes never pay first-run cost.</summary>
+    sealed class WarmupPass : IPass
+    {
+        public void Plugin(ISkyrimModGetter ov)
+        {
+            foreach (var rec in ov.EnumerateMajorRecords()) { _ = rec.FormKey; }
+            foreach (var c in ov.EnumerateMajorRecordContexts()) { _ = c.Record.FormKey; }
+        }
+    }
 
     sealed class FlatPass : IPass
     {
@@ -121,42 +150,38 @@ static class ParentInHandProbe
     {
         public long Records, Parents;
         public readonly Dictionary<FormKey, FormKey> Map = new();
-        public readonly Dictionary<string, long> PerProperty = new(StringComparer.Ordinal);
-        // One live child body per property, kept for the "is the parent in hand" reflection report.
-        public readonly Dictionary<string, (IMajorRecordGetter parent, IMajorRecordGetter child)> Sample = new(StringComparer.Ordinal);
 
         public void Plugin(ISkyrimModGetter ov)
         {
             var keys = new List<FormKey>();
             foreach (var rec in ov.EnumerateMajorRecords()) keys.Add(rec.FormKey);
-            Records += keys.Count;
 
             // The containment pass. The parent TYPES are not a hand list either: they are the types
             // OwnedChildContent.Fields answers non-empty for, which is WriteEngine.ChildBearingProperties.
+            long parents = 0;
+            var staged = new List<(FormKey Child, FormKey Parent)>();
             foreach (var parent in ParentBodies(ov))
             {
-                Parents++;
+                parents++;
                 foreach (var field in OwnedChildContent.Fields(parent).Keys)
                 {
                     var p = parent.GetType().GetProperty(field, BindingFlags.Public | BindingFlags.Instance);
                     if (p is null) continue;
                     object? val;
                     try { val = p.GetValue(parent); } catch { continue; }
-                    long n = 0;
                     var seen = new HashSet<FormKey>();
                     foreach (var child in DirectChildren(val, 0))
                     {
                         if (!seen.Add(child.FormKey)) continue;   // a block struct can expose the same list twice
-                        Map[child.FormKey] = parent.FormKey;
-                        n++;
-                        if (!Sample.ContainsKey(Key(parent, field))) Sample[Key(parent, field)] = (parent, child);
+                        staged.Add((child.FormKey, parent.FormKey));
                     }
-                    if (n > 0) PerProperty[Key(parent, field)] = PerProperty.GetValueOrDefault(Key(parent, field)) + n;
                 }
             }
-        }
 
-        static string Key(IMajorRecordGetter parent, string field) => $"{Short(parent.GetType())}.{field}";
+            Records += keys.Count;
+            Parents += parents;
+            foreach (var (child, parent) in staged) Map[child] = parent;
+        }
     }
 
     /// <summary>The same containment walk as FusedPass, storing the map PACKED — one ulong per side, off a dense
@@ -168,7 +193,8 @@ static class ParentInHandProbe
 
         public void Plugin(ISkyrimModGetter ov)
         {
-            foreach (var rec in ov.EnumerateMajorRecords()) { }         // the flat walk still happens, as today
+            foreach (var rec in ov.EnumerateMajorRecords()) { _ = rec.FormKey; }   // the flat walk still happens, as today
+            var staged = new List<(FormKey Child, FormKey Parent)>();
             foreach (var parent in ParentBodies(ov))
                 foreach (var field in OwnedChildContent.Fields(parent).Keys)
                 {
@@ -176,8 +202,9 @@ static class ParentInHandProbe
                     if (p is null) continue;
                     object? val;
                     try { val = p.GetValue(parent); } catch { continue; }
-                    foreach (var child in DirectChildren(val, 0)) Map[Pack(child.FormKey)] = Pack(parent.FormKey);
+                    foreach (var child in DirectChildren(val, 0)) staged.Add((child.FormKey, parent.FormKey));
                 }
+            foreach (var (child, parent) in staged) Map[Pack(child)] = Pack(parent);
         }
 
         ulong Pack(FormKey k)
@@ -194,23 +221,28 @@ static class ParentInHandProbe
     {
         public long Contexts, WithParent, ParentIsRecord, Reparented;
         public readonly Dictionary<ulong, ulong> Map = new();
-        // childType -> parentType, or "(no parent)" / "(parent is not a record: X)" — what the walk actually hands over.
+        // childType -> parentType, or "(no parent)" / "(parent chain holds no record)" — what the walk hands over.
         public readonly Dictionary<string, long> Edges = new(StringComparer.Ordinal);
         readonly Dictionary<ModKey, int> _mods = new();
 
         public void Plugin(ISkyrimModGetter ov)
         {
+            long contexts = 0, withParent = 0, parentIsRecord = 0;
+            var edges = new Dictionary<string, long>(StringComparer.Ordinal);
+            var staged = new List<(FormKey Child, FormKey Parent)>();
+            void Bump(string k) => edges[k] = edges.GetValueOrDefault(k) + 1;
+
             foreach (var c in ov.EnumerateMajorRecordContexts())
             {
-                Contexts++;
+                contexts++;
                 var child = Short(c.Record.GetType());
                 var parent = (c as IModContext)?.Parent;
                 if (parent is null) { Bump($"{child} -> (no parent)"); continue; }
-                WithParent++;
+                withParent++;
                 if (parent.Record is IMajorRecordGetter pr)
                 {
-                    ParentIsRecord++;
-                    Put(c.Record.FormKey, pr.FormKey);
+                    parentIsRecord++;
+                    staged.Add((c.Record.FormKey, pr.FormKey));
                     Bump($"{child} -> {Short(pr.GetType())}");
                 }
                 else
@@ -221,13 +253,19 @@ static class ParentInHandProbe
                     while (up is not null && up.Record is not IMajorRecordGetter && hops++ < 6) up = up.Parent;
                     if (up?.Record is IMajorRecordGetter anc)
                     {
-                        ParentIsRecord++;
-                        Put(c.Record.FormKey, anc.FormKey);
+                        parentIsRecord++;
+                        staged.Add((c.Record.FormKey, anc.FormKey));
                         Bump($"{child} -> {Short(anc.GetType())} (via {hops} group hop(s))");
                     }
                     else Bump($"{child} -> (parent chain holds no record)");
                 }
             }
+
+            Contexts += contexts;
+            WithParent += withParent;
+            ParentIsRecord += parentIsRecord;
+            foreach (var kv in edges) Edges[kv.Key] = Edges.GetValueOrDefault(kv.Key) + kv.Value;
+            foreach (var (child, parent) in staged) Put(child, parent);
         }
 
         // Does a LATER plugin ever put the same child under a DIFFERENT parent? That is what decides whether one
@@ -239,12 +277,38 @@ static class ParentInHandProbe
             Map[ck] = pk;
         }
 
-        void Bump(string k) => Edges[k] = Edges.GetValueOrDefault(k) + 1;
-
         ulong Pack(FormKey k)
         {
             if (!_mods.TryGetValue(k.ModKey, out var i)) _mods[k.ModKey] = i = _mods.Count;
             return ((ulong)(uint)i << 32) | k.ID;
+        }
+    }
+
+    /// <summary>The descriptive pass: distinct children per child-bearing property, and one real (parent, child)
+    /// pair per property for the question-1 report. Never timed — the samples pin live overlay bodies, and the
+    /// per-property sets are extra memory, both of which would distort the passes above.</summary>
+    sealed class DescribePass : IPass
+    {
+        public readonly Dictionary<string, HashSet<FormKey>> PerProperty = new(StringComparer.Ordinal);
+        public readonly Dictionary<string, (IMajorRecordGetter Parent, IMajorRecordGetter Child)> Sample = new(StringComparer.Ordinal);
+
+        public void Plugin(ISkyrimModGetter ov)
+        {
+            foreach (var parent in ParentBodies(ov))
+                foreach (var field in OwnedChildContent.Fields(parent).Keys)
+                {
+                    var p = parent.GetType().GetProperty(field, BindingFlags.Public | BindingFlags.Instance);
+                    if (p is null) continue;
+                    object? val;
+                    try { val = p.GetValue(parent); } catch { continue; }
+                    var key = $"{Short(parent.GetType())}.{field}";
+                    foreach (var child in DirectChildren(val, 0))
+                    {
+                        if (!PerProperty.TryGetValue(key, out var set)) PerProperty[key] = set = new HashSet<FormKey>();
+                        set.Add(child.FormKey);
+                        if (!Sample.ContainsKey(key)) Sample[key] = (parent, child);
+                    }
+                }
         }
     }
 
@@ -288,7 +352,7 @@ static class ParentInHandProbe
 
     sealed record PassResult(TimeSpan Wall, double RetainedMb, int Skipped);
 
-    static PassResult Sweep(IReadOnlyList<string> paths, string? dataDir, IPass pass)
+    static PassResult Sweep(IReadOnlyList<string> paths, string? dataDir, IPass pass, string name)
     {
         GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
         var before = GC.GetTotalMemory(true);
@@ -298,9 +362,20 @@ static class ParentInHandProbe
         {
             ISkyrimModGetter ov;
             try { ov = LoadOrderResolver.OpenOverlay(path, dataDir); }
-            catch { skipped++; continue; }
+            catch (Exception ex)
+            {
+                skipped++;
+                Console.WriteLine($"   ! {name}: cannot open {Path.GetFileName(path)} — {ex.Message} (plugin excluded)");
+                continue;
+            }
+            // A pass merges a plugin's work only when the plugin walks to the end, so a throw here excludes that
+            // plugin from the totals rather than half-counting it. The reason is printed, never swallowed.
             try { pass.Plugin(ov); }
-            catch { skipped++; }
+            catch (Exception ex)
+            {
+                skipped++;
+                Console.WriteLine($"   ! {name}: {Path.GetFileName(path)} threw — {ex.Message} (plugin excluded)");
+            }
             finally { (ov as IDisposable)?.Dispose(); }
         }
         sw.Stop();
@@ -315,38 +390,45 @@ static class ParentInHandProbe
     // the caller nothing but the child body, so if the child body does not name its parent, the parent is not
     // available at that moment by any means.
     // ---------------------------------------------------------------------------------------------------------
-    static void ReportParentInHand(FusedPass pass)
+    static void ReportParentInHand(DescribePass pass)
     {
         var props = ChildBearingSurface();
-        foreach (var (key, count) in props.Select(k => (k, pass.PerProperty.GetValueOrDefault(k))).OrderBy(t => t.k))
+        foreach (var (key, count) in props.Select(k => (k, pass.PerProperty.GetValueOrDefault(k)?.Count ?? 0)).OrderBy(t => t.k))
         {
             if (!pass.Sample.TryGetValue(key, out var s))
             {
                 Console.WriteLine($"   {key,-34} no sample in this order (0 children seen) — not measured");
                 continue;
             }
-            var hits = ParentNamingMembers(s.child, s.parent.FormKey).ToList();
-            var verdict = hits.Count > 0 ? "YES — " + string.Join(", ", hits) : "NO";
+            var hits = ParentNamingMembers(s.Child, s.Parent.FormKey, out var unreadable).ToList();
+            // An unreadable body must never masquerade as a clean "NO" — that is the answer being measured.
+            var verdict = hits.Count > 0 ? "YES — " + string.Join(", ", hits)
+                        : unreadable > 0 ? $"NO among the readable members ({unreadable} member(s) would not read)"
+                        : "NO";
             Console.WriteLine($"   {key,-34} {verdict}");
-            Console.WriteLine($"      sample child {s.child.FormKey} ({Short(s.child.GetType())}) under parent {s.parent.FormKey}; {count:N0} children of this kind in the order");
+            Console.WriteLine($"      sample child {s.Child.FormKey} ({Short(s.Child.GetType())}) under parent {s.Parent.FormKey}; {count:N0} distinct children of this kind in the order");
         }
     }
 
-    /// <summary>Every member of the child's own body whose value is, or resolves to, the parent's FormKey.</summary>
-    static IEnumerable<string> ParentNamingMembers(IMajorRecordGetter child, FormKey parent)
+    /// <summary>Every member of the child's own body whose value is, or resolves to, the parent's FormKey, plus a
+    /// count of the members that would not read at all.</summary>
+    static IEnumerable<string> ParentNamingMembers(IMajorRecordGetter child, FormKey parent, out int unreadable)
     {
+        var hits = new List<string>();
+        unreadable = 0;
         foreach (var p in child.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
         {
             if (p.GetIndexParameters().Length > 0) continue;
             object? v;
-            try { v = p.GetValue(child); } catch { continue; }
+            try { v = p.GetValue(child); } catch { unreadable++; continue; }
             switch (v)
             {
-                case IFormLinkGetter fl when fl.FormKey == parent: yield return $"{p.Name} (FormLink)"; break;
-                case IMajorRecordGetter mr when mr.FormKey == parent: yield return $"{p.Name} (record)"; break;
-                case FormKey fk when fk == parent: yield return $"{p.Name} (FormKey)"; break;
+                case IFormLinkGetter fl when fl.FormKey == parent: hits.Add($"{p.Name} (FormLink)"); break;
+                case IMajorRecordGetter mr when mr.FormKey == parent: hits.Add($"{p.Name} (record)"); break;
+                case FormKey fk when fk == parent: hits.Add($"{p.Name} (FormKey)"); break;
             }
         }
+        return hits;
     }
 
     /// <summary>The child-bearing property surface, by construction — every concrete Mutagen record type that has
@@ -396,9 +478,11 @@ static class ParentInHandProbe
             return null;
         }
         var order = Mo2LoadOrder.Build(p.ProfileDir, p.ModsDir, p.DataDir, p.OverwriteDir);
-        dataDir = LoadOrderResolver.ComputeDataDir(
-            order.OrderedPaths.Select((x, i) => (x, i)).ToDictionary(t => Path.GetFileName(t.x), t => t.i, StringComparer.OrdinalIgnoreCase),
-            order.OrderedPaths.ToArray());
+        // Last copy of a duplicate filename wins, the same rule LoadOrderResolver.Build uses; ToDictionary would
+        // throw on an order that resolves two paths to one filename.
+        var nameToIdx = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < order.OrderedPaths.Count; i++) nameToIdx[Path.GetFileName(order.OrderedPaths[i])] = i;
+        dataDir = LoadOrderResolver.ComputeDataDir(nameToIdx, order.OrderedPaths.ToArray());
         label = $"live MO2 instance {instanceDir} (profile {p.ProfileName})";
         return order.OrderedPaths;
     }

--- a/src/housecarl-generator/ParentInHandProbe.cs
+++ b/src/housecarl-generator/ParentInHandProbe.cs
@@ -562,25 +562,29 @@ static class ParentInHandProbe
         return order.OrderedPaths;
     }
 
-    /// <summary>The instance housecarl_set_mo2_instance saved, if any — the same file the server reads.</summary>
+    /// <summary>The instance housecarl_set_mo2_instance saved, if any — read through <see cref="UserConfigStore"/>,
+    /// the declared single owner of houseCARL.user.json, so this never hand-parses the file the server owns. The dirs
+    /// searched are the server's own: HOUSECARL_DATA_DIR when set, else beside the server exe — which is the install
+    /// dir, so both shipped install layouts are tried. An unreadable or corrupt file is REPORTED, never reported as
+    /// "none saved".</summary>
     static string? UserConfiguredInstance()
     {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         foreach (var dir in new[]
         {
             Environment.GetEnvironmentVariable("HOUSECARL_DATA_DIR"),
+            // Beside the server exe. The Claude Code plugin installs the server here;
+            Path.Combine(home, ".claude", "skills", "housecarl", "server"),
+            // and the Codex install puts it here.
             Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "housecarl", "server"),
         })
         {
-            if (string.IsNullOrEmpty(dir)) continue;
+            if (string.IsNullOrWhiteSpace(dir)) continue;
             var f = Path.Combine(dir, "houseCARL.user.json");
             if (!File.Exists(f)) continue;
-            try
-            {
-                using var doc = System.Text.Json.JsonDocument.Parse(File.ReadAllText(f));
-                if (doc.RootElement.TryGetProperty("Mo2InstanceDir", out var v) && v.GetString() is { Length: > 0 } s)
-                    return s;
-            }
-            catch { }
+            var cfg = new UserConfigStore(f).Load(out var note);
+            if (note is not null) Console.WriteLine($"   ! {note}");
+            if (cfg.Mo2InstanceDir is { Length: > 0 } s) return s;
         }
         return null;
     }

--- a/src/housecarl-generator/ParentInHandProbe.cs
+++ b/src/housecarl-generator/ParentInHandProbe.cs
@@ -173,32 +173,39 @@ static class ParentInHandProbe
     {
         public long Contexts, WithParent, ParentIsRecord, Reparented;
         public readonly Dictionary<ulong, ulong> Map = new();
-        // childType -> parentType, or "(no parent)" / "(parent chain holds no record)" — what the walk hands over.
+        // Filled in Finish. "ChildType -> ParentType" for the rows staged into Map, "(no parent)" /
+        // "(parent chain holds no record)" for the rows that were not.
         public readonly Dictionary<string, long> Edges = new(StringComparer.Ordinal);
+        public readonly Dictionary<string, long> NonEdges = new(StringComparer.Ordinal);
         readonly Dictionary<ModKey, int> _mods = new();
-        // First parent seen per child. Bookkeeping for the re-parent count, dropped in Finish so the reported
-        // memory is the packed map alone.
-        Dictionary<ulong, ulong>? _first = new();
+        // The by-type histogram, keyed on TYPE REFERENCES while the clock runs — a string key per context costs an
+        // allocation and two string hashes each, which on this order is a large fraction of the difference being
+        // measured. The keys are spelled in Finish, after the stopwatch has stopped.
+        readonly Dictionary<(Type Child, Type? Parent, int Hops), long> _shapes = new();
+        // Every staged edge in plugin order, so the re-parent count is DERIVED in Finish rather than maintained by a
+        // second dictionary write per edge inside the timed region. Dropped in Finish, before memory is read.
+        List<(ulong Child, ulong Parent)>? _order = new();
 
         public void Plugin(ISkyrimModGetter ov)
         {
             long contexts = 0, withParent = 0, parentIsRecord = 0;
-            var edges = new Dictionary<string, long>(StringComparer.Ordinal);
+            var shapes = new Dictionary<(Type, Type?, int), long>();
             var staged = new List<(FormKey Child, FormKey Parent)>();
-            void Bump(string k) => edges[k] = edges.GetValueOrDefault(k) + 1;
+            void Bump(Type child, Type? parent, int hops) =>
+                shapes[(child, parent, hops)] = shapes.GetValueOrDefault((child, parent, hops)) + 1;
 
             foreach (var c in ov.EnumerateMajorRecordContexts())
             {
                 contexts++;
-                var child = Short(c.Record.GetType());
+                var child = c.Record.GetType();
                 var parent = (c as IModContext)?.Parent;
-                if (parent is null) { Bump($"{child} -> (no parent)"); continue; }
+                if (parent is null) { Bump(child, null, NoParent); continue; }
                 withParent++;
                 if (parent.Record is IMajorRecordGetter pr)
                 {
                     parentIsRecord++;
                     staged.Add((c.Record.FormKey, pr.FormKey));
-                    Bump($"{child} -> {Short(pr.GetType())}");
+                    Bump(child, pr.GetType(), 0);
                 }
                 else
                 {
@@ -210,34 +217,55 @@ static class ParentInHandProbe
                     {
                         parentIsRecord++;
                         staged.Add((c.Record.FormKey, anc.FormKey));
-                        Bump($"{child} -> {Short(anc.GetType())} (via {hops} group hop(s))");
+                        Bump(child, anc.GetType(), hops);
                     }
-                    else Bump($"{child} -> (parent chain holds no record)");
+                    else Bump(child, null, NoRecordInChain);
                 }
             }
 
             Contexts += contexts;
             WithParent += withParent;
             ParentIsRecord += parentIsRecord;
-            foreach (var kv in edges) Edges[kv.Key] = Edges.GetValueOrDefault(kv.Key) + kv.Value;
-            foreach (var (child, parent) in staged) Put(child, parent);
+            foreach (var kv in shapes) _shapes[kv.Key] = _shapes.GetValueOrDefault(kv.Key) + kv.Value;
+            foreach (var (child, parent) in staged)
+            {
+                var ck = Pack(child); var pk = Pack(parent);
+                _order!.Add((ck, pk));
+                Map[ck] = pk;
+            }
         }
 
-        // Does a LATER plugin ever leave the same child under a DIFFERENT parent? That is what decides whether one
-        // whole-order map is well-defined or the map has to be per-plugin. Counted as DISTINCT children whose final
-        // parent differs from the first one seen — not as overwrite events, which double-count a child moved twice
-        // and count a child moved away and back as two.
-        void Put(FormKey child, FormKey parent)
-        {
-            var ck = Pack(child); var pk = Pack(parent);
-            _first!.TryAdd(ck, pk);
-            Map[ck] = pk;
-        }
+        // Sentinel hop counts for the two shapes that stage nothing into Map, so one histogram carries every context.
+        const int NoParent = -1, NoRecordInChain = -2;
 
         public void Finish()
         {
-            Reparented = _first!.Count(kv => Map[kv.Key] != kv.Value);
-            _first = null;
+            // Does a LATER plugin ever leave the same child under a DIFFERENT parent? That is what decides whether one
+            // whole-order map is well-defined or the map has to be per-plugin. Counted as DISTINCT children whose final
+            // parent differs from the first one seen — not as overwrite events, which double-count a child moved twice
+            // and count a child moved away and back as two.
+            var first = new Dictionary<ulong, ulong>(Map.Count);
+            foreach (var (child, parent) in _order!) first.TryAdd(child, parent);
+            Reparented = first.Count(kv => Map[kv.Key] != kv.Value);
+            _order = null;
+
+            foreach (var (key, count) in _shapes)
+            {
+                var child = Short(key.Child);
+                if (key.Hops is NoParent or NoRecordInChain)
+                {
+                    var nk = key.Hops == NoParent ? $"{child} -> (no parent)" : $"{child} -> (parent chain holds no record)";
+                    NonEdges[nk] = NonEdges.GetValueOrDefault(nk) + count;
+                }
+                else
+                {
+                    var k = key.Hops == 0
+                        ? $"{child} -> {Short(key.Parent!)}"
+                        : $"{child} -> {Short(key.Parent!)} (via {key.Hops} group hop(s))";
+                    Edges[k] = Edges.GetValueOrDefault(k) + count;
+                }
+            }
+            _shapes.Clear();
         }
 
         ulong Pack(FormKey k)

--- a/src/housecarl-generator/ParentInHandProbe.cs
+++ b/src/housecarl-generator/ParentInHandProbe.cs
@@ -11,17 +11,22 @@ namespace HousecarlGenerator;
 // #459 measurement. Two questions, one process, against a live MO2 order (or a single plugin).
 //
 //   1. Is the containing parent in hand during LoadOrderResolver.BuildIndex's flat ov.EnumerateMajorRecords()?
-//      Answered per child-bearing property (WriteEngine.ChildBearingProperties), by asking a REAL child body of
-//      each kind whether anything on it names its parent.
-//   2. What does the containment-aware second pass cost — wall time and retained memory — beside the flat pass
-//      the index build already runs, both fused into ONE overlay open per plugin. Measured three ways: a hand
-//      containment walk off ChildBearingProperties, the same map stored packed, and Mutagen's own
-//      EnumerateMajorRecordContexts (which carries the parent and needs no link cache).
+//      Answered per child-bearing property AND per distinct child type under it, by asking REAL child bodies —
+//      while the overlay is still open — whether anything on the body names the parent. The search descends
+//      through nested structs and polymorphic arms, because that is where a parent pointer actually lives
+//      (NavigationMesh.Data.Parent, whose CellNavmeshParent arm carries the cell link).
+//   2. What does capturing the parent cost beside the flat pass the index build already runs? Exactly two timed
+//      passes: A, today's flat walk, and E, Mutagen's own EnumerateMajorRecordContexts (which carries the parent
+//      and needs no link cache) building the packed ulong->ulong child-to-parent map. A and E run three times
+//      each, alternating, with everything released between runs; the median of each is reported.
 //
 //   dotnet run --project src/housecarl-generator parent-in-hand [instanceDir]
 //   dotnet run --project src/housecarl-generator parent-in-hand --plugin <path> [dataDir]
 static class ParentInHandProbe
 {
+    const int Rounds = 3;
+    const int SamplesPerChildType = 20;
+
     public static int Run(string[] args)
     {
         var paths = ResolvePaths(args, out var label, out var dataDir);
@@ -30,50 +35,78 @@ static class ParentInHandProbe
 
         // A discarded warm-up sweep runs first. Without it the first timed pass alone pays the JIT of both
         // enumerators and the cold file cache for every plugin, which is bigger than the difference being measured.
-        Sweep(paths, dataDir, new WarmupPass(), "warm-up");
+        var warm = Sweep(paths, dataDir, new WarmupPass(), "warm-up");
+        if (warm.Opened == 0)
+        {
+            Console.WriteLine("every plugin failed to open, so nothing was measured — check the instance path and the profile's load order.");
+            return 1;
+        }
         Console.WriteLine("warm-up sweep done and discarded; every timing below is warm.\n");
 
-        // ---- pass A: the flat walk BuildIndex runs today ------------------------------------------------------
-        var flat = new FlatPass();
-        var passA = Sweep(paths, dataDir, flat, "A");
+        // ---- the two timed passes, alternated A E A E A E ------------------------------------------------------
+        // Alternating removes the ordering advantage the second pass would otherwise get from the file cache, and
+        // each pass's own state is released before the next one starts, so neither measures the other's residue.
+        var aWall = new List<TimeSpan>();
+        var eWall = new List<TimeSpan>();
+        var eMemory = new List<double>();
+        long records = 0;
+        int aSkipped = 0, eSkipped = 0;
+        ContextPass? lastCtx = null;
 
-        Console.WriteLine($"A. flat pass (today's BuildIndex walk)");
-        Console.WriteLine($"   records          : {flat.Records:N0}");
-        Console.WriteLine($"   wall             : {passA.Wall.TotalSeconds:N2} s");
-        Console.WriteLine($"   retained after   : {passA.RetainedMb:N1} MB   (FormKey buffer only, as today)");
-        Console.WriteLine($"   plugins excluded : {passA.Skipped}\n");
+        for (var round = 1; round <= Rounds; round++)
+        {
+            var flat = new FlatPass();
+            var a = Sweep(paths, dataDir, flat, $"A{round}");
+            if (a.Opened == 0) { Console.WriteLine("every plugin failed to open, so nothing was measured — check the instance path and the profile's load order."); return 1; }
+            aWall.Add(a.Wall); records = flat.Records; aSkipped = a.Skipped;
+            flat = null;
+            GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
 
-        // ---- pass B: flat + containment, fused into the SAME open ---------------------------------------------
-        var both = new FusedPass();
-        var passB = Sweep(paths, dataDir, both, "B");
+            var ctx = new ContextPass();
+            var e = Sweep(paths, dataDir, ctx, $"E{round}");
+            if (e.Opened == 0) { Console.WriteLine("every plugin failed to open, so nothing was measured — check the instance path and the profile's load order."); return 1; }
+            eWall.Add(e.Wall); eMemory.Add(e.RetainedMb); eSkipped = e.Skipped;
+            lastCtx = ctx;
+            Console.WriteLine($"   round {round}: A {a.Wall.TotalSeconds:N2} s, E {e.Wall.TotalSeconds:N2} s");
+            if (round < Rounds) { lastCtx = null; ctx = null; GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect(); }
+        }
+        Console.WriteLine();
 
-        Console.WriteLine($"B. fused pass (flat walk + containment walk, one open per plugin)");
-        Console.WriteLine($"   records          : {both.Records:N0}");
-        Console.WriteLine($"   parents visited  : {both.Parents:N0}");
-        Console.WriteLine($"   child->parent    : {both.Map.Count:N0} distinct children");
-        Console.WriteLine($"   wall             : {passB.Wall.TotalSeconds:N2} s");
-        Console.WriteLine($"   retained after   : {passB.RetainedMb:N1} MB   (the child->parent map)");
-        Console.WriteLine($"   plugins excluded : {passB.Skipped}");
-        Console.WriteLine($"   MARGINAL time    : {(passB.Wall - passA.Wall).TotalSeconds:N2} s more than the flat pass " +
-                          $"(B in total is {(passA.Wall.TotalSeconds > 0 ? (passB.Wall.TotalSeconds / passA.Wall.TotalSeconds) : 0):N2}x A)");
-        Console.WriteLine($"   MARGINAL memory  : {(passB.RetainedMb - passA.RetainedMb):N1} MB\n");
+        var medA = Median(aWall);
+        var medE = Median(eWall);
+        var ctxFinal = lastCtx!;
 
-        // ---- pass C: the same map, packed --------------------------------------------------------------------
-        // A FormKey is a ModKey (a string reference + a type enum) plus a uint, so a Dictionary<FormKey,FormKey>
-        // pays for two of those per entry. The index already has a dense plugin index, so pack (modIdx, id) into
-        // one ulong and measure what the SAME map costs stored that way.
-        var packed = new PackedPass();
-        var passC = Sweep(paths, dataDir, packed, "C");
-        Console.WriteLine($"C. packed map (ulong -> ulong, (modIdx<<32|id)); same work as B, map stored packed");
-        Console.WriteLine($"   entries          : {packed.Map.Count:N0}");
-        Console.WriteLine($"   wall             : {passC.Wall.TotalSeconds:N2} s   (flat walk + containment walk, as B)");
-        Console.WriteLine($"   retained after   : {passC.RetainedMb:N1} MB   (map plus the small ModKey index; " +
-                          $"~{passC.RetainedMb * 1024 * 1024 / Math.Max(1, packed.Map.Count):N0} B/entry)\n");
+        Console.WriteLine($"A. flat pass (today's BuildIndex walk), median of {Rounds}");
+        Console.WriteLine($"   records          : {records:N0}");
+        Console.WriteLine($"   wall             : {medA.TotalSeconds:N2} s   (runs: {string.Join(", ", aWall.Select(w => $"{w.TotalSeconds:N2}"))})");
+        Console.WriteLine($"   plugins excluded : {aSkipped}\n");
 
-        // ---- the descriptive breakdown, deliberately OUTSIDE the timed passes --------------------------------
-        // Per-property distinct counts and one live sample body per property. Both would distort the figures
-        // above — the sample pins a whole overlay graph, the counts need a second set per property — so they are
-        // collected in their own sweep whose time and memory are not reported.
+        Console.WriteLine($"E. Mutagen context enumeration (EnumerateMajorRecordContexts, no link cache), median of {Rounds}");
+        Console.WriteLine($"   contexts         : {ctxFinal.Contexts:N0}");
+        Console.WriteLine($"   with a Parent    : {ctxFinal.WithParent:N0}");
+        Console.WriteLine($"   parent is a record : {ctxFinal.ParentIsRecord:N0}");
+        Console.WriteLine($"   child->parent    : {ctxFinal.Map.Count:N0} distinct children (packed ulong -> ulong, (modIdx<<32|id))");
+        Console.WriteLine($"   re-parented      : {ctxFinal.Reparented:N0} distinct children whose FINAL parent differs from the FIRST one seen " +
+                          "(distinct children, not overwrite events)");
+        Console.WriteLine($"   wall             : {medE.TotalSeconds:N2} s   (runs: {string.Join(", ", eWall.Select(w => $"{w.TotalSeconds:N2}"))})");
+        Console.WriteLine($"   retained after   : {Median(eMemory):N1} MB   (the packed map alone; " +
+                          $"~{Median(eMemory) * 1024 * 1024 / Math.Max(1, ctxFinal.Map.Count):N0} B/entry)");
+        Console.WriteLine($"   plugins excluded : {eSkipped}");
+        var delta = (medE - medA).TotalSeconds;
+        Console.WriteLine($"   vs the flat pass : {Math.Abs(delta):N2} s {(delta < 0 ? "less" : "more")} " +
+                          $"({(medA.TotalSeconds > 0 ? medE.TotalSeconds / medA.TotalSeconds : 0):N2}x A)");
+        Console.WriteLine("   edges the context walk hands over (child -> parent, by type):");
+        foreach (var kv in ctxFinal.Edges.Where(k => !k.Key.EndsWith("(no parent)", StringComparison.Ordinal))
+                                         .OrderByDescending(k => k.Value))
+            Console.WriteLine($"     {kv.Key,-52} {kv.Value,10:N0}");
+        Console.WriteLine($"     (no parent, {ctxFinal.Edges.Where(k => k.Key.EndsWith("(no parent)", StringComparison.Ordinal)).Sum(k => k.Value):N0} top-level records across {ctxFinal.Edges.Count(k => k.Key.EndsWith("(no parent)", StringComparison.Ordinal))} types)\n");
+
+        lastCtx = null;
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+
+        // ---- the descriptive breakdown and question 1, deliberately OUTSIDE the timed passes --------------------
+        // Per-property distinct counts, and the parent-naming check run on live bodies while the overlay is still
+        // open. Both would distort the figures above, so they get their own untimed sweep.
         var describe = new DescribePass();
         Sweep(paths, dataDir, describe, "describe");
 
@@ -88,34 +121,14 @@ static class ParentInHandProbe
             Console.WriteLine($"     {kv.Key,-34} {kv.Value.Count,10:N0}");
         Console.WriteLine();
 
-        // ---- pass E: Mutagen's own context enumeration, which carries a Parent ---------------------------------
-        // SkyrimModMixIn.EnumerateMajorRecordContexts(ISkyrimModGetter) needs NO link cache and yields
-        // IModContext<IMajorRecordGetter>, whose IModContext.Parent is the containing record's context. If that is
-        // populated, the containment map needs no custom walk at all — one enumeration replaces both passes.
-        var ctx = new ContextPass();
-        var passE = Sweep(paths, dataDir, ctx, "E");
-        Console.WriteLine($"E. Mutagen context enumeration (EnumerateMajorRecordContexts, no link cache)");
-        Console.WriteLine($"   contexts         : {ctx.Contexts:N0}");
-        Console.WriteLine($"   with a Parent    : {ctx.WithParent:N0}");
-        Console.WriteLine($"   parent is a record : {ctx.ParentIsRecord:N0}");
-        Console.WriteLine($"   child->parent    : {ctx.Map.Count:N0} distinct children (packed)");
-        Console.WriteLine($"   re-parented      : {ctx.Reparented:N0} (a later plugin put the same child under a DIFFERENT parent)");
-        Console.WriteLine($"   wall             : {passE.Wall.TotalSeconds:N2} s");
-        Console.WriteLine($"   retained after   : {passE.RetainedMb:N1} MB");
-        Console.WriteLine($"   plugins excluded : {passE.Skipped}");
-        Console.WriteLine($"   vs the flat pass : {(passE.Wall - passA.Wall).TotalSeconds:N2} s more");
-        Console.WriteLine("   edges the context walk hands over (child -> parent, by type):");
-        foreach (var kv in ctx.Edges.Where(k => !k.Key.EndsWith("(no parent)", StringComparison.Ordinal))
-                                    .OrderByDescending(k => k.Value))
-            Console.WriteLine($"     {kv.Key,-52} {kv.Value,10:N0}");
-        Console.WriteLine($"     (no parent, {ctx.Edges.Where(k => k.Key.EndsWith("(no parent)", StringComparison.Ordinal)).Sum(k => k.Value):N0} top-level records across {ctx.Edges.Count(k => k.Key.EndsWith("(no parent)", StringComparison.Ordinal))} types)\n");
-
-        // ---- question 1: is the parent in hand on the child body itself? ---------------------------------------
-        Console.WriteLine("D. is the parent in hand during the FLAT walk? (per child-bearing property)\n");
+        Console.WriteLine("D. is the parent in hand during the FLAT walk? (per child-bearing property, per child type)\n");
         ReportParentInHand(describe);
 
         return 0;
     }
+
+    static TimeSpan Median(List<TimeSpan> xs) => xs.OrderBy(x => x).ElementAt(xs.Count / 2);
+    static double Median(List<double> xs) => xs.OrderBy(x => x).ElementAt(xs.Count / 2);
 
     // ---------------------------------------------------------------------------------------------------------
     // The passes. Each opens one plugin at a time and disposes it, exactly as BuildIndex does, so the timings are
@@ -123,7 +136,12 @@ static class ParentInHandProbe
     // plugin has walked to the end, so a mid-plugin throw excludes the plugin instead of half-counting it.
     // ---------------------------------------------------------------------------------------------------------
 
-    interface IPass { void Plugin(ISkyrimModGetter ov); }
+    interface IPass
+    {
+        void Plugin(ISkyrimModGetter ov);
+        /// <summary>Drops anything that is bookkeeping rather than the thing being measured, before memory is read.</summary>
+        void Finish() { }
+    }
 
     /// <summary>Touches both enumerators on every plugin so the timed passes never pay first-run cost.</summary>
     sealed class WarmupPass : IPass
@@ -146,77 +164,9 @@ static class ParentInHandProbe
         }
     }
 
-    sealed class FusedPass : IPass
-    {
-        public long Records, Parents;
-        public readonly Dictionary<FormKey, FormKey> Map = new();
-
-        public void Plugin(ISkyrimModGetter ov)
-        {
-            var keys = new List<FormKey>();
-            foreach (var rec in ov.EnumerateMajorRecords()) keys.Add(rec.FormKey);
-
-            // The containment pass. The parent TYPES are not a hand list either: they are the types
-            // OwnedChildContent.Fields answers non-empty for, which is WriteEngine.ChildBearingProperties.
-            long parents = 0;
-            var staged = new List<(FormKey Child, FormKey Parent)>();
-            foreach (var parent in ParentBodies(ov))
-            {
-                parents++;
-                foreach (var field in OwnedChildContent.Fields(parent).Keys)
-                {
-                    var p = parent.GetType().GetProperty(field, BindingFlags.Public | BindingFlags.Instance);
-                    if (p is null) continue;
-                    object? val;
-                    try { val = p.GetValue(parent); } catch { continue; }
-                    var seen = new HashSet<FormKey>();
-                    foreach (var child in DirectChildren(val, 0))
-                    {
-                        if (!seen.Add(child.FormKey)) continue;   // a block struct can expose the same list twice
-                        staged.Add((child.FormKey, parent.FormKey));
-                    }
-                }
-            }
-
-            Records += keys.Count;
-            Parents += parents;
-            foreach (var (child, parent) in staged) Map[child] = parent;
-        }
-    }
-
-    /// <summary>The same containment walk as FusedPass, storing the map PACKED — one ulong per side, off a dense
-    /// ModKey index, which is the representation the resolver's own index could afford.</summary>
-    sealed class PackedPass : IPass
-    {
-        public readonly Dictionary<ulong, ulong> Map = new();
-        readonly Dictionary<ModKey, int> _mods = new();
-
-        public void Plugin(ISkyrimModGetter ov)
-        {
-            foreach (var rec in ov.EnumerateMajorRecords()) { _ = rec.FormKey; }   // the flat walk still happens, as today
-            var staged = new List<(FormKey Child, FormKey Parent)>();
-            foreach (var parent in ParentBodies(ov))
-                foreach (var field in OwnedChildContent.Fields(parent).Keys)
-                {
-                    var p = parent.GetType().GetProperty(field, BindingFlags.Public | BindingFlags.Instance);
-                    if (p is null) continue;
-                    object? val;
-                    try { val = p.GetValue(parent); } catch { continue; }
-                    foreach (var child in DirectChildren(val, 0)) staged.Add((child.FormKey, parent.FormKey));
-                }
-            foreach (var (child, parent) in staged) Map[Pack(child)] = Pack(parent);
-        }
-
-        ulong Pack(FormKey k)
-        {
-            if (!_mods.TryGetValue(k.ModKey, out var i)) _mods[k.ModKey] = i = _mods.Count;
-            return ((ulong)(uint)i << 32) | k.ID;
-        }
-    }
-
     /// <summary>Mutagen's own context walk — one enumeration per plugin, each context carrying the containing
-    /// record's context in IModContext.Parent. Measures whether the parent really arrives, and what the walk costs
-    /// beside the flat one.</summary>
+    /// record's context in IModContext.Parent. Measures whether the parent really arrives, what the walk costs
+    /// beside the flat one, and what the resulting packed map retains.</summary>
     sealed class ContextPass : IPass
     {
         public long Contexts, WithParent, ParentIsRecord, Reparented;
@@ -224,6 +174,9 @@ static class ParentInHandProbe
         // childType -> parentType, or "(no parent)" / "(parent chain holds no record)" — what the walk hands over.
         public readonly Dictionary<string, long> Edges = new(StringComparer.Ordinal);
         readonly Dictionary<ModKey, int> _mods = new();
+        // First parent seen per child. Bookkeeping for the re-parent count, dropped in Finish so the reported
+        // memory is the packed map alone.
+        Dictionary<ulong, ulong>? _first = new();
 
         public void Plugin(ISkyrimModGetter ov)
         {
@@ -268,13 +221,21 @@ static class ParentInHandProbe
             foreach (var (child, parent) in staged) Put(child, parent);
         }
 
-        // Does a LATER plugin ever put the same child under a DIFFERENT parent? That is what decides whether one
-        // whole-order map is well-defined or the map has to be per-plugin.
+        // Does a LATER plugin ever leave the same child under a DIFFERENT parent? That is what decides whether one
+        // whole-order map is well-defined or the map has to be per-plugin. Counted as DISTINCT children whose final
+        // parent differs from the first one seen — not as overwrite events, which double-count a child moved twice
+        // and count a child moved away and back as two.
         void Put(FormKey child, FormKey parent)
         {
             var ck = Pack(child); var pk = Pack(parent);
-            if (Map.TryGetValue(ck, out var had) && had != pk) Reparented++;
+            _first!.TryAdd(ck, pk);
             Map[ck] = pk;
+        }
+
+        public void Finish()
+        {
+            Reparented = _first!.Count(kv => Map[kv.Key] != kv.Value);
+            _first = null;
         }
 
         ulong Pack(FormKey k)
@@ -284,16 +245,33 @@ static class ParentInHandProbe
         }
     }
 
-    /// <summary>The descriptive pass: distinct children per child-bearing property, and one real (parent, child)
-    /// pair per property for the question-1 report. Never timed — the samples pin live overlay bodies, and the
-    /// per-property sets are extra memory, both of which would distort the passes above.</summary>
+    /// <summary>One sampled (property, child type) row of the question-1 answer.</summary>
+    sealed class NamingTally
+    {
+        public int Sampled, Naming, Unreadable;
+        public readonly HashSet<string> Paths = new(StringComparer.Ordinal);
+    }
+
+    /// <summary>The descriptive pass: distinct children per child-bearing property, and the parent-naming check
+    /// itself, run on live bodies WHILE THE OVERLAY IS OPEN — a retained overlay body reads differently after its
+    /// mod is disposed, so the answer has to be taken here. Never timed.</summary>
     sealed class DescribePass : IPass
     {
         public readonly Dictionary<string, HashSet<FormKey>> PerProperty = new(StringComparer.Ordinal);
-        public readonly Dictionary<string, (IMajorRecordGetter Parent, IMajorRecordGetter Child)> Sample = new(StringComparer.Ordinal);
+        // (property, child type) -> what the sampled bodies said. Every distinct child type under a property is
+        // sampled separately, because PlacedObject and PlacedNpc under Cell.Temporary are different bodies and one
+        // does not answer for the other.
+        public readonly Dictionary<(string Property, string ChildType), NamingTally> Naming = new();
+        public readonly Dictionary<(string Property, string ChildType), (FormKey Child, FormKey Parent)> Sample = new();
 
         public void Plugin(ISkyrimModGetter ov)
         {
+            // Staged per plugin and merged only when the plugin walks to the end, so a mid-plugin throw excludes
+            // the plugin rather than leaving half its rows behind.
+            var perProperty = new Dictionary<string, HashSet<FormKey>>(StringComparer.Ordinal);
+            var naming = new Dictionary<(string, string), NamingTally>();
+            var sample = new Dictionary<(string, string), (FormKey, FormKey)>();
+
             foreach (var parent in ParentBodies(ov))
                 foreach (var field in OwnedChildContent.Fields(parent).Keys)
                 {
@@ -304,11 +282,38 @@ static class ParentInHandProbe
                     var key = $"{Short(parent.GetType())}.{field}";
                     foreach (var child in DirectChildren(val, 0))
                     {
-                        if (!PerProperty.TryGetValue(key, out var set)) PerProperty[key] = set = new HashSet<FormKey>();
+                        if (!perProperty.TryGetValue(key, out var set)) perProperty[key] = set = new HashSet<FormKey>();
                         set.Add(child.FormKey);
-                        if (!Sample.ContainsKey(key)) Sample[key] = (parent, child);
+
+                        var childType = Short(child.GetType());
+                        var slot = (key, childType);
+                        var already = (Naming.GetValueOrDefault((key, childType))?.Sampled ?? 0)
+                                    + (naming.GetValueOrDefault(slot)?.Sampled ?? 0);
+                        if (already >= SamplesPerChildType) continue;
+
+                        if (!naming.TryGetValue(slot, out var tally)) naming[slot] = tally = new NamingTally();
+                        var paths = ParentNamingPaths(child, parent.FormKey, out var unreadable);
+                        tally.Sampled++;
+                        tally.Unreadable += unreadable;
+                        if (paths.Count > 0) { tally.Naming++; foreach (var path in paths) tally.Paths.Add(path); }
+                        sample.TryAdd(slot, (child.FormKey, parent.FormKey));
                     }
                 }
+
+            foreach (var kv in perProperty)
+            {
+                if (!PerProperty.TryGetValue(kv.Key, out var set)) PerProperty[kv.Key] = set = new HashSet<FormKey>();
+                set.UnionWith(kv.Value);
+            }
+            foreach (var kv in naming)
+            {
+                if (!Naming.TryGetValue(kv.Key, out var tally)) Naming[kv.Key] = tally = new NamingTally();
+                tally.Sampled += kv.Value.Sampled;
+                tally.Naming += kv.Value.Naming;
+                tally.Unreadable += kv.Value.Unreadable;
+                tally.Paths.UnionWith(kv.Value.Paths);
+            }
+            foreach (var kv in sample) Sample.TryAdd(kv.Key, kv.Value);
         }
     }
 
@@ -350,13 +355,13 @@ static class ParentInHandProbe
             }
     }
 
-    sealed record PassResult(TimeSpan Wall, double RetainedMb, int Skipped);
+    sealed record PassResult(TimeSpan Wall, double RetainedMb, int Skipped, int Opened);
 
     static PassResult Sweep(IReadOnlyList<string> paths, string? dataDir, IPass pass, string name)
     {
         GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
         var before = GC.GetTotalMemory(true);
-        int skipped = 0;
+        int skipped = 0, opened = 0;
         var sw = Stopwatch.StartNew();
         foreach (var path in paths)
         {
@@ -368,6 +373,7 @@ static class ParentInHandProbe
                 Console.WriteLine($"   ! {name}: cannot open {Path.GetFileName(path)} — {ex.Message} (plugin excluded)");
                 continue;
             }
+            opened++;
             // A pass merges a plugin's work only when the plugin walks to the end, so a throw here excludes that
             // plugin from the totals rather than half-counting it. The reason is printed, never swallowed.
             try { pass.Plugin(ov); }
@@ -379,57 +385,119 @@ static class ParentInHandProbe
             finally { (ov as IDisposable)?.Dispose(); }
         }
         sw.Stop();
+        pass.Finish();
         var after = GC.GetTotalMemory(true);
-        return new PassResult(sw.Elapsed, (after - before) / 1024.0 / 1024.0, skipped);
+        return new PassResult(sw.Elapsed, (after - before) / 1024.0 / 1024.0, skipped, opened);
     }
 
     // ---------------------------------------------------------------------------------------------------------
-    // Question 1. For each child-bearing property, take a real (parent, child) pair the containment walk found and
-    // ask the CHILD body whether anything on it names the parent — a populated FormLink or a record reference that
-    // resolves to the parent's FormKey. That is the whole content of "the parent is in hand": the flat walk hands
-    // the caller nothing but the child body, so if the child body does not name its parent, the parent is not
-    // available at that moment by any means.
+    // Question 1. For each child-bearing property and each distinct child type under it, take real (parent, child)
+    // pairs the containment walk found and ask the CHILD body whether anything on it names the parent — a
+    // populated FormLink, a FormKey, or a record reference that equals the parent's FormKey. That is the whole
+    // content of "the parent is in hand": the flat walk hands the caller nothing but the child body.
+    //
+    // The search is NOT one level deep. A parent pointer on a Skyrim child body sits inside a nested struct behind
+    // a polymorphic arm — NavigationMesh.Data.Parent is an abstract navmesh parent whose CellNavmeshParent arm
+    // carries the cell — so the walk descends through plain structs and reads each value's RUNTIME type, which is
+    // what makes the arm visible at all.
     // ---------------------------------------------------------------------------------------------------------
     static void ReportParentInHand(DescribePass pass)
     {
-        var props = ChildBearingSurface();
-        foreach (var (key, count) in props.Select(k => (k, pass.PerProperty.GetValueOrDefault(k)?.Count ?? 0)).OrderBy(t => t.k))
+        foreach (var key in ChildBearingSurface().OrderBy(k => k, StringComparer.Ordinal))
         {
-            if (!pass.Sample.TryGetValue(key, out var s))
+            var count = pass.PerProperty.GetValueOrDefault(key)?.Count ?? 0;
+            var rows = pass.Naming.Where(kv => kv.Key.Property == key).OrderBy(kv => kv.Key.ChildType, StringComparer.Ordinal).ToList();
+            if (rows.Count == 0)
             {
-                Console.WriteLine($"   {key,-34} no sample in this order (0 children seen) — not measured");
+                Console.WriteLine($"   {key,-34} no children in this order (0 seen) — not measured");
                 continue;
             }
-            var hits = ParentNamingMembers(s.Child, s.Parent.FormKey, out var unreadable).ToList();
-            // An unreadable body must never masquerade as a clean "NO" — that is the answer being measured.
-            var verdict = hits.Count > 0 ? "YES — " + string.Join(", ", hits)
-                        : unreadable > 0 ? $"NO among the readable members ({unreadable} member(s) would not read)"
+            Console.WriteLine($"   {key}   ({count:N0} distinct children in the order)");
+            foreach (var (slot, tally) in rows)
+            {
+                // An unreadable body must never masquerade as a clean "NO" — that is the answer being measured.
+                var verdict = tally.Naming == tally.Sampled && tally.Naming > 0
+                        ? $"YES via {string.Join(", ", tally.Paths.OrderBy(p => p, StringComparer.Ordinal))}"
+                    : tally.Naming > 0
+                        ? $"YES on {tally.Naming} of {tally.Sampled} sampled, via {string.Join(", ", tally.Paths.OrderBy(p => p, StringComparer.Ordinal))}"
+                    : tally.Unreadable > 0
+                        ? $"NO among the readable members ({tally.Unreadable} member read(s) threw)"
                         : "NO";
-            Console.WriteLine($"   {key,-34} {verdict}");
-            Console.WriteLine($"      sample child {s.Child.FormKey} ({Short(s.Child.GetType())}) under parent {s.Parent.FormKey}; {count:N0} distinct children of this kind in the order");
+                var sample = pass.Sample.TryGetValue(slot, out var s) ? $"; e.g. child {s.Child} under parent {s.Parent}" : "";
+                Console.WriteLine($"     {slot.ChildType,-24} {verdict}   ({tally.Sampled} sampled{sample})");
+            }
         }
     }
 
-    /// <summary>Every member of the child's own body whose value is, or resolves to, the parent's FormKey, plus a
-    /// count of the members that would not read at all.</summary>
-    static IEnumerable<string> ParentNamingMembers(IMajorRecordGetter child, FormKey parent, out int unreadable)
+    /// <summary>Every member path on the child's own body whose value is, or resolves to, the parent's FormKey,
+    /// spelled from the child body down (Data.Parent[CellNavmeshParent].Parent), plus a count of the members that
+    /// would not read at all.</summary>
+    static List<string> ParentNamingPaths(IMajorRecordGetter child, FormKey parent, out int unreadable)
     {
         var hits = new List<string>();
-        unreadable = 0;
-        foreach (var p in child.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        var seen = new HashSet<object>(ReferenceEqualityComparer.Instance);
+        var skip = OwnedChildContent.Fields(child).Keys.ToHashSet(StringComparer.Ordinal);
+        int failed = 0;
+        Descend(child, "", 0);
+        unreadable = failed;
+        return hits;
+
+        void Descend(object node, string path, int depth)
         {
-            if (p.GetIndexParameters().Length > 0) continue;
-            object? v;
-            try { v = p.GetValue(child); } catch { unreadable++; continue; }
-            switch (v)
+            if (depth > 5 || !seen.Add(node)) return;
+            foreach (var p in node.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
             {
-                case IFormLinkGetter fl when fl.FormKey == parent: hits.Add($"{p.Name} (FormLink)"); break;
-                case IMajorRecordGetter mr when mr.FormKey == parent: hits.Add($"{p.Name} (record)"); break;
-                case FormKey fk when fk == parent: hits.Add($"{p.Name} (FormKey)"); break;
+                if (p.GetIndexParameters().Length > 0) continue;
+                // A child-bearing property holds owned children, not a parent pointer, and walking one parses a
+                // whole cell's worth of placed references.
+                if (depth == 0 && skip.Contains(p.Name)) continue;
+                object? v;
+                try { v = p.GetValue(node); } catch { failed++; continue; }
+                Visit(v, path.Length == 0 ? p.Name : $"{path}.{p.Name}", p.PropertyType, depth);
             }
         }
-        return hits;
+
+        void Visit(object? v, string path, Type declared, int depth)
+        {
+            switch (v)
+            {
+                case null:
+                    return;
+                case IFormLinkGetter fl:
+                    if (fl.FormKey == parent) hits.Add(path);
+                    return;
+                case FormKey fk:
+                    if (fk == parent) hits.Add(path);
+                    return;
+                case IMajorRecordGetter mr:
+                    // Another record body: it can BE the parent, but its own fields are not the child's.
+                    if (mr.FormKey == parent) hits.Add(path);
+                    return;
+                case string:
+                    return;
+                case System.Collections.IEnumerable seq:
+                    var i = 0;
+                    foreach (var item in seq)
+                    {
+                        if (i >= 64) return;   // a bounded look: a parent pointer is a field, not a long list
+                        Visit(item, $"{path}[{i++}]", item?.GetType() ?? typeof(object), depth + 1);
+                    }
+                    return;
+                default:
+                    if (IsLeaf(v.GetType())) return;
+                    // A nested struct. Spell the polymorphic arm when the runtime type is not the declared one,
+                    // because that is the whole reason the member is reachable.
+                    var arm = declared != v.GetType() && (declared.IsAbstract || declared.IsInterface)
+                        ? $"{path}[{Short(v.GetType())}]" : path;
+                    Descend(v, arm, depth + 1);
+                    return;
+            }
+        }
     }
+
+    static bool IsLeaf(Type t) =>
+        t.IsPrimitive || t.IsEnum || t == typeof(string) || t == typeof(decimal) || t == typeof(DateTime)
+        || t == typeof(Guid) || t == typeof(ModKey) || t.Namespace?.StartsWith("System.Numerics", StringComparison.Ordinal) == true;
 
     /// <summary>The child-bearing property surface, by construction — every concrete Mutagen record type that has
     /// one, spelled Type.Property. This is the row set the report must cover.</summary>

--- a/src/housecarl-generator/ParentInHandProbe.cs
+++ b/src/housecarl-generator/ParentInHandProbe.cs
@@ -95,11 +95,20 @@ static class ParentInHandProbe
         var delta = (medE - medA).TotalSeconds;
         Console.WriteLine($"   vs the flat pass : {Math.Abs(delta):N2} s {(delta < 0 ? "less" : "more")} " +
                           $"({(medA.TotalSeconds > 0 ? medE.TotalSeconds / medA.TotalSeconds : 0):N2}x A)");
-        Console.WriteLine("   edges the context walk hands over (child -> parent, by type):");
-        foreach (var kv in ctxFinal.Edges.Where(k => !k.Key.EndsWith("(no parent)", StringComparison.Ordinal))
-                                         .OrderByDescending(k => k.Value))
+        // Only the rows that actually staged an edge into Map print under the edges heading; a row that staged nothing
+        // gets its own heading below, so neither table quietly carries the other's rows.
+        Console.WriteLine($"   edges the context walk hands over (child -> parent, by type; {ctxFinal.Edges.Values.Sum():N0} in total, " +
+                          $"the \"parent is a record\" count — Map holds {ctxFinal.Map.Count:N0} of them, one per distinct child):");
+        foreach (var kv in ctxFinal.Edges.OrderByDescending(k => k.Value))
             Console.WriteLine($"     {kv.Key,-52} {kv.Value,10:N0}");
-        Console.WriteLine($"     (no parent, {ctxFinal.Edges.Where(k => k.Key.EndsWith("(no parent)", StringComparison.Ordinal)).Sum(k => k.Value):N0} top-level records across {ctxFinal.Edges.Count(k => k.Key.EndsWith("(no parent)", StringComparison.Ordinal))} types)\n");
+        Console.WriteLine($"   contexts the walk hands over with NO usable parent ({ctxFinal.NonEdges.Values.Sum():N0} in total, none staged into the map):");
+        // The top-level records are one row per record type and say nothing individually, so they collapse to a tally;
+        // a parent chain that holds no record is the surprising shape, so those are named.
+        var topLevel = ctxFinal.NonEdges.Where(k => k.Key.EndsWith("(no parent)", StringComparison.Ordinal)).ToList();
+        Console.WriteLine($"     {"(no parent) — top-level records",-52} {topLevel.Sum(k => k.Value),10:N0}   across {topLevel.Count} types");
+        foreach (var kv in ctxFinal.NonEdges.Except(topLevel).OrderByDescending(k => k.Value))
+            Console.WriteLine($"     {kv.Key,-52} {kv.Value,10:N0}");
+        Console.WriteLine();
 
         lastCtx = null;
         GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();

--- a/src/housecarl-generator/ParentInHandProbe.cs
+++ b/src/housecarl-generator/ParentInHandProbe.cs
@@ -527,6 +527,13 @@ static class ParentInHandProbe
         if (args.Length > 0 && args[0] == "--plugin")
         {
             if (args.Length < 2) { Console.WriteLine("usage: parent-in-hand --plugin <path> [dataDir]"); return null; }
+            // Checked here so a typo'd path says so, instead of throwing inside OpenOverlay and landing on the
+            // instance-and-profile sentence, which names nothing the caller actually got wrong.
+            if (!File.Exists(args[1]))
+            {
+                Console.WriteLine($"no plugin file at {args[1]} — pass the path to an existing .esp/.esm/.esl.");
+                return null;
+            }
             dataDir = args.Length > 2 ? args[2] : Path.GetDirectoryName(args[1]);
             label = $"single plugin {Path.GetFileName(args[1])}";
             return new[] { args[1] };

--- a/src/housecarl-generator/ParentInHandProbe.cs
+++ b/src/housecarl-generator/ParentInHandProbe.cs
@@ -317,14 +317,37 @@ static class ParentInHandProbe
         }
     }
 
-    /// <summary>Every record in the plugin that BEARS children — the three parent types, asked of the corpus rather
-    /// than named here: a type is a parent iff OwnedChildContent.Fields answers non-empty for it.</summary>
+    /// <summary>Every record in the plugin that BEARS children, off the SAME source the report's row set comes from —
+    /// so a Mutagen bump that adds a child-bearing type cannot leave the probe printing "no children in this order"
+    /// for a type it simply never enumerated.</summary>
     static IEnumerable<IMajorRecordGetter> ParentBodies(ISkyrimModGetter ov)
     {
-        foreach (var c in ov.EnumerateMajorRecords<ICellGetter>()) yield return c;
-        foreach (var d in ov.EnumerateMajorRecords<IDialogTopicGetter>()) yield return d;
-        foreach (var w in ov.EnumerateMajorRecords<IWorldspaceGetter>()) yield return w;
+        foreach (var getter in ChildBearingGetters())
+            foreach (var rec in ov.EnumerateMajorRecords(getter, throwIfUnknown: true))
+                yield return (IMajorRecordGetter)rec;
     }
+
+    /// <summary>The child-bearing concrete record types, each paired with the getter interface the overlay enumerates
+    /// by. One source, asked once: WriteEngine.ChildBearingProperties over WriteSurfaceGuardProbe.ConcreteRecordTypes.
+    /// A child-bearing type with no getter interface is a real coverage gap, so it is named rather than dropped.</summary>
+    static IReadOnlyList<Type> ChildBearingGetters() => _childBearingGetters ??= BuildChildBearingGetters();
+    static IReadOnlyList<Type>? _childBearingGetters;
+
+    static IReadOnlyList<Type> BuildChildBearingGetters()
+    {
+        var getters = new List<Type>();
+        foreach (var t in ChildBearingTypes())
+        {
+            var getter = WriteEngine.PrimaryGetter(t);
+            if (getter is null) Console.WriteLine($"   ! {t.Name} bears children but has no getter interface — not enumerated.");
+            else if (!getters.Contains(getter)) getters.Add(getter);
+        }
+        return getters;
+    }
+
+    /// <summary>Every concrete record type Mutagen models that has a child-bearing property.</summary>
+    static IEnumerable<Type> ChildBearingTypes() =>
+        WriteSurfaceGuardProbe.ConcreteRecordTypes().Where(t => WriteEngine.ChildBearingProperties(t).Count > 0);
 
     /// <summary>The DIRECT child records held by one child-bearing field's value — stopping at the first major
     /// record on each branch, so a worldspace's SubCells yields its CELLs and not their placed references. Same cut
@@ -503,12 +526,9 @@ static class ParentInHandProbe
     /// one, spelled Type.Property. This is the row set the report must cover.</summary>
     static IEnumerable<string> ChildBearingSurface()
     {
-        foreach (var t in typeof(ISkyrimMod).Assembly.GetTypes())
-        {
-            if (t.IsAbstract || !t.IsClass || !typeof(IMajorRecord).IsAssignableFrom(t)) continue;
+        foreach (var t in ChildBearingTypes())
             foreach (var p in WriteEngine.ChildBearingProperties(t))
                 yield return $"{Short(t)}.{p.Name}";
-        }
     }
 
     static string Short(Type t)

--- a/src/housecarl-generator/ParentInHandProbe.cs
+++ b/src/housecarl-generator/ParentInHandProbe.cs
@@ -108,7 +108,9 @@ static class ParentInHandProbe
         // Per-property distinct counts, and the parent-naming check run on live bodies while the overlay is still
         // open. Both would distort the figures above, so they get their own untimed sweep.
         var describe = new DescribePass();
-        Sweep(paths, dataDir, describe, "describe");
+        var d = Sweep(paths, dataDir, describe, "describe");
+        if (d.Opened == 0) { Console.WriteLine("every plugin failed to open, so nothing was measured — check the instance path and the profile's load order."); return 1; }
+        Console.WriteLine($"   plugins excluded : {d.Skipped}");
 
         var temporary = describe.PerProperty.GetValueOrDefault("Cell.Temporary")?.Count ?? 0;
         var nonTemporary = describe.PerProperty.Where(k => k.Key != "Cell.Temporary")

--- a/src/housecarl-generator/ParentInHandProbe.cs
+++ b/src/housecarl-generator/ParentInHandProbe.cs
@@ -1,0 +1,428 @@
+using System.Diagnostics;
+using System.Reflection;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Plugins.Cache;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+// #459 measurement. Two questions, one process, against a live MO2 order (or a single plugin).
+//
+//   1. Is the containing parent in hand during LoadOrderResolver.BuildIndex's flat ov.EnumerateMajorRecords()?
+//      Answered per child-bearing property (WriteEngine.ChildBearingProperties), by asking a REAL child body of
+//      each kind whether anything on it names its parent.
+//   2. What does the containment-aware second pass cost — wall time and retained memory — beside the flat pass
+//      the index build already runs, both fused into ONE overlay open per plugin. Measured three ways: a hand
+//      containment walk off ChildBearingProperties, the same map stored packed, and Mutagen's own
+//      EnumerateMajorRecordContexts (which carries the parent and needs no link cache).
+//
+//   dotnet run --project src/housecarl-generator parent-in-hand [instanceDir]
+//   dotnet run --project src/housecarl-generator parent-in-hand --plugin <path> [dataDir]
+static class ParentInHandProbe
+{
+    public static int Run(string[] args)
+    {
+        var paths = ResolvePaths(args, out var label, out var dataDir);
+        if (paths is null) return 1;
+        Console.WriteLine($"parent-in-hand: {label} — {paths.Count} plugin(s)\n");
+
+        // ---- pass A: the flat walk BuildIndex runs today ------------------------------------------------------
+        var flat = new FlatPass();
+        var passA = Sweep(paths, dataDir, flat);
+
+        Console.WriteLine($"A. flat pass (today's BuildIndex walk)");
+        Console.WriteLine($"   records          : {flat.Records:N0}");
+        Console.WriteLine($"   wall             : {passA.Wall.TotalSeconds:N2} s");
+        Console.WriteLine($"   retained after   : {passA.RetainedMb:N1} MB   (FormKey buffer only, as today)");
+        Console.WriteLine($"   plugins skipped  : {passA.Skipped}\n");
+
+        // ---- pass B: flat + containment, fused into the SAME open ---------------------------------------------
+        var both = new FusedPass();
+        var passB = Sweep(paths, dataDir, both);
+
+        Console.WriteLine($"B. fused pass (flat walk + containment walk, one open per plugin)");
+        Console.WriteLine($"   records          : {both.Records:N0}");
+        Console.WriteLine($"   parents visited  : {both.Parents:N0}");
+        Console.WriteLine($"   child->parent    : {both.Map.Count:N0} distinct children");
+        Console.WriteLine($"   wall             : {passB.Wall.TotalSeconds:N2} s");
+        Console.WriteLine($"   retained after   : {passB.RetainedMb:N1} MB   (includes the child->parent map)");
+        Console.WriteLine($"   plugins skipped  : {passB.Skipped}");
+        Console.WriteLine($"   MARGINAL time    : {(passB.Wall - passA.Wall).TotalSeconds:N2} s " +
+                          $"({(passA.Wall.TotalSeconds > 0 ? (passB.Wall.TotalSeconds / passA.Wall.TotalSeconds) : 0):N2}x the flat pass)");
+        Console.WriteLine($"   MARGINAL memory  : {(passB.RetainedMb - passA.RetainedMb):N1} MB\n");
+
+        // ---- pass C: the same map, packed --------------------------------------------------------------------
+        // A FormKey is a ModKey (a string reference + a type enum) plus a uint, so a Dictionary<FormKey,FormKey>
+        // pays for two of those per entry. The index already has a dense plugin index, so pack (modIdx, id) into
+        // one ulong and measure what the SAME map costs stored that way.
+        var packed = new PackedPass();
+        var passC = Sweep(paths, dataDir, packed);
+        Console.WriteLine($"C. packed map only (ulong -> ulong, (modIdx<<32|id))");
+        Console.WriteLine($"   entries          : {packed.Map.Count:N0}");
+        Console.WriteLine($"   wall             : {passC.Wall.TotalSeconds:N2} s");
+        Console.WriteLine($"   retained after   : {passC.RetainedMb:N1} MB   ({passC.RetainedMb * 1024 * 1024 / Math.Max(1, packed.Map.Count):N0} B/entry)");
+        Console.WriteLine($"   without Cell.Temporary : {both.Map.Count - both.PerProperty.GetValueOrDefault("Cell.Temporary"):N0} entries\n");
+
+        Console.WriteLine("   per child-bearing property (children reached by the containment walk):");
+        foreach (var kv in both.PerProperty.OrderByDescending(k => k.Value))
+            Console.WriteLine($"     {kv.Key,-34} {kv.Value,10:N0}");
+        Console.WriteLine();
+
+        // ---- pass E: Mutagen's own context enumeration, which carries a Parent ---------------------------------
+        // SkyrimModMixIn.EnumerateMajorRecordContexts(ISkyrimModGetter) needs NO link cache and yields
+        // IModContext<IMajorRecordGetter>, whose IModContext.Parent is the containing record's context. If that is
+        // populated, the containment map needs no custom walk at all — one enumeration replaces both passes.
+        var ctx = new ContextPass();
+        var passE = Sweep(paths, dataDir, ctx);
+        Console.WriteLine($"E. Mutagen context enumeration (EnumerateMajorRecordContexts, no link cache)");
+        Console.WriteLine($"   contexts         : {ctx.Contexts:N0}");
+        Console.WriteLine($"   with a Parent    : {ctx.WithParent:N0}");
+        Console.WriteLine($"   parent is a record : {ctx.ParentIsRecord:N0}");
+        Console.WriteLine($"   child->parent    : {ctx.Map.Count:N0} distinct children (packed)");
+        Console.WriteLine($"   re-parented      : {ctx.Reparented:N0} (a later plugin put the same child under a DIFFERENT parent)");
+        Console.WriteLine($"   wall             : {passE.Wall.TotalSeconds:N2} s");
+        Console.WriteLine($"   retained after   : {passE.RetainedMb:N1} MB");
+        Console.WriteLine($"   plugins skipped  : {passE.Skipped}");
+        Console.WriteLine($"   vs the flat pass : {(passE.Wall - passA.Wall).TotalSeconds:N2} s more");
+        Console.WriteLine("   edges the context walk hands over (child -> parent, by type):");
+        foreach (var kv in ctx.Edges.Where(k => !k.Key.EndsWith("(no parent)", StringComparison.Ordinal))
+                                    .OrderByDescending(k => k.Value))
+            Console.WriteLine($"     {kv.Key,-52} {kv.Value,10:N0}");
+        Console.WriteLine($"     (no parent, {ctx.Edges.Where(k => k.Key.EndsWith("(no parent)", StringComparison.Ordinal)).Sum(k => k.Value):N0} top-level records across {ctx.Edges.Count(k => k.Key.EndsWith("(no parent)", StringComparison.Ordinal))} types)\n");
+
+        // ---- question 1: is the parent in hand on the child body itself? ---------------------------------------
+        Console.WriteLine("D. is the parent in hand during the FLAT walk? (per child-bearing property)\n");
+        ReportParentInHand(both);
+
+        return 0;
+    }
+
+    // ---------------------------------------------------------------------------------------------------------
+    // The two passes. Both open one plugin at a time and dispose it, exactly as BuildIndex does, so the timings
+    // are comparable and neither holds the order open.
+    // ---------------------------------------------------------------------------------------------------------
+
+    interface IPass { void Plugin(ISkyrimModGetter ov); }
+
+    sealed class FlatPass : IPass
+    {
+        public long Records;
+        public void Plugin(ISkyrimModGetter ov)
+        {
+            var keys = new List<FormKey>();
+            foreach (var rec in ov.EnumerateMajorRecords()) keys.Add(rec.FormKey);
+            Records += keys.Count;
+        }
+    }
+
+    sealed class FusedPass : IPass
+    {
+        public long Records, Parents;
+        public readonly Dictionary<FormKey, FormKey> Map = new();
+        public readonly Dictionary<string, long> PerProperty = new(StringComparer.Ordinal);
+        // One live child body per property, kept for the "is the parent in hand" reflection report.
+        public readonly Dictionary<string, (IMajorRecordGetter parent, IMajorRecordGetter child)> Sample = new(StringComparer.Ordinal);
+
+        public void Plugin(ISkyrimModGetter ov)
+        {
+            var keys = new List<FormKey>();
+            foreach (var rec in ov.EnumerateMajorRecords()) keys.Add(rec.FormKey);
+            Records += keys.Count;
+
+            // The containment pass. The parent TYPES are not a hand list either: they are the types
+            // OwnedChildContent.Fields answers non-empty for, which is WriteEngine.ChildBearingProperties.
+            foreach (var parent in ParentBodies(ov))
+            {
+                Parents++;
+                foreach (var field in OwnedChildContent.Fields(parent).Keys)
+                {
+                    var p = parent.GetType().GetProperty(field, BindingFlags.Public | BindingFlags.Instance);
+                    if (p is null) continue;
+                    object? val;
+                    try { val = p.GetValue(parent); } catch { continue; }
+                    long n = 0;
+                    var seen = new HashSet<FormKey>();
+                    foreach (var child in DirectChildren(val, 0))
+                    {
+                        if (!seen.Add(child.FormKey)) continue;   // a block struct can expose the same list twice
+                        Map[child.FormKey] = parent.FormKey;
+                        n++;
+                        if (!Sample.ContainsKey(Key(parent, field))) Sample[Key(parent, field)] = (parent, child);
+                    }
+                    if (n > 0) PerProperty[Key(parent, field)] = PerProperty.GetValueOrDefault(Key(parent, field)) + n;
+                }
+            }
+        }
+
+        static string Key(IMajorRecordGetter parent, string field) => $"{Short(parent.GetType())}.{field}";
+    }
+
+    /// <summary>The same containment walk as FusedPass, storing the map PACKED — one ulong per side, off a dense
+    /// ModKey index, which is the representation the resolver's own index could afford.</summary>
+    sealed class PackedPass : IPass
+    {
+        public readonly Dictionary<ulong, ulong> Map = new();
+        readonly Dictionary<ModKey, int> _mods = new();
+
+        public void Plugin(ISkyrimModGetter ov)
+        {
+            foreach (var rec in ov.EnumerateMajorRecords()) { }         // the flat walk still happens, as today
+            foreach (var parent in ParentBodies(ov))
+                foreach (var field in OwnedChildContent.Fields(parent).Keys)
+                {
+                    var p = parent.GetType().GetProperty(field, BindingFlags.Public | BindingFlags.Instance);
+                    if (p is null) continue;
+                    object? val;
+                    try { val = p.GetValue(parent); } catch { continue; }
+                    foreach (var child in DirectChildren(val, 0)) Map[Pack(child.FormKey)] = Pack(parent.FormKey);
+                }
+        }
+
+        ulong Pack(FormKey k)
+        {
+            if (!_mods.TryGetValue(k.ModKey, out var i)) _mods[k.ModKey] = i = _mods.Count;
+            return ((ulong)(uint)i << 32) | k.ID;
+        }
+    }
+
+    /// <summary>Mutagen's own context walk — one enumeration per plugin, each context carrying the containing
+    /// record's context in IModContext.Parent. Measures whether the parent really arrives, and what the walk costs
+    /// beside the flat one.</summary>
+    sealed class ContextPass : IPass
+    {
+        public long Contexts, WithParent, ParentIsRecord, Reparented;
+        public readonly Dictionary<ulong, ulong> Map = new();
+        // childType -> parentType, or "(no parent)" / "(parent is not a record: X)" — what the walk actually hands over.
+        public readonly Dictionary<string, long> Edges = new(StringComparer.Ordinal);
+        readonly Dictionary<ModKey, int> _mods = new();
+
+        public void Plugin(ISkyrimModGetter ov)
+        {
+            foreach (var c in ov.EnumerateMajorRecordContexts())
+            {
+                Contexts++;
+                var child = Short(c.Record.GetType());
+                var parent = (c as IModContext)?.Parent;
+                if (parent is null) { Bump($"{child} -> (no parent)"); continue; }
+                WithParent++;
+                if (parent.Record is IMajorRecordGetter pr)
+                {
+                    ParentIsRecord++;
+                    Put(c.Record.FormKey, pr.FormKey);
+                    Bump($"{child} -> {Short(pr.GetType())}");
+                }
+                else
+                {
+                    // A group/block context, not a record. Climb: the nearest record ancestor is the real parent.
+                    var up = parent;
+                    int hops = 0;
+                    while (up is not null && up.Record is not IMajorRecordGetter && hops++ < 6) up = up.Parent;
+                    if (up?.Record is IMajorRecordGetter anc)
+                    {
+                        ParentIsRecord++;
+                        Put(c.Record.FormKey, anc.FormKey);
+                        Bump($"{child} -> {Short(anc.GetType())} (via {hops} group hop(s))");
+                    }
+                    else Bump($"{child} -> (parent chain holds no record)");
+                }
+            }
+        }
+
+        // Does a LATER plugin ever put the same child under a DIFFERENT parent? That is what decides whether one
+        // whole-order map is well-defined or the map has to be per-plugin.
+        void Put(FormKey child, FormKey parent)
+        {
+            var ck = Pack(child); var pk = Pack(parent);
+            if (Map.TryGetValue(ck, out var had) && had != pk) Reparented++;
+            Map[ck] = pk;
+        }
+
+        void Bump(string k) => Edges[k] = Edges.GetValueOrDefault(k) + 1;
+
+        ulong Pack(FormKey k)
+        {
+            if (!_mods.TryGetValue(k.ModKey, out var i)) _mods[k.ModKey] = i = _mods.Count;
+            return ((ulong)(uint)i << 32) | k.ID;
+        }
+    }
+
+    /// <summary>Every record in the plugin that BEARS children — the three parent types, asked of the corpus rather
+    /// than named here: a type is a parent iff OwnedChildContent.Fields answers non-empty for it.</summary>
+    static IEnumerable<IMajorRecordGetter> ParentBodies(ISkyrimModGetter ov)
+    {
+        foreach (var c in ov.EnumerateMajorRecords<ICellGetter>()) yield return c;
+        foreach (var d in ov.EnumerateMajorRecords<IDialogTopicGetter>()) yield return d;
+        foreach (var w in ov.EnumerateMajorRecords<IWorldspaceGetter>()) yield return w;
+    }
+
+    /// <summary>The DIRECT child records held by one child-bearing field's value — stopping at the first major
+    /// record on each branch, so a worldspace's SubCells yields its CELLs and not their placed references. Same cut
+    /// as OwnedChildContent.ReachesRecord: a FormLink references, it does not own. A FormKey-less block struct
+    /// (WorldspaceBlock / WorldspaceSubBlock) is descended through its own properties, because it is a container
+    /// that is not itself IEnumerable — the shape that makes Mutagen's own transitive EnumerateMajorRecords the
+    /// easy answer and the wrong one, since that walk would hand back a worldspace's placed references too.</summary>
+    static IEnumerable<IMajorRecordGetter> DirectChildren(object? val, int depth)
+    {
+        if (val is null || depth > 8) yield break;
+        if (val is IFormLinkGetter or string) yield break;
+        if (val is IMajorRecordGetter rec) { yield return rec; yield break; }
+        if (val is System.Collections.IEnumerable seq)
+        {
+            foreach (var item in seq)
+                foreach (var r in DirectChildren(item, depth + 1))
+                    yield return r;
+            yield break;
+        }
+        if (val is IMajorRecordGetterEnumerable block)
+            foreach (var p in block.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (p.GetIndexParameters().Length > 0) continue;
+                object? v;
+                try { v = p.GetValue(block); } catch { continue; }
+                if (v is null || ReferenceEquals(v, block)) continue;
+                foreach (var r in DirectChildren(v, depth + 1)) yield return r;
+            }
+    }
+
+    sealed record PassResult(TimeSpan Wall, double RetainedMb, int Skipped);
+
+    static PassResult Sweep(IReadOnlyList<string> paths, string? dataDir, IPass pass)
+    {
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        var before = GC.GetTotalMemory(true);
+        int skipped = 0;
+        var sw = Stopwatch.StartNew();
+        foreach (var path in paths)
+        {
+            ISkyrimModGetter ov;
+            try { ov = LoadOrderResolver.OpenOverlay(path, dataDir); }
+            catch { skipped++; continue; }
+            try { pass.Plugin(ov); }
+            catch { skipped++; }
+            finally { (ov as IDisposable)?.Dispose(); }
+        }
+        sw.Stop();
+        var after = GC.GetTotalMemory(true);
+        return new PassResult(sw.Elapsed, (after - before) / 1024.0 / 1024.0, skipped);
+    }
+
+    // ---------------------------------------------------------------------------------------------------------
+    // Question 1. For each child-bearing property, take a real (parent, child) pair the containment walk found and
+    // ask the CHILD body whether anything on it names the parent — a populated FormLink or a record reference that
+    // resolves to the parent's FormKey. That is the whole content of "the parent is in hand": the flat walk hands
+    // the caller nothing but the child body, so if the child body does not name its parent, the parent is not
+    // available at that moment by any means.
+    // ---------------------------------------------------------------------------------------------------------
+    static void ReportParentInHand(FusedPass pass)
+    {
+        var props = ChildBearingSurface();
+        foreach (var (key, count) in props.Select(k => (k, pass.PerProperty.GetValueOrDefault(k))).OrderBy(t => t.k))
+        {
+            if (!pass.Sample.TryGetValue(key, out var s))
+            {
+                Console.WriteLine($"   {key,-34} no sample in this order (0 children seen) — not measured");
+                continue;
+            }
+            var hits = ParentNamingMembers(s.child, s.parent.FormKey).ToList();
+            var verdict = hits.Count > 0 ? "YES — " + string.Join(", ", hits) : "NO";
+            Console.WriteLine($"   {key,-34} {verdict}");
+            Console.WriteLine($"      sample child {s.child.FormKey} ({Short(s.child.GetType())}) under parent {s.parent.FormKey}; {count:N0} children of this kind in the order");
+        }
+    }
+
+    /// <summary>Every member of the child's own body whose value is, or resolves to, the parent's FormKey.</summary>
+    static IEnumerable<string> ParentNamingMembers(IMajorRecordGetter child, FormKey parent)
+    {
+        foreach (var p in child.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (p.GetIndexParameters().Length > 0) continue;
+            object? v;
+            try { v = p.GetValue(child); } catch { continue; }
+            switch (v)
+            {
+                case IFormLinkGetter fl when fl.FormKey == parent: yield return $"{p.Name} (FormLink)"; break;
+                case IMajorRecordGetter mr when mr.FormKey == parent: yield return $"{p.Name} (record)"; break;
+                case FormKey fk when fk == parent: yield return $"{p.Name} (FormKey)"; break;
+            }
+        }
+    }
+
+    /// <summary>The child-bearing property surface, by construction — every concrete Mutagen record type that has
+    /// one, spelled Type.Property. This is the row set the report must cover.</summary>
+    static IEnumerable<string> ChildBearingSurface()
+    {
+        foreach (var t in typeof(ISkyrimMod).Assembly.GetTypes())
+        {
+            if (t.IsAbstract || !t.IsClass || !typeof(IMajorRecord).IsAssignableFrom(t)) continue;
+            foreach (var p in WriteEngine.ChildBearingProperties(t))
+                yield return $"{Short(t)}.{p.Name}";
+        }
+    }
+
+    static string Short(Type t)
+    {
+        var n = t.Name;
+        foreach (var suffix in new[] { "BinaryOverlay", "Getter" })
+            if (n.EndsWith(suffix, StringComparison.Ordinal)) n = n[..^suffix.Length];
+        return n;
+    }
+
+    // ---------------------------------------------------------------------------------------------------------
+
+    static IReadOnlyList<string>? ResolvePaths(string[] args, out string label, out string? dataDir)
+    {
+        label = ""; dataDir = null;
+        if (args.Length > 0 && args[0] == "--plugin")
+        {
+            if (args.Length < 2) { Console.WriteLine("usage: parent-in-hand --plugin <path> [dataDir]"); return null; }
+            dataDir = args.Length > 2 ? args[2] : Path.GetDirectoryName(args[1]);
+            label = $"single plugin {Path.GetFileName(args[1])}";
+            return new[] { args[1] };
+        }
+
+        var instanceDir = args.Length > 0 ? args[0] : UserConfiguredInstance();
+        if (instanceDir is null)
+        {
+            Console.WriteLine("no MO2 instance given and none saved — pass one, or use --plugin <path>.");
+            return null;
+        }
+        var (ok, p, problems) = Mo2Instance.Validate(instanceDir);
+        if (!ok || p is null)
+        {
+            Console.WriteLine($"not a usable MO2 instance: {instanceDir}");
+            foreach (var problem in problems) Console.WriteLine($"  - {problem}");
+            return null;
+        }
+        var order = Mo2LoadOrder.Build(p.ProfileDir, p.ModsDir, p.DataDir, p.OverwriteDir);
+        dataDir = LoadOrderResolver.ComputeDataDir(
+            order.OrderedPaths.Select((x, i) => (x, i)).ToDictionary(t => Path.GetFileName(t.x), t => t.i, StringComparer.OrdinalIgnoreCase),
+            order.OrderedPaths.ToArray());
+        label = $"live MO2 instance {instanceDir} (profile {p.ProfileName})";
+        return order.OrderedPaths;
+    }
+
+    /// <summary>The instance housecarl_set_mo2_instance saved, if any — the same file the server reads.</summary>
+    static string? UserConfiguredInstance()
+    {
+        foreach (var dir in new[]
+        {
+            Environment.GetEnvironmentVariable("HOUSECARL_DATA_DIR"),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "housecarl", "server"),
+        })
+        {
+            if (string.IsNullOrEmpty(dir)) continue;
+            var f = Path.Combine(dir, "houseCARL.user.json");
+            if (!File.Exists(f)) continue;
+            try
+            {
+                using var doc = System.Text.Json.JsonDocument.Parse(File.ReadAllText(f));
+                if (doc.RootElement.TryGetProperty("Mo2InstanceDir", out var v) && v.GetString() is { Length: > 0 } s)
+                    return s;
+            }
+            catch { }
+        }
+        return null;
+    }
+}

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -23,6 +23,10 @@ if (args.Length > 0 && CiAll.TryDispatch(args[0], args[1..], out var ciRc)) retu
 // in ci-all: it is evidence re-run on demand after a change to the copy path, not a standing guard.
 if (args.Length > 0 && args[0] == "copy-differential") return CopyDifferentialHarness.Run(args[1..]);
 
+// #459 measurement: is the containing parent in hand during the flat index walk, and what does a containment-aware
+// pass cost on a real order. Needs a live MO2 instance (or --plugin), so it is a manual harness, not a CI probe.
+if (args.Length > 0 && args[0] == "parent-in-hand") return ParentInHandProbe.Run(args[1..]);
+
 // Maintenance diagnostic: re-verify the mutable-collection whitelist on a Mutagen bump.
 if (args.Length > 0 && args[0] == "vocab") return Probe.RunVocab();
 


### PR DESCRIPTION
A manual generator harness, `parent-in-hand`, that answers two questions about child records on a real load order.

**1. Is the parent in hand during the flat `EnumerateMajorRecords` walk the index build runs today?** For one child kind, yes: a `NavigationMesh` names its cell at `Data.Parent`, whose `CellNavmeshParent` arm carries the link. For everything else, no. The check descends nested structs and polymorphic arms, samples every distinct child type under each child-bearing property (20 bodies per pair, or all if fewer), and runs on live bodies while the overlay is still open. The parent types it walks and the rows it reports come from one source — `WriteEngine.ChildBearingProperties` over `WriteSurfaceGuardProbe.ConcreteRecordTypes()` — so a Mutagen bump that adds a child-bearing type cannot leave a row unmeasured. Measured on the ARR 2.0 order:

| Property | Child type | Names its parent | Via |
|---|---|---|---|
| `Cell.Landscape` | `Landscape` | NO | — |
| `Cell.NavigationMeshes` | `NavigationMesh` | YES | `Data[NavigationMeshData].Parent[CellNavmeshParent].Parent` |
| `Cell.Persistent` | `PlacedHazard` | NO | — |
| `Cell.Persistent` | `PlacedNpc` | NO | — |
| `Cell.Persistent` | `PlacedObject` | NO | — |
| `Cell.Persistent` | `PlacedTrap` | NO | — |
| `Cell.Temporary` | `PlacedHazard` | NO | — |
| `Cell.Temporary` | `PlacedNpc` | NO | — |
| `Cell.Temporary` | `PlacedObject` | NO | — |
| `Cell.Temporary` | `PlacedTrap` | NO | — |
| `DialogTopic.Responses` | `DialogResponses` | NO | — |
| `Worldspace.SubCells` | `Cell` | NO | — |
| `Worldspace.TopCell` | `Cell` | NO | — |

**2. What does capturing the parent cost?** Two timed passes only: A, today's flat walk, and E, `EnumerateMajorRecordContexts`, which carries the parent, needs no link cache, and builds the packed ulong-to-ulong child-to-parent map. They run three times each, alternating (A E A E A E), with everything released between runs, after a discarded warm-up; the median of each is reported. Nothing but the map build runs inside the stopwatch — the by-type report and the re-parent count are derived afterwards from staged data.

On the ARR 2.0 order (3,801 plugins, 3,691,385 records) the flat walk takes 7.98 s and the context walk 8.41 s — 0.43 s more, 1.05x — for 2,711,713 child-to-parent edges. The two walks are close enough that the machine's own run-to-run spread is a few tenths of the gap: a second run of the same build gave 8.75 s / 9.12 s, 0.37 s more, 1.04x. Stored packed the map is 77.3 MB (~30 B/entry). Across the order 2,363 distinct children end up under a different parent than the first plugin put them under, so a single whole-order map is not well defined and the map has to be per plugin.

The harness needs a live MO2 instance (or `--plugin`), so it is dispatched on its own and is not wired into `ci-all`. Not user-visible, so no changelog line.

Refs #459 #489
