### PR TITLE
Carry a merge's light flag, report the localized flag, fix asset_status provider tokens

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -16,12 +16,13 @@ saying it sets an expectation their install may contradict. Say what is known, a
 - **`housecarl_merge_plugins` now carries a donor's light (ESL) flag onto the merged plugin where it is valid to.**
   The flag is carried when every donor was light and every merged object id landed inside the light window
   `0x800–0xFFF`; the report says the output is light, so it need not be opened to find out. Otherwise the flag is
-  dropped and the report names which of the two conditions failed — a full donor in the set (run
-  `housecarl_compact_plugin` on the output), or ids that overflow the window (compact cannot rescue that one, and
-  the report says so instead of pointing at it). Master (ESM) status and the header Author/Description are still
-  never carried, and each drop is still stated.
-- **`housecarl_load_order_status` reports a plugin's LOCALIZED header flag** when `lookup=` names a plugin the load
-  order resolved to a file. A localized plugin's text lives in separate `.STRINGS` files, which is what an in-place
+  dropped and the report names which of the two conditions failed — a full donor in the set, or a merged id outside
+  the window — and then says whether `housecarl_compact_plugin` can still make it light: it can, by renumbering every
+  id into the window, unless the merged plugin defines more records than that window holds, in which case the report
+  says compact would refuse rather than pointing at it. Master (ESM) status and the header Author/Description are
+  still never carried, and each drop is still stated.
+- **`housecarl_load_order_status` reports a plugin's LOCALIZED header flag** when `lookup=` names a plugin, active or
+  inactive (a mod folder has no header and gets no line). A localized plugin's text lives in separate `.STRINGS` files, which is what an in-place
   write to it is refused over, so the refusal is visible before a job runs into it. Three answers, not two: a header
   houseCARL could not read is reported as unknown rather than as "not localized".
 - **`housecarl_asset_status` prints provider names the way the rest of the asset surface does** — inside double

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,21 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **`housecarl_merge_plugins` now carries a donor's light (ESL) flag onto the merged plugin where it is valid to.**
+  The flag is carried when every donor was light and every merged object id landed inside the light window
+  `0x800–0xFFF`; the report says the output is light, so it need not be opened to find out. Otherwise the flag is
+  dropped and the report names which of the two conditions failed — a full donor in the set (run
+  `housecarl_compact_plugin` on the output), or ids that overflow the window (compact cannot rescue that one, and
+  the report says so instead of pointing at it). Master (ESM) status and the header Author/Description are still
+  never carried, and each drop is still stated.
+- **`housecarl_load_order_status` reports a plugin's LOCALIZED header flag** when `lookup=` names a plugin the load
+  order resolved to a file. A localized plugin's text lives in separate `.STRINGS` files, which is what an in-place
+  write to it is refused over, so the refusal is visible before a job runs into it. Three answers, not two: a header
+  houseCARL could not read is reported as unknown rather than as "not localized".
+- **`housecarl_asset_status` prints provider names the way the rest of the asset surface does** — inside double
+  quotes, a character a Windows folder or file name cannot contain, with `(loose)` / `(BSA)` outside them. A mod
+  called `Face Extras (SE)` now reads back whole, and the printed token is the token `housecarl_place_asset`'s
+  `source_provider=` accepts.
 - **`housecarl_load_order_status` now names the running server's build in its header** — a `server:` line carrying
   the informational version the binary embeds (the release version `build-plugin.ps1` stamps from `plugin.json`,
   then `+` and the full commit sha: `1.9.5-dev+e942910…`), so checking that the installed houseCARL is the build you expect no longer means

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -2105,7 +2105,7 @@ public static class WritePatchBuilder
         IReadOnlyList<string>? MasterDonors = null, IReadOnlyList<RemapEngine.UnscannablePlugin>? UnscannablePlugins = null,
         IReadOnlyList<string>? LocalizedDonors = null,
         IReadOnlyList<RemapEngine.MasterDeclarer>? MasterDeclarers = null,
-        bool LightCarried = false)
+        bool LightCarried = false, int OriginatingRecords = 0)
     {
         public static MergeOutcome Fail(string error) =>
             new(false, error, "", "", Array.Empty<string>(), Array.Empty<string>(), 0, 0,
@@ -2519,12 +2519,15 @@ public static class WritePatchBuilder
     /// a dangling donor reference that would keep a donor as a master, an absent master, a serialize fault).
     /// <para><see cref="LightCarried"/> is whether the output got the LIGHT (ESL) header flag — true only when every
     /// donor was light and every merged id fit the light window. <see cref="LightDonors"/> stays the measured donor
-    /// set either way, so the report can say what was carried or what was dropped and why (#363).</para></summary>
+    /// set either way, so the report can say what was carried or what was dropped and why (#363).
+    /// <see cref="OriginatingRecords"/> is how many records the output DEFINES, which is the count a later
+    /// <c>compact_plugin</c> has to fit into the light window — the report needs it to know whether compact is a real
+    /// remedy for a dropped flag or a refusal waiting to happen.</para></summary>
     public sealed record MergeBuildResult(
         bool Success, string? Error, IReadOnlyList<string> Masters, int RecordsCopied, int RecordsRenumbered,
         IReadOnlyList<RemapEngine.MergeConflict> Conflicts, long Bytes,
         IReadOnlyList<string>? LightDonors = null, IReadOnlyList<string>? HeaderMetaDonors = null,
-        IReadOnlyList<string>? MasterDonors = null, bool LightCarried = false)
+        IReadOnlyList<string>? MasterDonors = null, bool LightCarried = false, int OriginatingRecords = 0)
     {
         public static MergeBuildResult Fail(string error) =>
             new(false, error, Array.Empty<string>(), 0, 0, Array.Empty<RemapEngine.MergeConflict>(), 0);
@@ -2597,9 +2600,11 @@ public static class WritePatchBuilder
 
         // The LIGHT (ESL) header flag, under the #363 rule. Carried only when BOTH hold: every donor was light — one
         // full donor means the merged content was never light-legal as a whole — AND every renumbered originating id
-        // fits the light window, which is the same bound compact enforces (the merge remap runs to the full 24-bit
-        // range, so a large merge lands ids above the ceiling and a light write of them would throw). The MASTER
-        // (ESM) flag is never carried at all; both drops are stated by the caller's report, carried or not.
+        // fits the light window, because a light write of an id above 0xFFF throws. The merge remap runs to the full
+        // 24-bit range and keeps any unclaimed id it finds there, so an id lands outside the light window either from
+        // a donor that already carried one or from a merge too big for 0x800–0xFFF — the fit check does not
+        // distinguish them, and the report reads the record count to tell which. The MASTER (ESM) flag is never
+        // carried at all; both drops are stated by the caller's report, carried or not.
         bool lightIdsFit = true;
         foreach (var nk in dict.Values) if (nk.ID < FormIdRange.EslWindowFloor || nk.ID > FormIdRange.EslWindowCeiling) { lightIdsFit = false; break; }
         bool lightCarried = lightDonors.Count == donorsByLoadOrder.Count && lightIdsFit;
@@ -2674,7 +2679,7 @@ public static class WritePatchBuilder
         }
         catch { /* best-effort read-back; the union is a correct superset */ }
         return new MergeBuildResult(true, null, writtenMasters, mr.RecordsCopied, mr.RecordsRenumbered, mr.Conflicts, bytes,
-            lightDonors, headerMetaDonors, masterDonors, lightCarried);
+            lightDonors, headerMetaDonors, masterDonors, lightCarried, dict.Count);
     }
 
     /// <summary>

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -2104,7 +2104,8 @@ public static class WritePatchBuilder
         IReadOnlyList<string>? LightDonors = null, IReadOnlyList<string>? HeaderMetaDonors = null,
         IReadOnlyList<string>? MasterDonors = null, IReadOnlyList<RemapEngine.UnscannablePlugin>? UnscannablePlugins = null,
         IReadOnlyList<string>? LocalizedDonors = null,
-        IReadOnlyList<RemapEngine.MasterDeclarer>? MasterDeclarers = null)
+        IReadOnlyList<RemapEngine.MasterDeclarer>? MasterDeclarers = null,
+        bool LightCarried = false)
     {
         public static MergeOutcome Fail(string error) =>
             new(false, error, "", "", Array.Empty<string>(), Array.Empty<string>(), 0, 0,
@@ -2515,12 +2516,15 @@ public static class WritePatchBuilder
 
     /// <summary>The result of the core merge build: success + the RESOLVED master set / record accounting / cross-donor
     /// conflicts / byte size, or a loud refusal with <c>outPath</c> UNTOUCHED (an unopenable donor, an engine fault,
-    /// a dangling donor reference that would keep a donor as a master, an absent master, a serialize fault).</summary>
+    /// a dangling donor reference that would keep a donor as a master, an absent master, a serialize fault).
+    /// <para><see cref="LightCarried"/> is whether the output got the LIGHT (ESL) header flag — true only when every
+    /// donor was light and every merged id fit the light window. <see cref="LightDonors"/> stays the measured donor
+    /// set either way, so the report can say what was carried or what was dropped and why (#363).</para></summary>
     public sealed record MergeBuildResult(
         bool Success, string? Error, IReadOnlyList<string> Masters, int RecordsCopied, int RecordsRenumbered,
         IReadOnlyList<RemapEngine.MergeConflict> Conflicts, long Bytes,
         IReadOnlyList<string>? LightDonors = null, IReadOnlyList<string>? HeaderMetaDonors = null,
-        IReadOnlyList<string>? MasterDonors = null)
+        IReadOnlyList<string>? MasterDonors = null, bool LightCarried = false)
     {
         public static MergeBuildResult Fail(string error) =>
             new(false, error, Array.Empty<string>(), 0, 0, Array.Empty<RemapEngine.MergeConflict>(), 0);
@@ -2571,8 +2575,9 @@ public static class WritePatchBuilder
                 mods.Add((name, ov));
                 // The merged plugin is built as a bare SkyrimMod, so anything living in a donor's HEADER is left
                 // behind. Measured here, while the overlay is open, so the report can state the loss instead of the
-                // caller discovering it (a light donor silently costing a full load-order slot). Whether these should
-                // be CARRIED is a separate decision that is not this lane's to make.
+                // caller discovering it (a light donor silently costing a full load-order slot). Of the three, only
+                // LIGHT is ever carried, and only under the two conditions checked after the merge; the other two are
+                // always dropped and always reported.
                 //
                 // LIGHT and MASTER are each read BOTH ways, because either alone under-reports the loss. The header
                 // bit is not the whole model: the engine force-treats the .esl extension as light regardless of the
@@ -2589,6 +2594,16 @@ public static class WritePatchBuilder
         }
         finally { foreach (var d in overlays) { try { d.Dispose(); } catch { /* best-effort */ } } }
         if (!mr.Success) return MergeBuildResult.Fail(mr.Error!);
+
+        // The LIGHT (ESL) header flag, under the #363 rule. Carried only when BOTH hold: every donor was light — one
+        // full donor means the merged content was never light-legal as a whole — AND every renumbered originating id
+        // fits the light window, which is the same bound compact enforces (the merge remap runs to the full 24-bit
+        // range, so a large merge lands ids above the ceiling and a light write of them would throw). The MASTER
+        // (ESM) flag is never carried at all; both drops are stated by the caller's report, carried or not.
+        bool lightIdsFit = true;
+        foreach (var nk in dict.Values) if (nk.ID < FormIdRange.EslWindowFloor || nk.ID > FormIdRange.EslWindowCeiling) { lightIdsFit = false; break; }
+        bool lightCarried = lightDonors.Count == donorsByLoadOrder.Count && lightIdsFit;
+        m.IsSmallMaster = lightCarried;
 
         // 2. Donor-master-survives check: after RemapLinks, NO link may still point into a donor. One that does is
         //    a reference to a FormID the donor never DEFINED (a dangling source ref — the dict maps every real donor key),
@@ -2659,7 +2674,7 @@ public static class WritePatchBuilder
         }
         catch { /* best-effort read-back; the union is a correct superset */ }
         return new MergeBuildResult(true, null, writtenMasters, mr.RecordsCopied, mr.RecordsRenumbered, mr.Conflicts, bytes,
-            lightDonors, headerMetaDonors, masterDonors);
+            lightDonors, headerMetaDonors, masterDonors, lightCarried);
     }
 
     /// <summary>

