### PR TITLE
Add the owned-child record lifecycle: create one, delete one

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -29,6 +29,16 @@ saying it sets an expectation their install may contradict. Say what is known, a
   quotes, a character a Windows folder or file name cannot contain, with `(loose)` / `(BSA)` outside them. A mod
   called `Face Extras (SE)` now reads back whole, and the printed token is the token `housecarl_place_asset`'s
   `source_provider=` accepts.
+- **A record that owns exactly one child can now be given one, and an owned child can be deleted.** A cell's
+  terrain (`Landscape`) and a worldspace's top cell are single owned child records, and neither end of their life
+  worked: a cell that carried no terrain could not be given any, because `housecarl_create`'s `parent=` only
+  reached child *collections*; and `housecarl_remove` on such a record silently dropped nothing, because Mutagen's
+  removal routes by group and a single owned child sits in none. Both now work on the record axis, with no new
+  tool: `housecarl_create` with `parent=` and `collection=` the slot's name authors one where the parent has none,
+  and `housecarl_remove` with the child's own FormID deletes one. A slot that already holds a child refuses rather
+  than overwriting the record that is there. A cell under a worldspace has two routes — its single top cell, or an
+  exterior cell in the block tree — so that one asks which you meant instead of guessing. The field-level refusals
+  that used to end at "this is an open gap" now name these calls.
 - **Two refusals about a collection element now name the call that works.** Editing one element of a polymorphic
   collection — an AI package's `Data`, a record's conditions, a script's VMAD properties — used to take several
   tries, because each refusal was correct about what was wrong and silent about what to do instead. Reaching

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -36,9 +36,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
   removal routes by group and a single owned child sits in none. Both now work on the record axis, with no new
   tool: `housecarl_create` with `parent=` and `collection=` the slot's name authors one where the parent has none,
   and `housecarl_remove` with the child's own FormID deletes one. A slot that already holds a child refuses rather
-  than overwriting the record that is there. A cell under a worldspace has two routes — its single top cell, or an
-  exterior cell in the block tree — so that one asks which you meant instead of guessing. The field-level refusals
-  that used to end at "this is an open gap" now name these calls.
+  than overwriting the record that is there — decided from the parent's real record, not from the copy the patch is
+  building. A cell under a worldspace has two routes — its single top cell (`collection='TopCell'`), or an exterior
+  cell in the block tree (`grid=`) — so that one asks which you meant instead of guessing. Deleting a child that
+  carries records of its own refuses until you name those too, so the removal report accounts for every record it
+  drops. The field-level refusals that used to end at "this is an open gap" now name these calls.
 - **Two refusals about a collection element now name the call that works.** Editing one element of a polymorphic
   collection — an AI package's `Data`, a record's conditions, a script's VMAD properties — used to take several
   tries, because each refusal was correct about what was wrong and silent about what to do instead. Reaching

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -38,7 +38,9 @@ saying it sets an expectation their install may contradict. Say what is known, a
   and `housecarl_remove` with the child's own FormID deletes one. A slot that already holds a child refuses rather
   than overwriting the record that is there — decided from the parent's real record, not from the copy the patch is
   building. A cell under a worldspace has two routes — its single top cell (`collection='TopCell'`), or an exterior
-  cell in the block tree (`grid=`) — so that one asks which you meant instead of guessing. Deleting a child that
+  cell in the block tree (`grid=`) — so that one asks which you meant instead of guessing. A cell authored through
+  the top-cell slot is refused when the patch already carries a cell with that editorid, the same refusal the other
+  two cell routes give. Deleting a child that
   carries records of its own refuses until you name those too, so the removal report accounts for every record it
   drops. The field-level refusals that used to end at "this is an open gap" now name these calls.
 - **Two refusals about a collection element now name the call that works.** Editing one element of a polymorphic

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -307,15 +307,15 @@ public sealed class CorpusRulebook
         // under it — a Worldspace's TopCell takes its persistent references with it. The list form of the same family
         // does delete an owned child (Cell.Persistent Remove key=0), but by INDEX, so the caller names which one; a
         // keyless clear of a singular child deletes a whole subtree implicitly, in one call, with no backup on the
-        // in-place lane. Deliberate owned-child deletion is an open gap, #350.
+        // in-place lane. Deliberate owned-child deletion is on the RECORD axis, where the caller names the record.
         if (string.Equals(req.Verb, "Remove", StringComparison.Ordinal)
             && SchemaClassifier.IsOwnedChildRecord(leaf, _corpus))
             return $"'{leaf.Name}' on '{leafOwner.Name}' holds an owned child RECORD ({leaf.TypeRef}): clearing the " +
                    "field deletes that record and every record under it, implicitly and in one call. The list form of " +
                    "this family deletes a child too, but by INDEX — you name which one; there is no such target here. " +
-                   "Deliberate deletion of an owned child record is an open gap (#350), not something clearing a " +
-                   $"field decides. (To see which record this is: read the parent at depth=2 — the '{leaf.Name}' " +
-                   "field shows the child's FormID.)";
+                   "Delete it on the record axis instead, where the record is named: " + ToolNames.Remove +
+                   " with the child's own FormID. (To see which record this is: read the parent at depth=2 — the " +
+                   $"'{leaf.Name}' field shows the child's FormID.)";
 
         // (3b) record identity (FormKey/ModKey) is a flat, honest reject regardless of Mutagen's setter.
         if (leaf.IsIdentity)
@@ -454,8 +454,9 @@ public sealed class CorpusRulebook
         // owned child records "coercible values". Answered from the same classification the collection verbs decide
         // with, and NOT verb-scoped: a record is not built from parts under any verb.
         //
-        // The two shapes carry different remedies, so they cannot share one sentence: create with parent= is refused
-        // for a singular child (which routes to the open gap #350) and is exactly the shape the collection serves.
+        // The two shapes carry different remedies, so they cannot share one sentence: both are created with parent=,
+        // but a singular slot holds exactly one and a collection takes another, so what to do about an occupied
+        // parent differs and the sentences say so separately.
         if (IsOwnedChildRecordCollection(leaf))
             return OwnedChildRecordCollectionRefusal(leaf);
         if (leaf.Cardinality != "list")
@@ -496,10 +497,10 @@ public sealed class CorpusRulebook
     /// Everything else — scalar/enum/value, formlink, formlink/modeled list, sub-struct, polymorphic arm —
     /// WriteEngine.CopyField transplants by construction.
     /// <para/>
-    /// The singular and collection arms word their remedies differently because only one remedy works per shape:
-    /// <c>housecarl_forward</c> carries the child record itself across for both, but <c>create</c> with
-    /// <c>parent=</c> is refused for a singular child, so only the collection arm may offer it; the singular case
-    /// routes to the lifecycle gap #350 instead.</summary>
+    /// The singular and collection arms word their remedies differently because the shapes differ in what a caller
+    /// does next: <c>housecarl_forward</c> carries the child record itself across for both, and <c>create</c> with
+    /// <c>parent=</c> authors a fresh one for both — but a singular slot names itself with <c>collection=</c> and
+    /// holds exactly one, so the singular sentence points at the slot by name.</summary>
     string? CopyFromLegality(FieldSchema leaf, TypeSchema owner, FieldSchema? ownedChildHop = null, TypeSchema? hopOwner = null)
     {
         if (leaf.IsIdentity)
@@ -526,8 +527,9 @@ public sealed class CorpusRulebook
                    "FIELD's value, not a record — copying it here would write another plugin's record, with its own " +
                    "FormID and everything under it, in as this parent's child. To carry that record across from " +
                    "another plugin use " + ToolNames.Forward + " on the CHILD record itself; read the parent at " +
-                   $"depth=2 and the '{leaf.Name}' field shows the child's FormID. Giving a parent a child it does " +
-                   "not have is an open gap (#350).";
+                   $"depth=2 and the '{leaf.Name}' field shows the child's FormID. To give a parent a child it does " +
+                   "not have, create one on the record axis: " + ToolNames.Create + " with parent= the parent's " +
+                   $"FormID and collection='{leaf.Name}' in its records= element.";
         // The same recogniser as the other two collection doors; the SENTENCE stays this door's own, because
         // CopyFrom's remedy is housecarl_forward (carrying across a record that already exists) rather than
         // housecarl_create with parent= alone. Shared predicate, per-door remedy.
@@ -554,7 +556,8 @@ public sealed class CorpusRulebook
         $"'{leaf.Name}' holds an owned child RECORD ({leaf.TypeRef}): a record is not a part of its parent, so it is " +
         $"neither built from parts (compose= / composes=) nor set from a value (value=). {AddressChildByFormId(leaf.Name)} A path through " +
         "the parent reaches a child only when the record being written already carries one, which a patch's fresh " +
-        "override of a parent never does; giving a parent a child it lacks is an open gap (#350).";
+        "override of a parent never does; to give a parent a child it lacks, create one on the record axis — " +
+        ToolNames.Create + $" with parent= the parent's FormID and collection='{leaf.Name}'.";
 
     /// <summary>How an owned child record that ALREADY EXISTS is written: on the record axis, by its own FormID.
     /// One sentence, shared by the value-shaped Set refusal and the element remedy, so the two doors cannot drift

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -314,8 +314,9 @@ public sealed class CorpusRulebook
                    "field deletes that record and every record under it, implicitly and in one call. The list form of " +
                    "this family deletes a child too, but by INDEX — you name which one; there is no such target here. " +
                    "Delete it on the record axis instead, where the record is named: " + ToolNames.Remove +
-                   " with the child's own FormID. (To see which record this is: read the parent at depth=2 — the " +
-                   $"'{leaf.Name}' field shows the child's FormID.)";
+                   " with the child's own FormID, plus the FormIDs of any records that child carries — the delete " +
+                   "refuses until every record it would drop is named. (To see which record this is: read the " +
+                   $"parent at depth=2 — the '{leaf.Name}' field shows the child's FormID.)";
 
         // (3b) record identity (FormKey/ModKey) is a flat, honest reject regardless of Mutagen's setter.
         if (leaf.IsIdentity)

--- a/src/housecarl-core/OwnedChildLifecycle.cs
+++ b/src/housecarl-core/OwnedChildLifecycle.cs
@@ -77,6 +77,27 @@ public static class OwnedChildLifecycle
         return false;
     }
 
