### PR TITLE
Name the working call in a collection element's refusals

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -29,6 +29,13 @@ saying it sets an expectation their install may contradict. Say what is known, a
   quotes, a character a Windows folder or file name cannot contain, with `(loose)` / `(BSA)` outside them. A mod
   called `Face Extras (SE)` now reads back whole, and the printed token is the token `housecarl_place_asset`'s
   `source_provider=` accepts.
+- **Two refusals about a collection element now name the call that works.** Editing one element of a polymorphic
+  collection — an AI package's `Data`, a record's conditions, a script's VMAD properties — used to take several
+  tries, because each refusal was correct about what was wrong and silent about what to do instead. Reaching
+  through an element to a field whose arms disagree on shape (`Data[7].Data`) still refuses to guess the arm, but
+  it now prints the container call to make once you have read it: the field's own path, the key you typed, and the
+  verbs that collection takes. Bracketing an element at the end of a path (`Data[7]`) prints the same path and key.
+  Which verbs get named comes from the collection's own shape, so a dict caller is never offered `SetAtIndex`.
 - **`housecarl_load_order_status` now names the running server's build in its header** — a `server:` line carrying
   the informational version the binary embeds (the release version `build-plugin.ps1` stamps from `plugin.json`,
   then `+` and the full commit sha: `1.9.5-dev+e942910…`), so checking that the installed houseCARL is the build you expect no longer means

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -35,7 +35,9 @@ saying it sets an expectation their install may contradict. Say what is known, a
   through an element to a field whose arms disagree on shape (`Data[7].Data`) still refuses to guess the arm, but
   it now prints the container call to make once you have read it: the field's own path, the key you typed, and the
   verbs that collection takes. Bracketing an element at the end of a path (`Data[7]`) prints the same path and key.
-  Which verbs get named comes from the collection's own shape, so a dict caller is never offered `SetAtIndex`.
+  Which verbs get named comes from the collection's own shape, so a dict caller is never offered `SetAtIndex`, and
+  a key the collection cannot actually be indexed by (`Data[notasbyte]`) is not handed back as a call to make. Inside
+  a `compose=`'s nested `sets`, the path is named in the `path` slot it belongs to rather than `field_path`.
 - **`housecarl_load_order_status` now names the running server's build in its header** — a `server:` line carrying
   the informational version the binary embeds (the release version `build-plugin.ps1` stamps from `plugin.json`,
   then `+` and the full commit sha: `1.9.5-dev+e942910…`), so checking that the installed houseCARL is the build you expect no longer means

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -36,7 +36,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
   it now prints the container call to make once you have read it: the field's own path, the key you typed, and the
   verbs that collection takes. Bracketing an element at the end of a path (`Data[7]`) prints the same path and key.
   Which verbs get named comes from the collection's own shape, so a dict caller is never offered `SetAtIndex`, and
-  a key the collection cannot actually be indexed by (`Data[notasbyte]`) is not handed back as a call to make. Inside
+  a key the collection cannot actually be indexed by (`Data[notasbyte]`) is not handed back as a call to make — on
+  the direct/CLI lane too, where the engine raises the same refusal. Every verb named alongside a key consumes it,
+  so a list caller who bracketed an existing element is not led with the append that would leave it untouched; and a
+  collection whose elements are owned child records (`Cell.Persistent`) is sent to the record axis rather than handed
+  a container call no verb takes. Inside
   a `compose=`'s nested `sets`, the path is named in the `path` slot it belongs to rather than `field_path`.
 - **`housecarl_load_order_status` now names the running server's build in its header** — a `server:` line carrying
   the informational version the binary embeds (the release version `build-plugin.ps1` stamps from `plugin.json`,

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -513,10 +513,15 @@ public sealed class CorpusRulebook
     /// lane cannot produce.</summary>
     static string OwnedChildSetRefusal(FieldSchema leaf) =>
         $"'{leaf.Name}' holds an owned child RECORD ({leaf.TypeRef}): a record is not a part of its parent, so it is " +
-        "neither built from parts (compose= / composes=) nor set from a value (value=). Address the child record " +
-        $"itself by its own FormID — read the parent at depth=2 and the '{leaf.Name}' field shows it. A path through " +
+        $"neither built from parts (compose= / composes=) nor set from a value (value=). {AddressChildByFormId(leaf.Name)} A path through " +
         "the parent reaches a child only when the record being written already carries one, which a patch's fresh " +
         "override of a parent never does; giving a parent a child it lacks is an open gap (#350).";
+
+    /// <summary>How an owned child record that ALREADY EXISTS is written: on the record axis, by its own FormID.
+    /// One sentence, shared by the value-shaped Set refusal and the element remedy, so the two doors cannot drift
+    /// on where the caller is being sent.</summary>
+    static string AddressChildByFormId(string fieldName) =>
+        $"Address the child record itself by its own FormID — read the parent at depth=2 and the '{fieldName}' field shows it.";
 
     /// <summary>True iff a leaf is the COLLECTION form of the owned-child shape — a list/dict whose ELEMENT is an
     /// owned child record (<c>Cell.Persistent</c>, <c>DialogTopic.Responses</c>, the typed record groups). The
@@ -1157,14 +1162,22 @@ public sealed class CorpusRulebook
     /// collection element the WORKING call is a corpus fact the walk already has, so it is named: the container's
     /// path, the caller's own key, and the verbs that shape takes. Without a bracketed hop there is no container to
     /// name, so it states the rule instead.
-    /// <para>The verbs are the PLACING-one filter, not the keyed one: this sentence promises to write the whole
-    /// element in one call, and <see cref="WriteVerbs.HowToAddress"/> would answer it with Remove — a verb that
-    /// composes nothing and deletes the element the caller came to edit. <see cref="WriteVerbs.HowToPlaceOne"/> is
-    /// the filter that matches the sentence.</para></summary>
+    /// <para>The verbs are the placing-one-AT-a-key filter, not the keyed one: this sentence promises to write the
+    /// whole element in one call, and <see cref="WriteVerbs.HowToAddress"/> would answer it with Remove — a verb
+    /// that composes nothing and deletes the element the caller came to edit. It is not the plain
+    /// <see cref="WriteVerbs.HowToPlaceOne"/> either: that names a list's keyless Add first, and the caller reading
+    /// this has just been handed a key. <see cref="WriteVerbs.HowToPlaceOneAt"/> is the filter that matches the
+    /// sentence.</para>
+    /// <para>An OWNED-RECORD element has no such call at all — the element is a record, reached on the record axis
+    /// by its own FormID — so that shape names no container path and no key: printing them would offer a call
+    /// nothing consumes.</para></summary>
     string ElementRemedy(ElementHop? elementHop) =>
         elementHop is { } h && WriteVerbs.OfField(h.Field, _corpus) is { } shape
-            ? $"Read the element to learn its concrete arm, then write the whole element in one call, composing that " +
-              $"arm: {h.Slot}='{h.Path}', key='{h.Key}' — {WriteVerbs.HowToPlaceOne(shape)}."
+            ? shape.Element == ElementPlacement.OwnedRecord
+                ? $"'{h.Field.Name}' holds owned child RECORDS ({h.Field.ElementTypeRef}), so no write verb reaches " +
+                  $"the element through its parent. {AddressChildByFormId(h.Field.Name)}"
+                : $"Read the element to learn its concrete arm, then write the whole element in one call, composing " +
+                  $"that arm: {h.Slot}='{h.Path}', key='{h.Key}' — {WriteVerbs.HowToPlaceOneAt(shape)}."
             : "Read the element first to learn its concrete arm, then target a field whose shape is unambiguous.";
 
     string FieldNotFound(TypeSchema owner, string name)

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -118,10 +118,16 @@ public sealed class CorpusRulebook
         // sit mid-path: the hops through it are where a verb acts on a record the call never named.
         FieldSchema? ownedChildHop = null;
         TypeSchema? ownedChildHopOwner = null;
+        // …and the bracketed hop that produced the type being walked RIGHT NOW, for the one refusal that cannot name
+        // the arm it needs (FindField's conflicting-shapes reject). Cleared on every plain hop, so it only ever
+        // describes the element the caller is standing in.
+        ElementHop? elementHop = null;
         for (int i = 0; i < req.Path.Length - 1; i++)
         {
             if (!TrySeg(req.Path[i], out var segName, out var segKey, out var segErr)) return segErr;
-            var field = FindField(current, segName, out _, out var polyErr);
+            var incoming = elementHop;
+            elementHop = null;
+            var field = FindField(current, segName, out _, out var polyErr, incoming);
             if (polyErr is not null) return polyErr;
             if (field is null) return FieldNotFound(current, segName);
             if (ownedChildHop is null && SchemaClassifier.IsOwnedChildRecord(field, _corpus))
@@ -204,6 +210,7 @@ public sealed class CorpusRulebook
                     && CheckValue(field.KeyType, segKey, $"dict key for '{segName}'", DictKeyType(field)?.AssemblyQualifiedName) is { } ke)
                     return ke;
                 current = elem;
+                elementHop = new ElementHop(PathTo(req.Path, i, segName), segKey, field);
             }
         }
 
