### PR TITLE
Give housecarl_skse the uniform transport lane

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -95,7 +95,10 @@ saying it sets an expectation their install may contradict. Say what is known, a
   answer now ends on `total / rendered / skipped / capped / truncated / offset / remaining / notes`, so what a window
   or a cap left out is a number rather than a silence. An unrecognized `format=` is refused naming the two the tool
   renders, and a negative `limit=`/`offset=` is refused naming both. Text output with neither knob passed is unchanged
-  apart from that closing accounting line.
+  apart from that closing accounting line. `max_chars` bounds the json document the way it bounds the text render:
+  what it cuts from a list the accounting does not count — one config's references, the inventory's config folders,
+  the pairing's unreadable `.pex` entries — is named on the spot as `references_truncated`,
+  `config_folders_truncated` and `unreadable_pex_truncated`.
 - **`housecarl_load_order_status` now names the running server's build in its header** — a `server:` line carrying
   the informational version the binary embeds (the release version `build-plugin.ps1` stamps from `plugin.json`,
   then `+` and the full commit sha: `1.9.5-dev+e942910…`), so checking that the installed houseCARL is the build you expect no longer means

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -86,6 +86,16 @@ saying it sets an expectation their install may contradict. Say what is known, a
   both halves now ends with the near-miss suggestion, so a typo or a guessed `.esp`/`.esl` extension names the
   plugin you meant.
 
+- **`housecarl_skse` now carries the same transport every other tool has: `format='json'`, `limit=`/`offset=` paging,
+  and an in-band accounting line on every answer.** `format='json'` returns the machine-readable twin of whichever
+  family ran — the same census, the same rows, the same numbers, in named fields, plus the family that ran and the two
+  that did not (the text footer's prose cannot ride a json document). `limit=`/`offset=` page the family's row list:
+  the DLLs for `findings='inventory'` (with `filter=`, its DLL and config matches), the native-declaring classes for
+  `'pairing'`, the config files for `'config'`. The census above the rows keeps stating the whole layer, and every
+  answer now ends on `total / rendered / skipped / capped / truncated / offset / remaining / notes`, so what a window
+  or a cap left out is a number rather than a silence. An unrecognized `format=` is refused naming the two the tool
+  renders, and a negative `limit=`/`offset=` is refused naming both. Text output with neither knob passed is unchanged
+  apart from that closing accounting line.
 - **`housecarl_load_order_status` now names the running server's build in its header** — a `server:` line carrying
   the informational version the binary embeds (the release version `build-plugin.ps1` stamps from `plugin.json`,
   then `+` and the full commit sha: `1.9.5-dev+e942910…`), so checking that the installed houseCARL is the build you expect no longer means

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -92,10 +92,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
   that did not (the text footer's prose cannot ride a json document). `limit=`/`offset=` page the family's row list:
   the DLLs for `findings='inventory'` (with `filter=`, its DLL and config matches), the native-declaring classes for
   `'pairing'`, the config files for `'config'`. The census above the rows keeps stating the whole layer, and every
-  answer now ends on `total / rendered / skipped / capped / truncated / offset / remaining / notes`, so what a window
-  or a cap left out is a number rather than a silence. An unrecognized `format=` is refused naming the two the tool
+  answer now carries `total / rendered / skipped / capped / truncated / offset / remaining / notes`, so what a window
+  or a cap left out is a number rather than a silence. It closes the render: on the text lane the one-line family
+  footer still follows it, on the json lane the `accounting` object is the document's last member. An unrecognized
+  `format=` is refused naming the two the tool
   renders, and a negative `limit=`/`offset=` is refused naming both. Text output with neither knob passed is unchanged
-  apart from that closing accounting line. `max_chars` bounds the json document the way it bounds the text render:
+  apart from that accounting line. `max_chars` bounds the json document the way it bounds the text render:
   what it cuts from a list the accounting does not count — one config's references, the inventory's config folders,
   the pairing's unreadable `.pex` entries — is named on the spot as `references_truncated`,
   `config_folders_truncated` and `unreadable_pex_truncated`.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -91,12 +91,14 @@ saying it sets an expectation their install may contradict. Say what is known, a
   family ran — the same census, the same rows, the same numbers, in named fields, plus the family that ran and the two
   that did not (the text footer's prose cannot ride a json document). `limit=`/`offset=` page the family's row list:
   the DLLs for `findings='inventory'` (with `filter=`, its DLL and config matches), the native-declaring classes for
-  `'pairing'`, the config files for `'config'`. The census above the rows keeps stating the whole layer, and every
-  answer now carries `total / rendered / skipped / capped / truncated / offset / remaining / notes`, so what a window
-  or a cap left out is a number rather than a silence. It closes the render: on the text lane the one-line family
-  footer still follows it, on the json lane the `accounting` object is the document's last member. An unrecognized
-  `format=` is refused naming the two the tool
-  renders, and a negative `limit=`/`offset=` is refused naming both. Text output with neither knob passed is unchanged
+  `'pairing'`, the config files for `'config'`. The census above the rows states the whole population the answer is
+  about — the layer, or, under `filter=`, the filter's matches — while the rows below it are the window; a count a
+  filter cannot scope (the inventory's uncategorized-file total, the pairing's `.pex` scan) is left out of a filtered
+  answer rather than stated for the whole layer beside numbers that are not. Every answer now carries
+  `total / rendered / skipped / capped / truncated / offset / remaining / notes`, so what a window or a cap left out
+  is a number rather than a silence. It closes the render: on the text lane the one-line family footer still follows
+  it, on the json lane the `accounting` object is the document's last member. An unrecognized `format=` is refused
+  naming the two the tool renders, and a negative `limit=`/`offset=` is refused naming both. Text output with neither knob passed is unchanged
   apart from that accounting line. `max_chars` bounds the json document the way it bounds the text render:
   what it cuts from a list the accounting does not count — one config's references, the inventory's config folders,
   the pairing's unreadable `.pex` entries — is named on the spot as `references_truncated`,

--- a/src/housecarl-mcp-tests/AssetSelectTests.cs
+++ b/src/housecarl-mcp-tests/AssetSelectTests.cs
@@ -234,6 +234,17 @@ public sealed class AssetSelectTests : IClassFixture<AssetSelectWorld>
         Assert.Contains("neither can be negative", text);
     }
 
+    /// <summary>And it is the sentence the WINDOW owns, not a second copy of it: asset_status and housecarl_skse
+    /// refuse the same input class, so a reword of one cannot leave the other answering the old wording.</summary>
+    [Fact]
+    public void TheNegativeWindowRefusalIsTheOneTheWindowItselfSpells()
+    {
+        Assert.Equal(new RowWindow(0, -1).Error,
+                     AssetTools.AssetStatus(_w.Svc, new[] { _w.Rel("0001.nif") }, limit: -1));
+        Assert.Equal(new RowWindow(-2, 0).Error,
+                     AssetTools.AssetStatus(_w.Svc, new[] { _w.Rel("0001.nif") }, offset: -2));
+    }
+
     /// <summary>An unpaged, uncut explicit-path call reports itself whole — the accounting is on every response, not
     /// only the ones that lost something.</summary>
     [Fact]

--- a/src/housecarl-mcp-tests/SkseFamilySelectionTests.cs
+++ b/src/housecarl-mcp-tests/SkseFamilySelectionTests.cs
@@ -165,4 +165,38 @@ public sealed class SkseFamilySelectionTests
         SkseTools.Dispatch(renders, SkseTools.SkseFamily.Pairing, filter: null, peek: false, max_chars: 1);
         Assert.True(renders.Cap >= 1);
     }
+
+    /// <summary>Every TRANSPORT knob the dispatch takes reaches the render on the call it composes. Without this the
+    /// window could be dropped between the published argument and the render and no test would notice: the renders
+    /// are driven directly everywhere else, so they would still page correctly over a window nothing handed them.
+    /// </summary>
+    [Fact]
+    public void TheTransportKnobsReachTheRenderOnTheCall()
+    {
+        var renders = new RecordingRenders();
+
+        SkseTools.Dispatch(renders, SkseTools.SkseFamily.Inventory, filter: "SkyPatcher", peek: true, max_chars: 9_000,
+                           json: false, window: new RowWindow(Offset: 4, Limit: 7));
+
+        Assert.Equal("SkyPatcher", renders.Call.Filter);
+        Assert.True(renders.Call.Peek);
+        Assert.False(renders.Call.Json);
+        Assert.Equal(new RowWindow(4, 7), renders.Call.Window);
+    }
+
+    /// <summary>format='json' reaches the render as the json flag AND suppresses the text footer — appending the
+    /// footer's prose to a document would only break it.</summary>
+    [Fact]
+    public void AJsonCallSetsTheJsonFlagAndTakesNoFooter()
+    {
+        var renders = new RecordingRenders();
+
+        var text = SkseTools.Dispatch(renders, SkseTools.SkseFamily.Config, filter: null, peek: false, max_chars: 9_000,
+                                      json: true, window: RowWindow.All);
+
+        Assert.True(renders.Call.Json);
+        Assert.Equal("CONFIG-BODY", text);
+        // The whole cap is the render's, since no footer is paid for out of it.
+        Assert.Equal(9_000, renders.Call.Cap);
+    }
 }

--- a/src/housecarl-mcp-tests/SkseFamilySelectionTests.cs
+++ b/src/housecarl-mcp-tests/SkseFamilySelectionTests.cs
@@ -127,9 +127,10 @@ public sealed class SkseFamilySelectionTests
     {
         public string? Called;
         public int Cap;
-        public string Inventory(string? filter, bool peek, int cap) { Called = "inventory"; Cap = cap; return "INVENTORY-BODY"; }
-        public string Pairing(string? filter, int cap) { Called = "pairing"; Cap = cap; return "PAIRING-BODY"; }
-        public string Config(string? filter, int cap) { Called = "config"; Cap = cap; return "CONFIG-BODY"; }
+        public SkseTools.FamilyCall Call;
+        public string Inventory(SkseTools.FamilyCall c) { Called = "inventory"; Cap = c.Cap; Call = c; return "INVENTORY-BODY"; }
+        public string Pairing(SkseTools.FamilyCall c) { Called = "pairing"; Cap = c.Cap; Call = c; return "PAIRING-BODY"; }
+        public string Config(SkseTools.FamilyCall c) { Called = "config"; Cap = c.Cap; Call = c; return "CONFIG-BODY"; }
     }
 
     /// <summary>Each findings= value runs its OWN family's render, and the answer ends on that family's footer. Without

--- a/src/housecarl-mcp-tests/SkseFindingsWireShapeTests.cs
+++ b/src/housecarl-mcp-tests/SkseFindingsWireShapeTests.cs
@@ -19,6 +19,56 @@ public sealed class SkseFindingsWireShapeTests
     readonly ServerFixture _s;
     public SkseFindingsWireShapeTests(ServerFixture s) => _s = s;
 
+    /// <summary>The TRANSPORT axes SPEC §2.1 makes uniform are published on this tool too — a surface missing one
+    /// is the bug #539 named, so their absence from the schema has to fail here.</summary>
+    [Theory]
+    [InlineData("format", "string")]
+    [InlineData("limit", "integer")]
+    [InlineData("offset", "integer")]
+    [InlineData("max_chars", "integer")]
+    public void TheTransportAxesArePublishedOnTheTool(string name, string type)
+    {
+        var prop = _s.PublishedTools[ToolNames.Skse].GetProperty("inputSchema").GetProperty("properties").GetProperty(name);
+
+        Assert.Contains(type, prop.GetProperty("type").ToString(), StringComparison.Ordinal);
+    }
+
+    /// <summary>An unrecognized format= is refused naming the two this tool renders — and, like the other argument
+    /// refusals, it outranks the config prompt: the value is wrong whether or not an instance is configured.</summary>
+    [Fact]
+    public void AnUnrecognizedFormatIsRefusedNamingTextAndJson()
+    {
+        var r = _s.Call(ToolNames.Skse, """{"format":"dense"}""");
+
+        Assert.StartsWith("error: ", r.Text, StringComparison.Ordinal);
+        Assert.Contains("'text'", r.Text, StringComparison.Ordinal);
+        Assert.Contains("'json'", r.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain(ServerFixture.ConfigPrompt, r.Text, StringComparison.Ordinal);
+    }
+
+    /// <summary>A negative window is one refusal naming both knobs, before any scan is paid for.</summary>
+    [Fact]
+    public void ANegativeWindowIsRefusedNamingBothKnobs()
+    {
+        var r = _s.Call(ToolNames.Skse, """{"limit":-1}""");
+
+        Assert.StartsWith("error: ", r.Text, StringComparison.Ordinal);
+        Assert.Contains("limit=0 for no limit", r.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain(ServerFixture.ConfigPrompt, r.Text, StringComparison.Ordinal);
+    }
+
+    /// <summary>With format='json' the tool's OWN refusals come back as json documents, not as a text sentence a
+    /// json consumer would have to sniff for — the json lane is never the degraded one.</summary>
+    [Fact]
+    public void AJsonCallsRefusalIsAJsonDocument()
+    {
+        var r = _s.Call(ToolNames.Skse, """{"findings":"errors","format":"json"}""");
+
+        using var doc = JsonDocument.Parse(r.Text);
+        Assert.False(doc.RootElement.GetProperty("ok").GetBoolean());
+        Assert.Contains("is not a family on this tool", doc.RootElement.GetProperty("error").GetString());
+    }
+
     /// <summary>The published declaration the shim judges against: a string OR an array, plus null for optional.</summary>
     [Fact]
     public void FindingsIsPublishedAsAStringOrAnArray()

--- a/src/housecarl-mcp-tests/SkseTransportTests.cs
+++ b/src/housecarl-mcp-tests/SkseTransportTests.cs
@@ -47,6 +47,18 @@ public sealed class SkseTransportTests
                                         new SksePluginReader.SksePluginInfo($"p{i}.dll", SksePluginReader.SksePluginKind.Modern, true, Version($"Plugin {i}"), null,
                                                                             new[] { "kernel32.dll" }), null) });
 
+    /// <summary>A class whose only candidate DLL is version-locked to a runtime that is not the installed one — the
+    /// PAIRED BUT DEAD finding.</summary>
+    static NativeClassEntry DeadCls(int i) =>
+        new($"scripts/d{i}.pex", $"Dead{i}", new[] { "Fn" }, new[] { Mod($"Other{i}") },
+            NativeProvenance.ThirdParty, NativePairingRung.SameMod, $"Other{i}",
+            new[] { new NativePairedDll($"SKSE/Plugins/d{i}.dll", $"d{i}.dll", "", $"Other{i}",
+                        new SksePluginReader.SksePluginInfo($"d{i}.dll", SksePluginReader.SksePluginKind.Modern, true,
+                            new SksePluginReader.SkseVersionInfo($"Dead {i}", "author", "", "1.0.0",
+                                UsesAddressLibrary: false, UsesSignatureScanning: false, UsesUpdatedStructs: false,
+                                DeclaresNoStructs: false, new[] { "1.5.97.0" }, null), null,
+                            new[] { "kernel32.dll" }), null) });
+
     /// <summary>A baseline class — carried by an official archive, implemented by the game executable. It is accounted
     /// for by a count on the "accounted for" line rather than by a section row of its own.</summary>
     static NativeClassEntry EngineCls(int i) =>
@@ -333,6 +345,86 @@ public sealed class SkseTransportTests
         Assert.Equal(new[] { "c3.ini", "c4.ini", "c5.ini" },
                      doc.RootElement.GetProperty("configs").EnumerateArray()
                         .Select(c => c.GetProperty("file_name").GetString()).ToArray());
+    }
+
+    // ---- the json census under filter= -----------------------------------------------------------
+
+    /// <summary>The config twin's <c>totals</c> under a filter counts the FILTER'S references, not the whole audit's.
+    /// A caller scoping to one folder and reading <c>totals.broken</c> was being told what the whole layer carries,
+    /// under a name that reads as the folder's — while <c>files</c> and <c>accounting</c> beside it named the
+    /// matches.</summary>
+    [Fact]
+    public void TheConfigTwinsCensusCountsTheFiltersReferencesNotTheWholeAudit()
+    {
+        using var doc = JsonDocument.Parse(SkseConfigAuditWire.RenderJson(ConfigAudit(5, refs: 2), "Mod3", 200_000));
+        var t = doc.RootElement.GetProperty("totals");
+
+        Assert.Equal(1, doc.RootElement.GetProperty("files").GetArrayLength());
+        Assert.Equal(1, doc.RootElement.GetProperty("accounting").GetProperty("total").GetInt32());
+        Assert.Equal(1, t.GetProperty("configs_scanned").GetInt32());
+        Assert.Equal(1, t.GetProperty("files_with_references").GetInt32());
+        Assert.Equal(2, t.GetProperty("references_checked").GetInt32());
+        Assert.Equal(2, t.GetProperty("inert").GetInt32());
+        Assert.Equal(0, t.GetProperty("read_errors").GetInt32());
+    }
+
+    /// <summary>The pairing twin's <c>totals</c> under a filter classifies the FILTER'S classes: a caller scoping to
+    /// one mod must not read other mods' dead pairings as its own. The scan counts that a filter cannot scope —
+    /// <c>pex_scanned</c>, <c>unreadable_pex</c> — are not stated rather than stated out of scope.</summary>
+    [Fact]
+    public void ThePairingTwinsCensusClassifiesTheFiltersClassesNotTheWholeAudit()
+    {
+        var d = Pairing(1) with
+        {
+            Classes = new[] { Cls(3) }.Concat(Enumerable.Range(1, 3).Select(DeadCls)).ToList(),
+            PexScanned = 4,
+        };
+
+        using var doc = JsonDocument.Parse(NativePairingWire.RenderJson(d, "Mod3", 200_000));
+        var t = doc.RootElement.GetProperty("totals");
+
+        Assert.Equal(1, doc.RootElement.GetProperty("classes").GetArrayLength());
+        Assert.Equal(1, t.GetProperty("classes").GetInt32());
+        Assert.Equal(1, t.GetProperty("healthy").GetInt32());
+        Assert.Equal(0, t.GetProperty("dead").GetInt32());          // the three dead ones belong to other mods
+        Assert.False(t.TryGetProperty("pex_scanned", out _));
+        Assert.False(t.TryGetProperty("unreadable_pex", out _));
+
+        // Unfiltered, the same audit states all four and both scan counts.
+        using var whole = JsonDocument.Parse(NativePairingWire.RenderJson(d, null, 200_000));
+        var w = whole.RootElement.GetProperty("totals");
+        Assert.Equal(4, w.GetProperty("classes").GetInt32());
+        Assert.Equal(3, w.GetProperty("dead").GetInt32());
+        Assert.Equal(4, w.GetProperty("pex_scanned").GetInt32());
+    }
+
+    /// <summary>The inventory twin's <c>totals</c> under a filter counts its matches, and the two members a filter
+    /// cannot scope are absent rather than layer-wide: <c>other_files</c> is counted-not-listed, and the folder table
+    /// is omitted instead of written empty — <c>[]</c> reads as "this layer has no config folders" rather than "this
+    /// view does not list them".</summary>
+    [Fact]
+    public void TheInventoryTwinsCensusCountsItsMatchesAndOmitsWhatAFilterCannotScope()
+    {
+        var layer = Inventory(5, configs: 3) with { OtherFileCount = 7 };
+
+        using var doc = JsonDocument.Parse(SkseInventoryWire.RenderJson(layer, "p3", 200_000));
+        var t = doc.RootElement.GetProperty("totals");
+
+        Assert.Equal(1, doc.RootElement.GetProperty("dlls").GetArrayLength());
+        Assert.Equal(1, t.GetProperty("dlls").GetInt32());
+        Assert.Equal(1, t.GetProperty("modern").GetInt32());
+        Assert.Equal(0, t.GetProperty("configs").GetInt32());
+        Assert.Equal(0, t.GetProperty("config_folders").GetInt32());
+        Assert.False(t.TryGetProperty("other_files", out _));
+        Assert.False(doc.RootElement.TryGetProperty("config_folders", out _));
+
+        // Unfiltered, the whole layer — including the folder table and the uncategorized-file count.
+        using var whole = JsonDocument.Parse(SkseInventoryWire.RenderJson(layer, null, 200_000));
+        var w = whole.RootElement.GetProperty("totals");
+        Assert.Equal(5, w.GetProperty("dlls").GetInt32());
+        Assert.Equal(3, w.GetProperty("configs").GetInt32());
+        Assert.Equal(7, w.GetProperty("other_files").GetInt32());
+        Assert.Equal(1, whole.RootElement.GetProperty("config_folders").GetArrayLength());
     }
 
     // ---- the pairing family's accounted-for baseline ---------------------------------------------

--- a/src/housecarl-mcp-tests/SkseTransportTests.cs
+++ b/src/housecarl-mcp-tests/SkseTransportTests.cs
@@ -27,14 +27,18 @@ public sealed class SkseTransportTests
                                                 new[] { "kernel32.dll" }),
             null);
 
-    static SkseFileEntry Config(int i) =>
-        new($"SKSE/Plugins/Group/c{i}.ini", $"c{i}.ini", "Group", new[] { Mod($"Mod{i}") }, null, null);
+    static SkseFileEntry Config(int i, string group = "Group") =>
+        new($"SKSE/Plugins/{group}/c{i}.ini", $"c{i}.ini", group, new[] { Mod($"Mod{i}") }, null, null);
 
-    static SkseInventoryData Inventory(int dlls, int configs = 0) =>
+    /// <summary>A caveat block big enough to be visible against a tight max_chars — what a reserve has to hold room
+    /// for, and what an unreserved tail overshoots the cap by.</summary>
+    static string[] Warnings(int n) => Enumerable.Range(1, n).Select(i => $"warning {i}: " + new string('w', 180)).ToArray();
+
+    static SkseInventoryData Inventory(int dlls, int configs = 0, int folders = 1, string[]? warnings = null) =>
         new(Enumerable.Range(1, dlls).Select(Dll).ToList(),
-            Enumerable.Range(1, configs).Select(Config).ToList(),
+            Enumerable.Range(1, configs).Select(i => Config(i, $"Group{i % folders}")).ToList(),
             OtherFileCount: 0, InstalledRuntime: "1.6.1170.0", BsaFailures: Array.Empty<string>(),
-            ReadIncomplete: false, Warnings: Array.Empty<string>(), ProfileName: "Default");
+            ReadIncomplete: false, Warnings: warnings ?? Array.Empty<string>(), ProfileName: "Default");
 
     static NativeClassEntry Cls(int i) =>
         new($"scripts/k{i}.pex", $"Klass{i}", new[] { "Fn" }, new[] { Mod($"Mod{i}") },
@@ -43,21 +47,25 @@ public sealed class SkseTransportTests
                                         new SksePluginReader.SksePluginInfo($"p{i}.dll", SksePluginReader.SksePluginKind.Modern, true, Version($"Plugin {i}"), null,
                                                                             new[] { "kernel32.dll" }), null) });
 