+    /// <summary>The child already in the SINGULAR slot <paramref name="slotName"/> on <paramref name="parent"/>, or
+    /// null when the slot is free. Asked of whatever body the caller holds — a load-order winner's read-only overlay
+    /// at pre-flight, or a patch's own copy — because that is what makes occupancy knowable BEFORE a create allocates
+    /// anything. A slot the body's type does not model, or one that throws on read, answers null: the create path's
+    /// own guard on the record it is about to write is the backstop.</summary>
+    public static IMajorRecordGetter? OccupantOf(IMajorRecordGetter parent, string slotName)
+    {
+        var p = parent.GetType().GetProperty(slotName,
+            BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+        if (p is null || p.GetIndexParameters().Length != 0) return null;
+        try { return p.GetValue(parent) as IMajorRecordGetter; } catch { return null; }
+    }
+
+    /// <summary>The records <paramref name="child"/> carries under it — what a detach of the child takes with it.
+    /// A caller that has not named these has not asked for them to be deleted, which is what makes an unnamed
+    /// descendant a refusal rather than a side effect.</summary>
+    public static IReadOnlyList<IMajorRecordGetter> DescendantsOf(IMajorRecordGetter child) =>
+        child is IMajorRecordGetterEnumerable e
+            ? e.EnumerateMajorRecords().Where(r => r.FormKey != child.FormKey).ToList()
+            : Array.Empty<IMajorRecordGetter>();
+
     /// <summary>The deepest container nesting the search follows — the same bound
     /// <see cref="WriteEngine.ChildBearingProperties"/>'s reachability walk uses, for the same reason: the deepest
     /// real path is a worldspace's cells at five hops, so this is a tripwire for a shape nobody has seen rather

--- a/src/housecarl-core/OwnedChildLifecycle.cs
+++ b/src/housecarl-core/OwnedChildLifecycle.cs
@@ -1,0 +1,150 @@
+using System.Reflection;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// The WRITE side of the owned-child shape: finding the slot on a parent that HOLDS a given child record, and
+/// detaching the child from it. <see cref="OwnedChildContent"/> answers the same question for the read side (what
+/// shape is this field, does it declare a child); this answers the one a delete needs — WHICH record holds this
+/// child, and in which of its slots.
+///
+/// <para><b>Why a delete needs it at all.</b> Mutagen's typed <c>Remove(FormKey, Type)</c> is the blessed drop for
+/// every record in a group, flat or nested, and it reaches placed references and INFOs. It does NOT reach a
+/// SINGULAR owned child: a cell's <c>Landscape</c> and a worldspace's <c>TopCell</c> are plain properties on their
+/// parent, not entries in any group, so the remove routing finds nothing to drop and returns without throwing —
+/// the silent no-op <see cref="WritePatchBuilder"/>'s survivor check exists to catch. The record is reachable
+/// (Mutagen's containment walk enumerates it) but not removable by FormKey alone. The slot is what removes it.</para>
+///
+/// <para><b>The slot set is not a hand list.</b> It is <see cref="WriteEngine.ChildBearingProperties"/> — the same
+/// reflected, recursive walk the forward lanes preserve children with and the read side classifies with — so a
+/// Mutagen bump that adds a child-bearing property is covered here without an edit. Nothing in this file names a
+/// record type.</para>
+/// </summary>
+public static class OwnedChildLifecycle
+{
+    /// <summary>Where a child record sits: the parent that owns it, the settable property on that parent, and how
+    /// that property holds it. <see cref="Container"/> is the live <c>IList</c> the child is an element of for a
+    /// <see cref="OwnedChildShape.Collection"/> slot — possibly nested inside the property rather than being it, as
+    /// a worldspace's cells sit under block structs — and null for a singular one.</summary>
+    public readonly record struct OwnedChildSlot(
+        IMajorRecord Parent, PropertyInfo Property, OwnedChildShape Shape,
+        System.Collections.IList? Container, IMajorRecord Child)
+    {
+        /// <summary>The slot named the way a message names it: the parent's type and the property.</summary>
+        public string Describe() => $"{Parent.GetType().Name}.{Property.Name}";
+    }
+
+    /// <summary>Find the slot in <paramref name="mod"/> that holds <paramref name="child"/>, if any. Returns false
+    /// when no record in the mod holds it in a child-bearing slot — which is the ordinary answer for the
+    /// overwhelming majority of records, since only a handful of types own children at all.
+    ///
+    /// <para>The scan walks the mod's own records and asks each one's child-bearing properties, so it is bounded by
+    /// the records that CAN own children rather than by the mod's size — every other type contributes an empty
+    /// property set and is skipped without reading a field.</para></summary>
+    public static bool TryFindSlot(IMajorRecordEnumerable mod, FormKey child, out OwnedChildSlot slot)
+    {
+        slot = default;
+        foreach (var parent in mod.EnumerateMajorRecords())
+        {
+            var props = WriteEngine.ChildBearingProperties(parent.GetType());
+            if (props.Count == 0) continue;
+            foreach (var p in props)
+            {
+                object? value;
+                // A property that throws on read is not a slot we can speak for. Skipping it cannot hide a child:
+                // the caller's survivor check still refuses if the record is still there afterwards.
+                try { value = p.GetValue(parent); } catch { continue; }
+                if (value is null) continue;
+                // SINGULAR: the property IS the child.
+                if (value is IMajorRecord single)
+                {
+                    if (single.FormKey != child) continue;
+                    slot = new OwnedChildSlot(parent, p, OwnedChildShape.Singular, null, single);
+                    return true;
+                }
+                // COLLECTION: the child is an element somewhere under the property. It may not be an element OF the
+                // property — a worldspace's cells sit two container levels down, under block structs — so the walk
+                // descends to the IList that actually holds it, which is the list a delete has to remove from.
+                if (FindInContainer(value, child, 0) is { } hit)
+                {
+                    slot = new OwnedChildSlot(parent, p, OwnedChildShape.Collection, hit.List, hit.Child);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /// <summary>The deepest container nesting the search follows — the same bound
+    /// <see cref="WriteEngine.ChildBearingProperties"/>'s reachability walk uses, for the same reason: the deepest
+    /// real path is a worldspace's cells at five hops, so this is a tripwire for a shape nobody has seen rather
+    /// than a limit the model approaches. Overrunning it means the child is simply not found, and the caller's
+    /// survivor check then refuses loud — the failure is a refusal, never a silent skip.</summary>
+    const int MaxDepth = 6;
+
+    static (System.Collections.IList List, IMajorRecord Child)? FindInContainer(object? value, FormKey child, int depth)
+    {
+        if (value is null || depth > MaxDepth) return null;
+        if (value is IFormLinkGetter) return null;             // a reference, not a child — the same cut the type walk makes
+        if (value is string) return null;
+        if (value is System.Collections.IList list)
+        {
+            // This list itself, first: an element that IS the child is the slot, and descending past it would find
+            // a deeper list that does not hold it.
+            for (int i = 0; i < list.Count; i++)
+                if (list[i] is IMajorRecord rec && rec.FormKey == child) return (list, rec);
+            for (int i = 0; i < list.Count; i++)
+                if (FindInContainer(list[i], child, depth + 1) is { } deeper) return deeper;
+            return null;
+        }
+        if (value is System.Collections.IEnumerable seq)
+        {
+            foreach (var item in seq)
+                if (FindInContainer(item, child, depth + 1) is { } deeper) return deeper;
+            return null;
+        }
+        // A non-collection intermediate (a block struct) — descend its own properties, which is how a worldspace's
+        // cells are reached at all.
+        var t = value.GetType();
+        if (value is IMajorRecord || !t.IsClass || t.Namespace?.StartsWith("Mutagen", StringComparison.Ordinal) != true)
+            return null;
+        foreach (var p in t.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (!p.CanRead || p.GetIndexParameters().Length != 0) continue;
+            object? v;
+            try { v = p.GetValue(value); } catch { continue; }
+            if (FindInContainer(v, child, depth + 1) is { } deeper) return deeper;
+        }
+        return null;
+    }
+
+    /// <summary>Detach the child in <paramref name="slot"/> from its parent — clear the property for a singular
+    /// slot, drop the element for a collection one. Returns null on success, else why it could not, so the caller
+    /// refuses with nothing written rather than serializing a file it cannot account for.</summary>
+    public static string? Detach(OwnedChildSlot slot)
+    {
+        try
+        {
+            if (slot.Shape == OwnedChildShape.Singular)
+            {
+                if (!slot.Property.CanWrite)
+                    return $"'{slot.Describe()}' holds {slot.Child.FormKey} but is not settable, so the child cannot " +
+                           "be detached from its parent — surfaced, not swallowed (Q3).";
+                slot.Property.SetValue(slot.Parent, null);
+                return null;
+            }
+            if (slot.Container is null)
+                return $"'{slot.Describe()}' holds {slot.Child.FormKey} in no list this engine can drop it from — " +
+                       "surfaced, not swallowed (Q3).";
+            slot.Container.Remove(slot.Child);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return $"detaching {slot.Child.FormKey} from '{slot.Describe()}' threw ({ex.GetType().Name}: " +
+                   $"{ex.Message}) — surfaced, not swallowed (Q3).";
+        }
+    }
+}

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1268,14 +1268,24 @@ public static class WriteEngine
     /// the model, not a hand-coded per-family list. Every false (no such containment, an ambiguous unnamed target, an
     /// unknown collection name) names what it checked.</summary>
     public static bool CanCreateNested(string childCatalogName, Type parentType, string? collectionName, out string? reason)
+        => TryResolveChildSlot(childCatalogName, parentType, collectionName, out _, out _, out reason);
+
+    /// <summary>The same question <see cref="CanCreateNested"/> asks, answering with WHICH slot resolved and what
+    /// SHAPE it has. Pre-flight needs both: a singular slot holds exactly one child, so whether the parent's real
+    /// body already fills it is knowable before anything is allocated.</summary>
+    public static bool TryResolveChildSlot(string childCatalogName, Type parentType, string? collectionName,
+        out string? slotName, out OwnedChildShape shape, out string? reason)
     {
+        slotName = null; shape = OwnedChildShape.None;
         var childType = ResolveConcreteRecordType(childCatalogName);
         if (childType is null)
         {
             reason = $"'{childCatalogName}' is absent from the Mutagen corpus — a real coverage gap to surface, not a value to guess.";
             return false;
         }
-        return TryFindNestedCollection(parentType, childType, collectionName, out _, out _, out reason);
+        if (!TryFindChildSlot(parentType, childType, collectionName, out var prop, out shape, out _, out reason)) return false;
+        slotName = prop!.Name;
+        return true;
     }
 
     /// <summary>Find the parent type's SETTABLE child-collection to allocate a <paramref name="childType"/> into — the
@@ -1330,13 +1340,20 @@ public static class WriteEngine
         }
         var parentName = parentType.Name;   // concrete class name, already clean (never an I…Getter here)
         var childName = childType.Name;
+        // A parent may ALSO file this child by COORDINATE, in a block tree no slot name reaches — the route
+        // AddExteriorCell serves. Derived by asking whether any child-bearing property reaches the child type
+        // through containers rather than holding it, so no record type is named and a Mutagen bump that nests
+        // another child that way is covered without an edit.
+        bool coordinateRoute = ReachesChildThroughContainers(parentType, childType);
         if (hits.Count == 0)
         {
             error = $"'{childName}' cannot be created under a '{parentName}' — that parent models no child slot that " +
                     "holds it (a real containment boundary, surfaced not guessed, Q3)." +
-                    (childType == typeof(Cell)
-                        ? " A Cell is coordinate-keyed, not collection-nested: create an EXTERIOR cell with parent=<Worldspace> + grid=<X,Y>, or an INTERIOR cell with no parent."
-                        : "");
+                    (coordinateRoute
+                        ? $" A {childName} is filed by coordinate under a {parentName}, not held in a slot: create it with parent=<{parentName}> + grid=<X,Y>."
+                        : childType == typeof(Cell)
+                            ? " A Cell is coordinate-keyed, not collection-nested: create an EXTERIOR cell with parent=<Worldspace> + grid=<X,Y>, or an INTERIOR cell with no parent."
+                            : "");
             return false;
         }
         if (collectionName is not null)
@@ -1344,40 +1361,55 @@ public static class WriteEngine
             var named = hits.Where(h => string.Equals(h.Prop.Name, collectionName, StringComparison.OrdinalIgnoreCase)).ToList();
             if (named.Count == 0)
             {
-                error = $"'{parentName}' has no child slot named '{collectionName}' that holds '{childName}'. Available: {string.Join(", ", matches)}.";
+                error = $"'{parentName}' has no child slot named '{collectionName}' that holds '{childName}'. Available: {string.Join(", ", matches)}"
+                      + (coordinateRoute ? " (or grid=<X,Y>, which files it by coordinate rather than in a slot)" : "") + ".";
                 return false;
             }
             (prop, shape) = named[0]; return true;
         }
-        // A CELL under a parent that also files cells by COORDINATE is ambiguous even at one hit, and the two
-        // routes are not interchangeable: a worldspace's TopCell is one record, its exterior cells are a block
-        // tree keyed by grid. Resolving the single slot silently would build the wrong one for the far commoner
-        // request (an exterior cell whose grid= was forgotten), so it is named rather than guessed — the same Q3
-        // rule the several-hits arm below applies, on a route the reflected slot set cannot see.
-        if (childType == typeof(Cell) && hits.Count == 1 && HasCoordinateKeyedCells(parentType))
+        // More than one route and no discriminator: name them all and refuse. The coordinate route counts as a
+        // route even when exactly one slot matches — a worldspace's TopCell is one record and its exterior cells
+        // are a grid-keyed block tree, so resolving the single slot silently would build the wrong thing for the
+        // far commoner request (an exterior cell whose grid= was forgotten). Q3, never a silent default.
+        if (hits.Count > 1 || coordinateRoute)
         {
-            error = $"'{childName}' can go under a '{parentName}' two different ways — as its single " +
-                    $"'{hits[0].Prop.Name}', or as an EXTERIOR cell in its block tree. Name which one: " +
-                    $"collection={hits[0].Prop.Name} for the single one, or grid=<X,Y> for an exterior cell. " +
-                    "(Q3 — never a silent default.)";
-            return false;
-        }
-        if (hits.Count > 1)
-        {
-            error = $"'{childName}' can be added to more than one child slot on '{parentName}' ({string.Join(", ", matches)}) — " +
-                    "name which one (the collection= discriminator). (Q3 — never a silent default.)";
+            var routes = matches.Select(m => $"collection={m}").ToList();
+            if (coordinateRoute) routes.Add("grid=<X,Y> for one filed by coordinate in its block tree");
+            error = $"'{childName}' can go under a '{parentName}' more than one way ({string.Join(", ", routes)}) — " +
+                    "name which one. (Q3 — never a silent default.)";
             return false;
         }
         (prop, shape) = hits[0]; return true;
     }
 
-    /// <summary>Does this parent file CELLS by coordinate, in a block tree the slot resolver cannot see? True when a
-    /// child-bearing property reaches a Cell through containers rather than holding one directly — the shape
-    /// <see cref="AddExteriorCell"/> serves. Derived from the same reflected child-bearing set as everything else,
-    /// so it is a question about the model rather than a named type.</summary>
-    static bool HasCoordinateKeyedCells(Type parentType) =>
+    /// <summary>Does this parent reach <paramref name="childType"/> through CONTAINERS rather than in a slot a
+    /// caller can name — the coordinate-keyed block tree <see cref="AddExteriorCell"/> serves? Asked of the same
+    /// reflected child-bearing set as everything else, so it is a question about the model and names no record
+    /// type. The walk stops at any record type: a child under a child belongs to that child, not to this parent.</summary>
+    static bool ReachesChildThroughContainers(Type parentType, Type childType) =>
         ChildBearingProperties(parentType).Any(p =>
-            ListElementType(p.PropertyType) is { } e && !typeof(IMajorRecordGetter).IsAssignableFrom(e));
+            !typeof(IMajorRecordGetter).IsAssignableFrom(p.PropertyType)      // a singular slot, not a container route
+            && ReachesRecordType(p.PropertyType, childType, new HashSet<Type>(), 0)
+            && !(ListElementType(p.PropertyType) is { } e && e.IsAssignableFrom(childType)));   // a nameable list slot
+
+    /// <summary>Can a value of <paramref name="t"/> hold a <paramref name="childType"/> record? The same walk and
+    /// bound as <see cref="ReachesOwnedRecord"/>, asked of ONE target type: links are cut, and a record type that
+    /// is not the target ends the branch rather than being descended into.</summary>
+    static bool ReachesRecordType(Type t, Type childType, HashSet<Type> seen, int depth)
+    {
+        if (depth > 6 || !seen.Add(t)) return false;
+        try
+        {
+            if (typeof(IFormLinkGetter).IsAssignableFrom(t)) return false;
+            if (typeof(IMajorRecordGetter).IsAssignableFrom(t)) return t.IsAssignableFrom(childType);
+            if (ElementTypeOf(t) is { } elem) return ReachesRecordType(elem, childType, seen, depth + 1);
+            if (!t.IsClass || t.Namespace?.StartsWith("Mutagen", StringComparison.Ordinal) != true) return false;
+            foreach (var p in t.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                if (ReachesRecordType(p.PropertyType, childType, seen, depth + 1)) return true;
+            return false;
+        }
+        finally { seen.Remove(t); }
+    }
 
     /// <summary>The element type of an <c>IList&lt;T&gt;</c>/<c>ExtendedList&lt;T&gt;</c>-shaped property, else null
     /// (a scalar, a string, a read-only sequence). Used to match a parent's child-collections to a child type.</summary>
@@ -1432,7 +1464,9 @@ public static class WriteEngine
         // A SINGULAR slot holds exactly one child, so an occupied one is not something create can resolve: appending
         // is not available and overwriting would drop the record already there — with its own FormKey, and
         // everything under it — as a side effect of a call that said "create". Refuse and name both real moves.
-        // Checked BEFORE anything is allocated, so a refusal costs no FormKey.
+        // Checked BEFORE anything is allocated, so a refusal costs no FormKey. This is the BACKSTOP: the pre-flight
+        // asks the same question of the parent's real body (WritePatchBuilder), which is the copy the caller is
+        // looking at; this one asks the copy about to be written, and catches a difference between the two.
         if (shape == OwnedChildShape.Singular && prop!.GetValue(parentInPatch) is IMajorRecordGetter occupant)
             throw new InvalidOperationException(
                 $"nested create: '{parentName}.{prop.Name}' already holds a {childType.Name} ({occupant.FormKey}" +

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1464,6 +1464,12 @@ public static class WriteEngine
                 "room to create another. Edit the one that is there by its own FormID, or remove it first with " +
                 ToolNames.Remove + " and create again.");
 
+        // A SINGULAR slot does not upsert either, and the record it holds can also be reachable by another route
+        // into the same patch — a worldspace's TopCell is a Cell, the identity the coordinate routes build — so the
+        // slot route runs their dedup rather than letting a second record at the same editorid in behind it. The
+        // COLLECTION route keeps its documented append: those children carry no stable editorid handle.
+        if (shape == OwnedChildShape.Singular) EnsureNoDuplicateEditorId(patchMod, childType, editorId);
+
         EnsureFormIdFloor(patchMod);   // a rehydrated (into=) counter below 0x800 would hand out engine-reserved IDs
         EnsureAllocatable(patchMod);
         var child = ConstructRecord(childType, AllocateNextFormKey(patchMod));
@@ -1503,7 +1509,7 @@ public static class WriteEngine
     public static Cell AddExteriorCell(SkyrimMod patchMod, Worldspace worldspaceInPatch, int gridX, int gridY, string? editorId)
     {
         // Floor + dedup BEFORE mutating the block tree — nothing is mutated before validation.
-        EnsureNoDuplicateCellEditorId(patchMod, editorId);   // no silent duplicate on an into= re-run (cells have a stable EditorID)
+        EnsureNoDuplicateEditorId(patchMod, typeof(Cell), editorId);   // no silent duplicate on an into= re-run (cells have a stable EditorID)
         EnsureFormIdFloor(patchMod);   // 0x800 floor, exactly like flat/nested create
         EnsureAllocatable(patchMod);
         int bx = FloorDiv(gridX, 32), by = FloorDiv(gridY, 32), sx = FloorDiv(gridX, 8), sy = FloorDiv(gridY, 8);
@@ -1532,7 +1538,7 @@ public static class WriteEngine
     /// <see cref="ApplyVerb"/> path).</summary>
     public static Cell AddInteriorCell(SkyrimMod patchMod, string? editorId)
     {
-        EnsureNoDuplicateCellEditorId(patchMod, editorId);   // no silent duplicate on an into= re-run (cells have a stable EditorID)
+        EnsureNoDuplicateEditorId(patchMod, typeof(Cell), editorId);   // no silent duplicate on an into= re-run (cells have a stable EditorID)
         EnsureFormIdFloor(patchMod);
         EnsureAllocatable(patchMod);
         var fk = AllocateNextFormKey(patchMod);
@@ -1549,20 +1555,22 @@ public static class WriteEngine
         return cell;
     }
 
-    /// <summary>Refuse loud if <paramref name="patchMod"/> ALREADY defines a cell with <paramref name="editorId"/>.
-    /// Coordinate-keyed cell create does NOT upsert (unlike flat <see cref="GenericUpsertNew"/>), so an into= re-run would
-    /// otherwise silently APPEND a second cell at the same identity — and a cell DOES carry a stable EditorID, so
-    /// WritePatchBuilder's "no stable handle to de-dup on" carve-out for nested children does not transfer to cells.
-    /// A no-op on a fresh patch. Within a single bulk_create, same-editorid specs are already caught by the pre-flight's
-    /// per-call editorid set; this closes the cross-call into= gap.</summary>
-    static void EnsureNoDuplicateCellEditorId(SkyrimMod patchMod, string? editorId)
+    /// <summary>Refuse loud if <paramref name="patchMod"/> ALREADY carries a <paramref name="recordType"/> record with
+    /// <paramref name="editorId"/>. Coordinate-keyed and singular-slot create do NOT upsert (unlike flat
+    /// <see cref="GenericUpsertNew"/>), so an into= re-run would otherwise silently carry a second record at the same
+    /// identity — and a cell reached through a worldspace's TopCell slot is the same identity the coordinate routes
+    /// build, so the two routes have to ask the same question. A no-op on a fresh patch. Within a single bulk_create,
+    /// same-editorid specs are already caught by the pre-flight's per-call editorid set; this closes the cross-call
+    /// into= gap.</summary>
+    static void EnsureNoDuplicateEditorId(SkyrimMod patchMod, Type recordType, string? editorId)
     {
         if (string.IsNullOrEmpty(editorId)) return;
-        foreach (var existing in patchMod.EnumerateMajorRecords<ICellGetter>())
-            if (string.Equals(existing.EditorID, editorId, StringComparison.Ordinal))
+        foreach (var existing in patchMod.EnumerateMajorRecords())
+            if (recordType.IsInstanceOfType(existing) && string.Equals(existing.EditorID, editorId, StringComparison.Ordinal))
                 throw new InvalidOperationException(
-                    $"a cell with editorid '{editorId}' already exists in this patch ({existing.FormKey}); creating it again " +
-                    "would duplicate it. Cell create does not upsert — edit the existing cell, or use a different editorid.");
+                    $"a {recordType.Name} with editorid '{editorId}' already exists in this patch ({existing.FormKey}); creating " +
+                    $"it again would duplicate it. {recordType.Name} create does not upsert here — edit the existing record, or " +
+                    "use a different editorid.");
     }
 
     static MethodInfo? _overrideMethod;

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1253,7 +1253,7 @@ public static class WriteEngine
     //  selector. The parent must already be settable IN the patch (the caller overrides
     //  or creates it first). Coordinate-keyed parents (an exterior Cell under the
     //  FormKey-LESS WorldspaceBlock/SubBlock structs) are not reachable here —
-    //  TryFindNestedCollection fails loud for them; see the coordinate-keyed create below.
+    //  TryFindChildSlot fails loud for them; see the coordinate-keyed create below.
     // ======================================================================
 
     /// <summary>Resolve a catalog/record-type name to its concrete Mutagen record <see cref="Type"/>. The namespace
@@ -1287,16 +1287,6 @@ public static class WriteEngine
         slotName = prop!.Name;
         return true;
     }
-
-    /// <summary>Find the parent type's SETTABLE child-collection to allocate a <paramref name="childType"/> into — the
-    /// generic add-target resolver. Reflects the parent's list/ExtendedList properties whose element type the child
-    /// satisfies. Outcomes: exactly one match ⇒ derivable by type, returned; several ⇒ the caller must NAME one
-    /// (<paramref name="collectionName"/> picks it); zero ⇒ the child cannot nest under this parent (a real
-    /// containment boundary). <paramref name="error"/> names the unnamed-ambiguous / no-containment / bad-name cases;
-    /// null on success.</summary>
-    static bool TryFindNestedCollection(Type parentType, Type childType, string? collectionName,
-        out PropertyInfo? prop, out List<string> matches, out string? error)
-        => TryFindChildSlot(parentType, childType, collectionName, out prop, out _, out matches, out error);
 
     /// <summary>Find the parent's SETTABLE child slot to put a new <paramref name="childType"/> into — the generic
     /// add-target resolver, over BOTH shapes the model has. A COLLECTION slot is a list property whose element type
@@ -1450,7 +1440,7 @@ public static class WriteEngine
     /// root fed into the SAME <see cref="ApplyVerb"/> path as a flat create or an override. The new record gets a fresh
     /// local 0x800+ FormKey from the SAME floor/counter as flat <see cref="GenericAddNew"/>. The parent MUST already be
     /// settable in the patch (overridden or created by the caller). Throws loud via
-    /// <see cref="TryFindNestedCollection"/> on a containment/ambiguity the pre-flight
+    /// <see cref="TryFindChildSlot"/> on a containment/ambiguity the pre-flight
     /// (<see cref="CanCreateNested"/>) should have caught — a throw here means the surface changed under us.</summary>
     public static IMajorRecord NestedAddNew(SkyrimMod patchMod, IMajorRecord parentInPatch,
         string childCatalogName, string? collectionName, string? editorId)

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1286,24 +1286,53 @@ public static class WriteEngine
     /// null on success.</summary>
     static bool TryFindNestedCollection(Type parentType, Type childType, string? collectionName,
         out PropertyInfo? prop, out List<string> matches, out string? error)
+        => TryFindChildSlot(parentType, childType, collectionName, out prop, out _, out matches, out error);
+
+    /// <summary>Find the parent's SETTABLE child slot to put a new <paramref name="childType"/> into — the generic
+    /// add-target resolver, over BOTH shapes the model has. A COLLECTION slot is a list property whose element type
+    /// the child satisfies (a cell's Persistent, a topic's Responses); a SINGULAR slot is a property that IS one
+    /// child record (a cell's Landscape, a worldspace's TopCell). Both are slots a caller names with
+    /// <c>collection=</c>; the shape only decides how the child is attached, which is
+    /// <see cref="NestedAddNew"/>'s job, not the caller's.
+    ///
+    /// <para>The singular half is why a parent that carries no child could not be given one: the old resolver
+    /// filtered to <c>IList</c>-shaped properties before it ever asked about the child type, so a slot holding
+    /// exactly one record was invisible to create while being perfectly visible to every other part of the engine.
+    /// Both halves are found by REFLECTION over the concrete parent class, so "what can nest under what" stays
+    /// defined by Mutagen's model and no record type is named here.</para>
+    ///
+    /// <para>Outcomes are unchanged: exactly one match ⇒ derivable, returned; several ⇒ the caller must NAME one;
+    /// zero ⇒ a real containment boundary. <paramref name="shape"/> reports which half matched.</para></summary>
+    static bool TryFindChildSlot(Type parentType, Type childType, string? collectionName,
+        out PropertyInfo? prop, out OwnedChildShape shape, out List<string> matches, out string? error)
     {
-        prop = null; error = null;
+        prop = null; error = null; shape = OwnedChildShape.None;
         matches = new List<string>();
-        var hits = new List<PropertyInfo>();
+        var hits = new List<(PropertyInfo Prop, OwnedChildShape Shape)>();
         foreach (var p in parentType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
         {
             if (p.GetGetMethod() is null) continue;                          // need a readable list instance to Add to
             var elem = ListElementType(p.PropertyType);
-            if (elem is null) continue;
-            if (!elem.IsAssignableFrom(childType)) continue;                 // the child fits this list's element type
-            if (!typeof(System.Collections.IList).IsAssignableFrom(p.PropertyType)) continue;  // addable (ExtendedList<T> is an IList)
-            hits.Add(p); matches.Add(p.Name);
+            if (elem is not null)
+            {
+                if (!elem.IsAssignableFrom(childType)) continue;             // the child fits this list's element type
+                if (!typeof(System.Collections.IList).IsAssignableFrom(p.PropertyType)) continue;  // addable (ExtendedList<T> is an IList)
+                hits.Add((p, OwnedChildShape.Collection)); matches.Add(p.Name);
+                continue;
+            }
+            // The SINGULAR half: a settable property that holds one owned child record of a type the child
+            // satisfies. Settability is required for the same reason the list half requires addability — an
+            // unsettable slot cannot receive the record — and it is what keeps a read-only getter off the list.
+            if (!p.CanWrite || p.GetIndexParameters().Length != 0) continue;
+            if (!typeof(IMajorRecordGetter).IsAssignableFrom(p.PropertyType)) continue;
+            if (!p.PropertyType.IsAssignableFrom(childType)) continue;
+            hits.Add((p, OwnedChildShape.Singular)); matches.Add(p.Name);
         }
         var parentName = parentType.Name;   // concrete class name, already clean (never an I…Getter here)
         var childName = childType.Name;
         if (hits.Count == 0)
         {
-            error = $"'{childName}' cannot be created under a '{parentName}' — that parent models no child-collection that " +
+            error = $"'{childName}' cannot be created under a '{parentName}' — that parent models no child slot that " +
                     "holds it (a real containment boundary, surfaced not guessed, Q3)." +
                     (childType == typeof(Cell)
                         ? " A Cell is coordinate-keyed, not collection-nested: create an EXTERIOR cell with parent=<Worldspace> + grid=<X,Y>, or an INTERIOR cell with no parent."
@@ -1312,22 +1341,43 @@ public static class WriteEngine
         }
         if (collectionName is not null)
         {
-            var named = hits.FirstOrDefault(h => string.Equals(h.Name, collectionName, StringComparison.OrdinalIgnoreCase));
-            if (named is null)
+            var named = hits.Where(h => string.Equals(h.Prop.Name, collectionName, StringComparison.OrdinalIgnoreCase)).ToList();
+            if (named.Count == 0)
             {
-                error = $"'{parentName}' has no child-collection named '{collectionName}' that holds '{childName}'. Available: {string.Join(", ", matches)}.";
+                error = $"'{parentName}' has no child slot named '{collectionName}' that holds '{childName}'. Available: {string.Join(", ", matches)}.";
                 return false;
             }
-            prop = named; return true;
+            (prop, shape) = named[0]; return true;
+        }
+        // A CELL under a parent that also files cells by COORDINATE is ambiguous even at one hit, and the two
+        // routes are not interchangeable: a worldspace's TopCell is one record, its exterior cells are a block
+        // tree keyed by grid. Resolving the single slot silently would build the wrong one for the far commoner
+        // request (an exterior cell whose grid= was forgotten), so it is named rather than guessed — the same Q3
+        // rule the several-hits arm below applies, on a route the reflected slot set cannot see.
+        if (childType == typeof(Cell) && hits.Count == 1 && HasCoordinateKeyedCells(parentType))
+        {
+            error = $"'{childName}' can go under a '{parentName}' two different ways — as its single " +
+                    $"'{hits[0].Prop.Name}', or as an EXTERIOR cell in its block tree. Name which one: " +
+                    $"collection={hits[0].Prop.Name} for the single one, or grid=<X,Y> for an exterior cell. " +
+                    "(Q3 — never a silent default.)";
+            return false;
         }
         if (hits.Count > 1)
         {
-            error = $"'{childName}' can be added to more than one collection on '{parentName}' ({string.Join(", ", matches)}) — " +
+            error = $"'{childName}' can be added to more than one child slot on '{parentName}' ({string.Join(", ", matches)}) — " +
                     "name which one (the collection= discriminator). (Q3 — never a silent default.)";
             return false;
         }
-        prop = hits[0]; return true;
+        (prop, shape) = hits[0]; return true;
     }
+
+    /// <summary>Does this parent file CELLS by coordinate, in a block tree the slot resolver cannot see? True when a
+    /// child-bearing property reaches a Cell through containers rather than holding one directly — the shape
+    /// <see cref="AddExteriorCell"/> serves. Derived from the same reflected child-bearing set as everything else,
+    /// so it is a question about the model rather than a named type.</summary>
+    static bool HasCoordinateKeyedCells(Type parentType) =>
+        ChildBearingProperties(parentType).Any(p =>
+            ListElementType(p.PropertyType) is { } e && !typeof(IMajorRecordGetter).IsAssignableFrom(e));
 
     /// <summary>The element type of an <c>IList&lt;T&gt;</c>/<c>ExtendedList&lt;T&gt;</c>-shaped property, else null
     /// (a scalar, a string, a read-only sequence). Used to match a parent's child-collections to a child type.</summary>
@@ -1375,15 +1425,28 @@ public static class WriteEngine
     {
         var childType = ResolveConcreteRecordType(childCatalogName)
             ?? throw new InvalidOperationException($"nested create: '{childCatalogName}' is absent from the Mutagen corpus.");
-        if (!TryFindNestedCollection(parentInPatch.GetType(), childType, collectionName, out var prop, out _, out var error))
+        if (!TryFindChildSlot(parentInPatch.GetType(), childType, collectionName, out var prop, out var shape, out _, out var error))
             throw new InvalidOperationException(error);
-        if (prop!.GetValue(parentInPatch) is not System.Collections.IList list)
-            throw new InvalidOperationException($"nested create: collection '{prop.Name}' on '{parentInPatch.GetType().Name}' is not an addable list.");
+        var parentName = parentInPatch.GetType().Name;
+
+        // A SINGULAR slot holds exactly one child, so an occupied one is not something create can resolve: appending
+        // is not available and overwriting would drop the record already there — with its own FormKey, and
+        // everything under it — as a side effect of a call that said "create". Refuse and name both real moves.
+        // Checked BEFORE anything is allocated, so a refusal costs no FormKey.
+        if (shape == OwnedChildShape.Singular && prop!.GetValue(parentInPatch) is IMajorRecordGetter occupant)
+            throw new InvalidOperationException(
+                $"nested create: '{parentName}.{prop.Name}' already holds a {childType.Name} ({occupant.FormKey}" +
+                (occupant.EditorID is { } oe ? $" editorid={oe}" : "") + ") and it holds exactly one, so there is no " +
+                "room to create another. Edit the one that is there by its own FormID, or remove it first with " +
+                ToolNames.Remove + " and create again.");
 
         EnsureFormIdFloor(patchMod);   // a rehydrated (into=) counter below 0x800 would hand out engine-reserved IDs
         EnsureAllocatable(patchMod);
         var child = ConstructRecord(childType, AllocateNextFormKey(patchMod));
         if (editorId is not null) child.EditorID = editorId;
+        if (shape == OwnedChildShape.Singular) { prop!.SetValue(parentInPatch, child); return child; }
+        if (prop!.GetValue(parentInPatch) is not System.Collections.IList list)
+            throw new InvalidOperationException($"nested create: collection '{prop.Name}' on '{parentName}' is not an addable list.");
         list.Add(child);
         return child;
     }
@@ -2733,10 +2796,11 @@ public static class WriteEngine
             throw new ExpectedApplyRejectionException(
                 $"'{segment}' holds an owned child RECORD ({Pretty(prop.PropertyType)}) and the record being written " +
                 "carries none, so there is nothing to write into. houseCARL will not synthesize a record as a " +
-                "sub-object — a record exists only with its own FormKey, and giving a parent a child it lacks is an " +
-                "open gap (#350). Address the child record by its own FormID instead. If the version you are patching " +
-                "does carry one, note that a patch's fresh override of a parent does not bring the parent's child " +
-                "records with it — the record axis reaches it, this path does not.");
+                "sub-object — a record exists only with its own FormKey. To give the parent a child it lacks, create " +
+                "one on the record axis: " + ToolNames.Create + $" with parent= the parent's FormID and " +
+                $"collection='{segment}' in its records= element. Address an existing child by its own FormID " +
+                "instead. If the version you are patching does carry one, note that a patch's fresh override of a " +
+                "parent does not bring the parent's child records with it — the record axis reaches it, this path does not.");
         object made;
         try { made = Instantiate(prop.PropertyType, null); }
         catch (CompositionRequiredException) { throw new CompositionRequiredException(segment, prop.PropertyType); }  // re-stamp with the path segment

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -1294,6 +1294,8 @@ public static class WritePatchBuilder
                 $"present-check passed but Remove threw — a real engine inconsistency, surfaced not swallowed (Q3): "
                 + $"{ex.GetType().Name}: {ex.Message}");
         }