@@ -225,12 +232,15 @@ public sealed class CorpusRulebook
             // caller is never handed index verbs nor a list caller key verbs. The verbless fallback is still reachable
             // — a bracketed typo ('Nope[0]') resolves no field — so it states the rule without naming verbs.
             var head = $"Path '{req.Path[^1]}' brackets a collection element at the LEAF; brackets navigate mid-path only. ";
+            // The remedy carries the caller's OWN key, not just the rule: the bracket they typed already says which
+            // element they meant, so the message can hand back the call that works rather than a shape to fill in.
             if (bracketed is not null && WriteVerbs.OfField(bracketed, _corpus) is { } bshape)
-                return head + $"Target the collection field '{leafName}' itself and address the element with the verb "
-                       + $"+ Key — {WriteVerbs.HowToAddress(bshape)}.";
+                return head + $"Target the collection field itself and address the element with the verb + Key: "
+                       + $"field_path='{PathTo(req.Path, req.Path.Length - 1, leafName)}', key='{leafKey}' — "
+                       + $"{WriteVerbs.HowToAddress(bshape)}.";
             return head + "Target the collection field itself and address the element with the verb + Key.";
         }
-        var leaf = FindField(current, leafName, out var leafOwner, out var leafPolyErr);
+        var leaf = FindField(current, leafName, out var leafOwner, out var leafPolyErr, elementHop);
         if (leafPolyErr is not null) return leafPolyErr;
         if (leaf is null) return FieldNotFound(current, leafName);
 
@@ -1108,6 +1118,27 @@ public sealed class CorpusRulebook
         catch (Exception ex) { name = segment; key = null; error = ex.Message; return false; }
     }
 
+    /// <summary>The bracketed hop that produced the type currently being walked: the collection field's own dotted
+    /// path, the key the caller indexed it with, and its schema. Held for the IMMEDIATELY preceding hop only, so a
+    /// refusal raised on the element's type can name the call that rewrites that element and nothing else.</summary>
+    readonly record struct ElementHop(string Path, string Key, FieldSchema Field);
+
+    /// <summary>The dotted field_path of the hop at <paramref name="index"/>, with its own bracket dropped —
+    /// earlier hops keep theirs, because they are still navigation.</summary>
+    static string PathTo(string[] path, int index, string name) =>
+        string.Join(".", path.Take(index).Append(name));
+
+    /// <summary>What to do about a field the over-arms search refused to pick an arm for. The refusal genuinely
+    /// cannot name the arm — that is what it is declining to guess — but when the caller is standing inside a
+    /// collection element the WORKING call is a corpus fact the walk already has, so it is named: the container's
+    /// path, the caller's own key, and the verbs that shape takes. Without a bracketed hop there is no container to
+    /// name, so it states the rule instead.</summary>
+    string ElementRemedy(ElementHop? elementHop) =>
+        elementHop is { } h && WriteVerbs.OfField(h.Field, _corpus) is { } shape
+            ? $"Read the element to learn its concrete arm, then write the whole element in one call, composing that " +
+              $"arm: field_path='{h.Path}', key='{h.Key}' — {WriteVerbs.HowToAddress(shape)}."
+            : "Read the element first to learn its concrete arm, then target a field whose shape is unambiguous.";
+
     string FieldNotFound(TypeSchema owner, string name)
     {
         var sample = owner.Fields.Select(f => f.Name).Take(12).ToList();
@@ -1128,7 +1159,8 @@ public sealed class CorpusRulebook
     /// turns out to be — the engine then resolves on the element's RUNTIME type and fails loud on a real mismatch);
     /// arms that DISAGREE reject by name, never guess. <paramref name="effectiveOwner"/> is the schema the found
     /// field belongs to (the arm for an arm-found field), so downstream messages name the real owner.</summary>
-    FieldSchema? FindField(TypeSchema owner, string name, out TypeSchema effectiveOwner, out string? error)
+    FieldSchema? FindField(TypeSchema owner, string name, out TypeSchema effectiveOwner, out string? error,
+        ElementHop? elementHop = null)
     {
         effectiveOwner = owner; error = null;
         if (owner.Fields.FirstOrDefault(f => f.Name == name) is { } direct) return direct;
@@ -1157,8 +1189,7 @@ public sealed class CorpusRulebook
             {
                 error = $"Field '{name}' exists on several arms of '{owner.Name}' with CONFLICTING shapes " +
                         $"('{firstArm.Name}': {firstField.Cardinality} {firstField.Type} vs '{arm.Name}': {f.Cardinality} {f.Type}) — " +
-                        "the validator cannot pick one statically. Read the element first to learn its concrete arm, " +
-                        "then target a field whose shape is unambiguous.";
+                        "the validator cannot pick one statically. " + ElementRemedy(elementHop);
                 return null;
             }
         effectiveOwner = firstArm;

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -105,8 +105,13 @@ public sealed class CorpusRulebook
     }
 
     /// <summary>Validate a write rooted at an arbitrary type — a record OR a struct being built from parts (so a
-    /// <see cref="StructSpec"/>'s nested writes validate by the identical leaf/path rules, recursively).</summary>
-    string? ValidateFromType(TypeSchema root, WriteRequest req, IReadOnlyCollection<string>? siblingEditorIds = null)
+    /// <see cref="StructSpec"/>'s nested writes validate by the identical leaf/path rules, recursively).
+    /// <para><paramref name="pathSlot"/> is what the caller's OWN input slot for <see cref="WriteRequest.Path"/> is
+    /// called at this root, and the paths this walk builds are relative to that root: <c>field_path</c> on a record,
+    /// <c>path</c> inside a compose's nested <c>sets</c>. A remedy that names a path must spell the slot for its
+    /// context or it names a call the caller cannot make.</para></summary>
+    string? ValidateFromType(TypeSchema root, WriteRequest req, IReadOnlyCollection<string>? siblingEditorIds = null,
+        string pathSlot = "field_path")
     {
         if (req.Path.Length == 0)
             return "Empty path: a write must target at least one field.";
@@ -199,18 +204,9 @@ public sealed class CorpusRulebook
                 // can't drift. A bare int.TryParse ACCEPTS a negative ('-1' parses), but apply's StepIntoElement list
                 // branch requires idx >= 0 and throws a PLAIN InvalidOperationException, which surfaces as the
                 // misleading "real inconsistency" wrapper. The in-range bound stays apply's job.
-                if (field.Cardinality == "list" && !WriteEngine.IsValidListIndexValue(segKey))
-                    return $"List '{segName}' on '{current.Name}' must be indexed by a non-negative integer; got '{segKey}'.";
-                // dict mid-path key SHAPE — the SAME recognizer pair (DictKeyType + CheckValue's AQ branch) the LEAF
-                // key block uses, so the mid-path hop and the leaf can't drift. Without the key's real CLR type
-                // (DictKeyType -> the dict AQ's args[0], the type apply keys on via StepIntoElement/ApplyDictVerb)
-                // CheckValue falls to the enum-catalog-by-name fallback and MISSES a non-enum key — e.g. Package.Data's
-                // sbyte key ('Data[notasbyte]') is accepted then throws FormatException at apply.
-                if (field.Cardinality == "dict"
-                    && CheckValue(field.KeyType, segKey, $"dict key for '{segName}'", DictKeyType(field)?.AssemblyQualifiedName) is { } ke)
-                    return ke;
+                if (KeyShapeError(field, current.Name, segName, segKey) is { } ke) return ke;
                 current = elem;
-                elementHop = new ElementHop(PathTo(req.Path, i, segName), segKey, field);
+                elementHop = new ElementHop(PathTo(req.Path, i, segName), segKey, field, pathSlot);
             }
         }
 