-    static NativePairingAuditData Pairing(int classes) =>
+    static NativePairingAuditData Pairing(int classes, int unreadable = 0, string[]? warnings = null) =>
         new(Enumerable.Range(1, classes).Select(Cls).ToList(), PexScanned: classes,
-            Unreadable: Array.Empty<NativeUnreadablePex>(), SkseLoaderSeen: true, InstalledRuntime: "1.6.1170.0",
-            BsaFailures: Array.Empty<string>(), ReadIncomplete: false, Warnings: Array.Empty<string>(), ProfileName: "Default");
+            Unreadable: Enumerable.Range(1, unreadable)
+                .Select(i => new NativeUnreadablePex($"scripts/bad{i}.pex", $"Mod{i}", "not a valid .pex header")).ToList(),
+            SkseLoaderSeen: true, InstalledRuntime: "1.6.1170.0",
+            BsaFailures: Array.Empty<string>(), ReadIncomplete: false, Warnings: warnings ?? Array.Empty<string>(), ProfileName: "Default");
 
-    static SkseConfigFileAudit ConfigFile(int i) =>
+    static SkseAuditedRef Ref(int i, int n) =>
+        new(new HousecarlCore.SkseConfigRef($"0x{0x800 + n:X6}|Ghost{i}.esp", HousecarlCore.SkseRefShape.FormToken,
+                                            $"Ghost{i}.esp", 0x800u + (uint)n, $"0x{0x800 + n:X6}", n, null),
+            SkseRefVerdict.PluginMissing, $"Ghost{i}.esp is not in the active load order");
+
+    static SkseConfigFileAudit ConfigFile(int i, int refs = 1) =>
         new($"SKSE/Plugins/Group/f{i}.ini", $"f{i}.ini", "Group", $"Mod{i}", 1, new[] { Mod($"Mod{i}") },
-            new[] { new SkseAuditedRef(new HousecarlCore.SkseConfigRef($"0x00080{i}|Ghost.esp",
-                                                                       HousecarlCore.SkseRefShape.FormToken, "Ghost.esp", 0x800u + (uint)i, "0x00080" + i, 3, null),
-                                       SkseRefVerdict.PluginMissing, "Ghost.esp is not in the active load order") },
-            ReadError: null);
+            Enumerable.Range(1, refs).Select(n => Ref(i, n)).ToList(), ReadError: null);
 
-    static SkseConfigAuditData ConfigAudit(int files) =>
-        new(Enumerable.Range(1, files).Select(ConfigFile).ToList(), ConfigCount: files,
-            BsaFailures: Array.Empty<string>(), ReadIncomplete: false, Warnings: Array.Empty<string>(), ProfileName: "Default");
+    static SkseConfigAuditData ConfigAudit(int files, int refs = 1, string[]? warnings = null) =>
+        new(Enumerable.Range(1, files).Select(i => ConfigFile(i, refs)).ToList(), ConfigCount: files,
+            BsaFailures: Array.Empty<string>(), ReadIncomplete: false, Warnings: warnings ?? Array.Empty<string>(), ProfileName: "Default");
 
     static string Text(string family, int rows, RowWindow window = default, string? filter = null) => family switch
     {
@@ -255,4 +263,61 @@ public sealed class SkseTransportTests
         Assert.True(a.GetProperty("rendered").GetInt32() < 40, "the cap should have dropped rows");
         Assert.Equal(40 - a.GetProperty("rendered").GetInt32(), a.GetProperty("truncated").GetInt32());
     }
+
+    // ---- a window over two concatenated populations ----------------------------------------------
+
+    /// <summary>A limit the FIRST population spends leaves nothing for the second. The inventory filter's row list is
+    /// its DLL matches then its config matches, so a limit=2 that the two DLL matches use up must render no config —
+    /// a spent budget is not "no budget", and an accounting that says the window was honoured while every config
+    /// rendered is the silently wrong answer.</summary>
+    [Fact]
+    public void ALimitTheFirstPopulationSpendsLeavesNothingForTheSecond()
+    {
+        var text = SkseInventoryWire.Render(Inventory(2, 30), "Mod", 80_000, new RowWindow(0, 2));
+
+        Assert.Contains("2 DLL + 30 config match(es)", text);           // the census still states the whole match set
+        Assert.Contains("[accounting] total=32 rendered=2 skipped=0 capped=30 truncated=0", text);
+        Assert.DoesNotContain("matching configs (", text);
+        Assert.Contains("re-call with limit=2 offset=2 for the next page.", text);
+    }
+
+    /// <summary>The json twin windows the two populations the same way — the two lanes may differ only in
+    /// formatting.</summary>
+    [Fact]
+    public void TheJsonTwinAlsoLeavesNothingForTheSecondPopulationOnASpentLimit()
+    {
+        using var doc = JsonDocument.Parse(SkseInventoryWire.RenderJson(Inventory(2, 30), "Mod", 200_000, new RowWindow(0, 2)));
+
+        Assert.Equal(2, doc.RootElement.GetProperty("dlls").GetArrayLength());
+        Assert.Equal(0, doc.RootElement.GetProperty("configs").GetArrayLength());
+        Assert.Equal(2, doc.RootElement.GetProperty("accounting").GetProperty("rendered").GetInt32());
+        Assert.Equal(30, doc.RootElement.GetProperty("accounting").GetProperty("capped").GetInt32());
+    }
+
+    /// <summary>A limit the first population only PARTLY spends still continues into the second — the fix for the
+    /// spent budget must not turn every continuation into an empty one.</summary>
+    [Fact]
+    public void ALimitTheFirstPopulationOnlyPartlySpendsContinuesIntoTheSecond()
+    {
+        using var doc = JsonDocument.Parse(SkseInventoryWire.RenderJson(Inventory(2, 30), "Mod", 200_000, new RowWindow(0, 5)));
+
+        Assert.Equal(2, doc.RootElement.GetProperty("dlls").GetArrayLength());
+        Assert.Equal(3, doc.RootElement.GetProperty("configs").GetArrayLength());
+        Assert.Equal(5, doc.RootElement.GetProperty("accounting").GetProperty("rendered").GetInt32());
+    }
+
+    /// <summary>An offset that lands INSIDE the second population still renders it — the continuation window's offset
+    /// arithmetic is untouched by the spent-limit marker.</summary>
+    [Fact]
+    public void AnOffsetLandingInsideTheSecondPopulationStillRendersIt()
+    {
+        using var doc = JsonDocument.Parse(SkseInventoryWire.RenderJson(Inventory(2, 30), "Mod", 200_000, new RowWindow(4, 3)));
+
+        Assert.Equal(0, doc.RootElement.GetProperty("dlls").GetArrayLength());
+        Assert.Equal(3, doc.RootElement.GetProperty("configs").GetArrayLength());
+        Assert.Equal(new[] { "c3.ini", "c4.ini", "c5.ini" },
+                     doc.RootElement.GetProperty("configs").EnumerateArray()
+                        .Select(c => c.GetProperty("file_name").GetString()).ToArray());
+    }
+
 }

--- a/src/housecarl-mcp-tests/SkseTransportTests.cs
+++ b/src/housecarl-mcp-tests/SkseTransportTests.cs
@@ -47,6 +47,21 @@ public sealed class SkseTransportTests
                                         new SksePluginReader.SksePluginInfo($"p{i}.dll", SksePluginReader.SksePluginKind.Modern, true, Version($"Plugin {i}"), null,
                                                                             new[] { "kernel32.dll" }), null) });
 
+    /// <summary>A baseline class — carried by an official archive, implemented by the game executable. It is accounted
+    /// for by a count on the "accounted for" line rather than by a section row of its own.</summary>
+    static NativeClassEntry EngineCls(int i) =>
+        new($"scripts/e{i}.pex", $"Engine{i}", new[] { "Fn" }, new[] { Mod("Skyrim.esm") },
+            NativeProvenance.Engine, null, null, Array.Empty<NativePairedDll>());
+
+    /// <summary>A layer whose first <paramref name="engine"/> classes are baseline and whose rest are healthy
+    /// third-party pairings — the two populations the "accounted for" block reconciles.</summary>
+    static NativePairingAuditData EngineThenThirdParty(int engine, int third) =>
+        new(Enumerable.Range(1, engine).Select(EngineCls)
+                .Concat(Enumerable.Range(1, third).Select(Cls)).ToList(),
+            PexScanned: engine + third, Unreadable: Array.Empty<NativeUnreadablePex>(),
+            SkseLoaderSeen: true, InstalledRuntime: "1.6.1170.0", BsaFailures: Array.Empty<string>(),
+            ReadIncomplete: false, Warnings: Array.Empty<string>(), ProfileName: "Default");
+
     static NativePairingAuditData Pairing(int classes, int unreadable = 0, string[]? warnings = null) =>
         new(Enumerable.Range(1, classes).Select(Cls).ToList(), PexScanned: classes,
             Unreadable: Enumerable.Range(1, unreadable)
@@ -318,6 +333,48 @@ public sealed class SkseTransportTests
         Assert.Equal(new[] { "c3.ini", "c4.ini", "c5.ini" },
                      doc.RootElement.GetProperty("configs").EnumerateArray()
                         .Select(c => c.GetProperty("file_name").GetString()).ToArray());
+    }
+
+    // ---- the pairing family's accounted-for baseline ---------------------------------------------
+
+    /// <summary>The "accounted for" block reconciles THIS PAGE: every row the window held that is not a finding. Its
+    /// engine and SKSE-core counts used to come from the whole audit while the healthy roster beside them came from
+    /// the window, so two different populations sat on adjacent lines with nothing saying which was which.</summary>
+    [Fact]
+    public void TheAccountedForBaselineCountsThePagesRowsNotTheWholeAudit()
+    {
+        var first = NativePairingWire.Render(EngineThenThirdParty(6, 4), null, 80_000, new RowWindow(0, 8));
+
+        Assert.Contains("accounted for: 6 engine class(es)", first);
+        Assert.Contains("paired healthy (2 class(es))", first);
+
+        // The sharp case: a page holding none of the baseline classes must not reprint their count as if it did.
+        var second = NativePairingWire.Render(EngineThenThirdParty(6, 4), null, 80_000, new RowWindow(6, 4));
+
+        Assert.Contains("accounted for: 0 engine class(es)", second);
+        Assert.Contains("paired healthy (4 class(es))", second);
+        // The summary above the sections still states the whole audit, which is where the layer's numbers live.
+        Assert.Contains("10 class(es) declare native functions", second);
+    }
+
+    /// <summary>The missing-loader alarm is a build-level fact, not a row: a window holding none of the SKSE-core
+    /// classes must not silence it.</summary>
+    [Fact]
+    public void TheMissingLoaderAlarmRidesTheWholeAuditNotTheWindow()
+    {
+        var d = EngineThenThirdParty(2, 4) with
+        {
+            Classes = new[] { new NativeClassEntry("scripts/su.pex", "StringUtil", new[] { "Fn" }, new[] { Mod("SKSE") },
+                                                   NativeProvenance.SkseCore, null, null, Array.Empty<NativePairedDll>()) }
+                .Concat(Enumerable.Range(1, 4).Select(Cls)).ToList(),
+            SkseLoaderSeen = false,
+        };
+
+        // The window starts past the one SKSE-core class, so the page carries none of them.
+        var text = NativePairingWire.Render(d, null, 80_000, new RowWindow(1, 4));
+
+        Assert.Contains("0 SKSE-core class(es)", text);   // the page holds none
+        Assert.Contains("no skse64 loader is visible", text);   // the audit does, so the alarm still rides
     }
 
     // ---- the json lane's own reserve --------------------------------------------------------------

--- a/src/housecarl-mcp-tests/SkseTransportTests.cs
+++ b/src/housecarl-mcp-tests/SkseTransportTests.cs
@@ -1,0 +1,258 @@
+using System.Text.Json;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// The TRANSPORT lane of <c>housecarl_skse</c> (SPEC §2.1): the in-band accounting every answer ends on, the
+/// <c>limit=</c>/<c>offset=</c> window over each family's row list, and the <c>format='json'</c> twin. Driven over
+/// synthetic data straight into the three family renders, which are pure over it — no live MO2 instance, and no
+/// dependence on what a real layer happens to contain.
+/// </summary>
+[Trait("tier", "unit")]
+public sealed class SkseTransportTests
+{
+    // ---- synthetic layers ------------------------------------------------------------------------
+
+    static SkseProvider Mod(string name) => new(name, "loose");
+
+    static SksePluginReader.SkseVersionInfo Version(string name) =>
+        new(name, "author", "", "1.0.0", UsesAddressLibrary: true, UsesSignatureScanning: false,
+            UsesUpdatedStructs: false, DeclaresNoStructs: false, new[] { "1.6.1170.0" }, null);
+
+    static SkseFileEntry Dll(int i) =>
+        new($"SKSE/Plugins/p{i}.dll", $"p{i}.dll", "", new[] { Mod($"Mod{i}") },
+            new SksePluginReader.SksePluginInfo($"p{i}.dll", SksePluginReader.SksePluginKind.Modern, true, Version($"Plugin {i}"), null,
+                                                new[] { "kernel32.dll" }),
+            null);
+
+    static SkseFileEntry Config(int i) =>
+        new($"SKSE/Plugins/Group/c{i}.ini", $"c{i}.ini", "Group", new[] { Mod($"Mod{i}") }, null, null);
+
+    static SkseInventoryData Inventory(int dlls, int configs = 0) =>
+        new(Enumerable.Range(1, dlls).Select(Dll).ToList(),
+            Enumerable.Range(1, configs).Select(Config).ToList(),
+            OtherFileCount: 0, InstalledRuntime: "1.6.1170.0", BsaFailures: Array.Empty<string>(),
+            ReadIncomplete: false, Warnings: Array.Empty<string>(), ProfileName: "Default");
+
+    static NativeClassEntry Cls(int i) =>
+        new($"scripts/k{i}.pex", $"Klass{i}", new[] { "Fn" }, new[] { Mod($"Mod{i}") },
+            NativeProvenance.ThirdParty, NativePairingRung.SameMod, $"Mod{i}",
+            new[] { new NativePairedDll($"SKSE/Plugins/p{i}.dll", $"p{i}.dll", "", $"Mod{i}",
+                                        new SksePluginReader.SksePluginInfo($"p{i}.dll", SksePluginReader.SksePluginKind.Modern, true, Version($"Plugin {i}"), null,
+                                                                            new[] { "kernel32.dll" }), null) });
+
+    static NativePairingAuditData Pairing(int classes) =>
+        new(Enumerable.Range(1, classes).Select(Cls).ToList(), PexScanned: classes,
+            Unreadable: Array.Empty<NativeUnreadablePex>(), SkseLoaderSeen: true, InstalledRuntime: "1.6.1170.0",
+            BsaFailures: Array.Empty<string>(), ReadIncomplete: false, Warnings: Array.Empty<string>(), ProfileName: "Default");
+
+    static SkseConfigFileAudit ConfigFile(int i) =>
+        new($"SKSE/Plugins/Group/f{i}.ini", $"f{i}.ini", "Group", $"Mod{i}", 1, new[] { Mod($"Mod{i}") },
+            new[] { new SkseAuditedRef(new HousecarlCore.SkseConfigRef($"0x00080{i}|Ghost.esp",
+                                                                       HousecarlCore.SkseRefShape.FormToken, "Ghost.esp", 0x800u + (uint)i, "0x00080" + i, 3, null),
+                                       SkseRefVerdict.PluginMissing, "Ghost.esp is not in the active load order") },
+            ReadError: null);
+
+    static SkseConfigAuditData ConfigAudit(int files) =>
+        new(Enumerable.Range(1, files).Select(ConfigFile).ToList(), ConfigCount: files,
+            BsaFailures: Array.Empty<string>(), ReadIncomplete: false, Warnings: Array.Empty<string>(), ProfileName: "Default");
+
+    static string Text(string family, int rows, RowWindow window = default, string? filter = null) => family switch
+    {
+        "inventory" => SkseInventoryWire.Render(Inventory(rows), filter, 80_000, window),
+        "pairing" => NativePairingWire.Render(Pairing(rows), filter, 80_000, window),
+        _ => SkseConfigAuditWire.Render(ConfigAudit(rows), filter, 80_000, window),
+    };
+
+    static JsonDocument Json(string family, int rows, RowWindow window = default, string? filter = null, int cap = 200_000) => family switch
+    {
+        "inventory" => JsonDocument.Parse(SkseInventoryWire.RenderJson(Inventory(rows), filter, cap, window)),
+        "pairing" => JsonDocument.Parse(NativePairingWire.RenderJson(Pairing(rows), filter, cap, window)),
+        _ => JsonDocument.Parse(SkseConfigAuditWire.RenderJson(ConfigAudit(rows), filter, cap, window)),
+    };
+
+    static readonly string[] Families = { "inventory", "pairing", "config" };
+
+    // ---- the accounting block --------------------------------------------------------------------
+
+    /// <summary>SPEC §2.1 makes the accounting required output, so it rides EVERY answer — not only a windowed one.
+    /// Without this a family could quietly go back to counting nothing.</summary>
+    [Theory]
+    [InlineData("inventory")]
+    [InlineData("pairing")]
+    [InlineData("config")]
+    public void EveryFamilysTextAnswerEndsOnTheAccountingBlock(string family)
+    {
+        var text = Text(family, 4);
+
+        Assert.Contains("[accounting] total=4 rendered=4 skipped=0 capped=0 truncated=0 offset=0 remaining=0 notes=0", text);
+        // Nothing was left out, so nothing advises a next page.
+        Assert.DoesNotContain("re-call with limit=", text);
+    }
+
+    /// <summary>The filter= view answers over its MATCHES, so its accounting counts those — a filtered response that
+    /// reported the whole layer's total would tell the caller to page through rows the filter already excluded.</summary>
+    [Theory]
+    [InlineData("inventory")]
+    [InlineData("pairing")]
+    [InlineData("config")]
+    public void TheFilteredViewAccountsForItsMatchesNotTheWholeLayer(string family)
+    {
+        var text = Text(family, 6, filter: "Mod3");
+
+        Assert.Contains("[accounting] total=1 rendered=1", text);
+    }
+
+    /// <summary>A filter that matches nothing is still an answer, and still says so in numbers.</summary>
+    [Theory]
+    [InlineData("inventory")]
+    [InlineData("pairing")]
+    [InlineData("config")]
+    public void AFilterThatMatchesNothingStillCarriesTheAccounting(string family)
+        => Assert.Contains("[accounting] total=0 rendered=0", Text(family, 4, filter: "NoSuchThing"));
+
+    // ---- the paging window -----------------------------------------------------------------------
+
+    /// <summary>offset= steps over rows BEFORE the window and limit= bounds it, and the two omissions are counted
+    /// apart: skipped is what offset passed, capped is what limit left behind.</summary>
+    [Theory]
+    [InlineData("inventory")]
+    [InlineData("pairing")]
+    [InlineData("config")]
+    public void LimitAndOffsetWindowTheRowsAndAreCountedApart(string family)
+    {
+        var text = Text(family, 10, new RowWindow(Offset: 2, Limit: 3));
+
+        Assert.Contains("[accounting] total=10 rendered=3 skipped=2 capped=5 truncated=0 offset=2 remaining=5", text);
+        // The next page starts at the first row this response did not show, and keeps the same window size.
+        Assert.Contains("re-call with limit=3 offset=5 for the next page.", text);
+    }
+
+    /// <summary>The census above the rows states the WHOLE layer even when the window shows three of it — the
+    /// AssetStatus contract. A windowed response that renamed the total would read as a smaller load order.</summary>
+    [Fact]
+    public void TheCensusStatesTheWholeLayerWhileTheRowsAreTheWindow()
+    {
+        var text = Text("inventory", 10, new RowWindow(Offset: 0, Limit: 3));
+
+        Assert.Contains("10 DLL(s)", text);
+        Assert.Contains("plugins: 10 with static metadata", text);
+        Assert.Contains("plugins with metadata (3)", text);   // the section lists the window
+    }
+
+    /// <summary>An offset past the end is answered with the fact, not with advice to re-call at the offset that
+    /// already overshot.</summary>
+    [Theory]
+    [InlineData("inventory")]
+    [InlineData("pairing")]
+    [InlineData("config")]
+    public void AnOffsetPastTheEndSaysSoInsteadOfAdvisingTheSameOffsetAgain(string family)
+    {
+        var text = Text(family, 3, new RowWindow(Offset: 9, Limit: 0));
+
+        Assert.Contains("offset=9 is past the end of the selection (3 ", text);
+        Assert.DoesNotContain("re-call with limit=", text);
+    }
+
+    /// <summary>Windows tile: paging the whole list one page at a time visits every row exactly once.</summary>
+    [Fact]
+    public void ConsecutiveWindowsTileTheWholeRowList()
+    {
+        var first = Text("pairing", 6, new RowWindow(0, 4));
+        var second = Text("pairing", 6, new RowWindow(4, 4));
+
+        Assert.Contains("Klass1", first);
+        Assert.Contains("Klass4", first);
+        Assert.DoesNotContain("Klass5", first);
+        Assert.Contains("Klass5", second);
+        Assert.Contains("Klass6", second);
+        Assert.Contains("[accounting] total=6 rendered=2 skipped=4 capped=0", second);
+    }
+
+    /// <summary>Both knobs are one refusal, because a caller who got one wrong usually typed the other in the same
+    /// call. It is one plain sentence naming what to pass instead.</summary>
+    [Theory]
+    [InlineData(-1, 0)]
+    [InlineData(0, -5)]
+    public void ANegativeLimitOrOffsetIsOneRefusalNamingBothKnobs(int limit, int offset)
+    {
+        var error = new RowWindow(offset, limit).Error;
+
+        Assert.NotNull(error);
+        Assert.StartsWith("error: ", error);
+        Assert.Contains("limit=0 for no limit", error);
+        Assert.Contains("offset=0", error);
+    }
+
+    // ---- the json twin ---------------------------------------------------------------------------
+
+    /// <summary>Every family's json answer is a valid document that names the family it ran and the two it did not
+    /// — the in-band twin of the text footer, which a json response cannot carry as prose.</summary>
+    [Theory]
+    [InlineData("inventory", "pairing", "config")]
+    [InlineData("pairing", "inventory", "config")]
+    [InlineData("config", "inventory", "pairing")]
+    public void TheJsonTwinNamesTheFamilyThatRanAndTheTwoThatDidNot(string family, string a, string b)
+    {
+        using var doc = Json(family, 3);
+        var root = doc.RootElement;
+
+        Assert.Equal(family, root.GetProperty("family").GetString());
+        Assert.Equal(new[] { a, b }, root.GetProperty("not_run").EnumerateArray().Select(e => e.GetString()).ToArray());
+        Assert.Equal("Default", root.GetProperty("profile").GetString());
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("filter").ValueKind);
+    }
+
+    /// <summary>The accounting rides IN the json document, in named fields — so a json consumer reads the numbers
+    /// off the shape rather than parsing the text line, and json is never the degraded lane.</summary>
+    [Theory]
+    [InlineData("inventory")]
+    [InlineData("pairing")]
+    [InlineData("config")]
+    public void TheJsonTwinCarriesTheSameAccountingInNamedFields(string family)
+    {
+        using var doc = Json(family, 10, new RowWindow(Offset: 2, Limit: 3));
+        var a = doc.RootElement.GetProperty("accounting");
+
+        Assert.Equal(10, a.GetProperty("total").GetInt32());
+        Assert.Equal(3, a.GetProperty("rendered").GetInt32());
+        Assert.Equal(2, a.GetProperty("skipped").GetInt32());
+        Assert.Equal(5, a.GetProperty("capped").GetInt32());
+        Assert.Equal(0, a.GetProperty("truncated").GetInt32());
+        Assert.Equal(2, a.GetProperty("offset").GetInt32());
+        Assert.Equal(5, a.GetProperty("remaining").GetInt32());
+        Assert.Equal(0, a.GetProperty("notes").GetInt32());
+    }
+
+    /// <summary>The twin carries the SAME rows the text render lists, so the two lanes can differ only in
+    /// formatting.</summary>
+    [Fact]
+    public void TheJsonTwinCarriesTheWindowedRows()
+    {
+        using var doc = Json("pairing", 6, new RowWindow(4, 4));
+        var names = doc.RootElement.GetProperty("classes").EnumerateArray()
+                       .Select(c => c.GetProperty("class_name").GetString()).ToArray();
+
+        Assert.Equal(new[] { "Klass5", "Klass6" }, names);
+        Assert.Equal(6, doc.RootElement.GetProperty("totals").GetProperty("classes").GetInt32());
+    }
+
+    /// <summary>Over max_chars the twin drops trailing ROWS and counts them — never a cut of the serialized string
+    /// at a byte budget, which would hand the caller malformed json.</summary>
+    [Theory]
+    [InlineData("inventory")]
+    [InlineData("pairing")]
+    [InlineData("config")]
+    public void OverMaxCharsTheJsonTwinDropsRowsAndStaysValid(string family)
+    {
+        // Parsing at all is half the assertion: a byte-budget cut would throw here.
+        using var doc = Json(family, 40, cap: 1_500);
+        var a = doc.RootElement.GetProperty("accounting");
+
+        Assert.Equal(40, a.GetProperty("total").GetInt32());
+        Assert.True(a.GetProperty("rendered").GetInt32() < 40, "the cap should have dropped rows");
+        Assert.Equal(40 - a.GetProperty("rendered").GetInt32(), a.GetProperty("truncated").GetInt32());
+    }
+}