+        if (DetachOwnedChildren(patchMod, toRemove) is { } detachFailed)
+            return RemovalOutcome.Fail(detachFailed + $" '{fileName}' is UNTOUCHED.");
         if (RemoveSurvivors(patchMod, toRemove) is { } survived)
             return RemovalOutcome.Fail(survived + $" '{fileName}' is UNTOUCHED.");
 
@@ -1331,6 +1333,31 @@ public static class WritePatchBuilder
     /// effect and only the post-write verify catches it. Checking the mutable mod first keeps a no-op loud with the
     /// file UNTOUCHED. Null ⇒ all targets gone; else the refusal text (the caller appends its lane's file-untouched
     /// suffix).</summary>
+    /// <summary>Drop the targets the typed <c>Remove</c> could not reach, by DETACHING them from the parent slot
+    /// that holds them. Shared by both remove lanes, run between the typed remove and the survivor check.
+    ///
+    /// <para>Mutagen's typed <c>Remove(FormKey, Type)</c> routes by GROUP, and a singular owned child is in none: a
+    /// cell's <c>Landscape</c> and a worldspace's <c>TopCell</c> are properties on their parent, so the routing
+    /// finds nothing and returns without throwing. The record is reachable — the present-check enumerates it, which
+    /// is why the caller believes it is there — but only its parent can let go of it.</para>
+    ///
+    /// <para>Run over the SURVIVORS rather than over every target, so the typed remove stays the one path for
+    /// everything it does handle and this reaches only what it left behind. Null ⇒ nothing left to do, or it was
+    /// done; else the refusal, with the file still untouched.</para></summary>
+    static string? DetachOwnedChildren(SkyrimMod mod, IReadOnlyList<RemovedRecord> toRemove)
+    {
+        var stillHere = new HashSet<FormKey>(toRemove.Select(rr => rr.Target));
+        stillHere.IntersectWith(mod.EnumerateMajorRecords().Select(r => r.FormKey));
+        foreach (var fk in stillHere)
+        {
+            // Not found in a slot is NOT an error here: it means this survivor is something else, and the survivor
+            // check below is the one that refuses for it. Reporting it here would name the wrong cause.
+            if (!OwnedChildLifecycle.TryFindSlot(mod, fk, out var slot)) continue;
+            if (OwnedChildLifecycle.Detach(slot) is { } err) return err;
+        }
+        return null;
+    }
+
     static string? RemoveSurvivors(SkyrimMod mod, IReadOnlyList<RemovedRecord> toRemove)
     {
         var mustBeGone = toRemove.Select(rr => rr.Target).ToHashSet();
@@ -1455,6 +1482,8 @@ public static class WritePatchBuilder
                 $"present-check passed but Remove threw — a real engine inconsistency, surfaced not swallowed (Q3): "
                 + $"{ex.GetType().Name}: {ex.Message}");
         }