--- a/src/housecarl-generator/LoadOrderStatusProbe.cs
+++ b/src/housecarl-generator/LoadOrderStatusProbe.cs
@@ -62,7 +62,7 @@ internal static class LoadOrderStatusProbe
 
             var logs = Array.Empty<LogFolderView>();   // render needs a log list; the log surface is out of scope here
             string Render(LoadOrderService svc, NamedProfileResult profiles, string? profileReq) =>
-                StatusWire.Render(svc.StatusData(), logs, profiles, lookup: null, cap: 80_000);
+                StatusWire.Render(svc.StatusData(), logs, profiles, lookup: null, localized: null, cap: 80_000);
 
             void WriteIni(string inst, string profile, string? baseDir = null)
             {
@@ -250,10 +250,10 @@ internal static class LoadOrderStatusProbe
             {
                 // masterName is "HcLosMaster.esm" — look it up WITHOUT the extension (the bare folder/no-ext case).
                 string noExt = Path.GetFileNameWithoutExtension(masterName);
-                var hit = StatusWire.Render(svc.StatusData(), logs, svc.NamedProfileComposition(null), lookup: noExt, cap: 80_000);
+                var hit = StatusWire.Render(svc.StatusData(), logs, svc.NamedProfileComposition(null), lookup: noExt, localized: svc.PluginLocalizedFlag(noExt), cap: 80_000);
                 Check(hit.Contains("not in the load order") && hit.Contains("Did you mean") && hit.Contains(masterName),
                       $"lookup='{noExt}' (no extension) → the plugin-miss line suggests '{masterName}'");
-                var farMiss = StatusWire.Render(svc.StatusData(), logs, svc.NamedProfileComposition(null), lookup: "ZzzNothingLikeIt.esp", cap: 80_000);
+                var farMiss = StatusWire.Render(svc.StatusData(), logs, svc.NamedProfileComposition(null), lookup: "ZzzNothingLikeIt.esp", localized: svc.PluginLocalizedFlag("ZzzNothingLikeIt.esp"), cap: 80_000);
                 Check(farMiss.Contains("not in the load order") && !farMiss.Contains("Did you mean"),
                       "an unrelated lookup renders the miss with NO suggestion (no spurious 'did you mean')");
             }

--- a/src/housecarl-generator/MergeServiceGuardProbe.cs
+++ b/src/housecarl-generator/MergeServiceGuardProbe.cs
@@ -33,13 +33,13 @@ namespace HousecarlGenerator;
 ///               headline (derived from the accounting, so a PURE-OVERRIDE donor claims no re-keying), the per-donor
 ///               renumber cause, the two external-referencer remedy orderings, and the mod-folder default. Each has
 ///               arms on BOTH sides — the multi-donor checks above are the negatives.
-///   HEADER    — nothing in a donor's header comes into the output: light (ESL) status, MASTER status, and
-///               Author/Description. Light and master are each counted BY FLAG OR BY EXTENSION (the engine treats
-///               .esl/.esm that way whatever the bit says), which is why one donor exists per spelling. Measured on
-///               the written file, then REPORTED: the ESL note carries the compact remedy's own cost (it renumbers
-///               from the floor) and suppresses the flat closing pointer so the costed advice is the one read last;
-///               master and header-text name no remedy because the surface has none. All three are keyed on what the
-///               DONORS carried, never on the donor count — a mixed multi-donor merge raises them too.
+///   HEADER    — MASTER status and Author/Description never come into the output; LIGHT (ESL) status is carried when
+///               every donor was light and the merged ids fit the window, and dropped with the reason otherwise
+///               (#363). Light and master are each counted BY FLAG OR BY EXTENSION (the engine treats .esl/.esm that
+///               way whatever the bit says), which is why one donor exists per spelling. Measured on the written
+///               file, then REPORTED: a carried flag suppresses the flat closing compact pointer, since the output is
+///               already light; master and header-text name no remedy because the surface has none. All are keyed on
+///               what the DONORS carried, never on the donor count — a mixed multi-donor merge raises them too.
 ///   REFUSE    — ZERO donors / unknown donor / output already active / output == donor / .esl output, all loud,
 ///               nothing written.
 ///   UNTOUCHED — the donor files are byte-identical after the merge (new-file lane only).
@@ -520,37 +520,35 @@ public static class MergeServiceGuardProbe
                         $"RENAME a below-floor id renumbers even with nothing to collide with (kept {dSolo?.Kept}, renumbered {dSolo?.Renumbered})");
                 }
 
-                // HEADER LOSS, positive side: the merged plugin is built as a bare mod, so a donor's light flag and
-                // its Author/Description do not come along. Both are stated rather than refused, and the ESL note's
-                // compact remedy carries the consequence that makes it honest — compact renumbers from the floor.
+                // HEADER, positive side: the merged plugin is built as a bare mod, so a donor's Author/Description do
+                // not come along, and the LIGHT flag comes along only under the #363 rule — every donor light and
+                // every merged id inside the window, which a single light donor with in-window ids satisfies.
                 var oEsl = svc.MergePlugins(new[] { "HcMgEsl.esp" }, "HcMgEslRenamed.esp");
-                bool eslDropped = false;
+                bool eslKept = false;
                 if (oEsl.Success && !string.IsNullOrEmpty(oEsl.OutputPath) && File.Exists(oEsl.OutputPath))
                 {
                     using var em = SkyrimMod.CreateFromBinaryOverlay(oEsl.OutputPath, SkyrimRelease.SkyrimSE);
-                    eslDropped = !em.IsSmallMaster                                        // the loss is REAL, not just claimed
-                              && string.IsNullOrEmpty(em.ModHeader.Author)
-                              && string.IsNullOrEmpty(em.ModHeader.Description);
+                    eslKept = em.IsSmallMaster                                            // the carry is REAL, not just claimed
+                           && string.IsNullOrEmpty(em.ModHeader.Author)                   // header text still dropped
+                           && string.IsNullOrEmpty(em.ModHeader.Description);
                 }
                 var renderedEsl = oEsl.Success ? WriteTools.RenderMerge(oEsl) : "";
-                Check(eslDropped, $"RENAME the donor's light flag and header text really are absent from the output (success {oEsl.Success})");
-                Check(renderedEsl.Contains("HcMgEsl.esp carried the LIGHT (ESL) status")
-                      && renderedEsl.Contains("takes a full load-order slot")
-                      && renderedEsl.Contains("renumbers object ids from 0x800 upward"),
-                    "RENAME the light-flag loss is REPORTED, with the compact remedy's own cost stated");
+                Check(eslKept, $"RENAME the donor's light flag is carried onto the output, its header text is not (success {oEsl.Success})");
+                Check(oEsl.LightCarried && renderedEsl.Contains("is written LIGHT too"),
+                    "RENAME the carried light flag is REPORTED, so the caller need not open the file to know");
                 Check(renderedEsl.Contains("header Author/Description carried by HcMgEsl.esp")
                       && !renderedEsl.Contains("housecarl_create_plugin on"),
                     "RENAME the header-text loss is stated bare — no remedy invented for it");
-                // ONE home for the compact recommendation: where the qualified note fired, the flat closing tail must
-                // not repeat it un-costed. Its negative is the plain merge, which has no note and so keeps the tail.
+                // ONE home for the compact recommendation: an output that is already light must not be told to run
+                // compact to become light. Its negative is the plain merge, which has no note and so keeps the tail.
                 Check(!renderedEsl.Contains("Want it light?"),
-                    "RENAME the flat 'want it light' tail steps aside when the qualified ESL note fired");
+                    "RENAME the flat 'want it light' tail steps aside when the output is already light");
 
                 // Light and master each arrive by EXTENSION as well as by flag; a flag-only reading misses these two
                 // donors entirely, which is the whole reason they exist.
                 var oEslExt = svc.MergePlugins(new[] { "HcMgEslExt.esl" }, "HcMgEslExtRenamed.esp");
                 var renderedEslExt = oEslExt.Success ? WriteTools.RenderMerge(oEslExt) : "";