--- a/src/housecarl-mcp-tests/SkseTransportTests.cs
+++ b/src/housecarl-mcp-tests/SkseTransportTests.cs
@@ -320,4 +320,83 @@ public sealed class SkseTransportTests
                         .Select(c => c.GetProperty("file_name").GetString()).ToArray());
     }
 
+    // ---- the json lane's own reserve --------------------------------------------------------------
+
+    /// <summary>The json tail — the caveats object and the accounting object — is paid for INSIDE max_chars, the way
+    /// every text render's reserve pays for its accounting line. What can still overrun is one row, because the cap is
+    /// tested before each row and not after; the tail here is ~12 KB of caveats inside a 20 KB cap, so an unreserved
+    /// one is unmissable.</summary>
+    [Theory]
+    [InlineData("inventory")]
+    [InlineData("pairing")]
+    [InlineData("config")]
+    public void TheJsonTailIsPaidForInsideMaxCharsRatherThanAppendedPastIt(string family)
+    {
+        const int cap = 20_000;
+        var warnings = Warnings(60);
+        string json = family switch
+        {
+            "inventory" => SkseInventoryWire.RenderJson(Inventory(40, warnings: warnings), null, cap),
+            "pairing" => NativePairingWire.RenderJson(Pairing(40, warnings: warnings), null, cap),
+            _ => SkseConfigAuditWire.RenderJson(ConfigAudit(40, warnings: warnings), null, cap),
+        };
+
+        using var doc = JsonDocument.Parse(json);   // still a document, never a byte-budget cut
+        int tail = warnings.Sum(x => x.Length);
+        Assert.True(json.Length < cap + OneRowSlack,
+                    $"{family}: {json.Length} chars against max_chars={cap} — the ~{tail}-char tail was not reserved.");
+    }
+
+    /// <summary>The one row the cap can overrun by. Every family's row is comfortably under this, and every family's
+    /// caveat tail in the test above is comfortably over it, so the bound tells the two apart.</summary>
+    const int OneRowSlack = 2_000;
+
+    /// <summary>One config can declare tens of thousands of form tokens — a large SkyPatcher INI is exactly that — so
+    /// max_chars bounds the reference array inside a file too, not only the file rows. The text render already bounds
+    /// references per line; an unbounded twin writes the whole array in one pass past the cap.</summary>
+    [Fact]
+    public void MaxCharsBoundsTheReferenceArrayInsideOneConfigFileToo()
+    {
+        const int cap = 3_000;
+        string json = SkseConfigAuditWire.RenderJson(ConfigAudit(1, refs: 4_000), null, cap);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.True(json.Length < cap + OneRowSlack, $"{json.Length} chars against max_chars={cap}");
+        var file = doc.RootElement.GetProperty("files").EnumerateArray().Single();
+        // The cut is stated on the file that carries it: the accounting counts files, not references.
+        Assert.Equal(4_000 - file.GetProperty("references").GetArrayLength(),
+                     file.GetProperty("references_truncated").GetInt32());
+    }
+
+    /// <summary>The two json arrays that are NOT row-list rows — the inventory's config folders and the pairing's
+    /// unreadable .pex list — say what the cap cut, the way their text twins do. The accounting cannot: it counts
+    /// rows, and these are not rows.</summary>
+    [Fact]
+    public void TheNonRowJsonArraysMarkWhatMaxCharsCutFromThem()
+    {
+        using var inv = JsonDocument.Parse(SkseInventoryWire.RenderJson(Inventory(1, configs: 400, folders: 400), null, 2_500));
+        var folders = inv.RootElement.GetProperty("config_folders").GetArrayLength();
+        Assert.True(folders < 400, "the cap should have cut folders");
+        Assert.Equal(400 - folders, inv.RootElement.GetProperty("config_folders_truncated").GetInt32());
+
+        using var pair = JsonDocument.Parse(NativePairingWire.RenderJson(Pairing(1, unreadable: 400), null, 2_500));
+        var shown = pair.RootElement.GetProperty("unreadable_pex").GetArrayLength();
+        Assert.True(shown < 400, "the cap should have cut unreadable .pex entries");
+        Assert.Equal(400 - shown, pair.RootElement.GetProperty("unreadable_pex_truncated").GetInt32());
+    }
+
+    /// <summary>Nothing cut, no marker: the two arrays carry the notice only when there is a cut to name.</summary>
+    [Fact]
+    public void TheNonRowJsonArraysCarryNoCutMarkerWhenNothingWasCut()
+    {
+        using var inv = JsonDocument.Parse(SkseInventoryWire.RenderJson(Inventory(1, configs: 4, folders: 4), null, 200_000));
+        Assert.False(inv.RootElement.TryGetProperty("config_folders_truncated", out _));
+
+        using var pair = JsonDocument.Parse(NativePairingWire.RenderJson(Pairing(1, unreadable: 4), null, 200_000));
+        Assert.False(pair.RootElement.TryGetProperty("unreadable_pex_truncated", out _));
+
+        using var cfg = JsonDocument.Parse(SkseConfigAuditWire.RenderJson(ConfigAudit(1, refs: 4), null, 200_000));
+        Assert.False(cfg.RootElement.GetProperty("files").EnumerateArray().Single()
+                        .TryGetProperty("references_truncated", out _));
+    }
 }

--- a/src/housecarl-mcp-tests/SkseTransportWireTests.cs
+++ b/src/housecarl-mcp-tests/SkseTransportWireTests.cs
@@ -1,0 +1,114 @@
+using System.Text.Json;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// One successful <c>housecarl_skse</c> answer driven all the way over the wire: an MO2 instance of SKSE configs, the
+/// tool called with <c>format='json'</c> and a <c>limit=</c>/<c>offset=</c> window, and the document that comes back.
+/// The rest of the transport lane is driven straight into the renders, which proves the renders and nothing about the
+/// path from the published arguments to them — a limit that never reaches the window would pass every one of those
+/// tests. This gets its OWN server, because the shared <see cref="ServerFixture"/> is deliberately unconfigured.
+/// </summary>
+[Trait("tier", "stdio")]
+public sealed class SkseTransportWireTests : IDisposable
+{
+    /// <summary>How many SKSE config files the world holds — the fixture-known total every accounting is read
+    /// against.</summary>
+    const int Configs = 6;
+
+    readonly string _root;
+    readonly string _instance;
+
+    public SkseTransportWireTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "hc-skse-wire-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(_root, "game", "Data"));
+
+        _instance = Path.Combine(_root, "inst");
+        var group = Path.Combine(_instance, "mods", "SkseWireMod", "SKSE", "Plugins", "HcWire");
+        Directory.CreateDirectory(group);
+        // Each config declares one form token against a plugin the order does not have — a stable, fixture-known
+        // verdict that needs no plugin on disk.
+        for (int i = 1; i <= Configs; i++)
+            File.WriteAllText(Path.Combine(group, $"f{i}.ini"), $"[General]\r\ntarget=0x00080{i}|Ghost.esp\r\n");
+
+        // One active plugin, because a profile that resolves none is refused before any family runs. Nothing reads its
+        // records — it is here so the order exists.
+        var key = new ModKey("HcWire", ModType.Plugin);
+        new SkyrimMod(key, SkyrimRelease.SkyrimSE).BeginWrite
+            .ToPath(Path.Combine(_instance, "mods", "SkseWireMod", key.FileName.String))
+            .WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+        File.WriteAllText(Path.Combine(_instance, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(_root, "game").Replace(@"\", @"\\") + ")\r\n");
+        var prof = Path.Combine(_instance, "profiles", "Default");
+        Directory.CreateDirectory(prof);
+        File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + key.FileName.String + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*" + key.FileName.String + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n+SkseWireMod\r\n");
+    }
+
+    ServerFixture Configured()
+    {
+        var server = new ServerFixture();
+        var set = server.Call(ToolNames.SetMo2Instance,
+            $$"""{"path": {{JsonSerializer.Serialize(_instance)}}}""");
+        Assert.Contains($"configured houseCARL -> MO2 instance '{_instance}'", set.Text, StringComparison.Ordinal);
+        return server;
+    }
+
+    /// <summary>format='json' with a window: the document comes back parseable, carries the windowed rows and the
+    /// in-band accounting, and the numbers are the ones the published limit= and offset= asked for. This is the seam
+    /// the render-level tests cannot see — a limit that never reached the window would pass all of them.</summary>
+    [Fact]
+    public void APagedJsonAnswerComesBackOverTheWireWithItsAccounting()
+    {
+        using var server = Configured();
+
+        var r = server.Call(ToolNames.Skse, """{"findings":"config","format":"json","limit":2,"offset":1}""");
+
+        Assert.False(r.IsError, r.Describe());
+        Assert.DoesNotContain(ServerFixture.ConfigPrompt, r.Text, StringComparison.Ordinal);
+
+        using var doc = JsonDocument.Parse(r.Text);
+        Assert.Equal("config", doc.RootElement.GetProperty("family").GetString());
+
+        var files = doc.RootElement.GetProperty("files").EnumerateArray()
+                       .Select(f => f.GetProperty("file_name").GetString()).ToArray();
+        Assert.Equal(new[] { "f2.ini", "f3.ini" }, files);
+
+        var a = doc.RootElement.GetProperty("accounting");
+        Assert.Equal(Configs, a.GetProperty("total").GetInt32());
+        Assert.Equal(2, a.GetProperty("rendered").GetInt32());
+        Assert.Equal(1, a.GetProperty("skipped").GetInt32());
+        Assert.Equal(Configs - 3, a.GetProperty("capped").GetInt32());
+        Assert.Equal(1, a.GetProperty("offset").GetInt32());
+    }
+
+    /// <summary>The same window over the TEXT lane, so the two formats are known to be reading the same published
+    /// arguments — and the text answer still ends on its accounting line and its family footer.</summary>
+    [Fact]
+    public void ThePagedTextAnswerCarriesTheSameWindowAndEndsOnTheFooter()
+    {
+        using var server = Configured();
+
+        var r = server.Call(ToolNames.Skse, """{"findings":"config","limit":2,"offset":1}""");
+
+        Assert.False(r.IsError, r.Describe());
+        Assert.Contains($"[accounting] total={Configs} rendered=2 skipped=1 capped={Configs - 3} truncated=0 offset=1",
+                        r.Text, StringComparison.Ordinal);
+        Assert.Contains("re-call with limit=2 offset=3 for the next page.", r.Text, StringComparison.Ordinal);
+        Assert.EndsWith(SkseTools.FamilyFooter(SkseTools.SkseFamily.Config), r.Text, StringComparison.Ordinal);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, true); } catch { /* temp cleanup best-effort */ }
+    }
+}

--- a/src/housecarl-mcp/AssetTools.cs
+++ b/src/housecarl-mcp/AssetTools.cs
@@ -55,9 +55,9 @@ public static class AssetTools
             return "error: asset_paths and under are both empty. Pass Data-relative asset path(s) in asset_paths " +
                    "(e.g. 'textures/armor/iron/cuirass_1.dds'), or a Data-relative directory or glob in under " +
                    "(e.g. 'meshes/actors/character/facegendata/facegeom/Skyrim.esm').";
-        if (limit < 0 || offset < 0)
-            return $"error: limit={limit} offset={offset} — neither can be negative. Pass limit=0 for no limit and " +
-                   "offset=0 to start at the beginning of the selection.";
+        // The window's own refusal, from the window: this tool and housecarl_skse answer the same input class, so the
+        // sentence is spelled once rather than reworded in two places.
+        if (new RowWindow(offset, limit).Error is { } bad) return bad;
         var data = svc.AssetStatus(asset_paths ?? Array.Empty<string>(), under, limit, offset);
         return AssetWire.Render(data, max_chars > 0 ? max_chars : 80_000);
     });

--- a/src/housecarl-mcp/AssetTools.cs
+++ b/src/housecarl-mcp/AssetTools.cs
@@ -92,8 +92,11 @@ static class AssetWire
             // appended past the cap. max_chars then means the same on this tool as on every other.
             reserve: AccountingReserve(d));
 
-        return body + Compose(Tally(d, rendered), everySentence: false);
+        return body + TransportAccounting.Compose(Tally(d, rendered), RowNoun, everySentence: false);
     }
+
+    /// <summary>What this family's accounting counts.</summary>
+    const string RowNoun = "path(s)";
 
     /// <summary>What each under= selector had to say for itself — a selector that matched nothing, or was rejected.
     /// Above the per-path list, with the other alarms, so a truncated sweep cannot cut it away. Capped like its two
@@ -106,76 +109,17 @@ static class AssetWire
         BatchRender.AppendLines(sb, notes, "selector(s)", cap);
     }
 
-    /// <summary>The numbers one accounting line states. A record so the real line and the widest-case line the reserve
-    /// measures go through ONE composer — a second formatter would be a second spelling, and the reserve would stop
-    /// bounding what is written.</summary>
-    readonly record struct Counts(int Total, int Rendered, int Skipped, int Capped, int Truncated, int Offset,
-                                  int Remaining, int Notes, int NextLimit);
+    /// <summary>What this response actually did, in the shared TRANSPORT vocabulary
+    /// (<see cref="TransportAccounting"/>): the selection total, the window this response rendered, and the four
+    /// distinct omissions.</summary>
+    static TransportCounts Tally(AssetStatusData d, int rendered) =>
+        TransportAccounting.Tally(d.Selected, d.Results.Count, rendered, new RowWindow(d.Offset, d.Limit),
+                                  d.SelectorNotes?.Count ?? 0);
 
-    /// <summary>The window the next-page advice names when the caller passed none. Without a limit= in the advice a
-    /// caller following it calls back with limit=0, which resolves the WHOLE remainder on every page — the paging is
-    /// only cheap if the advice keeps it paged.</summary>
-    internal const int DefaultPageLimit = 200;
-
-    /// <summary>What this response actually did. The four omissions have four distinct causes and each is counted
-    /// once, so <c>skipped + rendered + truncated + capped == total</c>: <c>skipped</c> is what offset= stepped over
-    /// BEFORE the window, <c>capped</c> what limit= left AFTER it, <c>truncated</c> what max_chars cut out of the
-    /// resolved window. <c>remaining</c> and the next page are measured off what was RENDERED, not off the resolved
-    /// window: a caller walking by this line's own advice must land on the first path it has not seen, and paths the
-    /// cap cut were resolved but never shown.</summary>
-    static Counts Tally(AssetStatusData d, int rendered) => new(
-        Total: d.Selected,
-        Rendered: rendered,
-        Skipped: Math.Min(d.Offset, d.Selected),
-        Capped: Math.Max(d.Selected - d.Offset - d.Results.Count, 0),
-        Truncated: Math.Max(d.Results.Count - rendered, 0),
-        Offset: d.Offset,
-        Remaining: Math.Max(d.Selected - (d.Offset + rendered), 0),
-        Notes: d.SelectorNotes?.Count ?? 0,
-        NextLimit: d.Limit > 0 ? d.Limit : DefaultPageLimit);
-
-    /// <summary>The chars held back from max_chars so the accounting block is always affordable — measured by
-    /// composing the WIDEST line this response could write, so no rendering of it can outgrow its own room.</summary>
-    internal static int AccountingReserve(AssetStatusData d) => Compose(Widest(d), everySentence: true).Length;
-
-    /// <summary>The widest line this response could produce: every count at its largest (so every digit slot is at its
-    /// real width) and, with <c>everySentence</c>, every optional sentence present. An upper bound, which is what a
-    /// reserve has to be.</summary>
-    static Counts Widest(AssetStatusData d)
-    {
-        int most = Math.Max(d.Selected, d.Results.Count);
-        return new Counts(most, d.Results.Count, most, most, d.Results.Count, d.Offset, most,
-                          d.SelectorNotes?.Count ?? 0, Math.Max(d.Limit, DefaultPageLimit));
-    }
-
-    /// <summary>The one machine-readable accounting line, always last: how many paths the selection named, how many
-    /// rendered, how many the paging window stepped over or left behind, and how many max_chars cut. A bulk consumer
-    /// keying results by path checks these numbers instead of counting prose it might miss (#246). Room for it is
-    /// reserved out of max_chars by <see cref="Render"/>, so it fits inside the cap rather than past it.</summary>
-    static string Compose(Counts c, bool everySentence)
-    {
-        var sb = new StringBuilder("\n\n[accounting] total=").Append(c.Total)
-            .Append(" rendered=").Append(c.Rendered)
-            .Append(" skipped=").Append(c.Skipped)
-            .Append(" capped=").Append(c.Capped)
-            .Append(" truncated=").Append(c.Truncated)
-            .Append(" offset=").Append(c.Offset)
-            .Append(" remaining=").Append(c.Remaining)
-            .Append(" notes=").Append(c.Notes);
-        // Only what is still AHEAD of what was rendered earns a next page, and the next offset starts at the first
-        // path this response did not show — so a caller following the advice sees every path exactly once. The advice
-        // carries limit= as well: without it the next call resolves the whole remainder instead of one page.
-        if (everySentence || c.Remaining > 0)
-            sb.Append("\nthe selection is longer than this window: re-call with limit=").Append(c.NextLimit)
-              .Append(" offset=").Append(c.Offset + c.Rendered).Append(" for the next page.");
-        // An offset past the end would otherwise be told to re-call at the offset it already used.
-        if (everySentence || (c.Remaining == 0 && c.Total > 0 && c.Offset >= c.Total))
-            sb.Append("\noffset=").Append(c.Offset).Append(" is past the end of the selection (")
-              .Append(c.Total).Append(" path(s)) — the last page starts before it.");
-        if (everySentence || c.Truncated > 0)
-            sb.Append("\nmax_chars cut ").Append(c.Truncated).Append(" resolved path(s) from the render: raise max_chars, or page with limit=/offset=.");
-        return sb.ToString();
-    }
+    /// <summary>The chars held back from max_chars so the accounting block is always affordable.</summary>
+    internal static int AccountingReserve(AssetStatusData d) =>
+        TransportAccounting.Reserve(d.Selected, d.Results.Count, new RowWindow(d.Offset, d.Limit),
+                                    d.SelectorNotes?.Count ?? 0, RowNoun);
 
     static void AppendPath(StringBuilder sb, AssetPathResult r, bool readIncomplete, bool discoveryIncomplete)
     {

--- a/src/housecarl-mcp/SkseJsonDoc.cs
+++ b/src/housecarl-mcp/SkseJsonDoc.cs
@@ -1,0 +1,78 @@
+using System.Text;
+using System.Text.Json;
+
+namespace HousecarlMcp;
+
+/// <summary>The json skeleton the three <c>housecarl_skse</c> family documents share: the family it ran, the two it
+/// did not (the in-band twin of the text footer — a json document cannot carry the footer's prose), the filter and
+/// profile it answered under, and the small writers the three bodies reuse. Each family's own serializer lives
+/// beside its text render rather than here, because the twin must classify with the SAME judge the text render uses
+/// — a copy elsewhere would be free to drift, which is the one thing a twin may not do.</summary>
+static class SkseJsonDoc
+{
+    /// <summary>Write one family document. <paramref name="body"/> gets the writer and the stream behind it, so a
+    /// row loop can flush and measure against max_chars the way every other json render does.</summary>
+    internal static string Write(SkseTools.SkseFamily family, string? filter, string profile,
+                                 Action<Utf8JsonWriter, MemoryStream> body)
+    {
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, JsonWire.WriterOptions))
+        {
+            w.WriteStartObject();
+            w.WriteString("family", family.ToString().ToLowerInvariant());
+            Strings(w, "not_run", SkseTools.NotRun(family));
+            Nullable(w, "filter", string.IsNullOrWhiteSpace(filter) ? null : filter.Trim());
+            w.WriteString("profile", profile);
+            body(w, ms);
+            w.WriteEndObject();
+        }
+        return Encoding.UTF8.GetString(ms.ToArray());
+    }
+
+    /// <summary>A string member whose null carries meaning — absent value, not empty value.</summary>
+    internal static void Nullable(Utf8JsonWriter w, string name, string? v)
+    {
+        if (v is null) w.WriteNull(name); else w.WriteString(name, v);
+    }
+
+    internal static void Strings(Utf8JsonWriter w, string name, IEnumerable<string> items)
+    {
+        w.WriteStartArray(name);
+        foreach (var i in items) w.WriteStringValue(i);
+        w.WriteEndArray();
+    }
+
+    /// <summary>The full winner-first provider chain, each tagged loose or BSA.</summary>
+    internal static void Providers(Utf8JsonWriter w, IReadOnlyList<SkseProvider> providers)
+    {
+        w.WriteStartArray("providers");
+        foreach (var p in providers)
+        {
+            w.WriteStartObject();
+            w.WriteString("name", p.Name);
+            w.WriteString("kind", p.Kind);
+            w.WriteEndObject();
+        }
+        w.WriteEndArray();
+    }
+
+    /// <summary>The build-level caveats every family carries — the same three the text render's caveat block writes,
+    /// and the three the accounting's <c>notes</c> counts.</summary>
+    internal static void Caveats(Utf8JsonWriter w, bool readIncomplete, IReadOnlyList<string> warnings,
+                                 IReadOnlyList<string> bsaFailures)
+    {
+        w.WriteStartObject("caveats");
+        w.WriteBoolean("read_incomplete", readIncomplete);
+        Strings(w, "warnings", warnings);
+        Strings(w, "archive_read_failures", bsaFailures);
+        w.WriteEndObject();
+    }
+
+    /// <summary>Is the document already at its char ceiling? The writer BUFFERS, so the stream length lags what has
+    /// been written — a row loop that budgets by stream length must flush first, as this does.</summary>
+    internal static bool Over(Utf8JsonWriter w, MemoryStream ms, int cap)
+    {
+        w.Flush();
+        return ms.Length >= cap;
+    }
+}