@@ -234,10 +230,16 @@ public sealed class CorpusRulebook
             var head = $"Path '{req.Path[^1]}' brackets a collection element at the LEAF; brackets navigate mid-path only. ";
             // The remedy carries the caller's OWN key, not just the rule: the bracket they typed already says which
             // element they meant, so the message can hand back the call that works rather than a shape to fill in.
+            // Only when the key PASSES the same shape recognisers the mid-path hop uses, though — an sbyte-keyed dict
+            // handed back 'Data[notasbyte]' would be naming a call that throws at apply, which is the dead end this
+            // refusal exists to close. A key that fails them gets the rule and the verb menu, as before.
             if (bracketed is not null && WriteVerbs.OfField(bracketed, _corpus) is { } bshape)
-                return head + $"Target the collection field itself and address the element with the verb + Key: "
-                       + $"field_path='{PathTo(req.Path, req.Path.Length - 1, leafName)}', key='{leafKey}' — "
-                       + $"{WriteVerbs.HowToAddress(bshape)}.";
+                return KeyShapeError(bracketed, current.Name, leafName, leafKey) is null
+                    ? head + "Target the collection field itself and address the element with the verb + Key: "
+                      + $"{pathSlot}='{PathTo(req.Path, req.Path.Length - 1, leafName)}', key='{leafKey}' — "
+                      + $"{WriteVerbs.HowToAddress(bshape)}."
+                    : head + $"Target the collection field '{leafName}' itself and address the element with the verb "
+                      + $"+ Key — {WriteVerbs.HowToAddress(bshape)}.";
             return head + "Target the collection field itself and address the element with the verb + Key.";
         }
         var leaf = FindField(current, leafName, out var leafOwner, out var leafPolyErr, elementHop);
@@ -994,7 +996,9 @@ public sealed class CorpusRulebook
             // (e.g. a VMAD quest-fragment's Property.Object=@<own quest>) validates by the SAME gates as a top-level
             // value (formlink-only + declared-earlier-or-self), recursively; on the edit path (null) it still rejects
             // loud rather than being silently accepted.
-            if (ValidateFromType(structSchema, s, siblingEditorIds) is { } e) return e;
+            // …and the slot name goes with it: these paths are rooted at the STRUCT, and the caller typed them in the
+            // nested 'path' slot, not the record-level 'field_path'. Any remedy naming a path must say which.
+            if (ValidateFromType(structSchema, s, siblingEditorIds, "path") is { } e) return e;
         return null;
     }
 
@@ -1119,24 +1123,48 @@ public sealed class CorpusRulebook
     }
 
     /// <summary>The bracketed hop that produced the type currently being walked: the collection field's own dotted
-    /// path, the key the caller indexed it with, and its schema. Held for the IMMEDIATELY preceding hop only, so a
-    /// refusal raised on the element's type can name the call that rewrites that element and nothing else.</summary>
-    readonly record struct ElementHop(string Path, string Key, FieldSchema Field);
+    /// path, the key the caller indexed it with, its schema, and the input slot that path belongs in at the root
+    /// this walk started from. Held for the IMMEDIATELY preceding hop only, so a refusal raised on the element's
+    /// type can name the call that rewrites that element and nothing else. The slot travels WITH the hop because
+    /// the path does: both are meaningless without the root they were built against.</summary>
+    readonly record struct ElementHop(string Path, string Key, FieldSchema Field, string Slot);
 
-    /// <summary>The dotted field_path of the hop at <paramref name="index"/>, with its own bracket dropped —
-    /// earlier hops keep theirs, because they are still navigation.</summary>
-    static string PathTo(string[] path, int index, string name) =>
+    /// <summary>The dotted path of the hop at <paramref name="index"/>, with its own bracket dropped — earlier hops
+    /// keep theirs, because they are still navigation. Relative to the root the walk started from, so the slot it is
+    /// printed in is whatever that root's slot is called.</summary>
+    internal static string PathTo(string[] path, int index, string name) =>
         string.Join(".", path.Take(index).Append(name));