-                Check(oEslExt.Success && renderedEslExt.Contains("HcMgEslExt.esl carried the LIGHT (ESL) status"),
+                Check(oEslExt.Success && oEslExt.LightCarried && renderedEslExt.Contains("is written LIGHT too"),
                     $"RENAME a .esl-EXTENSION donor counts as light even with the header bit unset (success {oEslExt.Success})");
                 var oEsm = svc.MergePlugins(new[] { "HcMgEsm.esm" }, "HcMgEsmRenamed.esp");
                 var renderedEsm = oEsm.Success ? WriteTools.RenderMerge(oEsm) : "";
@@ -564,8 +562,9 @@ public static class MergeServiceGuardProbe
                 // has quietly become count-keying (PR #346 R5 / PR #360 F2 class).
                 var oMixed = svc.MergePlugins(new[] { "HcMgEsl.esp", "HcMgEsm.esm" }, "HcMgMixed.esp");
                 var renderedMixed = oMixed.Success ? WriteTools.RenderMerge(oMixed) : "";
-                Check(oMixed.Success && oMixed.Donors.Count == 2
+                Check(oMixed.Success && oMixed.Donors.Count == 2 && !oMixed.LightCarried
                       && renderedMixed.Contains("carried the LIGHT (ESL) status")
+                      && renderedMixed.Contains("Not every donor was light (1 of 2 were)")
                       && renderedMixed.Contains("carried MASTER status")
                       && renderedMixed.Contains("header Author/Description carried by")
                       && renderedMixed.Contains("from 2 donors"),

--- a/src/housecarl-mcp-tests/AssetProviderTokenTests.cs
+++ b/src/housecarl-mcp-tests/AssetProviderTokenTests.cs
@@ -1,0 +1,58 @@
+using System.Text.RegularExpressions;
+using HousecarlCore;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>asset_status prints a provider the way every other asset surface does (#340): the name inside double
+/// quotes — a character a Windows file or folder name cannot contain — with the kind outside them. The old render
+/// appended the kind bare, so a caller could not tell a mod called "Face Extras (SE)" from a mod called "Face Extras"
+/// read out of a BSA, and the printed token was not the token a source selector takes.</summary>
+[Trait("tier", "integration")]
+public sealed class AssetProviderTokenTests : IClassFixture<AssetSelectWorld>
+{
+    readonly AssetSelectWorld _w;
+    public AssetProviderTokenTests(AssetSelectWorld w) => _w = w;
+
+    /// <summary>Every name the render delimits, in order of appearance.</summary>
+    static string[] Quoted(string text) => Regex.Matches(text, "\"([^\"]*)\"").Select(m => m.Groups[1].Value).ToArray();
+
+    /// <summary>A provider name with its own parenthetical still reads back whole: the delimiter says where the name
+    /// ends, and the kind is outside it. Stripping "the parenthetical" here would take part of the real name.</summary>
+    [Fact]
+    public void AProviderNameCarryingItsOwnParentheticalIsStillDelimitedWhole()
+    {
+        var text = AssetTools.AssetStatus(_w.Svc, new[] { AssetSelectWorld.ParenPath });
+
+        Assert.Contains(AssetSourceSelection.Describe(AssetSelectWorld.ParenMod, "loose"), text);
+        Assert.Contains(AssetSelectWorld.ParenMod, Quoted(text));
+    }
+
+    /// <summary>The whole provider chain goes through the one formatter, not just the winner line — a caller reading
+    /// a loser out of the chain gets the same token the winner line gives.</summary>
+    [Fact]
+    public void EveryNameInTheProviderChainIsPrintedByTheSharedFormatter()
+    {
+        var contested = _w.Rel("0002.nif");
+        var text = AssetTools.AssetStatus(_w.Svc, new[] { contested });
+
+        var data = _w.Svc.AssetStatus(new[] { contested });
+        var hit = Assert.Single(data.Results).Hit!;
+        foreach (var p in hit.Providers)
+            Assert.Contains(AssetSourceSelection.Describe(p.Source, p.Kind == AssetKind.Bsa ? "BSA" : "loose"), text);
+
+        // The bug's own signature: the bare "Name (kind)" form must be gone, or a caller copying the printed token
+        // back into a selector keeps handing it a name with decoration attached.
+        Assert.DoesNotContain("FaceHigher (loose)", text);
+    }
+
+    /// <summary>An archive provider is spelled the same way, so the two kinds cannot drift apart again.</summary>
+    [Fact]
+    public void AnArchiveProviderIsDelimitedLikeALooseOne()
+    {
+        var text = AssetTools.AssetStatus(_w.Svc, new[] { _w.Rel("0005.nif") });
+
+        Assert.Contains(AssetSourceSelection.Describe("HcArch.bsa", "BSA"), text);
+    }
+}

--- a/src/housecarl-mcp-tests/AssetSelectWorld.cs
+++ b/src/housecarl-mcp-tests/AssetSelectWorld.cs
@@ -15,6 +15,8 @@ namespace HousecarlMcpTests;
 ///   facetint <c>.dds</c> under textures\ so a glob has something to narrow away.</item>
 /// <item><c>ArchiveMod</c> — <c>HcArch.bsa</c>, authored by <see cref="BsaBuilder"/> and bound to the active
 ///   <c>HcArch.esp</c>, carrying <c>0005.nif</c> — reachable only through the archive lane.</item>
+/// <item><c>Face Extras (SE)</c> — a mod whose NAME carries a parenthetical, providing one file outside every sweep
+///   target above, so a rendered provider token can be read for where the name ends (#340).</item>
 /// </list>
 ///
 /// <para>No .esp is written to disk: asset resolution is decoupled from the record index, so the profile naming a
@@ -35,6 +37,12 @@ public sealed class AssetSelectWorld : IDisposable
     /// FaceHigher, one from the BSA (FaceHigher's 0002 is a contender, not a sixth file).</summary>
     public const int FaceGeomFiles = 5;
 
+    /// <summary>A mod folder whose own name carries a parenthetical, which is legal on Windows and common in the
+    /// wild ("SkyUI (SE)"). Its only file sits outside every sweep target above, so it changes no other count.</summary>
+    public const string ParenMod = "Face Extras (SE)";
+    /// <summary>The one path <see cref="ParenMod"/> provides.</summary>
+    public const string ParenPath = @"textures\hcextras\extra.dds";
+
     public string Rel(string leaf) => FaceGeomDir + "\\" + leaf;
 
     public AssetSelectWorld()
@@ -47,7 +55,8 @@ public sealed class AssetSelectWorld : IDisposable
         var faceBase = Path.Combine(mods, "FaceBase");
         var faceHigher = Path.Combine(mods, "FaceHigher");
         var archiveMod = Path.Combine(mods, "ArchiveMod");
-        foreach (var d in new[] { profile, data, faceBase, faceHigher, archiveMod }) Directory.CreateDirectory(d);
+        var parenMod = Path.Combine(mods, ParenMod);
+        foreach (var d in new[] { profile, data, faceBase, faceHigher, archiveMod, parenMod }) Directory.CreateDirectory(d);
 
         File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
             "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
@@ -59,6 +68,7 @@ public sealed class AssetSelectWorld : IDisposable
         Loose(faceBase, FaceTintDir + @"\0001.dds");
         Loose(faceHigher, Rel("0002.nif"));                    // contends with FaceBase and wins on priority
         Loose(faceHigher, Rel("0004.nif"));
+        Loose(parenMod, ParenPath);                            // a provider name that contains its own parenthetical
 
         File.WriteAllBytes(Path.Combine(archiveMod, "HcArch.bsa"),
             BsaBuilder.Build(105, BsaBuilder.HasFolderNames | BsaBuilder.HasFileNames,
@@ -67,7 +77,7 @@ public sealed class AssetSelectWorld : IDisposable
         File.WriteAllText(Path.Combine(profile, "loadorder.txt"), "# header\r\nHcArch.esp\r\n");
         File.WriteAllText(Path.Combine(profile, "plugins.txt"), "*HcArch.esp\r\n");
         // Listed first = higher priority, the MO2 modlist.txt order.
-        File.WriteAllText(Path.Combine(profile, "modlist.txt"), "# header\r\n+ArchiveMod\r\n+FaceHigher\r\n+FaceBase\r\n");
+        File.WriteAllText(Path.Combine(profile, "modlist.txt"), "# header\r\n+ArchiveMod\r\n+FaceHigher\r\n+FaceBase\r\n+" + ParenMod + "\r\n");
         File.WriteAllText(Path.Combine(profile, "Skyrim.ini"), "[Archive]\r\nsResourceArchiveList=\r\n");
 
         Svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(Root, "houseCARL.user.json")));

--- a/src/housecarl-mcp-tests/MergeLightCarryTests.cs
+++ b/src/housecarl-mcp-tests/MergeLightCarryTests.cs
@@ -1,0 +1,146 @@
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>The LIGHT (ESL) header flag on a merge (#363): carried when every donor was light and the merged ids fit
+/// the light window, dropped otherwise — and the report says which happened, and why, either way.</summary>
+[Trait("tier", "integration")]
+public sealed class MergeLightCarryTests : IClassFixture<MergeLightCarryWorld>
+{
+    readonly MergeLightCarryWorld _w;
+    public MergeLightCarryTests(MergeLightCarryWorld w) => _w = w;
+
+    static bool WrittenLight(WritePatchBuilder.MergeOutcome o)
+    {
+        using var m = SkyrimMod.CreateFromBinaryOverlay(o.OutputPath, SkyrimRelease.SkyrimSE);
+        return m.IsSmallMaster;
+    }
+
+    /// <summary>Two light donors whose merged ids stay inside 0x800–0xFFF: the output is written LIGHT, so the merge
+    /// does not cost a load-order slot the donors never cost.</summary>
+    [Fact]
+    public void EveryDonorLightAndTheIdsFittingCarriesTheLightFlagOntoTheOutput()
+    {
+        var o = _w.Svc.MergePlugins(new[] { MergeLightCarryWorld.LightA, MergeLightCarryWorld.LightB }, "HcLcBothLight.esp");
+
+        Assert.True(o.Success, o.Error);
+        Assert.True(o.LightCarried);
+        Assert.True(WrittenLight(o));
+        Assert.Contains("is written LIGHT too", WriteTools.RenderMerge(o));
+    }
+
+    /// <summary>One full donor in the set and the flag is dropped — merged content that was never light-legal as a
+    /// whole cannot be carried as light — with the drop and its reason both stated.</summary>
+    [Fact]
+    public void OneFullDonorDropsTheLightFlagAndTheReportSaysThatIsWhy()
+    {
+        var o = _w.Svc.MergePlugins(new[] { MergeLightCarryWorld.LightA, MergeLightCarryWorld.Full }, "HcLcMixed.esp");
+
+        Assert.True(o.Success, o.Error);
+        Assert.False(o.LightCarried);
+        Assert.False(WrittenLight(o));
+        var rendered = WriteTools.RenderMerge(o);
+        Assert.Contains("carried the LIGHT (ESL) status", rendered);
+        Assert.Contains("Not every donor was light (1 of 2 were)", rendered);
+    }
+
+    /// <summary>A donor set with no light donor at all claims nothing about the light flag either way — there is no
+    /// drop to report.</summary>
+    [Fact]
+    public void NoLightDonorRaisesNoLightNoteAtAll()
+    {
+        var o = _w.Svc.MergePlugins(new[] { MergeLightCarryWorld.Full }, "HcLcFullRenamed.esp");
+
+        Assert.True(o.Success, o.Error);
+        Assert.False(o.LightCarried);
+        Assert.DoesNotContain("LIGHT (ESL) status", WriteTools.RenderMerge(o));
+    }
+
+    /// <summary>The MASTER (ESM) flag is never carried, and the drop is always said — the other half of the ruling.</summary>
+    [Fact]
+    public void TheMasterFlagIsNeverCarriedAndTheDropIsSaid()
+    {
+        var o = _w.Svc.MergePlugins(new[] { MergeLightCarryWorld.Master }, "HcLcMasterRenamed.esp");
+
+        Assert.True(o.Success, o.Error);
+        using (var m = SkyrimMod.CreateFromBinaryOverlay(o.OutputPath, SkyrimRelease.SkyrimSE))
+            Assert.False(m.ModHeader.Flags.HasFlag(SkyrimModHeader.HeaderFlag.Master));
+        Assert.Contains("carried MASTER status", WriteTools.RenderMerge(o));
+    }
+
+    /// <summary>The second reason the flag can be dropped, at the render seam: every donor was light but the ids did
+    /// not fit, which is the one case compact cannot rescue — so the report must not send the caller there.</summary>
+    [Fact]
+    public void AllDonorsLightButTheIdsOverflowingReportsTheWindowAndOffersNoCompact()
+    {
+        var o = _w.Svc.MergePlugins(new[] { MergeLightCarryWorld.LightA, MergeLightCarryWorld.LightB }, "HcLcOverflowRender.esp");
+        Assert.True(o.Success, o.Error);
+        // The same outcome, re-stated as the overflow shape: both donors light, the flag not carried.
+        var overflowed = o with { LightCarried = false };
+
+        var rendered = WriteTools.RenderMerge(overflowed);
+
+        Assert.Contains("Every donor was light, but the merged object ids do not all fit the light window", rendered);
+        Assert.DoesNotContain("Want it light?", rendered);
+        Assert.Contains("cannot make it light either", rendered);
+    }
+}
+
+/// <summary>A synthetic MO2 instance for the merge light-carry arms: two light donors (one by header flag, one by the
+/// .esl extension with the bit unset) whose object ids sit inside the light window, one full plugin, and one master.
+/// Every donor originates a single weapon, so a merge of any pair keeps every id where it is.</summary>
+public sealed class MergeLightCarryWorld : IDisposable
+{
+    public string Root { get; }
+    public LoadOrderService Svc { get; }
+
+    public const string LightA = "HcLcLightA.esp";     // header bit set
+    public const string LightB = "HcLcLightB.esl";     // .esl extension, bit unset
+    public const string Full = "HcLcFull.esp";
+    public const string Master = "HcLcMaster.esm";
+
+    public MergeLightCarryWorld()
+    {
+        Root = Path.Combine(Path.GetTempPath(), "hc-merge-light-" + Guid.NewGuid().ToString("N"));
+        var instance = Path.Combine(Root, "instance");
+        var profile = Path.Combine(instance, "profiles", "Default");
+        var mods = Path.Combine(instance, "mods");
+        foreach (var d in new[] { profile, mods, Path.Combine(Root, "game", "Data") }) Directory.CreateDirectory(d);
+
+        File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(Root, "game").Replace(@"\", @"\\") + ")\r\n");
+
+        Write(mods, "LightAMod", new ModKey("HcLcLightA", ModType.Plugin), 0x801, light: true);
+        Write(mods, "LightBMod", new ModKey("HcLcLightB", ModType.Light), 0x802, light: false);
+        Write(mods, "FullMod", new ModKey("HcLcFull", ModType.Plugin), 0x803, light: false);
+        Write(mods, "MasterMod", new ModKey("HcLcMaster", ModType.Master), 0x804, light: false);
+
+        var order = new[] { Master, LightA, LightB, Full };
+        File.WriteAllText(Path.Combine(profile, "loadorder.txt"), "# header\r\n" + string.Join("\r\n", order) + "\r\n");
+        File.WriteAllText(Path.Combine(profile, "plugins.txt"), string.Join("\r\n", order.Select(p => "*" + p)) + "\r\n");
+        File.WriteAllText(Path.Combine(profile, "modlist.txt"),
+            "# header\r\n+MasterMod\r\n+FullMod\r\n+LightBMod\r\n+LightAMod\r\n");
+
+        Svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(Root, "houseCARL.user.json")));
+    }
+
+    static void Write(string mods, string folder, ModKey key, uint id, bool light)
+    {
+        var dir = Path.Combine(mods, folder);
+        Directory.CreateDirectory(dir);
+        var m = new SkyrimMod(key, SkyrimRelease.SkyrimSE) { IsSmallMaster = light };
+        m.Weapons.Add(new Weapon(new FormKey(key, id), SkyrimRelease.SkyrimSE) { EditorID = key.Name + "Weap" });
+        m.BeginWrite.ToPath(Path.Combine(dir, key.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+    }
+
+    public void Dispose()
+    {
+        Svc.Dispose();
+        try { Directory.Delete(Root, true); } catch { /* temp cleanup best-effort */ }
+    }
+}

--- a/src/housecarl-mcp-tests/MergeLightCarryTests.cs
+++ b/src/housecarl-mcp-tests/MergeLightCarryTests.cs
@@ -90,6 +90,23 @@ public sealed class MergeLightCarryTests : IClassFixture<MergeLightCarryWorld>
         Assert.DoesNotContain("cannot make it light either", rendered);
     }
 
+    /// <summary>Every donor light, every donor id inside the window, and the merge still overflows it on record count
+    /// alone — the reason must say the count, not blame a donor id above the ceiling that no donor has.</summary>
+    [Fact]
+    public void AllDonorsLightButTooManyRecordsBlamesTheCountNotAHighId()
+    {
+        var o = _w.Svc.MergePlugins(new[] { MergeLightCarryWorld.LightA, MergeLightCarryWorld.LightCrowd }, "HcLcLightCrowded.esp");
+
+        Assert.True(o.Success, o.Error);
+        Assert.False(o.LightCarried);
+        Assert.False(WrittenLight(o));
+        Assert.Equal(MergeLightCarryWorld.LightCrowdRecords + 1, o.OriginatingRecords);
+        var rendered = WriteTools.RenderMerge(o);
+        Assert.Contains("Every donor was light, but the donors together define more records than the light window", rendered);
+        Assert.DoesNotContain("an id already above the ceiling is kept where it is", rendered);
+        Assert.Contains("cannot make it light either", rendered);
+    }
+
     /// <summary>The merged plugin defines more records than a light plugin holds, so compact would refuse — the report
     /// says that instead of sending the caller to a tool that cannot help.</summary>
     [Fact]
@@ -109,9 +126,9 @@ public sealed class MergeLightCarryTests : IClassFixture<MergeLightCarryWorld>
 
 /// <summary>A synthetic MO2 instance for the merge light-carry arms: two light donors (one by header flag, one by the
 /// .esl extension with the bit unset) whose object ids sit inside the light window, a third light donor whose single
-/// id sits ABOVE the light ceiling, one full plugin, one full plugin with more records than the light window holds,
-/// and one master. Every donor but the crowded one originates a single weapon, so a merge of any pair of those keeps
-/// every id where it is.</summary>
+/// id sits ABOVE the light ceiling, a fourth light donor that fills the window exactly, one full plugin, one full
+/// plugin with more records than the light window holds, and one master. Every donor but the two crowded ones
+/// originates a single weapon, so a merge of any pair of those keeps every id where it is.</summary>
 public sealed class MergeLightCarryWorld : IDisposable
 {
     public string Root { get; }
@@ -122,10 +139,15 @@ public sealed class MergeLightCarryWorld : IDisposable
     public const string LightHighId = "HcLcLightC.esl";// .esl extension, one record at 0x5000 — outside the light window
     public const string Full = "HcLcFull.esp";
     public const string Crowd = "HcLcCrowd.esp";       // more originating records than the light window's 2048 ids
+    public const string LightCrowd = "HcLcLightFull.esl"; // light, and fills the window exactly — one more record overflows it
     public const string Master = "HcLcMaster.esm";
 
     /// <summary>One more than the light window holds, so any merge including this donor overflows it.</summary>
     public const int CrowdRecords = 2049;
+
+    /// <summary>Exactly the light window's capacity, so this donor is light-legal alone and any second donor pushes the
+    /// merge over — the overflow with every donor light and every donor id in the window.</summary>
+    public const int LightCrowdRecords = 2048;
 
     public MergeLightCarryWorld()
     {
@@ -144,16 +166,17 @@ public sealed class MergeLightCarryWorld : IDisposable
         Write(mods, "FullMod", new ModKey("HcLcFull", ModType.Plugin), 0x803, light: false);
         Write(mods, "MasterMod", new ModKey("HcLcMaster", ModType.Master), 0x804, light: false);
         Write(mods, "CrowdMod", new ModKey("HcLcCrowd", ModType.Plugin), 0x801, light: false, count: CrowdRecords);
+        Write(mods, "LightFullMod", new ModKey("HcLcLightFull", ModType.Light), 0x800, light: true, count: LightCrowdRecords);
         // Written under the .esp ModKey and renamed, because Mutagen refuses to serialize an id above the ESL ceiling
         // under a light ModKey. A plugin file carries no copy of its own name, so the renamed file reads back as the
         // .esl the engine force-treats as light — which is the donor shape this arm needs.
         WriteRenamed(mods, "LightCMod", new ModKey("HcLcLightC", ModType.Plugin), 0x5000, LightHighId);
 
-        var order = new[] { Master, LightA, LightB, LightHighId, Full, Crowd };
+        var order = new[] { Master, LightA, LightB, LightHighId, LightCrowd, Full, Crowd };
         File.WriteAllText(Path.Combine(profile, "loadorder.txt"), "# header\r\n" + string.Join("\r\n", order) + "\r\n");
         File.WriteAllText(Path.Combine(profile, "plugins.txt"), string.Join("\r\n", order.Select(p => "*" + p)) + "\r\n");
         File.WriteAllText(Path.Combine(profile, "modlist.txt"),
-            "# header\r\n+MasterMod\r\n+CrowdMod\r\n+FullMod\r\n+LightCMod\r\n+LightBMod\r\n+LightAMod\r\n");
+            "# header\r\n+MasterMod\r\n+CrowdMod\r\n+FullMod\r\n+LightFullMod\r\n+LightCMod\r\n+LightBMod\r\n+LightAMod\r\n");
 
         Svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(Root, "houseCARL.user.json")));
     }

--- a/src/housecarl-mcp-tests/MergeLightCarryTests.cs
+++ b/src/housecarl-mcp-tests/MergeLightCarryTests.cs
@@ -72,27 +72,46 @@ public sealed class MergeLightCarryTests : IClassFixture<MergeLightCarryWorld>
         Assert.Contains("carried MASTER status", WriteTools.RenderMerge(o));
     }
 
-    /// <summary>The second reason the flag can be dropped, at the render seam: every donor was light but the ids did
-    /// not fit, which is the one case compact cannot rescue — so the report must not send the caller there.</summary>
+    /// <summary>The second reason the flag can be dropped, end to end: every donor is light, but one of them defines
+    /// an id above the light ceiling, which the merge keeps where it is. Two records, so compact IS the remedy — the
+    /// report must not blame a record count the merge does not have.</summary>
     [Fact]
-    public void AllDonorsLightButTheIdsOverflowingReportsTheWindowAndOffersNoCompact()
+    public void AllDonorsLightWithAnIdAboveTheCeilingDropsTheFlagAndStillOffersCompact()
     {
-        var o = _w.Svc.MergePlugins(new[] { MergeLightCarryWorld.LightA, MergeLightCarryWorld.LightB }, "HcLcOverflowRender.esp");
+        var o = _w.Svc.MergePlugins(new[] { MergeLightCarryWorld.LightA, MergeLightCarryWorld.LightHighId }, "HcLcHighId.esp");
+
         Assert.True(o.Success, o.Error);
-        // The same outcome, re-stated as the overflow shape: both donors light, the flag not carried.
-        var overflowed = o with { LightCarried = false };
+        Assert.False(o.LightCarried);
+        Assert.False(WrittenLight(o));
+        var rendered = WriteTools.RenderMerge(o);
+        Assert.Contains("Every donor was light, but not every merged object id landed inside the light window", rendered);
+        Assert.DoesNotContain("Not every donor was light", rendered);
+        Assert.Contains("To make it light run", rendered);
+        Assert.DoesNotContain("cannot make it light either", rendered);
+    }
 
-        var rendered = WriteTools.RenderMerge(overflowed);
+    /// <summary>The merged plugin defines more records than a light plugin holds, so compact would refuse — the report
+    /// says that instead of sending the caller to a tool that cannot help.</summary>
+    [Fact]
+    public void TooManyRecordsForTheWindowSaysCompactCannotRescueIt()
+    {
+        var o = _w.Svc.MergePlugins(new[] { MergeLightCarryWorld.LightA, MergeLightCarryWorld.Crowd }, "HcLcCrowded.esp");
 
-        Assert.Contains("Every donor was light, but the merged object ids do not all fit the light window", rendered);
-        Assert.DoesNotContain("Want it light?", rendered);
+        Assert.True(o.Success, o.Error);
+        Assert.False(o.LightCarried);
+        Assert.Equal(MergeLightCarryWorld.CrowdRecords + 1, o.OriginatingRecords);
+        var rendered = WriteTools.RenderMerge(o);
+        Assert.Contains("Not every donor was light (1 of 2 were)", rendered);
         Assert.Contains("cannot make it light either", rendered);
+        Assert.DoesNotContain("To make it light run", rendered);
     }
 }
 
 /// <summary>A synthetic MO2 instance for the merge light-carry arms: two light donors (one by header flag, one by the