--- a/src/housecarl-mcp/SkseJsonDoc.cs
+++ b/src/housecarl-mcp/SkseJsonDoc.cs
@@ -75,4 +75,24 @@ static class SkseJsonDoc
         w.Flush();
         return ms.Length >= cap;
     }
+
+    /// <summary>The chars held back from max_chars for the tail every family document closes on — the caveats object,
+    /// the accounting object, and whatever conditional members that family may still write after its row arrays. The
+    /// json twin of <see cref="TransportAccounting.Reserve"/>: without it the row loops fill the document to the cap
+    /// and the tail is written past it. Measured by composing the widest tail, so no rendering of it can outgrow its
+    /// own room.</summary>
+    internal static int TailReserve(bool readIncomplete, IReadOnlyList<string> warnings, IReadOnlyList<string> bsaFailures,
+                                    TransportCounts widest, Action<Utf8JsonWriter>? conditional = null)
+    {
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, JsonWire.WriterOptions))
+        {
+            w.WriteStartObject();
+            conditional?.Invoke(w);
+            Caveats(w, readIncomplete, warnings, bsaFailures);
+            TransportAccounting.WriteJson(w, widest);
+            w.WriteEndObject();
+        }
+        return (int)ms.Length;
+    }
 }

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text;
+using System.Text.Json;
 using HousecarlCore;
 using ModelContextProtocol.Server;
 
@@ -90,18 +91,39 @@ public static class SkseTools
     /// and that the answer ends on the footer. <see cref="ServiceRenders"/> is the live implementation.</summary>
     internal interface IFamilyRenders
     {
-        string Inventory(string? filter, bool peek, int cap);
-        string Pairing(string? filter, int cap);
-        string Config(string? filter, int cap);
+        string Inventory(FamilyCall c);
+        string Pairing(FamilyCall c);
+        string Config(FamilyCall c);
     }
+
+    /// <summary>One call's shared render context: what to narrow to, the char budget, the TRANSPORT paging window,
+    /// and which format was asked for. A record so a new TRANSPORT axis lands here rather than as a fourth positional
+    /// argument on all three renders.</summary>
+    internal readonly record struct FamilyCall(string? Filter, bool Peek, int Cap, RowWindow Window, bool Json);
 
     /// <summary>The live renders: each family's data read from the service, handed to its own wire class.</summary>
     sealed class ServiceRenders(LoadOrderService svc) : IFamilyRenders
     {
-        public string Inventory(string? filter, bool peek, int cap)
-            => SkseInventoryWire.Render(svc.SkseInventory(peek ? filter!.Trim() : null), filter, cap);
-        public string Pairing(string? filter, int cap) => NativePairingWire.Render(svc.NativePairingAudit(), filter, cap);
-        public string Config(string? filter, int cap) => SkseConfigAuditWire.Render(svc.SkseConfigAudit(), filter, cap);
+        public string Inventory(FamilyCall c)
+        {
+            var d = svc.SkseInventory(c.Peek ? c.Filter!.Trim() : null);
+            return c.Json ? SkseInventoryWire.RenderJson(d, c.Filter, c.Cap, c.Window)
+                          : SkseInventoryWire.Render(d, c.Filter, c.Cap, c.Window);
+        }
+
+        public string Pairing(FamilyCall c)
+        {
+            var d = svc.NativePairingAudit();
+            return c.Json ? NativePairingWire.RenderJson(d, c.Filter, c.Cap, c.Window)
+                          : NativePairingWire.Render(d, c.Filter, c.Cap, c.Window);
+        }
+
+        public string Config(FamilyCall c)
+        {
+            var d = svc.SkseConfigAudit();
+            return c.Json ? SkseConfigAuditWire.RenderJson(d, c.Filter, c.Cap, c.Window)
+                          : SkseConfigAuditWire.Render(d, c.Filter, c.Cap, c.Window);
+        }
     }
 
     /// <summary>Runs the selected family and appends the footer. The footer's length is subtracted from max_chars so it
@@ -109,18 +131,28 @@ public static class SkseTools
     /// append their scope note, caveats and filter hint unconditionally, so a response can still overrun a tight cap by
     /// one item plus that tail. Under a cap too small to hold both, the footer wins: it is the line that says which
     /// family answered.</summary>
-    internal static string Dispatch(IFamilyRenders renders, SkseFamily family, string? filter, bool peek, int max_chars)
+    internal static string Dispatch(IFamilyRenders renders, SkseFamily family, string? filter, bool peek, int max_chars,
+                                    bool json = false, RowWindow window = default)
     {
-        var footer = FamilyFooter(family);
+        // The json document states the family and the two that did not run in-band, so appending the text footer to
+        // it would only break the document.
+        var footer = json ? "" : FamilyFooter(family);
         int cap = Math.Max(1, (max_chars > 0 ? max_chars : 80_000) - footer.Length);
+        var call = new FamilyCall(filter, peek, cap, window, json);
         var body = family switch
         {
-            SkseFamily.Inventory => renders.Inventory(filter, peek, cap),
-            SkseFamily.Pairing => renders.Pairing(filter, cap),
-            _ => renders.Config(filter, cap),
+            SkseFamily.Inventory => renders.Inventory(call),
+            SkseFamily.Pairing => renders.Pairing(call),
+            _ => renders.Config(call),
         };
         return body + footer;
     }
+
+    /// <summary>The two families this call did not run, in the spelling that would run them — the json twin of
+    /// <see cref="FamilyFooter"/>, so a json consumer learns the default narrowed exactly as a text one does.</summary>
+    internal static string[] NotRun(SkseFamily ran) =>
+        new[] { SkseFamily.Inventory, SkseFamily.Pairing, SkseFamily.Config }
+            .Where(f => f != ran).Select(f => f.ToString().ToLowerInvariant()).ToArray();
 
     [McpServerTool(Name = ToolNames.Skse, ReadOnly = true, Title = "The SKSE layer: DLL/config inventory, native pairing, config references"),
      Description(
@@ -143,7 +175,12 @@ public static class SkseTools
          "filter= narrows whichever family ran (its match domain is that family's own — see filter= below); peek= " +
          "belongs to the inventory family alone and is refused, not ignored, on the other two. NOT COVERED by any " +
          "family: distributor INIs in Data\\ root (SPID *_DISTR, KID *_KID) — they live outside SKSE\\Plugins and are " +
-         "owned by the spid-authoring / kid-authoring skills.")]
+         "owned by the spid-authoring / kid-authoring skills. " +
+         // ---- transport, the same axes every tool carries -------------------------------------------
+         "TRANSPORT: format= 'text' | 'json' (the same rows and accounting, machine-readable); limit=/offset= page " +
+         "the family's row list; max_chars= caps the render. Every response ends on the in-band accounting — " +
+         "total / rendered / skipped / capped / truncated / offset / remaining / notes — so what a window or a cap " +
+         "left out is a number, never a silence.")]
     public static string Skse(
         LoadOrderService svc,
         [Description(
@@ -215,18 +252,30 @@ public static class SkseTools
             "unfamiliar DLL touch'. Per-DLL by design: it reads whole images, so a whole-layer peek is refused rather " +
             "than dumped. Passed with findings='pairing' or 'config' it is refused, never silently ignored.")]
             bool peek = false,
+        [Description("TRANSPORT: 'text' (default) | 'json' (the machine-readable twin of whichever family ran — the same rows and the same accounting, in named fields).")]
+            string? format = null,
+        [Description("TRANSPORT: max rows to render from the family's row list — inventory: the DLLs (filter=: the DLL and config matches); pairing: the native-declaring classes; config: the config files. 0 = no limit. The census above the rows always states the whole layer, and the accounting line states what this window left out.")]
+            int limit = 0,
+        [Description("TRANSPORT: skip the first N rows of the family's row list, for paging a large layer. 0 = the beginning.")]
+            int offset = 0,
         [Description("Optional. Max characters before lists are cut with an explicit notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool(ToolNames.Skse, () =>
     {
         // The argument checks run BEFORE the config prompt: findings= is wrong in the same way whether or not an
         // instance is configured, and answering the prompt first would send the caller off to configure one only to
         // meet the same refusal.
-        if (!TryParseFamily(findings, out var family, out var famErr)) return famErr!;
-        if (PeekFamilyError(peek, family) is { } peekErr) return peekErr;
-        if (SkseInventoryWire.PeekArgError(peek, filter) is { } err) return err;
+        // format= is read first, because every refusal below has to be answered in the shape the caller asked for.
+        // Its OWN refusal is the one that cannot be: a value that did not parse named no shape.
+        bool json = Wire.WantsJson(format, out var fmtErr);
+        if (fmtErr is not null) return fmtErr;
+        if (!TryParseFamily(findings, out var family, out var famErr)) return Wire.Refuse(json, famErr!);
+        if (PeekFamilyError(peek, family) is { } peekErr) return Wire.Refuse(json, peekErr);
+        if (SkseInventoryWire.PeekArgError(peek, filter) is { } err) return Wire.Refuse(json, err);
+        var window = new RowWindow(offset, limit);
+        if (window.Error is { } winErr) return Wire.Refuse(json, winErr);
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
 
-        return Dispatch(new ServiceRenders(svc), family, filter, peek, max_chars);
+        return Dispatch(new ServiceRenders(svc), family, filter, peek, max_chars, json, window);
     });
 }
 
@@ -245,39 +294,70 @@ static class SkseInventoryWire
               "image). Pass filter='<DLL/plugin/mod name>' to name the DLL to peek, e.g. filter='SkyPatcher' peek=true."
             : null;
 
-    public static string Render(SkseInventoryData d, string? filter, int cap)
+    /// <summary>What this family's accounting counts: the DLL rows the whole-layer view lists. Configs are rendered
+    /// as folder groups there, so they are stated in the census rather than paged as rows; the filter= view, whose
+    /// population IS its matches, counts both and says so.</summary>
+    internal const string RowNoun = "DLL(s)";
+    internal const string MatchNoun = "match(es)";
+
+    /// <summary>The DLL population split by loader scope and manifest kind. One function so the whole-layer census
+    /// and the windowed row sections are computed the same way and cannot drift.</summary>
+    readonly record struct DllSplit(List<SkseFileEntry> Loaded, List<SkseFileEntry> Subfolder, List<SkseFileEntry> Modern,
+                                    List<SkseFileEntry> Legacy, List<SkseFileEntry> NotPlugin, List<SkseFileEntry> Unreadable,
+                                    List<SkseFileEntry> BsaOnly, List<SkseFileEntry> Locked);
+
+    static DllSplit Split(IReadOnlyList<SkseFileEntry> dlls)
     {
-        if (filter is { Length: > 0 }) return RenderFiltered(d, filter.Trim(), cap);
+        // DLLs split by SKSE-loader scope: top-level DLLs are what SKSE loads; subfolder DLLs are seen but not loader-scoped.
+        var loaded = dlls.Where(e => e.Group.Length == 0).ToList();
+        var modern = loaded.Where(e => e.Plugin is { Kind: SksePluginReader.SksePluginKind.Modern }).ToList();
+        return new DllSplit(
+            loaded,
+            dlls.Where(e => e.Group.Length > 0).ToList(),
+            modern,
+            loaded.Where(e => e.Plugin is { Kind: SksePluginReader.SksePluginKind.LegacyQuery }).ToList(),
+            loaded.Where(e => e.Plugin is { Kind: SksePluginReader.SksePluginKind.NotSkse }).ToList(),
+            loaded.Where(e => e.Plugin is { Kind: SksePluginReader.SksePluginKind.Unreadable }).ToList(),
+            loaded.Where(e => e.Plugin is null).ToList(),
+            modern.Where(e => !e.Plugin!.Version!.VersionIndependent).ToList());
+    }
+
+    public static string Render(SkseInventoryData d, string? filter, int cap, RowWindow window = default)
+    {
+        if (filter is { Length: > 0 }) return RenderFiltered(d, filter.Trim(), cap, window);
+
+        // The census states the WHOLE layer; limit=/offset= window only the rows listed below it. Room for the
+        // accounting block is held back out of the cap so it is paid for rather than appended past it.
+        var all = Split(d.Dlls);
+        int notes = NoteCount(d);
+        var rows = window.Apply(d.Dlls);
+        int reserve = TransportAccounting.Reserve(d.Dlls.Count, rows.Count, window, notes, RowNoun);
+        cap = Math.Max(1, cap - reserve);
+        var tally = new RowTally();
 
         var sb = new StringBuilder();
-        // DLLs split by SKSE-loader scope: top-level DLLs are what SKSE loads; subfolder DLLs are seen but not loader-scoped.
-        var loaded = d.Dlls.Where(e => e.Group.Length == 0).ToList();
-        var subfolder = d.Dlls.Where(e => e.Group.Length > 0).ToList();
-        var modern = loaded.Where(e => e.Plugin is { Kind: SksePluginReader.SksePluginKind.Modern }).ToList();
-        var legacy = loaded.Where(e => e.Plugin is { Kind: SksePluginReader.SksePluginKind.LegacyQuery }).ToList();
-        var notPlugin = loaded.Where(e => e.Plugin is { Kind: SksePluginReader.SksePluginKind.NotSkse }).ToList();
-        var unreadable = loaded.Where(e => e.Plugin is { Kind: SksePluginReader.SksePluginKind.Unreadable }).ToList();
-        var bsaOnly = loaded.Where(e => e.Plugin is null).ToList();
+        var w = Split(rows);
+        var loaded = w.Loaded; var subfolder = w.Subfolder; var modern = w.Modern; var legacy = w.Legacy;
+        var notPlugin = w.NotPlugin; var unreadable = w.Unreadable; var bsaOnly = w.BsaOnly; var locked = w.Locked;
 
-        int addrLib = modern.Count(e => e.Plugin!.Version!.UsesAddressLibrary);
-        int sig = modern.Count(e => e.Plugin!.Version!.UsesSignatureScanning);
-        var locked = modern.Where(e => !e.Plugin!.Version!.VersionIndependent).ToList();
+        int addrLib = all.Modern.Count(e => e.Plugin!.Version!.UsesAddressLibrary);
+        int sig = all.Modern.Count(e => e.Plugin!.Version!.UsesSignatureScanning);
         int groupCount = d.Configs.Select(e => e.Group).Distinct(StringComparer.OrdinalIgnoreCase).Count();
 
         sb.Append("SKSE plugin layer — profile '").Append(d.ProfileName).Append("' — ")
-          .Append(loaded.Count).Append(" DLL(s), ").Append(d.Configs.Count).Append(" config(s) across ")
+          .Append(all.Loaded.Count).Append(" DLL(s), ").Append(d.Configs.Count).Append(" config(s) across ")
           .Append(groupCount).Append(" folder(s)");
         if (d.OtherFileCount > 0) sb.Append(", ").Append(d.OtherFileCount).Append(" other file(s)");
         sb.Append(" (full depth of SKSE\\Plugins)\n");
-        sb.Append("plugins: ").Append(modern.Count).Append(" with static metadata");
-        if (legacy.Count > 0) sb.Append(" · ").Append(legacy.Count).Append(" legacy query-only");
-        if (notPlugin.Count > 0) sb.Append(" · ").Append(notPlugin.Count).Append(" non-plugin (bundled deps)");
-        if (bsaOnly.Count > 0) sb.Append(" · ").Append(bsaOnly.Count).Append(" BSA-only/unresolved");
-        if (unreadable.Count > 0) sb.Append(" · ").Append(unreadable.Count).Append(" unreadable");
-        if (subfolder.Count > 0) sb.Append(" · ").Append(subfolder.Count).Append(" in subfolders (not loader-scoped)");
+        sb.Append("plugins: ").Append(all.Modern.Count).Append(" with static metadata");
+        if (all.Legacy.Count > 0) sb.Append(" · ").Append(all.Legacy.Count).Append(" legacy query-only");
+        if (all.NotPlugin.Count > 0) sb.Append(" · ").Append(all.NotPlugin.Count).Append(" non-plugin (bundled deps)");
+        if (all.BsaOnly.Count > 0) sb.Append(" · ").Append(all.BsaOnly.Count).Append(" BSA-only/unresolved");
+        if (all.Unreadable.Count > 0) sb.Append(" · ").Append(all.Unreadable.Count).Append(" unreadable");
+        if (all.Subfolder.Count > 0) sb.Append(" · ").Append(all.Subfolder.Count).Append(" in subfolders (not loader-scoped)");
         sb.Append('\n');
         sb.Append("compat: ").Append(addrLib).Append(" Address Library · ").Append(sig).Append(" signature-scanning · ")
-          .Append(locked.Count).Append(" version-LOCKED\n");
+          .Append(all.Locked.Count).Append(" version-LOCKED\n");
 
         // ── Diagnostic subsets, first and in full. ──
 
@@ -294,7 +374,7 @@ static class SkseInventoryWire
                 var crt = x.Plugin!.DebugCrtImports;
                 return $"  - {x.FileName} → needs {string.Join(", ", crt)}" +
                        $"{DebugCrtLayerVerdict(crt, SksePluginReader.IsSystemDllResolvable)}{Provider(x)}";
-            });
+            }, tally);
         }
 
         if (locked.Count > 0)
@@ -314,7 +394,7 @@ static class SkseInventoryWire
                     ? (SksePluginReader.RuntimeCompatible(v, inst) ? "  = your game, loads" : "  ≠ your game — will NOT load")
                     : "";
                 return $"  - {e.FileName} → {rt}{verdict}   [\"{v.Name}\"{Provider(e)}]";
-            });
+            }, tally);
             if (d.InstalledRuntime is null)
             {
                 var distinctRuntimes = locked.SelectMany(e => e.Plugin!.Version!.CompatibleVersions)
@@ -326,19 +406,19 @@ static class SkseInventoryWire
         }
 
         AppendSubset(sb, "legacy query-only (SE/VR-era — metadata set at runtime, not statically readable)", legacy, cap,
-            e => $"  - {e.FileName}{Provider(e)}");
+            e => $"  - {e.FileName}{Provider(e)}", tally);
         AppendSubset(sb, "non-plugin DLLs (no SKSE export — a bundled dependency, not a plugin)", notPlugin, cap,
-            e => $"  - {e.FileName}{Provider(e)}");
+            e => $"  - {e.FileName}{Provider(e)}", tally);
         AppendSubset(sb, "subfolder DLLs (present but NOT on SKSE's loader path — bundled/parent-loaded, not plugins SKSE loads)", subfolder, cap,
-            e => $"  - {e.Group}\\{e.FileName}{Provider(e)}");
+            e => $"  - {e.Group}\\{e.FileName}{Provider(e)}", tally);
         AppendSubset(sb, "BSA-only / unresolved DLLs (SKSE loads loose DLLs only — these will NOT load)", bsaOnly, cap,
-            e => $"  - {e.FileName}{Provider(e)}  — {e.Note}");
+            e => $"  - {e.FileName}{Provider(e)}  — {e.Note}", tally);
         AppendSubset(sb, "unreadable DLLs (not a valid PE image)", unreadable, cap,
-            e => $"  - {e.FileName}{Provider(e)}  — {e.Plugin?.Note}");
+            e => $"  - {e.FileName}{Provider(e)}  — {e.Plugin?.Note}", tally);
 
         var contested = loaded.Where(e => e.ProviderCount > 1).ToList();
         AppendSubset(sb, "contested DLLs (shipped by >1 mod — winner-first conflict chain; verify the winner is the one you want)", contested, cap,
-            e => $"  - {e.FileName}: {Chain(e)}");
+            e => $"  - {e.FileName}: {Chain(e)}", tally);
 
         // ── Plugin roster: the loaded, metadata-bearing plugins, terse. ──
         sb.Append("\nplugins with metadata (").Append(modern.Count).Append(") — name · version · compat · winning mod:\n");
@@ -346,7 +426,7 @@ static class SkseInventoryWire
         {
             var v = e.Plugin!.Version!;
             return $"  - {e.FileName}  \"{v.Name}\" v{v.PluginVersion}  {CompatTag(v)}{Provider(e)}";
-        });
+        }, tally);
 
         // ── Config folders, grouped by the derived subfolder and sorted by size. ──
         if (d.Configs.Count > 0)
@@ -377,31 +457,46 @@ static class SkseInventoryWire
                   "grouped by folder above. Non-config content (animation/mesh/etc.) is counted in the 'other file(s)' total.)\n");
         AppendCaveats(sb, d);
         sb.Append("\n→ filter='<plugin/mod/DLL name>' for a plugin's full detail, or filter='<folder>' (e.g. SkyPatcher, OStim) to list a config group.");