+
+    /// <summary>Is <paramref name="key"/> a shape this collection can actually be indexed by? A list wants a
+    /// parseable NON-NEGATIVE int32 (<see cref="WriteEngine.IsValidListIndexValue"/> — the recogniser apply's
+    /// StepIntoElement list branch enforces; a bare int.TryParse accepts '-1', which then throws a plain
+    /// InvalidOperationException that surfaces as the misleading "real inconsistency" wrapper). A dict wants a value
+    /// of the key's real CLR type (DictKeyType → the dict AQ's args[0], the type apply keys on) — without that AQ,
+    /// CheckValue falls to the enum-catalog-by-name fallback and MISSES a non-enum key, e.g. Package.Data's sbyte
+    /// key ('Data[notasbyte]') accepted then throwing FormatException at apply. The in-range bound stays apply's job.
+    /// <para>One recogniser for both the mid-path hop and the leaf bracket, so the two cannot drift on what a usable
+    /// key is — and so a remedy only ever hands back a key it has checked.</para></summary>
+    string? KeyShapeError(FieldSchema field, string ownerName, string segName, string key) => field.Cardinality switch
+    {
+        "list" when !WriteEngine.IsValidListIndexValue(key) =>
+            $"List '{segName}' on '{ownerName}' must be indexed by a non-negative integer; got '{key}'.",
+        "dict" => CheckValue(field.KeyType, key, $"dict key for '{segName}'", DictKeyType(field)?.AssemblyQualifiedName),
+        _ => null,
+    };
 
     /// <summary>What to do about a field the over-arms search refused to pick an arm for. The refusal genuinely
     /// cannot name the arm — that is what it is declining to guess — but when the caller is standing inside a
     /// collection element the WORKING call is a corpus fact the walk already has, so it is named: the container's
     /// path, the caller's own key, and the verbs that shape takes. Without a bracketed hop there is no container to
-    /// name, so it states the rule instead.</summary>
+    /// name, so it states the rule instead.
+    /// <para>The verbs are the PLACING-one filter, not the keyed one: this sentence promises to write the whole
+    /// element in one call, and <see cref="WriteVerbs.HowToAddress"/> would answer it with Remove — a verb that
+    /// composes nothing and deletes the element the caller came to edit. <see cref="WriteVerbs.HowToPlaceOne"/> is
+    /// the filter that matches the sentence.</para></summary>
     string ElementRemedy(ElementHop? elementHop) =>
         elementHop is { } h && WriteVerbs.OfField(h.Field, _corpus) is { } shape
             ? $"Read the element to learn its concrete arm, then write the whole element in one call, composing that " +
-              $"arm: field_path='{h.Path}', key='{h.Key}' — {WriteVerbs.HowToAddress(shape)}."
+              $"arm: {h.Slot}='{h.Path}', key='{h.Key}' — {WriteVerbs.HowToPlaceOne(shape)}."
             : "Read the element first to learn its concrete arm, then target a field whose shape is unambiguous.";
 
     string FieldNotFound(TypeSchema owner, string name)

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1790,8 +1790,12 @@ public static class WriteEngine
     /// element. Dispatch at the leaf is on its <i>runtime</i> shape (dict / list /
     /// scalar), so execution stays corpus-independent: the corpus drives pre-flight (<see cref="CorpusRulebook"/>),
     /// reflection drives the write.
+    /// <para><paramref name="pathSlot"/> is what the caller's own input slot for <c>req.Path</c> is called at THIS
+    /// root — <c>field_path</c> on a record, <c>path</c> when a compose's nested <c>sets</c> are replayed here
+    /// against the freshly-built struct. Only the leaf-bracket throw reads it, and only to name a path the caller
+    /// can actually re-send; it mirrors the same parameter on <c>CorpusRulebook.ValidateFromType</c>.</para>
     /// </summary>
-    public static void ApplyVerb(object record, WriteRequest req)
+    public static void ApplyVerb(object record, WriteRequest req, string pathSlot = "field_path")
     {
         object current = record;
         for (int i = 0; i < req.Path.Length - 1; i++)
@@ -1819,17 +1823,22 @@ public static class WriteEngine
                 throw new InvalidOperationException(
                     $"Gendered field '{leafName}' on {current.GetType().Name} renders as [0]/[1] but is not a list — set " +
                     $"its halves by name: '{leafName}.Male' (=[0]) / '{leafName}.Female' (=[1]).");
-            // The gate's twin, by the same DERIVATION rather than a hand-typed recital. The corpus is not in scope
-            // here — the engine is schema-blind by design — so the shape comes off the live property type;
-            // WriteVerbs.OfRuntimeType and its schema-side sibling must give the same answer on every collection field
-            // in the corpus. A property that resolves to no collection at all still gets the rule, with no verb named.
+            // The gate's twin — its corpus-side recogniser is CorpusRulebook's leaf-bracket refusal, and the two must
+            // agree: same facts, same order, same slot. Pre-flight normally refuses first, so this fires only on a
+            // path that bypasses it (a direct / CLI --op call, or a compose's nested Sets replayed here), which is
+            // exactly why it has to say the same thing rather than a shorter version of it.
+            // Derived, not recited: the corpus is not in scope — the engine is schema-blind by design — so the shape
+            // comes off the live property type; WriteVerbs.OfRuntimeType and its schema-side sibling must give the
+            // same answer on every collection field in the corpus. The container path is joined by CorpusRulebook's
+            // own PathTo rather than a second copy of it, so the two messages cannot drift on the path either.
+            // A property that resolves to no collection at all still gets the rule, with no verb named.
             var head = $"Path segment '{req.Path[^1]}' brackets a collection element at the LEAF. Brackets navigate "
                        + "mid-path only; ";
             if (bracketProp is not null && WriteVerbs.OfRuntimeType(bracketProp.PropertyType) is { } bshape)
                 throw new InvalidOperationException(head
                     + "to operate on that element, target the field itself and use the verb + Key: "
-                    + $"field_path='{string.Join(".", req.Path[..^1].Append(leafName))}', key='{leafKey}' — "
-                    + $"{WriteVerbs.HowToAddress(bshape)}.");
+                    + $"{pathSlot}='{CorpusRulebook.PathTo(req.Path, req.Path.Length - 1, leafName)}', "
+                    + $"key='{leafKey}' — {WriteVerbs.HowToAddress(bshape)}.");
             throw new InvalidOperationException(head
                 + "to operate on a collection element at the leaf, target the collection field and use the verb + Key.");
         }
@@ -2163,7 +2172,9 @@ public static class WriteEngine
             else p.SetValue(instance, Coerce(val, p.PropertyType));
         }
         foreach (var req in spec.Sets ?? new())