-/// .esl extension with the bit unset) whose object ids sit inside the light window, one full plugin, and one master.
-/// Every donor originates a single weapon, so a merge of any pair keeps every id where it is.</summary>
+/// .esl extension with the bit unset) whose object ids sit inside the light window, a third light donor whose single
+/// id sits ABOVE the light ceiling, one full plugin, one full plugin with more records than the light window holds,
+/// and one master. Every donor but the crowded one originates a single weapon, so a merge of any pair of those keeps
+/// every id where it is.</summary>
 public sealed class MergeLightCarryWorld : IDisposable
 {
     public string Root { get; }
@@ -100,8 +119,13 @@ public sealed class MergeLightCarryWorld : IDisposable
 
     public const string LightA = "HcLcLightA.esp";     // header bit set
     public const string LightB = "HcLcLightB.esl";     // .esl extension, bit unset
+    public const string LightHighId = "HcLcLightC.esl";// .esl extension, one record at 0x5000 — outside the light window
     public const string Full = "HcLcFull.esp";
+    public const string Crowd = "HcLcCrowd.esp";       // more originating records than the light window's 2048 ids
     public const string Master = "HcLcMaster.esm";
+
+    /// <summary>One more than the light window holds, so any merge including this donor overflows it.</summary>
+    public const int CrowdRecords = 2049;
 
     public MergeLightCarryWorld()
     {
@@ -119,24 +143,35 @@ public sealed class MergeLightCarryWorld : IDisposable
         Write(mods, "LightBMod", new ModKey("HcLcLightB", ModType.Light), 0x802, light: false);
         Write(mods, "FullMod", new ModKey("HcLcFull", ModType.Plugin), 0x803, light: false);
         Write(mods, "MasterMod", new ModKey("HcLcMaster", ModType.Master), 0x804, light: false);
+        Write(mods, "CrowdMod", new ModKey("HcLcCrowd", ModType.Plugin), 0x801, light: false, count: CrowdRecords);
+        // Written under the .esp ModKey and renamed, because Mutagen refuses to serialize an id above the ESL ceiling
+        // under a light ModKey. A plugin file carries no copy of its own name, so the renamed file reads back as the
+        // .esl the engine force-treats as light — which is the donor shape this arm needs.
+        WriteRenamed(mods, "LightCMod", new ModKey("HcLcLightC", ModType.Plugin), 0x5000, LightHighId);
 
-        var order = new[] { Master, LightA, LightB, Full };
+        var order = new[] { Master, LightA, LightB, LightHighId, Full, Crowd };
         File.WriteAllText(Path.Combine(profile, "loadorder.txt"), "# header\r\n" + string.Join("\r\n", order) + "\r\n");
         File.WriteAllText(Path.Combine(profile, "plugins.txt"), string.Join("\r\n", order.Select(p => "*" + p)) + "\r\n");
         File.WriteAllText(Path.Combine(profile, "modlist.txt"),
-            "# header\r\n+MasterMod\r\n+FullMod\r\n+LightBMod\r\n+LightAMod\r\n");
+            "# header\r\n+MasterMod\r\n+CrowdMod\r\n+FullMod\r\n+LightCMod\r\n+LightBMod\r\n+LightAMod\r\n");
 
         Svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(Root, "houseCARL.user.json")));
     }
 