+        if (DetachOwnedChildren(targetMod, toRemove) is { } detachFailed)
+            return RemovalOutcome.Fail(detachFailed + $" Your original '{fileName}' is UNTOUCHED.");
         if (RemoveSurvivors(targetMod, toRemove) is { } survived)
             return RemovalOutcome.Fail(survived + $" Your original '{fileName}' is UNTOUCHED.");
 

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -1208,8 +1208,10 @@ public static class WritePatchBuilder
     /// override of it is dropped, so the load-order winner reverts by absence.
     ///
     /// <para>ONE call shape serves flat AND nested groups: Mutagen's <c>Remove(FormKey, Type, throwIfUnknown)</c>
-    /// reaches every group (incl. the nested Cell/Placed*/INFO/Navmesh/Landscape families) — no flat-vs-nested fork,
-    /// no parent-chain reconstruction. The bare <c>Remove(FormKey)</c> is [Obsolete]; use the typed overload.
+    /// reaches every group (incl. the nested Cell/Placed*/INFO families) — no flat-vs-nested fork, no parent-chain
+    /// reconstruction. It does NOT reach a SINGULAR owned child (a cell's Landscape, a worldspace's TopCell), which
+    /// is in no group at all and is detached from its parent slot instead — <see cref="DetachOwnedChildren"/>.
+    /// The bare <c>Remove(FormKey)</c> is [Obsolete]; use the typed overload.
     /// Clean-masters rides along for free: the serialize re-derives the header from the SURVIVING records' links, so a
     /// master orphaned by the removal drops automatically.</para>
     ///
@@ -1280,7 +1282,8 @@ public static class WritePatchBuilder
 
         // Literal drop-from-group (NOT flag-as-deleted). The typed overload Remove(FormKey, Type, throwIfUnknown) is
         // Mutagen's blessed path (the bare Remove(FormKey) is [Obsolete]) and reaches NESTED records
-        // (Cell/Placed*/INFO/Navmesh/Landscape) too, not just flat groups — so ONE call shape serves every record type.
+        // (Cell/Placed*/INFO) too, not just flat groups. A SINGULAR owned child is in no group and is not reached
+        // here (measured) — DetachOwnedChildren below is what drops one.
         // The runtime type captured in the present-check routes it straight to the right group; throwIfUnknown:true
         // keeps an unrecognized type loud, never a silent no-op. A throw here AFTER the present-check passed is a real
         // engine inconsistency — surfaced.
@@ -1328,12 +1331,6 @@ public static class WritePatchBuilder
         return new RemovalOutcome(true, null, outPath, toRemove, masters, remaining, bytes);
     }
 
-    /// <summary>IN-MEMORY absence verify run BEFORE any serialize, shared by both remove lanes: Mutagen's typed
-    /// <c>Remove</c> can no-op WITHOUT throwing, <c>throwIfUnknown:true</c> notwithstanding (a concrete subclass of an
-    /// abstract group's T does it), so trusting the void return and serializing anyway rewrites the whole file to no
-    /// effect and only the post-write verify catches it. Checking the mutable mod first keeps a no-op loud with the
-    /// file UNTOUCHED. Null ⇒ all targets gone; else the refusal text (the caller appends its lane's file-untouched
-    /// suffix).</summary>
     /// <summary>Drop the targets the typed <c>Remove</c> could not reach, by DETACHING them from the parent slot
     /// that holds them. Shared by both remove lanes, run between the typed remove and the survivor check.
     ///
@@ -1344,21 +1341,40 @@ public static class WritePatchBuilder
     ///
     /// <para>Run over the SURVIVORS rather than over every target, so the typed remove stays the one path for
     /// everything it does handle and this reaches only what it left behind. Null ⇒ nothing left to do, or it was
-    /// done; else the refusal, with the file still untouched.</para></summary>
+    /// done; else the refusal, with the file still untouched.</para>
+    ///
+    /// <para>A detached child takes everything under it, so a child that still carries records the caller did NOT
+    /// name is refused rather than dropped: the removal report accounts for the records the caller named, and
+    /// deleting more than that is the very hazard the field-lane refusal cites when it sends the caller here. Name
+    /// them in the same call and every one of them is reported.</para></summary>
     static string? DetachOwnedChildren(SkyrimMod mod, IReadOnlyList<RemovedRecord> toRemove)
     {
-        var stillHere = new HashSet<FormKey>(toRemove.Select(rr => rr.Target));
+        var named = new HashSet<FormKey>(toRemove.Select(rr => rr.Target));
+        var stillHere = new HashSet<FormKey>(named);
         stillHere.IntersectWith(mod.EnumerateMajorRecords().Select(r => r.FormKey));
         foreach (var fk in stillHere)
         {
             // Not found in a slot is NOT an error here: it means this survivor is something else, and the survivor
             // check below is the one that refuses for it. Reporting it here would name the wrong cause.
             if (!OwnedChildLifecycle.TryFindSlot(mod, fk, out var slot)) continue;
+            var unnamed = OwnedChildLifecycle.DescendantsOf(slot.Child).Where(d => !named.Contains(d.FormKey)).ToList();
+            if (unnamed.Count > 0)
+                return $"removing {fk} means detaching it from '{slot.Describe()}', which takes the "
+                     + $"{unnamed.Count} record(s) under it with it — and you named none of them: "
+                     + string.Join(", ", unnamed.Take(5).Select(d => $"{d.FormKey}{(d.EditorID is { } e ? $" ({e})" : "")}"))
+                     + (unnamed.Count > 5 ? $", and {unnamed.Count - 5} more" : "")
+                     + ". Name them in the same call so the removal reports every record it drops, or leave this one.";
             if (OwnedChildLifecycle.Detach(slot) is { } err) return err;
         }
         return null;
     }
 
+    /// <summary>IN-MEMORY absence verify run BEFORE any serialize, shared by both remove lanes: Mutagen's typed
+    /// <c>Remove</c> can no-op WITHOUT throwing, <c>throwIfUnknown:true</c> notwithstanding (a concrete subclass of an
+    /// abstract group's T does it), so trusting the void return and serializing anyway rewrites the whole file to no
+    /// effect and only the post-write verify catches it. Checking the mutable mod first keeps a no-op loud with the
+    /// file UNTOUCHED. Null ⇒ all targets gone; else the refusal text (the caller appends its lane's file-untouched
+    /// suffix).</summary>
     static string? RemoveSurvivors(SkyrimMod mod, IReadOnlyList<RemovedRecord> toRemove)
     {
         var mustBeGone = toRemove.Select(rr => rr.Target).ToHashSet();
@@ -1470,7 +1486,8 @@ public static class WritePatchBuilder
                 + string.Join("\n  - ", problems));
 
         // --- Phase 4: literal drop-from-group (NOT flag-as-deleted), the typed overload that reaches nested groups
-        //     (Cell/Placed*/INFO/Navmesh/Landscape) too. throwIfUnknown:true keeps an unrecognized type loud. A throw
+        //     (Cell/Placed*/INFO) too — but not a singular owned child, which DetachOwnedChildren below drops by
+        //     clearing its parent's slot. throwIfUnknown:true keeps an unrecognized type loud. A throw
         //     AFTER the present-check passed is a real engine inconsistency — surfaced, not swallowed. ---
         try
         {

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -218,9 +218,10 @@ public static class WritePatchBuilder
         /// record.</summary>
         public string? ParentRef { get; init; }
 
-        /// <summary>Optional — which of the parent's child-collections to add into, BY NAME (e.g. a Cell's
-        /// <c>Persistent</c>/<c>Temporary</c>). Null ⇒ the unique collection that accepts this child type (e.g. a
-        /// DialogTopic's one <c>Responses</c> list). Ignored when <see cref="ParentRef"/> is null.</summary>
+        /// <summary>Optional — which of the parent's child SLOTS to add into, BY NAME: a child list (a Cell's
+        /// <c>Persistent</c>/<c>Temporary</c>) or a single-child slot (a Cell's <c>Landscape</c>, a Worldspace's
+        /// <c>TopCell</c>). Null ⇒ the unique slot that accepts this child type (e.g. a DialogTopic's one
+        /// <c>Responses</c> list). Ignored when <see cref="ParentRef"/> is null.</summary>
         public string? IntoCollection { get; init; }
 
         /// <summary>Optional — the exterior-cell GRID as "X,Y". Set on a <c>Cell</c> create, it places the new cell
@@ -2838,6 +2839,7 @@ public static class WritePatchBuilder
             return carried.TryGetValue(fk, out var rec) ? rec : null;
         }
         var cellKinds = new CellCreate[specs.Count];   // cell-create routing per spec (None / Exterior / Interior)