-        return sb.ToString().TrimEnd('\n');
+        return sb.ToString().TrimEnd('\n')
+             + TransportAccounting.Compose(TransportAccounting.Tally(d.Dlls.Count, rows.Count, tally.Count, window, notes),
+                                           RowNoun, everySentence: false);
     }
 
     /// <summary>filter=: full detail for every matching DLL, then every matching config, matched by folder, filename or
     /// provider — so a folder name expands its group, a plugin name shows the manifest, and a mod name shows
     /// everything it provides.</summary>
-    static string RenderFiltered(SkseInventoryData d, string filter, int cap)
+    static string RenderFiltered(SkseInventoryData d, string filter, int cap, RowWindow window = default)
     {
         bool In(string? s) => s is not null && s.Contains(filter, StringComparison.OrdinalIgnoreCase);
         bool MatchCfg(SkseFileEntry e) => In(e.FileName) || In(e.WinningProvider) || In(e.Group);
 
         // SkseFileEntry.MatchesDll is the one DLL predicate, so the service peeks exactly the entries this view renders.
-        var dllHits = d.Dlls.Where(e => e.MatchesDll(filter)).OrderBy(e => e.FileName, StringComparer.OrdinalIgnoreCase).ToList();
-        var cfgHits = d.Configs.Where(MatchCfg).ToList();
+        var allDllHits = d.Dlls.Where(e => e.MatchesDll(filter)).OrderBy(e => e.FileName, StringComparer.OrdinalIgnoreCase).ToList();
+        var allCfgHits = d.Configs.Where(MatchCfg).ToList();
+
+        // The filter's population is its matches, DLLs then configs, so the window walks the DLL matches first and
+        // continues into the config matches. The header states the whole match count; the rows are the window.
+        int total = allDllHits.Count + allCfgHits.Count;
+        int notes = NoteCount(d);
+        var dllHits = window.Apply(allDllHits);
+        var cfgHits = window.After(allDllHits.Count, dllHits.Count).Apply(allCfgHits);
+        int windowed = dllHits.Count + cfgHits.Count;
+        int reserve = TransportAccounting.Reserve(total, windowed, window, notes, MatchNoun);
+        cap = Math.Max(1, cap - reserve);
+        var tally = new RowTally();
+        string Accounting() => TransportAccounting.Compose(
+            TransportAccounting.Tally(total, windowed, tally.Count, window, notes), MatchNoun, everySentence: false);
 
         var sb = new StringBuilder();
         sb.Append("SKSE plugin layer — filter '").Append(filter).Append("' — ")
-          .Append(dllHits.Count).Append(" DLL + ").Append(cfgHits.Count).Append(" config match(es) [profile '").Append(d.ProfileName).Append("']\n");
+          .Append(allDllHits.Count).Append(" DLL + ").Append(allCfgHits.Count).Append(" config match(es) [profile '").Append(d.ProfileName).Append("']\n");
 
-        if (dllHits.Count == 0 && cfgHits.Count == 0)
+        if (total == 0)
         {
             sb.Append("\nnothing under SKSE\\Plugins matched. ")
               .Append(HousecarlCore.PluginNameSuggest.DidYouMean(filter,
                   d.Dlls.Select(e => e.FileName).Concat(d.Configs.Select(e => e.Group).Where(g => g.Length > 0)).Distinct()));
-            return sb.ToString().TrimEnd('\n');
+            return sb.ToString().TrimEnd('\n') + Accounting();
         }
 
         var shownCfg = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -409,12 +504,13 @@ static class SkseInventoryWire
         {
             if (sb.Length >= cap) { sb.Append("\n  ... [remaining DLL matches omitted at max_chars=").Append(cap).Append("]\n"); break; }
             AppendDetail(sb, e, d, shownCfg);
+            tally.Mark(e.RelPath);
         }
 
         // peek= honoured with nothing to show is still an unanswered question. A bare peek=true fails in PeekArgError
         // and a matched-but-unpeekable DLL says so on its own entry, so this covers the last case: the filter matched
         // no DLL at all, leaving no entry to carry the notice.
-        if (d.PeekRequested && dllHits.Count == 0)
+        if (d.PeekRequested && allDllHits.Count == 0)
             sb.Append("\n[!] peek=true matched no DLL at all — nothing was peeked. Pass filter= the name of a loose DLL to peek it.\n");
 
         // Remaining matching configs (not already shown as a DLL's paired config), grouped by folder.
@@ -433,10 +529,12 @@ static class SkseInventoryWire
                 sb.Append("    - ").Append(e.FileName);
                 if (e.ProviderCount > 1) sb.Append(": ").Append(Chain(e));   // contested config → the full winner→loser chain
                 else sb.Append(Provider(e));
-                sb.Append('\n'); shown++;
+                sb.Append('\n'); shown++; tally.Mark(e.RelPath);
             }
         }
-        return sb.ToString().TrimEnd('\n');
+        // A config already shown as a DLL's paired config is a rendered row too, so it counts.
+        foreach (var e in cfgHits) if (shownCfg.Contains(e.RelPath)) tally.Mark(e.RelPath);
+        return sb.ToString().TrimEnd('\n') + Accounting();
     }
 
     static void AppendDetail(StringBuilder sb, SkseFileEntry e, SkseInventoryData d, HashSet<string> shownCfg)
@@ -653,21 +751,175 @@ static class SkseInventoryWire
     static string Chain(SkseFileEntry e) =>
         e.Providers.Count == 0 ? "(no active provider)" : string.Join(" › ", e.Providers.Select(p => $"{p.Name} ({p.Kind})"));
 
-    static void AppendSubset(StringBuilder sb, string label, IReadOnlyList<SkseFileEntry> items, int cap, Func<SkseFileEntry, string> line)
+    static void AppendSubset(StringBuilder sb, string label, IReadOnlyList<SkseFileEntry> items, int cap, Func<SkseFileEntry, string> line,
+                             RowTally? tally = null)
     {
         if (items.Count == 0) return;
         sb.Append('\n').Append(label).Append(" (").Append(items.Count).Append("):\n");
-        AppendCapped(sb, items, cap, line);
+        AppendCapped(sb, items, cap, line, tally);
     }
 
-    static void AppendCapped(StringBuilder sb, IReadOnlyList<SkseFileEntry> items, int cap, Func<SkseFileEntry, string> line)
+    static void AppendCapped(StringBuilder sb, IReadOnlyList<SkseFileEntry> items, int cap, Func<SkseFileEntry, string> line,
+                             RowTally? tally = null)
     {
         int shown = 0;
         foreach (var e in items)
         {
             if (sb.Length >= cap) { sb.Append("  ... [showing ").Append(shown).Append(" of ").Append(items.Count).Append("; raise max_chars or use filter= to see all]\n"); break; }
-            sb.Append(line(e)).Append('\n'); shown++;
+            sb.Append(line(e)).Append('\n'); shown++; tally?.Mark(e.RelPath);
         }
+    }
+
+    /// <summary>How many build-level caveat notes this answer carries — the accounting's <c>notes</c> count, and the
+    /// same three the caveat block renders.</summary>
+    internal static int NoteCount(SkseInventoryData d) => (d.ReadIncomplete ? 1 : 0) + d.Warnings.Count + d.BsaFailures.Count;
+
+    /// <summary>The json twin of <see cref="Render"/>: the same census, the same windowed rows, the same accounting,
+    /// in named fields. Rows are dropped from the tail when the document reaches max_chars — never a cut of the
+    /// serialized string, which would emit malformed json — and the accounting says how many that was.</summary>
+    public static string RenderJson(SkseInventoryData d, string? filter, int cap, RowWindow window = default)
+    {
+        bool filtered = filter is { Length: > 0 };
+        string f = filtered ? filter!.Trim() : "";
+        bool In(string? x) => x is not null && x.Contains(f, StringComparison.OrdinalIgnoreCase);
+
+        var allDlls = filtered ? d.Dlls.Where(e => e.MatchesDll(f)).OrderBy(e => e.FileName, StringComparer.OrdinalIgnoreCase).ToList()
+                               : d.Dlls.ToList();
+        var allCfgs = filtered ? d.Configs.Where(e => In(e.FileName) || In(e.WinningProvider) || In(e.Group)).ToList()
+                               : new List<SkseFileEntry>();
+        int total = allDlls.Count + allCfgs.Count;
+        var dlls = window.Apply(allDlls);
+        var cfgs = window.After(allDlls.Count, dlls.Count).Apply(allCfgs);
+        int windowed = dlls.Count + cfgs.Count;
+        var all = Split(d.Dlls);
+        int notes = NoteCount(d);
+        int rendered = 0;
+
+        return SkseJsonDoc.Write(SkseTools.SkseFamily.Inventory, filter, d.ProfileName, (w, ms) =>
+        {
+            SkseJsonDoc.Nullable(w, "installed_runtime", d.InstalledRuntime);
+            w.WriteStartObject("totals");
+            w.WriteNumber("dlls", all.Loaded.Count);
+            w.WriteNumber("subfolder_dlls", all.Subfolder.Count);
+            w.WriteNumber("configs", d.Configs.Count);
+            w.WriteNumber("config_folders", d.Configs.Select(e => e.Group).Distinct(StringComparer.OrdinalIgnoreCase).Count());
+            w.WriteNumber("other_files", d.OtherFileCount);
+            w.WriteNumber("modern", all.Modern.Count);
+            w.WriteNumber("legacy_query", all.Legacy.Count);
+            w.WriteNumber("non_plugin", all.NotPlugin.Count);
+            w.WriteNumber("bsa_only", all.BsaOnly.Count);
+            w.WriteNumber("unreadable", all.Unreadable.Count);
+            w.WriteNumber("address_library", all.Modern.Count(e => e.Plugin!.Version!.UsesAddressLibrary));
+            w.WriteNumber("signature_scanning", all.Modern.Count(e => e.Plugin!.Version!.UsesSignatureScanning));
+            w.WriteNumber("version_locked", all.Locked.Count);
+            w.WriteEndObject();
+
+            w.WriteStartArray("dlls");
+            foreach (var e in dlls)
+            {
+                if (SkseJsonDoc.Over(w, ms, cap)) break;
+                WriteDllJson(w, e, d);
+                rendered++;
+            }
+            w.WriteEndArray();
+
+            w.WriteStartArray("configs");
+            foreach (var e in cfgs)
+            {
+                if (SkseJsonDoc.Over(w, ms, cap)) break;
+                WriteConfigFileJson(w, e);
+                rendered++;
+            }
+            w.WriteEndArray();
+
+            // The whole-layer view groups configs by folder rather than listing them; the twin states the same table.
+            w.WriteStartArray("config_folders");
+            if (!filtered)
+                foreach (var g in d.Configs.GroupBy(e => e.Group, StringComparer.OrdinalIgnoreCase)
+                             .Select(g => (Name: g.Key.Length == 0 ? "(top level)" : g.Key, Count: g.Count(),
+                                           Providers: g.Select(e => e.WinningProvider).Where(x => x is not null).Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+                                           Contested: g.Count(e => e.ProviderCount > 1)))
+                             .OrderByDescending(g => g.Count).ThenBy(g => g.Name, StringComparer.OrdinalIgnoreCase))
+                {
+                    if (SkseJsonDoc.Over(w, ms, cap)) break;
+                    w.WriteStartObject();
+                    w.WriteString("folder", g.Name);
+                    w.WriteNumber("files", g.Count);
+                    SkseJsonDoc.Strings(w, "providers", g.Providers!);
+                    w.WriteNumber("contested", g.Contested);
+                    w.WriteEndObject();
+                }
+            w.WriteEndArray();
+
+            if (d.PeekRequested && allDlls.Count == 0)
+                w.WriteString("peek_note", "peek=true matched no DLL at all — nothing was peeked.");
+            SkseJsonDoc.Caveats(w, d.ReadIncomplete, d.Warnings, d.BsaFailures);
+            TransportAccounting.WriteJson(w, TransportAccounting.Tally(total, windowed, rendered, window, notes));
+        });
+    }
+
+    static void WriteDllJson(Utf8JsonWriter w, SkseFileEntry e, SkseInventoryData d)
+    {
+        w.WriteStartObject();
+        w.WriteString("rel_path", e.RelPath);
+        w.WriteString("file_name", e.FileName);
+        w.WriteString("group", e.Group);
+        w.WriteBoolean("loader_scoped", e.Group.Length == 0);
+        SkseJsonDoc.Nullable(w, "winning_provider", e.WinningProvider);
+        w.WriteString("provider_kind", e.ProviderKind);
+        w.WriteNumber("provider_count", e.ProviderCount);
+        SkseJsonDoc.Providers(w, e.Providers);
+        SkseJsonDoc.Nullable(w, "note", e.Note);
+        var p = e.Plugin;
+        SkseJsonDoc.Nullable(w, "kind", p is null ? null : p.Kind.ToString().ToLowerInvariant());
+        if (p?.Is64Bit is { } bits) w.WriteBoolean("is_64bit", bits); else w.WriteNull("is_64bit");
+        SkseJsonDoc.Strings(w, "debug_crt_imports", p?.DebugCrtImports ?? Array.Empty<string>());
+        // Null, not [], when the import walk never ran or failed: absence of evidence is not evidence of absence.
+        if (p?.Imports is { } imports) SkseJsonDoc.Strings(w, "imports", imports); else w.WriteNull("imports");
+        if (p?.Version is { } v)
+        {
+            w.WriteStartObject("version");
+            w.WriteString("name", v.Name);
+            w.WriteString("author", v.Author);
+            w.WriteString("support_email", v.SupportEmail);
+            w.WriteString("plugin_version", v.PluginVersion);
+            w.WriteBoolean("version_independent", v.VersionIndependent);
+            w.WriteBoolean("uses_address_library", v.UsesAddressLibrary);
+            w.WriteBoolean("uses_signature_scanning", v.UsesSignatureScanning);
+            w.WriteBoolean("uses_updated_structs", v.UsesUpdatedStructs);
+            w.WriteBoolean("declares_no_structs", v.DeclaresNoStructs);
+            SkseJsonDoc.Strings(w, "compatible_versions", v.CompatibleVersions);
+            SkseJsonDoc.Nullable(w, "minimum_xse_version", v.MinimumXseVersion);
+            if (d.InstalledRuntime is { } rt && !v.VersionIndependent)
+                w.WriteBoolean("loads_on_installed_runtime", SksePluginReader.RuntimeCompatible(v, rt));
+            w.WriteEndObject();
+        }
+        else w.WriteNull("version");
+        if (e.Peek is { } peek)
+        {
+            w.WriteStartObject("peek");
+            SkseJsonDoc.Strings(w, "config_paths", peek.ConfigPaths);
+            SkseJsonDoc.Strings(w, "plugin_refs", peek.PluginRefs);
+            w.WriteNumber("runs_scanned", peek.RunsScanned);
+            w.WriteNumber("bytes_scanned", peek.BytesScanned);
+            SkseJsonDoc.Nullable(w, "note", peek.Note);
+            w.WriteEndObject();
+        }
+        else w.WriteNull("peek");
+        w.WriteEndObject();
+    }
+
+    static void WriteConfigFileJson(Utf8JsonWriter w, SkseFileEntry e)
+    {
+        w.WriteStartObject();
+        w.WriteString("rel_path", e.RelPath);
+        w.WriteString("file_name", e.FileName);
+        w.WriteString("group", e.Group);
+        SkseJsonDoc.Nullable(w, "winning_provider", e.WinningProvider);
+        w.WriteString("provider_kind", e.ProviderKind);
+        w.WriteNumber("provider_count", e.ProviderCount);
+        SkseJsonDoc.Providers(w, e.Providers);
+        w.WriteEndObject();
     }
 
     static void AppendCaveats(StringBuilder sb, SkseInventoryData d)
@@ -692,25 +944,42 @@ static class SkseConfigAuditWire
         public HousecarlCore.SkseConfigRef Ref => Audited.Ref;
     }
 
-    public static string Render(SkseConfigAuditData d, string? filter, int cap)
-    {
-        if (filter is { Length: > 0 }) return RenderFiltered(d, filter.Trim(), cap);
+    /// <summary>What this family's accounting counts: the config FILES the audit covers.</summary>
+    internal const string RowNoun = "config(s)";
 
-        var flat = d.Files.SelectMany(f => f.Refs.Select(r => new Hit(f, r))).ToList();
+    public static string Render(SkseConfigAuditData d, string? filter, int cap, RowWindow window = default)
+    {
+        if (filter is { Length: > 0 }) return RenderFiltered(d, filter.Trim(), cap, window);
+
+        // Every count below states the WHOLE audit; limit=/offset= window only the files the sections LIST. Room for
+        // the accounting block is held back out of the cap so it is paid for rather than appended past it.
+        int notes = NoteCount(d);
+        var rows = window.Apply(d.Files);
+        int reserve = TransportAccounting.Reserve(d.Files.Count, rows.Count, window, notes, RowNoun);
+        cap = Math.Max(1, cap - reserve);
+        var tally = new RowTally();
+
+        var flatAll = d.Files.SelectMany(f => f.Refs.Select(r => new Hit(f, r))).ToList();
+        var flat = rows.SelectMany(f => f.Refs.Select(r => new Hit(f, r))).ToList();
         var missingGates = flat.Where(h => h.Audited.Verdict == SkseRefVerdict.PluginMissing && h.Ref.Shape == HousecarlCore.SkseRefShape.PathSegmentGate).ToList();
         var missingToks  = flat.Where(h => h.Audited.Verdict == SkseRefVerdict.PluginMissing && h.Ref.Shape == HousecarlCore.SkseRefShape.FormToken).ToList();
         var dangling     = flat.Where(h => h.Audited.Verdict == SkseRefVerdict.Dangling).ToList();
         var unparseable  = flat.Where(h => h.Audited.Verdict == SkseRefVerdict.Unparseable).ToList();
-        var readErrors   = d.Files.Where(f => f.ReadError is not null).ToList();
+        var readErrors   = rows.Where(f => f.ReadError is not null).ToList();
 
-        int refsChecked = flat.Count;
+        int Count(Func<Hit, bool> p) => flatAll.Count(p);
+        int danglingAll    = Count(h => h.Audited.Verdict == SkseRefVerdict.Dangling);
+        int unparseableAll = Count(h => h.Audited.Verdict == SkseRefVerdict.Unparseable);
+        int inertAll       = Count(h => h.Audited.Verdict == SkseRefVerdict.PluginMissing);
+
+        int refsChecked = flatAll.Count;
         // Two distinct signals, kept apart in the headline. BROKEN is a reference that should resolve and does not —
         // DANGLING (plugin present, record absent) or UNPARSEABLE (an unreadable token) — and is the actionable one.
         // INERT is PLUGIN MISSING, gate or token: the named plugin is not installed, so the entry does nothing. For a
         // config shipping optional support for a mod you do not have that is expected, not a fault, and counting it as
         // dead would make a healthy order read as thousands of dead references.
-        int broken = dangling.Count + unparseable.Count;
-        int inert  = missingGates.Count + missingToks.Count;
+        int broken = danglingAll + unparseableAll;
+        int inert  = inertAll;
         int notOk  = broken + inert;                       // every non-OK ref (kept for the accounted-for reconciliation below)
         int filesWithRefs = d.Files.Count(f => f.Refs.Count > 0);
 
@@ -726,7 +995,7 @@ static class SkseConfigAuditWire
         else
         {
             sb.Append("[!] ").Append(broken).Append(" BROKEN reference(s): ")
-              .Append(dangling.Count).Append(" dangling · ").Append(unparseable.Count).Append(" unparseable");
+              .Append(danglingAll).Append(" dangling · ").Append(unparseableAll).Append(" unparseable");
             if (inert > 0)
                 sb.Append("   ·   ").Append(inert).Append(" more inert (plugin not installed — usually optional support)");
             sb.Append('\n');
@@ -734,7 +1003,7 @@ static class SkseConfigAuditWire
 
         // ── Diagnostics first, in full. ──
         AppendHits(sb, "PLUGIN MISSING — folder gates (the plugin isn't installed, so the WHOLE file is inert)", missingGates, cap,
-            h => $"  - {h.File.RelPath}: folder '{h.Ref.Plugin}' not in the load order{Prov(h.File)}");
+            h => $"  - {h.File.RelPath}: folder '{h.Ref.Plugin}' not in the load order{Prov(h.File)}", tally);
         // Token-level plugin-missing is grouped by the target plugin: a whole-layer scan yields tens of thousands of
         // individual inert refs, so a per-ref list is an unreadable wall and the count-per-plugin table is the
         // actionable shape. filter= a plugin to see its individual refs.
@@ -742,7 +1011,7 @@ static class SkseConfigAuditWire
         {
             var byPlugin = missingToks.GroupBy(h => h.Ref.Plugin, StringComparer.OrdinalIgnoreCase)
                 .Select(g => (Plugin: g.Key, Refs: g.Count(),
-                              Files: g.Select(h => h.File.RelPath).Distinct(StringComparer.OrdinalIgnoreCase).Count(),
+                              Files: g.Select(h => h.File.RelPath).Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
                               Example: g.First().File.RelPath))
                 .OrderByDescending(g => g.Refs).ThenBy(g => g.Plugin, StringComparer.OrdinalIgnoreCase).ToList();
             sb.Append("\nPLUGIN MISSING — target plugin not in the load order (inert; often a config shipping optional support for a mod you don't have) — by plugin (")
@@ -752,14 +1021,15 @@ static class SkseConfigAuditWire
             {
                 if (sb.Length >= cap) { sb.Append("  ... [showing ").Append(shown).Append(" of ").Append(byPlugin.Count).Append(" plugins; raise max_chars or use filter=]\n"); break; }
                 sb.Append("  - ").Append(g.Plugin).Append(": ").Append(g.Refs).Append(" ref(s)");
-                if (g.Files > 1) sb.Append(" across ").Append(g.Files).Append(" file(s)");
+                if (g.Files.Count > 1) sb.Append(" across ").Append(g.Files.Count).Append(" file(s)");
                 sb.Append("  (e.g. ").Append(g.Example).Append(")\n"); shown++;
+                foreach (var f in g.Files) tally.Mark(f);
             }
         }
         AppendHits(sb, "DANGLING — plugin present but no such record (a dead reference)", dangling, cap,
-            h => $"  - {Loc(h)}: '{h.Ref.Raw}' → {h.Audited.Detail}{Prov(h.File)}");
+            h => $"  - {Loc(h)}: '{h.Ref.Raw}' → {h.Audited.Detail}{Prov(h.File)}", tally);
         AppendHits(sb, "UNPARSEABLE — shape-matched tokens that can't be normalized (flagged, never guessed)", unparseable, cap,
-            h => $"  - {Loc(h)}: '{h.Ref.Raw}' → {h.Audited.Detail}{Prov(h.File)}");
+            h => $"  - {Loc(h)}: '{h.Ref.Raw}' → {h.Audited.Detail}{Prov(h.File)}", tally);
         if (readErrors.Count > 0)
         {
             sb.Append("\nread errors — configs that could not be read/decoded (NOT counted as clean) (").Append(readErrors.Count).Append("):\n");
@@ -767,7 +1037,7 @@ static class SkseConfigAuditWire
             foreach (var f in readErrors)
             {
                 if (sb.Length >= cap) { sb.Append("  ... [").Append(shown).Append(" of ").Append(readErrors.Count).Append("; raise max_chars]\n"); break; }
-                sb.Append("  - ").Append(f.RelPath).Append(": ").Append(f.ReadError).Append(Prov(f)).Append('\n'); shown++;
+                sb.Append("  - ").Append(f.RelPath).Append(": ").Append(f.ReadError).Append(Prov(f)).Append('\n'); shown++; tally.Mark(f.RelPath);
             }
         }
 