-    static void Write(string mods, string folder, ModKey key, uint id, bool light)
+    static string Write(string mods, string folder, ModKey key, uint id, bool light, int count = 1)
     {
         var dir = Path.Combine(mods, folder);
         Directory.CreateDirectory(dir);
         var m = new SkyrimMod(key, SkyrimRelease.SkyrimSE) { IsSmallMaster = light };
-        m.Weapons.Add(new Weapon(new FormKey(key, id), SkyrimRelease.SkyrimSE) { EditorID = key.Name + "Weap" });
-        m.BeginWrite.ToPath(Path.Combine(dir, key.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        for (int i = 0; i < count; i++)
+            m.Weapons.Add(new Weapon(new FormKey(key, id + (uint)i), SkyrimRelease.SkyrimSE) { EditorID = key.Name + "Weap" + i });
+        var path = Path.Combine(dir, key.FileName.String);
+        m.BeginWrite.ToPath(path).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        return path;
     }
+
+    static void WriteRenamed(string mods, string folder, ModKey key, uint id, string fileName)
+        => File.Move(Write(mods, folder, key, id, light: false), Path.Combine(mods, folder, fileName));
 
     public void Dispose()
     {

--- a/src/housecarl-mcp-tests/ServerBuildLineTests.cs
+++ b/src/housecarl-mcp-tests/ServerBuildLineTests.cs
@@ -20,7 +20,7 @@ public class ServerBuildLineTests
     static string Render(string? lookup = null) => StatusWire.Render(
         Empty(), Array.Empty<LogFolderView>(),
         new NamedProfileResult(false, Array.Empty<string>(), null, null, null, Array.Empty<string>()),
-        lookup, cap: 80_000);
+        lookup, localized: null, cap: 80_000);
 
     [Fact]
     public void TheStatusHeaderNamesTheBuildTheServerAssemblyEmbeds()

--- a/src/housecarl-mcp-tests/StatusLocalizedLookupTests.cs
+++ b/src/housecarl-mcp-tests/StatusLocalizedLookupTests.cs
@@ -1,0 +1,105 @@
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>load_order_status' lookup= reports a plugin's LOCALIZED header flag (#376), so the in-place write refusal
+/// that flag causes can be seen coming instead of being met halfway through a job.</summary>
+[Trait("tier", "integration")]
+public sealed class StatusLocalizedLookupTests : IClassFixture<StatusLocalizedWorld>
+{
+    readonly StatusLocalizedWorld _w;
+    public StatusLocalizedLookupTests(StatusLocalizedWorld w) => _w = w;
+
+    string Lookup(string name) => StatusTools.LoadOrderStatus(_w.Svc, _w.Tools, lookup: name);
+
+    [Fact]
+    public void ALocalizedPluginIsNamedAsSuchWithTheInPlaceConsequence()
+    {
+        var text = Lookup(StatusLocalizedWorld.Localized);
+
+        Assert.Contains("localized:", text);
+        Assert.Contains("YES (header flag set)", text);
+        Assert.Contains("IN-PLACE", text);
+    }
+
+    [Fact]
+    public void APlainPluginSaysSoRatherThanSayingNothing()
+    {
+        var text = Lookup(StatusLocalizedWorld.Plain);
+
+        Assert.Contains("no (header flag clear)", text);
+    }
+
+    /// <summary>A mod folder is not a plugin, so there is no header to read and no line to write — the flag must not
+    /// be claimed for something that has none.</summary>
+    [Fact]
+    public void AModFolderLookupCarriesNoLocalizedLine()
+    {
+        Assert.DoesNotContain("localized:", Lookup("PlainMod"));
+    }
+}
+
+/// <summary>A synthetic MO2 instance with one plugin flagged LOCALIZED in its header and one not. The flag is stamped
+/// onto the written file's TES4 header rather than set through Mutagen, so the fixture needs no string tables.</summary>
+public sealed class StatusLocalizedWorld : IDisposable
+{
+    public string Root { get; }
+    public LoadOrderService Svc { get; }
+    public ToolPathResolver Tools { get; }
+
+    public const string Localized = "HcLocLoc.esp";
+    public const string Plain = "HcLocPlain.esp";
+
+    /// <summary>The LOCALIZED bit in the TES4 record's flags field, which starts at byte 8 of a plugin file.</summary>
+    const byte LocalizedBit = 0x80;
+    const int HeaderFlagsOffset = 8;
+
+    public StatusLocalizedWorld()
+    {
+        Root = Path.Combine(Path.GetTempPath(), "hc-status-loc-" + Guid.NewGuid().ToString("N"));
+        var instance = Path.Combine(Root, "instance");
+        var profile = Path.Combine(instance, "profiles", "Default");
+        var mods = Path.Combine(instance, "mods");
+        foreach (var d in new[] { profile, mods, Path.Combine(Root, "game", "Data") }) Directory.CreateDirectory(d);
+
+        File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(Root, "game").Replace(@"\", @"\\") + ")\r\n");
+
+        var locPath = Write(mods, "LocMod", new ModKey("HcLocLoc", ModType.Plugin));
+        Write(mods, "PlainMod", new ModKey("HcLocPlain", ModType.Plugin));
+
+        var bytes = File.ReadAllBytes(locPath);
+        bytes[HeaderFlagsOffset] |= LocalizedBit;
+        File.WriteAllBytes(locPath, bytes);
+
+        var order = new[] { Localized, Plain };
+        File.WriteAllText(Path.Combine(profile, "loadorder.txt"), "# header\r\n" + string.Join("\r\n", order) + "\r\n");
+        File.WriteAllText(Path.Combine(profile, "plugins.txt"), string.Join("\r\n", order.Select(p => "*" + p)) + "\r\n");
+        File.WriteAllText(Path.Combine(profile, "modlist.txt"), "# header\r\n+PlainMod\r\n+LocMod\r\n");
+
+        var store = new UserConfigStore(Path.Combine(Root, "houseCARL.user.json"));
+        Svc = LoadOrderService.WithInstance(instance, 0, store);
+        Tools = new ToolPathResolver(store);
+    }
+
+    static string Write(string mods, string folder, ModKey key)
+    {
+        var dir = Path.Combine(mods, folder);
+        Directory.CreateDirectory(dir);
+        var m = new SkyrimMod(key, SkyrimRelease.SkyrimSE);
+        m.Weapons.Add(new Weapon(new FormKey(key, 0x801), SkyrimRelease.SkyrimSE) { EditorID = key.Name + "Weap" });
+        var path = Path.Combine(dir, key.FileName.String);
+        m.BeginWrite.ToPath(path).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        return path;
+    }
+
+    public void Dispose()
+    {
+        Svc.Dispose();
+        try { Directory.Delete(Root, true); } catch { /* temp cleanup best-effort */ }
+    }
+}

--- a/src/housecarl-mcp-tests/StatusLocalizedLookupTests.cs
+++ b/src/housecarl-mcp-tests/StatusLocalizedLookupTests.cs
@@ -52,6 +52,17 @@ public sealed class StatusLocalizedLookupTests : IClassFixture<StatusLocalizedWo
         Assert.Contains("no (header flag clear)", text);
     }
 
+    /// <summary>Several mod folders provide the name: every copy is readable and MO2 priority decides which one
+    /// serves, so the served copy's flag is the answer — never UNKNOWN, which would claim a read that failed.</summary>
+    [Fact]
+    public void APluginSeveralModFoldersProvideAnswersFromTheServedCopy()
+    {
+        var text = Lookup(StatusLocalizedWorld.Duplicated);
+
+        Assert.Contains("YES (header flag set)", text);
+        Assert.DoesNotContain("could not read this plugin's header", text);
+    }
+
     /// <summary>A plugin whose header will not parse asserts neither answer — the third value, not a quiet "no".</summary>
     [Fact]
     public void AnUnreadableHeaderIsReportedAsUnknown()
@@ -63,9 +74,10 @@ public sealed class StatusLocalizedLookupTests : IClassFixture<StatusLocalizedWo
     }
 }
 
-/// <summary>A synthetic MO2 instance with one plugin flagged LOCALIZED in its header, one not, one unticked, and one
-/// unticked file that is not a plugin at all. The flag is stamped onto the written file's TES4 header rather than set
-/// through Mutagen, so the fixture needs no string tables.</summary>
+/// <summary>A synthetic MO2 instance with one plugin flagged LOCALIZED in its header, one not, one unticked, one
+/// unticked file that is not a plugin at all, and one unticked name two enabled mod folders provide. The flag is
+/// stamped onto the written file's TES4 header rather than set through Mutagen, so the fixture needs no string
+/// tables.</summary>
 public sealed class StatusLocalizedWorld : IDisposable
 {
     public string Root { get; }
@@ -76,6 +88,7 @@ public sealed class StatusLocalizedWorld : IDisposable
     public const string Plain = "HcLocPlain.esp";
     public const string Inactive = "HcLocOff.esp";        // in loadorder.txt, unticked in plugins.txt
     public const string Unreadable = "HcLocJunk.esp";     // unticked too, and not a plugin file at all
+    public const string Duplicated = "HcLocDup.esp";      // unticked, and provided by two enabled mod folders
 
     /// <summary>The LOCALIZED bit in the TES4 record's flags field, which starts at byte 8 of a plugin file.</summary>
     const byte LocalizedBit = 0x80;
@@ -101,16 +114,27 @@ public sealed class StatusLocalizedWorld : IDisposable
         Directory.CreateDirectory(Path.Combine(mods, "JunkMod"));
         File.WriteAllText(Path.Combine(mods, "JunkMod", Unreadable), "not a plugin");
 
-        var bytes = File.ReadAllBytes(locPath);
-        bytes[HeaderFlagsOffset] |= LocalizedBit;
-        File.WriteAllBytes(locPath, bytes);
+        // The same filename from two enabled mod folders. The higher-priority copy is the localized one, so an answer
+        // read from the loser would say the opposite of the served copy's.
+        var dupKey = new ModKey("HcLocDup", ModType.Plugin);
+        var dupWin = Write(mods, "DupWinMod", dupKey);
+        Write(mods, "DupLoseMod", dupKey);
+
+        foreach (var p in new[] { locPath, dupWin })
+        {
+            var b = File.ReadAllBytes(p);
+            b[HeaderFlagsOffset] |= LocalizedBit;
+            File.WriteAllBytes(p, b);
+        }
 
         var active = new[] { Localized, Plain };
+        var off = new[] { Inactive, Unreadable, Duplicated };
         File.WriteAllText(Path.Combine(profile, "loadorder.txt"),
-            "# header\r\n" + string.Join("\r\n", active.Concat(new[] { Inactive, Unreadable })) + "\r\n");
+            "# header\r\n" + string.Join("\r\n", active.Concat(off)) + "\r\n");
         File.WriteAllText(Path.Combine(profile, "plugins.txt"),
-            string.Join("\r\n", active.Select(p => "*" + p).Concat(new[] { Inactive, Unreadable })) + "\r\n");
-        File.WriteAllText(Path.Combine(profile, "modlist.txt"), "# header\r\n+JunkMod\r\n+OffMod\r\n+PlainMod\r\n+LocMod\r\n");
+            string.Join("\r\n", active.Select(p => "*" + p).Concat(off)) + "\r\n");
+        File.WriteAllText(Path.Combine(profile, "modlist.txt"),
+            "# header\r\n+DupWinMod\r\n+DupLoseMod\r\n+JunkMod\r\n+OffMod\r\n+PlainMod\r\n+LocMod\r\n");
 
         var store = new UserConfigStore(Path.Combine(Root, "houseCARL.user.json"));
         Svc = LoadOrderService.WithInstance(instance, 0, store);