+        var singularClaims = new HashSet<(string Parent, string Slot)>();   // one create per singular slot per call
         for (int i = 0; i < specs.Count; i++)
         {
             var s = specs[i];
@@ -2966,17 +2968,38 @@ public static class WritePatchBuilder
                     parentPlans[i] = (null, null, s.ParentRef, null);
                 }
                 if (parentType is null) { problems.Add($"{s.RecordType} '{s.EditorId}': could not resolve the parent's record type."); continue; }
-                if (IsCellType(s.RecordType))
+                // A Cell under a parent has TWO routes and they build different things: grid= files it by coordinate
+                // in a Worldspace's block tree, collection= puts it in a named slot (a Worldspace's single TopCell).
+                // Only the grid route bypasses the slot resolver; everything else — a named slot, or neither, which
+                // is the resolver's own "name which one" — goes through it like any other child.
+                if (IsCellType(s.RecordType) && s.Grid is not null)
                 {
-                    // A Cell WITH a parent: a grid ⇒ an EXTERIOR cell placed into the Worldspace's block tree (NOT a
-                    // child-collection nest). No grid ⇒ ambiguous — refuse loud.
-                    // (Parent resolution above already populated parentPlans[i] so Phase 3 can make the Worldspace settable.)
-                    if (s.Grid is null) { problems.Add($"Cell '{s.EditorId}': a Cell with parent= but no grid= is ambiguous — an exterior cell needs grid=<X,Y> under a Worldspace; an interior cell takes no parent."); continue; }
+                    if (s.IntoCollection is not null) { problems.Add($"Cell '{s.EditorId}': grid= and collection= are the two different routes a cell goes under a parent — name one, not both."); continue; }
                     if (parentType != typeof(Worldspace)) { problems.Add($"Cell '{s.EditorId}': an exterior cell nests under a Worldspace, but parent '{s.ParentRef}' resolved to a {parentType.Name}."); continue; }
                     if (!TryParseGrid(s.Grid, out _, out _)) { problems.Add($"Cell '{s.EditorId}': grid '{s.Grid}' must be two integers \"X,Y\" (e.g. \"5,-12\")."); continue; }
                     cellKinds[i] = CellCreate.Exterior;
                 }
-                else if (!WriteEngine.CanCreateNested(s.RecordType, parentType, s.IntoCollection, out var nestedWhy)) { problems.Add($"{s.RecordType} '{s.EditorId}': {nestedWhy}"); continue; }
+                else if (!WriteEngine.TryResolveChildSlot(s.RecordType, parentType, s.IntoCollection, out var slotName, out var slotShape, out var nestedWhy))
+                { problems.Add($"{s.RecordType} '{s.EditorId}': {nestedWhy}"); continue; }
+                // A SINGULAR slot holds exactly one child, so an occupied one is not something create can resolve —
+                // and occupancy is knowable HERE, from the parent body this call will host in, before a FormKey is
+                // allocated. Reading the patch's copy instead would answer for whatever the override carried, which
+                // on the into= lane is not the parent the caller is looking at.
+                else if (slotShape == OwnedChildShape.Singular)
+                {
+                    var body = parentPlans[i]!.Value.body ?? (IMajorRecordGetter?)parentPlans[i]!.Value.patchParent;
+                    if (body is not null && OwnedChildLifecycle.OccupantOf(body, slotName!) is { } occupant)
+                    {
+                        problems.Add($"{s.RecordType} '{s.EditorId}': '{parentType.Name}.{slotName}' already holds a {s.RecordType} ({occupant.FormKey}"
+                            + (occupant.EditorID is { } oe ? $" editorid={oe}" : "") + ") and it holds exactly one, so there is no room to create another. "
+                            + "Edit the one that is there by its own FormID, or remove it first and create again.");
+                        continue;
+                    }
+                    // Two specs claiming the same singular slot in one call is the same collision, one call earlier:
+                    // the first would fill it and the second would find it occupied at Phase 3, after allocation.
+                    if (!singularClaims.Add((s.ParentRef!, slotName!)))
+                    { problems.Add($"{s.RecordType} '{s.EditorId}': two records in this call are created into '{parentType.Name}.{slotName}' on parent '{s.ParentRef}', which holds exactly one."); continue; }
+                }
             }
 
             foreach (var req in s.Edits)

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -2849,6 +2849,12 @@ public static class WritePatchBuilder
             if (parentBodies.TryGetValue((plugin, fk), out var hit)) return hit;
             return parentBodies[(plugin, fk)] = view.GetRecord(session, plugin, fk);
         }
+        // The parent's real body in the LOAD ORDER — its definer's copy, else its winner's. Asked when the
+        // destination already carries the parent, because that copy is an override and carries none of the
+        // parent's children. Rides the same memo as every other parent-body read.
+        IMajorRecordGetter? OrderBodyOf(FormKey fk)
+            => ParentBodyFrom(fk.ModKey.FileName.String, fk)
+               ?? (view.ResolveWinner(fk) is { } ow ? ParentBodyFrom(ow.WinnerPlugin, fk) : null);
         Dictionary<FormKey, IMajorRecord>? carried = null;
         IMajorRecord? AlreadyCarried(FormKey fk)
         {
@@ -2999,13 +3005,20 @@ public static class WritePatchBuilder
                 else if (!WriteEngine.TryResolveChildSlot(s.RecordType, parentType, s.IntoCollection, out var slotName, out var slotShape, out var nestedWhy))
                 { problems.Add($"{s.RecordType} '{s.EditorId}': {nestedWhy}"); continue; }
                 // A SINGULAR slot holds exactly one child, so an occupied one is not something create can resolve —
-                // and occupancy is knowable HERE, from the parent body this call will host in, before a FormKey is
-                // allocated. Reading the patch's copy instead would answer for whatever the override carried, which
-                // on the into= lane is not the parent the caller is looking at.
+                // and occupancy is knowable HERE, from the parent bodies this call can see, before a FormKey is
+                // allocated.
                 else if (slotShape == OwnedChildShape.Singular)
                 {
-                    var body = parentPlans[i]!.Value.body ?? (IMajorRecordGetter?)parentPlans[i]!.Value.patchParent;
-                    if (body is not null && OwnedChildLifecycle.OccupantOf(body, slotName!) is { } occupant)
+                    // BOTH copies answer: the one the destination already carries, and the parent's real body in
+                    // the order. An override carries none of the parent's children, so on the into= and in-place
+                    // lanes the carried copy alone reads the slot free while the record the caller is looking at
+                    // declares a child — and creating there ships a second one under the same parent.
+                    var plan = parentPlans[i]!.Value;
+                    IMajorRecordGetter? Occupant(IMajorRecordGetter? b)
+                        => b is null ? null : OwnedChildLifecycle.OccupantOf(b, slotName!);
+                    var inOrder = plan.body
+                        ?? (plan.patchParent is not null && FormKey.TryFactory(s.ParentRef!, out var orderFk) ? OrderBodyOf(orderFk) : null);
+                    if ((Occupant(plan.patchParent) ?? Occupant(inOrder)) is { } occupant)
                     {
                         problems.Add($"{s.RecordType} '{s.EditorId}': '{parentType.Name}.{slotName}' already holds a {s.RecordType} ({occupant.FormKey}"
                             + (occupant.EditorID is { } oe ? $" editorid={oe}" : "") + ") and it holds exactly one, so there is no room to create another. "

--- a/src/housecarl-generator/NestedCreateProof.cs
+++ b/src/housecarl-generator/NestedCreateProof.cs
@@ -23,6 +23,8 @@ namespace HousecarlGenerator;
 ///   N12 — a Cell under a Worldspace with NEITHER route named → refused naming both (collection= and grid=).
 ///   N13 — DELETE a singular owned child: remove the N10 Landscape by its own FormID → re-open, the cell holds
 ///         none. Mutagen's typed remove reaches no singular owned child, so this is the detach path end to end.
+///   N14 — REJECT the same occupied slot on the into= lane, where the patch ALREADY carries the parent: that copy
+///         is an override and holds no terrain, so the order's body is what the refusal is decided from.
 ///   N3 — PlacedObject into an EXISTING Cell, collection='Persistent' (the named discriminator) →
 ///        re-open: the new ref is in the cell's Persistent list.
 ///   N4 — REJECT a nested type with NO parent: create 'DialogResponses' alone → refused, names the need for a parent.
@@ -238,6 +240,23 @@ public static class NestedCreateProof
             bool gone = File.Exists(n10Path) && CellLandscape(n10Path, landlessCellFk) is null;
             results.Add(("N13 singular child removed", removed && gone,
                 $"removed={YN(removed)} slot-empty-on-reopen={YN(gone)}" + (rem.Success ? "" : "  err=" + (rem.Error ?? "").Replace('\n', ' '))));
+        }
+
+        // ===================== N14 — REJECT an occupied singular slot on a parent the PATCH ALREADY CARRIES =====================
+        //   Call 1 puts a placed ref in the cell, so the patch carries the cell as a fresh override that holds no
+        //   terrain. Reading only that copy reads the slot free and ships a second LAND under a cell that has one.
+        {
+            var outPath = Path.Combine(outDir, "houseCARL_NestedCreate_N14.esp");
+            var s1 = WritePatchBuilder.CreateRecords(resolver, rulebook,
+                new[] { new WritePatchBuilder.CreateSpec { RecordType = "PlacedObject", EditorId = "HC_N14_Ref", ParentRef = terrainCellFk.ToString(), IntoCollection = "Persistent", Edits = Array.Empty<WriteRequest>() } },
+                outPath, extend: false);
+            var s2 = WritePatchBuilder.CreateRecords(resolver, rulebook,
+                new[] { new WritePatchBuilder.CreateSpec { RecordType = "Landscape", EditorId = "HC_N14_Land", ParentRef = terrainCellFk.ToString(), Edits = Array.Empty<WriteRequest>() } },
+                outPath, extend: true);
+            bool refused = !s2.Success && (s2.Error ?? "").Contains("already holds", StringComparison.OrdinalIgnoreCase);
+            bool noLand = File.Exists(outPath) && CellLandscape(outPath, terrainCellFk) is null;
+            results.Add(("N14 reject occupied slot, carried parent", s1.Success && refused && noLand,
+                $"call1-ok={YN(s1.Success)} refused={YN(refused)} no-land-in-patch={YN(noLand)}{Err(s2)}"));
         }
 
         // ===================== N4 — REJECT nested with no parent =====================

--- a/src/housecarl-generator/NestedCreateProof.cs
+++ b/src/housecarl-generator/NestedCreateProof.cs
@@ -14,8 +14,15 @@ namespace HousecarlGenerator;
 ///
 ///   N1 — ONE-SHOT: a DialogTopic (flat) + a DialogResponses/INFO under it (same-call
 ///        sibling parent) in ONE call → re-open: the INFO is in the NEW topic's Responses, both ids local 0x800+.
-///   N2 — INFO into an EXISTING topic (FormKey parent): the topic is overridden into the patch carrying its
-///        original lines, the new INFO appended → re-open: new INFO present AND the original responses survive.
+///   N2 — INFO into an EXISTING topic (FormKey parent): the topic is overridden into the patch and the new INFO
+///        appended → re-open: the new INFO is under it. What the override carries of the ORIGINAL lines is
+///        REPORTED, not asserted — see the note at the end of the run.
+///   N10 — a SINGULAR owned child: a Landscape under an existing cell that has none → re-open, the cell holds it.
+///   N11 — REJECT a singular slot that is already filled: a Landscape under a cell that has terrain → refused
+///         before anything is allocated, from the parent's REAL body (the patch's override carries no children).
+///   N12 — a Cell under a Worldspace with NEITHER route named → refused naming both (collection= and grid=).
+///   N13 — DELETE a singular owned child: remove the N10 Landscape by its own FormID → re-open, the cell holds
+///         none. Mutagen's typed remove reaches no singular owned child, so this is the detach path end to end.
 ///   N3 — PlacedObject into an EXISTING Cell, collection='Persistent' (the named discriminator) →
 ///        re-open: the new ref is in the cell's Persistent list.
 ///   N4 — REJECT a nested type with NO parent: create 'DialogResponses' alone → refused, names the need for a parent.
@@ -52,9 +59,20 @@ public static class NestedCreateProof
         foreach (var (fk, _, body) in resolver.WinnerRecordsOfType(new[] { typeof(ICellGetter) }))
             if (body is ICellGetter c && c.Persistent.Count > 0) { cellFk = fk; origPersistent = c.Persistent.Count; break; }
         FormKey weaponFk = resolver.WinnerRecordsOfType(new[] { typeof(IWeaponGetter) }).Select(x => x.fk).FirstOrDefault();
-        if (topicFk.IsNull || cellFk.IsNull || weaponFk.IsNull)
-        { Console.Error.WriteLine($"error: could not sample fixtures (topic={topicFk} cell={cellFk} weapon={weaponFk})."); return 1; }
+        // The SINGULAR owned-child arms need both halves of the slot: a cell that carries terrain and one that does not.
+        FormKey landlessCellFk = default, terrainCellFk = default;
+        foreach (var (fk, _, body) in resolver.WinnerRecordsOfType(new[] { typeof(ICellGetter) }))
+        {
+            if (body is not ICellGetter c) continue;
+            if (c.Landscape is null) { if (landlessCellFk.IsNull) landlessCellFk = fk; }
+            else if (terrainCellFk.IsNull) terrainCellFk = fk;
+            if (!landlessCellFk.IsNull && !terrainCellFk.IsNull) break;
+        }
+        FormKey worldspaceFk = resolver.WinnerRecordsOfType(new[] { typeof(IWorldspaceGetter) }).Select(x => x.fk).FirstOrDefault();
+        if (topicFk.IsNull || cellFk.IsNull || weaponFk.IsNull || landlessCellFk.IsNull || terrainCellFk.IsNull || worldspaceFk.IsNull)
+        { Console.Error.WriteLine($"error: could not sample fixtures (topic={topicFk} cell={cellFk} weapon={weaponFk} landless-cell={landlessCellFk} terrain-cell={terrainCellFk} worldspace={worldspaceFk})."); return 1; }
         Console.WriteLine($"fixtures: topic={topicFk} (responses={origResponses})  cell={cellFk} (persistent={origPersistent})  weapon={weaponFk}");
+        Console.WriteLine($"          landless-cell={landlessCellFk}  terrain-cell={terrainCellFk}  worldspace={worldspaceFk}");
         Console.WriteLine();
 
         var outDir = Path.GetFullPath(Path.Combine("write-output", "nested-create-proof"));
@@ -182,6 +200,46 @@ public static class NestedCreateProof
                 $"call1-ok={YN(s1.Success)} call2-ok={YN(s2.Success)} info-under-topic={YN(infoUnder)} absent-refused-loud={YN(ghostRefused)}{Err(s2)}"));
         }
 
