### PR TITLE
Add the quantified where= step and the SELECT exclusion terms

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -49,8 +49,9 @@ saying it sets an expectation their install may contradict. Say what is known, a
   A quantified step composes with the `->` link step and with another quantified step, at the cost the tool
   description declares (per-candidate work times list length, and one winner fetch per element under `->`). The bare
   `[*]` is the element SET and is refused in `where=`, naming the three fold tokens; a quantifier pointed at a field
-  that is not a list — a scalar, a dict, a raw byte block — is named in the scan's accounting with what that step read
-  instead, never counted as a silent non-match. An absent list reads as EMPTY, and so does one whose parent substruct
+  that is not a list — a scalar, a dict, a raw byte block — refuses the call by naming the step's real cardinality
+  wherever `types=` says which record type it lands on, and where the scope cannot say (no `types=`, or a mixed one)
+  the scan's accounting names what that step read instead; either way, never a silent non-match. An absent list reads as EMPTY, and so does one whose parent substruct
   is absent, so `VirtualMachineAdapter.Scripts[*count] = 0` finds the records that carry no script at all; where an
   element cannot be judged, the fold reports no verdict rather than claiming one. Reaching a list with a dotted
   segment still refuses, and its remedy now offers the quantified spelling alongside the bracketed index.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -42,6 +42,22 @@ saying it sets an expectation their install may contradict. Say what is known, a
   collection whose elements are owned child records (`Cell.Persistent`) is sent to the record axis rather than handed
   a container call no verb takes. Inside
   a `compose=`'s nested `sets`, the path is named in the `path` slot it belongs to rather than `field_path`.
+- **A `where=` path step can now quantify a list, so "does ANY element match?" is one call.** Four tokens go in the
+  step where the list binds: `Conditions[*any].Data.Function = IsGuard` (some element), `[*all]` (every one, and
+  vacuously true on an empty list), `[*none]` (absence, proved — `Effects[*none].BaseEffect->editorid startswith REQ_`),
+  and `[*count]`, which yields the number of elements for a numeric or membership comparison (`Effects[*count] > 2`).
+  A quantified step composes with the `->` link step and with another quantified step, at the cost the tool
+  description declares (per-candidate work times list length, and one winner fetch per element under `->`). The bare
+  `[*]` is the element SET and is refused in `where=`, naming the three fold tokens; a quantifier pointed at a field
+  that is not a list on the scanned records is named in the scan's accounting with what that step read instead, never
+  counted as a silent non-match. Reaching a list with a dotted segment still refuses, and its remedy now offers the
+  quantified spelling alongside the bracketed index.
+- **`where=` gains the two exclusion folds of `has`, and `references=` gains a negated entry.**
+  `BodyTemplate.FirstPersonFlags has_any 44,45` is true when at least one operand bit is set and `has_none` when
+  none is, beside the existing `has` (every operand bit set). A `!` before a `references=` entry inverts it —
+  `references=["!XXXXXX:A.esm"]` keeps only the records that do NOT reference that target — and plain and negated
+  entries in one call compose by AND. The negated form takes the same bounding `types=`/`plugins=`/`formids=` scope
+  the plain form takes.
 - **`housecarl_load_order_status` now names the running server's build in its header** — a `server:` line carrying
   the informational version the binary embeds (the release version `build-plugin.ps1` stamps from `plugin.json`,
   then `+` and the full commit sha: `1.9.5-dev+e942910…`), so checking that the installed houseCARL is the build you expect no longer means

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -61,8 +61,9 @@ saying it sets an expectation their install may contradict. Say what is known, a
   none is, beside the existing `has` (every operand bit set). The operand names flag bits — a flag name, a
   comma-separated list of them, or a bit mask (`0xC000`) — never a biped slot number. A `!` before a `references=` entry inverts it —
   `references=["!XXXXXX:A.esm"]` keeps only the records that do NOT reference that target — and plain and negated
-  entries in one call compose by AND. The negated form takes the same bounding `types=`/`plugins=`/`formids=` scope
-  the plain form takes.
+  entries in one call compose by AND. The sigil takes the `@file` spelling the plain entry takes, so
+  `references=["!@C:/work/targets.jsonl"]` excludes every target a list file or result artifact names. The negated
+  form takes the same bounding `types=`/`plugins=`/`formids=` scope the plain form takes.
 - **`housecarl_load_order_status` now names the running server's build in its header** — a `server:` line carrying
   the informational version the binary embeds (the release version `build-plugin.ps1` stamps from `plugin.json`,
   then `+` and the full commit sha: `1.9.5-dev+e942910…`), so checking that the installed houseCARL is the build you expect no longer means

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -49,12 +49,16 @@ saying it sets an expectation their install may contradict. Say what is known, a
   A quantified step composes with the `->` link step and with another quantified step, at the cost the tool
   description declares (per-candidate work times list length, and one winner fetch per element under `->`). The bare
   `[*]` is the element SET and is refused in `where=`, naming the three fold tokens; a quantifier pointed at a field
-  that is not a list on the scanned records is named in the scan's accounting with what that step read instead, never
-  counted as a silent non-match. Reaching a list with a dotted segment still refuses, and its remedy now offers the
-  quantified spelling alongside the bracketed index.
+  that is not a list — a scalar, a dict, a raw byte block — is named in the scan's accounting with what that step read
+  instead, never counted as a silent non-match. An absent list reads as EMPTY, and so does one whose parent substruct
+  is absent, so `VirtualMachineAdapter.Scripts[*count] = 0` finds the records that carry no script at all; where an
+  element cannot be judged, the fold reports no verdict rather than claiming one. Reaching a list with a dotted
+  segment still refuses, and its remedy now offers the quantified spelling alongside the bracketed index.
+  `project.fields` does not take these tokens yet and refuses them by name.
 - **`where=` gains the two exclusion folds of `has`, and `references=` gains a negated entry.**
-  `BodyTemplate.FirstPersonFlags has_any 44,45` is true when at least one operand bit is set and `has_none` when
-  none is, beside the existing `has` (every operand bit set). A `!` before a `references=` entry inverts it —
+  `BodyTemplate.FirstPersonFlags has_any Head,Hands` is true when at least one operand bit is set and `has_none` when
+  none is, beside the existing `has` (every operand bit set). The operand names flag bits — a flag name, a
+  comma-separated list of them, or a bit mask (`0xC000`) — never a biped slot number. A `!` before a `references=` entry inverts it —
   `references=["!XXXXXX:A.esm"]` keeps only the records that do NOT reference that target — and plain and negated
   entries in one call compose by AND. The negated form takes the same bounding `types=`/`plugins=`/`formids=` scope
   the plain form takes.

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -56,6 +56,45 @@ public sealed class CorpusRulebook
     public int TypeCount => _corpus.TotalTypes;
     public TypeSchema? Type(string name) => _corpus.Types.GetValueOrDefault(name);
 
+    /// <summary>The record types a scope token names — a catalog name, a 4-char signature, or a polymorphic-base
+    /// whose arms are records. Empty where the token names none, which is never a refusal here: the caller's own
+    /// type resolution has already refused an unknown type.</summary>
+    public IReadOnlyList<TypeSchema> RecordTypesNamed(string token)
+    {
+        var t = token.Trim();
+        var hits = new List<TypeSchema>();
+        foreach (var ts in _corpus.Types.Values)
+        {
+            if (ts.Kind == "record"
+                && (string.Equals(ts.Name, t, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(ts.Signature, t, StringComparison.OrdinalIgnoreCase)))
+                hits.Add(ts);
+            else if (ts.Kind == "polymorphic-base" && ts.Arms is { Count: > 0 } arms
+                     && string.Equals(ts.Name, t, StringComparison.OrdinalIgnoreCase))
+                foreach (var arm in arms)
+                    if (Type(arm) is { Kind: "record" } a && !hits.Contains(a)) hits.Add(a);
+        }
+        return hits;
+    }
+
+    /// <summary>The cardinality the schema gives one step of a read path, rooted at <paramref name="root"/> — "list",
+    /// "dict", "substruct", "value", and so on. Null where the schema cannot say (a hop it cannot descend, a field it
+    /// does not know, a polymorphic disagreement), which a caller must read as "no answer", never as a refusal.</summary>
+    public string? StepCardinality(TypeSchema root, IReadOnlyList<string> path, int index)
+    {
+        var current = root;
+        for (int i = 0; i < index; i++)
+        {
+            var hop = FindField(current, path[i], out _, out var hopErr);
+            if (hop is null || hopErr is not null) return null;
+            if (hop.Cardinality is not ("substruct" or "polymorphic") || hop.TypeRef is not { } tr) return null;
+            if (Type(tr) is not { } next) return null;
+            current = next;
+        }
+        var field = FindField(current, path[index], out _, out var err);
+        return err is null ? field?.Cardinality : null;
+    }
+
     /// <summary>The ONE source of truth for where corpus.json lives — every corpus read in the core
     /// resolves through it. Defaults to the dev-harness location ("generated/corpus.json", relative to
     /// the CWD, which is the repo root when the harness runs). The MCP server is launched by MO2 from an

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -802,7 +802,9 @@ public sealed class FieldPredicateSet
         if (WriteEngine.ClosedInterface(t, typeof(IList<>)) is not null
             || WriteEngine.ClosedInterface(t, typeof(IReadOnlyList<>)) is not null)
             return null;
-        return $"a single {RecordNaming.StripOverlay((val?.GetType() ?? t).Name)} value";
+        // Both strips, in that order: a CARRIED value reflects as BodyTemplateBinaryOverlay and a null one falls back
+        // to the declared IBodyTemplateGetter, so without both the same field is named two ways on two records.
+        return $"a single {RecordNaming.StripGetterInterface(RecordNaming.StripOverlay((val?.GetType() ?? t).Name))} value";
     }
 
     /// <summary>Fold one step's element verdicts into the record's. Same accounting shape

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -180,10 +180,14 @@ public sealed class FieldPredicateSet
     /// <summary>One quantified step of one predicate: the segments of the side it sits on, which one carries the
     /// fold, how it is spelled, and the predicate's own text for the message. A scan with a NAMED type scope walks
     /// these against the schema, so "that step is not a list on this type" refuses the call rather than becoming a
-    /// whole-scan accounting note.</summary>
-    public readonly record struct QuantifiedStep(IReadOnlyList<string> Path, int Index, string Token, string Text);
+    /// whole-scan accounting note. <paramref name="OnScannedType"/> says whether the step is rooted at the SCANNED
+    /// record type: the right side of a <c>-&gt;</c> is rooted at the link TARGET's type instead, and asking the
+    /// scanned type's schema about it would judge a field it was never on.</summary>
+    public readonly record struct QuantifiedStep(IReadOnlyList<string> Path, int Index, string Token, string Text,
+                                                 bool OnScannedType);
 
-    /// <summary>Every quantified step in the set, both sides of a <c>-&gt;</c> included.</summary>
+    /// <summary>Every quantified step in the set, both sides of a <c>-&gt;</c> included — each saying which type it
+    /// is rooted at.</summary>
     public IReadOnlyList<QuantifiedStep> QuantifiedSteps
     {
         get
@@ -191,16 +195,18 @@ public sealed class FieldPredicateSet
             var steps = new List<QuantifiedStep>();
             foreach (var p in _predicates)
             {
-                Collect(p.LinkPath, p.LinkFolds, p);
-                Collect(p.PathSegments, p.PathFolds, p);
+                // The link side always roots at the scanned type; the path side does only when there is no link,
+                // because with one it is the tail read on the resolved target.
+                Collect(p.LinkPath, p.LinkFolds, p, true);
+                Collect(p.PathSegments, p.PathFolds, p, p.LinkPath is null);
             }
             return steps;
 
-            void Collect(string[]? segs, Fold[]? folds, Predicate p)
+            void Collect(string[]? segs, Fold[]? folds, Predicate p, bool onScanned)
             {
                 if (segs is null || folds is null) return;
                 for (int i = 0; i < segs.Length && i < folds.Length; i++)
-                    if (folds[i] != Fold.None) steps.Add(new QuantifiedStep(segs, i, FoldToken(folds[i]), p.Text));
+                    if (folds[i] != Fold.None) steps.Add(new QuantifiedStep(segs, i, FoldToken(folds[i]), p.Text, onScanned));
             }
         }
     }

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -177,6 +177,34 @@ public sealed class FieldPredicateSet
     /// <summary>Candidate bodies tested so far — the denominator the accounting reports against.</summary>
     public long Scanned => _scanned;
 
+    /// <summary>One quantified step of one predicate: the segments of the side it sits on, which one carries the
+    /// fold, how it is spelled, and the predicate's own text for the message. A scan with a NAMED type scope walks
+    /// these against the schema, so "that step is not a list on this type" refuses the call rather than becoming a
+    /// whole-scan accounting note.</summary>
+    public readonly record struct QuantifiedStep(IReadOnlyList<string> Path, int Index, string Token, string Text);
+
+    /// <summary>Every quantified step in the set, both sides of a <c>-&gt;</c> included.</summary>
+    public IReadOnlyList<QuantifiedStep> QuantifiedSteps
+    {
+        get
+        {
+            var steps = new List<QuantifiedStep>();
+            foreach (var p in _predicates)
+            {
+                Collect(p.LinkPath, p.LinkFolds, p);
+                Collect(p.PathSegments, p.PathFolds, p);
+            }
+            return steps;
+
+            void Collect(string[]? segs, Fold[]? folds, Predicate p)
+            {
+                if (segs is null || folds is null) return;
+                for (int i = 0; i < segs.Length && i < folds.Length; i++)
+                    if (folds[i] != Fold.None) steps.Add(new QuantifiedStep(segs, i, FoldToken(folds[i]), p.Text));
+            }
+        }
+    }
+
     // ======================================================================
     //  PARSE — "<path> <op> <value>", longest-match the operator.
     //  The path is dotted/bracketed identifiers (no whitespace, no operator

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -33,8 +33,14 @@ namespace HousecarlCore;
 /// membership is <c>references=</c>'s job. The PRESENCE operators (<c>exists</c>/<c>missing</c>) are the exception:
 /// they DO match a carried substruct/list leaf (present and non-empty), the "which records carry a VMAD/Effects"
 /// query. The MEMBERSHIP operators (<c>formid in</c>/<c>formid not in</c> a supplied list) are the other non-leaf