--- a/src/housecarl-mcp-tests/StatusLocalizedLookupTests.cs
+++ b/src/housecarl-mcp-tests/StatusLocalizedLookupTests.cs
@@ -40,10 +40,32 @@ public sealed class StatusLocalizedLookupTests : IClassFixture<StatusLocalizedWo
     {
         Assert.DoesNotContain("localized:", Lookup("PlainMod"));
     }
+
+    /// <summary>An inactive plugin is one houseCARL still reads on request, so its header answers too — the plugin
+    /// verdict must not come back with the localized half silently missing.</summary>
+    [Fact]
+    public void AnInactivePluginStillGetsItsLocalizedAnswer()
+    {
+        var text = Lookup(StatusLocalizedWorld.Inactive);
+
+        Assert.Contains("INACTIVE", text);
+        Assert.Contains("no (header flag clear)", text);
+    }
+
+    /// <summary>A plugin whose header will not parse asserts neither answer — the third value, not a quiet "no".</summary>
+    [Fact]
+    public void AnUnreadableHeaderIsReportedAsUnknown()
+    {
+        var text = Lookup(StatusLocalizedWorld.Unreadable);
+
+        Assert.Contains("UNKNOWN — houseCARL could not read this plugin's header", text);
+        Assert.DoesNotContain("header flag clear", text);
+    }
 }
 
-/// <summary>A synthetic MO2 instance with one plugin flagged LOCALIZED in its header and one not. The flag is stamped
-/// onto the written file's TES4 header rather than set through Mutagen, so the fixture needs no string tables.</summary>
+/// <summary>A synthetic MO2 instance with one plugin flagged LOCALIZED in its header, one not, one unticked, and one
+/// unticked file that is not a plugin at all. The flag is stamped onto the written file's TES4 header rather than set
+/// through Mutagen, so the fixture needs no string tables.</summary>
 public sealed class StatusLocalizedWorld : IDisposable
 {
     public string Root { get; }
@@ -52,6 +74,8 @@ public sealed class StatusLocalizedWorld : IDisposable
 
     public const string Localized = "HcLocLoc.esp";
     public const string Plain = "HcLocPlain.esp";
+    public const string Inactive = "HcLocOff.esp";        // in loadorder.txt, unticked in plugins.txt
+    public const string Unreadable = "HcLocJunk.esp";     // unticked too, and not a plugin file at all
 
     /// <summary>The LOCALIZED bit in the TES4 record's flags field, which starts at byte 8 of a plugin file.</summary>
     const byte LocalizedBit = 0x80;
@@ -71,15 +95,22 @@ public sealed class StatusLocalizedWorld : IDisposable
 
         var locPath = Write(mods, "LocMod", new ModKey("HcLocLoc", ModType.Plugin));
         Write(mods, "PlainMod", new ModKey("HcLocPlain", ModType.Plugin));
+        Write(mods, "OffMod", new ModKey("HcLocOff", ModType.Plugin));
+        // Not a plugin: the header read fails on it, which is the whole point of the third value. It stays UNTICKED so
+        // the resolver never tries to index it — an unreadable file in the active order is a different lane's story.
+        Directory.CreateDirectory(Path.Combine(mods, "JunkMod"));
+        File.WriteAllText(Path.Combine(mods, "JunkMod", Unreadable), "not a plugin");
 
         var bytes = File.ReadAllBytes(locPath);
         bytes[HeaderFlagsOffset] |= LocalizedBit;
         File.WriteAllBytes(locPath, bytes);
 
-        var order = new[] { Localized, Plain };
-        File.WriteAllText(Path.Combine(profile, "loadorder.txt"), "# header\r\n" + string.Join("\r\n", order) + "\r\n");
-        File.WriteAllText(Path.Combine(profile, "plugins.txt"), string.Join("\r\n", order.Select(p => "*" + p)) + "\r\n");
-        File.WriteAllText(Path.Combine(profile, "modlist.txt"), "# header\r\n+PlainMod\r\n+LocMod\r\n");
+        var active = new[] { Localized, Plain };
+        File.WriteAllText(Path.Combine(profile, "loadorder.txt"),
+            "# header\r\n" + string.Join("\r\n", active.Concat(new[] { Inactive, Unreadable })) + "\r\n");
+        File.WriteAllText(Path.Combine(profile, "plugins.txt"),
+            string.Join("\r\n", active.Select(p => "*" + p).Concat(new[] { Inactive, Unreadable })) + "\r\n");
+        File.WriteAllText(Path.Combine(profile, "modlist.txt"), "# header\r\n+JunkMod\r\n+OffMod\r\n+PlainMod\r\n+LocMod\r\n");
 
         var store = new UserConfigStore(Path.Combine(Root, "houseCARL.user.json"));
         Svc = LoadOrderService.WithInstance(instance, 0, store);

--- a/src/housecarl-mcp/AssetTools.cs
+++ b/src/housecarl-mcp/AssetTools.cs
@@ -209,12 +209,15 @@ static class AssetWire
             return;
         }
 
-        sb.Append("  WINS: ").Append(hit.Winner!.Source).Append(" (").Append(Kind(hit.Winner.Kind)).Append(")\n");
+        // The provider token is spelled by the one formatter the asset surface uses, so the name printed here is the
+        // name place_asset's source_provider= accepts — the third surface of #340. A mod folder can legitimately hold
+        // a parenthetical ("SkyUI (SE)"), so the delimiter is what tells a caller where the name ends.
+        sb.Append("  WINS: ").Append(Provider(hit.Winner!)).Append('\n');
         sb.Append("  providers (").Append(hit.Providers.Count).Append("): ");
         for (int i = 0; i < hit.Providers.Count; i++)
         {
             if (i > 0) sb.Append(" > ");
-            sb.Append(hit.Providers[i].Source).Append(" (").Append(Kind(hit.Providers[i].Kind)).Append(')');
+            sb.Append(Provider(hit.Providers[i]));
         }
         sb.Append('\n');
         if (hit.Ambiguous)
@@ -223,4 +226,10 @@ static class AssetWire
     }
 
     static string Kind(HousecarlCore.AssetKind k) => k == HousecarlCore.AssetKind.Bsa ? "BSA" : "loose";
+
+    /// <summary>One provider, spelled by the shared formatter (#340): the name inside double quotes — a character a
+    /// Windows folder or file name cannot contain — with the kind outside them, so the printed token is the token a
+    /// source selector accepts.</summary>
+    static string Provider(HousecarlCore.AssetProvider p)
+        => HousecarlCore.AssetSourceSelection.Describe(p.Source, Kind(p.Kind));
 }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1833,7 +1833,8 @@ public sealed class LoadOrderService : IDisposable
     /// included — never a bool.
     /// <para>An INACTIVE plugin gets an answer too: the resolver indexes only the active order, so its path comes from
     /// the same on-disk locate every other lane uses. Reading an inactive plugin is a surface houseCARL advertises, and
-    /// a plugin answer with the localized half silently missing is the worse outcome.</para></summary>
+    /// a plugin answer with the localized half silently missing is the worse outcome. A name several mod folders
+    /// provide is answered from the copy MO2 priority serves, not called unreadable.</para></summary>
     public LocalizedFlagRead? PluginLocalizedFlag(string pluginName)
     {
         LoadOrderResolver.IndexView view;
@@ -1853,9 +1854,15 @@ public sealed class LoadOrderService : IDisposable
                         || comp.ImplicitPluginNames.Any(n => n.Equals(pluginName, StringComparison.OrdinalIgnoreCase));
         if (!isPlugin) return null;
         var loc = LocatePluginFileOnDisk(comp, modsDir, dataDir, overwriteDir, pluginName, null, offerModParam: false);
-        // Listed as a plugin but no single file behind the name (missing, or several folders provide it): the flag is
-        // not established, which is exactly what the third value says.
-        return loc.Path is null ? LocalizedFlagRead.Unreadable : WriteEngine.PluginIsLocalized(loc.Path);
+        if (loc.Path is { } path) return WriteEngine.PluginIsLocalized(path);
+        // Several folders provide the name: every copy is readable and MO2 priority already decides which one serves,
+        // so the served copy answers — the same rule the locate itself judges 'serves' by. UNKNOWN here would claim a
+        // header read failed when none was attempted.
+        if (loc.Ambiguous is { Count: > 0 } hits && hits.FirstOrDefault(h => h.Enabled) is { } served)
+            return WriteEngine.PluginIsLocalized(served.Path);
+        // Listed as a plugin, and no file behind the name serves it: the flag is not established, which is what the
+        // third value says.
+        return LocalizedFlagRead.Unreadable;
     }
 
     /// <summary>Read MO2's OWN local Nexus update cache — the modid / version / newestVersion / ignoredVersion /

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1829,13 +1829,33 @@ public sealed class LoadOrderService : IDisposable
     /// <summary>The LOCALIZED header flag of ONE plugin, for housecarl_load_order_status' lookup= (#376): a localized
     /// plugin's text lives in .STRINGS files rather than in the plugin, which is what the in-place write lanes refuse
     /// on, so a caller can see that refusal coming instead of meeting it mid-job. Null when the name is not a plugin