+        // ===================== N10 — a SINGULAR owned child under a parent that has none =====================
+        //   The shape parent= could not reach at all: a slot holding exactly one record, not a list. Driven through
+        //   the same production chain as every arm above — parent override → NestedAddNew → serialize → re-open.
+        FormKey n10Land = default; string n10Path = Path.Combine(outDir, "houseCARL_NestedCreate_N10.esp");
+        {
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "Landscape", EditorId = "HC_N10_Land", ParentRef = landlessCellFk.ToString(), Edits = Array.Empty<WriteRequest>() },
+            };
+            var o = WritePatchBuilder.CreateRecords(resolver, rulebook, specs, n10Path, extend: false);
+            bool ok = o.Success && o.Created.Count == 1;
+            n10Land = ok ? o.Created[0].FormKey : default;
+            var under = ok ? CellLandscape(n10Path, landlessCellFk) : null;
+            bool present = under == n10Land;
+            bool local = ok && n10Land.ID >= 0x800 && n10Land.ModKey.FileName.String.Equals(Path.GetFileName(n10Path), StringComparison.OrdinalIgnoreCase);
+            results.Add(("N10 singular child created", ok && present && local,
+                $"created={YN(ok)} land-under-cell={YN(present)} local-id={YN(local)}{Err(o)}"));
+        }
+
+        // ===================== N11 — REJECT a singular slot that is already filled =====================
+        //   Measured against the parent's REAL body: the patch's fresh override of the cell carries no children, so
+        //   a guard reading the copy would allocate a second, empty LAND and ship it.
+        results.Add(RejectCheck("N11 reject occupied singular slot", outDir, "N11", resolver, rulebook,
+            new[] { new WritePatchBuilder.CreateSpec { RecordType = "Landscape", EditorId = "HC_N11_Land", ParentRef = terrainCellFk.ToString(), Edits = Array.Empty<WriteRequest>() } },
+            msg => msg.Contains("already holds", StringComparison.OrdinalIgnoreCase)));
+
+        // ===================== N12 — REJECT a Cell under a Worldspace with neither route named =====================
+        results.Add(RejectCheck("N12 reject unnamed cell route", outDir, "N12", resolver, rulebook,
+            new[] { new WritePatchBuilder.CreateSpec { RecordType = "Cell", EditorId = "HC_N12_Cell", ParentRef = worldspaceFk.ToString(), Edits = Array.Empty<WriteRequest>() } },
+            msg => msg.Contains("TopCell", StringComparison.Ordinal) && msg.Contains("grid=", StringComparison.Ordinal)));
+
+        // ===================== N13 — DELETE the singular owned child N10 created =====================
+        {
+            var rem = WritePatchBuilder.RemoveRecords(resolver, new[] { n10Land }, n10Path);
+            bool removed = rem.Success && rem.Removed.Count == 1 && rem.Removed[0].Target == n10Land;
+            bool gone = File.Exists(n10Path) && CellLandscape(n10Path, landlessCellFk) is null;
+            results.Add(("N13 singular child removed", removed && gone,
+                $"removed={YN(removed)} slot-empty-on-reopen={YN(gone)}" + (rem.Success ? "" : "  err=" + (rem.Error ?? "").Replace('\n', ' '))));
+        }
+
         // ===================== N4 — REJECT nested with no parent =====================
         results.Add(RejectCheck("N4 reject nested no-parent", outDir, "N4", resolver, rulebook,
             new[] { new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HC_N4", Edits = Array.Empty<WriteRequest>() } },
@@ -274,6 +332,19 @@ public static class NestedCreateProof
             back = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
             var info = back.EnumerateMajorRecords<IDialogResponsesGetter>().FirstOrDefault(x => x.FormKey == infoFk);
             return info?.Prompt?.String;
+        }
+        catch { return null; }
+        finally { (back as IDisposable)?.Dispose(); }
+    }
+
+    /// <summary>The FormKey in a cell's singular terrain slot on re-open, or null when the slot is empty.</summary>
+    static FormKey? CellLandscape(string patchPath, FormKey cellFk)
+    {
+        ISkyrimModGetter? back = null;
+        try
+        {
+            back = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+            return back.EnumerateMajorRecords<ICellGetter>().FirstOrDefault(x => x.FormKey == cellFk)?.Landscape?.FormKey;
         }
         catch { return null; }
         finally { (back as IDisposable)?.Dispose(); }

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -1591,15 +1591,18 @@ public static class WriteSurfaceGuardProbe
             setDoors.All(s => s is not null) && setDoors.Distinct(StringComparer.Ordinal).Count() == 1,
             string.Join(" || ", setDoors.Select(s => s ?? "(accepted)")));
 
-        // The two refusals that route a caller to the lifecycle gap name it by NUMBER — the gap is what makes them
-        // honest rather than blank walls, so a renumber or a silent drop should fail here.
-        Check("the refusals that have no remedy route to the lifecycle gap by number (#350) — all THREE of them",
+        // The three refusals used to route to a lifecycle GAP by number, because neither creating a singular owned
+        // child nor deleting one existed. Both do now, on the record axis, so each names the call that does it
+        // instead — and none of them may still send a caller to an issue tracker for a capability that shipped.
+        Check("the three field-level refusals name a working record-axis call, not an open gap",
             new[]
             {
                 Rules.Validate(new WriteRequest { RecordType = "Cell", Path = new[] { "Landscape" }, Verb = "Remove" }),
                 Rules.Validate(new WriteRequest { RecordType = "Cell", Path = new[] { "Landscape" }, Verb = "CopyFrom" }),
                 Rules.Validate(new WriteRequest { RecordType = "Cell", Path = new[] { "Landscape" }, Verb = "Set", Value = "000800:Skyrim.esm" }),
-            }.All(s => s is not null && s.Contains("#350", StringComparison.Ordinal)),
+            }.All(s => s is not null && !s.Contains("#350", StringComparison.Ordinal)
+                       && (ToolNameMatch.ReferencedAtBoundary(s, "housecarl_create")
+                           || ToolNameMatch.ReferencedAtBoundary(s, "housecarl_remove"))),
             Rules.Validate(new WriteRequest { RecordType = "Cell", Path = new[] { "Landscape" }, Verb = "Set", Value = "000800:Skyrim.esm" })!);
 
         // …and every one of the three tells the caller where the FormID it asks for comes from. MEASURED before it
@@ -1615,22 +1618,18 @@ public static class WriteSurfaceGuardProbe
             }.All(s => s is not null && s.Contains("depth=2", StringComparison.Ordinal)),
             Rules.Validate(new WriteRequest { RecordType = "Cell", Path = new[] { "Landscape" }, Verb = "CopyFrom" })!);
 
-        // …and CopyFrom names the remedy that was MEASURED to work for this shape, not the one the list twin can
-        // honestly offer: housecarl_forward carries a LAND and a worldspace's top cell; create with parent= is refused
-        // for a singular child ("that parent models no child-collection that holds it"), so it must not appear here.
+        // …and CopyFrom names BOTH remedies this shape now has, each for what it does: housecarl_forward carries an
+        // existing LAND or top cell across from another plugin, housecarl_create with parent= authors a fresh one
+        // where the parent has none. The second half of that used to be refused, and this arm used to assert its
+        // ABSENCE; it now asserts its presence, because the sentence is only complete with it.
         //
-        // BOTH halves match on the WHOLE identifier (#468 round 1, measured on each): the positive
-        // Contains("housecarl_forward") was satisfied by the 1.x name housecarl_forward_record, so it passed
-        // whether or not the sentence had been repaired; and the negative had been narrowed to the exact phrase
-        // "housecarl_create with parent=", which a reviewer slipped by appending "Or author it with
-        // housecarl_create parent=<the parent FormID>" to the refusal — the very regression this arm names. The
-        // negative is now the claim itself: the singular arm must not name housecarl_create AT ALL, since
-        // create with parent= is measured-refused for a singular child and the collection twin is the only door
-        // that may offer it.
+        // BOTH halves match on the WHOLE identifier (#468 round 1, measured on each): Contains("housecarl_forward")
+        // was satisfied by the 1.x name housecarl_forward_record, so it passed whether or not the sentence had been
+        // repaired. ReferencedAtBoundary is what makes the claim the claim.
         var copyMsg = Rules.Validate(new WriteRequest { RecordType = "Cell", Path = new[] { "Landscape" }, Verb = "CopyFrom" })!;
-        Check("…and CopyFrom's refusal names housecarl_forward (measured) and NOT housecarl_create (measured refused for a singular child)",
+        Check("…and CopyFrom's refusal names housecarl_forward (carry an existing one) AND housecarl_create (author a new one)",
             ToolNameMatch.ReferencedAtBoundary(copyMsg, "housecarl_forward")
-            && !ToolNameMatch.ReferencedAtBoundary(copyMsg, "housecarl_create"), copyMsg);
+            && ToolNameMatch.ReferencedAtBoundary(copyMsg, "housecarl_create"), copyMsg);
 
         // --- THE REFUSALS, RENDERED. All three arms of RestoreChildGroup are user-facing sentences that no arm had
         //     ever produced (round-1 review [low]) — and this file's own standing lesson is that a message shipped

--- a/src/housecarl-mcp-tests/OwnedChildLifecycleDrivenTests.cs
+++ b/src/housecarl-mcp-tests/OwnedChildLifecycleDrivenTests.cs
@@ -1,0 +1,156 @@
+using HousecarlCore;
+using HousecarlMcp;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// The owned-child lifecycle DRIVEN through the tool surface (#350): <c>housecarl_create</c> with parent= and
+/// collection=, and <c>housecarl_remove</c> on the child's own FormID, against a real load order on disk. The
+/// engine-level twin (<c>OwnedChildLifecycleTests</c>) proves the primitives; this proves the calls the refusals
+/// name actually accept the arguments those sentences give, which is the half a unit test cannot see — pre-flight
+/// runs in the patch builder, not the engine.
+/// </summary>
+[Trait("tier", "integration")]
+public sealed class OwnedChildLifecycleDrivenTests
+{
+    static string Fid(FormKey fk) => OwnedChildWorld.Fid(fk);
+
+    /// <summary>Re-open a written patch and answer for one cell's singular terrain slot.</summary>
+    static FormKey? LandscapeUnder(string patchPath, FormKey cell)
+    {
+        using var back = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+        return back.EnumerateMajorRecords<ICellGetter>().FirstOrDefault(c => c.FormKey == cell)?.Landscape?.FormKey;
+    }
+
+    static FormKey? TopCellUnder(string patchPath, FormKey worldspace)
+    {
+        using var back = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+        return back.Worldspaces.FirstOrDefault(w => w.FormKey == worldspace)?.TopCell?.FormKey;
+    }
+
+    /// <summary>A cell whose parent carries no terrain gets some: the create lands, and the re-opened patch shows
+    /// the cell holding the new record.</summary>
+    [Fact]
+    public void CreatingAnAbsentSingularChildLandsItUnderTheParent()
+    {
+        using var w = new OwnedChildWorld();
+        var o = w.Svc.CreateRecordsBatch(
+            new[] { new CreateOp { RecordType = "Landscape", Editorid = "HcOcNewLand", Parent = Fid(w.CellC) } },
+            "HcOcCreateLand", null);
+
+        Assert.True(o.Success, "refused: " + o.Error);
+        Assert.Equal(LandscapeUnder(o.OutputPath, w.CellC), o.Created[0].FormKey);
+    }
+
+    /// <summary>The occupied-slot refusal is decided from the PARENT'S REAL BODY, not from the patch's fresh
+    /// override — which carries no children, so a guard that asked the copy would let this through and ship a cell
+    /// with a second, empty terrain record. CellA's winner declares nothing; its definer declares the LAND.</summary>
+    [Fact]
+    public void AnOccupiedSingularSlotIsRefusedEvenThoughThePatchCopyCarriesNoChild()
+    {
+        using var w = new OwnedChildWorld();
+        var o = w.Svc.CreateRecordsBatch(
+            new[] { new CreateOp { RecordType = "Landscape", Editorid = "HcOcSecondLand", Parent = Fid(w.CellA) } },
+            "HcOcSecondLandPatch", null);
+
+        Assert.False(o.Success);
+        Assert.Contains("already holds", o.Error);
+        Assert.Contains("NOTHING created", o.Error);
+    }
+
+    /// <summary>The route the rewritten refusals name — parent= plus collection='TopCell' — is reachable from the
+    /// tool. It was not: every Cell spec with a parent was intercepted before the slot resolver ran and refused for
+    /// a missing grid=.</summary>
+    [Fact]
+    public void TheTopCellRouteTheRefusalsNameIsReachableThroughTheTool()
+    {
+        using var w = new OwnedChildWorld();
+        var o = w.Svc.CreateRecordsBatch(
+            new[] { new CreateOp { RecordType = "Cell", Editorid = "HcOcNewTopCell", Parent = Fid(w.Worldspace), Collection = "TopCell" } },
+            "HcOcTopCellPatch", null);
+
+        Assert.True(o.Success, "refused: " + o.Error);
+        Assert.Equal(TopCellUnder(o.OutputPath, w.Worldspace), o.Created[0].FormKey);
+    }
+
+    /// <summary>…and naming NEITHER route is the ambiguity, which now renders on the production path and names both
+    /// moves — the single slot and the coordinate-keyed block tree.</summary>
+    [Fact]
+    public void ACellUnderAWorldspaceWithNeitherRouteNamedNamesBoth()
+    {
+        using var w = new OwnedChildWorld();
+        var o = w.Svc.CreateRecordsBatch(
+            new[] { new CreateOp { RecordType = "Cell", Editorid = "HcOcAmbiguousCell", Parent = Fid(w.Worldspace) } },
+            "HcOcAmbiguousPatch", null);
+
+        Assert.False(o.Success);
+        Assert.Contains("TopCell", o.Error);
+        Assert.Contains("grid=", o.Error);
+    }
+
+    /// <summary>Naming both routes at once is a contradiction, not a precedence rule to resolve silently.</summary>
+    [Fact]
+    public void NamingBothCellRoutesIsRefused()
+    {
+        using var w = new OwnedChildWorld();
+        var o = w.Svc.CreateRecordsBatch(
+            new[] { new CreateOp { RecordType = "Cell", Editorid = "HcOcBothRoutes", Parent = Fid(w.Worldspace), Collection = "TopCell", Grid = "1,2" } },
+            "HcOcBothRoutesPatch", null);
+
+        Assert.False(o.Success);
+        Assert.Contains("name one", o.Error);
+    }
+
+    /// <summary>The delete half, driven: a created owned child is removed by its own FormID, and the re-opened
+    /// patch shows the parent holding nothing. Mutagen's typed remove reaches no singular owned child, so before
+    /// the detach path this call reported "did not drop 1 record".</summary>
+    [Fact]
+    public void RemovingAnOwnedChildByItsOwnFormIdDropsIt()
+    {
+        using var w = new OwnedChildWorld();
+        var made = w.Svc.CreateRecordsBatch(
+            new[] { new CreateOp { RecordType = "Landscape", Editorid = "HcOcDoomedLand", Parent = Fid(w.CellC) } },
+            "HcOcRemoveLand", null);
+        Assert.True(made.Success, "refused: " + made.Error);
+        var patchFile = Path.GetFileName(made.OutputPath);
+
+        var gone = w.Svc.RemoveRecords(new[] { Fid(made.Created[0].FormKey) }, patch: patchFile);
+
+        Assert.True(gone.Success, "refused: " + gone.Error);
+        Assert.Single(gone.Removed);
+        Assert.Null(LandscapeUnder(gone.OutputPath, w.CellC));
+    }
+
+    /// <summary>A detached child takes everything under it, so one that still carries records the caller did not
+    /// name is refused rather than deleted with the report accounting for one. Naming them all is the way through,
+    /// and then every dropped record is in the report.</summary>
+    [Fact]
+    public void RemovingAnOwnedChildThatCarriesUnnamedRecordsIsRefusedUntilTheyAreNamedToo()
+    {
+        using var w = new OwnedChildWorld();
+        var top = w.Svc.CreateRecordsBatch(
+            new[] { new CreateOp { RecordType = "Cell", Editorid = "HcOcSubtreeTop", Parent = Fid(w.Worldspace), Collection = "TopCell" } },
+            "HcOcSubtree", null);
+        Assert.True(top.Success, "refused: " + top.Error);
+        var patchFile = Path.GetFileName(top.OutputPath);
+        var topCell = top.Created[0].FormKey;
+
+        var child = w.Svc.CreateRecordsBatch(
+            new[] { new CreateOp { RecordType = "PlacedObject", Editorid = "HcOcSubtreeRef", Parent = Fid(topCell), Collection = "Persistent" } },
+            null, patchFile);
+        Assert.True(child.Success, "refused: " + child.Error);
+
+        var refused = w.Svc.RemoveRecords(new[] { Fid(topCell) }, patch: patchFile);
+        Assert.False(refused.Success);
+        Assert.Contains("you named none of them", refused.Error);
+        Assert.Contains("UNTOUCHED", refused.Error);
+
+        var both = w.Svc.RemoveRecords(new[] { Fid(topCell), Fid(child.Created[0].FormKey) }, patch: patchFile);
+        Assert.True(both.Success, "refused: " + both.Error);
+        Assert.Equal(2, both.Removed.Count);
+        Assert.Null(TopCellUnder(both.OutputPath, w.Worldspace));
+    }
+}