-/// case: they test the record's IDENTITY against a pre-parsed FormKey set, no read walk at all.
-/// A wildcard over a list (<c>Effects[*].Magnitude &gt; 50</c>) is a deliberate future extension.</para>
+/// case: they test the record's IDENTITY against a pre-parsed FormKey set, no read walk at all.</para>
+///
+/// <para><b>The quantified step.</b> A path step may declare its multiplicity and its fold where it binds:
+/// <c>Conditions[*any].Data.Function = IsGuard</c>, <c>Effects[*none].BaseEffect-&gt;editorid startswith REQ_</c>,
+/// <c>Effects[*count] &gt; 2</c>. <c>[*any]</c>/<c>[*all]</c>/<c>[*none]</c> fold the elements into a boolean and
+/// <c>[*count]</c> into their number; the bare <c>[*]</c> is the element SET and is refused here (a set is not a
+/// boolean). The fold is the same one <see cref="EvalLinkStep"/> already runs over link targets, with the fan-out
+/// source swapped to the step's elements — so it composes with the <c>-&gt;</c> link step and with itself.</para>
 /// </summary>
 public sealed class FieldPredicateSet
 {
@@ -44,7 +50,9 @@ public sealed class FieldPredicateSet
     /// <see cref="Has"/> is a BITWISE set-test for a <c>[Flags]</c> enum (or plain integer) leaf — true iff every
     /// bit of the operand is set on the field, regardless of other bits — so a multi-slot BodyTemplate still
     /// matches the one slot asked for, which <see cref="Eq"/> (exact value) and the range ops cannot express. Its
-    /// operand is a bit value (decimal or <c>0x</c> hex) or a flag NAME.
+    /// operand is a bit value (decimal or <c>0x</c> hex) or a flag NAME. <see cref="HasAny"/> and
+    /// <see cref="HasNone"/> are the other two folds over the SAME bits — any bit of the operand set, and none of
+    /// them set — the exclusion terms a slot sweep needs, spelled to match the path step's any/all/none.
     /// <see cref="Exists"/>/<see cref="Missing"/> are PRESENCE tests that take NO operand — true iff the path
     /// resolves to a present, NON-EMPTY value (a scalar OR a carried substruct/list) / its complement. They are the
     /// only operators that MATCH a no-value container leaf: the "which records CARRY a VirtualMachineAdapter /
@@ -55,7 +63,13 @@ public sealed class FieldPredicateSet
     /// read cleave where identity sits beside Fields) and a list operand: inline comma-separated FormIDs, or
     /// <c>@&lt;absolute path&gt;</c> naming a file of them. Restricted to <c>formid</c> at parse (a named refusal on any
     /// other path) so a future generalization to leaf-value membership is an extension, not a behavior change.</summary>
-    enum Op { Eq, Ne, Gt, Ge, Lt, Le, Contains, StartsWith, Has, Exists, Missing, In, NotIn }
+    enum Op { Eq, Ne, Gt, Ge, Lt, Le, Contains, StartsWith, Has, HasAny, HasNone, Exists, Missing, In, NotIn }
+
+    /// <summary>A path step's declared multiplicity and fold. <see cref="None"/> is an ordinary step;
+    /// <see cref="Set"/> is the bare <c>[*]</c> (the element set — a PROJECT reading, refused in a predicate);
+    /// <see cref="Any"/>/<see cref="All"/>/<see cref="NoneOf"/> fold the elements into a boolean and
+    /// <see cref="Count"/> into their number.</summary>
+    enum Fold { None, Set, Any, All, NoneOf, Count }
 
     /// <summary>One parsed predicate: the split path segments (fed straight to <see cref="ReadEngine.ReadLeaf"/>),
     /// the operator, the raw operand, and — for a numeric operator — the operand pre-parsed to a double (validated
@@ -63,11 +77,15 @@ public sealed class FieldPredicateSet
     /// <paramref name="FormIds"/> is the pre-parsed membership set for <see cref="Op.In"/>/<see cref="Op.NotIn"/>
     /// (file already read + every token validated at parse — the scan never does IO), null for every other op.
     /// <paramref name="Artifact"/> is non-null when the list came from a result ARTIFACT: the epoch obligation the
-    /// consuming scan must check against the build it captures (see <see cref="ArtifactDemands"/>).</summary>
+    /// consuming scan must check against the build it captures (see <see cref="ArtifactDemands"/>).
+    /// <paramref name="PathFolds"/> / <paramref name="LinkFolds"/> are parallel to the segments of their side and
+    /// carry each step's quantifier, null when that side has none — the segments themselves are stored bare, so
+    /// the read walk sees an ordinary field name.</summary>
     sealed record Predicate(string Text, string[] PathSegments, string PathDisplay, Op Op, string Operand, double NumericOperand,
                             HashSet<FormKey>? FormIds = null, ArtifactDemand? Artifact = null,
                             string[]? LinkPath = null, string? LinkPathDisplay = null,
-                            PseudoPath Pseudo = PseudoPath.None, IReadOnlyList<string>? RawMembers = null);
+                            PseudoPath Pseudo = PseudoPath.None, IReadOnlyList<string>? RawMembers = null,
+                            Fold[]? PathFolds = null, Fold[]? LinkFolds = null);
 
     /// <summary>The identity pseudo-paths a predicate may name instead of a body leaf. <c>editorid</c> reads the
     /// record's EditorID (always available off the early EDID subrecord — never a reflection walk, and live even on
@@ -86,6 +104,8 @@ public sealed class FieldPredicateSet
     readonly long[] _listHop;     // per-predicate SUBSET of _noField: the path hopped THROUGH a list/dict with a dotted segment (a missing bracket, not a mistyped name)
     readonly string?[] _listHopOwner;  // the collection field the hop dead-ended on, for the remedy sentence
     readonly string?[] _listHopRemedy; // the leaf-checked remedy the read engine composed for that hop, quoted verbatim
+    readonly long[] _notList;     // per-predicate SUBSET of _noField: a quantified step landed on a value that is not a list — the fold has nothing to fan out over
+    readonly string?[] _notListWhat;   // what that step actually read, for the sentence
     long _scanned;
     string? _fatal;
 
@@ -138,6 +158,8 @@ public sealed class FieldPredicateSet
         _listHop = new long[predicates.Count];
         _listHopOwner = new string?[predicates.Count];
         _listHopRemedy = new string?[predicates.Count];
+        _notList = new long[predicates.Count];
+        _notListWhat = new string?[predicates.Count];
     }
 
     /// <summary>Set once when a numeric operator meets a non-numeric field value on the first value-bearing
@@ -198,7 +220,7 @@ public sealed class FieldPredicateSet
         // 2. skip whitespace to the operator.
         while (i < text.Length && char.IsWhiteSpace(text[i])) i++;
         if (i >= text.Length)
-            return (null, $"predicate '{raw}': no operator. Use one of = != > >= < <= contains startswith has exists missing in 'not in', e.g. \"{path} = <value>\" or \"{path} exists\".");
+            return (null, $"predicate '{raw}': no operator. Use one of = != > >= < <= contains startswith has has_any has_none exists missing in 'not in', e.g. \"{path} = <value>\" or \"{path} exists\".");
 
         // 3. operator — symbolic (longest match) or the 'contains' word.
         Op op;
@@ -211,7 +233,7 @@ public sealed class FieldPredicateSet
             else if (text[i] == '=') { op = Op.Eq; after = i + 1; }
             else if (text[i] == '>') { op = Op.Gt; after = i + 1; }
             else if (text[i] == '<') { op = Op.Lt; after = i + 1; }
-            else return (null, $"predicate '{raw}': unrecognized operator at '{text.Substring(i)}'. Use = != > >= < <= contains startswith has exists missing in 'not in'.");
+            else return (null, $"predicate '{raw}': unrecognized operator at '{text.Substring(i)}'. Use = != > >= < <= contains startswith has has_any has_none exists missing in 'not in'.");
         }
         else
         {
@@ -221,6 +243,8 @@ public sealed class FieldPredicateSet
             if (word.Equals("contains", StringComparison.OrdinalIgnoreCase)) op = Op.Contains;
             else if (word.Equals("startswith", StringComparison.OrdinalIgnoreCase)) op = Op.StartsWith;
             else if (word.Equals("has", StringComparison.OrdinalIgnoreCase)) op = Op.Has;
+            else if (word.Equals("has_any", StringComparison.OrdinalIgnoreCase)) op = Op.HasAny;
+            else if (word.Equals("has_none", StringComparison.OrdinalIgnoreCase)) op = Op.HasNone;
             else if (word.Equals("exists", StringComparison.OrdinalIgnoreCase)) op = Op.Exists;
             else if (word.Equals("missing", StringComparison.OrdinalIgnoreCase)) op = Op.Missing;
             else if (word.Equals("in", StringComparison.OrdinalIgnoreCase)) op = Op.In;
@@ -235,7 +259,7 @@ public sealed class FieldPredicateSet
                 op = Op.NotIn; w = w2;
             }
             else
-                return (null, $"predicate '{raw}': unrecognized operator '{word}'. Use = != > >= < <= contains startswith has exists missing in or 'not in'.");
+                return (null, $"predicate '{raw}': unrecognized operator '{word}'. Use = != > >= < <= contains startswith has has_any has_none exists missing in or 'not in'.");
             after = w;
         }
 
@@ -268,6 +292,22 @@ public sealed class FieldPredicateSet
         if (segs.Length == 0)
             return (null, $"predicate '{raw}': '{path}' is not a usable field path.");
 
+        // The quantified step: each side's segments are split into bare field names plus their fold tokens, so the
+        // read walk below sees an ordinary path and the fold rides beside it.
+        Fold[]? linkFolds = null;
+        if (linkSegs is not null)
+        {
+            var (lsegs, lfolds, lferr) = SplitFolds(raw, linkSegs, linkSide: true);
+            if (lferr is not null) return (null, lferr);
+            linkSegs = lsegs; linkFolds = lfolds;
+        }
+        var (psegs, pathFolds, pferr) = SplitFolds(raw, segs, linkSide: false);
+        if (pferr is not null) return (null, pferr);
+        segs = psegs;
+        if (pathFolds is not null && pathFolds[^1] == Fold.Count
+            && op is not (Op.Eq or Op.Ne or Op.Gt or Op.Ge or Op.Lt or Op.Le or Op.In or Op.NotIn))
+            return (null, $"predicate '{raw}': '[*count]' yields the number of elements — compare it with = != > >= < <= or in / 'not in' (got '{OpStr(op)}').");
+
         // Pseudo-path classification: 'editorid' (the record's EditorID), 'winner' (the provenance term — which
         // plugin WINS the record, resolution not content), 'formid' (the membership ops' identity path).
         var pseudo = segs.Length == 1 && !path.Contains('[')
@@ -285,7 +325,7 @@ public sealed class FieldPredicateSet
             if (op is not (Op.Eq or Op.Ne))
                 return (null, $"predicate '{raw}': 'winner' is the provenance term (which plugin WINS the record) and takes '=' or '!=' with a plugin filename — e.g. \"winner = Requiem.esp\".");
         }
-        if (pseudo == PseudoPath.EditorId && op is Op.Gt or Op.Ge or Op.Lt or Op.Le or Op.Has)
+        if (pseudo == PseudoPath.EditorId && op is Op.Gt or Op.Ge or Op.Lt or Op.Le or Op.Has or Op.HasAny or Op.HasNone)
             return (null, $"predicate '{raw}': 'editorid' is a text term — use = != contains startswith exists missing in 'not in' (got '{OpStr(op)}').");
 
         // A presence op (exists/missing) takes NO operand — a trailing value is a mistake, refused loud rather than
@@ -296,7 +336,7 @@ public sealed class FieldPredicateSet
                 return (null, $"predicate '{raw}': '{path}' always exists (every record has an identity and a winner) — a presence test on it can never filter. Use it with its own operators instead.");
             if (operand.Length != 0)
                 return (null, $"predicate '{raw}': '{OpStr(op)}' is a presence test and takes no value (got '{operand}'). Write it as \"{path} {OpStr(op)}\".");
-            return (new Predicate(text, segs, path, op, "", 0, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo), null);
+            return (new Predicate(text, segs, path, op, "", 0, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo, PathFolds: pathFolds, LinkFolds: linkFolds), null);
         }
 
         if (operand.Length == 0)
@@ -317,11 +357,11 @@ public sealed class FieldPredicateSet
             {
                 var (set, artifact, lerr) = ParseFormIdList(text, operand, parseFormId);
                 if (lerr is not null) return (null, lerr);
-                return (new Predicate(text, segs, path, op, operand, 0, set, artifact, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo), null);
+                return (new Predicate(text, segs, path, op, operand, 0, set, artifact, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo, PathFolds: pathFolds, LinkFolds: linkFolds), null);
             }
             var (members, mset, martifact, merr) = ParseValueList(text, operand);
             if (merr is not null) return (null, merr);
-            return (new Predicate(text, segs, path, op, operand, 0, mset, martifact, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo, RawMembers: members), null);
+            return (new Predicate(text, segs, path, op, operand, 0, mset, martifact, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo, RawMembers: members, PathFolds: pathFolds, LinkFolds: linkFolds), null);
         }
         if (pseudo == PseudoPath.FormId)
             return (null, $"predicate '{raw}': 'formid' takes the membership ops only — \"formid in <list>\" / \"formid not in <list>\" (a single record is \"formid in [XXXXXX:Plugin.esp]\").");
@@ -331,8 +371,53 @@ public sealed class FieldPredicateSet
         if (IsNumericOp(op) && !TryNum(operand, out num))
             return (null, $"predicate '{raw}': operator '{OpStr(op)}' needs a numeric value, got '{operand}'.");
 
-        return (new Predicate(text, segs, path, op, operand, num, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo), null);
+        return (new Predicate(text, segs, path, op, operand, num, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo, PathFolds: pathFolds, LinkFolds: linkFolds), null);
     }
+
+    /// <summary>Split one side's segments into bare field names plus their fold tokens: a bracket key beginning
+    /// <c>*</c> is a quantifier, and every other bracket key stays an ordinary index/dict key. Returns the first
+    /// refusal instead — an unknown quantifier word, the bare <c>[*]</c> set token (which is not a boolean), a
+    /// <c>[*count]</c> that is not the end of the path, or one on the link side (a number carries no link).</summary>
+    static (string[] Segs, Fold[]? Folds, string? Error) SplitFolds(string raw, string[] segs, bool linkSide)
+    {
+        Fold[]? folds = null;
+        var outSegs = segs;
+        for (int i = 0; i < segs.Length; i++)
+        {
+            var s = segs[i];
+            int open = s.IndexOf('[');
+            if (open < 0 || !s.EndsWith("]", StringComparison.Ordinal)) continue;
+            var key = s[(open + 1)..^1];
+            if (key.Length == 0 || key[0] != '*') continue;
+            if (open == 0)
+                return (segs, null, $"predicate '{raw}': '{s}' has no field name before '[' — a quantifier binds to a list field, e.g. 'Conditions{s}'.");
+            var word = key[1..];
+            var f = word.Length == 0 ? Fold.Set
+                  : word.Equals("any", StringComparison.OrdinalIgnoreCase) ? Fold.Any
+                  : word.Equals("all", StringComparison.OrdinalIgnoreCase) ? Fold.All
+                  : word.Equals("none", StringComparison.OrdinalIgnoreCase) ? Fold.NoneOf
+                  : word.Equals("count", StringComparison.OrdinalIgnoreCase) ? Fold.Count
+                  : Fold.None;
+            if (f == Fold.None)
+                return (segs, null, $"predicate '{raw}': '[{key}]' is not a quantifier — the tokens are [*any], [*all], [*none] and [*count].");
+            if (f == Fold.Set)
+                return (segs, null, $"predicate '{raw}': '[*]' yields the element SET, and a set is not a boolean — name the fold in the step: [*any], [*all] or [*none] (or [*count] for the number of elements).");
+            if (f == Fold.Count && linkSide)
+                return (segs, null, $"predicate '{raw}': '[*count]' yields a NUMBER, which carries no '->' link step — count on the predicate's own path instead.");
+            if (f == Fold.Count && i != segs.Length - 1)
+                return (segs, null, $"predicate '{raw}': nothing can follow '[*count]' — it yields how MANY elements there are, not an element to step into.");
+            if (folds is null) { folds = new Fold[segs.Length]; outSegs = (string[])segs.Clone(); }
+            folds[i] = f;
+            outSegs[i] = s[..open];
+        }
+        return (outSegs, folds, null);
+    }
+
+    /// <summary>The token a fold is spelled with, for a message.</summary>
+    static string FoldToken(Fold f) => f switch
+    {
+        Fold.Set => "[*]", Fold.Any => "[*any]", Fold.All => "[*all]", Fold.NoneOf => "[*none]", Fold.Count => "[*count]", _ => "",
+    };
 
     /// <summary>Parse a generalized (non-formid) membership list: same separators/wrapping as the formid grammar,
     /// but entries are arbitrary VALUE tokens (enum names, numbers, FormKeys) — validated only for non-emptiness.
@@ -513,6 +598,9 @@ public sealed class FieldPredicateSet
                 // A list hop IS a no-such-field miss, so it keeps that bucket; the extra counter is what lets the
                 // rollup tell a missing bracket from a mistyped name.
                 case EvalKind.ListHop: _noField[k]++; _listHop[k]++; _noValue[k]++; _listHopOwner[k] ??= _lastListHopOwner; _listHopRemedy[k] ??= _lastListHopRemedy; all = false; break;
+                // A quantified step on a non-list IS a no-such-field miss for the rollup; the extra counter is what
+                // lets the sentence say the step's real cardinality rather than "mistyped path".
+                case EvalKind.NotAList: _noField[k]++; _notList[k]++; _noValue[k]++; _notListWhat[k] ??= _lastNotList; all = false; break;
                 case EvalKind.Container: _container[k]++; _noValue[k]++; all = false; break;
                 case EvalKind.Unreadable: _unreadable[k]++; _noValue[k]++; all = false; break;
                 default: _noValue[k]++; all = false; break;   // Unset — a valid, value-less path
@@ -524,7 +612,7 @@ public sealed class FieldPredicateSet
     /// <summary>How one predicate's evaluation on one record resolved: a DEFINITE verdict (the value was read and
     /// compared, or an identity/presence test decided), or one of the no-verdict classes the accounting keys on.
     /// Mirrors the leaf-note vocabulary: no-such-field / container / read-fault / genuinely-unset.</summary>