-            ApplyVerb(instance, req);     // general nested writes — reuse the verb engine; recurses on struct-element Adds
+            // general nested writes — reuse the verb engine; recurses on struct-element Adds. These paths are rooted
+            // at the built struct and the caller typed them in the nested 'path' slot, so a refusal names that slot.
+            ApplyVerb(instance, req, "path");
         if (EmptyComposeRefusal(spec, type, instance) is { } why) throw new ExpectedApplyRejectionException(why);
         return instance;
     }

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1827,7 +1827,8 @@ public static class WriteEngine
                        + "mid-path only; ";
             if (bracketProp is not null && WriteVerbs.OfRuntimeType(bracketProp.PropertyType) is { } bshape)
                 throw new InvalidOperationException(head
-                    + $"to operate on an element of '{leafName}', target the field itself and use the verb + Key — "
+                    + "to operate on that element, target the field itself and use the verb + Key: "
+                    + $"field_path='{string.Join(".", req.Path[..^1].Append(leafName))}', key='{leafKey}' — "
                     + $"{WriteVerbs.HowToAddress(bshape)}.");
             throw new InvalidOperationException(head
                 + "to operate on a collection element at the leaf, target the collection field and use the verb + Key.");

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1834,11 +1834,19 @@ public static class WriteEngine
             // A property that resolves to no collection at all still gets the rule, with no verb named.
             var head = $"Path segment '{req.Path[^1]}' brackets a collection element at the LEAF. Brackets navigate "
                        + "mid-path only; ";
+            // …including the KEY gate. The gate side checks the key's shape (CorpusRulebook.KeyShapeError) before
+            // promoting it into a call to make; the engine cannot read that corpus check, but it owns the same two
+            // runtime recognisers apply itself keys on, so it applies those instead. A key that fails them falls
+            // back to the keyless form — echoing it would name a call that throws at apply, which is the dead end
+            // this message exists to close.
             if (bracketProp is not null && WriteVerbs.OfRuntimeType(bracketProp.PropertyType) is { } bshape)
                 throw new InvalidOperationException(head
-                    + "to operate on that element, target the field itself and use the verb + Key: "
-                    + $"{pathSlot}='{CorpusRulebook.PathTo(req.Path, req.Path.Length - 1, leafName)}', "
-                    + $"key='{leafKey}' — {WriteVerbs.HowToAddress(bshape)}.");
+                    + (KeyShapeUsable(bracketProp.PropertyType, leafKey)
+                        ? "to operate on that element, target the field itself and use the verb + Key: "
+                          + $"{pathSlot}='{CorpusRulebook.PathTo(req.Path, req.Path.Length - 1, leafName)}', "
+                          + $"key='{leafKey}' — {WriteVerbs.HowToAddress(bshape)}."
+                        : $"to operate on that element, target the field '{leafName}' itself and use the verb "
+                          + $"+ Key — {WriteVerbs.HowToAddress(bshape)}."));
             throw new InvalidOperationException(head
                 + "to operate on a collection element at the leaf, target the collection field and use the verb + Key.");
         }
@@ -2970,6 +2978,20 @@ public static class WriteEngine
     //  index is left to apply, where it fails named. Same shared-recognizer discipline as IsValidFormLinkValue.
     /// <summary>True iff <paramref name="text"/> is a legal list INDEX SHAPE: a non-negative int32 under the same
     /// parse the apply path uses (<see cref="ApplyListVerb"/>). Shape only — the in-range check is apply's.</summary>
+    /// <summary>Can this collection actually be indexed by <paramref name="key"/>? The runtime twin of
+    /// <c>CorpusRulebook.KeyShapeError</c>, built from the SAME two things apply keys on — a dict entry is reached
+    /// by <c>Coerce(key, keyType)</c>, a list element by a non-negative int32 — so a key this accepts is one
+    /// StepIntoElement can use, and the in-range bound stays apply's job. Only the leaf-bracket throw asks, and
+    /// only to decide whether the key is safe to hand back as part of a call to make.</summary>
+    static bool KeyShapeUsable(Type collectionType, string key)
+    {
+        if (ClosedInterface(collectionType, typeof(IDictionary<,>)) is { } di)
+            return TryCoerce(key, di.GetGenericArguments()[0], out _);
+        if (ClosedInterface(collectionType, typeof(IList<>)) is not null)
+            return IsValidListIndexValue(key);
+        return true;
+    }
+
     internal static bool IsValidListIndexValue(string? text) =>
         text is not null && int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i) && i >= 0;
 

--- a/src/housecarl-core/WriteVerbs.cs
+++ b/src/housecarl-core/WriteVerbs.cs
@@ -202,6 +202,18 @@ public static class WriteVerbs
             ? HowToPlace(shape)
             : Sentence(On(shape).Where(u => u.Places && !IsBatch(u.Input)));
 
+    /// <summary>"How do I put in ONE element AT the key I already have." <see cref="HowToPlaceOne"/> minus the
+    /// verbs that take no key — for a site that has already printed <c>key=</c> and would otherwise name a verb
+    /// that ignores it. On a LIST that drops <c>Add</c>, which the table orders first because it is the verb a
+    /// caller who has no key wants; a caller who bracketed an index that already holds an element and reads the
+    /// menu top-down would instead append, which the gate ACCEPTS — the list comes back one element longer with
+    /// element 0 untouched, and on a CTDA OR-run that silently changes what the record gates on. On a dict every
+    /// placing verb is keyed, so the menu is unchanged.</summary>
+    public static string HowToPlaceOneAt(CollectionShape shape) =>
+        shape.Element == ElementPlacement.OwnedRecord
+            ? HowToPlace(shape)
+            : Sentence(On(shape).Where(u => u.Places && u.NeedsKey && !IsBatch(u.Input)));
+
     /// <summary>The keyed verbs, in table order — how to reach ONE element of this collection by index or key.
     /// Named for what the filter is (a key is required), not for "an element that is already there": a list's
     /// <c>InsertAtIndex</c> takes a key and addresses the GAP at that index, and it belongs in the menu because a

--- a/src/housecarl-generator/RemedyVerbsGuardProbe.cs
+++ b/src/housecarl-generator/RemedyVerbsGuardProbe.cs
@@ -273,6 +273,7 @@ public static class RemedyVerbsGuardProbe
     static IEnumerable<VerbUse> Placing(CollectionShape s) => WriteVerbs.On(s).Where(u => u.Places);
     static IEnumerable<VerbUse> PlacingOne(CollectionShape s) => WriteVerbs.On(s)
         .Where(u => u.Places && u.Input is not (VerbInput.Values or VerbInput.Entries or VerbInput.Composes));
+    static IEnumerable<VerbUse> PlacingOneAt(CollectionShape s) => PlacingOne(s).Where(u => u.NeedsKey);
 
     static void SitesArm()
     {
@@ -330,6 +331,46 @@ public static class RemedyVerbsGuardProbe
                 && ToolNameMatch.ReferencedAtBoundary(setOnRecordList, "housecarl_create")
                 && !ListOnly.Any(v => setOnRecordList.Contains(v, StringComparison.Ordinal)),
             setOnRecordList ?? "(accepted)");
