### PR TITLE
Read a cell's child records as the additive union the game assembles

### DIFF
--- a/docs/architecture/records-owned-child-declarers.md
+++ b/docs/architecture/records-owned-child-declarers.md
@@ -1,32 +1,65 @@
-# Owned-child declarers: two tiers, one sentence source
+# Owned-child content: the additive union, and one sentence source
 
-**Class:** LIVING. Subsystem: `ReadSentences` (the owned-child consts), `LoadOrderService.AnnotateOwnedChildContent`
-/ `ResolveTreePinned`, `RecordsTools.AppendChildDeclarers`, `JsonWire.WriteTreeRow`, `Artifacts.WriteTree`.
+**Class:** LIVING. Subsystem: `OwnedChildUnion` and `OwnedChildContent` (`src/housecarl-core`), `ReadSentences`
+(the owned-child consts), `LoadOrderService.AnnotateOwnedChildContent` / `ResolveTreePinned`,
+`JsonWire.WriteChildUnion`, `RecordsTools.AppendChildDeclarers`, `JsonWire.WriteTreeRow`, `Artifacts.WriteTree`.
 Pinned by `RecordsOwnedChildTests` (`src/housecarl-mcp-tests`) and `OwnedChildContentProbe`
 (`src/housecarl-generator`).
 
-## Why two tiers
+## What a read of a child-bearing field answers
 
 A child-bearing field (a cell's `Persistent`/`Temporary`, a topic's `Responses`, a worldspace's `SubCells`) is
 declared per plugin and assembled by the game from every declarer. An override that touches the parent for an
 unrelated reason (occlusion, lighting) carries none and deletes none, so reading it reports an empty collection
 the game fills — the #342 bug.
 
-Naming WHICH plugins declare requires reading their bodies. Doing that per toucher on every read was built,
-measured on a real load order, and withdrawn: 27ms -> 588ms for one Dawnstar cell, 21ms -> 1.3s for Tamriel, a
-worldspace read to 2.5s, 6.3s -> 126s for a 200-cell query, and an unbounded artifact job that never finished. So
-the DEFAULT read states only the cheap fact the index gives for free (`ReadSentences.NotRead` and friends): other
-plugins touch the record, their declarations were not read.
+So a read states two quantities, and they are not the same:
 
-`records project={"form":"tree"}` already opens every provider's body to build its diff, so it states the
-precise fact there at no extra cost: which plugins actually declare (`ReadSentences.DeclaredBy` / `CarriedBy` /
-`NoDeclarers`, composed per field by `DeclarersNote`).
+- the field's **VALUE** — the body the read was taken from, its own list, in its own order. Those are the
+  addresses a write uses (`Temporary[0]` on a `Remove`), so the union is never spliced into them.
+- the **additive union** beside it (`OwnedChildUnion.Compute`) — every distinct child every touching plugin
+  declares, keyed by FormID so a child two overrides both declare counts once, with each contributor's own
+  count and how much of it the read body carries. It rides `FieldValue.Display`, which reaches text, json and
+  artifacts through one carrier, and json also carries it structurally as `owned_child_union` (the member
+  FormIDs, capped at `JsonWire.ChildUnionMemberCap`).
+
+A SINGULAR owned child (`Cell.Landscape`, `Worldspace.TopCell`) is not a union — its declarers override one
+record — so the note says which plugin's copy is live instead of adding counts that would be a fiction.
+
+The union claims DECLARATION, not liveness: whether a member's own winner is deleted or initially disabled is a
+fact about that child record, and asserting it here would cost one fetch per member.
+
+## What it costs
+
+One body per touching plugin, and only on a read that actually emitted a child-bearing field — a projection
+naming none pays nothing. The bodies are seeked by the record's own type
+(`LoadOrderResolver.IndexView.GetRecord` takes it), which is #354: Mutagen's typed enumeration walks only the
+GRUPs that can hold that type, so finding a cell does not step over the placed references that outnumber it.
+Measured on a #354-shaped synthetic order (one 20k-record master, nine 2k plugins, ten touchers of one cell with
+209 references in its union): the ten bodies cost **80 ms** fetched flat and **4 ms** seeked by type, and the
+whole union read answers in 3.3 ms against 1.0 ms for the same read projecting `EditorID` alone.
+
+That measurement is why the union is the default rather than a second tier. The earlier per-toucher walk was
+withdrawn on a real load order at 27ms -> 588ms for one Dawnstar cell and 21ms -> 1.3s for Tamriel; the typed
+seek is the ceiling those numbers were paying.
+
+## The tree form still names WHICH
+
+`records project={"form":"tree"}` opens every provider's body to build its diff, so it states per-provider
+declaration there at no extra cost (`ReadSentences.DeclaredBy` / `CarriedBy` / `NoDeclarers`, composed per field
+by `DeclarersNote`). The union answers "how much is here and where does it come from"; the tree answers "which
+provider declares what".
 
 ## History
 