-    enum EvalKind { Definite, NoField, ListHop, Container, Unreadable, Unset }
+    enum EvalKind { Definite, NoField, ListHop, NotAList, Container, Unreadable, Unset }
 
     /// <summary>The collection field named by the most recent list-hop note, stashed for the rollup.</summary>
     string? _lastListHopOwner;
@@ -533,6 +621,9 @@ public sealed class FieldPredicateSet
     /// TYPE in hand and checked the trailing segment against it. The rollup quotes this rather than composing its
     /// own, so the per-record leaf note and the whole-scan sentence cannot disagree about the same path.</summary>
     string? _lastListHopRemedy;
+
+    /// <summary>What a quantified step actually read where it was not a list, stashed for the rollup sentence.</summary>
+    string? _lastNotList;
 
     /// <summary>Sentence-case a remedy fragment lifted from a leaf note, which is composed lowercase to read
     /// mid-sentence there. Leading punctuation (a quoted field name) passes through unchanged.</summary>
@@ -609,8 +700,92 @@ public sealed class FieldPredicateSet
             return (p.Op == Op.In ? member : !member, EvalKind.Definite);
         }
 
-        var leaf = ReadEngine.ReadLeaf(body, p.PathSegments);   // internal, same assembly — the by-construction read walk
+        // The body-leaf side, quantified steps and all.
+        return EvalOwnPath(p, body, 0);
+    }
 
+    /// <summary>The predicate's own (non-link) path from segment <paramref name="from"/> down: an ordinary tail
+    /// reads its leaf, a quantified step navigates to the collection and folds the elements. Recurses, so a second
+    /// quantified step inside the first composes without a second rule.</summary>
+    (bool Satisfied, EvalKind Kind) EvalOwnPath(Predicate p, object obj, int from)
+    {
+        var segs = p.PathSegments;
+        int q = FirstFold(p.PathFolds, from, segs.Length);
+        if (q < 0)
+            return DecideLeaf(p, ReadEngine.ReadLeaf(obj, from == 0 ? segs : segs[from..]));   // internal, same assembly — the by-construction read walk
+
+        var (elems, parent, miss) = ElementsAt(obj, segs, p.PathFolds!, from, q);
+        if (miss is { } m) return (false, m);
+        var fold = p.PathFolds![q];
+        if (fold == Fold.Count) return DecideLeaf(p, ReadEngine.LeafRead.Value(elems!.Count.ToString(CultureInfo.InvariantCulture)));
+        return FoldOver(p, elems!, fold,
+                        e => q + 1 >= segs.Length ? DecideLeaf(p, ReadEngine.EmitToken(e, e.GetType(), parent!))
+                                                  : EvalOwnPath(p, e, q + 1));
+    }
+
+    /// <summary>The first quantified step at or after <paramref name="from"/>, or -1.</summary>
+    static int FirstFold(Fold[]? folds, int from, int len)
+    {
+        if (folds is null) return -1;
+        for (int i = from; i < len; i++) if (folds[i] != Fold.None) return i;
+        return -1;
+    }
+
+    /// <summary>Navigate to a quantified step's collection and hand back its elements (with the collection's owning
+    /// parent, which the element's token emit needs). An ABSENT collection reads as EMPTY — the same reading
+    /// <see cref="ReadEngine.KeywordKeys"/> already gives a record with no list. A step that is not a list at all
+    /// is a named no-verdict, never a silent non-match.</summary>
+    (List<object>? Elements, object? Parent, EvalKind? Miss) ElementsAt(object obj, string[] segs, Fold[] folds, int from, int q)
+    {
+        var (ok, val, parent, note) = ReadEngine.NavigateTo(obj, segs[from..(q + 1)]);
+        if (!ok) return (null, null, ClassifyMiss(note ?? ""));
+        if (val is null) return (new List<object>(), parent, null);
+        if (val is string || val is not System.Collections.IEnumerable en)
+        {
+            _lastNotList = $"'{segs[q]}{FoldToken(folds[q])}' reads as a single " +
+                           $"{RecordNaming.StripOverlay(val.GetType().Name)} value, not a list";
+            return (null, null, EvalKind.NotAList);
+        }
+        var list = new List<object>();
+        foreach (var e in en) if (e is not null) list.Add(e);
+        return (list, parent, null);
+    }
+
+    /// <summary>Fold one step's element verdicts into the record's. Same accounting shape
+    /// <see cref="EvalLinkStep"/> uses over link targets: a definite verdict decides, and where no element could be
+    /// judged the no-verdict class carries out rather than a silent non-match. An EMPTY list is a definite verdict
+    /// — <c>[*all]</c> and <c>[*none]</c> are vacuously true on it, <c>[*any]</c> false.</summary>
+    (bool Satisfied, EvalKind Kind) FoldOver(Predicate p, List<object> elems, Fold fold, Func<object, (bool, EvalKind)> eval)
+    {
+        if (elems.Count == 0) return (fold != Fold.Any, EvalKind.Definite);
+        bool anyVerdict = false, anyTrue = false, anyFalse = false, anyNoField = false, anyListHop = false;
+        foreach (var e in elems)
+        {
+            var (sat, kind) = eval(e);
+            if (_fatal is not null) return (false, EvalKind.Definite);
+            if (kind == EvalKind.Definite) { anyVerdict = true; if (sat) anyTrue = true; else anyFalse = true; }
+            else if (kind is EvalKind.NoField or EvalKind.ListHop or EvalKind.NotAList)
+            { anyNoField = true; anyListHop |= kind == EvalKind.ListHop; }
+        }
+        if (fold == Fold.Any && anyTrue) return (true, EvalKind.Definite);
+        if (fold == Fold.NoneOf && anyTrue) return (false, EvalKind.Definite);
+        if (fold == Fold.All && anyFalse) return (false, EvalKind.Definite);
+        if (anyVerdict) return (fold != Fold.Any, EvalKind.Definite);
+        return (false, anyNoField ? (anyListHop ? EvalKind.ListHop : EvalKind.NoField) : EvalKind.Unreadable);
+    }
+
+    /// <summary>Classify a navigation miss into the no-verdict vocabulary the accounting keys on.</summary>
+    EvalKind ClassifyMiss(string note)
+    {
+        if (note.StartsWith("(no field", StringComparison.Ordinal)) return ClassifyNoField(note);
+        if (note.StartsWith("(unreadable", StringComparison.Ordinal)) return EvalKind.Unreadable;
+        return EvalKind.Unset;
+    }
+
+    /// <summary>Decide one predicate against one leaf read — the shared tail of the plain path, a quantified step's
+    /// element, and a <c>[*count]</c>'s number, so the three cannot drift on what an operator means.</summary>
+    (bool Satisfied, EvalKind Kind) DecideLeaf(Predicate p, ReadEngine.LeafRead leaf)
+    {
         // Presence ops (exists/missing) are the ONE case where a no-value CONTAINER leaf is a MATCH, not a miss:
         // they test whether the path resolves to a present, non-empty value (a scalar OR a carried
         // substruct/list), the "which records carry a VMAD/Effects/Conditions" query the value ops can't express.
@@ -675,7 +850,33 @@ public sealed class FieldPredicateSet
             _fatal = "internal: a '->' link-step predicate was evaluated without a bound resolution context — this scan surface does not support it.";
             return (false, EvalKind.Definite);
         }
-        var (links, note) = ReadEngine.CollectLinksAt(body, p.LinkPath!);
+        return EvalLinkPath(p, body, 0);
+    }
+
+    /// <summary>The link step's left path from segment <paramref name="from"/> down. A quantified step there folds
+    /// the per-element link steps ("no effect whose BaseEffect is a REQ_ one"), which is one winner fetch per
+    /// element — the declared cost.</summary>
+    (bool Satisfied, EvalKind Kind) EvalLinkPath(Predicate p, object obj, int from)
+    {
+        var segs = p.LinkPath!;
+        int q = FirstFold(p.LinkFolds, from, segs.Length);
+        if (q >= 0)
+        {
+            var (elems, _, miss) = ElementsAt(obj, segs, p.LinkFolds!, from, q);
+            if (miss is { } m) return (false, m);
+            return FoldOver(p, elems!, p.LinkFolds![q],
+                            e => q + 1 >= segs.Length
+                                 ? JudgeTargets(p, ReadEngine.LinksIn(e, p.LinkPathDisplay ?? ""))
+                                 : EvalLinkPath(p, e, q + 1));
+        }
+        return JudgeTargets(p, ReadEngine.CollectLinksAt(obj, from == 0 ? segs : segs[from..]));
+    }
+
+    /// <summary>Resolve one collected link set to its winner bodies and judge the predicate's own side on them —
+    /// satisfied iff ANY target satisfies.</summary>
+    (bool Satisfied, EvalKind Kind) JudgeTargets(Predicate p, (List<FormKey>? Links, string? Note) collected)
+    {
+        var (links, note) = collected;
         if (links is null)
         {
             var n = note ?? "";
@@ -733,7 +934,7 @@ public sealed class FieldPredicateSet
         var flags = leaf.Flags;   // non-null iff the leaf is a [Flags] enum — carries (bit pattern, enum type)
         switch (p.Op)
         {
-            case Op.Has:
+            case Op.Has or Op.HasAny or Op.HasNone:
                 return CompareHas(p, token, flags);
 
             case Op.Gt or Op.Ge or Op.Lt or Op.Le:
@@ -779,19 +980,25 @@ public sealed class FieldPredicateSet
         {
             leafBits = fi.Bits;
             if (!TryResolveBits(p.Operand, fi.EnumType, out opBits))
-                return (false, $"predicate '{p.Text}': 'has' value '{p.Operand}' is not a bit value or a valid {fi.EnumType.Name} flag name.");
+                return (false, $"predicate '{p.Text}': '{OpStr(p.Op)}' value '{p.Operand}' is not a bit value or a valid {fi.EnumType.Name} flag name.");
         }
         else if (TryBits(token, out leafBits))   // a plain integer leaf — bit-test its numeric value
         {
             if (!TryBits(p.Operand, out opBits))
-                return (false, $"predicate '{p.Text}': 'has' value '{p.Operand}' must be a bit value (decimal or 0x hex) for the integer field '{p.PathDisplay}'.");
+                return (false, $"predicate '{p.Text}': '{OpStr(p.Op)}' value '{p.Operand}' must be a bit value (decimal or 0x hex) for the integer field '{p.PathDisplay}'.");
         }
         else
-            return (false, $"predicate '{p.Text}': 'has' needs a flags/bitmask or integer field, but '{p.PathDisplay}' read '{Trunc(token)}', not a number.");
+            return (false, $"predicate '{p.Text}': '{OpStr(p.Op)}' needs a flags/bitmask or integer field, but '{p.PathDisplay}' read '{Trunc(token)}', not a number.");
 
         if (opBits == 0)
-            return (false, $"predicate '{p.Text}': 'has 0' tests no bits — give a non-zero bit value or a flag name.");
-        return ((leafBits & opBits) == opBits, null);
+            return (false, $"predicate '{p.Text}': '{OpStr(p.Op)} 0' tests no bits — give a non-zero bit value or a flag name.");
+        // The three folds over the same bits: every bit of the operand set, at least one set, none set.
+        return (p.Op switch
+        {
+            Op.HasAny => (leafBits & opBits) != 0,
+            Op.HasNone => (leafBits & opBits) == 0,
+            _ => (leafBits & opBits) == opBits,
+        }, null);
     }
 
     /// <summary>Resolve a <c>has</c>/<c>=</c> operand against a [Flags] enum to its bit pattern: a numeric literal
@@ -861,7 +1068,16 @@ public sealed class FieldPredicateSet
                 const string loud = "yielded no readable value on any of";
                 long unset = _noValue[k] - _noField[k] - _container[k] - _unreadable[k];   // what is left: genuinely-unset valid fields
                 string reason;
-                if (_noField[k] == _scanned && _listHop[k] > 0)
+                if (_noField[k] == _scanned && _notList[k] > 0)
+                {
+                    // The quantifier is the thing to drop, and no schema advice fits: the step exists, it is just
+                    // not a list here, and the sentence names what it read instead.
+                    reason = $"predicate field '{path}' {loud} {_scanned:N0} scanned record(s) — the quantified step " +
+                             $"{_notListWhat[k] ?? "named there"} on {_notList[k]:N0} of them, so a fold has no elements to run over" +
+                             (_notList[k] == _scanned ? "" : "; on the rest the path is not a field at all") +
+                             ". Drop the quantifier, or point it at a list-valued field.";
+                }
+                else if (_noField[k] == _scanned && _listHop[k] > 0)
                 {
                     // The deeper, more specific path must not get the vaguer advice: this is a missing bracket, not
                     // a mistyped name, and the schema is the wrong place to send the caller. One list hop is enough
@@ -877,8 +1093,8 @@ public sealed class FieldPredicateSet
                              (owner is not null ? $"'{owner}', which is a list/dict, " : "a list/dict ") +
                              $"with a dotted segment, which dead-ends (on {_listHop[k]:N0} of them" +
                              (_listHop[k] == _scanned ? "" : "; on the rest the path is not a field at all") +
-                             $"). {Capitalize(remedy)}; a wildcard over a list is not supported. " +
-                             "For list->FormID membership use references=.";
+                             $"). {Capitalize(remedy)}; to ask about EVERY element instead, quantify the step " +
+                             "('Effects[*any].Data.Magnitude > 50'). For list->FormID membership use references=.";
                 }
                 else if (_noField[k] == _scanned)
                     reason = $"predicate field '{path}' {loud} {_scanned:N0} scanned record(s) — it is NOT A FIELD on these records " +
@@ -911,7 +1127,8 @@ public sealed class FieldPredicateSet
     static string OpStr(Op op) => op switch
     {
         Op.Eq => "=", Op.Ne => "!=", Op.Gt => ">", Op.Ge => ">=", Op.Lt => "<", Op.Le => "<=",
-        Op.Contains => "contains", Op.StartsWith => "startswith", Op.Has => "has", Op.Exists => "exists", Op.Missing => "missing",
+        Op.Contains => "contains", Op.StartsWith => "startswith", Op.Has => "has", Op.HasAny => "has_any", Op.HasNone => "has_none",
+        Op.Exists => "exists", Op.Missing => "missing",
         Op.In => "in", Op.NotIn => "not in", _ => "?",
     };
 

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -733,46 +733,89 @@ public sealed class FieldPredicateSet
 
     /// <summary>Navigate to a quantified step's collection and hand back its elements (with the collection's owning
     /// parent, which the element's token emit needs). An ABSENT collection reads as EMPTY — the same reading
-    /// <see cref="ReadEngine.KeywordKeys"/> already gives a record with no list. A step that is not a list at all
-    /// is a named no-verdict, never a silent non-match.</summary>
+    /// <see cref="ReadEngine.KeywordKeys"/> already gives a record with no list, and it holds whether the LEAF is
+    /// null or a substruct ABOVE it is (a record with no VirtualMachineAdapter carries no scripts either). A step
+    /// that is not a list at all is a named no-verdict, never a silent non-match — judged on the step's DECLARED
+    /// type, so a null non-list field is refused exactly as a carried one is.</summary>
     (List<object>? Elements, object? Parent, EvalKind? Miss) ElementsAt(object obj, string[] segs, Fold[] folds, int from, int q)
     {
-        var (ok, val, parent, note) = ReadEngine.NavigateTo(obj, segs[from..(q + 1)]);
-        if (!ok) return (null, null, ClassifyMiss(note ?? ""));
-        if (val is null) return (new List<object>(), parent, null);
-        if (val is string || val is not System.Collections.IEnumerable en)
+        var (ok, val, declared, parent, note) = ReadEngine.NavigateTo(obj, segs[from..(q + 1)]);
+        if (!ok)
         {
-            _lastNotList = $"'{segs[q]}{FoldToken(folds[q])}' reads as a single " +
-                           $"{RecordNaming.StripOverlay(val.GetType().Name)} value, not a list";
+            // A mid-path substruct that is absent makes the collection absent, which reads as empty like any other
+            // absent collection. Every other miss (no such field, a read fault) keeps its own no-verdict class.
+            if (note == ReadEngine.AbsentNote) return (new List<object>(), parent, null);
+            return (null, null, ClassifyMiss(note ?? ""));
+        }
+        if (NotListShape(declared, val) is { } what)
+        {
+            _lastNotList = $"'{segs[q]}{FoldToken(folds[q])}' reads as {what}, not a list";
             return (null, null, EvalKind.NotAList);
         }
+        if (val is null) return (new List<object>(), parent, null);
         var list = new List<object>();
-        foreach (var e in en) if (e is not null) list.Add(e);
+        foreach (var e in (System.Collections.IEnumerable)val) if (e is not null) list.Add(e);
         return (list, parent, null);
     }
 
+    /// <summary>What a quantified step actually reads where it is not a list — null when it IS one. Keyed on the
+    /// DECLARED type and on the same closed-interface test the read engine's emit side uses, so the two shapes that
+    /// merely happen to enumerate (a raw byte slice, a keyed dict) are named rather than folded over.</summary>
+    static string? NotListShape(Type declared, object? val)
+    {
+        var t = Nullable.GetUnderlyingType(declared) ?? declared;
+        if (t == typeof(object) && val is not null) t = val.GetType();   // a bracketed hop yields the element's own type
+        var name = t.Name;
+        if (name.StartsWith("MemorySlice", StringComparison.Ordinal) || name.StartsWith("ReadOnlyMemorySlice", StringComparison.Ordinal))
+            return "a raw block of bytes";
+        if (WriteEngine.ClosedInterface(t, typeof(IDictionary<,>)) is not null
+            || WriteEngine.ClosedInterface(t, typeof(IReadOnlyDictionary<,>)) is not null)
+            return "a dict of keyed entries";
+        if (WriteEngine.ClosedInterface(t, typeof(IList<>)) is not null
+            || WriteEngine.ClosedInterface(t, typeof(IReadOnlyList<>)) is not null)
+            return null;
+        return $"a single {RecordNaming.StripOverlay((val?.GetType() ?? t).Name)} value";
+    }
+
     /// <summary>Fold one step's element verdicts into the record's. Same accounting shape
-    /// <see cref="EvalLinkStep"/> uses over link targets: a definite verdict decides, and where no element could be
-    /// judged the no-verdict class carries out rather than a silent non-match. An EMPTY list is a definite verdict
-    /// — <c>[*all]</c> and <c>[*none]</c> are vacuously true on it, <c>[*any]</c> false.</summary>
+    /// <see cref="EvalLinkStep"/> uses over link targets: a definite verdict decides, and where an element could
+    /// NOT be judged the no-verdict class carries out rather than a silent non-match. An EMPTY list is a definite
+    /// verdict — <c>[*all]</c> and <c>[*none]</c> are vacuously true on it, <c>[*any]</c> false.
+    /// <para>One unjudged element is enough to sink a fold that the judged ones have not already decided: an
+    /// existential is decided by its first true, a universal (<c>[*all]</c>/<c>[*none]</c>) by its first
+    /// counterexample, and anything short of that is a claim over elements one of which was never read. The class
+    /// that carries out is the loudest one seen, so the rollup names a read fault as a read fault and a genuinely
+    /// value-less element as unset — never the other way round.</para></summary>
     (bool Satisfied, EvalKind Kind) FoldOver(Predicate p, List<object> elems, Fold fold, Func<object, (bool, EvalKind)> eval)
     {
         if (elems.Count == 0) return (fold != Fold.Any, EvalKind.Definite);
-        bool anyVerdict = false, anyTrue = false, anyFalse = false, anyNoField = false, anyListHop = false;
+        bool anyVerdict = false, anyTrue = false, anyFalse = false;
+        EvalKind? unjudged = null;
         foreach (var e in elems)
         {
             var (sat, kind) = eval(e);
             if (_fatal is not null) return (false, EvalKind.Definite);
             if (kind == EvalKind.Definite) { anyVerdict = true; if (sat) anyTrue = true; else anyFalse = true; }
-            else if (kind is EvalKind.NoField or EvalKind.ListHop or EvalKind.NotAList)
-            { anyNoField = true; anyListHop |= kind == EvalKind.ListHop; }
+            else if (unjudged is null || NoVerdictRank(kind) > NoVerdictRank(unjudged.Value)) unjudged = kind;
         }
+        // The decided cases: a true settles any/none whatever else the list held, a false settles all.
         if (fold == Fold.Any && anyTrue) return (true, EvalKind.Definite);
         if (fold == Fold.NoneOf && anyTrue) return (false, EvalKind.Definite);
         if (fold == Fold.All && anyFalse) return (false, EvalKind.Definite);
+        if (unjudged is { } u) return (false, u);
         if (anyVerdict) return (fold != Fold.Any, EvalKind.Definite);
-        return (false, anyNoField ? (anyListHop ? EvalKind.ListHop : EvalKind.NoField) : EvalKind.Unreadable);
+        return (false, EvalKind.Unreadable);
     }
+
+    /// <summary>Which no-verdict class wins when a fold saw more than one: a read fault outranks a schema miss,
+    /// which outranks a container or a genuinely-unset element.</summary>
+    static int NoVerdictRank(EvalKind k) => k switch
+    {
+        EvalKind.Unreadable => 4,
+        EvalKind.ListHop => 3, EvalKind.NotAList => 3, EvalKind.NoField => 3,
+        EvalKind.Container => 2,
+        _ => 1,   // Unset
+    };
 
     /// <summary>Classify a navigation miss into the no-verdict vocabulary the accounting keys on.</summary>
     EvalKind ClassifyMiss(string note)

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -301,16 +301,28 @@ public static class ReadEngine
             var nav = NavigateValue(record, path);
             if (!nav.ok) return (null, nav.note);
             if (nav.val is null) return (null, AbsentNote);
+            return LinksIn(nav.val, string.Join(".", path));
+        }
+        catch (Exception ex) { return (null, $"(unreadable: {ex.Message})"); }
+    }
+
+    /// <summary>The link-shape half of <see cref="CollectLinksAt"/>, over a value already navigated to — so a
+    /// quantified step can read the links of one list ELEMENT with exactly the same reading the whole-field form
+    /// gives. <paramref name="display"/> only names the value in a miss note.</summary>
+    internal static (List<FormKey>? Links, string? Note) LinksIn(object value, string display)
+    {
+        try
+        {
             var keys = new List<FormKey>();
             var seen = new HashSet<FormKey>();
             void Add(FormKey fk) { if (!fk.IsNull && seen.Add(fk)) keys.Add(fk); }
-            switch (nav.val)
+            switch (value)
             {
                 case IFormLinkGetter link:
                     Add(link.FormKey);
                     break;
                 case string:
-                    return (null, $"(no links: '{string.Join(".", path)}' is a string, not a link-bearing field)");
+                    return (null, $"(no links: '{display}' is a string, not a link-bearing field)");
                 case System.Collections.IEnumerable list:
                     foreach (var item in list)
                     {
@@ -323,11 +335,20 @@ public static class ReadEngine
                     foreach (var l in sub.EnumerateFormLinks()) Add(l.FormKey);
                     break;
                 default:
-                    return (null, $"(no links: '{string.Join(".", path)}' is not a link-bearing field)");
+                    return (null, $"(no links: '{display}' is not a link-bearing field)");
             }
             return (keys, null);
         }
         catch (Exception ex) { return (null, $"(unreadable: {ex.Message})"); }
+    }
+
+    /// <summary>Navigate a path READ-ONLY to its live value — the quantified step's fan-out source. Same walk
+    /// <see cref="ReadLeaf"/> makes, yielding the object, its owning parent, and the miss note in the leaf-note
+    /// vocabulary callers already classify.</summary>
+    internal static (bool Ok, object? Value, object Parent, string? Note) NavigateTo(object record, string[] path)
+    {
+        var nav = NavigateValue(record, path);
+        return (nav.ok, nav.val, nav.parent, nav.note);
     }
 
     /// <summary>A "no such field" note that, when the owner is a collection, points the caller at bracket

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -343,12 +343,13 @@ public static class ReadEngine
     }
 
     /// <summary>Navigate a path READ-ONLY to its live value — the quantified step's fan-out source. Same walk