-    /// this order resolved to a file; otherwise the three-way read, Unreadable included — never a bool.</summary>
+    /// at all (a mod folder, a typo — nothing has a header to read); otherwise the three-way read, Unreadable
+    /// included — never a bool.
+    /// <para>An INACTIVE plugin gets an answer too: the resolver indexes only the active order, so its path comes from
+    /// the same on-disk locate every other lane uses. Reading an inactive plugin is a surface houseCARL advertises, and
+    /// a plugin answer with the localized half silently missing is the worse outcome.</para></summary>
     public LocalizedFlagRead? PluginLocalizedFlag(string pluginName)
     {
         LoadOrderResolver.IndexView view;
         lock (_gate) { view = Resolver.Capture(); }
-        var path = view.PluginPath(pluginName);
-        return path is null ? null : WriteEngine.PluginIsLocalized(path);
+        if (view.PluginPath(pluginName) is { } activePath) return WriteEngine.PluginIsLocalized(activePath);
+
+        string modsDir, dataDir, overwriteDir, profileDir;
+        try { lock (_gate) { EnsurePathsDerived(); modsDir = _modsDir; dataDir = _dataDir; overwriteDir = _overwriteDir; profileDir = _profileDir; } }
+        catch { return null; }
+        Mo2Composition comp;
+        try { comp = Mo2LoadOrder.ReadComposition(profileDir); }
+        catch { return null; }
+        // Only a name the profile lists as a plugin: a mod folder and a typo both have no header, and inventing an
+        // UNKNOWN line for them would claim there is a plugin here whose flag simply could not be read.
+        bool isPlugin = comp.OrderedPluginNames.Any(n => n.Equals(pluginName, StringComparison.OrdinalIgnoreCase))
+                        || comp.InactivePluginNames.Any(n => n.Equals(pluginName, StringComparison.OrdinalIgnoreCase))
+                        || comp.ImplicitPluginNames.Any(n => n.Equals(pluginName, StringComparison.OrdinalIgnoreCase));
+        if (!isPlugin) return null;
+        var loc = LocatePluginFileOnDisk(comp, modsDir, dataDir, overwriteDir, pluginName, null, offerModParam: false);
+        // Listed as a plugin but no single file behind the name (missing, or several folders provide it): the flag is
+        // not established, which is exactly what the third value says.
+        return loc.Path is null ? LocalizedFlagRead.Unreadable : WriteEngine.PluginIsLocalized(loc.Path);
     }
 
     /// <summary>Read MO2's OWN local Nexus update cache — the modid / version / newestVersion / ignoredVersion /
@@ -6535,8 +6555,9 @@ public sealed class LoadOrderService : IDisposable
                 $"refused — '{outName}' has the .esl extension, which the game engine force-treats as a LIGHT master regardless " +
                 "of the header flag, but a merge never constrains object ids to the light window: it renumbers only what it must " +
                 "(cross-donor collisions, and ids below the write floor), so an id above 0xFFF would be misread in game. Merge to " +
-                "a '.esp' instead, then run " + ToolNames.CompactPlugin + " on it to make it light — that renumbers every id into " +
-                "the light window (the tools compose). Nothing was written.");
+                "a '.esp' instead: if every donor was light and every merged id landed in the window, the output is written LIGHT " +
+                "already; otherwise the report says so, and " + ToolNames.CompactPlugin + " on it renumbers every id into the light " +
+                "window (the tools compose). Nothing was written.");
         if (donorsRaw.Any(d => string.Equals(d, outName, StringComparison.OrdinalIgnoreCase)))
             return WritePatchBuilder.MergeOutcome.Fail($"the output '{outName}' cannot also be a donor — name a NEW plugin file.");
 
@@ -6723,7 +6744,7 @@ public sealed class LoadOrderService : IDisposable
                 plan.Donors, build.Conflicts, id.ExternalPlugins, id.ExternalOverriders,
                 id.PluginsScanned, id.UnscannableRecords, id.UnscannableSamples, build.Bytes, note,
                 assetRename, voiceRename, seqRegen, build.LightDonors, build.HeaderMetaDonors, build.MasterDonors,
-                id.UnscannablePlugins, localizedDonors, id.MasterDeclarers, build.LightCarried);
+                id.UnscannablePlugins, localizedDonors, id.MasterDeclarers, build.LightCarried, build.OriginatingRecords);
         }
     }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -6723,7 +6723,7 @@ public sealed class LoadOrderService : IDisposable
                 plan.Donors, build.Conflicts, id.ExternalPlugins, id.ExternalOverriders,
                 id.PluginsScanned, id.UnscannableRecords, id.UnscannableSamples, build.Bytes, note,
                 assetRename, voiceRename, seqRegen, build.LightDonors, build.HeaderMetaDonors, build.MasterDonors,
-                id.UnscannablePlugins, localizedDonors, id.MasterDeclarers);
+                id.UnscannablePlugins, localizedDonors, id.MasterDeclarers, build.LightCarried);
         }
     }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1826,6 +1826,18 @@ public sealed class LoadOrderService : IDisposable
             view.Epoch);
     }
 
+    /// <summary>The LOCALIZED header flag of ONE plugin, for housecarl_load_order_status' lookup= (#376): a localized
+    /// plugin's text lives in .STRINGS files rather than in the plugin, which is what the in-place write lanes refuse
+    /// on, so a caller can see that refusal coming instead of meeting it mid-job. Null when the name is not a plugin
+    /// this order resolved to a file; otherwise the three-way read, Unreadable included — never a bool.</summary>
+    public LocalizedFlagRead? PluginLocalizedFlag(string pluginName)
+    {
+        LoadOrderResolver.IndexView view;
+        lock (_gate) { view = Resolver.Capture(); }
+        var path = view.PluginPath(pluginName);
+        return path is null ? null : WriteEngine.PluginIsLocalized(path);
+    }
+
     /// <summary>Read MO2's OWN local Nexus update cache — the modid / version / newestVersion / ignoredVersion /
     /// lastNexusUpdate fields in every managed mod's meta.ini — with NO network (MO2 already paid the API cost). The
     /// cheap local pre-filter for update triage: it names which mods MO2 already learned a newer version for, plus the

--- a/src/housecarl-mcp/StatusTools.cs
+++ b/src/housecarl-mcp/StatusTools.cs
@@ -280,8 +280,8 @@ static class StatusWire
         // The LOCALIZED header flag (#376): a localized plugin's text lives in .STRINGS files rather than in the
         // plugin, and that is what the in-place write lanes refuse on — so the refusal is visible here, before a job
         // meets it halfway through. Three answers, never a bool: an unreadable header asserts nothing either way.
-        // Rendered only when the name resolved to a plugin file; an inactive plugin has no resolved path, and the
-        // plugin verdict above already said so.
+        // Rendered for every name the profile lists as a plugin, active or inactive — an inactive plugin is one a
+        // caller may still read, so it gets the answer too. A mod folder or a typo has no header and gets no line.
         if (localized is { } flag)
             sb.Append("  localized:   ").Append(flag switch
             {

--- a/src/housecarl-mcp/StatusTools.cs
+++ b/src/housecarl-mcp/StatusTools.cs
@@ -20,7 +20,8 @@ public static class StatusTools
          "each call when the profile changed — no restart needed (a 'refresh still pending' note appears only in the rare " +
          "case MO2 was mid-write). Pass lookup= a mod folder name (e.g. 'Requiem " +
          "Lite 2') or a plugin filename (e.g. 'Requiem.esp') to ask whether houseCARL sees that one as enabled/disabled " +
-         "(mod) or active/inactive/implicit (plugin). Also reports the resolved Papyrus script-log and SKSE crash-log " +
+         "(mod) or active/inactive/implicit (plugin) — a plugin lookup also reports its LOCALIZED header flag, which is " +
+         "what an in-place write to it would be refused over. Also reports the resolved Papyrus script-log and SKSE crash-log " +
          "FOLDERS — where to Read logs for triage/diagnosis (auto-detected, or as set via " + ToolNames.SetToolPath + "). " +
          "Also reports the RUNNING SERVER's build version (the binary's informational version — the release version, " +
          "then '+' and the full commit sha, e.g. '1.9.5-dev+e942910...'), so an installed-build-vs-source check never " +
@@ -46,7 +47,9 @@ public static class StatusTools
         var data = svc.StatusData();
         var logs = StatusWire.LogFolders(tools);                 // resolved Papyrus/crash log dirs (pure — no persist)
         var profiles = svc.NamedProfileComposition(profile);     // available-profile discovery + inactive-profile inspection: text parse only, no index build, no switch
-        return StatusWire.Render(data, logs, profiles, lookup, max_chars > 0 ? max_chars : 80_000);
+        // Read only for a lookup: the flag is a per-plugin header read, and the whole-profile summary asks about none.
+        var localized = lookup is { Length: > 0 } ? svc.PluginLocalizedFlag(lookup.Trim()) : null;
+        return StatusWire.Render(data, logs, profiles, lookup, localized, max_chars > 0 ? max_chars : 80_000);
     });
 }
 
@@ -59,7 +62,8 @@ static class StatusWire
     /// Public because the unconfigured answer returns before <see cref="Render"/> runs and prints this itself.</summary>
     public static string ServerLine => "server:   " + ServerBuild.Line + "\n";
 
-    public static string Render(LoadOrderStatusData d, IReadOnlyList<LogFolderView> logs, NamedProfileResult profiles, string? lookup, int cap)
+    public static string Render(LoadOrderStatusData d, IReadOnlyList<LogFolderView> logs, NamedProfileResult profiles,
+                                string? lookup, HousecarlCore.LocalizedFlagRead? localized, int cap)
     {
         var c = d.Composition;
         int checkedActive = c.ActivePluginNames.Count;
@@ -91,7 +95,7 @@ static class StatusWire
 
         if (lookup is { Length: > 0 })
         {
-            AppendLookup(sb, c, d.ExcludedPlugins, lookup.Trim());
+            AppendLookup(sb, c, d.ExcludedPlugins, lookup.Trim(), localized);
             return sb.ToString().TrimEnd('\n');
         }
 
@@ -237,7 +241,8 @@ static class StatusWire
     }
 
     static void AppendLookup(StringBuilder sb, HousecarlCore.Mo2Composition c,
-                             IReadOnlyDictionary<string, string> excluded, string name)
+                             IReadOnlyDictionary<string, string> excluded, string name,
+                             HousecarlCore.LocalizedFlagRead? localized = null)
     {
         sb.Append("\nlookup '").Append(name).Append("':\n");
 
@@ -271,6 +276,22 @@ static class StatusWire
         // "ACTIVE ... houseCARL reads/writes it" line above must not be taken as the whole truth.
         if (excluded.TryGetValue(name, out var why))
             sb.Append("  [!] EXCLUDED this session: ").Append(why).Append("\n      → houseCARL does NOT read this plugin (every other plugin is unaffected).\n");
+
+        // The LOCALIZED header flag (#376): a localized plugin's text lives in .STRINGS files rather than in the
+        // plugin, and that is what the in-place write lanes refuse on — so the refusal is visible here, before a job
+        // meets it halfway through. Three answers, never a bool: an unreadable header asserts nothing either way.
+        // Rendered only when the name resolved to a plugin file; an inactive plugin has no resolved path, and the
+        // plugin verdict above already said so.
+        if (localized is { } flag)
+            sb.Append("  localized:   ").Append(flag switch
+            {
+                HousecarlCore.LocalizedFlagRead.Localized =>
+                    "YES (header flag set) — its text lives in separate .STRINGS files, not in the plugin. An IN-PLACE " +
+                    "write to it is refused; write to a new plugin instead.",
+                HousecarlCore.LocalizedFlagRead.NotLocalized =>
+                    "no (header flag clear) — its text is inside the plugin.",
+                _ => "UNKNOWN — houseCARL could not read this plugin's header, so neither answer is established.",
+            }).Append('\n');
     }
 
     static bool Contains(IReadOnlyList<string> list, string name)

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -132,8 +132,8 @@ public static class WriteTools
          "A donor's HEADER mostly does not come along: master (ESM) status and Author/Description are always dropped, and the " +
          "report names each one it actually dropped. Light (ESL) status IS carried when every donor was light and every merged " +
          "object id fits the light window 0x800–0xFFF; otherwise it is dropped and the report says which of the two reasons it " +