@@ -776,6 +1046,9 @@ static class SkseConfigAuditWire
         int healthyRefs = healthyFiles.Sum(f => f.Refs.Count);
         int okInMixed = (refsChecked - notOk) - healthyRefs;   // OK refs living in a file that ALSO has a non-OK ref — so every ref reconciles: refsChecked = notOk + healthyRefs + okInMixed
         var noRefFiles = d.Files.Where(f => f.ReadError is null && f.Refs.Count == 0).ToList();
+        // A clean file is accounted for by the count line above, not by a row of its own, so it counts as rendered.
+        foreach (var f in rows)
+            if (f.ReadError is null && f.Refs.All(r => r.Verdict == SkseRefVerdict.Ok)) tally.Mark(f.RelPath);
         sb.Append("\naccounted for: ").Append(healthyFiles.Count).Append(" file(s) with ").Append(healthyRefs)
           .Append(" reference(s) all OK");
         if (okInMixed > 0) sb.Append(" · ").Append(okInMixed).Append(" more OK ref(s) in files that also carry a non-OK reference");
@@ -800,24 +1073,34 @@ static class SkseConfigAuditWire
                   "references but shows none may use a reference shape not yet recognized.)\n");
         AppendCaveats(sb, d);
         sb.Append("\n→ filter='<folder/mod/filename/plugin>' to audit one group and see every reference (OKs included).");
-        return sb.ToString().TrimEnd('\n');
+        return sb.ToString().TrimEnd('\n')
+             + TransportAccounting.Compose(TransportAccounting.Tally(d.Files.Count, rows.Count, tally.Count, window, notes),
+                                           RowNoun, everySentence: false);
     }
 
     /// <summary>filter=: audit just the matching configs — by folder, provider, filename, or a referenced plugin — and
     /// list every reference with its verdict, OKs included, so the view also serves as positive confirmation.</summary>
-    static string RenderFiltered(SkseConfigAuditData d, string filter, int cap)
+    static string RenderFiltered(SkseConfigAuditData d, string filter, int cap, RowWindow window = default)
     {
         bool In(string? s) => s is not null && s.Contains(filter, StringComparison.OrdinalIgnoreCase);
         bool Match(SkseConfigFileAudit f) =>
             In(f.FileName) || In(f.Group) || In(f.WinningProvider) || In(f.RelPath)
             || f.Refs.Any(r => In(r.Ref.Plugin));
-        var hits = d.Files.Where(Match)
+        var allHits = d.Files.Where(Match)
             .OrderBy(f => f.Group, StringComparer.OrdinalIgnoreCase).ThenBy(f => f.RelPath, StringComparer.OrdinalIgnoreCase).ToList();
+
+        int notes = NoteCount(d);
+        var hits = window.Apply(allHits);
+        int reserve = TransportAccounting.Reserve(allHits.Count, hits.Count, window, notes, RowNoun);
+        cap = Math.Max(1, cap - reserve);
+        var tally = new RowTally();
+        string Accounting() => TransportAccounting.Compose(
+            TransportAccounting.Tally(allHits.Count, hits.Count, tally.Count, window, notes), RowNoun, everySentence: false);
 
         var sb = new StringBuilder();
         sb.Append("SKSE config audit — filter '").Append(filter).Append("' — ")
-          .Append(hits.Count).Append(" config(s) match [profile '").Append(d.ProfileName).Append("']\n");
-        if (hits.Count == 0)
+          .Append(allHits.Count).Append(" config(s) match [profile '").Append(d.ProfileName).Append("']\n");
+        if (allHits.Count == 0)
         {
             // The suggestion pool must span every axis Match filters on, or a mistyped plugin or provider filter gets
             // only folder and filename suggestions. Match keys on filename, group, provider, relpath and
@@ -828,7 +1111,7 @@ static class SkseConfigAuditWire
                 .Concat(d.Files.SelectMany(f => f.Refs.Select(r => r.Ref.Plugin)));
             sb.Append("\nnothing under SKSE\\Plugins matched. ")
               .Append(HousecarlCore.PluginNameSuggest.DidYouMean(filter, suggestPool));
-            return sb.ToString().TrimEnd('\n');
+            return sb.ToString().TrimEnd('\n') + Accounting();
         }
 
         int shownFiles = 0;
@@ -839,16 +1122,16 @@ static class SkseConfigAuditWire
             if (f.ProviderCount > 1)
                 sb.Append("  [!] contested by ").Append(f.ProviderCount).Append(" mods (winner audited): ")
                   .Append(string.Join(" › ", f.Providers.Select(p => $"{p.Name} ({p.Kind})"))).Append('\n');
-            if (f.ReadError is not null) { sb.Append("  [!] ").Append(f.ReadError).Append('\n'); continue; }
-            if (f.Refs.Count == 0) { sb.Append("  (no form-shaped references)\n"); continue; }
+            if (f.ReadError is not null) { sb.Append("  [!] ").Append(f.ReadError).Append('\n'); tally.Mark(f.RelPath); continue; }
+            if (f.Refs.Count == 0) { sb.Append("  (no form-shaped references)\n"); tally.Mark(f.RelPath); continue; }
             foreach (var r in f.Refs)
                 sb.Append("  ").Append(Tag(r.Verdict)).Append(' ')
                   .Append(r.Ref.Shape == HousecarlCore.SkseRefShape.PathSegmentGate ? $"folder gate '{r.Ref.Plugin}'" : $"'{r.Ref.Raw}'")
                   .Append(r.Ref.Line > 0 ? $" (line {r.Ref.Line})" : "")
                   .Append(r.Detail is null ? "" : " → " + r.Detail).Append('\n');
-            shownFiles++;
+            shownFiles++; tally.Mark(f.RelPath);
         }
-        return sb.ToString().TrimEnd('\n');
+        return sb.ToString().TrimEnd('\n') + Accounting();
     }
 
     static string Tag(SkseRefVerdict v) => v switch
@@ -863,7 +1146,8 @@ static class SkseConfigAuditWire
     static string Loc(Hit h) => h.Ref.Line > 0 ? $"{h.File.RelPath}:{h.Ref.Line}" : h.File.RelPath;
     static string Prov(SkseConfigFileAudit f) => f.WinningProvider is null ? "" : $"  [← {f.WinningProvider}]";
 
-    static void AppendHits(StringBuilder sb, string label, IReadOnlyList<Hit> items, int cap, Func<Hit, string> line)
+    static void AppendHits(StringBuilder sb, string label, IReadOnlyList<Hit> items, int cap, Func<Hit, string> line,
+                           RowTally? tally = null)
     {
         if (items.Count == 0) return;
         sb.Append('\n').Append(label).Append(" (").Append(items.Count).Append("):\n");
@@ -871,9 +1155,92 @@ static class SkseConfigAuditWire
         foreach (var h in items)
         {
             if (sb.Length >= cap) { sb.Append("  ... [showing ").Append(shown).Append(" of ").Append(items.Count).Append("; raise max_chars or use filter=]\n"); break; }
-            sb.Append(line(h)).Append('\n'); shown++;
+            sb.Append(line(h)).Append('\n'); shown++; tally?.Mark(h.File.RelPath);
         }
     }
+
+    /// <summary>How many build-level caveat notes this answer carries — the accounting's <c>notes</c> count.</summary>
+    internal static int NoteCount(SkseConfigAuditData d) => (d.ReadIncomplete ? 1 : 0) + d.Warnings.Count + d.BsaFailures.Count;
+
+    /// <summary>The json twin of <see cref="Render"/>: the same census, the same windowed files with every reference
+    /// and its verdict, and the same accounting, in named fields.</summary>
+    public static string RenderJson(SkseConfigAuditData d, string? filter, int cap, RowWindow window = default)
+    {
+        bool filtered = filter is { Length: > 0 };
+        string f = filtered ? filter!.Trim() : "";
+        bool In(string? x) => x is not null && x.Contains(f, StringComparison.OrdinalIgnoreCase);
+
+        var allFiles = filtered
+            ? d.Files.Where(x => In(x.FileName) || In(x.Group) || In(x.WinningProvider) || In(x.RelPath) || x.Refs.Any(r => In(r.Ref.Plugin)))
+                     .OrderBy(x => x.Group, StringComparer.OrdinalIgnoreCase).ThenBy(x => x.RelPath, StringComparer.OrdinalIgnoreCase).ToList()
+            : d.Files.ToList();
+        var files = window.Apply(allFiles);
+        var flatAll = d.Files.SelectMany(x => x.Refs).ToList();
+        int notes = NoteCount(d);
+        int rendered = 0;
+
+        return SkseJsonDoc.Write(SkseTools.SkseFamily.Config, filter, d.ProfileName, (w, ms) =>
+        {
+            int Verdicts(SkseRefVerdict v) => flatAll.Count(r => r.Verdict == v);
+            w.WriteStartObject("totals");
+            w.WriteNumber("configs_scanned", d.ConfigCount);
+            w.WriteNumber("files_with_references", d.Files.Count(x => x.Refs.Count > 0));
+            w.WriteNumber("references_checked", flatAll.Count);
+            w.WriteNumber("ok", Verdicts(SkseRefVerdict.Ok));
+            w.WriteNumber("dangling", Verdicts(SkseRefVerdict.Dangling));
+            w.WriteNumber("unparseable", Verdicts(SkseRefVerdict.Unparseable));
+            w.WriteNumber("plugin_missing", Verdicts(SkseRefVerdict.PluginMissing));
+            // BROKEN is what should resolve and does not; INERT is a reference to a plugin you simply do not have.
+            w.WriteNumber("broken", Verdicts(SkseRefVerdict.Dangling) + Verdicts(SkseRefVerdict.Unparseable));
+            w.WriteNumber("inert", Verdicts(SkseRefVerdict.PluginMissing));
+            w.WriteNumber("read_errors", d.Files.Count(x => x.ReadError is not null));
+            w.WriteEndObject();
+
+            w.WriteStartArray("files");
+            foreach (var file in files)
+            {
+                if (SkseJsonDoc.Over(w, ms, cap)) break;
+                w.WriteStartObject();
+                w.WriteString("rel_path", file.RelPath);
+                w.WriteString("file_name", file.FileName);
+                w.WriteString("group", file.Group);
+                SkseJsonDoc.Nullable(w, "winning_provider", file.WinningProvider);
+                w.WriteNumber("provider_count", file.ProviderCount);
+                SkseJsonDoc.Providers(w, file.Providers);
+                SkseJsonDoc.Nullable(w, "read_error", file.ReadError);
+                w.WriteStartArray("references");
+                foreach (var r in file.Refs)
+                {
+                    w.WriteStartObject();
+                    w.WriteString("raw", r.Ref.Raw);
+                    w.WriteString("shape", r.Ref.Shape == HousecarlCore.SkseRefShape.PathSegmentGate ? "path_segment_gate" : "form_token");
+                    w.WriteString("plugin", r.Ref.Plugin);
+                    SkseJsonDoc.Nullable(w, "local_id", r.Ref.LocalId is { } id ? $"0x{id:X6}" : null);
+                    w.WriteNumber("line", r.Ref.Line);
+                    w.WriteString("verdict", VerdictName(r.Verdict));
+                    SkseJsonDoc.Nullable(w, "detail", r.Detail);
+                    w.WriteEndObject();
+                }
+                w.WriteEndArray();
+                w.WriteEndObject();
+                rendered++;
+            }
+            w.WriteEndArray();
+
+            SkseJsonDoc.Caveats(w, d.ReadIncomplete, d.Warnings, d.BsaFailures);
+            TransportAccounting.WriteJson(w, TransportAccounting.Tally(allFiles.Count, files.Count, rendered, window, notes));
+        });
+    }
+
+    /// <summary>The verdict's wire spelling — the json twin of <see cref="Tag"/>, from the same enum.</summary>
+    static string VerdictName(SkseRefVerdict v) => v switch
+    {
+        SkseRefVerdict.Ok => "ok",
+        SkseRefVerdict.PluginMissing => "plugin_missing",
+        SkseRefVerdict.Dangling => "dangling",
+        SkseRefVerdict.Unparseable => "unparseable",
+        _ => "unknown",
+    };
 
     static void AppendCaveats(StringBuilder sb, SkseConfigAuditData d)
     {
@@ -979,28 +1346,62 @@ static class NativePairingWire
         return any;
     }
 
-    public static string Render(NativePairingAuditData d, string? filter, int cap)
-    {
-        if (filter is { Length: > 0 }) return RenderFiltered(d, filter.Trim(), cap);
+    /// <summary>What this family's accounting counts: the native-declaring CLASS rows.</summary>
+    internal const string RowNoun = "class(es)";
 
-        var engine = d.Classes.Where(c => c.Provenance == NativeProvenance.Engine).ToList();
-        var skseCore = d.Classes.Where(c => c.Provenance == NativeProvenance.SkseCore).ToList();
-        var third = d.Classes.Where(c => c.Provenance == NativeProvenance.ThirdParty).ToList();
-        var unpaired = third.Where(c => c.Rung == NativePairingRung.Unpaired).ToList();
+    /// <summary>How many build-level caveat notes this answer carries — the accounting's <c>notes</c> count.</summary>
+    internal static int NoteCount(NativePairingAuditData d) => (d.ReadIncomplete ? 1 : 0) + d.Warnings.Count + d.BsaFailures.Count;
+
+    /// <summary>The class population split into the five disjoint buckets the view reports. One function so the
+    /// whole-audit summary and the windowed row sections are classified the same way and cannot drift.</summary>
+    readonly record struct ClassSplit(List<NativeClassEntry> Engine, List<NativeClassEntry> SkseCore,
+                                      List<NativeClassEntry> Unpaired, List<NativeClassEntry> Dead,
+                                      List<NativeClassEntry> Verify, List<NativeClassEntry> DebugBuilds,
+                                      List<NativeClassEntry> Healthy);
+
+    static ClassSplit Classify(IReadOnlyList<NativeClassEntry> classes, string? runtime)
+    {
+        var third = classes.Where(c => c.Provenance == NativeProvenance.ThirdParty).ToList();
         // One fate pass per paired class: the section split and the per-DLL tags come from the same Judge, so they
         // cannot disagree.
-        var byFate = third.Where(c => c.Rung != NativePairingRung.Unpaired)
-            .ToLookup(c => BestFate(c, d.InstalledRuntime));
-        var dead = byFate[DllFate.Dead].ToList();
-        var verify = byFate[DllFate.Verify].ToList();
+        var byFate = third.Where(c => c.Rung != NativePairingRung.Unpaired).ToLookup(c => BestFate(c, runtime));
         var loads = byFate[DllFate.Loads].ToList();
         // #417: a class whose only loadable candidate is a DEBUG build loads on THIS machine and nowhere else, so it is
         // a finding in its own right rather than a line of the healthy roster — which prints class names, not DLLs, and
         // would have carried the clean checkmark over exactly the file the author needs to hear about. EVERY loading
         // candidate must be debug-built: one clean DLL that loads keeps the class healthy, because that DLL implements
         // the class for everyone.
-        var debugBuilds = loads.Where(c => IsDebugOnly(c, d.InstalledRuntime)).ToList();
-        var healthy = loads.Except(debugBuilds).ToList();
+        var debugBuilds = loads.Where(c => IsDebugOnly(c, runtime)).ToList();
+        return new ClassSplit(
+            classes.Where(c => c.Provenance == NativeProvenance.Engine).ToList(),
+            classes.Where(c => c.Provenance == NativeProvenance.SkseCore).ToList(),
+            third.Where(c => c.Rung == NativePairingRung.Unpaired).ToList(),
+            byFate[DllFate.Dead].ToList(),
+            byFate[DllFate.Verify].ToList(),
+            debugBuilds,
+            loads.Except(debugBuilds).ToList());
+    }
+
+    public static string Render(NativePairingAuditData d, string? filter, int cap, RowWindow window = default)
+    {
+        if (filter is { Length: > 0 }) return RenderFiltered(d, filter.Trim(), cap, window);
+
+        // The summary states the WHOLE audit; limit=/offset= window only the classes the sections LIST. Room for the
+        // accounting block is held back out of the cap so it is paid for rather than appended past it.
+        int notes = NoteCount(d);
+        var rows = window.Apply(d.Classes);
+        int reserve = TransportAccounting.Reserve(d.Classes.Count, rows.Count, window, notes, RowNoun);
+        cap = Math.Max(1, cap - reserve);
+        var tally = new RowTally();
+
+        var all = Classify(d.Classes, d.InstalledRuntime);
+        var w = Classify(rows, d.InstalledRuntime);
+        var engine = all.Engine; var skseCore = all.SkseCore;
+        var unpaired = w.Unpaired; var dead = w.Dead; var verify = w.Verify;
+        var debugBuilds = w.DebugBuilds; var healthy = w.Healthy;
+        // A baseline class is accounted for by the engine / SKSE-core count line, not by a row of its own.
+        foreach (var c in rows)
+            if (c.Provenance != NativeProvenance.ThirdParty) tally.Mark(c.ClassName);
 
         var sb = new StringBuilder();
         sb.Append("native pairing audit — profile '").Append(d.ProfileName).Append("' — ")
@@ -1009,7 +1410,7 @@ static class NativePairingWire
         if (d.InstalledRuntime is { } rt) sb.Append("installed game runtime: ").Append(rt).Append('\n');
         else sb.Append("installed game runtime: could not be resolved — version-LOCKED findings degrade to 'verify'\n");
 
-        if (dead.Count == 0 && unpaired.Count == 0 && verify.Count == 0 && debugBuilds.Count == 0)
+        if (all.Dead.Count == 0 && all.Unpaired.Count == 0 && all.Verify.Count == 0 && all.DebugBuilds.Count == 0)
         {
             sb.Append("✓ every third-party native class pairs to a mod whose DLL statically loads — nothing dead, nothing unpaired");
             // The checkmark must not claim a universal the scan did not verify: unreadable .pex files were never
@@ -1018,12 +1419,12 @@ static class NativePairingWire
         }
         else
         {
-            sb.Append(dead.Count > 0 ? "[!] " : "✓ no dead pairings. ");
-            if (dead.Count > 0) sb.Append(dead.Count).Append(" class(es) PAIRED BUT DEAD — scripts installed, nothing that could implement them loads");
-            if (verify.Count > 0) sb.Append(dead.Count > 0 ? "   ·   " : "").Append(verify.Count).Append(" pairing(s) need a version check");
-            if (unpaired.Count > 0) sb.Append(dead.Count > 0 || verify.Count > 0 ? "   ·   " : "").Append(unpaired.Count).Append(" class(es) UNPAIRED (verify)");
-            if (debugBuilds.Count > 0) sb.Append(dead.Count > 0 || verify.Count > 0 || unpaired.Count > 0 ? "   ·   " : "")
-                                         .Append(debugBuilds.Count).Append(" class(es) paired only to a DEBUG BUILD");
+            sb.Append(all.Dead.Count > 0 ? "[!] " : "✓ no dead pairings. ");
+            if (all.Dead.Count > 0) sb.Append(all.Dead.Count).Append(" class(es) PAIRED BUT DEAD — scripts installed, nothing that could implement them loads");
+            if (all.Verify.Count > 0) sb.Append(all.Dead.Count > 0 ? "   ·   " : "").Append(all.Verify.Count).Append(" pairing(s) need a version check");
+            if (all.Unpaired.Count > 0) sb.Append(all.Dead.Count > 0 || all.Verify.Count > 0 ? "   ·   " : "").Append(all.Unpaired.Count).Append(" class(es) UNPAIRED (verify)");
+            if (all.DebugBuilds.Count > 0) sb.Append(all.Dead.Count > 0 || all.Verify.Count > 0 || all.Unpaired.Count > 0 ? "   ·   " : "")
+                                         .Append(all.DebugBuilds.Count).Append(" class(es) paired only to a DEBUG BUILD");
             sb.Append('\n');
         }
 
@@ -1031,19 +1432,19 @@ static class NativePairingWire
         if (dead.Count > 0)
         {
             sb.Append("\nPAIRED BUT DEAD — the high-confidence finding: every candidate DLL statically will not load, so every native these scripts declare is a silent no-op in game (").Append(dead.Count).Append("):\n");
-            AppendCapped(sb, dead, cap, c => DeadLine(c, d.InstalledRuntime));
+            AppendCapped(sb, dead, cap, c => DeadLine(c, d.InstalledRuntime), tally, c => c.ClassName);
         }
         if (verify.Count > 0)
         {
             sb.Append("\npaired, version-LOCKED, runtime unknown — verify the listed runtime matches your game (").Append(verify.Count).Append("):\n");
-            AppendCapped(sb, verify, cap, c => DeadLine(c, d.InstalledRuntime));
+            AppendCapped(sb, verify, cap, c => DeadLine(c, d.InstalledRuntime), tally, c => c.ClassName);
         }
         if (unpaired.Count > 0)
         {
             sb.Append("\nUNPAIRED — no mod shipping these scripts (winner or chain) ships any SKSE plugin DLL (").Append(unpaired.Count)
               .Append("). A VERIFY flag, not 'broken': most often a declaration copy of a framework that isn't installed — the calls will silently no-op if anything uses them:\n");
             AppendCapped(sb, unpaired, cap, c =>
-                $"  - {c.ClassName} ({c.NativeCount} native fn) ← {c.WinningProvider ?? "(no provider)"} ({c.ProviderKind})");
+                $"  - {c.ClassName} ({c.NativeCount} native fn) ← {c.WinningProvider ?? "(no provider)"} ({c.ProviderKind})", tally, c => c.ClassName);
         }
         if (debugBuilds.Count > 0)
         {
@@ -1051,7 +1452,7 @@ static class NativePairingWire
               .Append("). The debug C runtime ships with Visual Studio and is not redistributable, so the DLL fails with " +
                       "error 126 for anyone without it and every native these scripts declare is a silent no-op there. " +
                       "If you built it, ship a Release build; if you installed it, ask its author for one:\n");
-            AppendCapped(sb, debugBuilds, cap, c => DeadLine(c, d.InstalledRuntime));
+            AppendCapped(sb, debugBuilds, cap, c => DeadLine(c, d.InstalledRuntime), tally, c => c.ClassName);
         }
         if (d.Unreadable.Count > 0)
         {
@@ -1074,6 +1475,7 @@ static class NativePairingWire
         {
             if (sb.Length >= cap) { sb.Append("  ... [remaining healthy groups omitted; raise max_chars]\n"); break; }
             sb.Append("  - ").Append(g.Key).Append(": ").Append(string.Join(", ", g.Select(c => c.ClassName).OrderBy(n => n, StringComparer.OrdinalIgnoreCase))).Append('\n');
+            foreach (var c in g) tally.Mark(c.ClassName);
         }
 
         sb.Append("\n(scope: what the winning compiled scripts DECLARE, statically paired to what their mods ship. 'Paired' means the " +
@@ -1081,7 +1483,9 @@ static class NativePairingWire
                   "(registration is runtime behavior, the honest ceiling). Which mods CALL an unpaired class is not scanned (a possible Wave 2).)\n");
         AppendCaveats(sb, d);
         sb.Append("\n→ filter='<class/mod/DLL>' for full detail: native function names, pairing evidence, per-DLL manifests and load verdicts.");
-        return sb.ToString().TrimEnd('\n');
+        return sb.ToString().TrimEnd('\n')
+             + TransportAccounting.Compose(TransportAccounting.Tally(d.Classes.Count, rows.Count, tally.Count, window, notes),
+                                           RowNoun, everySentence: false);
     }
 
     /// <summary>The one-block render of a dead/verify pairing: the class line, then each candidate DLL's fate.</summary>
@@ -1112,17 +1516,25 @@ static class NativePairingWire
     /// <summary>filter=: full detail for every matching class — by class name, path, provider, paired mod, or a
     /// candidate DLL's filename — giving the declared native functions, the pairing evidence, each candidate DLL's
     /// manifest and load verdict, and the conflict chain.</summary>
-    static string RenderFiltered(NativePairingAuditData d, string filter, int cap)
+    static string RenderFiltered(NativePairingAuditData d, string filter, int cap, RowWindow window = default)
     {
         bool In(string? s) => s is not null && s.Contains(filter, StringComparison.OrdinalIgnoreCase);
         bool Match(NativeClassEntry c) => In(c.ClassName) || In(c.RelPath) || In(c.WinningProvider) || In(c.PairedMod)
             || c.PairedDlls.Any(x => In(x.FileName)) || c.Providers.Any(p => In(p.Name));
-        var hits = d.Classes.Where(Match).OrderBy(c => c.ClassName, StringComparer.OrdinalIgnoreCase).ToList();
+        var allHits = d.Classes.Where(Match).OrderBy(c => c.ClassName, StringComparer.OrdinalIgnoreCase).ToList();
+
+        int notes = NoteCount(d);
+        var hits = window.Apply(allHits);
+        int reserve = TransportAccounting.Reserve(allHits.Count, hits.Count, window, notes, RowNoun);
+        cap = Math.Max(1, cap - reserve);
+        var tally = new RowTally();
+        string Accounting() => TransportAccounting.Compose(
+            TransportAccounting.Tally(allHits.Count, hits.Count, tally.Count, window, notes), RowNoun, everySentence: false);
 
         var sb = new StringBuilder();
         sb.Append("native pairing audit — filter '").Append(filter).Append("' — ")
-          .Append(hits.Count).Append(" class(es) match [profile '").Append(d.ProfileName).Append("']\n");
-        if (hits.Count == 0)
+          .Append(allHits.Count).Append(" class(es) match [profile '").Append(d.ProfileName).Append("']\n");
+        if (allHits.Count == 0)
         {
             // The suggestion pool spans every axis Match filters on: class names, providers, paired mods, and DLL
             // filenames. PluginNameSuggest dedups and skips empties.
@@ -1133,7 +1545,7 @@ static class NativePairingWire
             sb.Append("\nno native-declaring class matched. ").Append(HousecarlCore.PluginNameSuggest.DidYouMean(filter, pool));
             sb.Append('\n');
             AppendCaveats(sb, d);   // a "no match" over an incompletely-read build must carry the caveat (Q3)
-            return sb.ToString().TrimEnd('\n');
+            return sb.ToString().TrimEnd('\n') + Accounting();
         }
 
         int shown = 0;
@@ -1165,23 +1577,142 @@ static class NativePairingWire
                 sb.Append(string.Join(", ", c.NativeFunctions.Take(8))).Append(", ... [").Append(c.NativeCount - 8).Append(" more; raise max_chars]");
             else sb.Append(fns);
             sb.Append('\n');
-            shown++;
+            shown++; tally.Mark(c.ClassName);
         }
         // The caveats ride the filtered view too: "no match", or a partial hit over a build whose BSA failed to read,
         // must not read as a clean answer.
         sb.Append('\n');
         AppendCaveats(sb, d);
-        return sb.ToString().TrimEnd('\n');
+        return sb.ToString().TrimEnd('\n') + Accounting();
     }
 