-    /// <see cref="ReadLeaf"/> makes, yielding the object, its owning parent, and the miss note in the leaf-note
-    /// vocabulary callers already classify.</summary>
-    internal static (bool Ok, object? Value, object Parent, string? Note) NavigateTo(object record, string[] path)
+    /// <see cref="ReadLeaf"/> makes, yielding the object, its DECLARED type (so a caller can judge the step's shape
+    /// even where the value is null), its owning parent, and the miss note in the leaf-note vocabulary callers
+    /// already classify.</summary>
+    internal static (bool Ok, object? Value, Type Declared, object Parent, string? Note) NavigateTo(object record, string[] path)
     {
         var nav = NavigateValue(record, path);
-        return (nav.ok, nav.val, nav.parent, nav.note);
+        return (nav.ok, nav.val, nav.type, nav.parent, nav.note);
     }
 
     /// <summary>A "no such field" note that, when the owner is a collection, points the caller at bracket

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Reflection;
 using System.Security.Cryptography;
 using Mutagen.Bethesda;

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Reflection;
 using System.Security.Cryptography;
 using Mutagen.Bethesda;
@@ -2726,6 +2726,13 @@ public static class WriteEngine
     /// </summary>
     internal static object StepIntoElement(object parent, PropertyInfo prop, string name, string key, bool materialize = false)
     {
+        // A '*' key is a quantifier token that reached a walk which indexes ONE concrete element — say that, whatever
+        // the field's shape, rather than reporting it as a malformed index or a missing dict key.
+        if (key.Length > 0 && key[0] == '*')
+            throw new InvalidOperationException(
+                $"'{name}[{key}]' cannot be indexed here — [*any], [*all] and [*none] fold a list into a boolean in " +
+                $"where=, and [*] and [*count] are project/walk path steps; index a concrete element ('{name}[0]') instead.");
+
         // Gendered field ([0]=male / [1]=female): a fixed two-slot pair (IGenderedItem<T>), NOT a list/dict, so it
         // never reaches the IList/IDictionary branches below. Its named arms (.Male/.Female) already navigate as
         // plain hops; [0]/[1] is the render-matching navigable alias. Handled by the same materialize-and-write-back
@@ -2764,12 +2771,6 @@ public static class WriteEngine
                      ?? ClosedInterface(prop.PropertyType, typeof(IReadOnlyList<>));
         if (listIface is not null)
         {
-            // A '*' key is a where= fold token that reached a walk which indexes one concrete element — say that,
-            // rather than reporting an unbuilt capability as a malformed index.
-            if (key.Length > 0 && key[0] == '*')
-                throw new InvalidOperationException(
-                    $"List '{name}' cannot take the quantifier token '[{key}]' here — the fold tokens [*any], [*all], [*none] " +
-                    $"and [*count] are where= path steps; index a concrete element ('{name}[0]') instead.");
             if (!int.TryParse(key, NumberStyles.Integer, CultureInfo.InvariantCulture, out var idx) || idx < 0)
                 throw new InvalidOperationException($"List '{name}' must be indexed by a non-negative integer; got '{key}'.");
             int j = 0;

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -2764,6 +2764,12 @@ public static class WriteEngine
                      ?? ClosedInterface(prop.PropertyType, typeof(IReadOnlyList<>));
         if (listIface is not null)
         {
+            // A '*' key is a where= fold token that reached a walk which indexes one concrete element — say that,
+            // rather than reporting an unbuilt capability as a malformed index.
+            if (key.Length > 0 && key[0] == '*')
+                throw new InvalidOperationException(
+                    $"List '{name}' cannot take the quantifier token '[{key}]' here — the fold tokens [*any], [*all], [*none] " +
+                    $"and [*count] are where= path steps; index a concrete element ('{name}[0]') instead.");
             if (!int.TryParse(key, NumberStyles.Integer, CultureInfo.InvariantCulture, out var idx) || idx < 0)
                 throw new InvalidOperationException($"List '{name}' must be indexed by a non-negative integer; got '{key}'.");
             int j = 0;

--- a/src/housecarl-mcp-tests/RecordsReferenceExclusionTests.cs
+++ b/src/housecarl-mcp-tests/RecordsReferenceExclusionTests.cs
@@ -1,4 +1,4 @@
-﻿using HousecarlMcp;
+using HousecarlMcp;
 using Xunit;
 
 namespace HousecarlMcpTests;

--- a/src/housecarl-mcp-tests/RecordsReferenceExclusionTests.cs
+++ b/src/housecarl-mcp-tests/RecordsReferenceExclusionTests.cs
@@ -56,6 +56,24 @@ public sealed class RecordsReferenceExclusionTests : RecordsTestBase
     }
 
     [Fact]
+    public void AQuantifierOnANonListStepIsRefusedFromTheSchemaWhenTheTypeIsNamed()
+    {
+        // The scan's refusal rides under the header line, so this is not the bare "error:" shape.
+        var r = RecordsTools.Records(Svc, types: new[] { "ARMO" },
+                                     where: new[] { "BodyTemplate[*any].FirstPersonFlags has Head" });
+        Assert.Contains("error:", r);
+        Assert.Contains("not a list", r);
+        Assert.Contains("substruct on Armor", r);
+    }
+
+    [Fact]
+    public void AQuantifierOnAListStepPassesTheSchemaCheck()
+    {
+        var r = RecordsTools.Records(Svc, types: new[] { "SPEL" }, where: new[] { "Effects[*count] > 0" });
+        Served(r, "HcRecSpellA");
+    }
+
+    [Fact]
     public void AFoldTokenInProjectFieldsIsRefused_ABooleanIsNotARow() =>
         Refused(RecordsTools.Records(Svc, types: new[] { "SPEL" },
                                      project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "Effects[*any].Data.Magnitude" } }),

--- a/src/housecarl-mcp-tests/RecordsReferenceExclusionTests.cs
+++ b/src/housecarl-mcp-tests/RecordsReferenceExclusionTests.cs
@@ -67,6 +67,28 @@ public sealed class RecordsReferenceExclusionTests : RecordsTestBase
     }
 
     [Fact]
+    public void ALinkPredicatesRightSideIsNotJudgedAgainstTheScannedType()
+    {
+        // 'Name' is a substruct on Spell, but this step lands on the link TARGET (a MagicEffect), so the scanned
+        // type's schema has no say — refusing it here would name a field the step was never rooted at.
+        var r = RecordsTools.Records(Svc, types: new[] { "SPEL" },
+                                     where: new[] { "Effects[*any].BaseEffect->Name[*count] > 0" });
+        Assert.DoesNotContain("on Spell", r);
+    }
+
+    [Fact]
+    public void AnUncheckableRightSideStepDoesNotSilenceACheckableOne()
+    {
+        // 'Conditions' is not a field on Spell at all, so that step has no schema answer; the second predicate's
+        // step is plainly checkable and must still be refused.
+        var r = RecordsTools.Records(Svc, types: new[] { "SPEL" },
+                                     where: new[] { "Effects[*any].BaseEffect->Conditions[*count] > 0",
+                                                    "Description[*any] = x" });
+        Assert.Contains("not a list", r);
+        Assert.Contains("on Spell", r);
+    }
+
+    [Fact]
     public void AQuantifierOnAListStepPassesTheSchemaCheck()
     {
         var r = RecordsTools.Records(Svc, types: new[] { "SPEL" }, where: new[] { "Effects[*count] > 0" });

--- a/src/housecarl-mcp-tests/RecordsReferenceExclusionTests.cs
+++ b/src/housecarl-mcp-tests/RecordsReferenceExclusionTests.cs
@@ -1,0 +1,57 @@
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>The negated <c>references=</c> entry (a leading '!') and the quantified <c>where=</c> step, driven
+/// end to end through the tool over a real scan.</summary>
+[Collection("records")]
+[Trait("tier", "integration")]
+public sealed class RecordsReferenceExclusionTests : RecordsTestBase
+{
+    public RecordsReferenceExclusionTests(RecordsFixture f) : base(f) { }
+
+    [Fact]
+    public void ANegatedReferenceKeepsOnlyTheRecordsThatDoNotLinkThatTarget()
+    {
+        var r = RecordsTools.Records(Svc, types: new[] { "SPEL" }, references: new[] { "!" + Fid(W.MgefA) });
+        Served(r, "HcRecSpellB");
+        Assert.DoesNotContain("HcRecSpellA", r);
+        Assert.DoesNotContain("HcRecSpellC", r);
+    }
+
+    [Fact]
+    public void APlainAndANegatedTargetInOneCallComposeByAnd()
+    {
+        var r = RecordsTools.Records(Svc, types: new[] { "SPEL" },
+                                     references: new[] { Fid(W.MgefA), "!" + Fid(W.MgefB) });
+        Served(r, "HcRecSpellA", "HcRecSpellC");
+        Assert.DoesNotContain("HcRecSpellB", r);
+    }
+
+    [Fact]
+    public void ANegatedReferenceStillNeedsABoundingScope() =>
+        Refused(RecordsTools.Records(Svc, references: new[] { "!" + Fid(W.MgefA) }), "types=");
+
+    [Fact]
+    public void ABareBangNamesNoTargetAndIsRefused() =>
+        Refused(RecordsTools.Records(Svc, types: new[] { "SPEL" }, references: new[] { "!" }), "names no target");
+
+    [Fact]
+    public void TheQuantifiedStepRidesWhereEndToEnd()
+    {
+        var r = RecordsTools.Records(Svc, types: new[] { "SPEL" },
+                                     where: new[] { "Effects[*any].Data.Magnitude > 8" });
+        Served(r, "HcRecSpellC");
+        Assert.DoesNotContain("HcRecSpellA", r);
+    }
+
+    [Fact]
+    public void TheBareStarIsRefusedThroughTheToolNamingTheFoldTokens()
+    {
+        // The scan's parse refusal rides under the header line, so this is not the bare "error:" shape.
+        var r = RecordsTools.Records(Svc, types: new[] { "SPEL" }, where: new[] { "Effects[*].Data.Magnitude > 8" });
+        Assert.Contains("error:", r);
+        Assert.Contains("[*any]", r);
+    }
+}

--- a/src/housecarl-mcp-tests/RecordsReferenceExclusionTests.cs
+++ b/src/housecarl-mcp-tests/RecordsReferenceExclusionTests.cs
@@ -39,6 +39,23 @@ public sealed class RecordsReferenceExclusionTests : RecordsTestBase
     }
 
     [Fact]