+
+        // (3b) the over-arms element remedy — the one site that prints a key BEFORE its verb menu. Every verb it
+        // names must therefore consume that key: a list's keyless Add appends, which the gate ACCEPTS, so a caller
+        // reading top-down lands one element longer with the element they meant to edit untouched.
+        var elementList = Rules.Validate(new WriteRequest
+        { RecordType = "Faction", Path = new[] { "Conditions[0]", "ComparisonValue" }, Verb = "Set", Value = "1" });
+        CheckShaped("SITE-ELEMENT-CONFLICT-LIST — the element remedy on a modeled LIST names the keyed placing verbs",
+            elementList, ListComposed, PlacingOneAt(ListComposed));
+        Check("SITE-ELEMENT-CONFLICT-LIST-KEYED — and names no verb that ignores the key it just printed",
+            elementList is not null
+                && elementList.Contains("key='0'", StringComparison.Ordinal)
+                && !elementList.Contains("Add (compose=)", StringComparison.Ordinal)
+                && elementList.IndexOf("SetAtIndex", StringComparison.Ordinal)
+                     < elementList.IndexOf("InsertAtIndex", StringComparison.Ordinal),
+            elementList ?? "(accepted)");
+        // The shape with no such call at all. Naming a container path and key here would offer a call nothing
+        // consumes — the element is a record, reached on the record axis.
+        var elementRecord = Rules.Validate(new WriteRequest
+        { RecordType = "Cell", Path = new[] { "Persistent[0]", "MajorFlags" }, Verb = "Set", Value = "1" });
+        Check("SITE-ELEMENT-CONFLICT-OWNEDRECORD — a collection of owned child records is sent to the record axis, with no container call to make",
+            elementRecord is not null
+                && elementRecord.Contains("owned child RECORDS", StringComparison.Ordinal)
+                && elementRecord.Contains("its own FormID", StringComparison.Ordinal)
+                && !elementRecord.Contains("field_path=", StringComparison.Ordinal)
+                && !elementRecord.Contains("key=", StringComparison.Ordinal)
+                && !ListOnly.Any(v => elementRecord.Contains(v, StringComparison.Ordinal)),
+            elementRecord ?? "(accepted)");
+
+        // (3c) the engine twin's KEY gate — its runtime recognisers, not the corpus, decide whether the key it was
+        // handed is one apply can use. A key that is not gets the rule and the menu, never a call that throws.
+        var engBadKey = Throws(() => WriteEngine.ApplyVerb(
+            new Mutagen.Bethesda.Skyrim.Package(NextFk(), Mutagen.Bethesda.Skyrim.SkyrimRelease.SkyrimSE),
+            new WriteRequest { RecordType = "Package", Path = new[] { "Data[notasbyte]" }, Verb = "Set" }));
+        CheckShaped("SITE-BRACKET-ENGINE-BADKEY — an unusable key still gets the shape's keyed verbs",
+            engBadKey, DictComposed, Keyed(DictComposed));
+        Check("SITE-BRACKET-ENGINE-BADKEY-WITHHELD — …and the key itself is withheld, so the message names no call that throws at apply",
+            engBadKey is not null
+                && !engBadKey.Contains("notasbyte'", StringComparison.Ordinal)
+                && !engBadKey.Contains("field_path=", StringComparison.Ordinal),
+            engBadKey ?? "(no throw)");
 
         // (4) the unknown-verb vocabulary — every verb the surface has, from its one home. Checked against the
         // literal set BELOW, not against WriteVerbs.All: comparing the message to the same collection that built

--- a/src/housecarl-mcp-tests/ElementRefusalRemedyTests.cs
+++ b/src/housecarl-mcp-tests/ElementRefusalRemedyTests.cs
@@ -1,0 +1,79 @@
+using HousecarlCore;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// The two pre-flight refusals a caller hits when editing one element of a POLYMORPHIC collection — an AI
+/// package's <c>Data</c> dict of <c>APackageData</c> arms is the reported shape (#319). Both were correct and both
+/// dead-ended: neither named the call that works, so landing one edit took four tries.
+///
+/// <para>Corpus-only, so it needs no records — the world is here for the generated corpus
+/// <c>CorpusRulebook.CorpusPath</c> points at.</para>
+/// </summary>
+[Trait("tier", "integration")]
+[Collection("bulk-records")]
+public sealed class ElementRefusalRemedyTests : BulkRecordsTestBase
+{
+    public ElementRefusalRemedyTests(BulkRecordsFixture f) : base(f) { }
+
+    static CorpusRulebook Book() => CorpusRulebook.Load();
+
+    static string Refusal(string[] path, string verb, string? key = null, string? value = null)
+    {
+        var r = Book().Validate(new WriteRequest
+        {
+            RecordType = "Package", Path = path, Verb = verb, Key = key, Value = value,
+        });
+        Assert.NotNull(r);
+        return r!;
+    }
+
+    /// <summary>Reaching THROUGH a polymorphic element to a field whose arms disagree on shape: the validator still
+    /// refuses to pick an arm, but it now hands back the container call — the field, the caller's own key, and the
+    /// verbs that shape takes — instead of "target a field whose shape is unambiguous".</summary>
+    [Fact]
+    public void AConflictingArmFieldUnderADictElementNamesTheContainerCall()
+    {
+        var r = Refusal(new[] { "Data[7]", "Data" }, "Set", value: "True");
+
+        Assert.Contains("CONFLICTING shapes", r);
+        Assert.Contains("field_path='Data'", r);
+        Assert.Contains("key='7'", r);
+        Assert.Contains("compose=", r);
+    }
+
+    /// <summary>…and the verbs it names are the DICT ones. Naming <c>SetAtIndex</c> here is the wrong turn the
+    /// reporter took on their second call.</summary>
+    [Fact]
+    public void TheContainerCallOnADictNamesNoIndexVerb()
+        => Assert.DoesNotContain("SetAtIndex", Refusal(new[] { "Data[7]", "Data" }, "Set", value: "True"));
+
+    /// <summary>A bracket at the LEAF was already told the rule and the verb menu; it now also carries the path and
+    /// the key the caller typed, which is the difference between a shape to fill in and a call to make.</summary>
+    [Fact]
+    public void ABracketedLeafNamesThePathAndKeyTheCallerTyped()
+    {
+        var r = Refusal(new[] { "Data[7]" }, "Set");
+
+        Assert.Contains("brackets a collection element at the LEAF", r);
+        Assert.Contains("field_path='Data'", r);
+        Assert.Contains("key='7'", r);
+    }
+
+    /// <summary>The container path keeps the hops ABOVE it — they are still navigation — and drops only its own
+    /// bracket, so a nested container is named in full rather than by its last segment.</summary>
+    [Fact]
+    public void ANestedContainerIsNamedByItsWholePath()
+    {
+        var r = Book().Validate(new WriteRequest
+        {
+            RecordType = "Npc", Path = new[] { "VirtualMachineAdapter", "Scripts[0]", "Properties[0]" },
+            Verb = "Set",
+        });
+
+        Assert.NotNull(r);
+        Assert.Contains("field_path='VirtualMachineAdapter.Scripts[0].Properties'", r!);
+        Assert.Contains("key='0'", r);
+    }
+}