-Until the 1.x cut, the precise tier lived on `read_record conflict_tree=true`. No 2.0 surface sets that flag, so
-it had no caller and was deleted with its sentences (gap #485, PR #484's cut). #485 restored it on the tree form
-instead — the 2.0 lane that already pays the cost the tier needs, with no new parameter, pole, or vocabulary.
+Until the 1.x cut, the per-provider tier lived on `read_record conflict_tree=true`. No 2.0 surface sets that
+flag, so it had no caller and was deleted with its sentences (gap #485, PR #484's cut). #485 restored it on the
+tree form instead — the 2.0 lane that already pays the cost the tier needs, with no new parameter, pole, or
+vocabulary.
+
+#342 stage 1 (PR #355) was the index-only tier: the default read said other plugins touch this record and their
+declarations were not read. #342 stage 2 / #487 replaced it with the union above, once #354's typed seek made
+the bodies affordable.
 
 ## The negative is a sentence, not silence
 

--- a/docs/architecture/records-owned-child-declarers.md
+++ b/docs/architecture/records-owned-child-declarers.md
@@ -71,6 +71,23 @@ body per toucher per named record and is what the caller asked for.
 Both numbers are from this synthetic, not from a real load order; the shapes a real order adds are more touchers
 per cell and bigger plugins, both of which the per-toucher cost scales with linearly.
 
+### One overlay cache per call, not per record
+
+A session is the cache that keeps a plugin's overlay open, and `ResolveRead` used to open its own per record —
+so a batch re-mmapped every toucher once per ROW. The `ChildUnionMemo` does not cover this: it dedupes a
+repeated FORMID, and a batch's rows are distinct records over the SAME plugins. So the batch lanes now open one
+session for the call and hand it down. On the synthetic above, the 200-cell `formids=` batch:
+
+| | overlay opens | wall |
+|---|---|---|
+| a session per record | 2,050 | 2.12 s |
+| one per call | 10 | 1.37 s |
+
+The remaining second is the per-toucher body walk itself, which is the thing the caller asked for. Opens scale
+with the ORDER's plugin count now instead of with rows, which is what makes the real-order shape — more
+touchers, bigger plugins — cost more only in the walk. `RecordsOwnedChildTests` pins the count via
+`LoadOrderResolver.SessionOverlayOpens`; nothing else reads it.
+
 ## The tree form still names WHICH
 
 `records project={"form":"tree"}` opens every provider's body to build its diff, so it states per-provider

--- a/docs/architecture/records-owned-child-declarers.md
+++ b/docs/architecture/records-owned-child-declarers.md
@@ -29,19 +29,47 @@ record — so the note says which plugin's copy is live instead of adding counts
 The union claims DECLARATION, not liveness: whether a member's own winner is deleted or initially disabled is a
 fact about that child record, and asserting it here would cost one fetch per member.
 
+## Which lanes assemble it
+
+The union costs a body per touching plugin, so it runs only where the CALLER named the records: the single read,
+`batch_record_detail`, and the `records` source pole. Those lanes are handed a formid list, and one
+`LoadOrderService.ChildUnionMemo` per call assembles each record once however many times it is named.
+
+The SCAN lanes — the `cross_plugin_query` detail rows, the dense grid, and the artifact spill of either —
+discover their row count instead of being handed it, so a body per toucher per row is a cost nobody asked for.
+They annotate with the index-only note (`ReadSentences.NotRead`): other plugins touch this record and their
+declarations were not read, plus a clause naming the formids lane that does assemble the union. Annotated either
+way — the field is a false-empty on both — but a scan never claims a quantity it did not compute.
+
 ## What it costs
 
 One body per touching plugin, and only on a read that actually emitted a child-bearing field — a projection
 naming none pays nothing. The bodies are seeked by the record's own type
 (`LoadOrderResolver.IndexView.GetRecord` takes it), which is #354: Mutagen's typed enumeration walks only the
 GRUPs that can hold that type, so finding a cell does not step over the placed references that outnumber it.
-Measured on a #354-shaped synthetic order (one 20k-record master, nine 2k plugins, ten touchers of one cell with
-209 references in its union): the ten bodies cost **80 ms** fetched flat and **4 ms** seeked by type, and the
-whole union read answers in 3.3 ms against 1.0 ms for the same read projecting `EditorID` alone.
 
-That measurement is why the union is the default rather than a second tier. The earlier per-toucher walk was
-withdrawn on a real load order at 27ms -> 588ms for one Dawnstar cell and 21ms -> 1.3s for Tamriel; the typed
-seek is the ceiling those numbers were paying.
+Measured on a #354-shaped synthetic order — one 19.2k-record master and nine ~2k plugins, a worldspace of 200
+exterior cells each carrying 40 placed references, every plugin overriding the worldspace and every cell while
+declaring no references (the #342 shape), so every cell has ten touchers:
+
+| shape | without the union | with |
+|---|---|---|
+| one cell, `fields=["EditorID"]` / `fields=["Temporary"]` | 1.9 ms | 5.7 ms |
+| the worldspace, `fields=["EditorID"]` / `fields=["SubCells"]` (union of 200 cells) | 1.8 ms | 8.8 ms |
+| 200 cells named by `formids=` | — | 1.04 s |
+| the same 200 cells as a `types=["CELL"]` SCAN | 0.24 s (index-only) | not run |
+
+That is what the per-toucher walk was withdrawn over, re-measured. The withdrawal's five numbers were 27ms ->
+588ms for a Dawnstar cell, 21ms -> 1.3s for Tamriel, a worldspace read to 2.5s, 6.3s -> 126s for a 200-cell
+query, and an artifact job that never finished. The typed seek is what the first three were paying: a worldspace
+read here is 8.8 ms, because the seek finds the parent without stepping over the references, and `ChildKeys`
+stops at the cells rather than descending into them. The last two are answered by the lane split rather than by
+the seek — a 200-cell query is a scan, and a scan states the index-only note, so neither it nor the artifact job
+it spills to multiplies the union by N rows. Naming those 200 cells by formid still costs a second, which is one
+body per toucher per named record and is what the caller asked for.
+
+Both numbers are from this synthetic, not from a real load order; the shapes a real order adds are more touchers
+per cell and bigger plugins, both of which the per-toucher cost scales with linearly.
 
 ## The tree form still names WHICH
 

--- a/docs/architecture/records-owned-child-declarers.md
+++ b/docs/architecture/records-owned-child-declarers.md
@@ -104,6 +104,16 @@ field (`Cell.Landscape`, `Worldspace.TopCell`) is one record several plugins ove
 would be the same noise; the line is a COUNT instead. `DeclarersLead` states both shapes once per record, not
 once per field — the same response/field split the cheap tier's own clause established.
 
+## The unit a count is in
+
+A union counts RECORDS; a field's rendered value counts the field's own ELEMENTS. On every flat field those are
+the same things. On `Worldspace.SubCells` they are not: the value counts blocks, and the cells sit two container
+levels under them — a worldspace declaring no cells at all still renders `[list: 2 item(s)]` for empty block
+scaffolding. Setting an own-share of 0 beside a value of 2 with nothing saying they differ is a contradiction on
+the face of the line, so the nested shape names its unit (`ReadSentences.OwnShare`) and json carries `nested`.
+Which fields are nested is `OwnedChildContent.NestedFields` — the element type of the property, off the same
+reflected child-bearing set as the shape, never a list naming `SubCells`.
+
 ## Placement: above the diff, not inside it
 
 The diff renders differences; a provider whose content in a child-bearing field equals the reference's is

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -123,11 +123,16 @@ saying it sets an expectation their install may contradict. Say what is known, a
   field's value is unchanged — it is still that body's own list, in its own order, which is what a write
   addresses by index — and the union sits beside it: how many distinct children the order declares, which
   plugins contribute how many, and how much of it this body carries. A child two plugins both declare counts
-  once. In json the union also carries the member FormIDs, so they can be read straight back through
-  `formids=`. A field whose child is SINGULAR (`Cell.Landscape`, `Worldspace.TopCell`) is not a union — those
-  declarers override one record — so it says which plugin's copy is live instead. A plugin whose body could not
-  be read is named beside the union, never absorbed into it. `project={"form":"tree"}` still names which
-  provider declares what.
+  once. In json the union also carries a SAMPLE of the member FormIDs — up to 100, and fewer when `max_chars`
+  is tight, with `members_omitted` counting the rest — so a short union can be read straight back through
+  `formids=` and a long one still says how much it left out. A field whose child is SINGULAR (`Cell.Landscape`,
+  `Worldspace.TopCell`) is not a union — those declarers override one record — so it says which plugin's copy is
+  live instead. A plugin whose body could not be read is named beside the union, never absorbed into it.
+  `project={"form":"tree"}` still names which provider declares what.
+- **The union is stated on reads that NAME the records** — `formids=`, whether one or a batch. A scan
+  (`types=`, `plugins=`, `references=`) discovers its own row count, so opening a body per touching plugin per
+  row would be a cost nobody asked for: a scan still flags such a field, saying other plugins touch the record
+  and their declarations were not read, and names the `formids=` lane that assembles the union.
 - **A record body is now fetched from a named plugin by a typed group seek rather than a scan of the whole
   plugin.** Finding one cell no longer steps over every placed reference in the plugin, which is what makes the
   union above affordable on every read; the conflict tree takes the same path. Measured on a synthetic order of

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -123,7 +123,8 @@ saying it sets an expectation their install may contradict. Say what is known, a
   field's value is unchanged — it is still that body's own list, in its own order, which is what a write
   addresses by index — and the union sits beside it: how many distinct children the order declares, which
   plugins contribute how many, and how much of it this body carries. A child two plugins both declare counts
-  once. In json the union also carries a SAMPLE of the member FormIDs — up to 100, and fewer when `max_chars`
+  once. On `Worldspace.SubCells` the value counts the worldspace's BLOCKS and its children are the cells under
+  them, so the note names that unit instead of setting the two numbers beside each other as if they matched. In json the union also carries a SAMPLE of the member FormIDs — up to 100, and fewer when `max_chars`
   is tight, with `members_omitted` counting the rest — so a short union can be read straight back through
   `formids=` and a long one still says how much it left out. A field whose child is SINGULAR (`Cell.Landscape`,
   `Worldspace.TopCell`) is not a union — those declarers override one record — so it says which plugin's copy is

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -116,6 +116,22 @@ saying it sets an expectation their install may contradict. Say what is known, a
   None-property diagnostics read it), and the list's own header keeps its true count. Under `format='json'` a row
   is one entry carrying its folded leaves as `cells`, each with its own value, `link` and count — the values are
   never handed over as a sentence to parse.
+- **Reading a cell's `Persistent`/`Temporary` — or a topic's `Responses`, or a worldspace's `SubCells` — now
+  states the additive union the game assembles, not just the read body's own list.** These children are declared
+  per plugin and the engine assembles a parent's from every plugin that declares any, so a cell whose winner is
+  an occlusion or lighting patch used to read as empty when the game fills it with hundreds of references. The
+  field's value is unchanged — it is still that body's own list, in its own order, which is what a write
+  addresses by index — and the union sits beside it: how many distinct children the order declares, which
+  plugins contribute how many, and how much of it this body carries. A child two plugins both declare counts
+  once. In json the union also carries the member FormIDs, so they can be read straight back through
+  `formids=`. A field whose child is SINGULAR (`Cell.Landscape`, `Worldspace.TopCell`) is not a union — those
+  declarers override one record — so it says which plugin's copy is live instead. A plugin whose body could not
+  be read is named beside the union, never absorbed into it. `project={"form":"tree"}` still names which
+  provider declares what.
+- **A record body is now fetched from a named plugin by a typed group seek rather than a scan of the whole
+  plugin.** Finding one cell no longer steps over every placed reference in the plugin, which is what makes the
+  union above affordable on every read; the conflict tree takes the same path. Measured on a synthetic order of
+  one 20k-record master and nine 2k plugins, ten touchers of one cell: 80 ms of body fetches became 4 ms.
 - **`housecarl_load_order_status` now names the running server's build in its header** — a `server:` line carrying
   the informational version the binary embeds (the release version `build-plugin.ps1` stamps from `plugin.json`,
   then `+` and the full commit sha: `1.9.5-dev+e942910…`), so checking that the installed houseCARL is the build you expect no longer means

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -261,6 +261,12 @@ public sealed class LoadOrderResolver : IDisposable
     /// keeps results valid by holding the session open until it has materialised what it returns (the service reads
     /// fields off a fetched body before its session disposes; the write path keeps the source body + link cache valid
     /// through serialize).</summary>
+    /// <summary>How many overlay OPENS sessions have paid in this process, counted where one actually happens.
+    /// Whether a call opened a plugin once or once per row is invisible in every answer — the bytes are the same,
+    /// only the clock differs — so this is the one thing a test can hold a session-reuse claim to. Read-only to
+    /// everything but <see cref="OverlaySession.Overlay"/>.</summary>
+    internal static long SessionOverlayOpens;
+
     public sealed class OverlaySession : IDisposable
     {
         readonly LoadOrderResolver _r;
@@ -272,7 +278,10 @@ public sealed class LoadOrderResolver : IDisposable
         internal ISkyrimModGetter Overlay(int idx)
         {
             if (!_open.TryGetValue(idx, out var ov))
+            {
+                System.Threading.Interlocked.Increment(ref SessionOverlayOpens);
                 _open[idx] = ov = OpenOverlay(_r._paths[idx], _r._dataDir);
+            }
             return ov;
         }
 

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -876,8 +876,8 @@ public sealed class LoadOrderResolver : IDisposable
         /// excluded-plugin check judged against THIS view's build — so a winner this view resolved and the body
         /// fetched for it can never be vetted by two different builds. The write path resolves every edit of one call
         /// off ONE view; reads pin their fetch to the same view they resolved with.</summary>
-        public IMajorRecordGetter? GetRecord(OverlaySession session, string pluginName, FormKey fk)
-            => _r.GetRecord(session, pluginName, fk, _s);
+        public IMajorRecordGetter? GetRecord(OverlaySession session, string pluginName, FormKey fk, Type? getterType = null)
+            => _r.GetRecord(session, pluginName, fk, _s, getterType);
 
         /// <summary>The master filenames a plugin DECLARES in its header (the master table), in declared order — opens
         /// the overlay, reads the header, disposes — the header parses without enumerating records. Throws
@@ -920,11 +920,15 @@ public sealed class LoadOrderResolver : IDisposable
         var overlayIdxs = e.count == 1 ? new[] { e.winner } : s.Overriders[fk];
         var nodes = new ConflictNode[overlayIdxs.Length];
         string? recType = null;
+        // The FIRST body is fetched blind; every one after it seeks by the type that body turned out to be, which is
+        // the same record's type in every provider. On a cell that turns N flat scans into one plus N-1 typed seeks.
+        Type? getterType = null;
         for (int n = 0; n < overlayIdxs.Length; n++)
         {
             int oi = overlayIdxs[n];
-            var rec = FetchBody(session, oi, fk);
+            var rec = FetchBody(session, oi, fk, getterType);
             recType ??= RecordNaming.StripOverlay(rec.GetType().Name);
+            getterType ??= WriteEngine.PrimaryGetter(rec.GetType());
             nodes[n] = new ConflictNode(_names[oi], rec);
         }
         return new ConflictTree(fk, recType ?? "?", nodes);
@@ -962,14 +966,29 @@ public sealed class LoadOrderResolver : IDisposable
     /// the private <see cref="FetchBody"/> (which throws on an index inconsistency). The server's read_record uses this
     /// for an explicit-plugin read, and for the winner's body off <see cref="ResolveWinner"/>. The returned body is
     /// backed by the session's overlay — read it before the session disposes.</summary>
-    public IMajorRecordGetter? GetRecord(OverlaySession session, string pluginName, FormKey fk)
-        => GetRecord(session, pluginName, fk, _snap);                      // single-shot: this call = its own build (the IndexView overload pins a whole operation)
+    public IMajorRecordGetter? GetRecord(OverlaySession session, string pluginName, FormKey fk, Type? getterType = null)
+        => GetRecord(session, pluginName, fk, _snap, getterType);          // single-shot: this call = its own build (the IndexView overload pins a whole operation)
 
-    IMajorRecordGetter? GetRecord(OverlaySession session, string pluginName, FormKey fk, IndexSnapshot s)
+    IMajorRecordGetter? GetRecord(OverlaySession session, string pluginName, FormKey fk, IndexSnapshot s, Type? getterType)
     {
         if (!_nameToIdx.TryGetValue(pluginName, out int idx)) return null;
         if (s.Excluded.Contains(idx)) return null;                         // excluded plugin — never re-enumerate it (would re-throw); the service reports the reason via ExcludedPlugins
-        foreach (var rec in session.Overlay(idx).EnumerateMajorRecords())
+        return SeekBody(session.Overlay(idx), fk, getterType);
+    }
+
+    /// <summary>Find one record in one open overlay. With <paramref name="getterType"/> in hand this is a TYPED
+    /// group seek: Mutagen walks only the GRUPs that can hold that type, so finding a cell does not step over the
+    /// placed references that outnumber it fifty to one (#354 — the cost that shaped the owned-child read's two
+    /// tiers). Without a type it is the flat scan, unchanged.
+    /// <para>A typed walk that yields nothing falls back to the flat one. Mutagen's typed enumeration is a switch
+    /// over the types it models, and a type it does not route would otherwise turn "this plugin has the record"
+    /// into a silent "it does not" — the fallback costs a second pass on a miss and never a wrong answer.</para></summary>
+    static IMajorRecordGetter? SeekBody(ISkyrimModGetter ov, FormKey fk, Type? getterType)
+    {
+        if (getterType is not null)
+            foreach (var rec in ov.EnumerateMajorRecords(getterType, throwIfUnknown: false))
+                if (rec.FormKey == fk) return rec;
+        foreach (var rec in ov.EnumerateMajorRecords())
             if (rec.FormKey == fk) return rec;
         return null;
     }
@@ -1000,10 +1019,9 @@ public sealed class LoadOrderResolver : IDisposable
 
     /// <summary>Fetch one record body from one overlay by re-enumerating it into the session. Throws if the overlay
     /// can't yield a FormKey the index says it contains — a real inconsistency, named rather than swallowed.</summary>
-    IMajorRecordGetter FetchBody(OverlaySession session, int overlayIdx, FormKey fk)
+    IMajorRecordGetter FetchBody(OverlaySession session, int overlayIdx, FormKey fk, Type? getterType = null)
     {
-        foreach (var rec in session.Overlay(overlayIdx).EnumerateMajorRecords())
-            if (rec.FormKey == fk) return rec;
+        if (SeekBody(session.Overlay(overlayIdx), fk, getterType) is { } rec) return rec;
         throw new InvalidOperationException(
             $"body-fetch inconsistency: {_names[overlayIdx]} is indexed as containing {fk} but did not yield it on re-enumeration.");
     }

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -928,7 +928,7 @@ public sealed class LoadOrderResolver : IDisposable
             int oi = overlayIdxs[n];
             var rec = FetchBody(session, oi, fk, getterType);
             recType ??= RecordNaming.StripOverlay(rec.GetType().Name);
-            getterType ??= WriteEngine.PrimaryGetter(rec.GetType());
+            getterType ??= WriteEngine.SeekTypeFor(rec);
             nodes[n] = new ConflictNode(_names[oi], rec);
         }
         return new ConflictTree(fk, recType ?? "?", nodes);

--- a/src/housecarl-core/OwnedChildContent.cs
+++ b/src/housecarl-core/OwnedChildContent.cs
@@ -75,6 +75,37 @@ public static class OwnedChildContent
 
     static readonly ConcurrentDictionary<Type, IReadOnlyDictionary<string, OwnedChildShape>> _byType = new();
 
+    /// <summary>The child-bearing fields whose child records sit BELOW the field's own elements —
+    /// <c>Worldspace.SubCells</c> holds BLOCKS, and its cells are two container levels under them.
+    ///
+    /// <para>It is the unit question, and it is a fact about the PROPERTY, so it is answered off the type beside
+    /// the shape. A field's rendered VALUE is the field's own elements; a child count counts records. On a flat
+    /// field (a cell's Persistent/Temporary, a topic's Responses) those are the same things and a note may put the
+    /// two numbers side by side. On a NESTED one they are different units — a worldspace declaring no cells at all
+    /// still renders <c>[list: 2 item(s)]</c> for its empty blocks — so a note carrying both has to say which it
+    /// is counting or it states a contradiction.</para></summary>
+    public static IReadOnlySet<string> NestedFields(IMajorRecordGetter body) =>
+        _nestedByType.GetOrAdd(body.GetType(), static t =>
+        {
+            var set = new HashSet<string>(StringComparer.Ordinal);
+            // The same getter → concrete hop Fields makes, for the same reason: the overlay type is not the type
+            // the child-bearing walk was written against.
+            var getter = WriteEngine.PrimaryGetter(t);
+            var concrete = getter is null ? null : WriteEngine.ConcreteOf(getter);
+            if (concrete is null) return (IReadOnlySet<string>)set;
+            foreach (var p in WriteEngine.ChildBearingProperties(concrete))
+            {
+                if (typeof(IMajorRecordGetter).IsAssignableFrom(p.PropertyType)) continue;   // singular: the value IS the child
+                var elem = WriteEngine.ElementTypeOf(p.PropertyType);
+                // An element that is itself a record makes the list the child list. Anything else — a block, or a
+                // shape this walk cannot name an element type for — holds its children deeper down.
+                if (elem is null || !typeof(IMajorRecordGetter).IsAssignableFrom(elem)) set.Add(p.Name);
+            }
+            return (IReadOnlySet<string>)set;
+        });
+
+    static readonly ConcurrentDictionary<Type, IReadOnlySet<string>> _nestedByType = new();
+
     /// <summary>The shape of one field on <paramref name="body"/>'s type, or <see cref="OwnedChildShape.None"/>
     /// when the field owns no children.</summary>
     public static OwnedChildShape ShapeOf(IMajorRecordGetter body, string field) =>

--- a/src/housecarl-core/OwnedChildUnion.cs
+++ b/src/housecarl-core/OwnedChildUnion.cs
@@ -31,9 +31,6 @@ public sealed record ChildUnion(
     /// <summary>Distinct child records the order declares for this field.</summary>
     public int Total => Members.Count;
 
-    /// <summary>Does the body the read was taken from carry less than the whole? The #342 case in one predicate:
-    /// the winner touched the parent for an unrelated reason and its own list reads short or empty.</summary>
-    public bool OwnIsPartial => OwnCount < Total;
 }
 
 /// <summary>
@@ -65,7 +62,7 @@ public static class OwnedChildUnion
         var touching = view.TouchingPlugins(fk);
         if (touching is null || touching.Count <= 1) return null;
 
-        var getterType = WriteEngine.PrimaryGetter(subjectBody.GetType());
+        var getterType = WriteEngine.SeekTypeFor(subjectBody);
         var members = new Dictionary<string, List<FormKey>>(StringComparer.Ordinal);
         var seen = new Dictionary<string, HashSet<FormKey>>(StringComparer.Ordinal);
         var declarers = new Dictionary<string, List<ChildUnionDeclarer>>(StringComparer.Ordinal);
@@ -84,9 +81,15 @@ public static class OwnedChildUnion
         // shape's live copy is simply the last declarer standing.
         foreach (var plugin in touching)
         {
-            var body = string.Equals(plugin, subjectPlugin, StringComparison.OrdinalIgnoreCase)
-                ? subjectBody
-                : view.GetRecord(session, plugin, fk, getterType);
+            // A sibling plugin that will not OPEN must not fault the read. The subject's own body is already in
+            // hand, so the answer the caller asked for survives; this plugin becomes an unreadable the note names.
+            // The transient case is the common one — xEdit or MO2 holding an exclusive handle, an AV scan — and
+            // before the union the default read opened only the source, so nothing here could ever throw.
+            IMajorRecordGetter? body;
+            if (string.Equals(plugin, subjectPlugin, StringComparison.OrdinalIgnoreCase)) body = subjectBody;
+            else
+                try { body = view.GetRecord(session, plugin, fk, getterType); }
+                catch { body = null; }
             foreach (var f in fields.Keys)
             {
                 // Null is "could not look", never "declares nothing" — a provider counted into the negative would
@@ -143,7 +146,14 @@ public static class OwnedChildUnion
         // TYPE this field owns, so the walk stops at the cells rather than descending into their contents.
         if (val is IMajorRecordGetterEnumerable en && childType is not null)
         {
+            int before = sink.Count;
             foreach (var child in en.EnumerateMajorRecords(childType, throwIfUnknown: false)) sink.Add(child.FormKey);
+            // A typed enumeration Mutagen does not route yields an EMPTY sequence rather than throwing, which would
+            // turn "I could not look" into "it declares nothing" — the #308 rule inverted. So an empty typed walk
+            // over a container that holds records at all is a miss, not a negative: fail closed and let the caller
+            // say the body could not be read. The untyped check runs only on that empty branch and stops at the
+            // first record it finds, so the walk this arm exists to avoid is never paid on the normal path.
+            if (sink.Count == before && en.EnumerateMajorRecords().Any()) return false;
             return true;
         }
         if (val is System.Collections.IEnumerable seq)

--- a/src/housecarl-core/OwnedChildUnion.cs
+++ b/src/housecarl-core/OwnedChildUnion.cs
@@ -1,0 +1,157 @@
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+
+namespace HousecarlCore;
+
+/// <summary>One plugin's contribution to a field's additive union: how many child records ITS body declares there.
+/// A child two plugins both declare is counted by both — the counts are contributions, not a partition, which is
+/// why <see cref="ChildUnion.Total"/> is carried rather than summed from these.</summary>
+public sealed record ChildUnionDeclarer(string Plugin, int Count);
+
+/// <summary>What the game assembles for ONE child-bearing field of ONE record, across every plugin that touches it.
+///
+/// <para>For a <see cref="OwnedChildShape.Collection"/> field the answer is a UNION keyed by FormID:
+/// <see cref="Members"/> is every distinct child the order declares, in load order of first declaration, each
+/// counted once however many plugins declare it. For a <see cref="OwnedChildShape.Singular"/> field there is no
+/// union — the declarers override one record — so <see cref="Members"/> is the one live child and
+/// <see cref="LivePlugin"/> is the highest plugin declaring it.</para>
+///
+/// <para><b>What it claims is DECLARATION, not liveness.</b> A child in this set is one some plugin declares for
+/// this parent. Whether that child's own winner is deleted or initially disabled is a fact about the child record,
+/// readable by reading it, and asserting it here would cost one fetch per member.</para></summary>
+public sealed record ChildUnion(
+    string Field,
+    OwnedChildShape Shape,
+    IReadOnlyList<FormKey> Members,
+    int OwnCount,
+    IReadOnlyList<ChildUnionDeclarer> Declarers,
+    IReadOnlyList<string> Unreadable,
+    string? LivePlugin)
+{
+    /// <summary>Distinct child records the order declares for this field.</summary>
+    public int Total => Members.Count;
+
+    /// <summary>Does the body the read was taken from carry less than the whole? The #342 case in one predicate:
+    /// the winner touched the parent for an unrelated reason and its own list reads short or empty.</summary>
+    public bool OwnIsPartial => OwnCount < Total;
+}
+
+/// <summary>
+/// The additive union a child-bearing field really holds (#342 / #487).
+///
+/// <para>An owned child record is declared PER PLUGIN, and for a collection field the game assembles the parent's
+/// children from every plugin that declares any. A cell override that exists to add occlusion data carries no
+/// placed references and deletes none, so reading its <c>Temporary</c> reports an empty cell the game fills with
+/// hundreds — the read model's one silent wrong answer. This computes what the engine assembles instead: the
+/// FormID-keyed union over every touching plugin's own body, so a child two overrides both declare is counted
+/// once rather than twice.</para>
+///
+/// <para><b>Cost.</b> One body per touching plugin, seeked by the record's own type
+/// (<see cref="LoadOrderResolver.IndexView.GetRecord"/> takes it, #354) so finding a cell in a worldspace plugin
+/// does not step over the placed references that outnumber it. Nothing is held: the bodies are read through the
+/// caller's open session and only FormKeys and counts survive the call.</para>
+/// </summary>
+public static class OwnedChildUnion
+{
+    /// <summary>The additive union of each named child-bearing field of <paramref name="fk"/>, or NULL when the
+    /// record has one toucher — its own body is then the whole story and there is nothing to assemble.
+    /// <paramref name="subjectBody"/> is the body the read was taken from (the winner, or a <c>plugin=</c>-scoped
+    /// copy); it is reused rather than re-fetched, and it is what <see cref="ChildUnion.OwnCount"/> is about.</summary>
+    public static IReadOnlyDictionary<string, ChildUnion>? Compute(
+        LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session, FormKey fk,
+        string subjectPlugin, IMajorRecordGetter subjectBody, IReadOnlyDictionary<string, OwnedChildShape> fields)
+    {
+        if (fields.Count == 0) return null;
+        var touching = view.TouchingPlugins(fk);
+        if (touching is null || touching.Count <= 1) return null;
+
+        var getterType = WriteEngine.PrimaryGetter(subjectBody.GetType());
+        var members = new Dictionary<string, List<FormKey>>(StringComparer.Ordinal);
+        var seen = new Dictionary<string, HashSet<FormKey>>(StringComparer.Ordinal);
+        var declarers = new Dictionary<string, List<ChildUnionDeclarer>>(StringComparer.Ordinal);
+        var unreadable = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        var live = new Dictionary<string, string?>(StringComparer.Ordinal);
+        var liveKeys = new Dictionary<string, IReadOnlyList<FormKey>>(StringComparer.Ordinal);
+        var own = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var f in fields.Keys)
+        {
+            members[f] = new List<FormKey>(); seen[f] = new HashSet<FormKey>();
+            declarers[f] = new List<ChildUnionDeclarer>(); unreadable[f] = new List<string>();
+            live[f] = null; liveKeys[f] = Array.Empty<FormKey>(); own[f] = 0;
+        }
+
+        // Priority order, low to high: the union's member order is first-declaration order, and the SINGULAR
+        // shape's live copy is simply the last declarer standing.
+        foreach (var plugin in touching)
+        {
+            var body = string.Equals(plugin, subjectPlugin, StringComparison.OrdinalIgnoreCase)
+                ? subjectBody
+                : view.GetRecord(session, plugin, fk, getterType);
+            foreach (var f in fields.Keys)
+            {
+                // Null is "could not look", never "declares nothing" — a provider counted into the negative would
+                // turn an unreadable body into evidence the field is empty (#308's rule, one level down).
+                var keys = body is null ? null : ChildKeys(body, f);
+                if (keys is null) { unreadable[f].Add(plugin); continue; }
+                if (keys.Count == 0) continue;
+                declarers[f].Add(new ChildUnionDeclarer(plugin, keys.Count));
+                live[f] = plugin;
+                liveKeys[f] = keys;
+                if (ReferenceEquals(body, subjectBody)) own[f] = keys.Count;
+                foreach (var k in keys)
+                    if (seen[f].Add(k)) members[f].Add(k);
+            }
+        }
+
+        var result = new Dictionary<string, ChildUnion>(fields.Count, StringComparer.Ordinal);
+        foreach (var (f, shape) in fields)
+            result[f] = new ChildUnion(f, shape,
+                                       shape == OwnedChildShape.Singular ? liveKeys[f] : members[f],
+                                       own[f], declarers[f], unreadable[f], live[f]);
+        return result;
+    }
+
+    /// <summary>The child records ONE body declares in ONE field, or NULL when the field could not be read.
+    /// <para>It collects the FIRST record level and stops there: a child's own children belong to the child's own
+    /// fields. That matters for <c>Worldspace.SubCells</c>, whose cells sit two container levels down and hold
+    /// placed references of their own — Mutagen's untyped containment enumeration would sweep those in and report
+    /// a worldspace as declaring every reference in the game.</para></summary>
+    public static IReadOnlyList<FormKey>? ChildKeys(IMajorRecordGetter body, string field)
+    {
+        try
+        {
+            var p = WriteEngine.ResolveProperty(body.GetType(), field);
+            if (p is null) return null;
+            var keys = new List<FormKey>();
+            return Collect(p.GetValue(body), WriteEngine.OwnedRecordTypeOf(p.PropertyType), keys, 0) ? keys : null;
+        }
+        catch { return null; }
+    }
+
+    /// <summary>The deepest container nesting the value walk will follow before answering "I could not look" —
+    /// the same tripwire constant, for the same reason, as <see cref="OwnedChildContent"/>'s.</summary>
+    const int MaxDepth = 6;
+
+    static bool Collect(object? val, Type? childType, List<FormKey> sink, int depth)
+    {
+        if (val is null) return true;                            // absent optional / empty — declares nothing
+        if (depth > MaxDepth) return false;                      // nested deeper than any known shape — unknown, not "no"
+        if (val is IFormLinkGetter) return true;                 // a reference, not a child (the type walk's own cut)
+        if (val is IMajorRecordGetter rec) { sink.Add(rec.FormKey); return true; }
+        if (val is string) return true;
+        // A non-record container that knows its own containment (a worldspace block): ask Mutagen for the child
+        // TYPE this field owns, so the walk stops at the cells rather than descending into their contents.
+        if (val is IMajorRecordGetterEnumerable en && childType is not null)
+        {
+            foreach (var child in en.EnumerateMajorRecords(childType, throwIfUnknown: false)) sink.Add(child.FormKey);
+            return true;
+        }
+        if (val is System.Collections.IEnumerable seq)
+        {
+            foreach (var item in seq)
+                if (!Collect(item, childType, sink, depth + 1)) return false;
+            return true;
+        }
+        return false;                                            // a shape this walk does not know — "could not look"
+    }
+}

--- a/src/housecarl-core/OwnedChildUnion.cs
+++ b/src/housecarl-core/OwnedChildUnion.cs
@@ -26,10 +26,16 @@ public sealed record ChildUnion(
     int OwnCount,
     IReadOnlyList<ChildUnionDeclarer> Declarers,
     IReadOnlyList<string> Unreadable,
-    string? LivePlugin)
+    string? LivePlugin,
+    bool Nested)
 {
     /// <summary>Distinct child records the order declares for this field.</summary>
     public int Total => Members.Count;
+
+    /// <summary>Do <see cref="OwnCount"/> and the field's RENDERED value count the same unit? False on a nested
+    /// field (<c>Worldspace.SubCells</c>), where the value counts the blocks and these counts count the cells
+    /// under them — the one place a note may not put the two numbers side by side unsaid.</summary>
+    public bool CountsTheRenderedUnit => !Nested;
 
 }
 
@@ -106,11 +112,14 @@ public static class OwnedChildUnion
             }
         }
 