+    public void ANegatedReferenceTakesTheAtFileSpellingToo()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "hc-refs-neg-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var listFile = Path.Combine(dir, "targets.txt");
+            File.WriteAllText(listFile, Fid(W.MgefA) + Environment.NewLine);
+            var r = RecordsTools.Records(Svc, types: new[] { "SPEL" }, references: new[] { "!@" + listFile });
+            Served(r, "HcRecSpellB");
+            Assert.DoesNotContain("HcRecSpellA", r);
+            Assert.DoesNotContain("bad references FormID", r);
+        }
+        finally { try { Directory.Delete(dir, true); } catch { } }
+    }
+
+    [Fact]
     public void ANegatedReferenceStillNeedsABoundingScope() =>
         Refused(RecordsTools.Records(Svc, references: new[] { "!" + Fid(W.MgefA) }), "types=");
 

--- a/src/housecarl-mcp-tests/RecordsReferenceExclusionTests.cs
+++ b/src/housecarl-mcp-tests/RecordsReferenceExclusionTests.cs
@@ -1,4 +1,4 @@
-using HousecarlMcp;
+﻿using HousecarlMcp;
 using Xunit;
 
 namespace HousecarlMcpTests;
@@ -30,6 +30,15 @@ public sealed class RecordsReferenceExclusionTests : RecordsTestBase
     }
 
     [Fact]
+    public void ANegatedReferenceKeepsADeletedRecord_WhichReferencesNothingAtAll()
+    {
+        // The positive term skips a record with no live body (it can never link the target); the negated term must
+        // not, because that record is the strongest match the term has.
+        var r = RecordsTools.Records(Svc, types: new[] { "WEAP" }, references: new[] { "!" + Fid(W.MgefA) });
+        Assert.Contains(Fid(W.Weapons[2]), r);
+    }
+
+    [Fact]
     public void ANegatedReferenceStillNeedsABoundingScope() =>
         Refused(RecordsTools.Records(Svc, references: new[] { "!" + Fid(W.MgefA) }), "types=");
 
@@ -45,6 +54,18 @@ public sealed class RecordsReferenceExclusionTests : RecordsTestBase
         Served(r, "HcRecSpellC");
         Assert.DoesNotContain("HcRecSpellA", r);
     }
+
+    [Fact]
+    public void AFoldTokenInProjectFieldsIsRefused_ABooleanIsNotARow() =>
+        Refused(RecordsTools.Records(Svc, types: new[] { "SPEL" },
+                                     project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "Effects[*any].Data.Magnitude" } }),
+                "not a row");
+
+    [Fact]
+    public void TheProjectionHalfOfTheQuantifiedStepIsRefusedAsUnbuilt_NeverSilentlyMisread() =>
+        Refused(RecordsTools.Records(Svc, types: new[] { "SPEL" },
+                                     project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "Effects[*count]" } }),
+                "not built yet");
 
     [Fact]
     public void TheBareStarIsRefusedThroughTheToolNamingTheFoldTokens()

--- a/src/housecarl-mcp-tests/RecordsReferenceExclusionTests.cs
+++ b/src/housecarl-mcp-tests/RecordsReferenceExclusionTests.cs
@@ -86,6 +86,15 @@ public sealed class RecordsReferenceExclusionTests : RecordsTestBase
                 "not built yet");
 
     [Fact]
+    public void ANonQuantifierTokenInProjectFieldsIsNamedATypo_NotAnUnbuiltCapability()
+    {
+        var r = RecordsTools.Records(Svc, types: new[] { "SPEL" },
+                                     project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "Effects[*sum].Data.Magnitude" } });
+        Assert.Contains("is not a quantifier", r);
+        Assert.DoesNotContain("not built yet", r);
+    }
+
+    [Fact]
     public void TheBareStarIsRefusedThroughTheToolNamingTheFoldTokens()
     {
         // The scan's parse refusal rides under the header line, so this is not the bare "error:" shape.

--- a/src/housecarl-mcp-tests/WhereQuantifierTests.cs
+++ b/src/housecarl-mcp-tests/WhereQuantifierTests.cs
@@ -251,6 +251,33 @@ public sealed class WhereQuantifierTests
     }
 
     [Fact]
+    public void ANonListStepIsNamedTheSameWhetherItIsCarriedOrNull()
+    {
+        // Only an OVERLAY body splits the two spellings: the carried value reflects as BodyTemplateBinaryOverlay
+        // while the null one falls back to the declared IBodyTemplateGetter, so the fixture must be read from disk.
+        var bare = _mod.Armors.AddNew(); bare.EditorID = "QArmorNamingNull";   // BodyTemplate left null
+        var dir = Path.Combine(Path.GetTempPath(), "hc-quant-naming-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var path = Path.Combine(dir, _mod.ModKey.FileName.String);
+            _mod.BeginWrite.ToPath(path).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            using var ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+            var carried = ov.Armors.First(a => a.EditorID == "QArmorHands");
+            var nulled = ov.Armors.First(a => a.EditorID == "QArmorNamingNull");
+            Assert.NotNull(carried.BodyTemplate);
+            Assert.Null(nulled.BodyTemplate);
+
+            var carriedNote = RunWithNote("BodyTemplate[*all].FirstPersonFlags has Head", new[] { (IMajorRecordGetter)carried }).Note;
+            var nullNote = RunWithNote("BodyTemplate[*all].FirstPersonFlags has Head", new[] { (IMajorRecordGetter)nulled }).Note;
+            Assert.Contains("a single BodyTemplate value", carriedNote);
+            Assert.Contains("a single BodyTemplate value", nullNote);
+            Assert.DoesNotContain("IBodyTemplateGetter", nullNote);
+        }
+        finally { try { Directory.Delete(dir, true); } catch { } }
+    }
+
+    [Fact]
     public void ADictStepIsNamedADict_NotFoldedOverItsEntries()
     {
         var cls = _mod.Classes.AddNew(); cls.EditorID = "QClass";

--- a/src/housecarl-mcp-tests/WhereQuantifierTests.cs
+++ b/src/housecarl-mcp-tests/WhereQuantifierTests.cs
@@ -1,4 +1,4 @@
-using Mutagen.Bethesda;
+﻿using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
@@ -70,12 +70,15 @@ public sealed class WhereQuantifierTests
         return a.FormKey;
     }
 
-    HashSet<FormKey> Run(string clause, IEnumerable<IMajorRecordGetter> bodies)
+    HashSet<FormKey> Run(string clause, IEnumerable<IMajorRecordGetter> bodies) => RunWithNote(clause, bodies).Hits;
+
+    (HashSet<FormKey> Hits, string Note) RunWithNote(string clause, IEnumerable<IMajorRecordGetter> bodies)
     {
         var (set, err) = FieldPredicateSet.Parse(new[] { clause });
         Assert.Null(err);
         if (set!.NeedsResolution) set.BindResolution(_ => null, fk => _targets.GetValueOrDefault(fk));
-        return bodies.Where(b => set.Matches(b)).Select(b => b.FormKey).ToHashSet();
+        var hits = bodies.Where(b => set.Matches(b)).Select(b => b.FormKey).ToHashSet();
+        return (hits, set.AccountingNote() ?? "");
     }
 
     static string Fid(FormKey fk) => $"{fk.ID:X6}:{fk.ModKey.FileName}";
@@ -225,6 +228,83 @@ public sealed class WhereQuantifierTests
         var note = set!.AccountingNote() ?? "";
         Assert.Contains("not a list", note);
         Assert.Contains("BodyTemplate[*any]", note);
+    }
+
+    // ---- a quantifier on a NULL non-list step ------------------------------------------------------
+
+    [Fact]
+    public void ANullNonListStepIsStillNamedNotAList_NeverAVacuouslyTrueEmptyList()
+    {
+        var bare = _mod.Armors.AddNew(); bare.EditorID = "QArmorNoTemplate";   // BodyTemplate left null
+        var (hits, note) = RunWithNote("BodyTemplate[*all].FirstPersonFlags has Head", new[] { (IMajorRecordGetter)bare });
+        Assert.Empty(hits);
+        Assert.Contains("not a list", note);
+    }
+
+    [Fact]
+    public void ANullScalarWithCountIsNotAnEmptyList()
+    {
+        var bare = _mod.Armors.AddNew(); bare.EditorID = "QArmorNoName";       // Name left null
+        var (hits, note) = RunWithNote("Name[*count] = 0", new[] { (IMajorRecordGetter)bare });
+        Assert.Empty(hits);
+        Assert.Contains("not a list", note);
+    }
+
+    [Fact]
+    public void ADictStepIsNamedADict_NotFoldedOverItsEntries()
+    {
+        var cls = _mod.Classes.AddNew(); cls.EditorID = "QClass";
+        cls.SkillWeights[Skill.OneHanded] = 5;
+        var (hits, note) = RunWithNote("SkillWeights[*any] = 5", new[] { (IMajorRecordGetter)cls });
+        Assert.Empty(hits);
+        Assert.Contains("dict", note);
+    }
+
+    [Fact]
+    public void AByteBlockStepIsNamedBytes_NotCountedElementByElement()
+    {
+        var st = _mod.Statics.AddNew(); st.EditorID = "QStatic";
+        st.Model = new Model { File = "meshes\\q.nif", Data = new byte[] { 1, 2, 3 } };
+        var (hits, note) = RunWithNote("Model.Data[*count] > 0", new[] { (IMajorRecordGetter)st });
+        Assert.Empty(hits);
+        Assert.Contains("bytes", note);
+    }
+
+    // ---- an absent collection reads as empty, however far up the absence starts --------------------
+
+    [Fact]
+    public void AnAbsentParentSubstructReadsAsAnEmptyCollection()
+    {
+        // No fixture armor carries a VirtualMachineAdapter, so "carries no script" must find all of them.
+        Assert.Equal(_armors.Select(a => a.FormKey).ToHashSet(),
+                     Run("VirtualMachineAdapter.Scripts[*count] = 0", _armors));
+    }
+
+    // ---- an element that could not be judged sinks the universal folds -----------------------------
+
+    [Fact]
+    public void OneUnjudgedElementStopsAllAndNoneClaimingAVerdict()
+    {
+        var s = _mod.Spells.AddNew(); s.EditorID = "QSpellHalfRead";
+        var blind = new Effect(); blind.BaseEffect.SetTo(_mgefPlain);          // no Data — Magnitude cannot be judged
+        var seen = new Effect(); seen.BaseEffect.SetTo(_mgefPlain); seen.Data = new EffectData { Magnitude = 5 };
+        s.Effects.Add(blind); s.Effects.Add(seen);
+        var one = new[] { (IMajorRecordGetter)s };
+        Assert.Empty(Run("Effects[*none].Data.Magnitude > 50", one));          // was a definite "proved absence"
+        Assert.Empty(Run("Effects[*all].Data.Magnitude < 50", one));
+        // …while a fold the judged elements already decide stays definite.
+        Assert.Single(Run("Effects[*any].Data.Magnitude < 50", one));
+    }
+
+    [Fact]
+    public void AnAllUnsetListIsNoVerdict_NotAReadFault()
+    {
+        var s = _mod.Spells.AddNew(); s.EditorID = "QSpellNoBases";
+        s.Effects.Add(new Effect { Data = new EffectData { Magnitude = 1 } }); // BaseEffect null → nothing to judge
+        s.Effects.Add(new Effect { Data = new EffectData { Magnitude = 2 } });
+        var (hits, note) = RunWithNote("Effects[*none].BaseEffect->editorid startswith REQ_", new[] { (IMajorRecordGetter)s });
+        Assert.Empty(hits);
+        Assert.DoesNotContain("read FAULT", note);
     }
 
     // ---- composition: a quantified step inside another ---------------------------------------------

--- a/src/housecarl-mcp-tests/WhereQuantifierTests.cs
+++ b/src/housecarl-mcp-tests/WhereQuantifierTests.cs
@@ -1,4 +1,4 @@
-﻿using Mutagen.Bethesda;
+using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;