-         "was. Want a dropped light flag back? Run " + ToolNames.CompactPlugin + " on the merged " +
-         "plugin afterward (the tools compose) — but it renumbers object ids from 0x800 upward, so ids the merge kept move.")]
+         "was, and whether " + ToolNames.CompactPlugin + " can still make it light — it can, by renumbering every id into that " +
+         "window (so ids the merge kept move), unless the merged plugin defines more than 2048 records, which no light plugin holds.")]
     public static string MergePlugins(
         LoadOrderService svc,
         [Description("The donor plugin filenames to merge (at least one, e.g. [\"CoolMod.esp\", \"CoolMod Patch.esp\"]) — each must be active in your load order. A SINGLE donor renames it into output=. This is a SET: a name repeated is still one donor. Argument order does not matter: houseCARL uses LOAD order for id priority and conflict resolution.")]
@@ -804,20 +804,27 @@ public static class WriteTools
         {
             sb.Append("NOTE — ").Append(string.Join(", ", light.Take(10)));
             if (light.Count > 10) sb.Append(" (+").Append(light.Count - 10).Append(" more)");
+            // Why the flag was not carried, never a bare drop. The REASON is which of the two conditions failed; the
+            // REMEDY is a separate question, because compact renumbers every id into the light window and so answers
+            // both reasons — until the record count itself overflows that window, which is the only case it cannot
+            // answer. So the reason is written per condition and the remedy per count, and the four combinations each
+            // get the true sentence.
+            const int lightCapacity = (int)(HousecarlCore.FormIdRange.EslWindowCeiling - HousecarlCore.FormIdRange.EslWindowFloor + 1);
+            string window = "0x" + HousecarlCore.FormIdRange.EslWindowFloor.ToString("X3") + "–0x" +
+                            HousecarlCore.FormIdRange.EslWindowCeiling.ToString("X3");
             sb.Append(" carried the LIGHT (ESL) status; ")
               .Append(o.OutputName).Append(" does NOT — it is written as a full plugin and takes a full load-order slot. ")
-              // Why the flag was not carried, never a bare drop — and the two reasons take different remedies, so the
-              // remedy is written per reason rather than once for both.
               .Append(light.Count < o.Donors.Count
                   ? "Not every donor was light (" + light.Count + " of " + o.Donors.Count + " were), and merged content " +
-                    "that was never light-legal as a whole cannot be carried as light. To make it light run " +
-                    ToolNames.CompactPlugin + " on '" + o.OutputName + "' (its esl defaults true) — but that renumbers " +
-                    "object ids from 0x800 upward, so the ids listed as kept above will move.\n"
-                  : "Every donor was light, but the merged object ids do not all fit the light window (0x" +
-                    HousecarlCore.FormIdRange.EslWindowFloor.ToString("X3") + "–0x" +
-                    HousecarlCore.FormIdRange.EslWindowCeiling.ToString("X3") + ") — the donors together define more " +
-                    "originating records than one light plugin holds, so " + ToolNames.CompactPlugin + " cannot make " +
-                    "it light either. Merge fewer donors if a light output is what you need.\n");
+                    "that was never light-legal as a whole cannot be carried as light. "
+                  : "Every donor was light, but not every merged object id landed inside the light window (" + window +
+                    ") — a merge renumbers only what it must, so an id already above the ceiling is kept where it is. ")
+              .Append(o.OriginatingRecords <= lightCapacity
+                  ? "To make it light run " + ToolNames.CompactPlugin + " on '" + o.OutputName + "' (its esl defaults " +
+                    "true) — but that renumbers object ids from 0x800 upward, so the ids listed as kept above will move.\n"
+                  : ToolNames.CompactPlugin + " cannot make it light either: it renumbers into the same window, and " +
+                    o.OriginatingRecords + " originating records do not fit its " + lightCapacity + " ids. Merge fewer " +
+                    "donors if a light output is what you need.\n");
         }
         if (o.MasterDonors is { Count: > 0 } masters)
         {

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -129,8 +129,10 @@ public static class WriteTools
          "same-named plugin is inactive — extract it into the mod folder (" + ToolNames.BsaExtract + ") or load it via a same-named " +
          "dummy plugin (" + ToolNames.CreatePlugin + "). Existing SAVES that depend on the donors will NOT survive (the records now " +
          "live under a different plugin name, and any id that had to be renumbered moved with it) — best for a new game. " +
-         "A donor's HEADER does not come along: light (ESL) status, master status, and Author/Description are dropped, and " +
-         "the report names each one it actually dropped. Want it light/ESL? Run " + ToolNames.CompactPlugin + " on the merged " +
+         "A donor's HEADER mostly does not come along: master (ESM) status and Author/Description are always dropped, and the " +
+         "report names each one it actually dropped. Light (ESL) status IS carried when every donor was light and every merged " +
+         "object id fits the light window 0x800–0xFFF; otherwise it is dropped and the report says which of the two reasons it " +
+         "was. Want a dropped light flag back? Run " + ToolNames.CompactPlugin + " on the merged " +
          "plugin afterward (the tools compose) — but it renumbers object ids from 0x800 upward, so ids the merge kept move.")]
     public static string MergePlugins(
         LoadOrderService svc,
@@ -788,16 +790,34 @@ public static class WriteTools
 
         // The merged plugin is built as a bare mod, so what lived in a donor's HEADER does not come along. Keyed on
         // what the DONORS carried, not on the donor count — a silent header loss has to be stated.
-        bool lightNoteShown = o.LightDonors is { Count: > 0 };
-        if (o.LightDonors is { Count: > 0 } light)
+        bool lightNoteShown = o.LightCarried || o.LightDonors is { Count: > 0 };
+        if (o.LightCarried)
+        {
+            // The one case where nothing is dropped, and it still gets a line: the caller has to know the output is
+            // light without opening it, because that is what decides whether it costs a load-order slot.
+            sb.Append("NOTE — every donor carried the LIGHT (ESL) status and every merged object id landed inside the ")
+              .Append("light window (0x").Append(HousecarlCore.FormIdRange.EslWindowFloor.ToString("X3")).Append("–0x")
+              .Append(HousecarlCore.FormIdRange.EslWindowCeiling.ToString("X3")).Append("), so ").Append(o.OutputName)
+              .Append(" is written LIGHT too — it takes no full load-order slot.\n");
+        }
+        else if (o.LightDonors is { Count: > 0 } light)
         {
             sb.Append("NOTE — ").Append(string.Join(", ", light.Take(10)));
             if (light.Count > 10) sb.Append(" (+").Append(light.Count - 10).Append(" more)");
             sb.Append(" carried the LIGHT (ESL) status; ")
               .Append(o.OutputName).Append(" does NOT — it is written as a full plugin and takes a full load-order slot. ")
-              .Append("To make it light again run " + ToolNames.CompactPlugin + " on '").Append(o.OutputName)
-              .Append("' (its esl defaults true) — but that renumbers object ids from 0x800 upward, so the ids listed as ")
-              .Append("kept above will move.\n");
+              // Why the flag was not carried, never a bare drop — and the two reasons take different remedies, so the
+              // remedy is written per reason rather than once for both.
+              .Append(light.Count < o.Donors.Count
+                  ? "Not every donor was light (" + light.Count + " of " + o.Donors.Count + " were), and merged content " +
+                    "that was never light-legal as a whole cannot be carried as light. To make it light run " +
+                    ToolNames.CompactPlugin + " on '" + o.OutputName + "' (its esl defaults true) — but that renumbers " +
+                    "object ids from 0x800 upward, so the ids listed as kept above will move.\n"
+                  : "Every donor was light, but the merged object ids do not all fit the light window (0x" +
+                    HousecarlCore.FormIdRange.EslWindowFloor.ToString("X3") + "–0x" +
+                    HousecarlCore.FormIdRange.EslWindowCeiling.ToString("X3") + ") — the donors together define more " +
+                    "originating records than one light plugin holds, so " + ToolNames.CompactPlugin + " cannot make " +
+                    "it light either. Merge fewer donors if a light output is what you need.\n");
         }
         if (o.MasterDonors is { Count: > 0 } masters)
         {

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -807,19 +807,25 @@ public static class WriteTools
             // Why the flag was not carried, never a bare drop. The REASON is which of the two conditions failed; the
             // REMEDY is a separate question, because compact renumbers every id into the light window and so answers
             // both reasons — until the record count itself overflows that window, which is the only case it cannot
-            // answer. So the reason is written per condition and the remedy per count, and the four combinations each
-            // get the true sentence.
+            // answer. So the reason is written per condition and the remedy per count. The ids-fit condition itself
+            // fails two ways — a donor id already above the ceiling, or a merge with more records than the window
+            // holds — and only the count tells them apart, so the reason reads it too rather than blaming a high
+            // donor id a crowded merge does not have.
             const int lightCapacity = (int)(HousecarlCore.FormIdRange.EslWindowCeiling - HousecarlCore.FormIdRange.EslWindowFloor + 1);
             string window = "0x" + HousecarlCore.FormIdRange.EslWindowFloor.ToString("X3") + "–0x" +
                             HousecarlCore.FormIdRange.EslWindowCeiling.ToString("X3");
+            bool countFits = o.OriginatingRecords <= lightCapacity;
             sb.Append(" carried the LIGHT (ESL) status; ")
               .Append(o.OutputName).Append(" does NOT — it is written as a full plugin and takes a full load-order slot. ")
               .Append(light.Count < o.Donors.Count
                   ? "Not every donor was light (" + light.Count + " of " + o.Donors.Count + " were), and merged content " +
                     "that was never light-legal as a whole cannot be carried as light. "
-                  : "Every donor was light, but not every merged object id landed inside the light window (" + window +
-                    ") — a merge renumbers only what it must, so an id already above the ceiling is kept where it is. ")
-              .Append(o.OriginatingRecords <= lightCapacity
+                  : countFits
+                      ? "Every donor was light, but not every merged object id landed inside the light window (" + window +
+                        ") — a merge renumbers only what it must, so an id already above the ceiling is kept where it is. "
+                      : "Every donor was light, but the donors together define more records than the light window (" +
+                        window + ") holds, so merged ids land outside it. ")
+              .Append(countFits
                   ? "To make it light run " + ToolNames.CompactPlugin + " on '" + o.OutputName + "' (its esl defaults " +
                     "true) — but that renumbers object ids from 0x800 upward, so the ids listed as kept above will move.\n"
                   : ToolNames.CompactPlugin + " cannot make it light either: it renumbers into the same window, and " +


### PR DESCRIPTION
Backlog item 18, the strings remainder, as one small PR: three independent fixes that each close an issue.

`merge_plugins` used to drop a donor's ESL flag unconditionally, so merging a set of light plugins silently cost a load-order slot. It now carries the flag under the 2026-09-05 ruling: only when every donor was light AND every merged object id landed inside the light window `0x800-0xFFF` (the same bound compact enforces — the merge remap runs to the full 24-bit range, so a large merge lands ids above the ceiling that a light write would throw on). Otherwise the flag is dropped and the report names which of the two conditions failed, because the two take different remedies: a full donor in the set is fixed by running `compact_plugin` on the output, while ids overflowing the window is the one case compact cannot rescue, so the report says that rather than pointing at it. The ESM flag is never carried and that drop is stated as before, and an output written light no longer gets the "want it light? run compact" tail.

`load_order_status`'s `lookup=` now reports a plugin's LOCALIZED header flag when the name resolved to a plugin file, so the in-place write refusal that flag causes is visible before a job runs into it. Three answers rather than a bool: an unreadable header is reported as unknown, never as "not localized".

`asset_status` prints provider names through the same formatter `place_asset` and the NIF tools use — the name inside double quotes, a character a Windows folder or file name cannot contain, with the kind outside them. This is the third surface of #340 (already closed), left unchanged by PR #545 because the render lives in a file that lane was told not to touch.

**Tests.** `dotnet build` clean, 1171 tests pass (1160 baseline + 11), `ci-all` 128/128. New: `MergeLightCarryTests` over its own instance of light, full and master donors covering the carry, both drop reasons and the ESM drop; `StatusLocalizedLookupTests` over a plugin whose TES4 header carries the localized bit; `AssetProviderTokenTests` over a mod folder named `Face Extras (SE)`, whose parenthetical is the case that makes a bare `Name (kind)` render unreadable. The merge probe's HEADER arms pinned the old unconditional drop and are updated to the new contract.

Closes #363
Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)