--- a/src/housecarl-mcp-tests/ElementRefusalRemedyTests.cs
+++ b/src/housecarl-mcp-tests/ElementRefusalRemedyTests.cs
@@ -96,6 +96,50 @@ public sealed class ElementRefusalRemedyTests : BulkRecordsTestBase
         Assert.DoesNotContain("Remove", r);
     }
 
+    // ---- the verb a keyed call leads with ----
+
+    /// <summary>On a LIST container the remedy has just printed <c>key='0'</c>, so every verb it then names must
+    /// consume that key. The keyless <c>Add</c> is the one wrong first choice on this branch that does NOT refuse:
+    /// it appends, leaving element 0 untouched, which on a CTDA OR-run changes what the record gates on.</summary>
+    [Fact]
+    public void AListElementRemedyNamesOnlyVerbsThatTakeTheKeyItPrinted()
+    {
+        var r = Book().Validate(new WriteRequest
+        {
+            RecordType = "Faction", Path = new[] { "Conditions[0]", "ComparisonValue" }, Verb = "Set", Value = "1",
+        });
+
+        Assert.NotNull(r);
+        Assert.Contains("field_path='Conditions'", r!);
+        Assert.Contains("key='0'", r);
+        Assert.Contains("SetAtIndex (compose= + key=)", r);
+        Assert.DoesNotContain("Add (compose=)", r);          // the keyless append
+        Assert.True(r.IndexOf("SetAtIndex", StringComparison.Ordinal)
+                    < r.IndexOf("InsertAtIndex", StringComparison.Ordinal),
+            "overwrite-in-place must lead insert-and-shift: " + r);
+    }
+
+    // ---- the shape with no call to name ----
+
+    /// <summary>A collection of owned child RECORDS has no write verb that places an element, so the remedy names
+    /// no container path and no key — nothing would consume them. It sends the caller to the record axis, the same
+    /// place the value-shaped Set refusal does.</summary>
+    [Fact]
+    public void AnOwnedRecordElementNamesNoContainerCall()
+    {
+        var r = Book().Validate(new WriteRequest
+        {
+            RecordType = "Cell", Path = new[] { "Persistent[0]", "MajorFlags" }, Verb = "Set", Value = "1",
+        });
+
+        Assert.NotNull(r);
+        Assert.Contains("CONFLICTING shapes", r!);
+        Assert.Contains("owned child RECORDS", r);
+        Assert.Contains("its own FormID", r);
+        Assert.DoesNotContain("field_path=", r);
+        Assert.DoesNotContain("key=", r);
+    }
+
     // ---- the slot a named path belongs in ----
 
     /// <summary>Rooted inside a compose's nested <c>sets</c>, the path the remedy names is relative to the STRUCT
@@ -185,6 +229,26 @@ public sealed class ElementRefusalRemedyTests : BulkRecordsTestBase
             Assert.Contains(fact, engine);
             Assert.Contains(fact, gate!);
         }
+    }
+
+    /// <summary>…and it withholds a key the same way, off its own runtime recognisers rather than the corpus: a
+    /// dict key that will not coerce to the dict's key type, and a negative list index, are both refused by apply,
+    /// so neither is promoted into a call to make. The rulebook's gate is schema-side; this is the twin.</summary>
+    [Theory]
+    [InlineData("Data[notasbyte]", "notasbyte")]   // Package.Data is sbyte-keyed — FormatException at apply
+    [InlineData("Effects[-3]", "-3")]              // refused by StepIntoElement's list branch
+    public void TheEngineTwinWithholdsAKeyThatCannotIndexTheCollection(string segment, string key)
+    {
+        var record = segment.StartsWith("Data", StringComparison.Ordinal)
+            ? (Mutagen.Bethesda.Plugins.Records.IMajorRecord)new Package(FormKey.Null, SkyrimRelease.SkyrimSE)
+            : new Perk(FormKey.Null, SkyrimRelease.SkyrimSE);
+        var msg = Assert.Throws<InvalidOperationException>(() => WriteEngine.ApplyVerb(
+            record, new WriteRequest { RecordType = "x", Path = new[] { segment }, Verb = "Set" })).Message;
+
+        Assert.Contains("brackets a collection element at the LEAF", msg);
+        Assert.DoesNotContain($"key='{key}'", msg);
+        Assert.DoesNotContain("field_path=", msg);
+        Assert.Contains("verb + Key", msg);            // the rule and the menu still stand
     }
 
     /// <summary>The engine names the compose slot too, on the lane that actually reaches it: a compose's nested

--- a/src/housecarl-mcp-tests/ElementRefusalRemedyTests.cs
+++ b/src/housecarl-mcp-tests/ElementRefusalRemedyTests.cs
@@ -1,4 +1,6 @@
 using HousecarlCore;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
 using Xunit;
 
 namespace HousecarlMcpTests;
@@ -62,7 +64,9 @@ public sealed class ElementRefusalRemedyTests : BulkRecordsTestBase
     }
 
     /// <summary>The container path keeps the hops ABOVE it — they are still navigation — and drops only its own
-    /// bracket, so a nested container is named in full rather than by its last segment.</summary>
+    /// bracket, so a nested container is named in full rather than by its last segment. Pinned to the refusal that
+    /// produces it: the whole-path claim is only about the LEAF-bracket remedy, and a walk that started refusing
+    /// somewhere earlier could satisfy the path assertion while proving nothing.</summary>
     [Fact]
     public void ANestedContainerIsNamedByItsWholePath()
     {
@@ -73,7 +77,136 @@ public sealed class ElementRefusalRemedyTests : BulkRecordsTestBase
         });
 
         Assert.NotNull(r);
-        Assert.Contains("field_path='VirtualMachineAdapter.Scripts[0].Properties'", r!);
+        Assert.Contains("brackets a collection element at the LEAF", r!);
+        Assert.Contains("field_path='VirtualMachineAdapter.Scripts[0].Properties'", r);
         Assert.Contains("key='0'", r);