--- a/src/housecarl-mcp-tests/WhereQuantifierTests.cs
+++ b/src/housecarl-mcp-tests/WhereQuantifierTests.cs
@@ -1,0 +1,240 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>The quantified path step (<c>[*any]</c> / <c>[*all]</c> / <c>[*none]</c> / <c>[*count]</c>) and the
+/// two exclusion folds of <c>has</c>, evaluated in memory over bodies this class builds — lists of more than one
+/// element, which is what a fold needs to be worth anything. No load order and no service call.</summary>
+[Trait("tier", "unit")]
+public sealed class WhereQuantifierTests
+{
+    readonly SkyrimMod _mod = new(new ModKey("QuantWorld", ModType.Master), SkyrimRelease.SkyrimSE);
+    readonly FormKey _mgefPlain, _mgefReq, _kwA, _kwB;
+    readonly List<IMajorRecordGetter> _spells = new();
+    readonly List<IMajorRecordGetter> _armors = new();
+    readonly Dictionary<FormKey, IMajorRecordGetter> _targets = new();
+    readonly FormKey _spellLow, _spellMixed, _spellHigh, _spellEmpty;
+    readonly FormKey _armorHeadBody, _armorHands, _armorFeet;
+
+    public WhereQuantifierTests()
+    {
+        var plain = _mod.MagicEffects.AddNew(); plain.EditorID = "QMgefPlain"; _mgefPlain = plain.FormKey;
+        var req = _mod.MagicEffects.AddNew(); req.EditorID = "REQ_QMgef"; _mgefReq = req.FormKey;
+        _targets[_mgefPlain] = plain; _targets[_mgefReq] = req;
+
+        _spellLow = AddSpell("QSpellLow", (5, _mgefPlain), (9, _mgefPlain));
+        _spellMixed = AddSpell("QSpellMixed", (5, _mgefPlain), (90, _mgefReq));
+        _spellHigh = AddSpell("QSpellHigh", (70, _mgefReq), (80, _mgefReq));
+        _spellEmpty = AddSpell("QSpellEmpty");
+
+        var kwa = _mod.Keywords.AddNew(); kwa.EditorID = "QKwA"; _kwA = kwa.FormKey;
+        var kwb = _mod.Keywords.AddNew(); kwb.EditorID = "QKwB"; _kwB = kwb.FormKey;
+        _armorHeadBody = AddArmor("QArmorHeadBody", BipedObjectFlag.Head | BipedObjectFlag.Body, _kwA);
+        _armorHands = AddArmor("QArmorHands", BipedObjectFlag.Hands, _kwA, _kwB);
+        _armorFeet = AddArmor("QArmorFeet", BipedObjectFlag.Feet);
+    }
+
+    FormKey AddSpell(string eid, params (ushort Magnitude, FormKey Base)[] effects)
+    {
+        var s = _mod.Spells.AddNew();
+        s.EditorID = eid;
+        foreach (var (mag, bse) in effects)
+        {
+            var e = new Effect();
+            e.BaseEffect.SetTo(bse);
+            e.Data = new EffectData { Magnitude = mag };
+            s.Effects.Add(e);
+        }
+        _spells.Add(s);
+        return s.FormKey;
+    }
+
+    FormKey AddArmor(string eid, BipedObjectFlag slots, params FormKey[] keywords)
+    {
+        var a = _mod.Armors.AddNew();
+        a.EditorID = eid;
+        a.BodyTemplate = new BodyTemplate { FirstPersonFlags = slots };
+        // Left NULL where there are none, so the keywordless armor exercises the absent-reads-as-empty path.
+        if (keywords.Length > 0)
+        {
+            var kws = new Noggog.ExtendedList<IFormLinkGetter<IKeywordGetter>>();
+            foreach (var k in keywords) kws.Add(new FormLink<IKeywordGetter>(k));
+            a.Keywords = kws;
+        }
+        _armors.Add(a);
+        return a.FormKey;
+    }
+
+    HashSet<FormKey> Run(string clause, IEnumerable<IMajorRecordGetter> bodies)
+    {
+        var (set, err) = FieldPredicateSet.Parse(new[] { clause });
+        Assert.Null(err);
+        if (set!.NeedsResolution) set.BindResolution(_ => null, fk => _targets.GetValueOrDefault(fk));
+        return bodies.Where(b => set.Matches(b)).Select(b => b.FormKey).ToHashSet();
+    }
+
+    static string Fid(FormKey fk) => $"{fk.ID:X6}:{fk.ModKey.FileName}";
+
+    // ---- the three boolean folds ------------------------------------------------------------------
+
+    [Fact]
+    public void Any_MatchesTheSpellsWithAtLeastOneBigEffect() =>
+        Assert.Equal(new[] { _spellMixed, _spellHigh }.ToHashSet(),
+                     Run("Effects[*any].Data.Magnitude > 50", _spells));
+
+    [Fact]
+    public void All_MatchesOnlyWhereEveryElementSatisfies_AndIsVacuouslyTrueOnTheEmptyList() =>
+        Assert.Equal(new[] { _spellHigh, _spellEmpty }.ToHashSet(),
+                     Run("Effects[*all].Data.Magnitude > 50", _spells));
+
+    [Fact]
+    public void None_IsTheProvedAbsence_TheEmptyListIncluded() =>
+        Assert.Equal(new[] { _spellLow, _spellEmpty }.ToHashSet(),
+                     Run("Effects[*none].Data.Magnitude > 50", _spells));
+
+    [Fact]
+    public void AnyOnAnEmptyListIsADefiniteNonMatch_NotANoVerdict() =>
+        Assert.DoesNotContain(_spellEmpty, Run("Effects[*any].Data.Magnitude > 0", _spells));
+
+    // ---- [*count] ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void Count_ComparesTheNumberOfElements() =>
+        Assert.Equal(new[] { _spellLow, _spellMixed, _spellHigh }.ToHashSet(),
+                     Run("Effects[*count] > 1", _spells));
+
+    [Fact]
+    public void Count_ReadsAnAbsentOrEmptyListAsZero() =>
+        Assert.Equal(new[] { _spellEmpty }.ToHashSet(), Run("Effects[*count] = 0", _spells));
+
+    [Fact]
+    public void Count_TakesTheMembershipOpsToo() =>
+        Assert.Equal(new[] { _spellEmpty }.ToHashSet(), Run("Effects[*count] in [0]", _spells));
+
+    // ---- the fold over a link step ----------------------------------------------------------------
+
+    [Fact]
+    public void NoneOverALinkStep_ProvesNoEffectPointsAtAReqBaseEffect() =>
+        Assert.Equal(new[] { _spellLow, _spellEmpty }.ToHashSet(),
+                     Run("Effects[*none].BaseEffect->editorid startswith REQ_", _spells));
+
+    [Fact]
+    public void AnyOverALinkStep_FindsTheSpellsThatDoPointAtOne() =>
+        Assert.Equal(new[] { _spellMixed, _spellHigh }.ToHashSet(),
+                     Run("Effects[*any].BaseEffect->editorid startswith REQ_", _spells));
+
+    // ---- the fold on the LAST step: the element itself is the leaf --------------------------------
+
+    [Fact]
+    public void AFoldOnTheLastStepComparesTheElementItself_ListMembershipByValue() =>
+        Assert.Equal(new[] { _armorHands }.ToHashSet(), Run($"Keywords[*any] = {Fid(_kwB)}", _armors));
+
+    [Fact]
+    public void NoneOnTheLastStepKeepsTheArmorsWithoutThatKeyword_TheKeywordlessOneIncluded() =>
+        Assert.Equal(new[] { _armorHeadBody, _armorFeet }.ToHashSet(), Run($"Keywords[*none] = {Fid(_kwB)}", _armors));
+
+    // ---- has / has_any / has_none ------------------------------------------------------------------
+
+    [Fact]
+    public void Has_StillRequiresEveryOperandBit() =>
+        Assert.Empty(Run("BodyTemplate.FirstPersonFlags has Head,Hands", _armors));
+
+    [Fact]
+    public void HasAny_MatchesWhenAtLeastOneOperandBitIsSet() =>
+        Assert.Equal(new[] { _armorHeadBody, _armorHands }.ToHashSet(),
+                     Run("BodyTemplate.FirstPersonFlags has_any Head,Hands", _armors));
+
+    [Fact]
+    public void HasNone_MatchesWhenNoOperandBitIsSet() =>
+        Assert.Equal(new[] { _armorFeet }.ToHashSet(),
+                     Run("BodyTemplate.FirstPersonFlags has_none Head,Hands", _armors));
+
+    [Fact]
+    public void HasNone_ZeroMaskIsRefusedByItsOwnName_NeverAVacuousMatch()
+    {
+        var (set, err) = FieldPredicateSet.Parse(new[] { "BodyTemplate.FirstPersonFlags has_none 0" });
+        Assert.Null(err);
+        set!.Matches(_armors[0]);
+        Assert.Contains("has_none 0", set.FatalError ?? "");
+    }
+
+    [Fact]
+    public void HasAny_OnANonFlagsTextTermIsAParseRefusal()
+    {
+        var (_, err) = FieldPredicateSet.Parse(new[] { "editorid has_any 3" });
+        Assert.Contains("text term", err ?? "");
+    }
+
+    // ---- the parse refusals ------------------------------------------------------------------------
+
+    [Fact]
+    public void BareStarIsRefusedInWhere_NamingTheThreeFoldTokens()
+    {
+        var (_, err) = FieldPredicateSet.Parse(new[] { "Effects[*].Data.Magnitude > 50" });
+        Assert.Contains("[*any]", err ?? "");
+    }
+
+    [Fact]
+    public void AnUnknownQuantifierWordIsRefusedNamingTheTokens()
+    {
+        var (_, err) = FieldPredicateSet.Parse(new[] { "Effects[*sum].Data.Magnitude > 50" });
+        Assert.Contains("not a quantifier", err ?? "");
+    }
+
+    [Fact]
+    public void NothingMayFollowACountStep()
+    {
+        var (_, err) = FieldPredicateSet.Parse(new[] { "Effects[*count].Data.Magnitude > 5" });
+        Assert.Contains("[*count]", err ?? "");
+    }
+
+    [Fact]
+    public void CountRefusesAnOperatorThatIsNotANumberComparison()
+    {
+        var (_, err) = FieldPredicateSet.Parse(new[] { "Effects[*count] contains 2" });
+        Assert.Contains("[*count]", err ?? "");
+    }
+
+    [Fact]
+    public void CountCannotCarryALinkStep()
+    {
+        var (_, err) = FieldPredicateSet.Parse(new[] { "Effects[*count]->editorid = x" });
+        Assert.Contains("link step", err ?? "");
+    }
+
+    [Fact]
+    public void AQuantifierWithNoFieldBeforeItIsRefused()
+    {
+        var (_, err) = FieldPredicateSet.Parse(new[] { "[*any].Data.Magnitude > 5" });
+        Assert.Contains("no field name", err ?? "");
+    }
+
+    // ---- a quantifier on something that is not a list ----------------------------------------------
+
+    [Fact]
+    public void AQuantifierOnANonListStepFailsLoudInTheAccounting_NeverASilentZeroMatches()
+    {
+        var (set, err) = FieldPredicateSet.Parse(new[] { "BodyTemplate[*any].FirstPersonFlags has Head" });
+        Assert.Null(err);
+        foreach (var a in _armors) Assert.False(set!.Matches(a));
+        var note = set!.AccountingNote() ?? "";
+        Assert.Contains("not a list", note);
+        Assert.Contains("BodyTemplate[*any]", note);
+    }
+
+    // ---- composition: a quantified step inside another ---------------------------------------------
+
+    [Fact]
+    public void TwoQuantifiedStepsComposeWithoutASecondRule()
+    {
+        // Every effect of the spell carries at least one condition — no fixture has conditions, so the inner
+        // fold sees an empty list and [*all] is vacuously true on each element.
+        Assert.Equal(new[] { _spellLow, _spellMixed, _spellHigh, _spellEmpty }.ToHashSet(),
+                     Run("Effects[*all].Conditions[*all].Data.RunOnType = Subject", _spells));
+    }
+}

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -3891,9 +3891,10 @@ public sealed class LoadOrderService : IDisposable
     public CrossQueryOutcome CrossQuery(string? type, IReadOnlyList<FormKey>? references, string? editoridContains,
                                         bool conflictsOnly, IReadOnlyList<string>? plugins, IReadOnlyList<string>? where, int limit,
                                         bool definedIn = false, string? groupBy = null, int offset = 0, string? whereSource = null,
-                                        IReadOnlyList<ArtifactDemand>? artifactDemands = null)
+                                        IReadOnlyList<ArtifactDemand>? artifactDemands = null,
+                                        IReadOnlyList<FormKey>? referencesNone = null)
         => CrossQuery(type is null ? null : new[] { type }, references, editoridContains, conflictsOnly, plugins, where,
-                      limit, definedIn, groupBy, offset, whereSource, artifactDemands);
+                      limit, definedIn, groupBy, offset, whereSource, artifactDemands, referencesNone: referencesNone);
 
     /// <summary>The formids-by-scan composition: <paramref name="formidSet"/> intersects the selection with an
     /// explicit identity set, inline or artifact-fed. With a body-bearing scope it is a cheap pre-filter on the
@@ -3908,7 +3909,8 @@ public sealed class LoadOrderService : IDisposable
                                         bool definedIn = false, string? groupBy = null, int offset = 0, string? whereSource = null,
                                         IReadOnlyList<ArtifactDemand>? artifactDemands = null,
                                         IReadOnlyList<FormKey>? formidSet = null,
-                                        LoadOrderResolver.IndexView? pinnedView = null)
+                                        LoadOrderResolver.IndexView? pinnedView = null,
+                                        IReadOnlyList<FormKey>? referencesNone = null)
     {
         var resolver = Resolver;
         // The caller's own build when its FormID door already captured one, so the tokens it parsed and the
@@ -3918,7 +3920,10 @@ public sealed class LoadOrderService : IDisposable
         bool hasType = typeSet is { Count: > 0 };
         bool hasWhere = where is { Count: > 0 };
         bool hasReferences = references is { Count: > 0 };
-        bool bodyFilter = hasReferences || !string.IsNullOrEmpty(editoridContains) || hasWhere;
+        // The negated half of references=: a record is kept only when it links to NONE of these. Same one-step
+        // reverse question, inverted, so it is the same body scan and takes the same bound.
+        var refNone = referencesNone is { Count: > 0 } ? new HashSet<FormKey>(referencesNone) : null;
+        bool bodyFilter = hasReferences || refNone is not null || !string.IsNullOrEmpty(editoridContains) || hasWhere;
         bool hasFormidSet = formidSet is { Count: > 0 };
 
         if (!hasType && !conflictsOnly && !hasPlugins && !bodyFilter && !hasFormidSet)
@@ -4075,7 +4080,7 @@ public sealed class LoadOrderService : IDisposable
                         }
                         if (conflictsOnly && (view.TouchingPlugins(fk)?.Count ?? 0) <= 1) continue;
                         if (DeletedRecordRule.HasNoLiveBody(body)
-                            && (refSet is not null || predicate is { NeedsLiveBody: true })) continue;
+                            && (refSet is not null || refNone is not null || predicate is { NeedsLiveBody: true })) continue;
                         if (!string.IsNullOrEmpty(editoridContains)
                             && (body.EditorID is null || body.EditorID.IndexOf(editoridContains, StringComparison.OrdinalIgnoreCase) < 0))
                             continue;
@@ -4088,6 +4093,7 @@ public sealed class LoadOrderService : IDisposable
                             if (hitSet.Count == 0) continue;
                             if (multiTarget && groups is null) hitTargets = references!.Where(hitSet.Contains).Distinct().ToList();
                         }
+                        if (refNone is not null && ExcludedByReference(body, refNone)) continue;
                         if (predicate is not null && !predicate.Matches(body))
                         {
                             if (predicate.FatalError is not null) break;
@@ -4196,7 +4202,7 @@ public sealed class LoadOrderService : IDisposable
                         // predicates actually READ body content: the header- and resolution-only terms must see
                         // deleted records exactly as editorid_contains= does.
                         if (DeletedRecordRule.HasNoLiveBody(filterBody)
-                            && (refSet is not null || predicate is { NeedsLiveBody: true })) continue;
+                            && (refSet is not null || refNone is not null || predicate is { NeedsLiveBody: true })) continue;
                         if (!string.IsNullOrEmpty(editoridContains)
                             && (filterBody.EditorID is null || filterBody.EditorID.IndexOf(editoridContains, StringComparison.OrdinalIgnoreCase) < 0))
                             continue;
@@ -4212,6 +4218,7 @@ public sealed class LoadOrderService : IDisposable
                             if (hitSet.Count == 0) continue;
                             if (multiTarget && groups is null) hitTargets = references!.Where(hitSet.Contains).Distinct().ToList();   // in input order; only the match-line path consumes it
                         }
+                        if (refNone is not null && ExcludedByReference(filterBody, refNone)) continue;
                         if (predicate is not null && !predicate.Matches(filterBody))    // value filter on the same in-hand body, no extra fetch
                         {
                             if (predicate.FatalError is not null) break;          // e.g. a numeric op against a non-numeric field — abort and surface it
@@ -4311,6 +4318,16 @@ public sealed class LoadOrderService : IDisposable
                  UnreadPlugins = unreadablePlugins.Select(u => u.PluginName).ToList() };
     }
 
+    /// <summary>The negated references= test: true when this body links to ANY excluded target, so the scan drops
+    /// it. A record that carries no links at all references nothing and is kept — that is the whole point of the
+    /// term.</summary>
+    static bool ExcludedByReference(IMajorRecordGetter body, HashSet<FormKey> excluded)
+    {
+        if (body is not IFormLinkContainerGetter flc) return false;
+        foreach (var l in flc.EnumerateFormLinks()) if (excluded.Contains(l.FormKey)) return true;
+        return false;
+    }
+
     // ---- the off-order scan ----------------------------------------------------------------------------
 
     /// <summary>The off-order scan: the file's own records are the universe, with the same filter grammar the
@@ -4324,7 +4341,8 @@ public sealed class LoadOrderService : IDisposable
         IReadOnlyList<FormKey>? references, string? editoridContains, IReadOnlyList<string>? scopePlugins,
         bool definedIn, IReadOnlyList<string>? where, int limit, string? groupBy, int offset,
         IReadOnlyList<FormKey>? formidSet, IReadOnlyList<ArtifactDemand>? artifactDemands,