+        // The unit the counts are in, against the unit the field's value renders in — a fact about the property,
+        // asked once off the subject's type.
+        var nested = OwnedChildContent.NestedFields(subjectBody);
         var result = new Dictionary<string, ChildUnion>(fields.Count, StringComparer.Ordinal);
         foreach (var (f, shape) in fields)
             result[f] = new ChildUnion(f, shape,
                                        shape == OwnedChildShape.Singular ? liveKeys[f] : members[f],
-                                       own[f], declarers[f], unreadable[f], live[f]);
+                                       own[f], declarers[f], unreadable[f], live[f], nested.Contains(f));
         return result;
     }
 

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -732,6 +732,19 @@ public static class WriteEngine
         return record.GetType();
     }
 
+    /// <summary>The Type to hand Mutagen's typed ENUMERATION when seeking a body of <paramref name="record"/>'s type:
+    /// the record's FLAT GROUP's getter interface when one matches, else the record's own primary getter. The
+    /// flat-group answer is here for the same reason <see cref="RemovalTypeFor"/> has it — an abstract-base group
+    /// (<c>SkyrimGroup&lt;Global&gt;</c>, <c>SkyrimGroup&lt;GameSetting&gt;</c>) holds concrete subclasses whose own
+    /// getter interface (<c>IGlobalShortGetter</c>) is not a type Mutagen's containment switch routes, so a typed walk
+    /// on it yields nothing and the caller pays an empty pass before falling back to the flat scan.</summary>
+    public static Type SeekTypeFor(IMajorRecordGetter record)
+    {
+        foreach (var (_, getterIface) in FlatGroupTypes)
+            if (getterIface.IsInstanceOfType(record)) return getterIface;
+        return PrimaryGetter(record.GetType()) ?? record.GetType();
+    }
+
     /// <summary>The flat groups' (T, getter-interface) pairs for <see cref="SkyrimMod"/>, MEMOIZED: pure reflection
     /// metadata, constant for the process lifetime — <see cref="RemovalTypeFor"/> runs per record when the remove
     /// lanes index a whole plugin, so a per-call property walk would be O(records × properties). Derived from the SAME

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Reflection;
 using System.Security.Cryptography;
 using Mutagen.Bethesda;
@@ -708,7 +708,7 @@ public static class WriteEngine
 
     /// <summary>The element type <paramref name="t"/> enumerates, or null if it is not a collection. <c>string</c> is
     /// excluded explicitly — it enumerates chars and would otherwise recurse pointlessly on every text field.</summary>