--- a/src/housecarl-mcp-tests/OwnedChildLifecycleDrivenTests.cs
+++ b/src/housecarl-mcp-tests/OwnedChildLifecycleDrivenTests.cs
@@ -61,6 +61,28 @@ public sealed class OwnedChildLifecycleDrivenTests
         Assert.Contains("NOTHING created", o.Error);
     }
 
+    /// <summary>…and the same refusal holds when the patch ALREADY carries the parent: that copy is an override and
+    /// carries none of the parent's children, so reading it alone would read the slot free and ship a second terrain
+    /// record under a cell that already declares one.</summary>
+    [Fact]
+    public void AnOccupiedSingularSlotIsRefusedWhenThePatchAlreadyCarriesTheParent()
+    {
+        using var w = new OwnedChildWorld();
+        var first = w.Svc.CreateRecordsBatch(
+            new[] { new CreateOp { RecordType = "PlacedObject", Editorid = "HcOcCarriedRef", Parent = Fid(w.CellA), Collection = "Persistent" } },
+            "HcOcCarriedParent", null);
+        Assert.True(first.Success, "refused: " + first.Error);
+        var patchFile = Path.GetFileName(first.OutputPath);
+
+        var o = w.Svc.CreateRecordsBatch(
+            new[] { new CreateOp { RecordType = "Landscape", Editorid = "HcOcCarriedLand", Parent = Fid(w.CellA) } },
+            null, patchFile);
+
+        Assert.False(o.Success);
+        Assert.Contains("already holds", o.Error);
+        Assert.Contains("NOTHING created", o.Error);
+    }
+
     /// <summary>The route the rewritten refusals name — parent= plus collection='TopCell' — is reachable from the
     /// tool. It was not: every Cell spec with a parent was intercepted before the slot resolver ran and refused for
     /// a missing grid=.</summary>

--- a/src/housecarl-mcp-tests/OwnedChildLifecycleDrivenTests.cs
+++ b/src/housecarl-mcp-tests/OwnedChildLifecycleDrivenTests.cs
@@ -83,6 +83,26 @@ public sealed class OwnedChildLifecycleDrivenTests
         Assert.Contains("NOTHING created", o.Error);
     }
 
+    /// <summary>A cell reached through the singular slot is the same identity the coordinate routes build, so it
+    /// gets their editorid dedup: cell create does not upsert, and without this the patch carries two cells named
+    /// the same.</summary>
+    [Fact]
+    public void ACellThroughTheSingularSlotGetsTheSameEditorIdDedupAsTheOtherCellRoutes()
+    {
+        using var w = new OwnedChildWorld();
+        var interior = w.Svc.CreateRecordsBatch(
+            new[] { new CreateOp { RecordType = "Cell", Editorid = "HcOcTwiceNamed" } }, "HcOcDedup", null);
+        Assert.True(interior.Success, "refused: " + interior.Error);
+        var patchFile = Path.GetFileName(interior.OutputPath);
+
+        var again = w.Svc.CreateRecordsBatch(
+            new[] { new CreateOp { RecordType = "Cell", Editorid = "HcOcTwiceNamed", Parent = Fid(w.Worldspace), Collection = "TopCell" } },
+            null, patchFile);
+
+        Assert.False(again.Success);
+        Assert.Contains("already exists in this patch", again.Error);
+    }
+
     /// <summary>The route the rewritten refusals name — parent= plus collection='TopCell' — is reachable from the
     /// tool. It was not: every Cell spec with a parent was intercepted before the slot resolver ran and refused for
     /// a missing grid=.</summary>

--- a/src/housecarl-mcp-tests/OwnedChildLifecycleDrivenTests.cs
+++ b/src/housecarl-mcp-tests/OwnedChildLifecycleDrivenTests.cs
@@ -103,6 +103,23 @@ public sealed class OwnedChildLifecycleDrivenTests
         Assert.Contains("already exists in this patch", again.Error);
     }
 
+    /// <summary>The field-lane refusal sends the caller to the record axis, and a child that carries records of its
+    /// own — a top cell holds the worldspace's persistent references — refuses until those are named too. The
+    /// sentence says so, so the call it names works on the first try.</summary>
+    [Fact]
+    public void TheFieldLaneRemoveRefusalSaysToNameTheRecordsUnderTheChild()
+    {
+        using var w = new OwnedChildWorld();   // stands up the generated corpus this rulebook loads
+        var refusal = CorpusRulebook.Load().Validate(new WriteRequest
+        {
+            RecordType = "Worldspace", Path = new[] { "TopCell" }, Verb = "Remove",
+        });
+
+        Assert.NotNull(refusal);
+        Assert.Contains(ToolNames.Remove, refusal!);
+        Assert.Contains("refuses until every record it would drop is named", refusal);
+    }
+
     /// <summary>The route the rewritten refusals name — parent= plus collection='TopCell' — is reachable from the
     /// tool. It was not: every Cell spec with a parent was intercepted before the slot resolver ran and refused for
     /// a missing grid=.</summary>

--- a/src/housecarl-mcp-tests/OwnedChildLifecycleTests.cs
+++ b/src/housecarl-mcp-tests/OwnedChildLifecycleTests.cs
@@ -164,28 +164,78 @@ public sealed class OwnedChildLifecycleTests
         Assert.False(OwnedChildLifecycle.TryFindSlot(mod, weapon.FormKey, out _));
     }
 
-    /// <summary>The slot set is DERIVED, not listed: every child-bearing property the engine's reflected walk finds
-    /// classifies as one of the two shapes, over every record type Mutagen models. A bump that adds a property is
-    /// covered here without an edit — and an empty answer is this test's subject, not a reason to pass.</summary>
+    /// <summary>The slot set is DERIVED, not listed — and the walk this asserts through is the one CREATE calls,
+    /// not the reflected set beside it. For every child-bearing property Mutagen models, the create resolver must
+    /// either accept the property BY NAME for the record it holds (a slot a caller can name), or, when the property
+    /// only reaches records through containers, refuse and name the coordinate route instead. Those are the two
+    /// answers the lane has; a third would be a shape the lifecycle cannot speak for.</summary>
     [Fact]
-    public void EveryChildBearingPropertyClassifiesAsOneOfTheTwoShapes()
+    public void EveryChildBearingPropertyIsASlotCreateCanNameOrACoordinateRouteItNames()
     {
-        int seen = 0;
+        int slots = 0, coordinateRoutes = 0;
         foreach (var t in typeof(Weapon).Assembly.GetTypes())
         {
             if (!t.IsClass || t.IsAbstract || !typeof(IMajorRecord).IsAssignableFrom(t)) continue;
             if (t.Name.EndsWith("BinaryOverlay", StringComparison.Ordinal)) continue;
             foreach (var p in WriteEngine.ChildBearingProperties(t))
             {
-                seen++;
-                var singular = typeof(IMajorRecordGetter).IsAssignableFrom(p.PropertyType);
-                // Whichever half it is, the create resolver must be able to name it: a singular slot by its own
-                // type, a collection slot by its element type. A property that is neither would be a shape the
-                // lifecycle cannot speak for.
-                Assert.True(singular || typeof(System.Collections.IEnumerable).IsAssignableFrom(p.PropertyType),
-                    $"{t.Name}.{p.Name} is child-bearing but neither one record nor a collection.");
+                var held = HeldRecordType(p.PropertyType);
+                if (held is not null)
+                {
+                    slots++;
+                    Assert.True(WriteEngine.CanCreateNested(held.Name, t, p.Name, out var why),
+                        $"{t.Name}.{p.Name} holds a {held.Name} but create cannot name it: {why}");
+                    continue;
+                }
+                // A container route: no record to name the property by, so create must refuse the NAME and, asked
+                // for the record the tree eventually holds, say how it is really addressed.
+                foreach (var leaf in LeafRecordTypesUnder(p.PropertyType, new HashSet<Type>(), 0))
+                {
+                    coordinateRoutes++;
+                    Assert.False(WriteEngine.CanCreateNested(leaf.Name, t, p.Name, out _),
+                        $"{t.Name}.{p.Name} is a container tree, not a slot create can add into by name.");
+                    Assert.False(WriteEngine.CanCreateNested(leaf.Name, t, null, out var why));
+                    Assert.Contains("grid=", why!);
+                }
             }
         }
-        Assert.True(seen > 0, "ChildBearingProperties answering nothing is this test's subject, not a reason to pass.");
+        Assert.True(slots > 0 && coordinateRoutes > 0,
+            "both halves answering nothing is this test's subject, not a reason to pass.");
+    }
+
+    /// <summary>The record a property holds DIRECTLY — itself, or as its list's element type — else null (it only
+    /// reaches records through containers).</summary>
+    static Type? HeldRecordType(Type t)
+    {
+        if (typeof(IMajorRecordGetter).IsAssignableFrom(t)) return t;
+        var elem = t.GetInterfaces().Append(t)
+            .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IList<>))
+            ?.GetGenericArguments()[0];
+        return elem is not null && typeof(IMajorRecordGetter).IsAssignableFrom(elem) ? elem : null;
+    }
+
+    /// <summary>The concrete record types a container tree eventually holds — the test's own walk, deliberately
+    /// independent of the engine's, so the two agreeing is a measurement rather than a tautology.</summary>
+    static IEnumerable<Type> LeafRecordTypesUnder(Type t, HashSet<Type> seen, int depth)
+    {
+        if (depth > 6 || !seen.Add(t)) yield break;
+        if (typeof(Mutagen.Bethesda.Plugins.IFormLinkGetter).IsAssignableFrom(t)) yield break;
+        if (typeof(IMajorRecordGetter).IsAssignableFrom(t))
+        {
+            if (t.IsClass && !t.IsAbstract) yield return t;
+            yield break;
+        }
+        var elem = t.GetInterfaces().Append(t)
+            .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            ?.GetGenericArguments()[0];
+        if (elem is not null)
+        {
+            foreach (var leaf in LeafRecordTypesUnder(elem, seen, depth + 1)) yield return leaf;
+            yield break;
+        }
+        if (!t.IsClass || t.Namespace?.StartsWith("Mutagen", StringComparison.Ordinal) != true) yield break;
+        foreach (var p in t.GetProperties())
+            foreach (var leaf in LeafRecordTypesUnder(p.PropertyType, seen, depth + 1))
+                yield return leaf;
     }
 }