-        LoadOrderResolver.IndexView? pinnedView = null)
+        LoadOrderResolver.IndexView? pinnedView = null,
+        IReadOnlyList<FormKey>? referencesNone = null)
     {
         var resolver = Resolver;
         var view = pinnedView ?? resolver.Capture();   // the caller's door build when it captured one — see CrossQuery
@@ -4387,6 +4405,7 @@ public sealed class LoadOrderService : IDisposable
         catch (Exception ex) { return CrossQueryOutcome.Fail($"could not open '{pole.Path}' as a Skyrim plugin: {ex.Message}") with { Epoch = view.Epoch }; }
 
         var refSet = references is { Count: > 0 } ? new HashSet<FormKey>(references) : null;
+        var refNone = referencesNone is { Count: > 0 } ? new HashSet<FormKey>(referencesNone) : null;
         bool multiTarget = references is { Count: >= 2 };
         var setFilter = formidSet is { Count: > 0 } ? new HashSet<FormKey>(formidSet) : null;
 
@@ -4433,7 +4452,7 @@ public sealed class LoadOrderService : IDisposable
                         if (touchers is null || !touchers.Any(scopeSet.Contains)) continue;
                     }
                     if (DeletedRecordRule.HasNoLiveBody(rec)
-                        && (refSet is not null || predicate is { NeedsLiveBody: true })) continue;
+                        && (refSet is not null || refNone is not null || predicate is { NeedsLiveBody: true })) continue;
                     if (!string.IsNullOrEmpty(editoridContains)
                         && (rec.EditorID is null || rec.EditorID.IndexOf(editoridContains, StringComparison.OrdinalIgnoreCase) < 0))
                         continue;
@@ -4446,6 +4465,7 @@ public sealed class LoadOrderService : IDisposable
                         if (hitSet.Count == 0) continue;
                         if (multiTarget && groups is null) hitTargets = references!.Where(hitSet.Contains).Distinct().ToList();
                     }
+                    if (refNone is not null && ExcludedByReference(rec, refNone)) continue;
                     if (predicate is not null && !predicate.Matches(rec))
                     {
                         if (predicate.FatalError is not null) break;

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1,4 +1,4 @@
-﻿using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Aspects;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4335,15 +4335,21 @@ public sealed class LoadOrderService : IDisposable
 
         foreach (var step in predicate.QuantifiedSteps)
         {
+            // A '->' right side is rooted at the link TARGET's type, not the scanned one, so the scanned type's
+            // schema has no say on it — the runtime accounting is that side's backstop.
+            if (!step.OnScannedType) continue;
             var whatItIs = new List<string>();
+            bool unanswered = false;
             foreach (var ts in schemas)
             {
                 var card = Rulebook.StepCardinality(ts, step.Path, step.Index);
-                if (card is null) return null;              // the schema cannot say — the runtime accounting answers
+                // The schema cannot say for this type, so this STEP goes to the runtime accounting — the other
+                // steps of the same call are still checkable and must not be silenced with it.
+                if (card is null) { unanswered = true; break; }
                 if (card == "list") { whatItIs.Clear(); break; }
                 whatItIs.Add($"a {card} on {ts.Name}");
             }
-            if (whatItIs.Count == 0) continue;
+            if (unanswered || whatItIs.Count == 0) continue;
             return $"predicate '{step.Text}': '{step.Path[step.Index]}{step.Token}' quantifies a step that is not a list — " +
                    $"it is {string.Join(", ", whatItIs.Take(3))}{(whatItIs.Count > 3 ? $", and {whatItIs.Count - 3} more" : "")}. " +
                    "Drop the quantifier, or point it at a list-valued field.";

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1,4 +1,4 @@
-using Mutagen.Bethesda.Plugins;
+﻿using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Aspects;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
@@ -4080,7 +4080,7 @@ public sealed class LoadOrderService : IDisposable
                         }
                         if (conflictsOnly && (view.TouchingPlugins(fk)?.Count ?? 0) <= 1) continue;
                         if (DeletedRecordRule.HasNoLiveBody(body)
-                            && (refSet is not null || refNone is not null || predicate is { NeedsLiveBody: true })) continue;
+                            && (refSet is not null || predicate is { NeedsLiveBody: true })) continue;
                         if (!string.IsNullOrEmpty(editoridContains)
                             && (body.EditorID is null || body.EditorID.IndexOf(editoridContains, StringComparison.OrdinalIgnoreCase) < 0))
                             continue;
@@ -4202,7 +4202,7 @@ public sealed class LoadOrderService : IDisposable
                         // predicates actually READ body content: the header- and resolution-only terms must see
                         // deleted records exactly as editorid_contains= does.
                         if (DeletedRecordRule.HasNoLiveBody(filterBody)
-                            && (refSet is not null || refNone is not null || predicate is { NeedsLiveBody: true })) continue;
+                            && (refSet is not null || predicate is { NeedsLiveBody: true })) continue;
                         if (!string.IsNullOrEmpty(editoridContains)
                             && (filterBody.EditorID is null || filterBody.EditorID.IndexOf(editoridContains, StringComparison.OrdinalIgnoreCase) < 0))
                             continue;
@@ -4320,9 +4320,11 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>The negated references= test: true when this body links to ANY excluded target, so the scan drops
     /// it. A record that carries no links at all references nothing and is kept — that is the whole point of the
-    /// term.</summary>
+    /// term, and a DELETED record (no live body to read links from) is the strongest case of it, so it is kept
+    /// rather than skipped the way the positive term skips it.</summary>
     static bool ExcludedByReference(IMajorRecordGetter body, HashSet<FormKey> excluded)
     {
+        if (DeletedRecordRule.HasNoLiveBody(body)) return false;
         if (body is not IFormLinkContainerGetter flc) return false;
         foreach (var l in flc.EnumerateFormLinks()) if (excluded.Contains(l.FormKey)) return true;
         return false;
@@ -4452,7 +4454,7 @@ public sealed class LoadOrderService : IDisposable
                         if (touchers is null || !touchers.Any(scopeSet.Contains)) continue;
                     }
                     if (DeletedRecordRule.HasNoLiveBody(rec)
-                        && (refSet is not null || refNone is not null || predicate is { NeedsLiveBody: true })) continue;
+                        && (refSet is not null || predicate is { NeedsLiveBody: true })) continue;
                     if (!string.IsNullOrEmpty(editoridContains)
                         && (rec.EditorID is null || rec.EditorID.IndexOf(editoridContains, StringComparison.OrdinalIgnoreCase) < 0))
                         continue;

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4026,6 +4026,9 @@ public sealed class LoadOrderService : IDisposable
         }
         catch (ArgumentException ex) { return CrossQueryOutcome.Fail(ex.Message); }   // unknown type
 
+        if (predicate is not null && hasType && QuantifierShapeRefusal(typeSet!, predicate) is { } qerr)
+            return CrossQueryOutcome.Fail(qerr) with { Epoch = view.Epoch };
+
         var keys = new List<FormKey>();
         var sources = new List<string?>();                                    // parallel to keys: the plugin whose body matched (null ⇒ winner), so the render displays the SAME body it filtered
         List<string?>? matched = multiTarget ? new() : null;                  // parallel to keys: which target(s) each hit referenced (multi-target references= un-merge); null when 0/1 target
@@ -4318,6 +4321,36 @@ public sealed class LoadOrderService : IDisposable
                  UnreadPlugins = unreadablePlugins.Select(u => u.PluginName).ToList() };
     }
 
+    /// <summary>The schema's answer to a quantifier on a step that is not a list: a refusal sentence naming the
+    /// step's real cardinality, or null. Only a NAMED type scope can be asked — the schema decides per record type,
+    /// so an unscoped or mixed scan keeps the per-record accounting as its backstop — and the refusal lands only
+    /// where the step is a non-list on EVERY named type, so a union arm that does hold a list still runs.</summary>
+    string? QuantifierShapeRefusal(IReadOnlyList<string> typeTokens, FieldPredicateSet predicate)
+    {
+        var schemas = new List<TypeSchema>();
+        foreach (var token in typeTokens)
+            foreach (var ts in Rulebook.RecordTypesNamed(token))
+                if (!schemas.Contains(ts)) schemas.Add(ts);
+        if (schemas.Count == 0) return null;
+
+        foreach (var step in predicate.QuantifiedSteps)
+        {
+            var whatItIs = new List<string>();
+            foreach (var ts in schemas)
+            {
+                var card = Rulebook.StepCardinality(ts, step.Path, step.Index);
+                if (card is null) return null;              // the schema cannot say — the runtime accounting answers
+                if (card == "list") { whatItIs.Clear(); break; }
+                whatItIs.Add($"a {card} on {ts.Name}");
+            }
+            if (whatItIs.Count == 0) continue;
+            return $"predicate '{step.Text}': '{step.Path[step.Index]}{step.Token}' quantifies a step that is not a list — " +
+                   $"it is {string.Join(", ", whatItIs.Take(3))}{(whatItIs.Count > 3 ? $", and {whatItIs.Count - 3} more" : "")}. " +
+                   "Drop the quantifier, or point it at a list-valued field.";
+        }
+        return null;
+    }
+
     /// <summary>The negated references= test: true when this body links to ANY excluded target, so the scan drops
     /// it. A record that carries no links at all references nothing and is kept — that is the whole point of the
     /// term, and a DELETED record (no live body to read links from) is the strongest case of it, so it is kept
@@ -4386,6 +4419,9 @@ public sealed class LoadOrderService : IDisposable
             else types = null;
         }
         catch (ArgumentException ex) { return CrossQueryOutcome.Fail(ex.Message); }
+
+        if (predicate is not null && typeSet is { Count: > 0 } && QuantifierShapeRefusal(typeSet, predicate) is { } qerr)
+            return CrossQueryOutcome.Fail(qerr) with { Epoch = view.Epoch };
 
         var scopeSet = scopePlugins is { Count: > 0 }
             ? new HashSet<string>(scopePlugins.Select(p => p.Trim()), StringComparer.OrdinalIgnoreCase)

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -34,7 +34,7 @@ public static class RecordsTools
         [Description("The form: 'identity' (FormID -> type/editorid/name/winner — the labeling form; needs formids=) | 'summary' (identity plus winner/override-depth header facts — the default) | 'fields' (named field values; takes fields= and depth=) | 'everything' (the full record body; takes depth=) | 'aggregate' (a counted table; takes group_by=) | 'delta' (subject vs reference, differences only — source= is the subject, versus= the reference; takes fields= to narrow) | 'tree' (every provider of each record in priority order, winner last, each diffed against the reference pole — default the winner; takes fields=. On a record type that OWNS child records — a cell's placed references, a topic's INFO lines, a worldspace's cells — it also states, per such field, which providers DECLARE children there (a COLLECTION field) or how many do (a SINGULAR one, e.g. Cell.Landscape), and says so when none do) | 'info_order' (DIAL topics only: the effective MERGED INFO sequence across every touching plugin — the order the game walks, with MOVED annotations; the 'why does the wrong line play' diagnostic) | 'chain' (a walk's own paths, endpoints and cycles rather than the records it reached; needs walk=, and carries the NPC-template inheritance report and the reverse MGEF carrier rows).")]
         public string? form { get; set; }
 
-        [Description("fields form only: dotted field paths to read, e.g. [\"BasicStats.Damage\", \"Keywords\", \"Effects\"]. Index a list/dict element with BRACKETS ('Effects[0].Data.Magnitude').")]
+        [Description("fields form only: dotted field paths to read, e.g. [\"BasicStats.Damage\", \"Keywords\", \"Effects\"]. Index a list/dict element with BRACKETS ('Effects[0].Data.Magnitude'). where='s quantifier tokens are not read here: [*any]/[*all]/[*none] fold to a boolean, which is not a row, and [*] / [*count] as a PROJECTION are not built yet — both are refused by name.")]
         public string[]? fields { get; set; }
 
         [Description("fields/everything forms: expansion depth for list/dict/substruct CONTENTS (default 1 = a container shown as a count). THIS is the expansion knob: fields=[\"Effects\"], depth=4 reaches every effect's Magnitude/Area/Duration — no hand-written index guessing.")]
@@ -102,7 +102,9 @@ public static class RecordsTools
          "QUANTIFIED STEPS over a list field: 'Conditions[*any].Data.Function = IsGuard', " +
          "'Effects[*none].BaseEffect->editorid startswith REQ_' (absence, proved), 'Effects[*count] > 2' — " +
          "[*any]/[*all]/[*none] fold the elements into a boolean, [*count] into their number, and [*all] is " +
-         "vacuously true on an empty list, presence 'VirtualMachineAdapter " +
+         "vacuously true on an empty list; a quantified step COSTS the list's length (per-candidate work times the " +
+         "number of elements) and, where its sub-path carries '->', one winner fetch PER ELEMENT — " +
+         "'Temporary[*any]->…' on a dense cell is hundreds of fetches per candidate, presence 'VirtualMachineAdapter " +
          "exists', membership 'formid not in @<file>' / 'Race in [XXXXXX:A.esm, YYYYYY:B.esm]' (list entries " +
          "separate on commas/newlines with brackets and quotes stripped — a value that itself contains a comma " +
          "or bracket is not expressible in a list; test it with '='), ONE '->' link step " +
@@ -220,6 +222,14 @@ public static class RecordsTools
             return Wire.Refuse(json, $"error: project.fields belongs to the 'fields'/'delta'/'tree' forms (got form='{form}'). Set project.form, or drop fields.");
         if (form == "fields" && project?.fields is not { Length: > 0 })
             return Wire.Refuse(json, "error: the 'fields' form names its field paths — pass project.fields=[\"<path>\", …] (or use form='everything' for the full body).");
+        // The quantifier tokens are where='s, not a projection's — refused by name here so a caller who tries one
+        // gets the rule rather than an unreadable-field note from the read walk.
+        if (project?.fields is { Length: > 0 } pf)
+            foreach (var path in pf)
+                if (QuantifierToken(path) is { } qt)
+                    return Wire.Refuse(json, qt.ToLowerInvariant() is "[*any]" or "[*all]" or "[*none]"
+                        ? $"error: project.fields path '{path}' folds the elements into a boolean, and a boolean is not a row — use {qt} in where= to SELECT the records, and name a concrete element ('Effects[0].Data.Magnitude') or the list itself to read one."
+                        : $"error: project.fields path '{path}' uses '{qt}', which is a where= step today — the projection half of the quantified step (a row per element, and the element count as a cell) is not built yet. Name a concrete element ('Effects[0].Data.Magnitude') or the list itself, which renders as a summary with project.depth.");
         if (project?.depth is { } dv)
         {
             // Any explicit depth is form-scoped — the rule must not depend on the value, or depth:1 is accepted
@@ -1995,6 +2005,21 @@ public static class RecordsTools
         foreach (var (key, count) in rows.Select(r => (r.Key, r.Value)))
             sb.Append("  ").Append(count.ToString().PadLeft(6)).Append("  ").Append(key).Append('\n');
         return sb.ToString();
+    }
+
+    /// <summary>The first quantifier token in a projection path, or null — a bracket key beginning '*', spelled back
+    /// as the caller wrote it so the refusal names their own token.</summary>
+    static string? QuantifierToken(string? path)
+    {
+        if (string.IsNullOrEmpty(path)) return null;
+        foreach (var seg in path.Split('.'))
+        {
+            int open = seg.IndexOf('[');
+            if (open < 0 || !seg.EndsWith("]", StringComparison.Ordinal)) continue;
+            var key = seg[(open + 1)..^1];
+            if (key.Length > 0 && key[0] == '*') return $"[{key}]";
+        }
+        return null;
     }
 
     /// <summary>Split references= into the targets a match must link to and the ones it must NOT: a leading '!'

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -113,7 +113,8 @@ public static class RecordsTools
          "scan) | references= (reverse, one step — requires a bounding types=/plugins= scope; the reverse-reference " +
          "index that would lift the bound is a known future capability. A '!' before an entry NEGATES it — " +
          "references=[\"!XXXXXX:A.esm\"] keeps only records that do NOT reference that target, and plain and " +
-         "negated entries in one call compose by AND). UNION-ARM tip: when a field is one of " +
+         "negated entries in one call compose by AND; the sigil takes the @file spelling too — " +
+         "references=[\"!@C:/work/targets.jsonl\"] excludes every target the file names). UNION-ARM tip: when a field is one of " +
          "several shapes (an NPC's Configuration.Level is a fixed level OR a PC-level multiplier), a scalar " +
          "predicate on one arm's sub-field doubles as an ARM-PRESENCE test: where=[\"Configuration.Level.LevelMult " +
          ">= 0\"] returns exactly the NPCs on a multiplier. formids= COMPOSES with the scan terms: the identity set " +