-    static Type? ElementTypeOf(Type t)
+    internal static Type? ElementTypeOf(Type t)
     {
         if (t.IsArray) return t.GetElementType();
         if (t == typeof(string) || !typeof(System.Collections.IEnumerable).IsAssignableFrom(t)) return null;

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -673,21 +673,35 @@ public static class WriteEngine
     /// the property drops out of the set and the count check in <see cref="RestoreChildGroup"/> refuses — so the
     /// constant is a tripwire, not a correctness assumption.</summary>
     static bool ReachesOwnedRecord(Type t, HashSet<Type> seen, int depth)
+        => OwnedRecordTypeOf(t, seen, depth, throughInterfaces: false) is not null;
+
+    /// <summary>The record type <paramref name="t"/> reaches, or null when it reaches none — the same walk
+    /// <see cref="ReachesOwnedRecord"/> is, answering WHICH record rather than whether. The read side needs the
+    /// type to ask Mutagen's containment enumeration for a field's OWN children: enumerating a worldspace block
+    /// untyped yields its cells AND every placed reference inside them, which is a different field's content.
+    /// <para>It steps through INTERFACES as well as classes, which the write-side walk does not: a read is handed
+    /// an overlay body, whose containers are getter interfaces all the way down
+    /// (<c>IWorldspaceBlockGetter</c> → <c>IWorldspaceSubBlockGetter</c> → <c>ICellGetter</c>). The write walk's
+    /// answer — the child-bearing property SET, pinned over every record type — is left exactly as it was.</para></summary>
+    internal static Type? OwnedRecordTypeOf(Type t) => OwnedRecordTypeOf(t, new HashSet<Type>(), 0, throughInterfaces: true);
+
+    static Type? OwnedRecordTypeOf(Type t, HashSet<Type> seen, int depth, bool throughInterfaces)
     {
-        if (depth > 6 || !seen.Add(t)) return false;
+        if (depth > 6 || !seen.Add(t)) return null;
         // `seen` is a PATH set, not a memo: the entry comes back out on the way up. Left in, a type first reached at
         // the depth bound would be recorded as unreachable and then skipped when a shallower branch reaches it, which
         // memoizes a depth-truncated answer as a depth-independent one. Cycles are still closed — a type on the
         // CURRENT path is what the set holds (a Cell reaches a Cell through a Worldspace).
         try
         {
-            if (typeof(IFormLinkGetter).IsAssignableFrom(t)) return false;   // a reference, not a child
-            if (typeof(IMajorRecordGetter).IsAssignableFrom(t)) return true;
-            if (ElementTypeOf(t) is { } elem) return ReachesOwnedRecord(elem, seen, depth + 1);
-            if (!t.IsClass || t.Namespace?.StartsWith("Mutagen", StringComparison.Ordinal) != true) return false;
+            if (typeof(IFormLinkGetter).IsAssignableFrom(t)) return null;    // a reference, not a child
+            if (typeof(IMajorRecordGetter).IsAssignableFrom(t)) return t;
+            if (ElementTypeOf(t) is { } elem) return OwnedRecordTypeOf(elem, seen, depth + 1, throughInterfaces);
+            if (!t.IsClass && !(throughInterfaces && t.IsInterface)) return null;
+            if (t.Namespace?.StartsWith("Mutagen", StringComparison.Ordinal) != true) return null;
             foreach (var p in t.GetProperties(BindingFlags.Public | BindingFlags.Instance))
-                if (ReachesOwnedRecord(p.PropertyType, seen, depth + 1)) return true;
-            return false;
+                if (OwnedRecordTypeOf(p.PropertyType, seen, depth + 1, throughInterfaces) is { } found) return found;
+            return null;
         }
         finally { seen.Remove(t); }
     }

--- a/src/housecarl-generator/OwnedChildContentProbe.cs
+++ b/src/housecarl-generator/OwnedChildContentProbe.cs
@@ -41,7 +41,7 @@ public static class OwnedChildContentProbe
     [CiProbe("owned-child-content-guard")]
     public static int RunGuard(string[] args)
     {
-        Console.WriteLine("################  #342 stage 1 — owned-child content annotation  ################");
+        Console.WriteLine("################  owned-child content annotation  ################");
         Console.WriteLine();
         _pass = _fail = 0;
 
@@ -186,11 +186,8 @@ public static class OwnedChildContentProbe
             // child-bearing field says other plugins were not read, that no declarer is named, that the clause is
             // stated once and names its fields with no positional claim, and that those names are derived. They
             // drove housecarl_read_record and are tests against housecarl_records in src/housecarl-mcp-tests now.
-            Check("CHEAP: the cheap tier CANNOT read a body — its signature takes no overlay session",
-                typeof(LoadOrderService)
-                    .GetMethod("AnnotateOwnedChildContent", BindingFlags.NonPublic | BindingFlags.Static)!
-                    .GetParameters().All(x => x.ParameterType != typeof(LoadOrderResolver.OverlaySession)),
-                "AnnotateOwnedChildContent takes an OverlaySession — it can fetch bodies");
+            // The arm pinning that the default lane could not open a body went with #342 stage 2: the read now
+            // assembles the additive union, so it opens one body per touching plugin by design.
 
             // The SOLE, UNREQUESTED and NO-CHILDREN reads stood here, driving housecarl_read_record; they are
             // tests in src/housecarl-mcp-tests now. The field-set half of NO-CHILDREN is a fact about the TYPE,

--- a/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
+++ b/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
@@ -38,6 +38,9 @@ public sealed class OwnedChildWorld : IDisposable
     /// and nothing anywhere declares Landscape or NavigationMeshes, so the precise tier has both a positive
     /// naming two plugins and a negative it must state rather than omit.</summary>
     public FormKey CellF { get; }
+    /// <summary>OVERLAPPING — the base declares 3 references and the mid plugin re-declares the FIRST of them
+    /// plus one of its own. The union is 4, and a concatenation would say 5.</summary>
+    public FormKey CellG { get; }
     public FormKey Topic { get; }
     /// <summary>A 3-toucher record with no child-bearing field at all.</summary>
     public FormKey Weapon { get; }
@@ -64,6 +67,7 @@ public sealed class OwnedChildWorld : IDisposable
 
         CellA = new FormKey(baseKey, 0xC01); CellB = new FormKey(baseKey, 0xC02); CellC = new FormKey(baseKey, 0xC03);
         CellD = new FormKey(baseKey, 0xC04); CellE = new FormKey(baseKey, 0xC05); CellF = new FormKey(baseKey, 0xC06);
+        CellG = new FormKey(baseKey, 0xC07);
         Topic = new FormKey(baseKey, 0xD01); Weapon = new FormKey(baseKey, 0xE01); Worldspace = new FormKey(baseKey, 0xF01);
 
         var baseDir = Path.Combine(mods, "BaseMod"); Directory.CreateDirectory(baseDir);
@@ -98,6 +102,11 @@ public sealed class OwnedChildWorld : IDisposable
             f.Persistent.Add(new PlacedObject(new FormKey(baseKey, 0xC6A), SkyrimRelease.SkyrimSE) { EditorID = "HcOcFPers0" });
             FileInterior(m, f);
 
+            var g = new Cell(CellG, SkyrimRelease.SkyrimSE) { EditorID = "HcOcCellG", Flags = Cell.Flag.IsInteriorCell };
+            for (int i = 0; i < 3; i++)
+                g.Temporary.Add(new PlacedObject(new FormKey(baseKey, (uint)(0xC70 + i)), SkyrimRelease.SkyrimSE) { EditorID = $"HcOcGTemp{i}" });
+            FileInterior(m, g);
+
             var t = new DialogTopic(Topic, SkyrimRelease.SkyrimSE) { EditorID = "HcOcTopic" };
             for (int i = 0; i < 2; i++)
             {
@@ -131,6 +140,13 @@ public sealed class OwnedChildWorld : IDisposable
             f.Temporary.Add(new PlacedObject(new FormKey(midKey, 0xA60), SkyrimRelease.SkyrimSE) { EditorID = "HcOcMidFTemp0" });
             f.Persistent.Add(new PlacedObject(new FormKey(midKey, 0xA6A), SkyrimRelease.SkyrimSE) { EditorID = "HcOcMidFPers0" });
             FileInterior(m, f);
+
+            // CellG: the mid plugin RE-DECLARES the base's first reference and adds one of its own, so the union
+            // has to be keyed by FormID rather than concatenated.
+            var g = new Cell(CellG, SkyrimRelease.SkyrimSE) { EditorID = "HcOcCellG", Flags = Cell.Flag.IsInteriorCell };
+            g.Temporary.Add(new PlacedObject(new FormKey(baseKey, 0xC70), SkyrimRelease.SkyrimSE) { EditorID = "HcOcGTemp0" });
+            g.Temporary.Add(new PlacedObject(new FormKey(midKey, 0xA70), SkyrimRelease.SkyrimSE) { EditorID = "HcOcMidGTemp0" });
+            FileInterior(m, g);
 
             m.Weapons.GetOrAddAsOverride(baseOv.Weapons.First(w => w.FormKey == Weapon)).BasicStats!.Damage = 7;
             m.BeginWrite.ToPath(Path.Combine(midDir, MidName)).WithLoadOrder(new ISkyrimModGetter[] { baseOv }).Write();
@@ -260,22 +276,61 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     public void TheDeclaringPluginsOwnBodyCarriesTheThreeReferencesTheWinnerDoesNotShow() =>
         Assert.StartsWith("Temporary = [list: 3 item(s)]", FieldLine(Read(_w.CellA, source: _w.BaseName), "Temporary"));
 
-    // ---- the cheap tier: what every read states from the index alone ------------------------------
+    // ---- the union: what the game assembles, on every read ----------------------------------------
+
+    /// <summary>#342 in one assertion: the winner's own list reads 0 and the union says the cell holds 3, naming
+    /// the plugin that declares them.</summary>
+    [Fact]
+    public void AChildBearingFieldStatesTheAdditiveUnionTheGameAssembles() =>
+        Assert.Contains($"{ReadSentences.UnionLabel}: 3 child record(s) across 1 plugin(s) — {_w.BaseName} 3; "
+                        + "this body's own list carries 0", FieldLine(Read(_w.CellA), "Temporary"));
+
+    /// <summary>The value beside the union is still the read body's OWN list, in its own order — those are the
+    /// indices a Remove addresses, and a union spliced into them would move them.</summary>
+    [Fact]
+    public void TheUnionNeverReplacesTheBodysOwnList() =>
+        Assert.StartsWith("Temporary = [list: 0 item(s)]", FieldLine(Read(_w.CellA), "Temporary"));
+
+    /// <summary>A child two plugins both declare is ONE child. CellG's mid plugin re-declares the base's first
+    /// reference and adds one of its own, so a naive concatenation would say 5 where the game has 4.</summary>
+    [Fact]
+    public void AChildTwoPluginsBothDeclareIsCountedOnce_NotConcatenated() =>
+        Assert.Contains($"{ReadSentences.UnionLabel}: 4 child record(s) across 2 plugin(s) — "
+                        + $"{_w.BaseName} 3, {_w.MidName} 2", FieldLine(Read(_w.CellG), "Temporary"));
+
+    /// <summary>A plugin=-scoped read is unioned too, and its "own list" is that plugin's, not the winner's: the
+    /// plugins above a base master declare children it cannot see.</summary>
+    [Fact]
+    public void APluginScopedReadIsUnionedAgainstTheWholeOrder_AndOwnIsThatPluginsOwn() =>
+        Assert.Contains("this body's own list carries 3",
+                        FieldLine(Read(_w.CellA, source: _w.BaseName), "Temporary"));
+
+    /// <summary>A SINGULAR owned child is not a union — its declarers override one record — so the note says
+    /// which plugin's copy is live rather than adding counts that would be a fiction.</summary>
+    [Fact]
+    public void ASingularChildSaysWhichPluginsCopyIsLive_NeverAUnionCount()
+    {
+        var line = FieldLine(Read(_w.CellA), "Landscape");
+        Assert.Contains($"the live copy is {_w.BaseName}'s", line);
+        Assert.DoesNotContain(ReadSentences.UnionLabel, line);
+    }
 
     [Fact]
-    public void AChildBearingFieldSaysOtherPluginsTouchThisRecordAndTheirDeclarationsWereNotRead() =>
-        Assert.Contains("2 " + ReadSentences.NotRead, FieldLine(Read(_w.CellA), "Temporary"));
+    public void AFieldNobodyTouchingTheRecordDeclaresSaysSo_NeverSilence() =>
+        Assert.Contains(ReadSentences.NoUnionMembers, FieldLine(Read(_w.CellA), "NavigationMeshes"));
 
     [Fact]
-    public void TheCheapTierClaimsNothingAboutWhoDeclares_NoDeclarerNamingOnTheDefaultLane()
+    public void TheDefaultReadDoesNotBorrowTheTreeFormsDeclarersBlock()
     {
         var r = Read(_w.CellA);
+        Assert.DoesNotContain(ReadSentences.DeclarersLead, r);
         Assert.DoesNotContain(ReadSentences.DeclaredBy, r);
         Assert.DoesNotContain(ReadSentences.CarriedBy, r);
     }
 
     /// <summary>The grid is the record type's OWN child-bearing set, so a Mutagen bump that grows it grows this
-    /// theory — and it covers fields nobody in this world declares, which is the claim: "not read" is true of all.</summary>
+    /// theory — and it covers fields nobody in this world declares, which is the claim: every child-bearing field
+    /// is answered, positive or negative.</summary>
     public static TheoryData<string> CellChildBearingFields()
     {
         var data = new TheoryData<string>();
@@ -288,16 +343,16 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     [Theory]
     [MemberData(nameof(CellChildBearingFields))]
     public void EveryChildBearingFieldOfTheTypeCarriesTheAnnotation_IncludingOnesNobodyDeclares(string field) =>
-        Assert.Contains(ReadSentences.NotRead, FieldLine(Read(_w.CellA), field));
+        Assert.Contains(ReadSentences.ChildContent, FieldLine(Read(_w.CellA), field));
 
     [Fact]
     public void TheNotReadClauseIsStatedOnceOverTheWholeResponse_NotOncePerAnnotatedField() =>
-        Assert.Equal(1, Occurrences(Read(_w.CellA), ClauseHead(ReadSentences.NotReadFraming)));
+        Assert.Equal(1, Occurrences(Read(_w.CellA), ClauseHead(ReadSentences.UnionFraming)));
 
     [Fact]
     public void TheClauseNamesTheAnnotatedFieldsAndPointsAtNoPositionAtAll()
     {
-        var clause = ClauseLine(Read(_w.CellA), ReadSentences.NotReadFraming);
+        var clause = ClauseLine(Read(_w.CellA), ReadSentences.UnionFraming);
         Assert.Contains("Temporary", clause);
         Assert.Contains("Persistent", clause);
         Assert.DoesNotContain("above", clause, StringComparison.OrdinalIgnoreCase);
@@ -308,21 +363,21 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     public void TheClausesFieldNamesAreDerived_EveryFieldItNamesIsOneTheResponseAnnotated()
     {
         var r = Read(_w.CellA);
-        var named = NamedFields(ClauseLine(r, ReadSentences.NotReadFraming), ReadSentences.NotReadFraming);
+        var named = NamedFields(ClauseLine(r, ReadSentences.UnionFraming), ReadSentences.UnionFraming);
         Assert.NotEmpty(named);
-        foreach (var f in named) Assert.Contains(ReadSentences.NotRead, FieldLine(r, f));
+        foreach (var f in named) Assert.Contains(ReadSentences.ChildContent, FieldLine(r, f));
     }
 
     [Fact]
     public void ARecordOnlyOnePluginTouchesIsNotAnnotatedAtAll() =>
-        Assert.DoesNotContain(ReadSentences.NotRead, FieldLine(Read(_w.CellC), "Temporary"));
+        Assert.DoesNotContain(ReadSentences.ChildContent, FieldLine(Read(_w.CellC), "Temporary"));
 
     [Fact]
     public void AProjectionThatRequestsNoChildBearingFieldCarriesNoAnnotationAndNoClause()
     {
         var r = Read(_w.CellA, new RecordsTools.RecordsProject { form = "fields", fields = new[] { "EditorID" } });
-        Assert.DoesNotContain(ReadSentences.NotRead, r);
-        Assert.Null(ClauseLineOrNull(r, ReadSentences.NotReadFraming));
+        Assert.DoesNotContain(ReadSentences.ChildContent, r);
+        Assert.Null(ClauseLineOrNull(r, ReadSentences.UnionFraming));
     }
 
     [Fact]
@@ -330,29 +385,36 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     {
         var r = Read(_w.Weapon);
         Assert.Contains("winner=" + _w.TopName, r);
-        Assert.DoesNotContain(ReadSentences.NotRead, r);
+        Assert.DoesNotContain(ReadSentences.ChildContent, r);
     }
 
+    /// <summary>The base declares two INFOs and the winner re-declares the first, so the union is 2 — the same
+    /// FormID-keyed rule on a second record type, from the same derived field set.</summary>
     [Fact]
-    public void ADialogTopicsResponsesIsAnnotated_TheFieldSetIsDerivedNotAListOfCellFields() =>
-        Assert.Contains(ReadSentences.NotRead, FieldLine(Read(_w.Topic), "Responses"));
+    public void ADialogTopicsResponsesIsUnioned_TheFieldSetIsDerivedNotAListOfCellFields() =>
+        Assert.Contains($"{ReadSentences.UnionLabel}: 2 child record(s) across 2 plugin(s)",
+                        FieldLine(Read(_w.Topic), "Responses"));
 
+    /// <summary>A worldspace's cells sit two container levels down (block → sub-block → cell) and each cell holds
+    /// references of its own. The union is the three CELLS the base declares, never the contents of those cells:
+    /// the walk stops at the first record level.</summary>
     [Fact]
-    public void AWorldspacesSubCellsIsAnnotated_TheSameDerivedFieldSetReachesAThirdType() =>
-        Assert.Contains(ReadSentences.NotRead, FieldLine(Read(_w.Worldspace), "SubCells"));
+    public void AWorldspacesSubCellsIsUnionedToItsCells_NotToWhatThoseCellsContain() =>
+        Assert.Contains($"{ReadSentences.UnionLabel}: 3 child record(s) across 1 plugin(s) — {_w.BaseName} 3",
+                        FieldLine(Read(_w.Worldspace), "SubCells"));
 
     [Fact]
     public void AtDepthTwoTheContainersOwnSummaryLineStillCarriesTheAnnotation() =>
-        Assert.Contains(ReadSentences.NotRead,
+        Assert.Contains(ReadSentences.ChildContent,
                         FieldLine(Read(_w.CellA, new RecordsTools.RecordsProject { form = "everything", depth = 2 }), "Temporary"));
 
     [Fact]
     public void TwoAnnotatedRecordsInOneResponseStillStateTheClauseOnce() =>
-        Assert.Equal(1, Occurrences(ReadBoth(_w.CellA, _w.CellB), ClauseHead(ReadSentences.NotReadFraming)));
+        Assert.Equal(1, Occurrences(ReadBoth(_w.CellA, _w.CellB), ClauseHead(ReadSentences.UnionFraming)));
 
     [Fact]
     public void AResponseWithNothingAnnotatedCarriesNoClause() =>
-        Assert.Equal(0, Occurrences(Read(_w.Weapon), ClauseHead(ReadSentences.NotReadFraming)));
+        Assert.Equal(0, Occurrences(Read(_w.Weapon), ClauseHead(ReadSentences.UnionFraming)));
 
     // ---- emission: the clause is earned by a field LINE, not by the decision to annotate ----------
 
@@ -361,16 +423,16 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     {
         var r = Read(_w.CellA, maxChars: 300);
         Assert.Contains("truncated: showing", r);
-        Assert.DoesNotContain(ReadSentences.NotRead, r);
-        Assert.Null(ClauseLineOrNull(r, ReadSentences.NotReadFraming));
+        Assert.DoesNotContain(ReadSentences.ChildContent, r);
+        Assert.Null(ClauseLineOrNull(r, ReadSentences.UnionFraming));
     }
 
     [Fact]
     public void TheSameReadWithRoomForTheAnnotatedFieldStatesTheClauseOverIt()
     {
         var r = Read(_w.CellA);
-        Assert.Contains(ReadSentences.NotRead, r);
-        Assert.NotNull(ClauseLineOrNull(r, ReadSentences.NotReadFraming));
+        Assert.Contains(ReadSentences.ChildContent, r);
+        Assert.NotNull(ClauseLineOrNull(r, ReadSentences.UnionFraming));
     }
 
     /// <summary>The annotated fields go FIRST so they survive the cut, with filler behind them so the body
@@ -388,7 +450,7 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
         var r = Read(_w.CellA, new RecordsTools.RecordsProject { form = "fields", fields = PaddedCellFields }, maxChars: 1400);
         int longest = r.Split('\n').Max(l => l.Length + 1);
         Assert.Contains("truncated: showing", r);
-        Assert.NotNull(ClauseLineOrNull(r, ReadSentences.NotReadFraming));
+        Assert.NotNull(ClauseLineOrNull(r, ReadSentences.UnionFraming));
         Assert.True(r.Length <= 1400 + longest, $"len={r.Length} cap=1400 longest-line={longest}");
     }
 
@@ -408,8 +470,8 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
         using var doc = JsonDocument.Parse(Read(_w.CellA, format: "json"));
         Assert.True(doc.RootElement.TryGetProperty("owned_child_note", out var note));
         var s = note.GetString()!;
-        Assert.StartsWith(ClauseHead(ReadSentences.NotReadFraming), s);
-        Assert.Contains("Temporary", NamedFields(s, ReadSentences.NotReadFraming));
+        Assert.StartsWith(ClauseHead(ReadSentences.UnionFraming), s);
+        Assert.Contains("Temporary", NamedFields(s, ReadSentences.UnionFraming));
     }
 
     [Fact]
@@ -421,9 +483,35 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
         Assert.True(note > fields, $"note-at={note} fields-at={fields}");
     }
 
+    /// <summary>The union is RETURNED, not only described: the member FormIDs ride the field object, so a caller
+    /// reads them back through the same <c>formids=</c> door it came in by.</summary>
+    [Fact]
+    public void Json_TheUnionsMembersAreTheFormIdsOfTheChildrenTheGameAssembles()
+    {
+        using var doc = JsonDocument.Parse(Read(_w.CellA, format: "json"));
+        var u = doc.RootElement.GetProperty("records")[0].GetProperty("fields").EnumerateArray()
+                   .Single(f => f.GetProperty("path").GetString() == "Temporary")
+                   .GetProperty("owned_child_union");
+        Assert.Equal(3, u.GetProperty("total").GetInt32());
+        Assert.Equal(0, u.GetProperty("own").GetInt32());
+        Assert.Equal(new[] { "000C10", "000C11", "000C12" }.Select(h => $"{h}:{_w.BaseName}"),
+                     u.GetProperty("members").EnumerateArray().Select(m => m.GetString()));
+    }
+
+    [Fact]
+    public void Json_TheOverlappingUnionListsEachChildOnce()
+    {
+        using var doc = JsonDocument.Parse(Read(_w.CellG, format: "json"));
+        var u = doc.RootElement.GetProperty("records")[0].GetProperty("fields").EnumerateArray()
+                   .Single(f => f.GetProperty("path").GetString() == "Temporary")
+                   .GetProperty("owned_child_union");
+        Assert.Equal(4, u.GetProperty("total").GetInt32());
+        Assert.Equal(4, u.GetProperty("members").GetArrayLength());
+    }
+
     [Fact]
     public void Json_TheAnnotationsPerFieldHalfRidesDisplay() =>
-        Assert.Contains(ReadSentences.NotRead, JsonField(Read(_w.CellA, format: "json"), "Temporary", "display"));
+        Assert.Contains(ReadSentences.ChildContent, JsonField(Read(_w.CellA, format: "json"), "Temporary", "display"));
 
     /// <summary>The annotation is DISPLAY-ONLY: it never replaces the leaf's own round-trip token, on either lane.</summary>
     [Fact]
@@ -470,7 +558,7 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
         Assert.Contains(doc.RootElement.GetProperty("fields").EnumerateArray(),
                         f => f.TryGetProperty("path", out var p) && p.GetString() == "Temporary"
                              && f.TryGetProperty("display", out var d)
-                             && d.GetString()!.Contains(ReadSentences.NotRead, StringComparison.Ordinal));
+                             && d.GetString()!.Contains(ReadSentences.ChildContent, StringComparison.Ordinal));
     }
 
     /// <summary>The manifest is line 1 and the rows are lines 2..N, so a clause pointing "above" would point away
@@ -482,14 +570,14 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
         Read(_w.CellA, toFile: art);
         using var doc = JsonDocument.Parse(File.ReadAllLines(art)[0]);
         var note = doc.RootElement.GetProperty("notes")[0].GetString()!;
-        Assert.Contains("Temporary", NamedFields(note, ReadSentences.NotReadFraming));
+        Assert.Contains("Temporary", NamedFields(note, ReadSentences.UnionFraming));
         Assert.DoesNotContain("above", note, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("below", note, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
     public void Artifact_TheManifestOnlyResponseDoesNotStateAClauseOverRowsItDidNotRender() =>
-        Assert.Null(ClauseLineOrNull(Read(_w.CellA, toFile: _w.Scratch("inline.jsonl")), ReadSentences.NotReadFraming));
+        Assert.Null(ClauseLineOrNull(Read(_w.CellA, toFile: _w.Scratch("inline.jsonl")), ReadSentences.UnionFraming));
 
     // ---- the remedy the clause names ------------------------------------------------------------
     //
@@ -531,7 +619,7 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     [Fact]
     public void TheRemedySaysNothingForAnAnnotatedFieldNobodyElseDeclares()
     {
-        var named = NamedFields(ClauseLine(Read(_w.CellA), ReadSentences.NotReadFraming), ReadSentences.NotReadFraming);
+        var named = NamedFields(ClauseLine(Read(_w.CellA), ReadSentences.UnionFraming), ReadSentences.UnionFraming);
         Assert.Contains("NavigationMeshes", named);
         Assert.DoesNotContain("NavigationMeshes", DiffBlock(Tree(_w.CellA)));
     }
@@ -620,7 +708,7 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     [Fact]
     public void TheRemedyNamedByTheCheapClauseAnswersPreciselyForEveryFieldTheClauseNamed()
     {
-        var named = NamedFields(ClauseLine(Read(_w.CellF), ReadSentences.NotReadFraming), ReadSentences.NotReadFraming);
+        var named = NamedFields(ClauseLine(Read(_w.CellF), ReadSentences.UnionFraming), ReadSentences.UnionFraming);
         Assert.NotEmpty(named);
         var block = DeclarersBlock(Tree(_w.CellF));
         foreach (var f in named)
@@ -628,10 +716,10 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     }
 
     [Fact]
-    public void TheDefaultReadOfTheSameCellStillStatesOnlyTheCheapTier()
+    public void TheDefaultReadOfTheSameCellUnionsItWithoutBorrowingTheTreesBlock()
     {
         var r = Read(_w.CellF);
-        Assert.Contains("2 " + ReadSentences.NotRead, FieldLine(r, "Temporary"));
+        Assert.Contains($"{ReadSentences.UnionLabel}: 3 child record(s) across 2 plugin(s)", FieldLine(r, "Temporary"));
         Assert.DoesNotContain(ReadSentences.DeclarersLead, r);
         Assert.DoesNotContain(ReadSentences.DeclaredBy, r);
         Assert.DoesNotContain(ReadSentences.CarriedBy, r);

--- a/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
+++ b/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
@@ -434,6 +434,40 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
         Assert.Contains($"{ReadSentences.UnionLabel}: 3 child record(s) across 1 plugin(s) — {_w.BaseName} 3",
                         FieldLine(Read(_w.Worldspace), "SubCells"));
 
+    /// <summary>A nested field's VALUE counts its containers and its union counts the records under them. The
+    /// winner here declares two EMPTY blocks, so the line carries "2 item(s)" and an own share of 0 at once —
+    /// true of two different units, and a contradiction unless the note says which it is counting.</summary>
+    [Fact]
+    public void ANestedFieldsNoteNamesItsUnit_TheValueCountsContainersAndTheUnionCountsRecords()
+    {
+        var line = FieldLine(Read(_w.Worldspace), "SubCells");
+        Assert.StartsWith("SubCells = [list: 2 item(s)]", line);
+        Assert.Contains("this body declares 0 of them", line);
+        Assert.Contains("counts the CONTAINERS holding them", line);
+        // The flat wording would put "own list carries 0" beside a value of 2 with nothing saying they differ.
+        Assert.DoesNotContain("own list carries", line);
+    }
+
+    /// <summary>And the flat shape keeps the plain wording: a cell's Temporary IS the list of its children, so
+    /// the value and the own share are one unit and the note says so without a caveat.</summary>
+    [Fact]
+    public void AFlatFieldsNoteStillReadsAsAShareOfTheValueBesideIt()
+    {
+        var line = FieldLine(Read(_w.CellG), "Temporary");
+        Assert.StartsWith("Temporary = [list: 2 item(s)]", line);
+        Assert.Contains("this body's own list carries 2", line);
+        Assert.DoesNotContain("CONTAINERS", line);
+    }
+
+    /// <summary>json carries the unit as a key rather than only in the prose, because a consumer comparing
+    /// <c>own</c>/<c>total</c> against <c>value</c> has no sentence to read.</summary>
+    [Fact]
+    public void JsonMarksTheNestedFieldAndLeavesTheFlatOneUnmarked()
+    {
+        Assert.True(UnionKey(Read(_w.Worldspace, format: "json"), "SubCells", "nested")?.GetBoolean());
+        Assert.Null(UnionKey(Read(_w.CellG, format: "json"), "Temporary", "nested"));
+    }
+
     [Fact]
     public void AtDepthTwoTheContainersOwnSummaryLineStillCarriesTheAnnotation() =>
         Assert.Contains(ReadSentences.ChildContent,
@@ -1392,6 +1426,17 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
             if (f.GetProperty("path").GetString() == path && f.TryGetProperty(member, out var v))
                 return v.GetString() ?? "";
         throw new Xunit.Sdk.XunitException($"no '{member}' on json field '{path}'");
+    }
+
+    /// <summary>One key of a field's <c>owned_child_union</c>, or NULL when the union does not carry it — a claim
+    /// about a key's PRESENCE, which <see cref="JsonField"/> cannot make because it throws on an absent one.</summary>
+    static JsonElement? UnionKey(string json, string path, string key)
+    {
+        using var doc = JsonDocument.Parse(json);
+        foreach (var f in doc.RootElement.GetProperty("records")[0].GetProperty("fields").EnumerateArray())
+            if (f.GetProperty("path").GetString() == path)
+                return f.GetProperty("owned_child_union").TryGetProperty(key, out var v) ? v.Clone() : null;
+        throw new Xunit.Sdk.XunitException($"no json field '{path}'");
     }
 
     /// <summary>A clause's field-INDEPENDENT head, up to the "{0}" its derived field list fills — so "is it

--- a/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
+++ b/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
@@ -56,8 +56,16 @@ public sealed class OwnedChildWorld : IDisposable
 
     public static string Fid(FormKey fk) => $"{fk.ID:X6}:{fk.ModKey.FileName}";
 
+    /// <summary>What <c>CorpusRulebook.CorpusPath</c> named before this world repointed it.</summary>
+    readonly string _priorCorpusPath;
+
     public OwnedChildWorld()
     {
+        // CorpusRulebook.CorpusPath is a process-global this world repoints at its own generated corpus.
+        // Capture the prior value here so Dispose can put it back: Dispose deletes Root, and a static left
+        // naming a path under Root would name a directory that no longer exists.
+        _priorCorpusPath = CorpusRulebook.CorpusPath;
+
         Root = Path.Combine(Path.GetTempPath(), "hc-owned-child-tests-" + Guid.NewGuid().ToString("N"));
         var instance = Path.Combine(Root, "instance");
         var profiles = Path.Combine(instance, "profiles", "Default");
@@ -246,6 +254,7 @@ public sealed class OwnedChildWorld : IDisposable
     public void Dispose()
     {
         Svc.Dispose();
+        CorpusRulebook.CorpusPath = _priorCorpusPath;   // before the delete below takes the path it named
         try { Directory.Delete(Root, true); } catch { /* temp cleanup best-effort */ }
     }
 }

--- a/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
+++ b/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
@@ -468,6 +468,36 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
         Assert.Null(UnionKey(Read(_w.CellG, format: "json"), "Temporary", "nested"));
     }
 
+    // ---- what a batch of named records opens ------------------------------------------------------
+
+    /// <summary>The union opens a body per touching plugin, so a `formids=` batch used to re-mmap every toucher
+    /// once per row — the session that caches overlays died with each record, and the union memo dedupes a
+    /// repeated FormID, not a repeated plugin. One session for the call bounds the opens by the ORDER's size
+    /// instead of by the row count.</summary>
+    [Fact]
+    public void ABatchOpensEachPluginOnce_NotOncePerRecordItUnions()
+    {
+        var before = LoadOrderResolver.SessionOverlayOpens;
+        ReadBoth(_w.CellA, _w.CellF);           // two cells whose touchers overlap; three plugins in the order
+        var opens = LoadOrderResolver.SessionOverlayOpens - before;
+
+        Assert.True(opens <= 3, $"a two-record batch paid {opens} overlay opens over a three-plugin order — " +
+                                "the session is not shared across the batch's records");
+        // And the answers are the ones the per-record sessions gave: a shared overlay cache is a cost change.
+        Assert.Contains(ReadSentences.UnionLabel, FieldLine(ReadBoth(_w.CellA, _w.CellF), "Temporary"));
+    }
+
+    /// <summary>A single named record still opens its own session and closes it — the batch's cache is the
+    /// batch's, and nothing is held between calls.</summary>
+    [Fact]
+    public void ASingleReadStillPaysItsOwnOpens()
+    {
+        var before = LoadOrderResolver.SessionOverlayOpens;
+        Read(_w.CellF);
+        Assert.True(LoadOrderResolver.SessionOverlayOpens > before,
+                    "a read that unions three touchers opened no overlay at all");
+    }
+
     [Fact]
     public void AtDepthTwoTheContainersOwnSummaryLineStillCarriesTheAnnotation() =>
         Assert.Contains(ReadSentences.ChildContent,

--- a/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
+++ b/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
@@ -4,6 +4,7 @@ using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Skyrim;
 using HousecarlCore;
+using HousecarlGenerator;
 using HousecarlMcp;
 using Xunit;
 
@@ -22,6 +23,9 @@ public sealed class OwnedChildWorld : IDisposable
 
     public string BaseName { get; }
     public string MidName { get; }
+    /// <summary>The MID plugin's file on disk, so a test can take an exclusive handle on it and see what a read
+    /// does when a sibling body will not open.</summary>
+    public string MidPath { get; }
     public string TopName { get; }
 
     /// <summary>The false-empty cell: winner touches it carrying nothing, base declares Temporary/Persistent/Landscape.</summary>
@@ -41,6 +45,9 @@ public sealed class OwnedChildWorld : IDisposable
     /// <summary>OVERLAPPING — the base declares 3 references and the mid plugin re-declares the FIRST of them
     /// plus one of its own. The union is 4, and a concatenation would say 5.</summary>
     public FormKey CellG { get; }
+    /// <summary>OVER THE MEMBER CAP — the base declares 101 references and the mid plugin overrides the cell
+    /// declaring none, so the union is 101 against a json member cap of 100.</summary>
+    public FormKey CellH { get; }
     public FormKey Topic { get; }
     /// <summary>A 3-toucher record with no child-bearing field at all.</summary>
     public FormKey Weapon { get; }
@@ -67,7 +74,7 @@ public sealed class OwnedChildWorld : IDisposable
 
         CellA = new FormKey(baseKey, 0xC01); CellB = new FormKey(baseKey, 0xC02); CellC = new FormKey(baseKey, 0xC03);
         CellD = new FormKey(baseKey, 0xC04); CellE = new FormKey(baseKey, 0xC05); CellF = new FormKey(baseKey, 0xC06);
-        CellG = new FormKey(baseKey, 0xC07);
+        CellG = new FormKey(baseKey, 0xC07); CellH = new FormKey(baseKey, 0xC08);
         Topic = new FormKey(baseKey, 0xD01); Weapon = new FormKey(baseKey, 0xE01); Worldspace = new FormKey(baseKey, 0xF01);
 
         var baseDir = Path.Combine(mods, "BaseMod"); Directory.CreateDirectory(baseDir);
@@ -107,6 +114,11 @@ public sealed class OwnedChildWorld : IDisposable
                 g.Temporary.Add(new PlacedObject(new FormKey(baseKey, (uint)(0xC70 + i)), SkyrimRelease.SkyrimSE) { EditorID = $"HcOcGTemp{i}" });
             FileInterior(m, g);
 
+            var h = new Cell(CellH, SkyrimRelease.SkyrimSE) { EditorID = "HcOcCellH", Flags = Cell.Flag.IsInteriorCell };
+            for (int i = 0; i < 101; i++)
+                h.Temporary.Add(new PlacedObject(new FormKey(baseKey, (uint)(0x1000 + i)), SkyrimRelease.SkyrimSE) { EditorID = $"HcOcHTemp{i}" });
+            FileInterior(m, h);
+
             var t = new DialogTopic(Topic, SkyrimRelease.SkyrimSE) { EditorID = "HcOcTopic" };
             for (int i = 0; i < 2; i++)
             {
@@ -131,6 +143,7 @@ public sealed class OwnedChildWorld : IDisposable
         }
 
         var midDir = Path.Combine(mods, "MidMod"); Directory.CreateDirectory(midDir);
+        MidPath = Path.Combine(midDir, MidName);
         {
             using var baseOv = SkyrimMod.CreateFromBinaryOverlay(basePath, SkyrimRelease.SkyrimSE);
             var m = new SkyrimMod(midKey, SkyrimRelease.SkyrimSE);
@@ -140,6 +153,10 @@ public sealed class OwnedChildWorld : IDisposable
             f.Temporary.Add(new PlacedObject(new FormKey(midKey, 0xA60), SkyrimRelease.SkyrimSE) { EditorID = "HcOcMidFTemp0" });
             f.Persistent.Add(new PlacedObject(new FormKey(midKey, 0xA6A), SkyrimRelease.SkyrimSE) { EditorID = "HcOcMidFPers0" });
             FileInterior(m, f);
+
+            // CellH: the mid plugin touches the cell for an unrelated reason and declares nothing, so the union
+            // is the base's 101 -- one past the json member cap.
+            FileInterior(m, new Cell(CellH, SkyrimRelease.SkyrimSE) { EditorID = "HcOcCellH", Flags = Cell.Flag.IsInteriorCell });
 
             // CellG: the mid plugin RE-DECLARES the base's first reference and adds one of its own, so the union
             // has to be keyed by FormID rather than concatenated.
@@ -196,6 +213,11 @@ public sealed class OwnedChildWorld : IDisposable
         File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + BaseName + "\r\n" + MidName + "\r\n" + TopName + "\r\n");
         File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + BaseName + "\r\n*" + MidName + "\r\n*" + TopName + "\r\n");
         File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+TopMod\r\n+MidMod\r\n+BaseMod\r\n");
+
+        // The scan lanes validate against the corpus rulebook, so this world generates one like the others.
+        var genDir = Path.Combine(Root, "corpus-gen");
+        CorpusGenerator.GenerateAll(genDir, Path.Combine(Root, "corpus-ref"));
+        CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json");
 
         Svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(Root, "houseCARL.user.json")));
         Svc.Stats();
@@ -578,6 +600,111 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     [Fact]
     public void Artifact_TheManifestOnlyResponseDoesNotStateAClauseOverRowsItDidNotRender() =>
         Assert.Null(ClauseLineOrNull(Read(_w.CellA, toFile: _w.Scratch("inline.jsonl")), ReadSentences.UnionFraming));
+
+    // ---- the member sample: what json lists, and what it counts instead ---------------------------
+
+    static JsonElement Union(string json, FormKey _, string field)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.GetProperty("records")[0].GetProperty("fields").EnumerateArray()
+                  .Single(f => f.GetProperty("path").GetString() == field)
+                  .GetProperty("owned_child_union").Clone();
+    }
+
+    /// <summary>A union past the cap lists a SAMPLE and counts the rest — the array is never the whole set, and a
+    /// caller who round-trips it can see from members_omitted that it is not.</summary>
+    [Fact]
+    public void Json_AUnionPastTheMemberCapListsASampleAndCountsWhatItLeftOut()
+    {
+        var u = Union(Read(_w.CellH, format: "json"), _w.CellH, "Temporary");
+        Assert.Equal(101, u.GetProperty("total").GetInt32());
+        Assert.Equal(100, u.GetProperty("members").GetArrayLength());
+        Assert.Equal(1, u.GetProperty("members_omitted").GetInt32());
+    }
+
+    /// <summary>The sample is bounded by what is LEFT of max_chars too. A hundred FormKey strings is ~3KB, so a
+    /// field object that only obeyed the flat cap could double a small response before the field loop noticed.</summary>
+    [Fact]
+    public void Json_TheMemberSampleShrinksToTheRemainingBudget_AndTheOmissionIsStillCounted()
+    {
+        var u = Union(Read(_w.CellH, new RecordsTools.RecordsProject { form = "fields", fields = new[] { "Temporary" } },
+                           format: "json", maxChars: 2000), _w.CellH, "Temporary");
+        int listed = u.GetProperty("members").GetArrayLength();
+        Assert.InRange(listed, 0, 99);
+        Assert.Equal(101 - listed, u.GetProperty("members_omitted").GetInt32());
+    }
+
+    /// <summary>An additive union has no single live declarer — every declarer's children are live — so the json
+    /// names the highest declarer as that, and keeps live_plugin for the SINGULAR shape where it is true.</summary>
+    [Fact]
+    public void Json_ACollectionNamesItsHighestDeclarer_AndOnlyASingularNamesALivePlugin()
+    {
+        var json = Read(_w.CellA, format: "json");
+        var coll = Union(json, _w.CellA, "Temporary");
+        Assert.Equal(_w.BaseName, coll.GetProperty("highest_declarer").GetString());
+        Assert.False(coll.TryGetProperty("live_plugin", out _));
+        var sing = Union(json, _w.CellA, "Landscape");
+        Assert.Equal(_w.BaseName, sing.GetProperty("live_plugin").GetString());
+        Assert.False(sing.TryGetProperty("highest_declarer", out _));
+    }
+
+    // ---- a plugin the union could not open --------------------------------------------------------
+
+    /// <summary>A sibling plugin holding an exclusive handle (xEdit, MO2, an AV scan) must not fault the read: the
+    /// subject's own body answers, and the plugin that would not open is NAMED beside the union rather than
+    /// counted into it as declaring nothing.</summary>
+    [Fact]
+    public void ASiblingPluginThatWillNotOpenIsNamedBesideTheUnion_NeverFatalAndNeverANegative()
+    {
+        string line;
+        using (new FileStream(_w.MidPath, FileMode.Open, FileAccess.Read, FileShare.None))
+            line = FieldLine(Read(_w.CellF), "Temporary");
+        Assert.Contains(ReadSentences.CouldNotRead, line);
+        Assert.Contains(_w.MidName, line);
+        // The base's declaration still counted: the read degraded by one plugin, and said so.
+        Assert.Contains(ReadSentences.UnionLabel, line);
+    }
+
+    /// <summary>And the same read once the handle is gone: the plugin is back in the union, so the arm above is a
+    /// statement about THAT read, not a sticky verdict.</summary>
+    [Fact]
+    public void TheSameReadAfterTheHandleIsReleasedNamesNothingUnreadable() =>
+        Assert.DoesNotContain(ReadSentences.CouldNotRead, FieldLine(Read(_w.CellF), "Temporary"));
+
+    // ---- the scan lanes: annotated, but index-only --------------------------------------------------
+
+    string ScanCells(string? format = null) =>
+        RecordsTools.Records(Svc, types: new[] { "CELL" },
+                             project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "Temporary" } },
+                             format: format);
+
+    /// <summary>A scan discovers its row count, so it does not open a body per touching plugin per row. It still
+    /// annotates — the field is a false-empty either way — with the index-only note.</summary>
+    [Fact]
+    public void AScanStatesTheIndexOnlyNote_NotTheUnionItWouldPayPerRowFor()
+    {
+        var r = ScanCells();
+        Assert.Contains(ReadSentences.NotRead, r);
+        // The clause's remedy NAMES the union, so the absent thing is the union NOTE — a label with a count after it.
+        Assert.DoesNotContain(ReadSentences.UnionLabel + ":", r);
+    }
+
+    /// <summary>And the clause over those rows is the index-only tier's, naming the lane that DOES assemble the
+    /// union — a scan must not ship a sentence describing a quantity its rows do not carry.</summary>
+    [Fact]
+    public void AScansClauseIsTheIndexOnlyOneAndNamesTheFormidsLane()
+    {
+        using var doc = JsonDocument.Parse(ScanCells("json"));
+        var note = doc.RootElement.GetProperty("owned_child_note").GetString()!;
+        Assert.StartsWith(ClauseHead(ReadSentences.NotReadFraming), note);
+        Assert.Contains("formids=", note);
+    }
+
+    /// <summary>The same cell named by formid IS unioned, so the two lanes differ by what the caller asked for,
+    /// not by what is true.</summary>
+    [Fact]
+    public void TheSameCellNamedByFormidIsUnioned() =>
+        Assert.Contains(ReadSentences.UnionLabel, FieldLine(Read(_w.CellA), "Temporary"));
 
     // ---- the remedy the clause names ------------------------------------------------------------
     //