--- a/src/housecarl-mcp-tests/OwnedChildLifecycleTests.cs
+++ b/src/housecarl-mcp-tests/OwnedChildLifecycleTests.cs
@@ -1,0 +1,191 @@
+using HousecarlCore;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// The lifecycle of a SINGULAR owned child record — the shape a cell's <c>Landscape</c> and a worldspace's
+/// <c>TopCell</c> have (#350). Neither half existed: a parent carrying none could not be given one, because the
+/// create lane resolved <c>parent=</c> only into LIST-shaped child slots; and an existing one could not be
+/// deleted, because Mutagen's typed <c>Remove(FormKey, Type)</c> routes by group and a singular child is in none.
+///
+/// <para>Engine-level and world-free: both halves are decided by reflection over Mutagen's own model, so a
+/// synthetic mod in memory is the whole world they need. The record types named here are SUBJECTS, not coverage —
+/// what is covered is whatever <c>ChildBearingProperties</c> answers.</para>
+/// </summary>
+[Trait("tier", "unit")]
+public sealed class OwnedChildLifecycleTests
+{
+    static SkyrimMod Mod() => new(new ModKey("HcLifecycle", ModType.Plugin), SkyrimRelease.SkyrimSE);
+
+    /// <summary>A patch holding one interior cell, through the engine's own create path.</summary>
+    static (SkyrimMod Mod, Cell Cell) WithCell()
+    {
+        var mod = Mod();
+        return (mod, WriteEngine.AddInteriorCell(mod, "HcLifecycleCell"));
+    }
+
+    // ---- half 1: create a singular owned child where the parent has none ----
+
+    /// <summary>The pre-flight gate now ANSWERS for a singular slot. It used to refuse — the resolver filtered to
+    /// list-shaped properties before it ever asked about the child type, so a slot holding exactly one record was
+    /// invisible to create while every other part of the engine could see it.</summary>
+    [Fact]
+    public void ASingularOwnedChildCanBeCreatedUnderItsParent()
+    {
+        Assert.True(WriteEngine.CanCreateNested("Landscape", typeof(Cell), null, out var why), why);
+    }
+
+    /// <summary>…and the create actually attaches it: the parent that carried no child carries one afterwards, with
+    /// its own allocated FormKey, reachable by Mutagen's containment walk like any other record.</summary>
+    [Fact]
+    public void CreatingASingularOwnedChildAttachesItToTheParent()
+    {
+        var (mod, cell) = WithCell();
+        Assert.Null(cell.Landscape);
+
+        var child = WriteEngine.NestedAddNew(mod, cell, "Landscape", null, "HcLifecycleLand");
+
+        Assert.NotNull(cell.Landscape);
+        Assert.Equal(child.FormKey, cell.Landscape!.FormKey);
+        Assert.Equal("HcLifecycleLand", cell.Landscape.EditorID);
+        Assert.Contains(mod.EnumerateMajorRecords(), r => r.FormKey == child.FormKey);
+    }
+
+    /// <summary>A singular slot holds exactly ONE, so an occupied one is refused rather than resolved: appending is
+    /// not available and overwriting would drop the record already there, with everything under it, as a side
+    /// effect of a call that said "create". The refusal names both real moves.</summary>
+    [Fact]
+    public void CreatingASecondSingularChildIsRefusedAndNamesBothMoves()
+    {
+        var (mod, cell) = WithCell();
+        WriteEngine.NestedAddNew(mod, cell, "Landscape", null, "HcLifecycleLand");
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => WriteEngine.NestedAddNew(mod, cell, "Landscape", null, "HcLifecycleLand2"));
+
+        Assert.Contains("already holds", ex.Message);
+        Assert.Contains("housecarl_remove", ex.Message);
+    }
+
+    /// <summary>A CELL under a worldspace is the one child that has two routes — the worldspace's single TopCell,
+    /// and its coordinate-keyed block tree — and they build different things. One reflected slot matching is not
+    /// enough to resolve it, so it is named rather than guessed; resolving it silently would build a top cell for
+    /// the far commoner request whose grid= was forgotten.</summary>
+    [Fact]
+    public void ACellUnderAWorldspaceMustNameWhichRoute()
+    {
+        Assert.False(WriteEngine.CanCreateNested("Cell", typeof(Worldspace), null, out var why));
+
+        Assert.Contains("TopCell", why!);
+        Assert.Contains("grid=", why);
+    }
+
+    /// <summary>…and naming the slot resolves it. The discriminator that picks between two collections picks a
+    /// singular slot the same way — it names a child SLOT, and the shape only decides how the child is attached.</summary>
+    [Fact]
+    public void NamingTheSingularSlotResolvesTheAmbiguity()
+    {
+        Assert.True(WriteEngine.CanCreateNested("Cell", typeof(Worldspace), "TopCell", out var why), why);
+    }
+
+    /// <summary>A real containment boundary still refuses: a type the parent models no slot for is not created
+    /// under it, and the refusal says that rather than inventing a place to put it.</summary>
+    [Fact]
+    public void ATypeThatFitsNoSlotIsStillRefused()
+    {
+        Assert.False(WriteEngine.CanCreateNested("Weapon", typeof(Cell), null, out var why));
+        Assert.Contains("cannot be created under", why!);
+    }
+
+    // ---- half 2: delete an owned child ----
+
+    /// <summary>The measured fact the delete path exists for: Mutagen's typed remove — the blessed drop, the one
+    /// that reaches placed references and INFOs — silently does nothing to a singular owned child, and does not
+    /// throw. Pinned as a test so a Mutagen bump that fixes it shows up here rather than leaving dead code.</summary>
+    [Fact]
+    public void TheTypedRemoveDoesNotReachASingularOwnedChild()
+    {
+        var (mod, cell) = WithCell();
+        var child = WriteEngine.NestedAddNew(mod, cell, "Landscape", null, "HcLifecycleLand");
+
+        ((IMajorRecordEnumerable)mod).Remove(child.FormKey, WriteEngine.RemovalTypeFor(child), throwIfUnknown: true);
+
+        Assert.NotNull(cell.Landscape);
+        Assert.Contains(mod.EnumerateMajorRecords(), r => r.FormKey == child.FormKey);
+    }
+
+    /// <summary>…and the slot finder plus detach is what does reach it: the child is gone from the parent and from
+    /// the mod's containment walk, which is the walk the remove lanes verify absence with.</summary>
+    [Fact]
+    public void DetachingASingularOwnedChildDropsItFromTheMod()
+    {
+        var (mod, cell) = WithCell();
+        var child = WriteEngine.NestedAddNew(mod, cell, "Landscape", null, "HcLifecycleLand");
+
+        Assert.True(OwnedChildLifecycle.TryFindSlot(mod, child.FormKey, out var slot));
+        Assert.Equal(OwnedChildShape.Singular, slot.Shape);
+        Assert.Equal("Cell.Landscape", slot.Describe());
+        Assert.Null(OwnedChildLifecycle.Detach(slot));
+
+        Assert.Null(cell.Landscape);
+        Assert.DoesNotContain(mod.EnumerateMajorRecords(), r => r.FormKey == child.FormKey);
+    }
+
+    /// <summary>The COLLECTION half of the same shape goes through the same finder, and reports the list it found
+    /// the child in — so one delete path serves both shapes rather than a singular special case beside the
+    /// list-shaped one that already worked.</summary>
+    [Fact]
+    public void TheSameFinderReachesAChildInACollectionSlot()
+    {
+        var (mod, cell) = WithCell();
+        var placed = WriteEngine.NestedAddNew(mod, cell, "PlacedObject", "Persistent", "HcLifecyclePlaced");
+
+        Assert.True(OwnedChildLifecycle.TryFindSlot(mod, placed.FormKey, out var slot));
+        Assert.Equal(OwnedChildShape.Collection, slot.Shape);
+        Assert.Equal("Cell.Persistent", slot.Describe());
+        Assert.Null(OwnedChildLifecycle.Detach(slot));
+
+        Assert.DoesNotContain(mod.EnumerateMajorRecords(), r => r.FormKey == placed.FormKey);
+    }
+
+    /// <summary>A record that is nobody's child is found in no slot — the answer that keeps the remove lanes'
+    /// survivor check the one that speaks for an ordinary record, rather than this path claiming it.</summary>
+    [Fact]
+    public void ARecordInNoChildSlotIsNotFound()
+    {
+        var mod = Mod();
+        var weapon = new Weapon(mod.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "HcLifecycleWeapon" };
+        mod.Weapons.Add(weapon);
+
+        Assert.False(OwnedChildLifecycle.TryFindSlot(mod, weapon.FormKey, out _));
+    }
+
+    /// <summary>The slot set is DERIVED, not listed: every child-bearing property the engine's reflected walk finds
+    /// classifies as one of the two shapes, over every record type Mutagen models. A bump that adds a property is
+    /// covered here without an edit — and an empty answer is this test's subject, not a reason to pass.</summary>
+    [Fact]
+    public void EveryChildBearingPropertyClassifiesAsOneOfTheTwoShapes()
+    {
+        int seen = 0;
+        foreach (var t in typeof(Weapon).Assembly.GetTypes())
+        {
+            if (!t.IsClass || t.IsAbstract || !typeof(IMajorRecord).IsAssignableFrom(t)) continue;
+            if (t.Name.EndsWith("BinaryOverlay", StringComparison.Ordinal)) continue;
+            foreach (var p in WriteEngine.ChildBearingProperties(t))
+            {
+                seen++;
+                var singular = typeof(IMajorRecordGetter).IsAssignableFrom(p.PropertyType);
+                // Whichever half it is, the create resolver must be able to name it: a singular slot by its own
+                // type, a collection slot by its element type. A property that is neither would be a shape the
+                // lifecycle cannot speak for.
+                Assert.True(singular || typeof(System.Collections.IEnumerable).IsAssignableFrom(p.PropertyType),
+                    $"{t.Name}.{p.Name} is child-bearing but neither one record nor a collection.");
+            }
+        }
+        Assert.True(seen > 0, "ChildBearingProperties answering nothing is this test's subject, not a reason to pass.");
+    }
+}

--- a/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
+++ b/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
@@ -222,7 +222,8 @@ public sealed class OwnedChildWorld : IDisposable
         File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + BaseName + "\r\n*" + MidName + "\r\n*" + TopName + "\r\n");
         File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+TopMod\r\n+MidMod\r\n+BaseMod\r\n");
 
-        // The scan lanes validate against the corpus rulebook, so this world generates one like the others.
+        // The scan lanes validate against the corpus rulebook and the write lanes resolve a record_type
+        // through it, so this world generates one — the same by-construction catalog the other worlds build.
         var genDir = Path.Combine(Root, "corpus-gen");
         CorpusGenerator.GenerateAll(genDir, Path.Combine(Root, "corpus-ref"));
         CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json");

--- a/src/housecarl-mcp/CreateTools.cs
+++ b/src/housecarl-mcp/CreateTools.cs
@@ -46,8 +46,10 @@ public static class CreateTools
          "value:'@MyTopic'}, {field_path:'PreviousDialog', value:'@MyTopic_L1'}]). '@editorid' must name a record " +
          "declared EARLIER in the array or the record being created ITSELF (self-reference — e.g. a quest's VMAD " +
          "alias fragment whose Property.Object is the quest). Only on FormLink fields, including inside a compose " +
-         "spec. collection= names WHICH of the parent's child-lists to add into (e.g. a cell's " +
-         "'Persistent'/'Temporary') — needed only when more than one fits. grid= is the EXTERIOR cell's \"X,Y\" " +
+         "spec. collection= names WHICH of the parent's child slots to add into — a child LIST (e.g. a cell's " +
+         "'Persistent'/'Temporary') or a SINGLE-child slot (a cell's 'Landscape', a worldspace's 'TopCell', which " +
+         "hold exactly one and refuse rather than overwrite when occupied) — needed only when more than one fits. " +
+         "grid= is the EXTERIOR cell's \"X,Y\" " +
          "(record_type 'Cell' with parent= a Worldspace; houseCARL files it into the worldspace's block tree). A " +
          "'Cell' with NO parent and NO grid is an INTERIOR cell.\n\n" +
          "LANE — where the write lands. Default: a NEW patch named patch= (auto-suffixed if taken, so a prior patch " +

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -1215,7 +1215,7 @@ public sealed record CreateOp
     [JsonPropertyName("parent"), Description("Optional. For a NESTED record: the parent it nests under — an EXISTING parent's FormID 'XXXXXX:Plugin.esp', OR the editorid of a record declared EARLIER in this same records array (a same-call sibling). Omit for a flat top-level record.")]
     public string? Parent { get; init; }
 
-    [JsonPropertyName("collection"), Description("Optional. Which of the parent's child-collections to add into, BY NAME (e.g. a cell's 'Persistent') — needed only when more than one fits. Omit when unique or when parent is omitted.")]
+    [JsonPropertyName("collection"), Description("Optional. Which of the parent's child slots to add into, BY NAME — a child list (e.g. a cell's 'Persistent') or a single-child slot (a cell's 'Landscape', a worldspace's 'TopCell') — needed only when more than one fits. Omit when unique or when parent is omitted.")]
     public string? Collection { get; init; }
 
     [JsonPropertyName("grid"), Description("Optional. For an EXTERIOR cell only (record_type 'Cell' with parent= a Worldspace): the cell's grid as \"X,Y\" (e.g. \"5,-12\"). houseCARL files it into the worldspace's block tree by block=floor(grid/32), subblock=floor(grid/8). A 'Cell' with NO parent and NO grid is an INTERIOR cell (self-files by FormID). Ignored for non-Cell types.")]


### PR DESCRIPTION
Stacked on #548 (`claude/polymorphic-refusal`) — review that one first; this branch's diff against it is the owned-child work alone.

A cell's terrain and a worldspace's top cell are single owned child records, and neither end of their life worked. A cell carrying no `Landscape` could not be given one: `parent=` resolved into child *collections* only, filtering to `IList`-shaped properties before it ever asked about the child type, so a slot holding exactly one record was invisible to create while `ChildBearingProperties`, `SchemaClassifier` and the read side could all see it. And an existing one could not be deleted: Mutagen's typed `Remove(FormKey, Type)` routes by group, a singular child sits in none, so the removal found nothing to drop and returned without throwing — the silent no-op the survivor check caught and reported as an engine inconsistency.

Both halves land on the record axis, as values on the verbs that already exist. `create` with `parent=` now resolves either shape of child slot; `collection=` names a singular slot exactly as it names a collection, and the shape only decides how the child is attached, which is the engine's business rather than the caller's. `remove` with the child's own FormID now reaches it: a new `OwnedChildLifecycle` finds the slot holding a given child and detaches it — clearing the property for a singular slot, dropping the element for a collection one — and both remove lanes run it between the typed remove and the survivor check, so it reaches only what the typed remove left behind and the survivor check still speaks for every ordinary record.

Neither slot set is a type list. Both come from the same reflected child-bearing walk the forward lanes preserve children with, so a Mutagen bump that adds a child-bearing property is covered without an edit here, and a test asserts every such property over every modeled record type classifies as one of the two shapes.

Two boundaries the shape creates, both refused rather than guessed. A singular slot that already holds a child is refused — appending is not available and overwriting would drop the record that is there, with everything under it, as a side effect of a call that said "create" — and the refusal names the two real moves. A `Cell` under a `Worldspace` has two routes that build different things, its single `TopCell` and its coordinate-keyed block tree, so one reflected slot matching is not enough to resolve it; silently taking the slot would build a top cell for the far commoner request whose `grid=` was forgotten.

The three field-level refusals that used to end at "an open gap (#350)" now name these calls, and the probe arm that pinned the old contract — CopyFrom's refusal must NOT mention `housecarl_create` — asserts the new one. Field-level `Set`/`Remove`/`CopyFrom` on the slot stay refused: a record is not a field's value, and that rule has not changed. What changed is that their remedies now exist.

Eleven tests, engine-level and world-free since both halves are decided by reflection. One of them pins the measurement this work rests on: the typed remove silently misses a singular owned child and does not throw, so a Mutagen bump that fixes it surfaces here rather than leaving dead code behind.

1182 tests pass, `ci-all` 128/128.

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)