+    }
+
+    /// <summary>The remedy for "write the whole element, composing that arm" names the verbs that PLACE one element
+    /// — not the keyed menu, which answers a different question and leads with a verb that deletes the element the
+    /// caller came to edit.</summary>
+    [Fact]
+    public void TheContainerCallNamesNoDeleteVerb()
+    {
+        var r = Refusal(new[] { "Data[7]", "Data" }, "Set", value: "True");
+
+        Assert.Contains("composing that arm", r);
+        Assert.Contains("Set (compose= + key=)", r);
+        Assert.Contains("Add (compose= + key=)", r);
+        Assert.DoesNotContain("Remove", r);
+    }
+
+    // ---- the slot a named path belongs in ----
+
+    /// <summary>Rooted inside a compose's nested <c>sets</c>, the path the remedy names is relative to the STRUCT
+    /// being built and the caller typed it in the <c>path</c> slot. Printing <c>field_path=</c> there would name a
+    /// top-level call that resolves no such field — the exact dead end this refusal exists to close.</summary>
+    [Fact]
+    public void AComposeNestedRefusalNamesTheComposeSlot()
+    {
+        var r = Book().Validate(new WriteRequest
+        {
+            RecordType = "Npc", Path = new[] { "VirtualMachineAdapter", "Scripts" }, Verb = "Add",
+            Struct = new StructSpec
+            {
+                Type = "ScriptEntry",
+                Sets = new() { new WriteRequest { RecordType = "Npc", Path = new[] { "Properties[0]" }, Verb = "Set" } },
+            },
+        });
+
+        Assert.NotNull(r);
+        Assert.Contains("brackets a collection element at the LEAF", r!);
+        Assert.Contains("path='Properties'", r);
+        Assert.DoesNotContain("field_path=", r);
+    }
+
+    // ---- a key is only handed back once it is known to work ----
+
+    /// <summary>A key that cannot index this collection is NOT promoted into the remedy. <c>Package.Data</c> is
+    /// keyed by <c>sbyte</c>, so echoing 'notasbyte' back would name a call that throws FormatException at apply —
+    /// the accept-then-throw the mid-path hop already guards against. The rule and the verb menu still stand.</summary>
+    [Fact]
+    public void AMalformedDictKeyIsNotEchoedAsACallToMake()
+    {
+        var r = Refusal(new[] { "Data[notasbyte]" }, "Set");
+
+        Assert.Contains("brackets a collection element at the LEAF", r);
+        Assert.DoesNotContain("key='notasbyte'", r);
+        Assert.DoesNotContain("field_path=", r);
+        Assert.Contains("Set (compose= + key=)", r);   // the menu is still shape-derived
+    }
+
+    /// <summary>Same gate on the LIST half: a negative index parses as an int but is refused by apply, so it never
+    /// becomes a suggested call either.</summary>
+    [Fact]
+    public void ANegativeListIndexIsNotEchoedAsACallToMake()
+    {
+        var r = Book().Validate(new WriteRequest { RecordType = "Perk", Path = new[] { "Effects[-3]" }, Verb = "Set" });
+
+        Assert.NotNull(r);
+        Assert.Contains("brackets a collection element at the LEAF", r!);
+        Assert.DoesNotContain("key='-3'", r);
+        Assert.Contains("SetAtIndex", r);
+    }
+
+    /// <summary>…and a well-formed key of the same shapes still IS handed back, so the gate above narrows the
+    /// remedy rather than removing it.</summary>
+    [Fact]
+    public void AWellFormedListIndexIsStillHandedBack()
+    {
+        var r = Book().Validate(new WriteRequest { RecordType = "Perk", Path = new[] { "Effects[3]" }, Verb = "Set" });
+
+        Assert.NotNull(r);
+        Assert.Contains("field_path='Effects'", r!);
+        Assert.Contains("key='3'", r);
+    }
+
+    // ---- the engine twin ----
+
+    /// <summary>The engine's own leaf-bracket throw, driven directly: pre-flight normally refuses first, so this
+    /// message only ever reaches a caller who bypassed the gate (a direct / CLI call) — which is precisely why it
+    /// must carry the same facts rather than a shorter version of them.</summary>
+    static string EngineThrow(string[] path) => Assert.Throws<InvalidOperationException>(
+        () => WriteEngine.ApplyVerb(new Perk(FormKey.Null, SkyrimRelease.SkyrimSE),
+            new WriteRequest { RecordType = "Perk", Path = path, Verb = "Set" })).Message;
+
+    /// <summary>The two recognisers must agree. Both are asked about the same bracketed leaf and must name the same
+    /// container path, the same key, and the same verb menu — the rulebook off the corpus, the engine off the live
+    /// property type. A drift in either (including the hand-rolled path join this replaced) fails here.</summary>
+    [Fact]
+    public void TheEngineTwinNamesTheSameCallAsTheRulebook()
+    {
+        var engine = EngineThrow(new[] { "Effects[3]" });
+        var gate = Book().Validate(new WriteRequest { RecordType = "Perk", Path = new[] { "Effects[3]" }, Verb = "Set" });
+
+        Assert.NotNull(gate);
+        foreach (var fact in new[] { "field_path='Effects'", "key='3'", "SetAtIndex" })
+        {
+            Assert.Contains(fact, engine);
+            Assert.Contains(fact, gate!);
+        }
+    }
+
+    /// <summary>The engine names the compose slot too, on the lane that actually reaches it: a compose's nested
+    /// <c>sets</c> are replayed through <c>ApplyVerb</c> against the freshly-built struct, so a bracketed leaf there
+    /// is rooted at the struct and belongs in <c>path=</c>.</summary>
+    [Fact]
+    public void TheEngineTwinNamesTheComposeSlotOnNestedSets()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => WriteEngine.ApplyVerb(
+            new Npc(FormKey.Null, SkyrimRelease.SkyrimSE),
+            new WriteRequest
+            {
+                RecordType = "Npc", Path = new[] { "VirtualMachineAdapter", "Scripts" }, Verb = "Add",
+                Struct = new StructSpec
+                {
+                    Type = "ScriptEntry",
+                    Sets = new() { new WriteRequest { RecordType = "Npc", Path = new[] { "Properties[0]" }, Verb = "Set" } },
+                },
+            }));
+
+        Assert.Contains("brackets a collection element at the LEAF", ex.Message);
+        Assert.Contains("path='Properties'", ex.Message);
+        Assert.DoesNotContain("field_path=", ex.Message);
     }
 }


### PR DESCRIPTION
Editing one element of a polymorphic collection took four calls: every refusal along the way was correct, and none of them named a call that works. `Data[7].Data` on an AI package refused because the arms disagree on the field's shape, and then told the caller to read the element first — which they had already done — without saying how to use that. `Data[7]` at the leaf refused with the rule and a verb menu but no path and no key. Both refusals already hold, from the path walk they just did, everything the working call needs.

Now they print it. The over-arms conflict remembers the bracketed hop that produced the type it is standing on — the container's dotted path, the key the caller typed, and the field's schema — and ends with the container call to make once the arm is known, with the verbs derived from that collection's shape through `WriteVerbs`, so a dict caller cannot be handed `SetAtIndex`. The hop is cleared on every plain descent, so the remedy only ever describes the element the caller is actually inside; with no bracketed hop it states the rule as before. The leaf-bracket refusal gains the same two facts, `field_path=` and `key=`, and its engine twin in `WriteEngine` gains them too so the two recognisers keep saying the same thing.

Both fixes are corpus-static — no on-disk read, no instance awareness. The reporter's secondary ask (accepting the scalar path when the element's arm on disk is unambiguous) is not taken; it was scoped out at triage.

The wrong-cardinality verb refusals (`SetAtIndex is only valid on list; 'Data' is dict.`) are the same class and still dead-end. They were left alone: with these two fixes the reported sequence is one call, so naming the working verbs there does not save one.

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)