-    static void AppendCapped<T>(StringBuilder sb, IReadOnlyList<T> items, int cap, Func<T, string> line)
+    static void AppendCapped<T>(StringBuilder sb, IReadOnlyList<T> items, int cap, Func<T, string> line,
+                                RowTally? tally = null, Func<T, string>? key = null)
     {
         int shown = 0;
         foreach (var e in items)
         {
             if (sb.Length >= cap) { sb.Append("  ... [showing ").Append(shown).Append(" of ").Append(items.Count).Append("; raise max_chars or use filter= to see all]\n"); break; }
             sb.Append(line(e)).Append('\n'); shown++;
+            if (tally is not null && key is not null) tally.Mark(key(e));
         }
+    }
+
+    /// <summary>The json twin of <see cref="Render"/>: the same census, the same windowed classes, and the same
+    /// per-DLL fates — from the same <see cref="Judge"/>, so the two renders cannot disagree about what loads.</summary>
+    public static string RenderJson(NativePairingAuditData d, string? filter, int cap, RowWindow window = default)
+    {
+        bool filtered = filter is { Length: > 0 };
+        string f = filtered ? filter!.Trim() : "";
+        bool In(string? x) => x is not null && x.Contains(f, StringComparison.OrdinalIgnoreCase);
+
+        var allClasses = filtered
+            ? d.Classes.Where(c => In(c.ClassName) || In(c.RelPath) || In(c.WinningProvider) || In(c.PairedMod)
+                                || c.PairedDlls.Any(x => In(x.FileName)) || c.Providers.Any(pr => In(pr.Name)))
+                       .OrderBy(c => c.ClassName, StringComparer.OrdinalIgnoreCase).ToList()
+            : d.Classes.ToList();
+        var classes = window.Apply(allClasses);
+        var all = Classify(d.Classes, d.InstalledRuntime);
+        int notes = NoteCount(d);
+        int rendered = 0;
+
+        return SkseJsonDoc.Write(SkseTools.SkseFamily.Pairing, filter, d.ProfileName, (w, ms) =>
+        {
+            SkseJsonDoc.Nullable(w, "installed_runtime", d.InstalledRuntime);
+            // Tri-state: null is "the check itself failed", never a checked-and-absent verdict.
+            if (d.SkseLoaderSeen is { } seen) w.WriteBoolean("skse_loader_seen", seen); else w.WriteNull("skse_loader_seen");
+            w.WriteStartObject("totals");
+            w.WriteNumber("classes", d.Classes.Count);
+            w.WriteNumber("pex_scanned", d.PexScanned);
+            w.WriteNumber("engine", all.Engine.Count);
+            w.WriteNumber("skse_core", all.SkseCore.Count);
+            w.WriteNumber("unpaired", all.Unpaired.Count);
+            w.WriteNumber("dead", all.Dead.Count);
+            w.WriteNumber("verify", all.Verify.Count);
+            w.WriteNumber("debug_build", all.DebugBuilds.Count);
+            w.WriteNumber("healthy", all.Healthy.Count);
+            w.WriteNumber("unreadable_pex", d.Unreadable.Count);
+            w.WriteEndObject();
+
+            w.WriteStartArray("classes");
+            foreach (var c in classes)
+            {
+                if (SkseJsonDoc.Over(w, ms, cap)) break;
+                w.WriteStartObject();
+                w.WriteString("class_name", c.ClassName);
+                w.WriteString("rel_path", c.RelPath);
+                w.WriteString("provenance", c.Provenance switch
+                {
+                    NativeProvenance.Engine => "engine",
+                    NativeProvenance.SkseCore => "skse_core",
+                    _ => "third_party",
+                });
+                SkseJsonDoc.Nullable(w, "rung", c.Rung switch
+                {
+                    NativePairingRung.SameMod => "same_mod",
+                    NativePairingRung.ChainMod => "chain_mod",
+                    NativePairingRung.Unpaired => "unpaired",
+                    _ => null,
+                });
+                w.WriteString("verdict", VerdictName(c, d.InstalledRuntime));
+                SkseJsonDoc.Nullable(w, "winning_provider", c.WinningProvider);
+                w.WriteString("provider_kind", c.ProviderKind);
+                w.WriteNumber("provider_count", c.ProviderCount);
+                SkseJsonDoc.Providers(w, c.Providers);
+                SkseJsonDoc.Nullable(w, "paired_mod", c.PairedMod);
+                w.WriteNumber("native_count", c.NativeCount);
+                SkseJsonDoc.Strings(w, "native_functions", c.NativeFunctions);
+                w.WriteStartArray("paired_dlls");
+                foreach (var dll in c.PairedDlls)
+                {
+                    var (fate, detail) = Judge(dll, d.InstalledRuntime);
+                    w.WriteStartObject();
+                    w.WriteString("rel_path", dll.RelPath);
+                    w.WriteString("file_name", dll.FileName);
+                    w.WriteString("group", dll.Group);
+                    SkseJsonDoc.Nullable(w, "winning_provider", dll.WinningProvider);
+                    w.WriteString("fate", fate.ToString().ToLowerInvariant());
+                    w.WriteString("detail", detail);
+                    SkseJsonDoc.Nullable(w, "plugin_name", dll.Info?.Version?.Name);
+                    SkseJsonDoc.Nullable(w, "plugin_version", dll.Info?.Version?.PluginVersion);
+                    SkseJsonDoc.Strings(w, "debug_crt_imports", dll.Info?.DebugCrtImports ?? Array.Empty<string>());
+                    w.WriteEndObject();
+                }
+                w.WriteEndArray();
+                w.WriteEndObject();
+                rendered++;
+            }
+            w.WriteEndArray();
+
+            w.WriteStartArray("unreadable_pex");
+            foreach (var u in d.Unreadable)
+            {
+                if (SkseJsonDoc.Over(w, ms, cap)) break;
+                w.WriteStartObject();
+                w.WriteString("rel_path", u.RelPath);
+                SkseJsonDoc.Nullable(w, "winning_provider", u.WinningProvider);
+                w.WriteString("reason", u.Reason);
+                w.WriteEndObject();
+            }
+            w.WriteEndArray();
+
+            SkseJsonDoc.Caveats(w, d.ReadIncomplete, d.Warnings, d.BsaFailures);
+            TransportAccounting.WriteJson(w, TransportAccounting.Tally(allClasses.Count, classes.Count, rendered, window, notes));
+        });
+    }
+
+    /// <summary>Which section of the text render this class lands in, as one word — from the same Judge, so the two
+    /// renders classify identically.</summary>
+    static string VerdictName(NativeClassEntry c, string? runtime)
+    {
+        if (c.Provenance != NativeProvenance.ThirdParty) return "baseline";
+        if (c.Rung == NativePairingRung.Unpaired) return "unpaired";
+        return BestFate(c, runtime) switch
+        {
+            DllFate.Dead => "dead",
+            DllFate.Verify => "verify",
+            _ => IsDebugOnly(c, runtime) ? "debug_build" : "healthy",
+        };
     }
 
     static void AppendCaveats(StringBuilder sb, NativePairingAuditData d)

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -1422,7 +1422,10 @@ static class NativePairingWire
 
         var all = Classify(d.Classes, d.InstalledRuntime);
         var w = Classify(rows, d.InstalledRuntime);
-        var engine = all.Engine; var skseCore = all.SkseCore;
+        // Every section below the summary states the WINDOW, the accounted-for baseline included: it reconciles this
+        // page's rows against its findings, so a layer-wide engine count beside a windowed healthy count would put two
+        // different populations on adjacent lines. The whole-audit numbers are the summary's, above.
+        var engine = w.Engine; var skseCore = w.SkseCore;
         var unpaired = w.Unpaired; var dead = w.Dead; var verify = w.Verify;
         var debugBuilds = w.DebugBuilds; var healthy = w.Healthy;
         // A baseline class is accounted for by the engine / SKSE-core count line, not by a row of its own.
@@ -1486,14 +1489,16 @@ static class NativePairingWire
             AppendCapped(sb, d.Unreadable, cap, u => $"  - {u.RelPath}: {u.Reason}{(u.WinningProvider is { } p ? $"  [← {p}]" : "")}");
         }
 
-        // ── Accounted-for baseline: everything that is not a finding, so nothing is dropped. ──
+        // ── Accounted-for baseline: every row of THIS page that is not a finding, so nothing on it is dropped. ──
         sb.Append("\naccounted for: ").Append(engine.Count).Append(" engine class(es) (carried by an official archive — implemented by the game executable) · ")
           .Append(skseCore.Count).Append(" SKSE-core class(es) (skse64's script additions — implemented by the game-root loader)");
         // Tri-state: false means checked and genuinely absent, so the definite note; null means the check itself
         // failed, which must not render as a checked-and-absent verdict.
-        if (skseCore.Count > 0 && d.SkseLoaderSeen == false)
+        // The alarm is a build-level fact, not a row of the page, so it rides the whole audit's SKSE-core count — a
+        // window that happens to hold none of those classes must not silence it.
+        if (all.SkseCore.Count > 0 && d.SkseLoaderSeen == false)
             sb.Append("\n  [!] SKSE-core classes are present but no skse64 loader is visible (game root or enabled mods' Root\\ folders) — if SKSE isn't actually installed, every one of these is dead");