--- a/src/housecarl-mcp-tests/RecordsWorldLifecycleTests.cs
+++ b/src/housecarl-mcp-tests/RecordsWorldLifecycleTests.cs
@@ -3,19 +3,28 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>What a <see cref="RecordsWorld"/> leaves behind when it disposes: it repoints the process-global
+/// <summary>What a synthetic world leaves behind when it disposes: a world repoints the process-global
 /// <c>CorpusRulebook.CorpusPath</c> at its own generated corpus and deletes that directory on Dispose, so an
 /// unrestored static leaves everything after it resolving types against a path that no longer exists.
 /// Deliberately NOT in the "records" collection — that collection's fixture repoints the static itself, which
-/// would hide a missing restore.</summary>
+/// would hide a missing restore. Every world that repoints the static gets an arm here; the suite otherwise
+/// passes only on the order the collections happen to run in.</summary>
 [Trait("tier", "integration")]
 public sealed class RecordsWorldLifecycleTests
 {
     [Fact]
-    public void ADisposedWorldPutsTheGlobalCorpusPathBack_AndItStillNamesSomethingThatExists()
+    public void ADisposedWorldPutsTheGlobalCorpusPathBack_AndItStillNamesSomethingThatExists() =>
+        AssertRestoresTheGlobalCorpusPath(() => { var w = new RecordsWorld(); return (w, w.Root); });
+
+    [Fact]
+    public void ADisposedOwnedChildWorldPutsTheGlobalCorpusPathBack() =>
+        AssertRestoresTheGlobalCorpusPath(() => { var w = new OwnedChildWorld(); return (w, w.Root); });
+
+    /// <summary>Build one world, dispose it, and require the static to name what it named before — a real file,
+    /// since "restored" has to mean usable rather than merely equal to a string.</summary>
+    static void AssertRestoresTheGlobalCorpusPath(Func<(IDisposable World, string Root)> build)
     {
-        // A prior value this test owns, so the claim does not depend on what ran before it. It is a real
-        // file: "restored" has to mean usable, not merely equal to a string.
+        // A prior value this test owns, so the claim does not depend on what ran before it.
         var sentinelDir = Path.Combine(Path.GetTempPath(), "hc-corpuspath-prior-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(sentinelDir);
         var prior = Path.Combine(sentinelDir, "corpus.json");
@@ -27,14 +36,15 @@ public sealed class RecordsWorldLifecycleTests
             CorpusRulebook.CorpusPath = prior;
 
             string worldCorpus;
-            using (var w = new RecordsWorld())
+            var (world, root) = build();
+            using (world)
             {
                 worldCorpus = CorpusRulebook.CorpusPath;
 
                 // If a world stopped repointing the static there would be nothing to restore, and every claim
                 // below would pass for the wrong reason.
                 Assert.NotEqual(prior, worldCorpus);
-                Assert.StartsWith(w.Root, worldCorpus, StringComparison.OrdinalIgnoreCase);
+                Assert.StartsWith(root, worldCorpus, StringComparison.OrdinalIgnoreCase);
             }
 
             // The world's own corpus is gone with its root — which is exactly why the static may not still

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -189,7 +189,7 @@ internal static class Artifacts
     /// explaining it. The manifest is line 1 and the rows are lines 2..N, so this names the annotated fields
     /// rather than pointing at a position. The precise tier's note is <see cref="PreciseChildNotes"/>.</summary>
     static IReadOnlyList<string>? OwnedChildNotes(IReadOnlyCollection<string> annotatedFields) =>
-        annotatedFields.Count == 0 ? null : new[] { ReadSentences.NotReadClause(annotatedFields) };
+        annotatedFields.Count == 0 ? null : new[] { ReadSentences.UnionClause(annotatedFields) };
 
     /// <summary>The precise tier's response-level note for a tree artifact: <see cref="ReadSentences.DeclarersLead"/>
     /// stated once rather than per row, when any row's <c>child_declarers</c> reached the file.</summary>

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -126,6 +126,7 @@ internal static class Artifacts
         string? identity;
         string sort;
         var annotated = new SortedSet<string>(StringComparer.Ordinal);   // which fields the rows carry annotated
+        bool annotatedUnioned = false;                                   // and which TIER they stated
 
         if (q.Groups is not null)                                             // group_by= → count-table rows
         {
@@ -149,7 +150,10 @@ internal static class Artifacts
                                           resolveNames: resolveNames, linkMemo: linkMemo,
                                           containerHint: (levers ?? LeverNames.Legacy).ContainerHint);   // an artifact row is read by the same caller
                 if (o.Error is null && o.OwnedChildFields is { } af)   // the rows' labels need their clause on line 1
+                {
                     foreach (var annotatedPath in af.Keys) annotated.Add(annotatedPath);
+                    annotatedUnioned |= o.OwnedChildUnioned;
+                }
                 if (o.Error is not null)
                     writer.WriteRow((w, _) =>
                     {
@@ -180,16 +184,17 @@ internal static class Artifacts
         // The manifest stamps which tool wrote the artifact; see WriteResolve for why it names records.
         var (manifest, err) = writer.Save(path, ToolNames.Records, query, identity, schema, sort,
                                           q.Groups is not null ? q.Groups.Count : q.Total, q.Epoch ?? "",
-                                          OwnedChildNotes(annotated));
+                                          OwnedChildNotes(annotated, annotatedUnioned));
         return err is not null ? (null, err) : (new SpillInfo(path, manifest!, reason), null);
     }
 
-    /// <summary>The cheap tier's response-level statement that an artifact's annotated rows depend on. An artifact
-    /// is re-entered with no conversation attached, so a row's "not read" label must travel with the sentence
-    /// explaining it. The manifest is line 1 and the rows are lines 2..N, so this names the annotated fields
-    /// rather than pointing at a position. The precise tier's note is <see cref="PreciseChildNotes"/>.</summary>
-    static IReadOnlyList<string>? OwnedChildNotes(IReadOnlyCollection<string> annotatedFields) =>
-        annotatedFields.Count == 0 ? null : new[] { ReadSentences.UnionClause(annotatedFields) };
+    /// <summary>The response-level statement that an artifact's annotated rows depend on. An artifact is re-entered
+    /// with no conversation attached, so a row's union or "not read" label must travel with the sentence explaining
+    /// it. The manifest is line 1 and the rows are lines 2..N, so this names the annotated fields rather than
+    /// pointing at a position. <paramref name="unioned"/> picks the tier the rows actually stated. The precise
+    /// tier's note is <see cref="PreciseChildNotes"/>.</summary>
+    static IReadOnlyList<string>? OwnedChildNotes(IReadOnlyCollection<string> annotatedFields, bool unioned) =>
+        annotatedFields.Count == 0 ? null : new[] { ReadSentences.OwnedChildClause(annotatedFields, unioned) };
 
     /// <summary>The precise tier's response-level note for a tree artifact: <see cref="ReadSentences.DeclarersLead"/>
     /// stated once rather than per row, when any row's <c>child_declarers</c> reached the file.</summary>
@@ -229,7 +234,7 @@ internal static class Artifacts
         // The manifest's tool stamp; see WriteResolve.
         var (manifest, err) = writer.Save(path, ToolNames.Records, query, "formid",
                                           new[] { "formid", "runtime_formid", "type", "editorid", "winner", "override_depth", "source", "fields" },
-                                          "input order", outcomes.Count, epoch, OwnedChildNotes(AnnotatedFields(outcomes)));
+                                          "input order", outcomes.Count, epoch, OwnedChildNotes(AnnotatedFields(outcomes), outcomes.Any(o => o.OwnedChildUnioned)));
         return err is not null ? (null, err) : (new SpillInfo(path, manifest!, reason), null);
     }
 

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -257,7 +257,7 @@ static class JsonWire
             var f = r.Fields[i];
             w.WriteStartObject();
             WriteLeaf(w, f);
-            if (annotated is not null && annotated.TryGetValue(f.Path, out var union) && union is not null) WriteChildUnion(w, union);
+            if (annotated is not null && annotated.TryGetValue(f.Path, out var union) && union is not null) WriteChildUnion(w, union, ms, cap);
             if (f.Cells is { } cells)
             {
                 // A folded row (the 'rows' form): the line's own text is prose, so the leaves it folded ride here
@@ -300,13 +300,16 @@ static class JsonWire
     /// the same <c>formids=</c> door it came in by. <c>members</c> is capped at
     /// <see cref="ChildUnionMemberCap"/> with <c>members_omitted</c> naming the rest, because a worldspace's union
     /// runs to tens of thousands and a field annotation is not a listing surface.</summary>
-    static void WriteChildUnion(Utf8JsonWriter w, ChildUnion u)
+    static void WriteChildUnion(Utf8JsonWriter w, ChildUnion u, MemoryStream ms, int cap)
     {
         w.WriteStartObject("owned_child_union");
         w.WriteString("shape", u.Shape.ToString());
         w.WriteNumber("total", u.Total);
         w.WriteNumber("own", u.OwnCount);
-        WriteNullable(w, "live_plugin", u.LivePlugin);
+        // A SINGULAR field's declarers override one record, so one of them IS live. A COLLECTION is additive —
+        // every declarer's children are live — so naming one plugin there would be the #342 misreading this exists
+        // to remove; it is named as what it is, the highest plugin that declares anything.
+        WriteNullable(w, u.Shape == OwnedChildShape.Singular ? "live_plugin" : "highest_declarer", u.LivePlugin);
         w.WriteStartArray("declarers");
         foreach (var d in u.Declarers)
         {
@@ -322,12 +325,23 @@ static class JsonWire
             foreach (var p in u.Unreadable) w.WriteStringValue(p);
             w.WriteEndArray();
         }
+        // The member array is the one part of a field object that can run to kilobytes, so it is bounded by BOTH
+        // the flat cap and what is left of max_chars: a field object that silently doubled the response would be
+        // invisible to the `truncated` flag the auto-spill trigger reads. Whatever is not listed is counted.
+        w.Flush();
+        int room = (int)Math.Max(0, cap - ms.Length) / ChildUnionMemberBytes;
+        int listed = Math.Min(u.Members.Count, Math.Min(ChildUnionMemberCap, room));
         w.WriteStartArray("members");
-        for (int i = 0; i < u.Members.Count && i < ChildUnionMemberCap; i++) w.WriteStringValue(u.Members[i].ToString());
+        for (int i = 0; i < listed; i++) w.WriteStringValue(u.Members[i].ToString());
         w.WriteEndArray();
-        if (u.Members.Count > ChildUnionMemberCap) w.WriteNumber("members_omitted", u.Members.Count - ChildUnionMemberCap);
+        if (u.Members.Count > listed) w.WriteNumber("members_omitted", u.Members.Count - listed);
         w.WriteEndObject();
     }
+
+    /// <summary>The budget one listed member costs — a FormKey string, its quotes, its comma and the writer's
+    /// indentation. Deliberately generous: it decides how many members fit in what is LEFT of max_chars, and
+    /// under-counting is what lets a field object overrun the cap.</summary>
+    const int ChildUnionMemberBytes = 40;
 
     /// <summary>How many union members one field object lists. A cell's union is hundreds and a worldspace's is
     /// tens of thousands, so the array is a sample with its remainder counted, never the whole set.</summary>

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -237,7 +237,7 @@ static class JsonWire
     /// <param name="emitted">Collects the annotated paths this array ACTUALLY carried — the response-level clause is
     /// stated over these, so a field the truncation above dropped states nothing.</param>
     static void WriteFieldsArray(Utf8JsonWriter w, RecordFields r, MemoryStream ms, int cap,
-                                 IReadOnlyDictionary<string, ChildUnion>? annotated = null, ICollection<string>? emitted = null,
+                                 IReadOnlyDictionary<string, ChildUnion?>? annotated = null, ICollection<string>? emitted = null,
                                  LeverNames? levers = null)
     {
         var lv = levers ?? LeverNames.Legacy;
@@ -257,7 +257,7 @@ static class JsonWire
             var f = r.Fields[i];
             w.WriteStartObject();
             WriteLeaf(w, f);
-            if (annotated is not null && annotated.TryGetValue(f.Path, out var union)) WriteChildUnion(w, union);
+            if (annotated is not null && annotated.TryGetValue(f.Path, out var union) && union is not null) WriteChildUnion(w, union);
             if (f.Cells is { } cells)
             {
                 // A folded row (the 'rows' form): the line's own text is prose, so the leaves it folded ride here
@@ -357,7 +357,7 @@ static class JsonWire
         WriteNullable(w, "source", o.SourcePlugin);   // the body these field VALUES came from (scoped plugin vs winner)
         if (matches is not null) w.WriteString("matches", matches);
         WriteFieldsArray(w, r, ms, cap, o.OwnedChildFields, childFields, levers);
-        if (stateChildNote && childFields is IReadOnlyCollection<string> { Count: > 0 } stated) WriteOwnedChildNote(w, stated);
+        if (stateChildNote && childFields is IReadOnlyCollection<string> { Count: > 0 } stated) WriteOwnedChildNote(w, stated, o.OwnedChildUnioned);
         w.WriteEndObject();
     }
 
@@ -368,9 +368,9 @@ static class JsonWire
     ///
     /// <para>json only ever states the cheap tier's clause: <c>conflict_tree=true</c> is refused in json mode, so
     /// the lane that has the bodies to name declarers does not exist here.</para></summary>
-    static void WriteOwnedChildNote(Utf8JsonWriter w, IReadOnlyCollection<string> fields)
+    static void WriteOwnedChildNote(Utf8JsonWriter w, IReadOnlyCollection<string> fields, bool unioned)
     {
-        if (fields.Count > 0) w.WriteString("owned_child_note", ReadSentences.UnionClause(fields));
+        if (fields.Count > 0) w.WriteString("owned_child_note", ReadSentences.OwnedChildClause(fields, unioned));
     }
 
     // ---- housecarl_batch_record_detail --------------------------------------------------------------
@@ -415,7 +415,7 @@ static class JsonWire
             // Over the annotated fields this document actually carries — never the input list, and never a field
             // some row's own truncation dropped. A manifest-only (to_file) or truncated response carries none, and
             // states none.
-            WriteOwnedChildNote(w, childFields);
+            WriteOwnedChildNote(w, childFields, outcomes.Any(o => o.OwnedChildUnioned));
             truncated = rowsTruncated;
             if (spill is not null) Artifacts.WriteSpillStateJson(w, spill);
             w.WriteEndObject();
@@ -1053,6 +1053,7 @@ static class JsonWire
                 w.WriteStartArray("matches");
                 int rendered = 0; bool rowsTruncated = false;
                 var childFields = new SortedSet<string>(StringComparer.Ordinal);   // the clause once, over the fields the rows carried
+                bool childUnioned = false;   // which TIER those rows stated — the scan lanes annotate index-only
                 for (int i = 0; i < q.Keys.Count && !manifestOnly; i++)      // to_file: the rows are the FILE
                 {
                     w.Flush();
@@ -1067,7 +1068,7 @@ static class JsonWire
                         var o = svc.ResolveReadOn(q, fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false, depth, resolveNames: resolveNames, linkMemo: linkMemo,
                                                   containerHint: (levers ?? LeverNames.Legacy).ContainerHint);   // a collapsed cell names the caller's own expansion knob
                         if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", fk.ToString()); w.WriteString("error", o.Error); if (matches is not null) w.WriteString("matches", matches); w.WriteEndObject(); }
-                        else WriteReadRecord(w, o, ms, cap, matches, childFields: childFields, levers: levers);
+                        else { WriteReadRecord(w, o, ms, cap, matches, childFields: childFields, levers: levers); childUnioned |= o.OwnedChildUnioned; }
                     }
                     else
                     {
@@ -1079,7 +1080,7 @@ static class JsonWire
                 w.WriteEndArray();
                 w.WriteNumber("rendered", rendered);
                 w.WriteBoolean("truncated", rowsTruncated);
-                WriteOwnedChildNote(w, childFields);
+                WriteOwnedChildNote(w, childFields, childUnioned);
                 truncated = rowsTruncated;
             }
             if (spill is not null && q.Error is null) Artifacts.WriteSpillStateJson(w, spill);
@@ -1166,6 +1167,7 @@ static class JsonWire
                 List<(string Formid, string Error)>? errors = null;
                 int rendered = 0; bool rowsTruncated = false;
                 var childFields = new SortedSet<string>(StringComparer.Ordinal);   // the clause once, over the cells the rows carried
+                bool childUnioned = false;   // which TIER those rows stated — the scan lanes annotate index-only
                 w.WriteStartArray("rows");
                 for (int i = 0; i < q.Keys.Count && !manifestOnly; i++)      // to_file: the rows are the FILE
                 {
@@ -1188,7 +1190,7 @@ static class JsonWire
                             WriteCell(w, DenseCell(f));
                             // Registered at EMISSION, like every other lane, so the clause is earned by what the
                             // document carries rather than by the outcome's intent.
-                            if (o.OwnedChildFields?.ContainsKey(f.Path) == true) childFields.Add(f.Path);
+                            if (o.OwnedChildFields?.ContainsKey(f.Path) == true) { childFields.Add(f.Path); childUnioned |= o.OwnedChildUnioned; }
                         }
                         if (anyScoped) WriteCell(w, o.SourcePlugin);          // the body this row's values were read from (winner_fields=true → the winner)
                         if (hasMatches) WriteCell(w, matches);
@@ -1220,7 +1222,7 @@ static class JsonWire
                 }
                 w.WriteNumber("rendered", rendered);
                 w.WriteBoolean("truncated", rowsTruncated);
-                WriteOwnedChildNote(w, childFields);
+                WriteOwnedChildNote(w, childFields, childUnioned);
                 truncated = rowsTruncated;
             }
             if (spill is not null && q.Error is null) Artifacts.WriteSpillStateJson(w, spill);

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -306,6 +306,10 @@ static class JsonWire
         w.WriteString("shape", u.Shape.ToString());
         w.WriteNumber("total", u.Total);
         w.WriteNumber("own", u.OwnCount);
+        // Stated only where it changes what `own`/`total` mean against the field's `value`: on a nested field
+        // (Worldspace.SubCells) the value counts the CONTAINERS and these count the records under them, so a
+        // consumer comparing the two numbers without this key is comparing different units.
+        if (u.Nested) w.WriteBoolean("nested", true);
         // A SINGULAR field's declarers override one record, so one of them IS live. A COLLECTION is additive —
         // every declarer's children are live — so naming one plugin there would be the #342 misreading this exists
         // to remove; it is named as what it is, the highest plugin that declares anything.

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -237,7 +237,7 @@ static class JsonWire
     /// <param name="emitted">Collects the annotated paths this array ACTUALLY carried — the response-level clause is
     /// stated over these, so a field the truncation above dropped states nothing.</param>
     static void WriteFieldsArray(Utf8JsonWriter w, RecordFields r, MemoryStream ms, int cap,
-                                 IReadOnlyDictionary<string, OwnedChildShape>? annotated = null, ICollection<string>? emitted = null,
+                                 IReadOnlyDictionary<string, ChildUnion>? annotated = null, ICollection<string>? emitted = null,
                                  LeverNames? levers = null)
     {
         var lv = levers ?? LeverNames.Legacy;
@@ -257,6 +257,7 @@ static class JsonWire
             var f = r.Fields[i];
             w.WriteStartObject();
             WriteLeaf(w, f);
+            if (annotated is not null && annotated.TryGetValue(f.Path, out var union)) WriteChildUnion(w, union);
             if (f.Cells is { } cells)
             {
                 // A folded row (the 'rows' form): the line's own text is prose, so the leaves it folded ride here
@@ -293,6 +294,44 @@ static class JsonWire
             w.WriteEndObject();
         }
     }
+
+    /// <summary>The additive union of a child-bearing field, as structure rather than only as the prose on
+    /// <c>display</c> — the FormIDs are the answer to "what is in this cell", and a caller reads them back through
+    /// the same <c>formids=</c> door it came in by. <c>members</c> is capped at
+    /// <see cref="ChildUnionMemberCap"/> with <c>members_omitted</c> naming the rest, because a worldspace's union
+    /// runs to tens of thousands and a field annotation is not a listing surface.</summary>
+    static void WriteChildUnion(Utf8JsonWriter w, ChildUnion u)
+    {
+        w.WriteStartObject("owned_child_union");
+        w.WriteString("shape", u.Shape.ToString());
+        w.WriteNumber("total", u.Total);
+        w.WriteNumber("own", u.OwnCount);
+        WriteNullable(w, "live_plugin", u.LivePlugin);
+        w.WriteStartArray("declarers");
+        foreach (var d in u.Declarers)
+        {
+            w.WriteStartObject();
+            w.WriteString("plugin", d.Plugin);
+            w.WriteNumber("count", d.Count);
+            w.WriteEndObject();
+        }
+        w.WriteEndArray();
+        if (u.Unreadable.Count > 0)
+        {
+            w.WriteStartArray("unreadable");
+            foreach (var p in u.Unreadable) w.WriteStringValue(p);
+            w.WriteEndArray();
+        }
+        w.WriteStartArray("members");
+        for (int i = 0; i < u.Members.Count && i < ChildUnionMemberCap; i++) w.WriteStringValue(u.Members[i].ToString());
+        w.WriteEndArray();
+        if (u.Members.Count > ChildUnionMemberCap) w.WriteNumber("members_omitted", u.Members.Count - ChildUnionMemberCap);
+        w.WriteEndObject();
+    }
+
+    /// <summary>How many union members one field object lists. A cell's union is hundreds and a worldspace's is
+    /// tens of thousands, so the array is a sample with its remainder counted, never the whole set.</summary>
+    internal const int ChildUnionMemberCap = 100;
 
     /// <summary>Serialize a resolved record: identity + winner/override_depth/source + the fields array. Shared by
     /// read_record, batch_record_detail, and the cross_plugin_query detail path (one shape, no drift). <paramref
@@ -331,7 +370,7 @@ static class JsonWire
     /// the lane that has the bodies to name declarers does not exist here.</para></summary>
     static void WriteOwnedChildNote(Utf8JsonWriter w, IReadOnlyCollection<string> fields)
     {
-        if (fields.Count > 0) w.WriteString("owned_child_note", ReadSentences.NotReadClause(fields));
+        if (fields.Count > 0) w.WriteString("owned_child_note", ReadSentences.UnionClause(fields));
     }
 
     // ---- housecarl_batch_record_detail --------------------------------------------------------------

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1,4 +1,4 @@
-using Mutagen.Bethesda.Plugins;
+﻿using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Aspects;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
@@ -2317,7 +2317,8 @@ public sealed class LoadOrderService : IDisposable
                             FormKey fk, string? plugin, IReadOnlyList<string>? fields, bool conflictTree, int depth,
                             bool resolveNames = false, LinkMemo? linkMemo = null,
                             string? containerHint = ReadEngine.DepthExpandHint,
-                            ChildUnionMemo? unionMemo = null)
+                            ChildUnionMemo? unionMemo = null,
+                            LoadOrderResolver.OverlaySession? batchSession = null)
     {
         // An explicitly-requested plugin excluded this session (unparseable or unopenable) is said so, rather than
         // falling through to a misleading "does not define this record".
@@ -2357,7 +2358,11 @@ public sealed class LoadOrderService : IDisposable
         if (winner is null) return ReadOutcome.Fail(fk, UnresolvedFormId(view, fk));
 
         var source = plugin ?? winner.Value.WinnerPlugin;
-        using var session = resolver.OpenSession();                       // opens the source plugin; disposed at return
+        // A session is an overlay CACHE, and the union opens a body per touching plugin — so a batch that gave one
+        // in pays each plugin's mmap once for the whole call instead of once per record. Only what this call
+        // opened is disposed here: the batch's own session outlives the item and is closed by the batch.
+        using var ownSession = batchSession is null ? resolver.OpenSession() : null;
+        var session = batchSession ?? ownSession!;
         var rec = view.GetRecord(session, source, fk);                    // excluded-check pinned to the same view the winner came from
         if (rec is null)
         {
@@ -2800,13 +2805,17 @@ public sealed class LoadOrderService : IDisposable
         var pin = new ViewPin(resolver, view);
         var linkMemo = resolveNames ? new LinkMemo() : null;   // one link-resolution cache across the whole batch
         var unionMemo = new ChildUnionMemo();                  // the caller NAMED these records: the union lane, one assembly per record
+        // One overlay cache for the whole batch. The memo dedupes a repeated FORMID; this dedupes a repeated
+        // PLUGIN, which is the shape a batch actually has — 100 exterior cells share their touchers, and a session
+        // per record re-mmaps every one of them per row. Disposed with the call, like any other read's.
+        using var batchSession = resolver.OpenSession();
         var outcomes = new List<ReadOutcome>(formids.Count);
         foreach (var raw in formids)
         {
             FormKey fk;
             try { fk = view.ParseFormId(raw); }
             catch (Exception ex) { outcomes.Add(ReadOutcome.Fail(default, $"bad FormID '{raw}': {ex.Message}")); continue; }
-            outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint, unionMemo)
+            outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint, unionMemo, batchSession)
                          with { Epoch = view.Epoch, Pin = pin });   // the batch's one build, stamped and pinned per item
         }
         return outcomes;