@@ -1036,7 +1037,7 @@ public static class RecordsTools
             var refs = references;
             if (refs is { Length: > 0 })
             {
-                var (toks, demand, echoSrc, xerr) = Artifacts.ExpandListInput(refs, "references");
+                var (toks, demand, echoSrc, xerr) = ExpandReferenceList(refs);
                 if (xerr is not null) return Wire.Refuse(json, xerr);
                 refs = toks!; refDemand = demand; refEcho = echoSrc;
             }
@@ -1343,7 +1344,7 @@ public static class RecordsTools
             var refs = references;
             if (refs is { Length: > 0 })
             {
-                var (toks, demand, echoSrc2, xerr) = Artifacts.ExpandListInput(refs, "references");
+                var (toks, demand, echoSrc2, xerr) = ExpandReferenceList(refs);
                 if (xerr is not null) return Wire.Refuse(json, xerr);
                 refs = toks!; refDemand = demand; refEcho = echoSrc2;
             }
@@ -2027,6 +2028,29 @@ public static class RecordsTools
             if (key.Length > 0 && key[0] == '*') return $"[{key}]";
         }
         return null;
+    }
+
+    /// <summary>references= @file expansion with the negation sigil carried across it: '!@&lt;path&gt;' excludes every
+    /// target the file names, so the negated entry spells a list file the same way the positive one does. The sigil
+    /// is stripped before the expander sees it — the expander decides "this is a file" on the first character — and
+    /// put back on each expanded token.</summary>
+    static (string[]? Tokens, HousecarlCore.ArtifactDemand? Demand, string? EchoSource, string? Error)
+        ExpandReferenceList(string[] refs)
+    {
+        var bare = new string[refs.Length];
+        bool anyNegatedFile = false;
+        for (int i = 0; i < refs.Length; i++)
+        {
+            var t = refs[i]?.TrimStart() ?? "";
+            if (t.Length > 1 && t[0] == '!' && t[1..].TrimStart().StartsWith("@", StringComparison.Ordinal))
+            { anyNegatedFile = true; bare[i] = t[1..].TrimStart(); }
+            else bare[i] = refs[i];
+        }
+        if (!anyNegatedFile) return Artifacts.ExpandListInput(refs, "references");
+        var (toks, demand, echo, err) = Artifacts.ExpandListInput(bare, "references");
+        if (err is not null) return (null, null, null, err);
+        // '@file' stands in place of the whole list, so a negated one negates every token it expanded to.
+        return (toks!.Select(t => "!" + t.Trim()).ToArray(), demand, echo is null ? null : "!" + echo, null);
     }
 
     /// <summary>Split references= into the targets a match must link to and the ones it must NOT: a leading '!'

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -97,14 +97,21 @@ public static class RecordsTools
          "earlier call (its identity column becomes the list, epoch-checked against the then-current build).\n\n" +
          "SELECT: formids= | types= | plugins= (scope: which records are considered) | conflicts_only= | where= " +
          "(body predicates, ANDed: comparisons 'BasicStats.Damage >= 50', 'editorid contains Iron', 'editorid " +
-         "startswith REQ_', flag tests 'BodyTemplate.FirstPersonFlags has Body', presence 'VirtualMachineAdapter " +
+         "startswith REQ_', flag tests 'BodyTemplate.FirstPersonFlags has Body' — every operand bit set — with " +
+         "'has_any' (at least one set) and 'has_none' (none set) as the other two folds over the same bits, " +
+         "QUANTIFIED STEPS over a list field: 'Conditions[*any].Data.Function = IsGuard', " +
+         "'Effects[*none].BaseEffect->editorid startswith REQ_' (absence, proved), 'Effects[*count] > 2' — " +
+         "[*any]/[*all]/[*none] fold the elements into a boolean, [*count] into their number, and [*all] is " +
+         "vacuously true on an empty list, presence 'VirtualMachineAdapter " +
          "exists', membership 'formid not in @<file>' / 'Race in [XXXXXX:A.esm, YYYYYY:B.esm]' (list entries " +
          "separate on commas/newlines with brackets and quotes stripped — a value that itself contains a comma " +
          "or bracket is not expressible in a list; test it with '='), ONE '->' link step " +
          "'Perks->editorid startswith REQ_NULL_', and the provenance term 'winner = X.esp' — which records does X " +
          "WIN; that term forces winner resolution over the scanned scope, the same declared cost as any winner " +
          "scan) | references= (reverse, one step — requires a bounding types=/plugins= scope; the reverse-reference " +
-         "index that would lift the bound is a known future capability). UNION-ARM tip: when a field is one of " +
+         "index that would lift the bound is a known future capability. A '!' before an entry NEGATES it — " +
+         "references=[\"!XXXXXX:A.esm\"] keeps only records that do NOT reference that target, and plain and " +
+         "negated entries in one call compose by AND). UNION-ARM tip: when a field is one of " +
          "several shapes (an NPC's Configuration.Level is a fixed level OR a PC-level multiplier), a scalar " +
          "predicate on one arm's sub-field doubles as an ARM-PRESENCE test: where=[\"Configuration.Level.LevelMult " +
          ">= 0\"] returns exactly the NPCs on a multiplier. formids= COMPOSES with the scan terms: the identity set " +
@@ -1016,17 +1023,13 @@ public static class RecordsTools
                 if (xerr is not null) return Wire.Refuse(json, xerr);
                 refs = toks!; refDemand = demand; refEcho = echoSrc;
             }
-            IReadOnlyList<FormKey>? refFks = null;
+            IReadOnlyList<FormKey>? refFks = null, refNoneFks = null;
             if (refs is { Length: > 0 })
             {
-                var list = new List<FormKey>();
-                foreach (var r in refs)
-                {
-                    if (string.IsNullOrWhiteSpace(r)) continue;
-                    try { list.Add(door.Parse(r)); }
-                    catch (Exception ex) { return Wire.Refuse(json, $"error: bad references FormID '{r}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
-                }
-                if (list.Count > 0) refFks = list.Distinct().ToList();
+                var (pos, neg, rerr) = SplitReferenceTargets(refs, door);
+                if (rerr is not null) return Wire.Refuse(json, rerr);
+                if (pos!.Count > 0) refFks = pos.Distinct().ToList();
+                if (neg!.Count > 0) refNoneFks = neg.Distinct().ToList();
             }
 
             var scanPlugins = scopePlusPole ? plugins!.names : (srcName is not null ? new[] { srcName } : plugins?.names);
@@ -1057,7 +1060,8 @@ public static class RecordsTools
             if (fidDemand is not null) demandsList.Add(fidDemand);
             var outcome = svc.CrossQuery(types, refFks, null, conflicts_only, scanPlugins, where,
                                          effLimit, definedIn, groupBy, offset, where_source,
-                                         demandsList.Count > 0 ? demandsList : null, formidSet, door.CapturedView);
+                                         demandsList.Count > 0 ? demandsList : null, formidSet, door.CapturedView,
+                                         refNoneFks);
             // The probe-to-scan seam is epoch-compared: the source statement must describe the same build the
             // rows were scanned from.
             if (probeEpoch is not null && outcome.Error is null && outcome.Epoch is not null && outcome.Epoch != probeEpoch)
@@ -1326,17 +1330,13 @@ public static class RecordsTools
                 if (xerr is not null) return Wire.Refuse(json, xerr);
                 refs = toks!; refDemand = demand; refEcho = echoSrc2;
             }
-            IReadOnlyList<FormKey>? refFks = null;
+            IReadOnlyList<FormKey>? refFks = null, refNoneFks = null;
             if (refs is { Length: > 0 })
             {
-                var list = new List<FormKey>();
-                foreach (var r in refs)
-                {
-                    if (string.IsNullOrWhiteSpace(r)) continue;
-                    try { list.Add(door.Parse(r)); }
-                    catch (Exception ex) { return Wire.Refuse(json, $"error: bad references FormID '{r}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
-                }
-                if (list.Count > 0) refFks = list.Distinct().ToList();
+                var (pos, neg, rerr) = SplitReferenceTargets(refs, door);
+                if (rerr is not null) return Wire.Refuse(json, rerr);
+                if (pos!.Count > 0) refFks = pos.Distinct().ToList();
+                if (neg!.Count > 0) refNoneFks = neg.Distinct().ToList();
             }
             HousecarlCore.ArtifactDemand? fidDemand = null; string? fidEcho = null;
             IReadOnlyList<FormKey>? formidSet = null;
@@ -1364,7 +1364,8 @@ public static class RecordsTools
 
             var outcome = svc.OffOrderQuery(pole, types, refFks, null, plugins?.names,
                                             plugins?.defined_in ?? false, where, offLimit, offGroupBy, offset,
-                                            formidSet, offDemands.Count > 0 ? offDemands : null, door.CapturedView);
+                                            formidSet, offDemands.Count > 0 ? offDemands : null, door.CapturedView,
+                                            refNoneFks);
 
             List<KeyValuePair<string, string>> Echo()
             {
@@ -1994,5 +1995,27 @@ public static class RecordsTools
         foreach (var (key, count) in rows.Select(r => (r.Key, r.Value)))
             sb.Append("  ").Append(count.ToString().PadLeft(6)).Append("  ").Append(key).Append('\n');
         return sb.ToString();
+    }
+
+    /// <summary>Split references= into the targets a match must link to and the ones it must NOT: a leading '!'
+    /// negates that entry. The two compose by AND — "links to A and to neither B nor C" is one call. A FormID
+    /// never begins with '!', so the sigil cannot collide with a target token.</summary>
+    static (List<FormKey>? Positive, List<FormKey>? Negative, string? Error)
+        SplitReferenceTargets(string[] refs, FormIdDoor door)
+    {
+        var pos = new List<FormKey>();
+        var neg = new List<FormKey>();
+        foreach (var r in refs)
+        {
+            if (string.IsNullOrWhiteSpace(r)) continue;
+            var tok = r.Trim();
+            bool negated = tok[0] == '!';
+            if (negated) tok = tok[1..].Trim();
+            if (tok.Length == 0)
+                return (null, null, "error: a references= entry is just '!' and names no target — write '!XXXXXX:Plugin.esp' to exclude the records that reference it.");
+            try { (negated ? neg : pos).Add(door.Parse(tok)); }
+            catch (Exception ex) { return (null, null, $"error: bad references FormID '{r}': {ex.Message}. Expected 'XXXXXX:Plugin.esp', or '!XXXXXX:Plugin.esp' to exclude."); }
+        }
+        return (pos, neg, null);
     }
 }

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -227,9 +227,16 @@ public static class RecordsTools
         if (project?.fields is { Length: > 0 } pf)
             foreach (var path in pf)
                 if (QuantifierToken(path) is { } qt)
-                    return Wire.Refuse(json, qt.ToLowerInvariant() is "[*any]" or "[*all]" or "[*none]"
+                {
+                    var qtl = qt.ToLowerInvariant();
+                    // A token outside the vocabulary is a typo, not a capability that is coming — say so in the
+                    // parser's own words, so where= and project.fields judge the same token the same way.
+                    if (qtl is not ("[*]" or "[*count]" or "[*any]" or "[*all]" or "[*none]"))
+                        return Wire.Refuse(json, $"error: project.fields path '{path}': '{qt}' is not a quantifier — the tokens are [*], [*count], [*any], [*all] and [*none] (the last three fold to a boolean and belong in where=).");
+                    return Wire.Refuse(json, qtl is "[*any]" or "[*all]" or "[*none]"
                         ? $"error: project.fields path '{path}' folds the elements into a boolean, and a boolean is not a row — use {qt} in where= to SELECT the records, and name a concrete element ('Effects[0].Data.Magnitude') or the list itself to read one."
                         : $"error: project.fields path '{path}' uses '{qt}', which is a where= step today — the projection half of the quantified step (a row per element, and the element count as a cell) is not built yet. Name a concrete element ('Effects[0].Data.Magnitude') or the list itself, which renders as a summary with project.depth.");
+                }
         if (project?.depth is { } dv)
         {
             // Any explicit depth is form-scoped — the rule must not depend on the value, or depth:1 is accepted


### PR DESCRIPTION
A `where=` path step can now declare its multiplicity and its fold where the list binds, and `where=`/`references=` gain the exclusion spellings that go with it. This is step 1 of E1, the parser and the evaluation over what the current flat index already answers; containment (`*parent`, #459) and the reverse-reference index (#489) are the next two steps and are not touched here.

Four tokens land in the step: `Conditions[*any].Data.Function = IsGuard` matches when some element does, `[*all]` when every one does (vacuously true on an empty list), `[*none]` when none does — the "absence, proved" query, `Effects[*none].BaseEffect->editorid startswith REQ_` — and `[*count]` yields the number of elements for a numeric or membership comparison. The fold is the one `EvalLinkStep` already ran over link targets with the fan-out source swapped to the step's elements, so it composes with the `->` link step and with another quantified step for free; an absent list reads as empty, and so does one whose parent substruct is absent, so `VirtualMachineAdapter.Scripts[*count] = 0` finds the records that carry no script at all. The step's shape is judged on its DECLARED type, so a null non-list field is refused exactly as a carried one is, and a dict or a raw byte block is named rather than folded over. Where one element cannot be judged, the fold reports no verdict rather than claiming one — a universal over a list with an unread element is not proved.

The refusals: the bare `[*]` is the element set and is refused in a predicate naming the three fold tokens; an unknown quantifier word is refused naming all four; `[*count]` refuses anything after it and refuses an operator that is not a number comparison; a quantifier on a step that is not a list is refused from the schema wherever `types=` says which record type it lands on (naming the step's real cardinality), and where the scope cannot say — no `types=`, or a mixed one whose arms disagree — the scan's per-record accounting names what that step read instead. A fold token in `project.fields` is refused too: a boolean is not a row. The same token reaching the concrete-index walk now says which parameter each token belongs to rather than reporting an unbuilt capability as a malformed index, and the list-hop remedy offers the quantified spelling beside the bracketed one. The quantified step's cost — per-candidate work times list length, and one winner fetch per element under `->` — is named in the tool description beside the tokens, per SPEC §2's amendment.

For the exclusion half: `has` gains `has_any` (at least one operand bit set) and `has_none` (none set) — the same any/all/none fold over the bits of one leaf, three branches on an op enum that already evaluated `Has` bitwise — and a `!` before a `references=` entry inverts it, so `references=["!XXXXXX:A.esm"]` keeps only the records that do not reference that target. Plain and negated entries in one call compose by AND, and the negated form takes the same bounding `types=`/`plugins=`/`formids=` scope the plain form takes. A record with no live body is kept by the negated term — it references nothing at all, which is the strongest match the term has — rather than riding the skip the positive term needs.

**What is left of #458.** The PROJECT half is not here, so this PR references #458 rather than closing it. `fields` taking `[*]` and `[*count]`, and `dense`'s row-per-element reading, are named in SPEC §2.2's amendment but not specified far enough to build blind: neither the design page nor the SPEC says what `[*]` renders in `format=text`/`json`, what happens when two quantified paths in one `fields=` list have different element counts (a product, an alignment, or a refusal), or which identity columns the extra dense rows carry. Rather than guess a row shape that a skill would then be authored against, this PR ships the half that is specified — the `where=` vocabulary — and refuses the tokens in `project.fields` by name so nothing reads them silently. The remainder is #458's PROJECT half, and it is vocabulary, so it still needs to land before W6.

One thing the design page and the SPEC did not settle: the *spelling* of the negated `references=`. Both say the term "gains a negated spelling" without naming it. I took `!<formid>` on the §5.5 sigil rule — a FormID token can never begin with `!`, so the sigil is disjoint from the co-resident space by construction — and made mixed plain/negated entries compose by AND rather than refusing, since the AND is well defined and a refusal would leave "references A but not B" unaskable. If Aaron wants a different spelling it is a one-line change in `RecordsTools.SplitReferenceTargets` plus the tool description, and it is vocabulary, so it should be settled before W6. Its *meaning* is a second question, raised in the review and left for Aaron in a comment below.

Build, tests and probes green: 1202 tests (baseline 1160) and 128/128 probes. Every token and every refusal has a test.

Refs #458 (SELECT half; the PROJECT half stated above remains)
Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)