-        else if (skseCore.Count > 0 && d.SkseLoaderSeen is null)
+        else if (all.SkseCore.Count > 0 && d.SkseLoaderSeen is null)
             sb.Append("\n  (skse64 loader visibility could not be checked)");
         sb.Append("\npaired healthy (").Append(healthy.Count).Append(" class(es)) — implementing mod ← its classes:\n");
         foreach (var g in healthy.GroupBy(c => c.PairedMod ?? "(?)", StringComparer.OrdinalIgnoreCase)

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -774,6 +774,10 @@ static class SkseInventoryWire
     /// same three the caveat block renders.</summary>
     internal static int NoteCount(SkseInventoryData d) => (d.ReadIncomplete ? 1 : 0) + d.Warnings.Count + d.BsaFailures.Count;
 
+    /// <summary>The json twin of the text render's "peek=true matched no DLL" notice — one spelling, so the reserve
+    /// measures the string the document actually writes.</summary>
+    const string PeekNoDllNote = "peek=true matched no DLL at all — nothing was peeked.";
+
     /// <summary>The json twin of <see cref="Render"/>: the same census, the same windowed rows, the same accounting,
     /// in named fields. Rows are dropped from the tail when the document reaches max_chars — never a cut of the
     /// serialized string, which would emit malformed json — and the accounting says how many that was.</summary>
@@ -794,6 +798,12 @@ static class SkseInventoryWire
         var all = Split(d.Dlls);
         int notes = NoteCount(d);
         int rendered = 0;
+        int folderCount = d.Configs.Select(e => e.Group).Distinct(StringComparer.OrdinalIgnoreCase).Count();
+        // The tail — peek note, the folder cut marker, caveats, accounting — is paid for inside max_chars, not
+        // appended past it, exactly as the text render's own reserve does.
+        cap = Math.Max(1, cap - SkseJsonDoc.TailReserve(d.ReadIncomplete, d.Warnings, d.BsaFailures,
+            TransportAccounting.Widest(total, windowed, window, notes),
+            tw => { tw.WriteString("peek_note", PeekNoDllNote); tw.WriteNumber("config_folders_truncated", folderCount); }));
 
         return SkseJsonDoc.Write(SkseTools.SkseFamily.Inventory, filter, d.ProfileName, (w, ms) =>
         {
@@ -834,6 +844,7 @@ static class SkseInventoryWire
 
             // The whole-layer view groups configs by folder rather than listing them; the twin states the same table.
             w.WriteStartArray("config_folders");
+            int folders = 0;
             if (!filtered)
                 foreach (var g in d.Configs.GroupBy(e => e.Group, StringComparer.OrdinalIgnoreCase)
                              .Select(g => (Name: g.Key.Length == 0 ? "(top level)" : g.Key, Count: g.Count(),
@@ -848,11 +859,15 @@ static class SkseInventoryWire
                     SkseJsonDoc.Strings(w, "providers", g.Providers!);
                     w.WriteNumber("contested", g.Contested);
                     w.WriteEndObject();
+                    folders++;
                 }
             w.WriteEndArray();
+            // These are not row-list rows, so the accounting does not count them — the cut says so here instead, the
+            // way the text render's "showing N of M folders" notice does.
+            if (!filtered && folders < folderCount) w.WriteNumber("config_folders_truncated", folderCount - folders);
 
             if (d.PeekRequested && allDlls.Count == 0)
-                w.WriteString("peek_note", "peek=true matched no DLL at all — nothing was peeked.");
+                w.WriteString("peek_note", PeekNoDllNote);
             SkseJsonDoc.Caveats(w, d.ReadIncomplete, d.Warnings, d.BsaFailures);
             TransportAccounting.WriteJson(w, TransportAccounting.Tally(total, windowed, rendered, window, notes));
         });
@@ -1178,6 +1193,9 @@ static class SkseConfigAuditWire
         var flatAll = d.Files.SelectMany(x => x.Refs).ToList();
         int notes = NoteCount(d);
         int rendered = 0;
+        // The caveats and accounting tail is paid for inside max_chars rather than appended past it.
+        cap = Math.Max(1, cap - SkseJsonDoc.TailReserve(d.ReadIncomplete, d.Warnings, d.BsaFailures,
+            TransportAccounting.Widest(allFiles.Count, files.Count, window, notes)));
 
         return SkseJsonDoc.Write(SkseTools.SkseFamily.Config, filter, d.ProfileName, (w, ms) =>
         {
@@ -1209,8 +1227,12 @@ static class SkseConfigAuditWire
                 SkseJsonDoc.Providers(w, file.Providers);
                 SkseJsonDoc.Nullable(w, "read_error", file.ReadError);
                 w.WriteStartArray("references");
+                int refs = 0;
                 foreach (var r in file.Refs)
                 {
+                    // One config can carry tens of thousands of form tokens, so the cap bounds the inner loop too —
+                    // otherwise a single file writes its whole reference array past max_chars in one pass.
+                    if (SkseJsonDoc.Over(w, ms, cap)) break;
                     w.WriteStartObject();
                     w.WriteString("raw", r.Ref.Raw);
                     w.WriteString("shape", r.Ref.Shape == HousecarlCore.SkseRefShape.PathSegmentGate ? "path_segment_gate" : "form_token");
@@ -1220,8 +1242,12 @@ static class SkseConfigAuditWire
                     w.WriteString("verdict", VerdictName(r.Verdict));
                     SkseJsonDoc.Nullable(w, "detail", r.Detail);
                     w.WriteEndObject();
+                    refs++;
                 }
                 w.WriteEndArray();
+                // The file's own row is on the page; how many of its references the cap cut is said here, because the
+                // accounting counts files, not references.
+                if (refs < file.Refs.Count) w.WriteNumber("references_truncated", file.Refs.Count - refs);
                 w.WriteEndObject();
                 rendered++;
             }
@@ -1615,6 +1641,10 @@ static class NativePairingWire
         var all = Classify(d.Classes, d.InstalledRuntime);
         int notes = NoteCount(d);
         int rendered = 0;
+        // The tail — the unreadable-pex cut marker, caveats, accounting — is paid for inside max_chars.
+        cap = Math.Max(1, cap - SkseJsonDoc.TailReserve(d.ReadIncomplete, d.Warnings, d.BsaFailures,
+            TransportAccounting.Widest(allClasses.Count, classes.Count, window, notes),
+            tw => tw.WriteNumber("unreadable_pex_truncated", d.Unreadable.Count)));
 
         return SkseJsonDoc.Write(SkseTools.SkseFamily.Pairing, filter, d.ProfileName, (w, ms) =>
         {
@@ -1685,6 +1715,7 @@ static class NativePairingWire
             w.WriteEndArray();
 
             w.WriteStartArray("unreadable_pex");
+            int unreadable = 0;
             foreach (var u in d.Unreadable)
             {
                 if (SkseJsonDoc.Over(w, ms, cap)) break;
@@ -1693,8 +1724,12 @@ static class NativePairingWire
                 SkseJsonDoc.Nullable(w, "winning_provider", u.WinningProvider);
                 w.WriteString("reason", u.Reason);
                 w.WriteEndObject();
+                unreadable++;
             }
             w.WriteEndArray();
+            // Not row-list rows, so the accounting does not count them — the cut is named here instead, the way the
+            // text render's own cut notice does.
+            if (unreadable < d.Unreadable.Count) w.WriteNumber("unreadable_pex_truncated", d.Unreadable.Count - unreadable);
 
             SkseJsonDoc.Caveats(w, d.ReadIncomplete, d.Warnings, d.BsaFailures);
             TransportAccounting.WriteJson(w, TransportAccounting.Tally(allClasses.Count, classes.Count, rendered, window, notes));

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -795,7 +795,12 @@ static class SkseInventoryWire
         var dlls = window.Apply(allDlls);
         var cfgs = window.After(allDlls.Count, dlls.Count).Apply(allCfgs);
         int windowed = dlls.Count + cfgs.Count;
-        var all = Split(d.Dlls);
+        // The census states the population THIS document answers over — the filter's matches when there is a filter,
+        // the whole layer when there is not — so no number in it describes a wider set than the rows beside it. The
+        // text lane's filtered view publishes no census at all, and a filtered twin restating the layer's counts under
+        // the same names is the lane difference §2.1 exists to remove.
+        var all = Split(allDlls);
+        var censusCfgs = filtered ? allCfgs : d.Configs;
         int notes = NoteCount(d);
         int rendered = 0;
         int folderCount = d.Configs.Select(e => e.Group).Distinct(StringComparer.OrdinalIgnoreCase).Count();
@@ -811,9 +816,11 @@ static class SkseInventoryWire
             w.WriteStartObject("totals");
             w.WriteNumber("dlls", all.Loaded.Count);
             w.WriteNumber("subfolder_dlls", all.Subfolder.Count);
-            w.WriteNumber("configs", d.Configs.Count);
-            w.WriteNumber("config_folders", d.Configs.Select(e => e.Group).Distinct(StringComparer.OrdinalIgnoreCase).Count());
-            w.WriteNumber("other_files", d.OtherFileCount);
+            w.WriteNumber("configs", censusCfgs.Count);
+            w.WriteNumber("config_folders", censusCfgs.Select(e => e.Group).Distinct(StringComparer.OrdinalIgnoreCase).Count());
+            // Uncategorized files are counted, never listed, so a filter has nothing to match them on: the number is
+            // the whole layer's, and a filtered document does not state it rather than stating it out of scope.
+            if (!filtered) w.WriteNumber("other_files", d.OtherFileCount);
             w.WriteNumber("modern", all.Modern.Count);
             w.WriteNumber("legacy_query", all.Legacy.Count);
             w.WriteNumber("non_plugin", all.NotPlugin.Count);
@@ -843,9 +850,12 @@ static class SkseInventoryWire
             w.WriteEndArray();
 
             // The whole-layer view groups configs by folder rather than listing them; the twin states the same table.
-            w.WriteStartArray("config_folders");
-            int folders = 0;
+            // A filtered document lists its matching configs individually above, so it omits the table rather than
+            // writing an empty one — [] would read as "this layer has no config folders".
             if (!filtered)
+            {
+                w.WriteStartArray("config_folders");
+                int folders = 0;
                 foreach (var g in d.Configs.GroupBy(e => e.Group, StringComparer.OrdinalIgnoreCase)
                              .Select(g => (Name: g.Key.Length == 0 ? "(top level)" : g.Key, Count: g.Count(),
                                            Providers: g.Select(e => e.WinningProvider).Where(x => x is not null).Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
@@ -861,10 +871,11 @@ static class SkseInventoryWire
                     w.WriteEndObject();
                     folders++;
                 }
-            w.WriteEndArray();
-            // These are not row-list rows, so the accounting does not count them — the cut says so here instead, the
-            // way the text render's "showing N of M folders" notice does.
-            if (!filtered && folders < folderCount) w.WriteNumber("config_folders_truncated", folderCount - folders);
+                w.WriteEndArray();
+                // These are not row-list rows, so the accounting does not count them — the cut says so here instead,
+                // the way the text render's "showing N of M folders" notice does.
+                if (folders < folderCount) w.WriteNumber("config_folders_truncated", folderCount - folders);
+            }
 
             if (d.PeekRequested && allDlls.Count == 0)
                 w.WriteString("peek_note", PeekNoDllNote);
@@ -1190,7 +1201,10 @@ static class SkseConfigAuditWire
                      .OrderBy(x => x.Group, StringComparer.OrdinalIgnoreCase).ThenBy(x => x.RelPath, StringComparer.OrdinalIgnoreCase).ToList()
             : d.Files.ToList();
         var files = window.Apply(allFiles);
-        var flatAll = d.Files.SelectMany(x => x.Refs).ToList();
+        // Every census number below is measured over the population this document answers over — the filter's matches
+        // when there is a filter. A verdict tally taken over the whole audit under filter= tells a caller scoping to
+        // one folder how many broken references the WHOLE layer carries, under a name that reads as the folder's.
+        var flatAll = allFiles.SelectMany(x => x.Refs).ToList();
         int notes = NoteCount(d);
         int rendered = 0;
         // The caveats and accounting tail is paid for inside max_chars rather than appended past it.
@@ -1201,8 +1215,8 @@ static class SkseConfigAuditWire
         {
             int Verdicts(SkseRefVerdict v) => flatAll.Count(r => r.Verdict == v);
             w.WriteStartObject("totals");
-            w.WriteNumber("configs_scanned", d.ConfigCount);
-            w.WriteNumber("files_with_references", d.Files.Count(x => x.Refs.Count > 0));
+            w.WriteNumber("configs_scanned", filtered ? allFiles.Count : d.ConfigCount);
+            w.WriteNumber("files_with_references", allFiles.Count(x => x.Refs.Count > 0));
             w.WriteNumber("references_checked", flatAll.Count);
             w.WriteNumber("ok", Verdicts(SkseRefVerdict.Ok));
             w.WriteNumber("dangling", Verdicts(SkseRefVerdict.Dangling));
@@ -1211,7 +1225,7 @@ static class SkseConfigAuditWire
             // BROKEN is what should resolve and does not; INERT is a reference to a plugin you simply do not have.
             w.WriteNumber("broken", Verdicts(SkseRefVerdict.Dangling) + Verdicts(SkseRefVerdict.Unparseable));
             w.WriteNumber("inert", Verdicts(SkseRefVerdict.PluginMissing));
-            w.WriteNumber("read_errors", d.Files.Count(x => x.ReadError is not null));
+            w.WriteNumber("read_errors", allFiles.Count(x => x.ReadError is not null));
             w.WriteEndObject();
 
             w.WriteStartArray("files");
@@ -1643,7 +1657,9 @@ static class NativePairingWire
                        .OrderBy(c => c.ClassName, StringComparer.OrdinalIgnoreCase).ToList()
             : d.Classes.ToList();
         var classes = window.Apply(allClasses);
-        var all = Classify(d.Classes, d.InstalledRuntime);
+        // Classified over the population this document answers over, so a caller scoping to one mod is not told about
+        // dead pairings that belong to other mods under a name that reads as its own.
+        var all = Classify(allClasses, d.InstalledRuntime);
         int notes = NoteCount(d);
         int rendered = 0;
         // The tail — the unreadable-pex cut marker, caveats, accounting — is paid for inside max_chars.
@@ -1657,8 +1673,12 @@ static class NativePairingWire
             // Tri-state: null is "the check itself failed", never a checked-and-absent verdict.
             if (d.SkseLoaderSeen is { } seen) w.WriteBoolean("skse_loader_seen", seen); else w.WriteNull("skse_loader_seen");
             w.WriteStartObject("totals");
-            w.WriteNumber("classes", d.Classes.Count);
-            w.WriteNumber("pex_scanned", d.PexScanned);
+            w.WriteNumber("classes", allClasses.Count);
+            // The .pex scan and the unparseable-.pex list are the SCAN, not the selection: an unreadable .pex has no
+            // class name, provider or paired mod for a filter to match on. A filtered document does not state them
+            // rather than stating them out of scope; the array below stays whole, since dropping it would hide the
+            // one caveat saying those files were NOT counted as native-free.
+            if (!filtered) w.WriteNumber("pex_scanned", d.PexScanned);
             w.WriteNumber("engine", all.Engine.Count);
             w.WriteNumber("skse_core", all.SkseCore.Count);
             w.WriteNumber("unpaired", all.Unpaired.Count);
@@ -1666,7 +1686,7 @@ static class NativePairingWire
             w.WriteNumber("verify", all.Verify.Count);
             w.WriteNumber("debug_build", all.DebugBuilds.Count);
             w.WriteNumber("healthy", all.Healthy.Count);
-            w.WriteNumber("unreadable_pex", d.Unreadable.Count);
+            if (!filtered) w.WriteNumber("unreadable_pex", d.Unreadable.Count);
             w.WriteEndObject();
 
             w.WriteStartArray("classes");

--- a/src/housecarl-mcp/TransportAccounting.cs
+++ b/src/housecarl-mcp/TransportAccounting.cs
@@ -108,7 +108,8 @@ internal static class TransportAccounting
                                    Math.Max(w.Limit, DefaultPageLimit));
     }
 
-    /// <summary>The one machine-readable accounting line, always last: how many rows the selection named, how many
+    /// <summary>The one machine-readable accounting line, closing the render body — a surface that appends a footer of
+    /// its own (housecarl_skse's one-line family footer) writes it after this: how many rows the selection named, how many
     /// rendered, how many the paging window stepped over or left behind, and how many max_chars cut. A bulk consumer
     /// checks these numbers instead of counting prose it might miss. <paramref name="rowNoun"/> names what the
     /// counts count, e.g. "path(s)" or "DLL(s)".</summary>

--- a/src/housecarl-mcp/TransportAccounting.cs
+++ b/src/housecarl-mcp/TransportAccounting.cs
@@ -1,0 +1,150 @@
+using System.Text;
+using System.Text.Json;
+
+namespace HousecarlMcp;
+
+/// <summary>The TRANSPORT paging window (SPEC §2.1): <c>offset=</c> steps over rows before the window,
+/// <c>limit=</c> bounds the window. <c>Limit = 0</c> is no limit, the shape every surface defaults to, so a call
+/// that passes neither renders exactly what it rendered before paging existed.</summary>
+internal readonly record struct RowWindow(int Offset, int Limit)
+{
+    /// <summary>The whole list — no offset, no limit.</summary>
+    internal static readonly RowWindow All = new(0, 0);
+
+    /// <summary>The window of <paramref name="rows"/> this describes.</summary>
+    internal IReadOnlyList<T> Apply<T>(IReadOnlyList<T> rows)
+    {
+        if (Offset <= 0 && Limit <= 0) return rows;
+        var q = rows.Skip(Offset);
+        if (Limit > 0) q = q.Take(Limit);
+        return q.ToList();
+    }
+
+    /// <summary>The window over a SECOND list that continues the first — the shape a family whose row list is two
+    /// concatenated populations needs (SKSE inventory: DLLs then configs). <paramref name="consumed"/> is how many
+    /// rows the first list held, so the offset lands where the first list stopped and the limit counts what the
+    /// first list already spent.</summary>
+    internal RowWindow After(int consumed, int taken) =>
+        new(Math.Max(Offset - consumed, 0), Limit <= 0 ? 0 : Math.Max(Limit - taken, 0));
+
+    /// <summary>The window's own refusal, or null when both values are legal. One sentence naming both knobs,
+    /// because a caller who got one wrong usually typed the other in the same call.</summary>
+    internal string? Error =>
+        Offset < 0 || Limit < 0
+            ? $"error: limit={Limit} offset={Offset} — neither can be negative. Pass limit=0 for no limit and offset=0 to start at the beginning of the selection."
+            : null;
+}
+
+/// <summary>How many DISTINCT rows a render actually put on the page. A set, not a counter, because a render whose
+/// sections overlap — one DLL listed both as version-locked and in the plugin roster — would otherwise count it
+/// twice and report more rendered rows than the window held.</summary>
+internal sealed class RowTally
+{
+    readonly HashSet<string> _seen = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Record that the row with this key reached the page.</summary>
+    internal void Mark(string key) => _seen.Add(key);
+
+    /// <summary>How many distinct rows reached the page.</summary>
+    internal int Count => _seen.Count;
+}
+
+/// <summary>The numbers one in-band accounting block states. A record so the real line, the JSON twin and the
+/// widest-case line the reserve measures all go through ONE composer — a second formatter would be a second
+/// spelling, and the reserve would stop bounding what is written.</summary>
+internal readonly record struct TransportCounts(int Total, int Rendered, int Skipped, int Capped, int Truncated,
+                                                int Offset, int Remaining, int Notes, int NextLimit);
+
+/// <summary>The one in-band accounting block (SPEC §2.1: <c>total / rendered / capped / truncated / notes</c> is
+/// required output on every bulk lane), shared by every surface that pages a row list. One composer for the text
+/// line, one writer for its JSON twin, and one reserve so the block is paid for INSIDE max_chars rather than
+/// appended past it.
+///
+/// <para>The four omissions have four distinct causes and each is counted once, so
+/// <c>skipped + rendered + truncated + capped == total</c>: <c>skipped</c> is what <c>offset=</c> stepped over
+/// BEFORE the window, <c>capped</c> what <c>limit=</c> left AFTER it, <c>truncated</c> what <c>max_chars</c> cut
+/// out of the window. <c>remaining</c> and the next page are measured off what was RENDERED, not off the window: a
+/// caller walking by this block's own advice must land on the first row it has not seen, and rows the cap cut were
+/// selected but never shown.</para></summary>
+internal static class TransportAccounting
+{
+    /// <summary>The window the next-page advice names when the caller passed none. Without a limit= in the advice a
+    /// caller following it calls back with limit=0, which resolves the WHOLE remainder on every page — the paging is
+    /// only cheap if the advice keeps it paged.</summary>
+    internal const int DefaultPageLimit = 200;
+
+    /// <summary>What this response actually did. <paramref name="windowed"/> is how many rows the window handed the
+    /// render; <paramref name="rendered"/> how many of those it got onto the page.</summary>
+    internal static TransportCounts Tally(int total, int windowed, int rendered, RowWindow w, int notes) => new(
+        Total: total,
+        Rendered: rendered,
+        Skipped: Math.Min(w.Offset, total),
+        Capped: Math.Max(total - w.Offset - windowed, 0),
+        Truncated: Math.Max(windowed - rendered, 0),
+        Offset: w.Offset,
+        Remaining: Math.Max(total - (w.Offset + rendered), 0),
+        Notes: notes,
+        NextLimit: w.Limit > 0 ? w.Limit : DefaultPageLimit);
+
+    /// <summary>The chars held back from max_chars so the accounting block is always affordable — measured by
+    /// composing the WIDEST line this response could write, so no rendering of it can outgrow its own room.</summary>
+    internal static int Reserve(int total, int windowed, RowWindow w, int notes, string rowNoun)
+        => Compose(Widest(total, windowed, w, notes), rowNoun, everySentence: true).Length;
+
+    /// <summary>The widest line this response could produce: every count at its largest (so every digit slot is at
+    /// its real width) and, with <c>everySentence</c>, every optional sentence present. An upper bound, which is
+    /// what a reserve has to be.</summary>
+    static TransportCounts Widest(int total, int windowed, RowWindow w, int notes)
+    {
+        int most = Math.Max(total, windowed);
+        return new TransportCounts(most, windowed, most, most, windowed, w.Offset, most, notes,
+                                   Math.Max(w.Limit, DefaultPageLimit));
+    }
+
+    /// <summary>The one machine-readable accounting line, always last: how many rows the selection named, how many
+    /// rendered, how many the paging window stepped over or left behind, and how many max_chars cut. A bulk consumer
+    /// checks these numbers instead of counting prose it might miss. <paramref name="rowNoun"/> names what the
+    /// counts count, e.g. "path(s)" or "DLL(s)".</summary>
+    internal static string Compose(TransportCounts c, string rowNoun, bool everySentence)
+    {
+        var sb = new StringBuilder("\n\n[accounting] total=").Append(c.Total)
+            .Append(" rendered=").Append(c.Rendered)
+            .Append(" skipped=").Append(c.Skipped)
+            .Append(" capped=").Append(c.Capped)
+            .Append(" truncated=").Append(c.Truncated)
+            .Append(" offset=").Append(c.Offset)
+            .Append(" remaining=").Append(c.Remaining)
+            .Append(" notes=").Append(c.Notes);
+        // Only what is still AHEAD of what was rendered earns a next page, and the next offset starts at the first
+        // row this response did not show — so a caller following the advice sees every row exactly once. The advice
+        // carries limit= as well: without it the next call resolves the whole remainder instead of one page.
+        if (everySentence || c.Remaining > 0)
+            sb.Append("\nthe selection is longer than this window: re-call with limit=").Append(c.NextLimit)
+              .Append(" offset=").Append(c.Offset + c.Rendered).Append(" for the next page.");
+        // An offset past the end would otherwise be told to re-call at the offset it already used.
+        if (everySentence || (c.Remaining == 0 && c.Total > 0 && c.Offset >= c.Total))
+            sb.Append("\noffset=").Append(c.Offset).Append(" is past the end of the selection (")
+              .Append(c.Total).Append(' ').Append(rowNoun).Append(") — the last page starts before it.");
+        if (everySentence || c.Truncated > 0)
+            sb.Append("\nmax_chars cut ").Append(c.Truncated).Append(' ').Append(rowNoun)
+              .Append(" from the render: raise max_chars, or page with limit=/offset=.");
+        return sb.ToString();
+    }
+
+    /// <summary>The JSON twin of <see cref="Compose"/>: the same eight numbers, in-band, under one
+    /// <c>accounting</c> object — so a json consumer reads the accounting off named fields instead of parsing the
+    /// text line. Field names match the text spelling exactly; a name added here is a name added there.</summary>
+    internal static void WriteJson(Utf8JsonWriter w, TransportCounts c)
+    {
+        w.WriteStartObject("accounting");
+        w.WriteNumber("total", c.Total);
+        w.WriteNumber("rendered", c.Rendered);
+        w.WriteNumber("skipped", c.Skipped);
+        w.WriteNumber("capped", c.Capped);
+        w.WriteNumber("truncated", c.Truncated);
+        w.WriteNumber("offset", c.Offset);
+        w.WriteNumber("remaining", c.Remaining);
+        w.WriteNumber("notes", c.Notes);
+        w.WriteEndObject();
+    }
+}

--- a/src/housecarl-mcp/TransportAccounting.cs
+++ b/src/housecarl-mcp/TransportAccounting.cs
@@ -5,8 +5,12 @@ namespace HousecarlMcp;
 
 /// <summary>The TRANSPORT paging window (SPEC §2.1): <c>offset=</c> steps over rows before the window,
 /// <c>limit=</c> bounds the window. <c>Limit = 0</c> is no limit, the shape every surface defaults to, so a call
-/// that passes neither renders exactly what it rendered before paging existed.</summary>
-internal readonly record struct RowWindow(int Offset, int Limit)
+/// that passes neither renders exactly what it rendered before paging existed.
+///
+/// <para><paramref name="Spent"/> is the third state the two numbers cannot express: a limit that WAS asked for and
+/// is now used up. Without it a continuation window whose budget ran out is spelled <c>Limit = 0</c>, which
+/// <see cref="Apply"/> reads as "no limit" and renders the whole second list.</para></summary>
+internal readonly record struct RowWindow(int Offset, int Limit, bool Spent = false)
 {
     /// <summary>The whole list — no offset, no limit.</summary>
     internal static readonly RowWindow All = new(0, 0);
@@ -14,6 +18,7 @@ internal readonly record struct RowWindow(int Offset, int Limit)
     /// <summary>The window of <paramref name="rows"/> this describes.</summary>
     internal IReadOnlyList<T> Apply<T>(IReadOnlyList<T> rows)
     {
+        if (Spent) return Array.Empty<T>();
         if (Offset <= 0 && Limit <= 0) return rows;
         var q = rows.Skip(Offset);
         if (Limit > 0) q = q.Take(Limit);
@@ -23,9 +28,11 @@ internal readonly record struct RowWindow(int Offset, int Limit)
     /// <summary>The window over a SECOND list that continues the first — the shape a family whose row list is two
     /// concatenated populations needs (SKSE inventory: DLLs then configs). <paramref name="consumed"/> is how many
     /// rows the first list held, so the offset lands where the first list stopped and the limit counts what the
-    /// first list already spent.</summary>
+    /// first list already spent. A limit the first list exhausted carries over as spent, not as no limit.</summary>
     internal RowWindow After(int consumed, int taken) =>
-        new(Math.Max(Offset - consumed, 0), Limit <= 0 ? 0 : Math.Max(Limit - taken, 0));
+        new(Math.Max(Offset - consumed, 0),
+            Limit <= 0 ? 0 : Math.Max(Limit - taken, 0),
+            Spent || (Limit > 0 && taken >= Limit));
 
     /// <summary>The window's own refusal, or null when both values are legal. One sentence naming both knobs,
     /// because a caller who got one wrong usually typed the other in the same call.</summary>
@@ -94,7 +101,7 @@ internal static class TransportAccounting
     /// <summary>The widest line this response could produce: every count at its largest (so every digit slot is at
     /// its real width) and, with <c>everySentence</c>, every optional sentence present. An upper bound, which is
     /// what a reserve has to be.</summary>
-    static TransportCounts Widest(int total, int windowed, RowWindow w, int notes)
+    internal static TransportCounts Widest(int total, int windowed, RowWindow w, int notes)
     {
         int most = Math.Max(total, windowed);
         return new TransportCounts(most, windowed, most, most, windowed, w.Offset, most, notes,


### PR DESCRIPTION
`housecarl_skse` carried `max_chars=` and nothing else: no `format=json`, no `limit=`/`offset=`, no in-band accounting. SPEC §2.1 makes those axes uniform across every tool, so the gap is a bug rather than a parity request. This gives the tool the same lane the recently landed surfaces have, out of shared code rather than a bespoke variant: `housecarl_asset_status` owned the only accounting block on the read surface, so its counts, composer, reserve and paging window move into a shared `TransportAccounting` that both tools now render through — the extraction is behaviour-preserving for `asset_status` apart from one word in its truncation sentence, which is now parameterised on the row noun.

On `housecarl_skse` itself: `format='json'` returns the machine-readable twin of whichever family ran, carrying the same census, the same windowed rows and the same numbers in named fields, plus the family that ran and the two that did not — the text footer's prose cannot ride a json document, so it becomes `family` and `not_run`. `limit=`/`offset=` page each family's row list: the DLLs for `findings='inventory'` (with `filter=`, its DLL and config matches, the window walking the DLLs first and continuing into the configs), the native-declaring classes for `'pairing'`, the config files for `'config'`. The census above the rows keeps stating the whole layer while the rows are the window — the `asset_status` contract — and every answer ends on `total / rendered / skipped / capped / truncated / offset / remaining / notes`, so what a window or a cap left out is a number rather than a silence. `rendered` counts distinct rows that reached the page, because the inventory view lists one DLL in more than one section. An unrecognized `format=` is refused naming the two shapes the tool renders, a negative `limit=`/`offset=` is refused naming both knobs, and every one of the tool's own refusals now comes back in the shape the caller asked for.

Each family's json serializer lives beside its text render rather than in `JsonWire`, deliberately: the pairing twin has to classify with the same `Judge`/`BestFate` the text render uses, and the inventory twin with the same DLL split, so a copy in another file would be free to drift — which is the one thing a twin may not do. The shared skeleton the three documents have in common is in `SkseJsonDoc`. Text output with neither knob passed is unchanged apart from the closing accounting line.

Closes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)