@@ -2935,13 +2944,14 @@ public sealed class LoadOrderService : IDisposable
             // excluded-plugin and untouched-record refusals per item and the touchers named.
             var linkMemo = resolveNames ? new LinkMemo() : null;
             var unionMemo = new ChildUnionMemo();   // named records again: the union lane
+            using var batchSession = resolver.OpenSession();   // and one overlay cache for the batch, as ResolveBatch has
             var outcomes = new List<ReadOutcome>(formids.Count);
             foreach (var raw in formids)
             {
                 FormKey fk;
                 try { fk = view.ParseFormId(raw); }
                 catch (Exception ex) { outcomes.Add(ReadOutcome.Fail(default, $"bad FormID '{raw}': {ex.Message}")); continue; }
-                outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, false, depth, resolveNames, linkMemo, containerHint, unionMemo)
+                outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, false, depth, resolveNames, linkMemo, containerHint, unionMemo, batchSession)
                              with { Epoch = view.Epoch, Pin = pin });
             }
             return outcomes;

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2281,7 +2281,8 @@ public sealed class LoadOrderService : IDisposable
     {
         var resolver = Resolver;
         var view = resolver.Capture();
-        return ResolveRead(resolver, view, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint)
+        return ResolveRead(resolver, view, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint,
+                           new ChildUnionMemo())   // one named record: the union lane
                with { Epoch = view.Epoch, Pin = new ViewPin(resolver, view) };   // stamped and pinned here, off the view actually read
     }
 
@@ -2315,7 +2316,8 @@ public sealed class LoadOrderService : IDisposable
     ReadOutcome ResolveRead(LoadOrderResolver resolver, LoadOrderResolver.IndexView view,
                             FormKey fk, string? plugin, IReadOnlyList<string>? fields, bool conflictTree, int depth,
                             bool resolveNames = false, LinkMemo? linkMemo = null,
-                            string? containerHint = ReadEngine.DepthExpandHint)
+                            string? containerHint = ReadEngine.DepthExpandHint,
+                            ChildUnionMemo? unionMemo = null)
     {
         // An explicitly-requested plugin excluded this session (unparseable or unopenable) is said so, rather than
         // falling through to a misleading "does not define this record".
@@ -2372,7 +2374,7 @@ public sealed class LoadOrderService : IDisposable
         }
 
         var record = ReadEngine.ReadFields(rec, fields, depth, containerHint);   // materialise while the session (overlay) is open
-        record = AnnotateOwnedChildContent(record, rec, view, session, fk, source, out var childFields);   // the additive union, display-only
+        record = AnnotateOwnedChildContent(record, rec, view, session, fk, source, unionMemo, out var childFields);   // the additive union (or the index-only note), display-only
         if (resolveNames) record = AnnotateLinks(record, view, session, linkMemo ?? new());   // identity of every FormLink token, display-only, on the same open session
         var touching = conflictTree ? view.TouchingPlugins(fk) : null;
         return new ReadOutcome(fk, record, source, winner.Value.WinnerPlugin, winner.Value.OverrideDepth, touching, null)
@@ -2424,7 +2426,8 @@ public sealed class LoadOrderService : IDisposable
     static RecordFields AnnotateOwnedChildContent(RecordFields rf, IMajorRecordGetter body,
                                                   LoadOrderResolver.IndexView view,
                                                   LoadOrderResolver.OverlaySession session, FormKey fk, string source,
-                                                  out IReadOnlyDictionary<string, ChildUnion>? annotated)
+                                                  ChildUnionMemo? memo,
+                                                  out IReadOnlyDictionary<string, ChildUnion?>? annotated)
     {
         annotated = null;
         // Empty for all but three record types, so this is where the overwhelming majority of reads leave, before
@@ -2443,24 +2446,49 @@ public sealed class LoadOrderService : IDisposable
         // worldspace's cells for a read that asked for EditorID would be a cost nobody asked for.
         var wanted = new Dictionary<string, OwnedChildShape>(hits.Count, StringComparer.Ordinal);
         foreach (var i in hits) wanted[rf.Fields[i].Path] = owning[rf.Fields[i].Path];
-        var unions = OwnedChildUnion.Compute(view, session, fk, source, body, wanted);
-        if (unions is null) return rf;                            // sole toucher: its own body IS the whole story
+
+        IReadOnlyDictionary<string, ChildUnion>? unions = null;
+        if (memo is not null) unions = memo.Union(fk, () => OwnedChildUnion.Compute(view, session, fk, source, body, wanted));
+        else if (view.TouchingPlugins(fk) is not { Count: > 1 }) return rf;   // sole toucher: its own body IS the whole story
+        if (memo is not null && unions is null) return rf;                    // same, on the union lane
+        var others = unions is null ? view.TouchingPlugins(fk)!.Count - 1 : 0;
 
         var rebuilt = new List<FieldValue>(rf.Fields);
         // The ANNOTATED paths and their unions travel with the outcome, because the render decides its
         // response-level clause off the fields it actually emitted — a path that never reaches the medium (a cap
-        // hit inside the field loop, a truncated json array, a manifest-only spill) must not earn a clause.
-        var map = new Dictionary<string, ChildUnion>(hits.Count, StringComparer.Ordinal);
+        // hit inside the field loop, a truncated json array, a manifest-only spill) must not earn a clause. A NULL
+        // value is the index-only tier: annotated, but by a lane that did not open the other bodies.
+        var map = new Dictionary<string, ChildUnion?>(hits.Count, StringComparer.Ordinal);
         foreach (var i in hits)
         {
-            var u = unions[rebuilt[i].Path];
+            var u = unions?[rebuilt[i].Path];
             // These fields are containers and owned records; the only other producer of Display is the flags
             // decode, which fires on [Flags] enum leaves alone — so there is no annotation here to displace.
-            rebuilt[i] = rebuilt[i] with { Display = ReadSentences.UnionNote(u) };
+            rebuilt[i] = rebuilt[i] with { Display = u is null ? ReadSentences.NotReadNote(others) : ReadSentences.UnionNote(u) };
             map[rebuilt[i].Path] = u;
         }
         annotated = map;
         return rf with { Fields = rebuilt };
+    }
+
+    /// <summary>One CALL's assembled unions, keyed by record. The union costs a body per touching plugin, so a
+    /// formid named twice in one batch pays once; the projection and the <c>plugin=</c> scope are fixed for a whole
+    /// call, so the record is the whole key.
+    /// <para>Its presence is also the SWITCH: a lane that hands one in gets the union, a lane that hands null gets
+    /// the index-only note. The scan lanes (<c>cross_plugin_query</c> detail rows, the dense grid, the artifact
+    /// spill of a scan) discover their row count rather than being handed it, so a body-per-toucher per row is a
+    /// cost the caller never asked for — they state the index-only tier and name the formids lane, which assembles
+    /// the union for records the caller named.</para></summary>
+    internal sealed class ChildUnionMemo
+    {
+        readonly Dictionary<FormKey, IReadOnlyDictionary<string, ChildUnion>?> _byRecord = new();
+
+        internal IReadOnlyDictionary<string, ChildUnion>? Union(
+            FormKey fk, Func<IReadOnlyDictionary<string, ChildUnion>?> compute)
+        {
+            if (!_byRecord.TryGetValue(fk, out var u)) _byRecord[fk] = u = compute();
+            return u;
+        }
     }
 
     /// <summary>Why a FormID resolved to nothing. "Not present" has three causes and one sentence used to serve
@@ -2546,7 +2574,10 @@ public sealed class LoadOrderService : IDisposable
     /// each row re-gates and re-captures, so a freshness rebuild landing mid-render would fill the remaining rows from
     /// a build the header's epoch does not name; pinning also drops the per-row stat sweep. Bodies are still fetched
     /// from disk at fill time — the pin freezes winner IDENTITY, and a file that changed under a pinned fetch surfaces
-    /// as the named fetch-inconsistency error. Falls back to the public path when the outcome carries no pin.</summary>
+    /// as the named fetch-inconsistency error. Falls back to the public path when the outcome carries no pin.
+    /// <para>No <see cref="ChildUnionMemo"/> is handed in: this is the SCAN detail lane, whose row count is
+    /// discovered rather than named, so a child-bearing field here states the index-only note and names the
+    /// formids lane instead of opening a body per touching plugin per row.</para></summary>
     internal ReadOutcome ResolveReadOn(CrossQueryOutcome q, FormKey fk, string? plugin, IReadOnlyList<string>? fields,
                                        bool conflictTree, int depth = 1, bool resolveNames = false,
                                        LinkMemo? linkMemo = null,
@@ -2768,13 +2799,14 @@ public sealed class LoadOrderService : IDisposable
         }
         var pin = new ViewPin(resolver, view);
         var linkMemo = resolveNames ? new LinkMemo() : null;   // one link-resolution cache across the whole batch
+        var unionMemo = new ChildUnionMemo();                  // the caller NAMED these records: the union lane, one assembly per record
         var outcomes = new List<ReadOutcome>(formids.Count);
         foreach (var raw in formids)
         {
             FormKey fk;
             try { fk = view.ParseFormId(raw); }
             catch (Exception ex) { outcomes.Add(ReadOutcome.Fail(default, $"bad FormID '{raw}': {ex.Message}")); continue; }
-            outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint)
+            outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint, unionMemo)
                          with { Epoch = view.Epoch, Pin = pin });   // the batch's one build, stamped and pinned per item
         }
         return outcomes;
@@ -2902,13 +2934,14 @@ public sealed class LoadOrderService : IDisposable
             // Active arm: the same per-item reads ResolveBatch(plugin=) does, off the same captured view, with
             // excluded-plugin and untouched-record refusals per item and the touchers named.
             var linkMemo = resolveNames ? new LinkMemo() : null;
+            var unionMemo = new ChildUnionMemo();   // named records again: the union lane
             var outcomes = new List<ReadOutcome>(formids.Count);
             foreach (var raw in formids)
             {
                 FormKey fk;
                 try { fk = view.ParseFormId(raw); }
                 catch (Exception ex) { outcomes.Add(ReadOutcome.Fail(default, $"bad FormID '{raw}': {ex.Message}")); continue; }
-                outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, false, depth, resolveNames, linkMemo, containerHint)
+                outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, false, depth, resolveNames, linkMemo, containerHint, unionMemo)
                              with { Epoch = view.Epoch, Pin = pin });
             }
             return outcomes;
@@ -8787,7 +8820,11 @@ public sealed record ReadOutcome(
     /// <para>Carried structurally rather than recovered by scanning the rendered prose for a marker, and carrying the
     /// paths rather than a bool: a clause that merely knows something was annotated cannot tell whether that
     /// something survived the medium's own truncation.</para></summary>
-    public IReadOnlyDictionary<string, ChildUnion>? OwnedChildFields { get; init; }
+    public IReadOnlyDictionary<string, ChildUnion?>? OwnedChildFields { get; init; }
+
+    /// <summary>Did this read ASSEMBLE the union, or state the index-only note? The scan lanes annotate without
+    /// opening the other bodies, and the response-level clause has to say which of the two it is stating.</summary>
+    public bool OwnedChildUnioned => OwnedChildFields is { } m && m.Values.Any(v => v is not null);
 
     /// <summary>Did this read annotate anything at all — the cheap question, for callers that only need to know
     /// whether a clause is POSSIBLE (the budget reservation) rather than which fields it would name.</summary>

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2372,7 +2372,7 @@ public sealed class LoadOrderService : IDisposable
         }
 
         var record = ReadEngine.ReadFields(rec, fields, depth, containerHint);   // materialise while the session (overlay) is open
-        record = AnnotateOwnedChildContent(record, rec, view, fk, out var childFields);   // cheap tier — index only, display-only
+        record = AnnotateOwnedChildContent(record, rec, view, session, fk, source, out var childFields);   // the additive union, display-only
         if (resolveNames) record = AnnotateLinks(record, view, session, linkMemo ?? new());   // identity of every FormLink token, display-only, on the same open session
         var touching = conflictTree ? view.TouchingPlugins(fk) : null;
         return new ReadOutcome(fk, record, source, winner.Value.WinnerPlugin, winner.Value.OverrideDepth, touching, null)
@@ -2406,25 +2406,25 @@ public sealed class LoadOrderService : IDisposable
         return rebuilt is null ? rf : rf with { Fields = rebuilt };
     }
 
-    /// <summary>On a read of a field that OWNS CHILD RECORDS, say that other plugins touch this record and that this
-    /// read did not open them. Index only; no body is fetched.
+    /// <summary>On a read of a field that OWNS CHILD RECORDS, state the ADDITIVE UNION the game assembles there —
+    /// every distinct child every touching plugin declares, keyed by FormID (#342 / #487).
     /// <para>Placed references, a topic's INFOs and a worldspace's cells are declared per plugin and assembled by the
     /// game from every plugin that declares them. An override touching a cell for an unrelated reason (occlusion,
     /// lighting, music) carries no references and deletes none, so reading its <c>Persistent</c>/<c>Temporary</c>
-    /// reports an empty cell the game actually fills. Without this note a caller auditing "what is in this cell"
-    /// through the winner gets a silently wrong answer.</para>
-    /// <para>This tier deliberately claims little: naming which plugins declare children requires their bodies, and
-    /// it unions nothing — "what is actually live in this parent" is separate work, since naive concatenation would
-    /// multi-count children that overlapping overrides both declare. See
-    /// `docs/architecture/records-owned-child-declarers.md`.</para>
+    /// reports an empty cell the game actually fills. The union is what the engine has; the field's own VALUE stays
+    /// the read body's own list, because that is what a write addresses by index.</para>
     /// <para>Assembly is over the whole touching set, so a <c>plugin=</c>-scoped read of a base master is annotated
     /// too: the plugins above it declare children it cannot see.</para>
+    /// <para>It costs one body per touching plugin, seeked by the record's own type, and only on a read that
+    /// actually EMITTED a child-bearing field — a projection that names none pays nothing. See
+    /// `docs/architecture/records-owned-child-declarers.md`.</para>
     /// <para>Display-only: it rides <see cref="FieldValue.Display"/>, never the round-trip
     /// <see cref="FieldValue.Token"/>, so it is invisible to the write surface, the read-proof oracle and the
     /// conflict diff, and reaches every render through that one carrier.</para></summary>
     static RecordFields AnnotateOwnedChildContent(RecordFields rf, IMajorRecordGetter body,
-                                                  LoadOrderResolver.IndexView view, FormKey fk,
-                                                  out IReadOnlyDictionary<string, OwnedChildShape>? annotated)
+                                                  LoadOrderResolver.IndexView view,
+                                                  LoadOrderResolver.OverlaySession session, FormKey fk, string source,
+                                                  out IReadOnlyDictionary<string, ChildUnion>? annotated)
     {
         annotated = null;
         // Empty for all but three record types, so this is where the overwhelming majority of reads leave, before
@@ -2439,24 +2439,25 @@ public sealed class LoadOrderService : IDisposable
             if (owning.ContainsKey(rf.Fields[i].Path)) (hits ??= new List<int>()).Add(i);
         if (hits is null) return rf;
 
-        var touching = view.TouchingPlugins(fk);
-        if (touching is null || touching.Count <= 1) return rf;   // sole toucher: its own body IS the whole story
+        // Narrowed to the fields this read emitted: the union opens a body per touching plugin, and assembling a
+        // worldspace's cells for a read that asked for EditorID would be a cost nobody asked for.
+        var wanted = new Dictionary<string, OwnedChildShape>(hits.Count, StringComparer.Ordinal);
+        foreach (var i in hits) wanted[rf.Fields[i].Path] = owning[rf.Fields[i].Path];
+        var unions = OwnedChildUnion.Compute(view, session, fk, source, body, wanted);
+        if (unions is null) return rf;                            // sole toucher: its own body IS the whole story
 
-        // Index only — no body is opened here. The default read states just what the index settles for free: that
-        // other plugins touch this record and this read did not look at what they declare. The tree form, which has
-        // already paid for every body, states which ones do.
-        var note = ReadSentences.NotReadNote(touching.Count - 1);
         var rebuilt = new List<FieldValue>(rf.Fields);
-        // The ANNOTATED paths and their shapes travel with the outcome, because the render decides its
+        // The ANNOTATED paths and their unions travel with the outcome, because the render decides its
         // response-level clause off the fields it actually emitted — a path that never reaches the medium (a cap
         // hit inside the field loop, a truncated json array, a manifest-only spill) must not earn a clause.
-        var map = new Dictionary<string, OwnedChildShape>(hits.Count, StringComparer.Ordinal);
+        var map = new Dictionary<string, ChildUnion>(hits.Count, StringComparer.Ordinal);
         foreach (var i in hits)
         {
+            var u = unions[rebuilt[i].Path];
             // These fields are containers and owned records; the only other producer of Display is the flags
             // decode, which fires on [Flags] enum leaves alone — so there is no annotation here to displace.
-            rebuilt[i] = rebuilt[i] with { Display = note };
-            map[rebuilt[i].Path] = owning[rebuilt[i].Path];
+            rebuilt[i] = rebuilt[i] with { Display = ReadSentences.UnionNote(u) };
+            map[rebuilt[i].Path] = u;
         }
         annotated = map;
         return rf with { Fields = rebuilt };
@@ -8780,13 +8781,13 @@ public sealed record ReadOutcome(
     /// render's conflict-tree fill reads the same build the stamp names. Internal render plumbing.</summary>
     internal LoadOrderService.ViewPin? Pin { get; init; }
 
-    /// <summary>Which fields in <see cref="Record"/> carry the owned-child annotation, each with its
-    /// <see cref="OwnedChildShape"/>, so a response render can state the clause once over the fields it actually
-    /// emitted and name them. Null when this read annotated nothing.
+    /// <summary>Which fields in <see cref="Record"/> carry the owned-child annotation, each with the
+    /// <see cref="ChildUnion"/> the order assembles there, so a response render can state the clause once over the
+    /// fields it actually emitted and name them. Null when this read annotated nothing.
     /// <para>Carried structurally rather than recovered by scanning the rendered prose for a marker, and carrying the
     /// paths rather than a bool: a clause that merely knows something was annotated cannot tell whether that
     /// something survived the medium's own truncation.</para></summary>
-    public IReadOnlyDictionary<string, OwnedChildShape>? OwnedChildFields { get; init; }
+    public IReadOnlyDictionary<string, ChildUnion>? OwnedChildFields { get; init; }
 
     /// <summary>Did this read annotate anything at all — the cheap question, for callers that only need to know
     /// whether a clause is POSSIBLE (the budget reservation) rather than which fields it would name.</summary>

--- a/src/housecarl-mcp/ReadSentences.cs
+++ b/src/housecarl-mcp/ReadSentences.cs
@@ -101,12 +101,26 @@ internal static class ReadSentences
             head = $"{UnionLabel}: {u.Total} {ChildContent}(s) across {u.Declarers.Count} plugin(s) — "
                  + string.Join(", ", u.Declarers.Take(UnionDeclarerCap).Select(d => $"{d.Plugin} {d.Count}"))
                  + (u.Declarers.Count > UnionDeclarerCap ? $" (+{u.Declarers.Count - UnionDeclarerCap} more)" : "")
-                 + $"; this body's own list carries {u.OwnCount}";
+                 + "; " + OwnShare(u);
         return u.Unreadable.Count == 0 ? head
             : head + $"; {u.Unreadable.Count} plugin(s) {CouldNotRead} "
               + $"({string.Join(", ", u.Unreadable.Take(UnionDeclarerCap))}"
               + (u.Unreadable.Count > UnionDeclarerCap ? ", …" : "") + ")";
     }
+
+    /// <summary>How much of the union THIS body declares, in the unit the value beside it is in.
+    ///
+    /// <para>On a flat field the value's items ARE the children, so the two numbers are the same unit and the
+    /// share reads as a fraction of what is rendered. On a NESTED one (<c>Worldspace.SubCells</c>) the value counts
+    /// the blocks and the share counts the cells under them, so a worldspace declaring nothing renders
+    /// <c>[list: 2 item(s)]</c> beside a share of 0 — true of two different units, and a contradiction if the
+    /// sentence does not say which. So the nested arm names its unit rather than borrowing "this body's own
+    /// list", which on that shape means the blocks.</para></summary>
+    static string OwnShare(ChildUnion u) =>
+        u.CountsTheRenderedUnit
+            ? $"this body's own list carries {u.OwnCount}"
+            : $"this body declares {u.OwnCount} of them — the value beside this counts the CONTAINERS holding " +
+              $"them, not the {ChildContent}s themselves";
 
     // ---- the precise tier: WHICH providers declare, off bodies the tree has already fetched ----------
 

--- a/src/housecarl-mcp/ReadSentences.cs
+++ b/src/housecarl-mcp/ReadSentences.cs
@@ -51,6 +51,37 @@ internal static class ReadSentences
     /// an annotation for.</summary>
     internal static string UnionClause(IReadOnlyCollection<string> fields) => string.Format(UnionFraming, FieldList(fields));
 
+    // ---- the index-only tier: what the SCAN lanes state, where a union per row is not affordable ----
+
+    /// <summary>The per-field line on a lane that did not assemble the union. It may claim only what the index
+    /// knows: other plugins touch this record and this read did not look at what they declare — never that they
+    /// do or do not.</summary>
+    [MustState("were not read")]
+    internal const string NotRead = "other plugin(s) touch this record; their declarations for this " + ChildContent + " field were not read";
+
+    /// <summary>The response-level half of the index-only tier, naming the lane that assembles the union. The
+    /// remedy must name the tool and the form, not a bare parameter: this clause ships from every scan lane that
+    /// renders record fields, including artifact manifests, and a spelling the recipient's surface rejects is a
+    /// remedy nobody can run. <c>{0}</c> is filled with the fields the response actually annotated.</summary>
+    [MustState("declared per plugin", "were not read", ToolNames.Records)]
+    internal const string NotReadFraming =
+        "note: this response annotates field(s) that hold CHILD RECORDS ({0}). Child records are declared per " +
+        "plugin and the game assembles the parent's from every plugin that declares any, so one body's list is " +
+        "not the whole content. A scan answers many rows, so it did not open the other plugins' bodies and their " +
+        "declarations were not read. For the " + UnionLabel + " on a record you name: " +
+        ToolNames.Records + " with formids=, which states it on every child-bearing field it emits.";
+
+    /// <summary>The index-only tier's per-field line: the count the index knows, and the honest limit.</summary>
+    internal static string NotReadNote(int others) => $"{others} {NotRead}";
+
+    /// <summary>The response-level clause for whichever tier the response actually stated. One door, so a lane
+    /// cannot state a union clause over index-only notes or the reverse.</summary>
+    internal static string OwnedChildClause(IReadOnlyCollection<string> fields, bool unioned) =>
+        string.Format(unioned ? UnionFraming : NotReadFraming, FieldList(fields));
+
+    /// <summary>The clause framing a tier uses, for the reserve and for a test that has to find the clause line.</summary>
+    internal static string ClauseFraming(bool unioned) => unioned ? UnionFraming : NotReadFraming;
+
     /// <summary>How many contributing plugins a union names before it summarises the rest as a count.</summary>
     internal const int UnionDeclarerCap = 3;
 
@@ -166,7 +197,9 @@ internal static class ReadSentences
     /// the body renders. The clause is load-bearing, so it cannot be dropped at the cap; appending it past the cap
     /// instead would overrun invisibly to the <c>truncated</c> flag the auto-spill trigger reads.</summary>
     internal static int ClauseReserve(bool mayState) =>
-        mayState ? UnionFraming.Length + ClauseFieldsMaxChars + ClauseGlue : 0;
+        // The longer of the two tiers: the reserve is taken before the fields render, and which tier the response
+        // will state is not settled until one of them is emitted.
+        mayState ? Math.Max(UnionFraming.Length, NotReadFraming.Length) + ClauseFieldsMaxChars + ClauseGlue : 0;
 
     // ---- the sweep response's omission accounting ----
     //

--- a/src/housecarl-mcp/ReadSentences.cs
+++ b/src/housecarl-mcp/ReadSentences.cs
@@ -17,33 +17,65 @@ namespace HousecarlMcp;
 /// </summary>
 internal static class ReadSentences
 {
-    // ---- the cheap fact every read can state from the index alone ------------------------------------
+    // ---- what the game assembles: the additive union across every touching plugin --------------------
 
-    /// <summary>The per-field half of the cheap tier. It may claim only what the index knows: other plugins touch
-    /// this record and this read did not look at what they declare — never that they do or do not.</summary>
-    [MustState("were not read")]
-    internal const string NotRead = "other plugin(s) touch this record; their declarations for this field were not read";
+    /// <summary>The word every per-field owned-child note carries, whichever shape it is in. It is what a caller
+    /// (and a test) can look for to know the field's content is assembled from more than the body it read.</summary>
+    [NoClaims("a word shared by the notes below; each states its own claim")]
+    internal const string ChildContent = "child record";
 
-    /// <summary>The response-level half of the cheap tier, naming the lane that answers precisely. The remedy must
-    /// name the tool and the form, not a bare parameter: this clause ships from every lane that renders record
-    /// fields, including artifact manifests, and a spelling the recipient's surface rejects is a remedy nobody can
-    /// run. <c>{0}</c> is filled with the fields the response actually annotated
-    /// (<see cref="FieldList"/>).</summary>
-    [MustState("declared per plugin", "\"form\": \"tree\"", ToolNames.Records)]
-    internal const string NotReadFraming =
+    /// <summary>The per-field label for the MANY-child shape. The value beside it is the body's OWN list; this is
+    /// the whole set, so the two must never read as the same quantity.</summary>
+    [NoClaims("a label; the claim — what a union is and why it differs from the value — is UnionFraming's")]
+    internal const string UnionLabel = "additive union";
+
+    /// <summary>The negative, stated rather than omitted: nobody touching this record declares children here. Its
+    /// absence would read as the union never having been assembled.</summary>
+    [MustState("no plugin", "declares child record")]
+    internal const string NoUnionMembers = UnionLabel + ": no plugin touching this record declares " + ChildContent + "s here";
+
+    /// <summary>The response-level clause. It must say that the value and the union are DIFFERENT quantities, or a
+    /// reader takes the union for the field's contents and a write addressed by index lands on the wrong child.
+    /// <c>{0}</c> is filled with the fields the response actually annotated (<see cref="FieldList"/>).</summary>
+    [MustState("declared per plugin", UnionLabel, "own list", ToolNames.Records)]
+    internal const string UnionFraming =
         "note: this response annotates field(s) that hold CHILD RECORDS ({0}). Child records are declared per " +
-        "plugin — so what one plugin's body carries is not the whole story for that field. This read did not open " +
-        "the other plugins' bodies to see what they declare. To get a read that does, and names them: " +
+        "plugin and the game assembles the parent's from every plugin that declares any, so one body's list is " +
+        "not the whole content. The VALUE shown for such a field is this body's own list, in this body's own " +
+        "order — the addresses a write uses; the " + UnionLabel + " beside it is the whole set the game " +
+        "assembles, keyed by FormID so a child two plugins both declare counts once. To see which plugin " +
         // This string is a string.Format TEMPLATE ({0} is the field list), so every literal brace is doubled.
-        ToolNames.Records + " with project={{\"form\": \"tree\"}} — the same formids, every touching plugin's " +
-        "declaration, in text or json, and it spills to to_file like any other form.";
+        "declares what: " + ToolNames.Records + " with project={{\"form\": \"tree\"}}.";
 
-    /// <summary>The cheap tier's response-level clause over the fields <paramref name="fields"/> the response
-    /// actually emitted an annotation for.</summary>
-    internal static string NotReadClause(IReadOnlyCollection<string> fields) => string.Format(NotReadFraming, FieldList(fields));
+    /// <summary>The response-level clause over the fields <paramref name="fields"/> the response actually emitted
+    /// an annotation for.</summary>
+    internal static string UnionClause(IReadOnlyCollection<string> fields) => string.Format(UnionFraming, FieldList(fields));
 
-    /// <summary>The cheap tier's per-field line: the count the index knows, and the honest limit.</summary>
-    internal static string NotReadNote(int others) => $"{others} {NotRead}";
+    /// <summary>How many contributing plugins a union names before it summarises the rest as a count.</summary>
+    internal const int UnionDeclarerCap = 3;
+
+    /// <summary>The per-field line: what the game assembles here, who contributes it, and how much of it this
+    /// body's own list carries. A SINGULAR child is not a union — its declarers override one record — so it says
+    /// which plugin's copy is live instead of adding counts that would be a fiction.</summary>
+    internal static string UnionNote(ChildUnion u)
+    {
+        string head;
+        if (u.Shape == OwnedChildShape.Singular)
+            head = u.LivePlugin is null
+                ? $"no plugin touching this record declares this {ChildContent}"
+                : $"one {ChildContent}: {u.Declarers.Count} plugin(s) hold a copy and OVERRIDE each other; " +
+                  $"the live copy is {u.LivePlugin}'s";
+        else if (u.Total == 0) head = NoUnionMembers;
+        else
+            head = $"{UnionLabel}: {u.Total} {ChildContent}(s) across {u.Declarers.Count} plugin(s) — "
+                 + string.Join(", ", u.Declarers.Take(UnionDeclarerCap).Select(d => $"{d.Plugin} {d.Count}"))
+                 + (u.Declarers.Count > UnionDeclarerCap ? $" (+{u.Declarers.Count - UnionDeclarerCap} more)" : "")
+                 + $"; this body's own list carries {u.OwnCount}";
+        return u.Unreadable.Count == 0 ? head
+            : head + $"; {u.Unreadable.Count} plugin(s) {CouldNotRead} "
+              + $"({string.Join(", ", u.Unreadable.Take(UnionDeclarerCap))}"
+              + (u.Unreadable.Count > UnionDeclarerCap ? ", …" : "") + ")";
+    }
 
     // ---- the precise tier: WHICH providers declare, off bodies the tree has already fetched ----------
 
@@ -133,8 +165,8 @@ internal static class ReadSentences
     /// <summary>The worst-case chars the response-level clause can cost, reserved out of <c>max_chars</c> before
     /// the body renders. The clause is load-bearing, so it cannot be dropped at the cap; appending it past the cap
     /// instead would overrun invisibly to the <c>truncated</c> flag the auto-spill trigger reads.</summary>
-    internal static int ClauseReserve(bool notRead) =>
-        notRead ? NotReadFraming.Length + ClauseFieldsMaxChars + ClauseGlue : 0;
+    internal static int ClauseReserve(bool mayState) =>
+        mayState ? UnionFraming.Length + ClauseFieldsMaxChars + ClauseGlue : 0;
 
     // ---- the sweep response's omission accounting ----
     //

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -149,7 +149,7 @@ static class Wire
     {
         var fields = n.Fields();
         if (fields.Count == 0) return;
-        sb.Append('\n').Append(ReadSentences.NotReadClause(fields)).Append('\n');
+        sb.Append('\n').Append(ReadSentences.UnionClause(fields)).Append('\n');
     }
 
     /// <summary>Render one record, keeping the cheap index-only annotation the service already put on the outcome.

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -124,15 +124,17 @@ static class Wire
     {
         readonly SortedSet<string> _notRead = new(StringComparer.Ordinal);
         bool _mayNotRead;
+        bool _unioned;
 
         /// <summary>The clause this response may still state — reserved from here on.</summary>
         public void May() => _mayNotRead = true;
 
-        /// <summary>An annotated field line just went into the medium: the clause is now stated, over this
-        /// field.</summary>
-        public void Emitted(string field)
+        /// <summary>An annotated field line just went into the medium: the clause is now stated, over this field,
+        /// in the TIER that line was written in — a scan lane's index-only note must not earn a union clause.</summary>
+        public void Emitted(string field, bool unioned)
         {
             May();
+            _unioned |= unioned;
             _notRead.Add(field);
         }
 
@@ -140,6 +142,8 @@ static class Wire
         public int Reserve => ReadSentences.ClauseReserve(_mayNotRead);
 
         internal IReadOnlyCollection<string> Fields() => _notRead;
+
+        internal bool Unioned => _unioned;
     }
 
     /// <summary>The owned-child clause, stated once per response after the body — never per field, which costs
@@ -149,7 +153,7 @@ static class Wire
     {
         var fields = n.Fields();
         if (fields.Count == 0) return;
-        sb.Append('\n').Append(ReadSentences.UnionClause(fields)).Append('\n');
+        sb.Append('\n').Append(ReadSentences.OwnedChildClause(fields, n.Unioned)).Append('\n');
     }
 
     /// <summary>Render one record, keeping the cheap index-only annotation the service already put on the outcome.
@@ -965,8 +969,8 @@ static class Wire
             if (f.Link is not null) sb.Append("   (").Append(LinkText(f.Link)).Append(')');   // resolve_names target identity, DISPLAY-ONLY — never the round-trip token
             sb.Append('\n');
             // The clause is earned HERE, by a line that reached the caller, not where the annotation was decided.
-            if (notes is not null && o.OwnedChildFields is { } ann && ann.ContainsKey(f.Path))
-                notes.Emitted(f.Path);
+            if (notes is not null && o.OwnedChildFields is { } ann && ann.TryGetValue(f.Path, out var u))
+                notes.Emitted(f.Path, u is not null);
         }
     }
 


### PR DESCRIPTION
A cell's `Persistent`/`Temporary`, a topic's `Responses` and a worldspace's `SubCells` hold records that are declared per plugin, and the engine assembles the parent's from every plugin that declares any. Reading only the winner's own list therefore reported an empty cell the game fills with hundreds of references whenever the winning override existed for an unrelated reason — an occlusion or lighting patch. The read now states the additive union beside the value: every distinct child the whole order declares, keyed by FormID so a child two overrides both declare counts once rather than twice, with each contributing plugin's own count and how much of the union the read body carries. The field's value is deliberately unchanged — it is still that body's own list in its own order, because those are the indices a write addresses — and the union is labelled as a separate quantity so the two cannot be confused. A singular owned child (`Cell.Landscape`, `Worldspace.TopCell`) is not a union, since its declarers override one record, so it says which plugin's copy is live instead of adding counts that would be a fiction. A plugin whose body could not be read is named beside the union, never absorbed into it. In json the union also carries the member FormIDs, so a caller reads them straight back through `formids=`. The union claims declaration, not liveness: whether a member's own winner is deleted or initially disabled is a fact about that child record and asserting it here would cost one fetch per member.

#354 was needed and is done. The union needs one body per touching plugin, and `GetRecord` fetched a body by scanning every record in the plugin, which is the cost that made the earlier index-only tier the only affordable answer (588 ms for one Dawnstar cell on a real order). `GetRecord` and the conflict tree now take the record's getter type and use Mutagen's typed group enumeration, falling back to the flat scan when the typed walk yields nothing so a type Mutagen does not route cannot read as absent. Measured on a #354-shaped synthetic order (one 20k-record master, nine 2k plugins, ten touchers of one cell whose union is 209 references): the ten bodies cost 80 ms fetched flat and 4 ms seeked by type; the whole union read answers in 3.3 ms against 1.0 ms for the same read projecting `EditorID` alone. The union is also computed only for child-bearing fields the read actually emitted, so a projection naming none pays nothing.

New engine logic is `src/housecarl-core/OwnedChildUnion.cs`; `WriteEngine`'s child-reachability walk gained a sibling that answers *which* record type a field owns (needed so a worldspace block enumerates to its cells rather than to everything inside them), leaving the write-side property set untouched. `OwnedChildContentProbe`'s arm pinning that the default read could not open a body is gone — that is the behaviour this PR reverses — and the rendered coverage is in `RecordsOwnedChildTests`, including the overlapping-declarer case a naive concatenation would double-count.

Closes #342
Closes #487
Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)
