### PR TITLE
Add the *parent containment step

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -72,6 +72,18 @@ saying it sets an expectation their install may contradict. Say what is known, a
   collection whose elements are owned child records (`Cell.Persistent`) is sent to the record axis rather than handed
   a container call no verb takes. Inside
   a `compose=`'s nested `sets`, the path is named in the `path` slot it belongs to rather than `field_path`.
+- **A path can now step to the record that CONTAINS this one, with `*parent`.** DIAL→INFO, CELL→REFR/ACHR and
+  WRLD→CELL ownership is group nesting rather than a form link, so `references=` correctly returns nothing for it
+  and the child's own body names no owner — there was no way back from an INFO to its topic, or from a crash log's
+  placed reference to its cell. `*parent` is one step on the paths that already exist: `where=["*parent.EditorID =
+  GreetingsTopic"]`, `project={"form":"fields","fields":["*parent.EditorID"]}`, and a walk's `seed_paths`/`follow`.
+  It leads a path and it chains, so `*parent.*parent` reaches a placed reference's worldspace, and everything below
+  the hop — `editorid`, `winner`, `formid` membership, leaves, quantified steps — reads the containing record with
+  no separate spelling. A `*parent` after a field step, carrying a quantifier, or with nothing after it refuses by
+  name; a record nothing contains is stated as such, naming the properties containment runs from, never returned as
+  an empty answer. The parent set is Mutagen's own containment walk, captured at index build, so a Mutagen version
+  that adds a child-bearing container grows `*parent`'s reach with no further change. Index build costs about 0.3 s
+  more over a 3,800-plugin order; check yours against the build time `housecarl_load_order_status` reports.
 - **A `where=` path step can now quantify a list, so "does ANY element match?" is one call.** Four tokens go in the
   step where the list binds: `Conditions[*any].Data.Function = IsGuard` (some element), `[*all]` (every one, and
   vacuously true on an empty list), `[*none]` (absence, proved — `Effects[*none].BaseEffect->editorid startswith REQ_`),

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -79,7 +79,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
   GreetingsTopic"]`, `project={"form":"fields","fields":["*parent.EditorID"]}`, and a walk's `seed_paths`/`follow`.
   It leads a path and it chains, so `*parent.*parent` reaches a placed reference's worldspace, and everything below
   the hop — `editorid`, `winner`, `formid` membership, leaves, quantified steps — reads the containing record with
-  no separate spelling. A record a patch DELETED still answers the question — the hop reads its identity, not its
+  no separate spelling. `fields=` takes it on every form that reads through the load order, the comparison forms
+  `delta` and `tree` included, so the same spelling works wherever `fields=` does bar the out-of-order arm named
+  below; and a child-bearing field reached through the hop carries the same "other plugins declare children here
+  and this read did not open them" note that reading it on the container directly does, so the two spellings of one
+  question cannot disagree. A record a patch DELETED still answers the question — the hop reads its identity, not its
   body — which is the crash-log case exactly, since patches delete placed references constantly. A `*parent` after
   a field step, carrying a quantifier, or with nothing after it refuses by name, in the same words on every surface
   that takes a path; a record nothing contains is stated as such, naming the properties containment runs from,

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -79,18 +79,24 @@ saying it sets an expectation their install may contradict. Say what is known, a
   GreetingsTopic"]`, `project={"form":"fields","fields":["*parent.EditorID"]}`, and a walk's `seed_paths`/`follow`.
   It leads a path and it chains, so `*parent.*parent` reaches a placed reference's worldspace, and everything below
   the hop — `editorid`, `winner`, `formid` membership, leaves, quantified steps — reads the containing record with
-  no separate spelling. A `*parent` after a field step, carrying a quantifier, or with nothing after it refuses by
-  name; a record nothing contains is stated as such, naming the properties containment runs from, never returned as
-  an empty answer. The parent set is Mutagen's own containment walk, captured at index build, so a Mutagen version
-  that adds a child-bearing container grows `*parent`'s reach with no further change. Index build costs about 0.3 s
-  more over a 3,800-plugin order; check yours against the build time `housecarl_load_order_status` reports.
+  no separate spelling. A record a patch DELETED still answers the question — the hop reads its identity, not its
+  body — which is the crash-log case exactly, since patches delete placed references constantly. A `*parent` after
+  a field step, carrying a quantifier, or with nothing after it refuses by name, in the same words on every surface
+  that takes a path; a record nothing contains is stated as such, naming the properties containment runs from,
+  never returned as an empty answer; and over an out-of-load-order file (`source=`), where the containment of the
+  file's own records was never indexed, `*parent` refuses rather than answering from the active order's map. The
+  parent set is Mutagen's own containment walk, captured at index build, so a Mutagen version that adds a
+  child-bearing container grows `*parent`'s reach with no further change. Index build costs about 0.3 s more over a
+  3,800-plugin order, and `housecarl_load_order_status` now reports how many child records the map holds, so its
+  size is stated rather than discovered.
 - **A `where=` path step can now quantify a list, so "does ANY element match?" is one call.** Four tokens go in the
   step where the list binds: `Conditions[*any].Data.Function = IsGuard` (some element), `[*all]` (every one, and
   vacuously true on an empty list), `[*none]` (absence, proved — `Effects[*none].BaseEffect->editorid startswith REQ_`),
   and `[*count]`, which yields the number of elements for a numeric or membership comparison (`Effects[*count] > 2`).
   A quantified step composes with the `->` link step and with another quantified step, at the cost the tool
   description declares (per-candidate work times list length, and one winner fetch per element under `->`). The bare
-  `[*]` is the element SET and is refused in `where=`, naming the three fold tokens; a quantifier pointed at a field
+  `[*]` is the element SET and is refused in `where=`, naming the three fold tokens; a quantifier on `editorid`,
+  `winner` or `formid` refuses by name, since a record has one identity rather than a list of them; a quantifier pointed at a field
   that is not a list — a scalar, a dict, a raw byte block — refuses the call by naming the step's real cardinality
   wherever `types=` says which record type it lands on, and where the scope cannot say (no `types=`, or a mixed one)
   the scan's accounting names what that step read instead; either way, never a silent non-match. An absent list reads as EMPTY, and so does one whose parent substruct

--- a/src/housecarl-core/ContainmentIndex.cs
+++ b/src/housecarl-core/ContainmentIndex.cs
@@ -1,0 +1,91 @@
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Cache;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// The child → parent map: the second edge kind, beside the form link. A DIAL owns its INFOs, a CELL its placed
+/// references and navmeshes, a WRLD its cells — group nesting, not a link, so <c>references=</c> cannot see it and
+/// the child body names nothing (only a NavigationMesh does, at <c>Data.Parent</c>). This is what the
+/// <c>*parent</c> path step reads.
+///
+/// <para><b>Captured at index build, from Mutagen's own containment walk.</b>
+/// <see cref="LoadOrderResolver"/> already enumerates every plugin once; swapping that walk from the flat
+/// <c>EnumerateMajorRecords</c> to <c>EnumerateMajorRecordContexts</c> yields the identical record set with the
+/// containing context attached, for about 0.4 s more over a 3,800-plugin order. There is no per-record-type parent
+/// map here and none is possible: the parent arrives from Mutagen, so a Mutagen bump that adds a child-bearing
+/// container grows <c>*parent</c>'s reach with no edit — the first cornerstone applied to an edge kind.</para>
+///
+/// <para><b>Later plugin wins, like everything else.</b> Across a real order thousands of children end up under a
+/// different parent than the first plugin put them under (a placed reference moved between cells), so the map is
+/// merged per plugin in priority order and the last declaration stands — the same rule the winner index follows.
+/// A plugin that throws part-way through its walk merges nothing, so a half-read plugin never leaves partial
+/// containment behind.</para>
+///
+/// <para><b>Packed.</b> Entries are ulong → ulong ((interned mod index &lt;&lt; 32) | FormID), not FormKey → FormKey:
+/// ~44 B an entry, about 77 MB for the 2.7M children of a large order, of which <c>Cell.Temporary</c> is four
+/// fifths. Pure data — no bodies, no file handles.</para></summary>
+public sealed class ContainmentIndex
+{
+    readonly Dictionary<ulong, ulong> _map = new();
+    readonly Dictionary<ModKey, int> _modToIdx = new();
+    readonly List<ModKey> _idxToMod = new();
+
+    /// <summary>How far a group/block context is climbed to reach the nearest record ancestor. Mutagen hands a
+    /// worldspace's cells up through block and sub-block contexts that carry no record of their own; the deepest
+    /// real chain is two hops. A chain that holds no record inside the bound stages no edge, so <c>*parent</c>
+    /// says it has none rather than guessing at one.</summary>
+    const int MaxGroupHops = 6;
+
+    /// <summary>Distinct children with a recorded parent.</summary>
+    public int Count => _map.Count;
+
+    /// <summary>The containing record of <paramref name="child"/>, or null when this build recorded none — the
+    /// record is top-level, or its context chain held no record ancestor.</summary>
+    public FormKey? ParentOf(FormKey child)
+    {
+        if (!_modToIdx.TryGetValue(child.ModKey, out int i)) return null;
+        if (!_map.TryGetValue(((ulong)(uint)i << 32) | child.ID, out var packed)) return null;
+        return new FormKey(_idxToMod[(int)(packed >> 32)], (uint)packed);
+    }
+
+    /// <summary>Stage one plugin's containment edges, read off the context walk. Returns the pairs for the caller to
+    /// merge only if the whole plugin enumerated — the same plugin-atomic rule the winner index follows.</summary>
+    internal static void Stage(IModContext context, List<(FormKey Child, FormKey Parent)> into)
+    {
+        if (context.Record is not IMajorRecordGetter child) return;
+        var up = context.Parent;
+        for (int hops = 0; up is not null && hops <= MaxGroupHops; hops++, up = up.Parent)
+            if (up.Record is IMajorRecordGetter ancestor) { into.Add((child.FormKey, ancestor.FormKey)); return; }
+    }
+
+    /// <summary>Merge one fully-enumerated plugin's edges, later-wins.</summary>
+    internal void Merge(IReadOnlyList<(FormKey Child, FormKey Parent)> edges)
+    {
+        foreach (var (child, parent) in edges) _map[Pack(child)] = Pack(parent);
+    }
+
+    ulong Pack(FormKey k)
+    {
+        if (!_modToIdx.TryGetValue(k.ModKey, out int i))
+        {
+            _modToIdx[k.ModKey] = i = _idxToMod.Count;
+            _idxToMod.Add(k.ModKey);
+        }
+        return ((ulong)(uint)i << 32) | k.ID;
+    }
+
+    /// <summary>The child-bearing property surface, spelled <c>Type.Property</c> — what a <c>*parent</c> refusal
+    /// names as the reason a record has no containing record. Derived from
+    /// <see cref="WriteEngine.ChildBearingProperties"/> over every concrete record type Mutagen models, the same
+    /// source the write surface's child preservation runs on, so it is never a hand list.</summary>
+    public static string ChildBearingSurface() => _surface ??= string.Join(", ",
+        typeof(Weapon).Assembly.GetTypes()
+            .Where(t => t.IsClass && !t.IsAbstract && !t.Name.EndsWith("BinaryOverlay", StringComparison.Ordinal)
+                        && typeof(IMajorRecord).IsAssignableFrom(t))
+            .SelectMany(t => WriteEngine.ChildBearingProperties(t).Select(p => $"{t.Name}.{p.Name}"))
+            .OrderBy(s => s, StringComparer.Ordinal));
+    static string? _surface;
+}

--- a/src/housecarl-core/ContainmentIndex.cs
+++ b/src/housecarl-core/ContainmentIndex.cs
@@ -14,7 +14,9 @@ namespace HousecarlCore;
 /// <para><b>Captured at index build, from Mutagen's own containment walk.</b>
 /// <see cref="LoadOrderResolver"/> already enumerates every plugin once; swapping that walk from the flat
 /// <c>EnumerateMajorRecords</c> to <c>EnumerateMajorRecordContexts</c> yields the identical record set with the
-/// containing context attached, for about 0.4 s more over a 3,800-plugin order. There is no per-record-type parent
+/// containing context attached, for about 0.3 s more over a 3,800-plugin order — 0.31 s to 0.43 s across repeated
+/// alternating runs on the ARR 2.0 order (3,801 plugins, 3.69M records), which is that machine's own run-to-run
+/// spread; the changelog quotes the low end. There is no per-record-type parent
 /// map here and none is possible: the parent arrives from Mutagen, so a Mutagen bump that adds a child-bearing
 /// container grows <c>*parent</c>'s reach with no edit — the first cornerstone applied to an edge kind.</para>
 ///
@@ -25,8 +27,9 @@ namespace HousecarlCore;
 /// containment behind.</para>
 ///
 /// <para><b>Packed.</b> Entries are ulong → ulong ((interned mod index &lt;&lt; 32) | FormID), not FormKey → FormKey:
-/// ~44 B an entry, about 77 MB for the 2.7M children of a large order, of which <c>Cell.Temporary</c> is four
-/// fifths. Pure data — no bodies, no file handles.</para></summary>
+/// ~30 B an entry, about 77 MB measured for the 2,711,713 children of a large order, of which
+/// <c>Cell.Temporary</c> is four fifths. Pure data — no bodies, no file handles. The count is reported in band on
+/// <c>housecarl_load_order_status</c>, so the cost is declared rather than discovered.</para></summary>
 public sealed class ContainmentIndex
 {
     /// <summary>The one spelling of the containment step, shared by every surface that takes a path — a
@@ -35,15 +38,47 @@ public sealed class ContainmentIndex
     /// takeable.</summary>
     public const string ParentToken = "*parent";
 
+    /// <summary>True when this path segment IS the containment step.</summary>
+    public static bool IsParentStep(string seg) => string.Equals(seg, ParentToken, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>The ONE grammar check for a <c>*parent</c> run, shared by every surface that takes a path — the
+    /// <c>where=</c> predicate and the <c>project.fields</c> read walk both call this, so an identical mistake
+    /// gets an identical sentence instead of a typo hint on one surface and a named refusal on the other.
+    /// Returns how many hops lead <paramref name="segs"/>, or the refusal (unprefixed, so each surface wraps it
+    /// in its own voice). A hop leads a path by definition — the containing record is a property of the RECORD,
+    /// not of a field value — so a <c>*parent</c> anywhere else refuses by name, as does one carrying a
+    /// quantifier, one with nothing after it, and any other <c>*</c> token.</summary>
+    /// <param name="display">How the caller spelled this side, for the message.</param>
+    /// <param name="isLinkLeft">The left side of a <c>-&gt;</c> step, whose all-hops case wants a link, not a value.</param>
+    /// <param name="allowBare">A walk's seed path or follow, where a path of nothing but hops IS the edge crossed —
+    /// the containing record is the walk's next node, not a value to read.</param>
+    public static (int Hops, string? Error) SplitHops(string[] segs, string display, bool isLinkLeft = false, bool allowBare = false)
+    {
+        int hops = 0;
+        while (hops < segs.Length && IsParentStep(segs[hops])) hops++;
+        for (int i = hops; i < segs.Length; i++)
+        {
+            var s = segs[i];
+            if (IsParentStep(s))
+                return (0, $"'{ParentToken}' is the record that CONTAINS this one, so it can only lead a path — " +
+                           $"in '{display}' it follows a field step. Write the hops first ('{ParentToken}.EditorID').");
+            int open = s.IndexOf('[');
+            if (open > 0 && s.EndsWith("]", StringComparison.Ordinal)
+                && string.Equals(s[..open], ParentToken, StringComparison.OrdinalIgnoreCase))
+                return (0, $"'{s}' — '{ParentToken}' names ONE containing record, not a list, so it takes no quantifier. Write '{ParentToken}'.");
+            if (s.Length > 0 && s[0] == '*' && open != 0)
+                return (0, $"'{s}' is not a path token — the tokens are '{ParentToken}' (the containing record) and the quantifiers [*any], [*all], [*none] and [*count] on a list step.");
+        }
+        if (hops == segs.Length && hops > 0 && !allowBare)
+            return (0, isLinkLeft
+                ? $"'{display}' is the containing record, which is not a link-bearing field — name one on it ('{display}.Quest->editorid')."
+                : $"'{display}' names the containing record, not a value — follow it with a field ('{display}.EditorID').");
+        return (hops, null);
+    }
+
     readonly Dictionary<ulong, ulong> _map = new();
     readonly Dictionary<ModKey, int> _modToIdx = new();
     readonly List<ModKey> _idxToMod = new();
-
-    /// <summary>How far a group/block context is climbed to reach the nearest record ancestor. Mutagen hands a
-    /// worldspace's cells up through block and sub-block contexts that carry no record of their own; the deepest
-    /// real chain is two hops. A chain that holds no record inside the bound stages no edge, so <c>*parent</c>
-    /// says it has none rather than guessing at one.</summary>
-    const int MaxGroupHops = 6;
 
     /// <summary>Distinct children with a recorded parent.</summary>
     public int Count => _map.Count;
@@ -58,12 +93,19 @@ public sealed class ContainmentIndex
     }
 
     /// <summary>Stage one plugin's containment edges, read off the context walk. Returns the pairs for the caller to
-    /// merge only if the whole plugin enumerated — the same plugin-atomic rule the winner index follows.</summary>
+    /// merge only if the whole plugin enumerated — the same plugin-atomic rule the winner index follows.
+    ///
+    /// <para>The climb to the nearest record ancestor is UNBOUNDED, deliberately. Mutagen hands a worldspace's
+    /// cells up through block and sub-block contexts that carry no record of their own, and the deepest chain
+    /// today is two such hops — but a cap here would turn a chain one level deeper than the cap into a staged
+    /// nothing, which <c>ParentOf</c> then reports as "no record contains this", a false statement rather than a
+    /// missing one. The chain is finite and Mutagen-owned (each context's Parent terminates at the mod), so
+    /// walking it to the end makes "no containing record" true by construction and lets a Mutagen bump that nests
+    /// one level deeper keep working with no edit here.</para></summary>
     internal static void Stage(IModContext context, List<(FormKey Child, FormKey Parent)> into)
     {
         if (context.Record is not IMajorRecordGetter child) return;
-        var up = context.Parent;
-        for (int hops = 0; up is not null && hops <= MaxGroupHops; hops++, up = up.Parent)
+        for (var up = context.Parent; up is not null; up = up.Parent)
             if (up.Record is IMajorRecordGetter ancestor) { into.Add((child.FormKey, ancestor.FormKey)); return; }
     }
 

--- a/src/housecarl-core/ContainmentIndex.cs
+++ b/src/housecarl-core/ContainmentIndex.cs
@@ -29,6 +29,12 @@ namespace HousecarlCore;
 /// fifths. Pure data — no bodies, no file handles.</para></summary>
 public sealed class ContainmentIndex
 {
+    /// <summary>The one spelling of the containment step, shared by every surface that takes a path — a
+    /// predicate, a field projection, a walk's seed paths and follow. The <c>*</c> sigil is §5.5's rule: the
+    /// co-resident space is field names, and <c>Worldspace.Parent</c> is a real field, so a bare <c>parent</c> is
+    /// takeable.</summary>
+    public const string ParentToken = "*parent";
+
     readonly Dictionary<ulong, ulong> _map = new();
     readonly Dictionary<ModKey, int> _modToIdx = new();
     readonly List<ModKey> _idxToMod = new();
@@ -76,6 +82,26 @@ public sealed class ContainmentIndex
         }
         return ((ulong)(uint)i << 32) | k.ID;
     }
+
+    /// <summary>The <c>*parent</c> hop a field read takes: this build's containment map, then the containing
+    /// record's winner body through the caller's own session, so a read that already holds one plugin open pays
+    /// nothing extra. A record nothing contains comes back with the plain sentence saying so and naming the
+    /// properties containment runs from — never a null the render has to guess at.</summary>
+    public static Func<IMajorRecordGetter, (IMajorRecordGetter? Parent, string? Why)> ReadHop(
+        LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session) => child =>
+    {
+        var pk = view.ParentOf(child.FormKey);
+        if (pk is null)
+            return (null, $"no record contains this {RecordNaming.StripOverlay(child.GetType().Name)} — containment runs " +
+                          $"from these properties only: {ChildBearingSurface()}");
+        var winner = view.ResolveWinner(pk.Value);
+        if (winner is null)
+            return (null, $"the containing record {pk.Value} is not in the active load order");
+        var body = view.GetRecord(session, winner.Value.WinnerPlugin, pk.Value);
+        return body is null
+            ? (null, $"the containing record {pk.Value} would not fetch from its winner '{winner.Value.WinnerPlugin}'")
+            : (body, null);
+    };
 
     /// <summary>The child-bearing property surface, spelled <c>Type.Property</c> — what a <c>*parent</c> refusal
     /// names as the reason a record has no containing record. Derived from

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -489,9 +489,6 @@ public sealed class FieldPredicateSet
         return (outSegs, folds, null);
     }
 
-    /// <summary>The containment step token: reverse containment, spelled with the <c>*</c> sigil because
-    /// <c>Worldspace.Parent</c> is a real field and a bare <c>parent</c> is takeable.</summary>
-    internal const string ParentToken = "*parent";
 
     /// <summary>Strip a side's leading <c>*parent</c> hops and hand back the rest of the path. A hop leads a path
     /// by definition — the containing record is a property of the RECORD, not of a field value — so a <c>*parent</c>
@@ -504,15 +501,15 @@ public sealed class FieldPredicateSet
         for (int i = hops; i < segs.Length; i++)
         {
             if (IsParentStep(segs[i]))
-                return (segs, 0, $"predicate '{raw}': '{ParentToken}' is the record that CONTAINS this one, so it can only lead a path — " +
-                                 $"in '{display}' it follows a field step. Write the hops first ('{ParentToken}.EditorID').");
+                return (segs, 0, $"predicate '{raw}': '{ContainmentIndex.ParentToken}' is the record that CONTAINS this one, so it can only lead a path — " +
+                                 $"in '{display}' it follows a field step. Write the hops first ('{ContainmentIndex.ParentToken}.EditorID').");
             var s = segs[i];
             int open = s.IndexOf('[');
             if (open > 0 && s.EndsWith("]", StringComparison.Ordinal)
-                && string.Equals(s[..open], ParentToken, StringComparison.OrdinalIgnoreCase))
-                return (segs, 0, $"predicate '{raw}': '{s}' — '{ParentToken}' names ONE containing record, not a list, so it takes no quantifier. Write '{ParentToken}'.");
+                && string.Equals(s[..open], ContainmentIndex.ParentToken, StringComparison.OrdinalIgnoreCase))
+                return (segs, 0, $"predicate '{raw}': '{s}' — '{ContainmentIndex.ParentToken}' names ONE containing record, not a list, so it takes no quantifier. Write '{ContainmentIndex.ParentToken}'.");
             if (s.Length > 0 && s[0] == '*' && open != 0)
-                return (segs, 0, $"predicate '{raw}': '{s}' is not a path token — the tokens are '{ParentToken}' (the containing record) and the quantifiers [*any], [*all], [*none] and [*count] on a list step.");
+                return (segs, 0, $"predicate '{raw}': '{s}' is not a path token — the tokens are '{ContainmentIndex.ParentToken}' (the containing record) and the quantifiers [*any], [*all], [*none] and [*count] on a list step.");
         }
         if (hops == 0) return (segs, 0, null);
         if (hops == segs.Length)
@@ -522,7 +519,7 @@ public sealed class FieldPredicateSet
         return (segs[hops..], hops, null);
     }
 
-    static bool IsParentStep(string seg) => string.Equals(seg, ParentToken, StringComparison.OrdinalIgnoreCase);
+    static bool IsParentStep(string seg) => string.Equals(seg, ContainmentIndex.ParentToken, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>The token a fold is spelled with, for a message.</summary>
     static string FoldToken(Fold f) => f switch
@@ -1040,7 +1037,7 @@ public sealed class FieldPredicateSet
     {
         if (_parentOf is null || _fetchWinnerBody is null)
         {
-            _fatal = $"internal: a '{ParentToken}' containment predicate was evaluated without a bound resolution context — this scan surface does not support it.";
+            _fatal = $"internal: a '{ContainmentIndex.ParentToken}' containment predicate was evaluated without a bound resolution context — this scan surface does not support it.";
             return (null, EvalKind.Definite);
         }
         for (int i = 0; i < hops; i++)

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records;
 

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records;
 
@@ -41,6 +41,13 @@ namespace HousecarlCore;
 /// <c>[*count]</c> into their number; the bare <c>[*]</c> is the element SET and is refused here (a set is not a
 /// boolean). The fold is the same one <see cref="EvalLinkStep"/> already runs over link targets, with the fan-out
 /// source swapped to the step's elements — so it composes with the <c>-&gt;</c> link step and with itself.</para>
+///
+/// <para><b>The containment step.</b> A path may LEAD with <c>*parent</c>, the second edge kind: the record that
+/// CONTAINS this one — a DIAL over its INFO, a CELL over its placed references, a WRLD over its cells
+/// (<c>*parent.EditorID = GreetingsTopic</c>, <c>*parent.*parent.EditorID = Tamriel</c>). It is a step, so it
+/// chains and everything below it — the winner term, <c>editorid</c>, <c>formid</c> membership, leaves, folds —
+/// reads the parent with no second rule. It leads a path by definition: the containing record is a property of the
+/// RECORD, not of a field value, so a <c>*parent</c> anywhere else refuses by name.</para>
 /// </summary>
 public sealed class FieldPredicateSet
 {
@@ -80,12 +87,16 @@ public sealed class FieldPredicateSet
     /// consuming scan must check against the build it captures (see <see cref="ArtifactDemands"/>).
     /// <paramref name="PathFolds"/> / <paramref name="LinkFolds"/> are parallel to the segments of their side and
     /// carry each step's quantifier, null when that side has none — the segments themselves are stored bare, so
-    /// the read walk sees an ordinary field name.</summary>
+    /// the read walk sees an ordinary field name.
+    /// <paramref name="ParentHops"/> / <paramref name="LinkParentHops"/> are how many leading <c>*parent</c>
+    /// containment steps that side opens with; the segments after them are stored bare, so once the hop lands on
+    /// the containing record everything downstream reads an ordinary path.</summary>
     sealed record Predicate(string Text, string[] PathSegments, string PathDisplay, Op Op, string Operand, double NumericOperand,
                             HashSet<FormKey>? FormIds = null, ArtifactDemand? Artifact = null,
                             string[]? LinkPath = null, string? LinkPathDisplay = null,
                             PseudoPath Pseudo = PseudoPath.None, IReadOnlyList<string>? RawMembers = null,
-                            Fold[]? PathFolds = null, Fold[]? LinkFolds = null);
+                            Fold[]? PathFolds = null, Fold[]? LinkFolds = null,
+                            int ParentHops = 0, int LinkParentHops = 0);
 
     /// <summary>The identity pseudo-paths a predicate may name instead of a body leaf. <c>editorid</c> reads the
     /// record's EditorID (always available off the early EDID subrecord — never a reflection walk, and live even on
@@ -106,6 +117,8 @@ public sealed class FieldPredicateSet
     readonly string?[] _listHopRemedy; // the leaf-checked remedy the read engine composed for that hop, quoted verbatim
     readonly long[] _notList;     // per-predicate SUBSET of _noField: a quantified step landed on a value that is not a list — the fold has nothing to fan out over
     readonly string?[] _notListWhat;   // what that step actually read, for the sentence
+    readonly long[] _noParent;    // per-predicate SUBSET of _noField: a '*parent' step found no containing record
+    readonly string?[] _noParentWhat;  // the record type it found none for, for the sentence
     long _scanned;
     string? _fatal;
 
@@ -115,6 +128,9 @@ public sealed class FieldPredicateSet
     // evaluating an unbound term is a FatalError, never a silent non-match.
     Func<FormKey, string?>? _winnerOf;
     Func<FormKey, IMajorRecordGetter?>? _fetchWinnerBody;
+    // The `*parent` containment step reads the index's child→parent map, then fetches that parent's winner body
+    // through _fetchWinnerBody like any other cross-record hop.
+    Func<FormKey, FormKey?>? _parentOf;
     // Link-step targets recur across candidates — fetch once per scan. Unbounded by design for the set's lifetime
     // (one call): magnitude is the DISTINCT link-target population of the scanned scope, which for realistic link
     // paths (Perks, Effects, Keywords) is hundreds-to-low-thousands of record getters, small beside the scan
@@ -125,26 +141,35 @@ public sealed class FieldPredicateSet
     /// <summary>Whether any predicate needs the scan's resolution context (<c>winner</c> term or a <c>-&gt;</c>
     /// link step) — the call site checks this to bind <see cref="BindResolution"/> (and open the body-fetch
     /// session the link step needs) before the first <see cref="Matches"/>.</summary>
-    public bool NeedsResolution => _predicates.Any(p => p.Pseudo == PseudoPath.Winner || p.LinkPath is not null);
+    public bool NeedsResolution => _predicates.Any(p => p.Pseudo == PseudoPath.Winner || p.LinkPath is not null || Hops(p) > 0);
 
-    /// <summary>Whether any predicate follows a <c>-&gt;</c> link step (needs winner BODY fetches, not just the
-    /// winner name) — the call site opens an overlay session for the fetch when true.</summary>
-    public bool NeedsBodyResolution => _predicates.Any(p => p.LinkPath is not null);
+    /// <summary>Whether any predicate follows a <c>-&gt;</c> link step or a <c>*parent</c> containment step (needs
+    /// winner BODY fetches, not just the winner name) — the call site opens an overlay session for the fetch when
+    /// true.</summary>
+    public bool NeedsBodyResolution => _predicates.Any(p => p.LinkPath is not null || Hops(p) > 0);
+
+    /// <summary>Whether any predicate takes a <c>*parent</c> containment step — the call site binds the index's
+    /// child→parent lookup when true.</summary>
+    public bool NeedsContainment => _predicates.Any(p => Hops(p) > 0);
+
+    static int Hops(Predicate p) => p.ParentHops + p.LinkParentHops;
 
     /// <summary>Whether any predicate reads record BODY content (a leaf walk or a link step) — false when every
     /// term is header/resolution-only (`editorid`, `winner`, `formid` membership). The scan's deleted-record check
     /// keys on this: a deleted record has no live body for the CONTENT filters, but its EditorID and its winner
     /// resolution are real facts, so a header-only predicate set must still see it.</summary>
-    public bool NeedsLiveBody => _predicates.Any(p => p.LinkPath is not null || p.Pseudo == PseudoPath.None);
+    public bool NeedsLiveBody => _predicates.Any(p => p.LinkPath is not null || p.Pseudo == PseudoPath.None || Hops(p) > 0);
 
     /// <summary>Bind the scan's resolution context: <paramref name="winnerOf"/> answers "which plugin wins this
     /// FormKey" (the `winner` term), <paramref name="fetchWinnerBody"/> produces a linked target's winner body
     /// (the `-&gt;` link step; null when the target doesn't resolve). Both must come from the SAME captured view
     /// the scan answers from.</summary>
-    public void BindResolution(Func<FormKey, string?> winnerOf, Func<FormKey, IMajorRecordGetter?>? fetchWinnerBody = null)
+    public void BindResolution(Func<FormKey, string?> winnerOf, Func<FormKey, IMajorRecordGetter?>? fetchWinnerBody = null,
+                               Func<FormKey, FormKey?>? parentOf = null)
     {
         _winnerOf = winnerOf;
         _fetchWinnerBody = fetchWinnerBody;
+        _parentOf = parentOf;
     }
 
     FieldPredicateSet(IReadOnlyList<Predicate> predicates)
@@ -160,6 +185,8 @@ public sealed class FieldPredicateSet
         _listHopRemedy = new string?[predicates.Count];
         _notList = new long[predicates.Count];
         _notListWhat = new string?[predicates.Count];
+        _noParent = new long[predicates.Count];
+        _noParentWhat = new string?[predicates.Count];
     }
 
     /// <summary>Set once when a numeric operator meets a non-numeric field value on the first value-bearing
@@ -326,6 +353,21 @@ public sealed class FieldPredicateSet
         if (segs.Length == 0)
             return (null, $"predicate '{raw}': '{path}' is not a usable field path.");
 
+        // The containment step: a leading run of '*parent' hops from the record to the record that CONTAINS it,
+        // and the rest of the side is read on that. Stripped first, because a hop leads a path by definition.
+        int linkParentHops = 0, parentHops;
+        if (linkSegs is not null)
+        {
+            var (lrest, lhops, lherr) = SplitParentHops(raw, linkSegs, linkDisplay!, isLinkLeft: true);
+            if (lherr is not null) return (null, lherr);
+            linkSegs = lrest; linkParentHops = lhops;
+        }
+        {
+            var (rest, hops, herr) = SplitParentHops(raw, segs, path, isLinkLeft: false);
+            if (herr is not null) return (null, herr);
+            segs = rest; parentHops = hops;
+        }
+
         // The quantified step: each side's segments are split into bare field names plus their fold tokens, so the
         // read walk below sees an ordinary path and the fold rides beside it.
         Fold[]? linkFolds = null;
@@ -370,7 +412,7 @@ public sealed class FieldPredicateSet
                 return (null, $"predicate '{raw}': '{path}' always exists (every record has an identity and a winner) — a presence test on it can never filter. Use it with its own operators instead.");
             if (operand.Length != 0)
                 return (null, $"predicate '{raw}': '{OpStr(op)}' is a presence test and takes no value (got '{operand}'). Write it as \"{path} {OpStr(op)}\".");
-            return (new Predicate(text, segs, path, op, "", 0, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo, PathFolds: pathFolds, LinkFolds: linkFolds), null);
+            return (new Predicate(text, segs, path, op, "", 0, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo, PathFolds: pathFolds, LinkFolds: linkFolds, ParentHops: parentHops, LinkParentHops: linkParentHops), null);
         }
 
         if (operand.Length == 0)
@@ -391,11 +433,11 @@ public sealed class FieldPredicateSet
             {
                 var (set, artifact, lerr) = ParseFormIdList(text, operand, parseFormId);
                 if (lerr is not null) return (null, lerr);
-                return (new Predicate(text, segs, path, op, operand, 0, set, artifact, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo, PathFolds: pathFolds, LinkFolds: linkFolds), null);
+                return (new Predicate(text, segs, path, op, operand, 0, set, artifact, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo, PathFolds: pathFolds, LinkFolds: linkFolds, ParentHops: parentHops, LinkParentHops: linkParentHops), null);
             }
             var (members, mset, martifact, merr) = ParseValueList(text, operand);
             if (merr is not null) return (null, merr);
-            return (new Predicate(text, segs, path, op, operand, 0, mset, martifact, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo, RawMembers: members, PathFolds: pathFolds, LinkFolds: linkFolds), null);
+            return (new Predicate(text, segs, path, op, operand, 0, mset, martifact, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo, RawMembers: members, PathFolds: pathFolds, LinkFolds: linkFolds, ParentHops: parentHops, LinkParentHops: linkParentHops), null);
         }
         if (pseudo == PseudoPath.FormId)
             return (null, $"predicate '{raw}': 'formid' takes the membership ops only — \"formid in <list>\" / \"formid not in <list>\" (a single record is \"formid in [XXXXXX:Plugin.esp]\").");
@@ -405,7 +447,7 @@ public sealed class FieldPredicateSet
         if (IsNumericOp(op) && !TryNum(operand, out num))
             return (null, $"predicate '{raw}': operator '{OpStr(op)}' needs a numeric value, got '{operand}'.");
 
-        return (new Predicate(text, segs, path, op, operand, num, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo, PathFolds: pathFolds, LinkFolds: linkFolds), null);
+        return (new Predicate(text, segs, path, op, operand, num, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo, PathFolds: pathFolds, LinkFolds: linkFolds, ParentHops: parentHops, LinkParentHops: linkParentHops), null);
     }
 
     /// <summary>Split one side's segments into bare field names plus their fold tokens: a bracket key beginning
@@ -446,6 +488,41 @@ public sealed class FieldPredicateSet
         }
         return (outSegs, folds, null);
     }
+
+    /// <summary>The containment step token: reverse containment, spelled with the <c>*</c> sigil because
+    /// <c>Worldspace.Parent</c> is a real field and a bare <c>parent</c> is takeable.</summary>
+    internal const string ParentToken = "*parent";
+
+    /// <summary>Strip a side's leading <c>*parent</c> hops and hand back the rest of the path. A hop leads a path
+    /// by definition — the containing record is a property of the RECORD, not of a field value — so a <c>*parent</c>
+    /// anywhere else refuses by name, as does one carrying a quantifier, one with nothing after it, and any other
+    /// <c>*</c> token.</summary>
+    static (string[] Tail, int Hops, string? Error) SplitParentHops(string raw, string[] segs, string display, bool isLinkLeft)
+    {
+        int hops = 0;
+        while (hops < segs.Length && IsParentStep(segs[hops])) hops++;
+        for (int i = hops; i < segs.Length; i++)
+        {
+            if (IsParentStep(segs[i]))
+                return (segs, 0, $"predicate '{raw}': '{ParentToken}' is the record that CONTAINS this one, so it can only lead a path — " +
+                                 $"in '{display}' it follows a field step. Write the hops first ('{ParentToken}.EditorID').");
+            var s = segs[i];
+            int open = s.IndexOf('[');
+            if (open > 0 && s.EndsWith("]", StringComparison.Ordinal)
+                && string.Equals(s[..open], ParentToken, StringComparison.OrdinalIgnoreCase))
+                return (segs, 0, $"predicate '{raw}': '{s}' — '{ParentToken}' names ONE containing record, not a list, so it takes no quantifier. Write '{ParentToken}'.");
+            if (s.Length > 0 && s[0] == '*' && open != 0)
+                return (segs, 0, $"predicate '{raw}': '{s}' is not a path token — the tokens are '{ParentToken}' (the containing record) and the quantifiers [*any], [*all], [*none] and [*count] on a list step.");
+        }
+        if (hops == 0) return (segs, 0, null);
+        if (hops == segs.Length)
+            return (segs, 0, isLinkLeft
+                ? $"predicate '{raw}': '{display}' is the containing record, which is not a link-bearing field — name one on it ('{display}.Quest->editorid')."
+                : $"predicate '{raw}': '{display}' names the containing record, not a value — follow it with a field ('{display}.EditorID').");
+        return (segs[hops..], hops, null);
+    }
+
+    static bool IsParentStep(string seg) => string.Equals(seg, ParentToken, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>The token a fold is spelled with, for a message.</summary>
     static string FoldToken(Fold f) => f switch
@@ -635,6 +712,9 @@ public sealed class FieldPredicateSet
                 // A quantified step on a non-list IS a no-such-field miss for the rollup; the extra counter is what
                 // lets the sentence say the step's real cardinality rather than "mistyped path".
                 case EvalKind.NotAList: _noField[k]++; _notList[k]++; _noValue[k]++; _notListWhat[k] ??= _lastNotList; all = false; break;
+                // A '*parent' step on a record nothing contains is likewise a no-such-field miss for the rollup; the
+                // extra counter is what lets the sentence name the child-bearing properties instead of a typo hint.
+                case EvalKind.NoParent: _noField[k]++; _noParent[k]++; _noValue[k]++; _noParentWhat[k] ??= _lastNoParent; all = false; break;
                 case EvalKind.Container: _container[k]++; _noValue[k]++; all = false; break;
                 case EvalKind.Unreadable: _unreadable[k]++; _noValue[k]++; all = false; break;
                 default: _noValue[k]++; all = false; break;   // Unset — a valid, value-less path
@@ -646,7 +726,11 @@ public sealed class FieldPredicateSet
     /// <summary>How one predicate's evaluation on one record resolved: a DEFINITE verdict (the value was read and
     /// compared, or an identity/presence test decided), or one of the no-verdict classes the accounting keys on.
     /// Mirrors the leaf-note vocabulary: no-such-field / container / read-fault / genuinely-unset.</summary>
-    enum EvalKind { Definite, NoField, ListHop, NotAList, Container, Unreadable, Unset }
+    enum EvalKind { Definite, NoField, ListHop, NotAList, NoParent, Container, Unreadable, Unset }
+
+    /// <summary>The type of the record the most recent <c>*parent</c> hop found no containing record for, stashed
+    /// for the rollup sentence.</summary>
+    string? _lastNoParent;
 
     /// <summary>The collection field named by the most recent list-hop note, stashed for the rollup.</summary>
     string? _lastListHopOwner;
@@ -686,6 +770,16 @@ public sealed class FieldPredicateSet
     /// <see cref="_fatal"/> on a typed predicate error (numeric op vs non-numeric field, unbound winner term).</summary>
     (bool Satisfied, EvalKind Kind) EvalCore(Predicate p, IMajorRecordGetter body)
     {
+        // The `*parent` containment step: climb to the containing record FIRST, then run every term below on it.
+        // That is what makes it a step — the winner term, editorid, formid membership, leaves and folds all read
+        // the parent without a second rule each.
+        if (p.ParentHops > 0)
+        {
+            var (hopped, miss) = HopToParent(body, p.ParentHops);
+            if (miss is { } m) return (false, m);
+            body = hopped!;
+        }
+
         // The `winner` provenance term: reads the record's RESOLUTION off the bound view — never its body.
         if (p.Pseudo == PseudoPath.Winner)
         {
@@ -848,7 +942,7 @@ public sealed class FieldPredicateSet
     static int NoVerdictRank(EvalKind k) => k switch
     {
         EvalKind.Unreadable => 4,
-        EvalKind.ListHop => 3, EvalKind.NotAList => 3, EvalKind.NoField => 3,
+        EvalKind.ListHop => 3, EvalKind.NotAList => 3, EvalKind.NoField => 3, EvalKind.NoParent => 3,
         EvalKind.Container => 2,
         _ => 1,   // Unset
     };
@@ -929,7 +1023,36 @@ public sealed class FieldPredicateSet
             _fatal = "internal: a '->' link-step predicate was evaluated without a bound resolution context — this scan surface does not support it.";
             return (false, EvalKind.Definite);
         }
+        if (p.LinkParentHops > 0)
+        {
+            var (hopped, miss) = HopToParent(body, p.LinkParentHops);
+            if (miss is { } m) return (false, m);
+            body = hopped!;
+        }
         return EvalLinkPath(p, body, 0);
+    }
+
+    /// <summary>Climb <paramref name="hops"/> containment steps from one record to the record that contains it,
+    /// fetching each parent's winner body through the same bound view the <c>-&gt;</c> step resolves through. A
+    /// record with no containing record is a NAMED no-verdict, never a silent non-match: the rollup says which
+    /// properties own children at all.</summary>
+    (IMajorRecordGetter? Body, EvalKind? Miss) HopToParent(IMajorRecordGetter body, int hops)
+    {
+        if (_parentOf is null || _fetchWinnerBody is null)
+        {
+            _fatal = $"internal: a '{ParentToken}' containment predicate was evaluated without a bound resolution context — this scan surface does not support it.";
+            return (null, EvalKind.Definite);
+        }
+        for (int i = 0; i < hops; i++)
+        {
+            var pk = _parentOf(body.FormKey);
+            if (pk is null) { _lastNoParent = RecordNaming.StripOverlay(body.GetType().Name); return (null, EvalKind.NoParent); }
+            if (!_targetCache.TryGetValue(pk.Value, out var parent))
+                _targetCache[pk.Value] = parent = _fetchWinnerBody(pk.Value);
+            if (parent is null) return (null, EvalKind.Unreadable);   // the parent is indexed but its body would not fetch
+            body = parent;
+        }
+        return (body, null);
     }
 
     /// <summary>The link step's left path from segment <paramref name="from"/> down. A quantified step there folds
@@ -979,7 +1102,7 @@ public sealed class FieldPredicateSet
                 anyVerdict = true;
                 if (sat) return (true, EvalKind.Definite);
             }
-            else if (kind is EvalKind.NoField or EvalKind.ListHop) { anyNoField = true; anyListHop |= kind == EvalKind.ListHop; }
+            else if (kind is EvalKind.NoField or EvalKind.ListHop or EvalKind.NoParent) { anyNoField = true; anyListHop |= kind == EvalKind.ListHop; }
         }
         if (anyVerdict) return (false, EvalKind.Definite);
         return (false, anyNoField ? (anyListHop ? EvalKind.ListHop : EvalKind.NoField) : EvalKind.Unreadable);
@@ -1147,7 +1270,16 @@ public sealed class FieldPredicateSet
                 const string loud = "yielded no readable value on any of";
                 long unset = _noValue[k] - _noField[k] - _container[k] - _unreadable[k];   // what is left: genuinely-unset valid fields
                 string reason;
-                if (_noField[k] == _scanned && _notList[k] > 0)
+                if (_noField[k] == _scanned && _noParent[k] > 0)
+                {
+                    // Nothing CONTAINS these records, so the hop has nowhere to go. Name the properties that own
+                    // children at all — that is the whole reason, and it is derived from Mutagen, not a hand list.
+                    reason = $"predicate field '{path}' {loud} {_scanned:N0} scanned record(s) — no record CONTAINS " +
+                             $"{(_noParentWhat[k] is { } t ? $"a {t}" : "these records")}, on {_noParent[k]:N0} of them" +
+                             (_noParent[k] == _scanned ? "" : "; on the rest the path is not a field at all") +
+                             $". Containment runs from these properties only: {ContainmentIndex.ChildBearingSurface()}.";
+                }
+                else if (_noField[k] == _scanned && _notList[k] > 0)
                 {
                     // The quantifier is the thing to drop, and no schema advice fits: the step exists, it is just
                     // not a list here, and the sentence names what it read instead.

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -222,8 +222,9 @@ public sealed class FieldPredicateSet
     /// fold, how it is spelled, and the predicate's own text for the message. A scan with a NAMED type scope walks
     /// these against the schema, so "that step is not a list on this type" refuses the call rather than becoming a
     /// whole-scan accounting note. <paramref name="OnScannedType"/> says whether the step is rooted at the SCANNED
-    /// record type: the right side of a <c>-&gt;</c> is rooted at the link TARGET's type instead, and asking the
-    /// scanned type's schema about it would judge a field it was never on.</summary>
+    /// record type: the right side of a <c>-&gt;</c> is rooted at the link TARGET's type instead, and a side that
+    /// opens with a <c>*parent</c> hop at the CONTAINING record's — asking the scanned type's schema about either
+    /// would judge a field the step was never on.</summary>
     public readonly record struct QuantifiedStep(IReadOnlyList<string> Path, int Index, string Token, string Text,
                                                  bool OnScannedType);
 
@@ -236,10 +237,10 @@ public sealed class FieldPredicateSet
             var steps = new List<QuantifiedStep>();
             foreach (var p in _predicates)
             {
-                // The link side always roots at the scanned type; the path side does only when there is no link,
-                // because with one it is the tail read on the resolved target.
-                Collect(p.LinkPath, p.LinkFolds, p, true);
-                Collect(p.PathSegments, p.PathFolds, p, p.LinkPath is null);
+                // A side roots at the scanned type only when nothing has moved off it first: a '*parent' hop roots
+                // that side at the CONTAINING record's type, and the right side of a '->' at the link target's.
+                Collect(p.LinkPath, p.LinkFolds, p, p.LinkParentHops == 0);
+                Collect(p.PathSegments, p.PathFolds, p, p.LinkPath is null && p.ParentHops == 0);
             }
             return steps;
 

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -136,6 +136,13 @@ public sealed class FieldPredicateSet
     // paths (Perks, Effects, Keywords) is hundreds-to-low-thousands of record getters, small beside the scan
     // itself. A pathological whole-order high-fan-out path is bounded by the scope the grammar already requires
     // (types= / plugins=).
+    //
+    // The '*parent' hop shares this cache and does NOT share that bound, which is stated here rather than left
+    // for a reader to infer: types= bounds the CHILD type, not the parent population, so
+    // types=["PlacedObject"] where=["*parent.EditorID startswith Whiterun"] retains one getter per distinct CELL —
+    // five figures on vanilla Skyrim before any mod — and a '*parent.*parent' chain adds every worldspace on top.
+    // Still one call's lifetime and still bodies the scan would have fetched anyway, so it is retention, not
+    // repeated work; the declared cost of the step, not a hidden one.
     readonly Dictionary<FormKey, IMajorRecordGetter?> _targetCache = new();
 
     /// <summary>Whether any predicate needs the scan's resolution context (<c>winner</c> term or a <c>-&gt;</c>
@@ -154,11 +161,18 @@ public sealed class FieldPredicateSet
 
     static int Hops(Predicate p) => p.ParentHops + p.LinkParentHops;
 
-    /// <summary>Whether any predicate reads record BODY content (a leaf walk or a link step) — false when every
-    /// term is header/resolution-only (`editorid`, `winner`, `formid` membership). The scan's deleted-record check
-    /// keys on this: a deleted record has no live body for the CONTENT filters, but its EditorID and its winner
-    /// resolution are real facts, so a header-only predicate set must still see it.</summary>
-    public bool NeedsLiveBody => _predicates.Any(p => p.LinkPath is not null || p.Pseudo == PseudoPath.None || Hops(p) > 0);
+    /// <summary>Whether any predicate reads the CANDIDATE record's own body content (a leaf walk or a link step on
+    /// it) — false when every term is header/resolution-only (`editorid`, `winner`, `formid` membership). The
+    /// scan's deleted-record check keys on this: a deleted record has no live body for the CONTENT filters, but its
+    /// EditorID and its winner resolution are real facts, so a header-only predicate set must still see it.
+    ///
+    /// <para>A <c>*parent</c> hop is header-only for the CHILD: it reads <c>body.FormKey</c> and nothing else, and
+    /// every term below the hop reads the PARENT's body, which is live. So a hop leading a side makes that side
+    /// header-only on the candidate — which is what keeps a patch-deleted placed reference in the results of
+    /// <c>where=["*parent.EditorID = SomeCell"]</c>, the crash-log lookup this step exists for.</para></summary>
+    public bool NeedsLiveBody => _predicates.Any(p => p.LinkPath is not null
+        ? p.LinkParentHops == 0                                        // the link's LEFT path is read on the candidate
+        : p.ParentHops == 0 && p.Pseudo == PseudoPath.None);           // the own path's leaf walk is read on the candidate
 
     /// <summary>Bind the scan's resolution context: <paramref name="winnerOf"/> answers "which plugin wins this
     /// FormKey" (the `winner` term), <paramref name="fetchWinnerBody"/> produces a linked target's winner body
@@ -387,12 +401,24 @@ public sealed class FieldPredicateSet
         // Pseudo-path classification: 'editorid' (the record's EditorID), 'winner' (the provenance term — which
         // plugin WINS the record, resolution not content), 'formid' (the membership ops' identity path).
         // Classified off the segment left AFTER the '*parent' hops, not the raw path, so '*parent.editorid' reads
-        // the containing record's identity rather than falling through to a case-sensitive field walk.
-        var term = segs.Length == 1 && !segs[0].Contains('[') ? segs[0] : "";
+        // the containing record's identity rather than falling through to a case-sensitive field walk. A step that
+        // carried a quantifier is NOT an identity term, and the fold must be read off pathFolds rather than off the
+        // segment: SplitFolds has already stripped the bracket, so 'editorid[*any]' reaches here spelled 'editorid'
+        // and would otherwise classify as the pseudo term with its quantifier silently dropped.
+        var term = segs.Length == 1 && !segs[0].Contains('[') && (pathFolds is null || pathFolds[0] == Fold.None)
+                   ? segs[0] : "";
         var pseudo = term.Equals("editorid", StringComparison.OrdinalIgnoreCase) ? PseudoPath.EditorId
                    : term.Equals("winner", StringComparison.OrdinalIgnoreCase) ? PseudoPath.Winner
                    : term.Equals("formid", StringComparison.OrdinalIgnoreCase) ? PseudoPath.FormId
                    : PseudoPath.None;
+
+        // An identity term is one value per record, so a quantifier on it has nothing to fold over. Named here
+        // rather than left to the walk, which would look for a lowercase field of that name and report a typo.
+        if (segs.Length == 1 && pathFolds is not null && pathFolds[0] != Fold.None
+            && (segs[0].Equals("editorid", StringComparison.OrdinalIgnoreCase)
+                || segs[0].Equals("winner", StringComparison.OrdinalIgnoreCase)
+                || segs[0].Equals("formid", StringComparison.OrdinalIgnoreCase)))
+            return (null, $"predicate '{raw}': '{segs[0]}' is the record's own {(segs[0].Equals("winner", StringComparison.OrdinalIgnoreCase) ? "winning plugin" : "identity")} — one value per record, not a list, so it takes no '{FoldToken(pathFolds[0])}'. Write '{segs[0]}' on its own.");
 
         // Op-compatibility, validated at parse so an unusable pairing refuses the CALL, never a silent all-miss.
         if (pseudo == PseudoPath.Winner)
@@ -491,36 +517,15 @@ public sealed class FieldPredicateSet
     }
 
 
-    /// <summary>Strip a side's leading <c>*parent</c> hops and hand back the rest of the path. A hop leads a path
-    /// by definition — the containing record is a property of the RECORD, not of a field value — so a <c>*parent</c>
-    /// anywhere else refuses by name, as does one carrying a quantifier, one with nothing after it, and any other
-    /// <c>*</c> token.</summary>
+    /// <summary>Strip a side's leading <c>*parent</c> hops and hand back the rest of the path. The grammar itself
+    /// is <see cref="ContainmentIndex.SplitHops"/>, shared with the read walk, so the two surfaces cannot drift on
+    /// the same mistake; only the <c>predicate '…':</c> voice is added here.</summary>
     static (string[] Tail, int Hops, string? Error) SplitParentHops(string raw, string[] segs, string display, bool isLinkLeft)
     {
-        int hops = 0;
-        while (hops < segs.Length && IsParentStep(segs[hops])) hops++;
-        for (int i = hops; i < segs.Length; i++)
-        {
-            if (IsParentStep(segs[i]))
-                return (segs, 0, $"predicate '{raw}': '{ContainmentIndex.ParentToken}' is the record that CONTAINS this one, so it can only lead a path — " +
-                                 $"in '{display}' it follows a field step. Write the hops first ('{ContainmentIndex.ParentToken}.EditorID').");
-            var s = segs[i];
-            int open = s.IndexOf('[');
-            if (open > 0 && s.EndsWith("]", StringComparison.Ordinal)
-                && string.Equals(s[..open], ContainmentIndex.ParentToken, StringComparison.OrdinalIgnoreCase))
-                return (segs, 0, $"predicate '{raw}': '{s}' — '{ContainmentIndex.ParentToken}' names ONE containing record, not a list, so it takes no quantifier. Write '{ContainmentIndex.ParentToken}'.");
-            if (s.Length > 0 && s[0] == '*' && open != 0)
-                return (segs, 0, $"predicate '{raw}': '{s}' is not a path token — the tokens are '{ContainmentIndex.ParentToken}' (the containing record) and the quantifiers [*any], [*all], [*none] and [*count] on a list step.");
-        }
-        if (hops == 0) return (segs, 0, null);
-        if (hops == segs.Length)
-            return (segs, 0, isLinkLeft
-                ? $"predicate '{raw}': '{display}' is the containing record, which is not a link-bearing field — name one on it ('{display}.Quest->editorid')."
-                : $"predicate '{raw}': '{display}' names the containing record, not a value — follow it with a field ('{display}.EditorID').");
-        return (segs[hops..], hops, null);
+        var (hops, err) = ContainmentIndex.SplitHops(segs, display, isLinkLeft);
+        if (err is not null) return (segs, 0, $"predicate '{raw}': {err}");
+        return (hops == 0 ? segs : segs[hops..], hops, null);
     }
-
-    static bool IsParentStep(string seg) => string.Equals(seg, ContainmentIndex.ParentToken, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>The token a fold is spelled with, for a message.</summary>
     static string FoldToken(Fold f) => f switch

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -386,12 +386,13 @@ public sealed class FieldPredicateSet
 
         // Pseudo-path classification: 'editorid' (the record's EditorID), 'winner' (the provenance term — which
         // plugin WINS the record, resolution not content), 'formid' (the membership ops' identity path).
-        var pseudo = segs.Length == 1 && !path.Contains('[')
-            ? (path.Equals("editorid", StringComparison.OrdinalIgnoreCase) ? PseudoPath.EditorId
-               : path.Equals("winner", StringComparison.OrdinalIgnoreCase) ? PseudoPath.Winner
-               : path.Equals("formid", StringComparison.OrdinalIgnoreCase) ? PseudoPath.FormId
-               : PseudoPath.None)
-            : PseudoPath.None;
+        // Classified off the segment left AFTER the '*parent' hops, not the raw path, so '*parent.editorid' reads
+        // the containing record's identity rather than falling through to a case-sensitive field walk.
+        var term = segs.Length == 1 && !segs[0].Contains('[') ? segs[0] : "";
+        var pseudo = term.Equals("editorid", StringComparison.OrdinalIgnoreCase) ? PseudoPath.EditorId
+                   : term.Equals("winner", StringComparison.OrdinalIgnoreCase) ? PseudoPath.Winner
+                   : term.Equals("formid", StringComparison.OrdinalIgnoreCase) ? PseudoPath.FormId
+                   : PseudoPath.None;
 
         // Op-compatibility, validated at parse so an unusable pairing refuses the CALL, never a silent all-miss.
         if (pseudo == PseudoPath.Winner)

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -160,6 +160,7 @@ public sealed class LoadOrderResolver : IDisposable
         public readonly Dictionary<string, string> ExcludedPlugins;           // excluded plugin name → reason
         public readonly int MaxDepth;
         public readonly string Epoch;                                         // this build's fingerprint — immutable with the snapshot
+        public readonly ContainmentIndex Containment;                         // child → parent, off the same one-pass walk
 
         /// <summary>Per plugin index: is it a LIGHT plugin? Read off the header while the build already had the
         /// overlay open (the .esl extension counts too — the engine force-treats it as light). This is what decides
@@ -184,10 +185,11 @@ public sealed class LoadOrderResolver : IDisposable
         public IndexSnapshot(Dictionary<FormKey, (int winner, int count)> index, Dictionary<FormKey, int[]> overriders,
                              List<string> loadFailures, HashSet<int> excluded, HashSet<int> unopenable,
                              Dictionary<string, string> excludedPlugins, int maxDepth, string epoch,
-                             bool[] light, int firstUnknownKind, string? firstUnknownKindName)
+                             bool[] light, int firstUnknownKind, string? firstUnknownKindName,
+                             ContainmentIndex containment)
         {
             Index = index; Overriders = overriders; LoadFailures = loadFailures; Excluded = excluded; Unopenable = unopenable;
-            ExcludedPlugins = excludedPlugins; MaxDepth = maxDepth; Epoch = epoch; Light = light;
+            ExcludedPlugins = excludedPlugins; MaxDepth = maxDepth; Epoch = epoch; Light = light; Containment = containment;
             FirstUnknownKind = firstUnknownKind; FirstUnknownKindName = firstUnknownKindName;
             Slots = new Lazy<RuntimeSlots>(() => RuntimeSlots.Build(light));
         }
@@ -574,6 +576,7 @@ public sealed class LoadOrderResolver : IDisposable
         var unopenable = new HashSet<int>();                          // the could-not-be-OPENED subset
         var excludedPlugins = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         var light = new bool[_paths.Length];
+        var containment = new ContainmentIndex();                     // child → parent, off the same walk
         int firstUnknownKind = -1;
         string? firstUnknownKindName = null;
         int maxDepth = 0;
@@ -597,13 +600,25 @@ public sealed class LoadOrderResolver : IDisposable
             // whatever the header bit says, and an esp-fe carries the bit without the extension.
             light[i] = ov.IsSmallMaster || ov.ModKey.Type == ModType.Light;
 
-            // Buffer the WHOLE plugin's keys first (plugin-atomic). EnumerateMajorRecords() constructs each record
-            // body as it advances, so a record Mutagen rejects (e.g. a malformed PKCU data-count) throws HERE. The
+            // Buffer the WHOLE plugin's keys first (plugin-atomic). The walk constructs each record body as it
+            // advances, so a record Mutagen rejects (e.g. a malformed PKCU data-count) throws HERE. The
             // throw is non-resumable, so we can't skip just that record — but catching it lets us EXCLUDE this one
             // plugin and carry on with every other, instead of letting the throw kill the entire index. The buffer
             // means a partial enumeration is discarded, not merged.
+            //
+            // The CONTEXT walk, not the flat one: it yields the same record set and carries each record's containing
+            // context, which is the only place the parent is in hand — only a NavigationMesh names its cell on its
+            // own body. It costs about 0.4 s more over a 3,800-plugin order, inside that order's run-to-run spread.
             var keys = new List<FormKey>();
-            try { foreach (var rec in ov.EnumerateMajorRecords()) keys.Add(rec.FormKey); }
+            var edges = new List<(FormKey Child, FormKey Parent)>();
+            try
+            {
+                foreach (var ctx in ov.EnumerateMajorRecordContexts())
+                {
+                    keys.Add(ctx.Record.FormKey);
+                    if (ctx is IModContext c) ContainmentIndex.Stage(c, edges);
+                }
+            }
             catch (Exception ex)
             {
                 Exclude(i, $"contains a record Mutagen cannot parse, so the whole plugin is excluded from this " +
@@ -615,6 +630,7 @@ public sealed class LoadOrderResolver : IDisposable
             }
             finally { (ov as IDisposable)?.Dispose(); }                    // one plugin open at a time — never the whole floor
 
+            containment.Merge(edges);                                      // later plugin wins, like the winner index
             foreach (var fk in keys)                                       // merge the COMPLETE plugin into the index
             {
                 if (!index.TryGetValue(fk, out var e))
@@ -636,7 +652,7 @@ public sealed class LoadOrderResolver : IDisposable
             index,
             overriders.ToDictionary(kv => kv.Key, kv => kv.Value.ToArray()),  // trim List overhead → int[]
             failures, excluded, unopenable, excludedPlugins, maxDepth, ComputeEpoch(_names, _paths, _stamps, excludedPlugins),
-            light, firstUnknownKind, firstUnknownKindName);
+            light, firstUnknownKind, firstUnknownKindName, containment);
     }
 
     /// <summary>The epoch fingerprint: a compact, deterministic identity for ONE index build, derived from the
@@ -888,6 +904,15 @@ public sealed class LoadOrderResolver : IDisposable
         /// <summary>O(1): the winning plugin + override depth for a FormKey. null if the FormKey isn't in the order.</summary>
         public WinnerInfo? ResolveWinner(FormKey fk)
             => _s.Index.TryGetValue(fk, out var e) ? new WinnerInfo(fk, _r._names[e.winner], e.count) : null;
+
+        /// <summary>O(1): the record that CONTAINS this one in THIS build — a DIAL over its INFO, a CELL over its
+        /// placed references and navmeshes, a WRLD over its cells. The second edge kind, read by the <c>*parent</c>
+        /// path step. Null when the record is top-level or is not in the order; a caller that must tell those apart
+        /// asks <see cref="ResolveWinner"/> too.</summary>
+        public FormKey? ParentOf(FormKey fk) => _s.Containment.ParentOf(fk);
+
+        /// <summary>Distinct children this build recorded a containing record for.</summary>
+        public int ContainedRecordCount => _s.Containment.Count;
 
         /// <summary>Every FormKey overridden by more than one plugin (the whole-order conflict set).</summary>
         public IEnumerable<FormKey> ConflictKeys() => _s.Overriders.Keys;

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -616,7 +616,7 @@ public sealed class LoadOrderResolver : IDisposable
                 foreach (var ctx in ov.EnumerateMajorRecordContexts())
                 {
                     keys.Add(ctx.Record.FormKey);
-                    if (ctx is IModContext c) ContainmentIndex.Stage(c, edges);
+                    ContainmentIndex.Stage(ctx, edges);
                 }
             }
             catch (Exception ex)

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Reflection;
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Reflection;
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
@@ -194,7 +194,8 @@ public static class ReadEngine
     /// so the server's reads inherit the read-proof by construction. Per-leaf fault isolation: an unreadable field
     /// names itself in its <see cref="FieldValue.Note"/>, never throws out of the record read.</summary>
     public static RecordFields ReadFields(IMajorRecordGetter record, IReadOnlyList<string>? paths = null, int depth = 1,
-                                          string? containerHint = DepthExpandHint)
+                                          string? containerHint = DepthExpandHint,
+                                          Func<IMajorRecordGetter, (IMajorRecordGetter? Parent, string? Why)>? parentOf = null)
     {
         var typeName = RecordNaming.StripGetterInterface(WriteEngine.PrimaryGetter(record.GetType())?.Name ?? "I?Getter");
         var targets = paths is { Count: > 0 } ? (IEnumerable<string>)paths : ModeledFieldNames(typeName, record.GetType());
@@ -206,7 +207,9 @@ public static class ReadEngine
             foreach (var p in targets)
             {
                 var seg = p.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-                var r = ReadLeaf(record, seg);
+                var (on, tail, hopNote) = HopToParent(record, seg, parentOf);
+                if (hopNote is not null) { fields.Add(new FieldValue(p, false, null, hopNote, null, Present: false, Count: null, Readable: false)); continue; }
+                var r = ReadLeaf(on, tail);
                 string? note = r.HasValue ? null : r.Note;
                 // An UNEXPANDED container / substruct leaf self-documents the lever that opens it: at the depth-1
                 // default it renders as a count/summary ("[list: 2 item(s)]", "[BodyTemplate]"). No-value NOTES are
@@ -221,10 +224,42 @@ public static class ReadEngine
         else
         {
             int budget = MaxExpandNodes;
-            foreach (var p in targets) EmitWithDepth(record, p, depth, fields, ref budget);
+            foreach (var p in targets)
+            {
+                var seg = p.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                var (on, tail, hopNote) = HopToParent(record, seg, parentOf);
+                if (hopNote is not null) { fields.Add(new FieldValue(p, false, null, hopNote, null, Present: false, Count: null, Readable: false)); continue; }
+                EmitWithDepth(on, string.Join(".", tail), depth, fields, ref budget, p);
+            }
         }
         return new RecordFields(typeName, record.FormKey.ToString(), record.EditorID, fields);
     }
+
+    /// <summary>The <c>*parent</c> containment step on a read path: strip the leading hops, climb to the record
+    /// that CONTAINS this one, and hand back what the rest of the path should be read on. The parent set is
+    /// Mutagen's own containment walk, captured at index build — never a per-record-type map here. Returns a note
+    /// instead when the hop cannot be taken: the record has no containing record, or this read surface carries no
+    /// load-order index to ask.</summary>
+    static (IMajorRecordGetter On, string[] Tail, string? Note) HopToParent(
+        IMajorRecordGetter record, string[] segs,
+        Func<IMajorRecordGetter, (IMajorRecordGetter? Parent, string? Why)>? parentOf)
+    {
+        int hops = 0;
+        while (hops < segs.Length && string.Equals(segs[hops], ContainmentIndex.ParentToken, StringComparison.OrdinalIgnoreCase)) hops++;
+        if (hops == 0) return (record, segs, null);
+        if (hops == segs.Length)
+            return (record, segs, $"('{ContainmentIndex.ParentToken}' names the containing record, not a value — follow it with a field, e.g. '{ContainmentIndex.ParentToken}.EditorID')");
+        if (parentOf is null)
+            return (record, segs, $"('{ContainmentIndex.ParentToken}' needs the load-order index, which this read does not carry — read the record through the load order instead)");
+        for (int i = 0; i < hops; i++)
+        {
+            var (parent, why) = parentOf(record);
+            if (parent is null) return (record, segs, $"({why ?? "no record contains this one"})");
+            record = parent;
+        }
+        return (record, segs[hops..], null);
+    }
+
 
     // ======================================================================
     //  THE READ PRIMITIVE — navigate a path read-only, emit the leaf token.
@@ -483,16 +518,19 @@ public static class ReadEngine
     /// this one target (an unparseable nested getter, an enumerator that faults mid-list, an ambiguous identity
     /// reflection) names itself "(unreadable …)" and never escapes the record read — so one bad field can't crash
     /// a whole-record depth dump. Lines already emitted before a mid-expansion fault are real reads and are kept.</summary>
-    static void EmitWithDepth(object record, string path, int depth, List<FieldValue> sink, ref int budget)
+    /// <summary><paramref name="display"/> is how the emitted rows spell the path when it differs from what is
+    /// navigated — a <c>*parent</c> hop reads on the parent but the caller asked for '*parent.Responses'.</summary>
+    static void EmitWithDepth(object record, string path, int depth, List<FieldValue> sink, ref int budget, string? display = null)
     {
+        var shown = display ?? path;
         try
         {
             var seg = path.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
             var nav = NavigateValue(record, seg);
-            if (!nav.ok) { Emit(sink, ref budget, new FieldValue(path, false, null, nav.note, Present: false)); return; }
-            Expand(nav.val, nav.type, nav.parent, path, depth, sink, ref budget);
+            if (!nav.ok) { Emit(sink, ref budget, new FieldValue(shown, false, null, nav.note, Present: false)); return; }
+            Expand(nav.val, nav.type, nav.parent, shown, depth, sink, ref budget);
         }
-        catch (Exception ex) { Emit(sink, ref budget, new FieldValue(path, false, null, $"(unreadable: {ex.Message})", Present: false)); }
+        catch (Exception ex) { Emit(sink, ref budget, new FieldValue(shown, false, null, $"(unreadable: {ex.Message})", Present: false)); }
     }
 
     /// <summary>Recursively emit <paramref name="val"/> at <paramref name="path"/>: a value leaf → its token;

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -238,17 +238,17 @@ public static class ReadEngine
     /// <summary>The <c>*parent</c> containment step on a read path: strip the leading hops, climb to the record
     /// that CONTAINS this one, and hand back what the rest of the path should be read on. The parent set is
     /// Mutagen's own containment walk, captured at index build — never a per-record-type map here. Returns a note
-    /// instead when the hop cannot be taken: the record has no containing record, or this read surface carries no
-    /// load-order index to ask.</summary>
+    /// instead when the hop cannot be taken: the path spells the step wrongly (one grammar, shared with the
+    /// <c>where=</c> surface via <see cref="ContainmentIndex.SplitHops"/>, so an identical mistake gets an
+    /// identical sentence), the record has no containing record, or this read surface carries no load-order index
+    /// to ask.</summary>
     static (IMajorRecordGetter On, string[] Tail, string? Note) HopToParent(
         IMajorRecordGetter record, string[] segs,
         Func<IMajorRecordGetter, (IMajorRecordGetter? Parent, string? Why)>? parentOf)
     {
-        int hops = 0;
-        while (hops < segs.Length && string.Equals(segs[hops], ContainmentIndex.ParentToken, StringComparison.OrdinalIgnoreCase)) hops++;
+        var (hops, gerr) = ContainmentIndex.SplitHops(segs, string.Join(".", segs));
+        if (gerr is not null) return (record, segs, $"({gerr})");
         if (hops == 0) return (record, segs, null);
-        if (hops == segs.Length)
-            return (record, segs, $"('{ContainmentIndex.ParentToken}' names the containing record, not a value — follow it with a field, e.g. '{ContainmentIndex.ParentToken}.EditorID')");
         if (parentOf is null)
             return (record, segs, $"('{ContainmentIndex.ParentToken}' needs the load-order index, which this read does not carry — read the record through the load order instead)");
         for (int i = 0; i < hops; i++)

--- a/src/housecarl-generator/ParentInHandProbe.cs
+++ b/src/housecarl-generator/ParentInHandProbe.cs
@@ -135,6 +135,26 @@ static class ParentInHandProbe
         Console.WriteLine("D. is the parent in hand during the FLAT walk? (per child-bearing property, per child type)\n");
         ReportParentInHand(describe);
 
+        // ---- question 3: do the two walks yield the SAME record set? --------------------------------------------
+        // The swap is not scoped to *parent — the winner index, the overrider lists and the whole resolution
+        // surface are built from the context walk now. So this is the load-bearing claim, and it is checked here
+        // over a REAL order rather than asserted in a comment. Untimed, and per plugin, so a difference names the
+        // file it is in. (The fixture-scale arm of the same check is a test: RecordsContainmentTests.)
+        Console.WriteLine("\nE2. does the context walk yield the same record set as the flat walk? (per plugin, as a multiset)\n");
+        var equiv = new EquivalencePass();
+        var q = Sweep(paths, dataDir, equiv, "equivalence");
+        if (q.Opened == 0) { Console.WriteLine("every plugin failed to open, so nothing was compared."); return 1; }
+        Console.WriteLine($"   plugins compared : {q.Opened - q.Skipped:N0}   (excluded: {q.Skipped})");
+        Console.WriteLine($"   records compared : {equiv.Records:N0}");
+        if (equiv.Differences.Count == 0)
+            Console.WriteLine("   identical on every plugin — no record dropped, duplicated or substituted.");
+        else
+        {
+            Console.WriteLine($"   DIFFERENT on {equiv.Differences.Count} plugin(s) — printed in full, never truncated:");
+            foreach (var d2 in equiv.Differences) Console.WriteLine($"     {d2}");
+            return 1;
+        }
+
         return 0;
     }
 
@@ -161,6 +181,31 @@ static class ParentInHandProbe
         {
             foreach (var rec in ov.EnumerateMajorRecords()) { _ = rec.FormKey; }
             foreach (var c in ov.EnumerateMajorRecordContexts()) { _ = c.Record.FormKey; }
+        }
+    }
+
+    /// <summary>Both enumerations over one plugin, compared as MULTISETS of FormKey — so a dropped record, a
+    /// duplicated one and a substituted one are all differences, not just a changed total. Untimed: it holds two
+    /// dictionaries per plugin and would distort the passes above.</summary>
+    sealed class EquivalencePass : IPass
+    {
+        public long Records;
+        public readonly List<string> Differences = new();
+
+        public void Plugin(ISkyrimModGetter ov)
+        {
+            var flat = new Dictionary<FormKey, int>();
+            foreach (var rec in ov.EnumerateMajorRecords()) flat[rec.FormKey] = flat.GetValueOrDefault(rec.FormKey) + 1;
+            var ctx = new Dictionary<FormKey, int>();
+            foreach (var c in ov.EnumerateMajorRecordContexts()) ctx[c.Record.FormKey] = ctx.GetValueOrDefault(c.Record.FormKey) + 1;
+            Records += flat.Values.Sum();
+
+            var onlyFlat = flat.Where(kv => ctx.GetValueOrDefault(kv.Key) != kv.Value).Take(5).ToList();
+            var onlyCtx = ctx.Where(kv => flat.GetValueOrDefault(kv.Key) != kv.Value).Take(5).ToList();
+            if (onlyFlat.Count == 0 && onlyCtx.Count == 0) return;
+            Differences.Add($"{ov.ModKey.FileName}: flat {flat.Values.Sum():N0} / contexts {ctx.Values.Sum():N0}; " +
+                            $"flat-only {string.Join(", ", onlyFlat.Select(kv => $"{kv.Key}x{kv.Value}"))}; " +
+                            $"context-only {string.Join(", ", onlyCtx.Select(kv => $"{kv.Key}x{kv.Value}"))}");
         }
     }
 

--- a/src/housecarl-mcp-tests/RecordsContainmentTests.cs
+++ b/src/housecarl-mcp-tests/RecordsContainmentTests.cs
@@ -100,7 +100,7 @@ public sealed class RecordsContainmentTests : IClassFixture<OwnedChildFixture>
     /// <summary>Worldspace.TopCell — the second, singular worldspace child property.</summary>
     [Fact]
     public void WorldspaceTopCell_TheIndexKnowsTheWorldspaceATopCellBelongsTo() =>
-        Assert.Equal(_w.Worldspace, Svc.CaptureView().ParentOf(_w.TopCell));
+        Assert.Equal(_w.TopCellWorldspace, Svc.CaptureView().ParentOf(_w.TopCell));
 
     // ---- the later-wins merge, both halves --------------------------------------------------------
 
@@ -174,9 +174,8 @@ public sealed class RecordsContainmentTests : IClassFixture<OwnedChildFixture>
     [Fact]
     public void AReadThroughTheHopCarriesTheContainingCellsOwnedChildNote()
     {
-        const string note = "their declarations for this field were not read";
-        Assert.Contains(note, Read(_w.CellA, "Temporary"));
-        Assert.Contains(note, Read(new FormKey(_w.CellA.ModKey, 0xC10), "*parent.Temporary"));
+        Assert.Contains(ReadSentences.UnionLabel, Read(_w.CellA, "Temporary"));
+        Assert.Contains(ReadSentences.UnionLabel, Read(new FormKey(_w.CellA.ModKey, 0xC10), "*parent.Temporary"));
     }
 
     // ---- every in-order read lane answers it ------------------------------------------------------
@@ -197,7 +196,7 @@ public sealed class RecordsContainmentTests : IClassFixture<OwnedChildFixture>
         var r = RecordsTools.Records(Svc, formids: new[] { OwnedChildWorld.Fid(_w.ReparentedRef) },
                                      source: form == "delta" ? Pole(_w.MidName) : null, versus: Pole(copy),
                                      project: new RecordsTools.RecordsProject { form = form, fields = new[] { "*parent.EditorID" } });
-        Assert.Contains("HcOcCellH", r);
+        Assert.Contains("HcOcCellJ", r);
         Assert.Contains("needs the load-order index", r);
     }
 

--- a/src/housecarl-mcp-tests/RecordsContainmentTests.cs
+++ b/src/housecarl-mcp-tests/RecordsContainmentTests.cs
@@ -1,0 +1,115 @@
+using Mutagen.Bethesda.Plugins;
+using HousecarlCore;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// The <c>*parent</c> containment edge end to end, against the real plugins <see cref="OwnedChildWorld"/> writes:
+/// the index build captures each record's containing record from Mutagen's context walk, and the token then reads,
+/// filters and walks across it. This is the reported gap — an INFO found by content, and no way back to its owning
+/// DIAL, because group nesting is not a FormLink and <c>references=</c> correctly returns nothing.
+/// </summary>
+[Collection("records")]
+[Trait("tier", "integration")]
+public sealed class RecordsContainmentTests : IClassFixture<OwnedChildFixture>
+{
+    readonly OwnedChildWorld _w;
+
+    /// <summary>The owned-child world supplies the records; the records collection's fixture is taken only for the
+    /// generated corpus a types= scan resolves record-type names against.</summary>
+    public RecordsContainmentTests(OwnedChildFixture f, RecordsFixture corpus) { _w = f.W; _ = corpus; }
+
+    LoadOrderService Svc => _w.Svc;
+
+    /// <summary>An INFO the base master declares under HcOcTopic, and only the base master.</summary>
+    FormKey Info => new(_w.Topic.ModKey, 0xD11);
+
+    string Read(FormKey fk, params string[] fields) =>
+        RecordsTools.Records(Svc, formids: new[] { OwnedChildWorld.Fid(fk) },
+                             project: new RecordsTools.RecordsProject { form = "fields", fields = fields });
+
+    string Query(string type, params string[] where) =>
+        RecordsTools.Records(Svc, types: new[] { type }, where: where,
+                             project: new RecordsTools.RecordsProject { form = "summary" });
+
+    // ---- the index captured it -------------------------------------------------------------------
+
+    [Fact]
+    public void TheIndexKnowsTheOwningTopicOfAnInfo()
+    {
+        var view = Svc.CaptureView();
+        Assert.Equal(_w.Topic, view.ParentOf(Info));
+    }
+
+    [Fact]
+    public void TheIndexKnowsTheCellAPlacedReferenceSitsIn()
+    {
+        var view = Svc.CaptureView();
+        Assert.Equal(_w.CellA, view.ParentOf(new FormKey(_w.CellA.ModKey, 0xC10)));
+    }
+
+    /// <summary>The chain, which is what the crash-log case needs: a placed reference to its cell to its
+    /// worldspace, through the block and sub-block contexts that carry no record of their own.</summary>
+    [Fact]
+    public void TheIndexClimbsBlockContextsToPutAWorldspacesCellUnderTheWorldspace()
+    {
+        var view = Svc.CaptureView();
+        Assert.Equal(_w.Worldspace, view.ParentOf(new FormKey(_w.Worldspace.ModKey, 0xF10)));
+    }
+
+    [Fact]
+    public void ATopLevelRecordHasNoContainingRecord() =>
+        Assert.Null(Svc.CaptureView().ParentOf(_w.Weapon));
+
+    // ---- reading it ------------------------------------------------------------------------------
+
+    [Fact]
+    public void ProjectFieldsReadsTheOwningTopicsEditorIdOffTheInfo() =>
+        Assert.Contains("HcOcTopic", Read(Info, "*parent.EditorID"));
+
+    [Fact]
+    public void TheChainReadsThroughTwoHops() =>
+        Assert.Contains("HcOcWrld", Read(new FormKey(_w.Worldspace.ModKey, 0xF10), "*parent.EditorID"));
+
+    /// <summary>Never a null: a record nothing contains says so, and says what containment runs from.</summary>
+    [Fact]
+    public void AReadOnARecordNothingContainsNamesTheChildBearingProperties()
+    {
+        var r = Read(_w.Weapon, "*parent.EditorID");
+        Assert.Contains("no record contains", r);
+        Assert.Contains("DialogTopic.Responses", r);
+    }
+
+    // ---- filtering on it -------------------------------------------------------------------------
+
+    [Fact]
+    public void WhereFiltersInfosByTheirOwningTopic()
+    {
+        var r = Query("DialogResponses", "*parent.EditorID = HcOcTopic");
+        Assert.Contains(OwnedChildWorld.Fid(Info), r);
+    }
+
+    [Fact]
+    public void WhereOnAWrongOwningTopicMatchesNothing() =>
+        Assert.DoesNotContain(OwnedChildWorld.Fid(Info), Query("DialogResponses", "*parent.EditorID = HcOcCellA"));
+
+    /// <summary>The whole point of the class-scoped fix, not the DIAL row alone: the same token answers the
+    /// crash-log question — which cell holds this placed reference.</summary>
+    [Fact]
+    public void WhereFiltersPlacedReferencesByTheCellThatHoldsThem() =>
+        Assert.Contains(OwnedChildWorld.Fid(new FormKey(_w.CellA.ModKey, 0xC10)),
+                        Query("PlacedObject", "*parent.EditorID = HcOcCellA"));
+
+    // ---- walking it ------------------------------------------------------------------------------
+
+    [Fact]
+    public void AWalkSeededOnParentReachesTheOwningTopic()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { OwnedChildWorld.Fid(Info) },
+                                     walk: new RecordsTools.RecordsWalk { seed_paths = new[] { "*parent" }, depth = 1 },
+                                     project: new RecordsTools.RecordsProject { form = "summary" });
+        Assert.Contains(OwnedChildWorld.Fid(_w.Topic), r);
+    }
+}

--- a/src/housecarl-mcp-tests/RecordsContainmentTests.cs
+++ b/src/housecarl-mcp-tests/RecordsContainmentTests.cs
@@ -1,4 +1,8 @@
+using System.Text.Json;
 using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Cache;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
 using HousecarlCore;
 using HousecarlMcp;
 using Xunit;
@@ -63,15 +67,96 @@ public sealed class RecordsContainmentTests : IClassFixture<OwnedChildFixture>
     public void ATopLevelRecordHasNoContainingRecord() =>
         Assert.Null(Svc.CaptureView().ParentOf(_w.Weapon));
 
+    // ---- every child kind the SPEC amendment names, not a third of them ---------------------------
+    //
+    // The amendment's set is seven properties over three types, and it is derived rather than typed
+    // (WriteEngine.ChildBearingProperties). One row each here, so a Mutagen bump that drops one is a failure
+    // rather than a quiet coverage hole.
+
+    /// <summary>ACHR — named in the issue title and the SPEC amendment, and the fixture had none.</summary>
+    [Fact]
+    public void CellPersistent_TheIndexKnowsTheCellAPlacedNpcSitsIn() =>
+        Assert.Equal(_w.CellI, Svc.CaptureView().ParentOf(_w.PlacedNpc));
+
+    [Fact]
+    public void CellPersistent_TheIndexKnowsTheCellAPersistentReferenceSitsIn() =>
+        Assert.Equal(_w.CellA, Svc.CaptureView().ParentOf(_w.PersistentRef));
+
+    /// <summary>Cell.Landscape is a SINGULAR child property — one record, not a collection.</summary>
+    [Fact]
+    public void CellLandscape_TheIndexKnowsTheCellALandscapeBelongsTo() =>
+        Assert.Equal(_w.CellA, Svc.CaptureView().ParentOf(_w.LandscapeRec));
+
+    /// <summary>The one child kind that ALSO names its parent on its own body (<c>Data.Parent</c>, through the
+    /// CellNavmeshParent arm) — so it is the only place the index and the record could disagree. Both are read
+    /// here, and they must say the same cell.</summary>
+    [Fact]
+    public void CellNavigationMeshes_TheIndexAndTheNavmeshsOwnBodyNameTheSameCell()
+    {
+        Assert.Equal(_w.CellI, Svc.CaptureView().ParentOf(_w.Navmesh));
+        Assert.Contains(OwnedChildWorld.Fid(_w.CellI), Read(_w.Navmesh, "Data.Parent.Parent"));
+    }
+
+    /// <summary>Worldspace.TopCell — the second, singular worldspace child property.</summary>
+    [Fact]
+    public void WorldspaceTopCell_TheIndexKnowsTheWorldspaceATopCellBelongsTo() =>
+        Assert.Equal(_w.Worldspace, Svc.CaptureView().ParentOf(_w.TopCell));
+
+    // ---- the later-wins merge, both halves --------------------------------------------------------
+
+    /// <summary>The reason the map is built per plugin and merged rather than filled once: across a real order
+    /// thousands of children end up under a different parent than the first plugin put them under. Mid declares
+    /// base's reference under a cell of its own, and the later declaration stands.</summary>
+    [Fact]
+    public void ALaterPluginThatMovesAChildToAnotherCellWins() =>
+        Assert.Equal(_w.CellJ, Svc.CaptureView().ParentOf(_w.ReparentedRef));
+
+    /// <summary>…and the inverse, which matters as much: Mid re-declares CellI carrying NOTHING, and that must
+    /// not erase the edges base staged for the children it did declare there. Absent is not empty.</summary>
+    [Fact]
+    public void AReDeclarationCarryingNoChildrenErasesNoEdge()
+    {
+        var view = Svc.CaptureView();
+        Assert.Equal(_w.CellI, view.ParentOf(_w.PlacedNpc));
+        Assert.Equal(_w.CellI, view.ParentOf(_w.Navmesh));
+    }
+
+    /// <summary>The swap from Mutagen's flat <c>EnumerateMajorRecords</c> to <c>EnumerateMajorRecordContexts</c>
+    /// is not scoped to <c>*parent</c> — the winner index, the overrider lists and the whole resolution surface
+    /// are built from it now. The comment at the swap asserts the two walks yield the same record set; this is
+    /// what pins it, per plugin and as a multiset, so a kind the context walk ever dropped or duplicated fails
+    /// here rather than becoming a silently mis-resolved order.</summary>
+    [Fact]
+    public void TheContextWalkYieldsTheSameRecordSetAsTheFlatWalk()
+    {
+        foreach (var path in _w.PluginPaths)
+        {
+            var ov = LoadOrderResolver.OpenOverlay(path, null);   // the same door the index build opens
+            try
+            {
+                var flat = ov.EnumerateMajorRecords().Select(r => r.FormKey).OrderBy(k => k.ToString(), StringComparer.Ordinal).ToList();
+                var ctx = ov.EnumerateMajorRecordContexts().Select(c => c.Record.FormKey).OrderBy(k => k.ToString(), StringComparer.Ordinal).ToList();
+                Assert.Equal(flat, ctx);
+            }
+            finally { (ov as IDisposable)?.Dispose(); }
+        }
+    }
+
     // ---- reading it ------------------------------------------------------------------------------
 
     [Fact]
     public void ProjectFieldsReadsTheOwningTopicsEditorIdOffTheInfo() =>
         Assert.Contains("HcOcTopic", Read(Info, "*parent.EditorID"));
 
+    /// <summary>The crash-log chain end to end against the real index, not a hand-built dictionary: a placed
+    /// reference to its cell to its worldspace. One hop lands on the cell, two on the worldspace — both asserted,
+    /// so a chain that quietly takes one hop and stops cannot pass.</summary>
     [Fact]
-    public void TheChainReadsThroughTwoHops() =>
-        Assert.Contains("HcOcWrld", Read(new FormKey(_w.Worldspace.ModKey, 0xF10), "*parent.EditorID"));
+    public void TheChainReadsThroughTwoHops()
+    {
+        Assert.Contains("HcOcWsCell0", Read(_w.WorldCellRef, "*parent.EditorID"));
+        Assert.Contains("HcOcWrld", Read(_w.WorldCellRef, "*parent.*parent.EditorID"));
+    }
 
     /// <summary>Never a null: a record nothing contains says so, and says what containment runs from.</summary>
     [Fact]
@@ -101,6 +186,70 @@ public sealed class RecordsContainmentTests : IClassFixture<OwnedChildFixture>
     public void WhereFiltersPlacedReferencesByTheCellThatHoldsThem() =>
         Assert.Contains(OwnedChildWorld.Fid(new FormKey(_w.CellA.ModKey, 0xC10)),
                         Query("PlacedObject", "*parent.EditorID = HcOcCellA"));
+
+    /// <summary>The case the changelog headlines and the one a deleted-record skip would silently swallow: a
+    /// patch DELETED this placed reference, and patches delete placed references constantly. The hop reads its
+    /// FormKey and nothing else, and the term below the hop reads the CELL's body, which is live — so a
+    /// *parent-only predicate is header-only for the child and must still see it.</summary>
+    [Fact]
+    public void ADeletedPlacedReferenceIsStillFilteredByTheCellThatHoldsIt()
+    {
+        // The record really is deleted: a predicate that reads its BODY drops it, which is the standing rule.
+        Assert.DoesNotContain(OwnedChildWorld.Fid(_w.DeletedRef), Query("PlacedObject", "Base exists"));
+        // The hop is not a body read, so the same record answers the containment question.
+        Assert.Contains(OwnedChildWorld.Fid(_w.DeletedRef), Query("PlacedObject", "*parent.EditorID = HcOcCellI"));
+    }
+
+    /// <summary>The two-hop filter, against the same machinery, so the chain is pinned on the where= surface
+    /// too and not only on the read.</summary>
+    [Fact]
+    public void WhereFiltersAPlacedReferenceByTheWorldspaceTwoStepsAboveIt() =>
+        Assert.Contains(OwnedChildWorld.Fid(_w.WorldCellRef), Query("PlacedObject", "*parent.*parent.EditorID = HcOcWrld"));
+
+    /// <summary>An ACHR filters by its cell exactly as a REFR does — one step, no per-type rule.</summary>
+    [Fact]
+    public void WhereFiltersAPlacedNpcByTheCellThatHoldsIt() =>
+        Assert.Contains(OwnedChildWorld.Fid(_w.PlacedNpc), Query("PlacedNpc", "*parent.EditorID = HcOcCellI"));
+
+    // ---- the grammar, one validator over every surface --------------------------------------------
+    //
+    // The where= surface refuses a misspelled hop by name. The read surface must give the SAME sentence for the
+    // same mistake, or a caller who mistypes on project.fields gets a typo hint where where= would have named
+    // the real problem.
+
+    static string WhereRefusal(LoadOrderService svc, string term) =>
+        RecordsTools.Records(svc, types: new[] { "DialogResponses" }, where: new[] { term },
+                             project: new RecordsTools.RecordsProject { form = "summary" });
+
+    [Theory]
+    [InlineData("Responses.*parent.EditorID", "it can only lead a path")]
+    [InlineData("*parent[*any].EditorID", "takes no quantifier")]
+    [InlineData("*owner.EditorID", "is not a path token")]
+    [InlineData("*parent", "not a value")]
+    public void TheReadSurfaceRefusesTheSameHopMistakeTheWhereSurfaceDoes(string path, string fragment)
+    {
+        Assert.Contains(fragment, Read(Info, path));
+        Assert.Contains(fragment, WhereRefusal(Svc, path + " = X"));
+    }
+
+    // ---- the off-order lane -----------------------------------------------------------------------
+
+    /// <summary>The containment map is built from the ACTIVE order's plugins only. A same-named copy of an active
+    /// plugin resolves in that map, so a *parent filter over the copy would answer from the OTHER file's edges —
+    /// which is the second cornerstone's case exactly. Refused by name instead.</summary>
+    [Fact]
+    public void AParentFilterOverAnOutOfLoadOrderFileRefusesRatherThanAnsweringFromTheActiveIndex()
+    {
+        var copy = _w.Scratch("offorder", _w.BaseName);
+        File.Copy(_w.PluginPaths[0], copy, overwrite: true);
+        var r = RecordsTools.Records(Svc, types: new[] { "DialogResponses" },
+                                     where: new[] { "*parent.EditorID = HcOcTopic" },
+                                     source: JsonDocument.Parse(JsonSerializer.Serialize(copy)).RootElement.Clone(),
+                                     project: new RecordsTools.RecordsProject { form = "summary" });
+        Assert.Contains("error:", r);
+        Assert.Contains("out-of-load-order", r);
+        Assert.DoesNotContain(OwnedChildWorld.Fid(Info) + " ", r);
+    }
 
     // ---- walking it ------------------------------------------------------------------------------
 

--- a/src/housecarl-mcp-tests/RecordsContainmentTests.cs
+++ b/src/housecarl-mcp-tests/RecordsContainmentTests.cs
@@ -179,6 +179,28 @@ public sealed class RecordsContainmentTests : IClassFixture<OwnedChildFixture>
         Assert.Contains(note, Read(new FormKey(_w.CellA.ModKey, 0xC10), "*parent.Temporary"));
     }
 
+    // ---- every in-order read lane answers it ------------------------------------------------------
+
+    static JsonElement Pole(string s) => JsonDocument.Parse(JsonSerializer.Serialize(s)).RootElement.Clone();
+
+    /// <summary>The comparison forms take fields= and hold the order's own index, so the hop answers on their
+    /// in-order arms too — the refusal naming "read the record through the load order instead" must not fire on a
+    /// read that IS through the load order. Measured against an off-order arm, which genuinely carries no
+    /// containment map and keeps saying so, so both halves are on one call and neither passes by accident.</summary>
+    [Theory]
+    [InlineData("delta")]
+    [InlineData("tree")]
+    public void TheComparisonFormsReadTheHopOnTheirInOrderArm(string form)
+    {
+        var copy = _w.Scratch(form + "-offorder", _w.BaseName);
+        File.Copy(_w.PluginPaths[0], copy, overwrite: true);
+        var r = RecordsTools.Records(Svc, formids: new[] { OwnedChildWorld.Fid(_w.ReparentedRef) },
+                                     source: form == "delta" ? Pole(_w.MidName) : null, versus: Pole(copy),
+                                     project: new RecordsTools.RecordsProject { form = form, fields = new[] { "*parent.EditorID" } });
+        Assert.Contains("HcOcCellH", r);
+        Assert.Contains("needs the load-order index", r);
+    }
+
     // ---- filtering on it -------------------------------------------------------------------------
 
     [Fact]

--- a/src/housecarl-mcp-tests/RecordsContainmentTests.cs
+++ b/src/housecarl-mcp-tests/RecordsContainmentTests.cs
@@ -167,6 +167,18 @@ public sealed class RecordsContainmentTests : IClassFixture<OwnedChildFixture>
         Assert.Contains("DialogTopic.Responses", r);
     }
 
+    /// <summary>Reading a child-bearing field THROUGH the hop is the same question as reading it on the container
+    /// directly, so it must carry the same owned-child note. Without it the crash-log reading this PR headlines —
+    /// a placed reference up to its cell's contents — would be the one spelling that reports the winner's contents
+    /// as the whole story.</summary>
+    [Fact]
+    public void AReadThroughTheHopCarriesTheContainingCellsOwnedChildNote()
+    {
+        const string note = "their declarations for this field were not read";
+        Assert.Contains(note, Read(_w.CellA, "Temporary"));
+        Assert.Contains(note, Read(new FormKey(_w.CellA.ModKey, 0xC10), "*parent.Temporary"));
+    }
+
     // ---- filtering on it -------------------------------------------------------------------------
 
     [Fact]

--- a/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
+++ b/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
@@ -57,8 +57,12 @@ public sealed class OwnedChildWorld : IDisposable
     public FormKey Topic { get; }
     /// <summary>A 3-toucher record with no child-bearing field at all.</summary>
     public FormKey Weapon { get; }
-    /// <summary>REACH — the base holds one block with 3 real cells; the winner holds 2 empty blocks.</summary>
+    /// <summary>REACH — the base holds one block with 3 real cells; the winner holds 2 empty blocks. Its TopCell
+    /// slot is deliberately EMPTY: the create/remove lifecycle tests fill it themselves.</summary>
     public FormKey Worldspace { get; }
+    /// <summary>A second worldspace whose only child is a TopCell — the singular Worldspace child property, kept
+    /// off <see cref="Worldspace"/> so the lifecycle tests still find that slot free.</summary>
+    public FormKey TopCellWorldspace { get; }
 
     /// <summary>ACHR under <see cref="CellI"/>.Persistent — the child type the issue title names and the fixture
     /// otherwise had none of.</summary>
@@ -76,7 +80,7 @@ public sealed class OwnedChildWorld : IDisposable
     public FormKey PersistentRef { get; }
     /// <summary>Base's landscape under <see cref="CellA"/> — the Cell.Landscape row (a SINGULAR child).</summary>
     public FormKey LandscapeRec { get; }
-    /// <summary>The worldspace's TopCell — the second Worldspace child property, and a singular one.</summary>
+    /// <summary><see cref="TopCellWorldspace"/>'s TopCell — the second Worldspace child property, and a singular one.</summary>
     public FormKey TopCell { get; }
     /// <summary>The first of the worldspace's sub-block cells (<c>Worldspace.SubCells</c>).</summary>
     public FormKey WorldCell { get; }
@@ -118,6 +122,7 @@ public sealed class OwnedChildWorld : IDisposable
         CellG = new FormKey(baseKey, 0xC07); CellH = new FormKey(baseKey, 0xC08);
         CellI = new FormKey(baseKey, 0xC09); CellJ = new FormKey(midKey, 0xA09);
         Topic = new FormKey(baseKey, 0xD01); Weapon = new FormKey(baseKey, 0xE01); Worldspace = new FormKey(baseKey, 0xF01);
+        TopCellWorldspace = new FormKey(baseKey, 0xF02);
         PlacedNpc = new FormKey(baseKey, 0xC80); Navmesh = new FormKey(baseKey, 0xC82);
         DeletedRef = new FormKey(baseKey, 0xC83); ReparentedRef = new FormKey(baseKey, 0xC84);
         PersistentRef = new FormKey(baseKey, 0xC1A); LandscapeRec = new FormKey(baseKey, 0xC1B);
@@ -204,8 +209,15 @@ public sealed class OwnedChildWorld : IDisposable
                 sub.Items.Add(wc);
             }
             blk.Items.Add(sub); ws.SubCells.Add(blk);
-            ws.TopCell = new Cell(TopCell, SkyrimRelease.SkyrimSE) { EditorID = "HcOcWsTop" };
             m.Worldspaces.Add(ws);
+
+            // The singular Worldspace child property, on a worldspace of its own so the create/remove lifecycle
+            // tests still find the main worldspace's TopCell slot free.
+            m.Worldspaces.Add(new Worldspace(TopCellWorldspace, SkyrimRelease.SkyrimSE)
+            {
+                EditorID = "HcOcWrldTop",
+                TopCell = new Cell(TopCell, SkyrimRelease.SkyrimSE) { EditorID = "HcOcWsTop" },
+            });
 
             m.BeginWrite.ToPath(basePath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
         }

--- a/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
+++ b/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
@@ -48,11 +48,44 @@ public sealed class OwnedChildWorld : IDisposable
     /// <summary>OVER THE MEMBER CAP — the base declares 101 references and the mid plugin overrides the cell
     /// declaring none, so the union is 101 against a json member cap of 100.</summary>
     public FormKey CellH { get; }
+    /// <summary>The child-KIND cell: the placed-NPC (ACHR), navmesh and deleted-reference children the other
+    /// cells don't carry, plus the reference Mid re-parents out of it. Its own declarers picture is deliberately
+    /// dull — the containment tests read it, the annotation tests don't.</summary>
+    public FormKey CellI { get; }
+    /// <summary>Declared only by Mid, and it steals base's <see cref="ReparentedRef"/> out of <see cref="CellI"/>.</summary>
+    public FormKey CellJ { get; }
     public FormKey Topic { get; }
     /// <summary>A 3-toucher record with no child-bearing field at all.</summary>
     public FormKey Weapon { get; }
     /// <summary>REACH — the base holds one block with 3 real cells; the winner holds 2 empty blocks.</summary>
     public FormKey Worldspace { get; }
+
+    /// <summary>ACHR under <see cref="CellI"/>.Persistent — the child type the issue title names and the fixture
+    /// otherwise had none of.</summary>
+    public FormKey PlacedNpc { get; }
+    /// <summary>NAVM under <see cref="CellI"/>.NavigationMeshes — the one child kind that also names its parent on
+    /// its own body, so the only place the index and the record body could disagree.</summary>
+    public FormKey Navmesh { get; }
+    /// <summary>A placed reference base DELETED — the patch-deleted crash-log case a *parent filter must still
+    /// answer, since the hop reads its FormKey and nothing else.</summary>
+    public FormKey DeletedRef { get; }
+    /// <summary>Base declares it under <see cref="CellI"/>; Mid declares the SAME FormKey under
+    /// <see cref="CellJ"/>. Later wins, so containment says CellJ.</summary>
+    public FormKey ReparentedRef { get; }
+    /// <summary>Base's persistent reference under <see cref="CellA"/> — the Cell.Persistent row.</summary>
+    public FormKey PersistentRef { get; }
+    /// <summary>Base's landscape under <see cref="CellA"/> — the Cell.Landscape row (a SINGULAR child).</summary>
+    public FormKey LandscapeRec { get; }
+    /// <summary>The worldspace's TopCell — the second Worldspace child property, and a singular one.</summary>
+    public FormKey TopCell { get; }
+    /// <summary>The first of the worldspace's sub-block cells (<c>Worldspace.SubCells</c>).</summary>
+    public FormKey WorldCell { get; }
+    /// <summary>A placed reference inside <see cref="WorldCell"/> — REFR → CELL → WRLD, the real two-hop chain
+    /// the crash-log case walks.</summary>
+    public FormKey WorldCellRef { get; }
+
+    /// <summary>The three plugins on disk, so a test can enumerate them the way the index build does.</summary>
+    public IReadOnlyList<string> PluginPaths { get; }
 
     public static string Fid(FormKey fk) => $"{fk.ID:X6}:{fk.ModKey.FileName}";
 
@@ -83,7 +116,13 @@ public sealed class OwnedChildWorld : IDisposable
         CellA = new FormKey(baseKey, 0xC01); CellB = new FormKey(baseKey, 0xC02); CellC = new FormKey(baseKey, 0xC03);
         CellD = new FormKey(baseKey, 0xC04); CellE = new FormKey(baseKey, 0xC05); CellF = new FormKey(baseKey, 0xC06);
         CellG = new FormKey(baseKey, 0xC07); CellH = new FormKey(baseKey, 0xC08);
+        CellI = new FormKey(baseKey, 0xC09); CellJ = new FormKey(midKey, 0xA09);
         Topic = new FormKey(baseKey, 0xD01); Weapon = new FormKey(baseKey, 0xE01); Worldspace = new FormKey(baseKey, 0xF01);
+        PlacedNpc = new FormKey(baseKey, 0xC80); Navmesh = new FormKey(baseKey, 0xC82);
+        DeletedRef = new FormKey(baseKey, 0xC83); ReparentedRef = new FormKey(baseKey, 0xC84);
+        PersistentRef = new FormKey(baseKey, 0xC1A); LandscapeRec = new FormKey(baseKey, 0xC1B);
+        TopCell = new FormKey(baseKey, 0xF20); WorldCell = new FormKey(baseKey, 0xF10);
+        WorldCellRef = new FormKey(baseKey, 0xF30);
 
         var baseDir = Path.Combine(mods, "BaseMod"); Directory.CreateDirectory(baseDir);
         var basePath = Path.Combine(baseDir, BaseName);
@@ -127,6 +166,21 @@ public sealed class OwnedChildWorld : IDisposable
                 h.Temporary.Add(new PlacedObject(new FormKey(baseKey, (uint)(0x1000 + i)), SkyrimRelease.SkyrimSE) { EditorID = $"HcOcHTemp{i}" });
             FileInterior(m, h);
 
+            // The child-KIND cell: an ACHR, a navmesh, a DELETED placed reference, and the reference Mid moves out.
+            var iCell = new Cell(CellI, SkyrimRelease.SkyrimSE) { EditorID = "HcOcCellI", Flags = Cell.Flag.IsInteriorCell };
+            iCell.Persistent.Add(new PlacedNpc(PlacedNpc, SkyrimRelease.SkyrimSE) { EditorID = "HcOcAchr" });
+            // The navmesh names its own cell at Data.Parent as well as sitting under it, so the index and the
+            // record body can be checked against each other — the only child kind where that is possible.
+            iCell.NavigationMeshes.Add(new NavigationMesh(Navmesh, SkyrimRelease.SkyrimSE)
+            {
+                EditorID = "HcOcNavm",
+                Data = new NavigationMeshData { Parent = new CellNavmeshParent { Parent = CellI.ToLink<ICellGetter>() } },
+            });
+            iCell.Temporary.Add(new PlacedObject(DeletedRef, SkyrimRelease.SkyrimSE) { EditorID = "HcOcGone", IsDeleted = true });
+            iCell.Temporary.Add(new PlacedObject(ReparentedRef, SkyrimRelease.SkyrimSE) { EditorID = "HcOcMoves" });
+            FileInterior(m, iCell);
+
+
             var t = new DialogTopic(Topic, SkyrimRelease.SkyrimSE) { EditorID = "HcOcTopic" };
             for (int i = 0; i < 2; i++)
             {
@@ -143,8 +197,14 @@ public sealed class OwnedChildWorld : IDisposable
             var blk = new WorldspaceBlock { BlockNumberX = 0, BlockNumberY = 0, GroupType = GroupTypeEnum.ExteriorCellBlock };
             var sub = new WorldspaceSubBlock { BlockNumberX = 0, BlockNumberY = 0, GroupType = GroupTypeEnum.ExteriorCellSubBlock };
             for (int i = 0; i < 3; i++)
-                sub.Items.Add(new Cell(new FormKey(baseKey, (uint)(0xF10 + i)), SkyrimRelease.SkyrimSE) { EditorID = $"HcOcWsCell{i}" });
+            {
+                var wc = new Cell(new FormKey(baseKey, (uint)(0xF10 + i)), SkyrimRelease.SkyrimSE) { EditorID = $"HcOcWsCell{i}" };
+                // A placed reference two containment steps under the worldspace: REFR -> CELL -> WRLD.
+                if (i == 0) wc.Temporary.Add(new PlacedObject(WorldCellRef, SkyrimRelease.SkyrimSE) { EditorID = "HcOcWsRef" });
+                sub.Items.Add(wc);
+            }
             blk.Items.Add(sub); ws.SubCells.Add(blk);
+            ws.TopCell = new Cell(TopCell, SkyrimRelease.SkyrimSE) { EditorID = "HcOcWsTop" };
             m.Worldspaces.Add(ws);
 
             m.BeginWrite.ToPath(basePath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
@@ -172,6 +232,14 @@ public sealed class OwnedChildWorld : IDisposable
             g.Temporary.Add(new PlacedObject(new FormKey(baseKey, 0xC70), SkyrimRelease.SkyrimSE) { EditorID = "HcOcGTemp0" });
             g.Temporary.Add(new PlacedObject(new FormKey(midKey, 0xA70), SkyrimRelease.SkyrimSE) { EditorID = "HcOcMidGTemp0" });
             FileInterior(m, g);
+
+            // The later-wins merge, both halves. Mid re-declares CellI carrying NOTHING — which must not erase
+            // base's edges for the children it declared there — and declares base's ReparentedRef under a cell of
+            // its own, which must move that one child and only that one.
+            FileInterior(m, new Cell(CellI, SkyrimRelease.SkyrimSE) { EditorID = "HcOcCellI", Flags = Cell.Flag.IsInteriorCell });
+            var jCell = new Cell(CellJ, SkyrimRelease.SkyrimSE) { EditorID = "HcOcCellJ", Flags = Cell.Flag.IsInteriorCell };
+            jCell.Temporary.Add(new PlacedObject(ReparentedRef, SkyrimRelease.SkyrimSE) { EditorID = "HcOcMoves" });
+            FileInterior(m, jCell);
 
             m.Weapons.GetOrAddAsOverride(baseOv.Weapons.First(w => w.FormKey == Weapon)).BasicStats!.Damage = 7;
             m.BeginWrite.ToPath(Path.Combine(midDir, MidName)).WithLoadOrder(new ISkyrimModGetter[] { baseOv }).Write();
@@ -217,6 +285,8 @@ public sealed class OwnedChildWorld : IDisposable
             m.Weapons.GetOrAddAsOverride(baseOv.Weapons.First(w => w.FormKey == Weapon)).BasicStats!.Damage = 9;
             m.BeginWrite.ToPath(Path.Combine(topDir, TopName)).WithLoadOrder(new ISkyrimModGetter[] { baseOv }).Write();
         }
+
+        PluginPaths = new[] { basePath, Path.Combine(midDir, MidName), Path.Combine(topDir, TopName) };
 
         File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + BaseName + "\r\n" + MidName + "\r\n" + TopName + "\r\n");
         File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + BaseName + "\r\n*" + MidName + "\r\n*" + TopName + "\r\n");

--- a/src/housecarl-mcp-tests/WhereContainmentTests.cs
+++ b/src/housecarl-mcp-tests/WhereContainmentTests.cs
@@ -1,0 +1,136 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>The <c>*parent</c> containment step in a predicate, evaluated in memory over a hand-bound child→parent
+/// map: the grammar's own refusals, the hop, the chain, and what it does on a record nothing contains. The map the
+/// real index builds is covered against real plugins in <see cref="RecordsContainmentTests"/>.</summary>
+[Trait("tier", "unit")]
+public sealed class WhereContainmentTests
+{
+    readonly SkyrimMod _mod = new(new ModKey("ParentWorld", ModType.Master), SkyrimRelease.SkyrimSE);
+    readonly Dictionary<FormKey, FormKey> _parents = new();
+    readonly Dictionary<FormKey, IMajorRecordGetter> _bodies = new();
+    readonly IMajorRecordGetter _info, _otherInfo, _placed, _topLevelWeapon;
+
+    public WhereContainmentTests()
+    {
+        var wrld = new Worldspace(_mod.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "PwTamriel" };
+        var cell = new Cell(_mod.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "PwWhiterun" };
+        var topic = new DialogTopic(_mod.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "PwGreetings" };
+        var otherTopic = new DialogTopic(_mod.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "PwFarewells" };
+        var info = new DialogResponses(_mod.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "PwLine0" };
+        var otherInfo = new DialogResponses(_mod.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "PwLine1" };
+        var placed = new PlacedObject(_mod.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "PwRef0" };
+        var weapon = _mod.Weapons.AddNew(); weapon.EditorID = "PwSword";
+
+        foreach (var r in new IMajorRecordGetter[] { wrld, cell, topic, otherTopic, info, otherInfo, placed, weapon })
+            _bodies[r.FormKey] = r;
+        _parents[info.FormKey] = topic.FormKey;
+        _parents[otherInfo.FormKey] = otherTopic.FormKey;
+        _parents[placed.FormKey] = cell.FormKey;
+        _parents[cell.FormKey] = wrld.FormKey;
+
+        _info = info; _otherInfo = otherInfo; _placed = placed; _topLevelWeapon = weapon;
+    }
+
+    /// <summary>Match one body, returning the verdict and the scan's own rollup sentence for the predicate.</summary>
+    (bool Matched, string? Note) Run(string clause, IMajorRecordGetter body)
+    {
+        var (set, err) = FieldPredicateSet.Parse(new[] { clause });
+        Assert.Null(err);
+        set!.BindResolution(fk => _bodies.ContainsKey(fk) ? "ParentWorld.esm" : null,
+                            fk => _bodies.GetValueOrDefault(fk),
+                            fk => _parents.TryGetValue(fk, out var p) ? p : null);
+        var matched = set.Matches(body);
+        return (matched, set.AccountingNote());
+    }
+
+    static string? Refusal(string clause) => FieldPredicateSet.Parse(new[] { clause }).Error;
+
+    // ---- the hop --------------------------------------------------------------------------------
+
+    [Fact]
+    public void ParentReadsTheOwningTopicOfAnInfo() =>
+        Assert.True(Run("*parent.EditorID = PwGreetings", _info).Matched);
+
+    [Fact]
+    public void ParentDoesNotMatchAnInfoUnderADifferentTopic() =>
+        Assert.False(Run("*parent.EditorID = PwGreetings", _otherInfo).Matched);
+
+    [Fact]
+    public void TheStepChains_APlacedReferenceReachesItsWorldspaceThroughItsCell() =>
+        Assert.True(Run("*parent.*parent.EditorID = PwTamriel", _placed).Matched);
+
+    [Fact]
+    public void OneHopShortOfTheWorldspaceReadsTheCell() =>
+        Assert.True(Run("*parent.EditorID = PwWhiterun", _placed).Matched);
+
+    /// <summary>The hop is a step, so the identity terms below it read the PARENT's identity, not the child's.</summary>
+    [Fact]
+    public void TheIdentityTermsBelowTheHopReadTheParent()
+    {
+        var topic = _parents[_info.FormKey];
+        Assert.True(Run($"*parent.formid in [{topic.ID:X6}:{topic.ModKey.FileName}]", _info).Matched);
+        Assert.False(Run($"*parent.formid in [{_info.FormKey.ID:X6}:{_info.FormKey.ModKey.FileName}]", _info).Matched);
+    }
+
+    // ---- a record nothing contains ---------------------------------------------------------------
+
+    [Fact]
+    public void ARecordNothingContainsIsNoVerdict_NotASilentNonMatch()
+    {
+        var (matched, note) = Run("*parent.EditorID = PwGreetings", _topLevelWeapon);
+        Assert.False(matched);
+        Assert.Contains("no record CONTAINS", note);
+    }
+
+    /// <summary>The reason is the child-bearing property set, derived from Mutagen — never a hand list, and never
+    /// the "did you mistype the path" advice a plain no-such-field miss would get.</summary>
+    [Fact]
+    public void TheNoParentSentenceNamesTheChildBearingProperties()
+    {
+        var note = Run("*parent.EditorID = PwGreetings", _topLevelWeapon).Note;
+        Assert.Contains("DialogTopic.Responses", note);
+        Assert.Contains("Cell.Temporary", note);
+        Assert.DoesNotContain("check the schema", note ?? "");
+    }
+
+    // ---- the refusals ----------------------------------------------------------------------------
+
+    [Fact]
+    public void ParentAfterAFieldStepRefuses_ItLeadsAPath() =>
+        Assert.Contains("can only lead a path", Refusal("Responses.*parent.EditorID = X"));
+
+    [Fact]
+    public void ParentWithNothingAfterItRefuses_ItIsARecordNotAValue() =>
+        Assert.Contains("not a value", Refusal("*parent = X"));
+
+    [Fact]
+    public void ParentWithAQuantifierRefuses_ThereIsOnlyEverOneContainingRecord() =>
+        Assert.Contains("not a list", Refusal("*parent[*any].EditorID = X"));
+
+    [Fact]
+    public void AnUnknownStarTokenNamesTheTwoThatExist()
+    {
+        var r = Refusal("*owner.EditorID = X");
+        Assert.Contains("*parent", r);
+        Assert.Contains("[*any]", r);
+    }
+
+    // ---- composition with the other steps ---------------------------------------------------------
+
+    [Fact]
+    public void TheHopComposesWithALinkStepOnItsOwnLeftSide() =>
+        // The left side hops to the cell, then reads a link on IT — nothing on the placed reference itself.
+        Assert.Null(Refusal("*parent.Location->editorid = X"));
+
+    [Fact]
+    public void ParentOnTheLinkSideWithNoFieldAfterItRefuses_AContainingRecordIsNotALink() =>
+        Assert.Contains("not a link-bearing field", Refusal("*parent->editorid = X"));
+}

--- a/src/housecarl-mcp-tests/WhereContainmentTests.cs
+++ b/src/housecarl-mcp-tests/WhereContainmentTests.cs
@@ -134,6 +134,17 @@ public sealed class WhereContainmentTests
     public void ParentOnTheLinkSideWithNoFieldAfterItRefuses_AContainingRecordIsNotALink() =>
         Assert.Contains("not a link-bearing field", Refusal("*parent->editorid = X"));
 
+    /// <summary>A presence test BELOW the hop is a real filter, not an identity that always exists: an exterior
+    /// CELL usually has no EditorID at all, so "which placed references sit in an unnamed cell" must parse and
+    /// answer rather than being refused as unfilterable.</summary>
+    [Fact]
+    public void APresenceTestOnTheParentsEditorIdIsAFilter_NotARefusal()
+    {
+        Assert.Null(Refusal("*parent.EditorID missing"));
+        Assert.True(Run("*parent.EditorID exists", _info).Matched);
+        Assert.False(Run("*parent.EditorID missing", _info).Matched);
+    }
+
     // ---- which type a quantified step is judged against -------------------------------------------
 
     /// <summary>A quantified step BELOW a hop is rooted at the CONTAINING record's type, so the scan's schema check

--- a/src/housecarl-mcp-tests/WhereContainmentTests.cs
+++ b/src/housecarl-mcp-tests/WhereContainmentTests.cs
@@ -133,4 +133,24 @@ public sealed class WhereContainmentTests
     [Fact]
     public void ParentOnTheLinkSideWithNoFieldAfterItRefuses_AContainingRecordIsNotALink() =>
         Assert.Contains("not a link-bearing field", Refusal("*parent->editorid = X"));
+
+    // ---- which type a quantified step is judged against -------------------------------------------
+
+    /// <summary>A quantified step BELOW a hop is rooted at the CONTAINING record's type, so the scan's schema check
+    /// must not judge it against the scanned type — the same rule the right side of a '-&gt;' already follows.
+    /// Getting this wrong refuses a valid call, or silences a real refusal, wherever a child and its container both
+    /// carry a field of that name with different cardinality.</summary>
+    [Fact]
+    public void AQuantifiedStepBelowAHopIsNotRootedAtTheScannedType()
+    {
+        static FieldPredicateSet Set(string clause)
+        {
+            var (set, err) = FieldPredicateSet.Parse(new[] { clause });
+            Assert.Null(err);
+            return set!;
+        }
+        Assert.True(Assert.Single(Set("Responses[*any].Text = hi").QuantifiedSteps).OnScannedType);
+        Assert.False(Assert.Single(Set("*parent.Responses[*any].Text = hi").QuantifiedSteps).OnScannedType);
+        Assert.False(Assert.Single(Set("*parent.Keywords[*any]->editorid = X").QuantifiedSteps).OnScannedType);
+    }
 }

--- a/src/housecarl-mcp-tests/WhereQuantifierTests.cs
+++ b/src/housecarl-mcp-tests/WhereQuantifierTests.cs
@@ -333,6 +333,31 @@ public sealed class WhereQuantifierTests
         Assert.Empty(hits);
         Assert.DoesNotContain("read FAULT", note);
     }
+    // ---- a quantifier on an identity term ----------------------------------------------------------
+    //
+    // The pseudo-path classification runs AFTER the fold split, which has already rewritten 'editorid[*any]' to
+    // the bare segment 'editorid'. Left to match on the segment alone it would classify as the identity term and
+    // return before the fold was ever read — the quantifier accepted and silently ignored, a different filter
+    // from the one the caller wrote. It refuses by name instead.
+
+    [Theory]
+    [InlineData("editorid[*any] = QSpellLow")]
+    [InlineData("winner[*all] = QuantWorld.esm")]
+    [InlineData("formid[*any] in [000800:QuantWorld.esm]")]
+    [InlineData("editorid[*count] > 2")]
+    public void AQuantifierOnAnIdentityTermRefusesByName_NeverSilentlyDropped(string clause)
+    {
+        var (set, err) = FieldPredicateSet.Parse(new[] { clause });
+        Assert.Null(set);
+        Assert.Contains("not a list", err ?? "");
+        Assert.Contains("takes no", err ?? "");
+    }
+
+    /// <summary>…and the unquantified spellings still classify as the identity terms they are — the gate is on
+    /// the fold, not on the name.</summary>
+    [Fact]
+    public void TheSameTermsWithoutAQuantifierAreStillTheIdentityTerms() =>
+        Assert.Equal(new[] { _spellLow }.ToHashSet(), Run("editorid = QSpellLow", _spells));
 
     // ---- composition: a quantified step inside another ---------------------------------------------
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1,4 +1,4 @@
-﻿using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Aspects;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1824,7 +1824,7 @@ public sealed class LoadOrderService : IDisposable
         var comp = Mo2LoadOrder.ReadComposition(profileDir);       // fresh composition (always current)
         return new LoadOrderStatusData(
             comp, warnings, view.PluginCount, _maxPlugins, profileChanged, profileDir, profileName, instanceDir, view.ExcludedPlugins,
-            view.Epoch);
+            view.Epoch, view.ContainedRecordCount);
     }
 
     /// <summary>The LOCALIZED header flag of ONE plugin, for housecarl_load_order_status' lookup= (#376): a localized
@@ -3698,8 +3698,10 @@ public sealed class LoadOrderService : IDisposable
             }
             // The '*parent' containment step: hop to the record that CONTAINS this one, then read the rest of the
             // path there. A path that is nothing but hops IS the edge — the parent is what the walk crosses to.
-            int hops = 0;
-            while (hops < segs.Length && string.Equals(segs[hops], ContainmentIndex.ParentToken, StringComparison.OrdinalIgnoreCase)) hops++;
+            // Same grammar the where= and project.fields surfaces enforce, so a misspelled step refuses by name
+            // here too rather than falling through to a "no such field" hint.
+            var (hops, gerr) = ContainmentIndex.SplitHops(segs, string.Join(".", segs), allowBare: true);
+            if (gerr is not null) { note = $"({gerr})"; return new List<FormKey>(); }
             for (int i = 0; i < hops; i++)
             {
                 var pk = view.ParentOf(body.FormKey);
@@ -4223,6 +4225,12 @@ public sealed class LoadOrderService : IDisposable
                         return w is null ? null : view.GetRecord(winnerSession!, w.Value.WinnerPlugin, fk);
                     }
                     : null,
+                // The containment map is WHOLE-ORDER and later-wins, on both lanes — including the plugins= lane,
+                // where every other term reads the scoped plugin's OWN body. That is deliberate and it is the only
+                // well-defined reading: which record contains a child is a fact about the assembled order, not
+                // about one file (thousands of children across a real order sit under a different parent than the
+                // first plugin that declared them). So plugins=["A.esp"] where=["*parent.EditorID = X"] filters
+                // A.esp's own bodies by the order's containment, and a later plugin's re-parenting is what answers.
                 predicate.NeedsContainment ? fk => view.ParentOf(fk) : null);
             // where_source=winner needs one body per CANDIDATE, not per record in the order, and fetching them one
             // at a time is a whole-overlay walk each (#251). So the scan buffers a CHUNK of candidates off the one
@@ -4525,6 +4533,17 @@ public sealed class LoadOrderService : IDisposable
             var (set, perr) = FieldPredicateSet.Parse(where, FormIdDoor.On(view).Parse);
             if (perr is not null) return CrossQueryOutcome.Fail(perr);
             predicate = set;
+            // The containment map is built from the ACTIVE order's plugins only. An off-order file's own records
+            // are not in it, and worse, a file sharing a filename with an active plugin — the routine case of
+            // inspecting a disabled or older copy of Foo.esp — resolves to the ACTIVE order's parent for the same
+            // FormID, so the scan would filter this file's bodies against an edge another file declared. Refused
+            // by name rather than answered from the wrong index.
+            if (predicate.NeedsContainment)
+                return CrossQueryOutcome.Fail(
+                    $"'{ContainmentIndex.ParentToken}' reads the containment map built from the ACTIVE load order, and this scan streams an " +
+                    $"out-of-load-order FILE whose own containment was never indexed — the answer would come from a different file's " +
+                    $"edges. Drop source= to filter on containment in the active order, or filter this file on its own body instead.")
+                    with { Epoch = view.Epoch };
         }
         foreach (var demand in (artifactDemands ?? Array.Empty<ArtifactDemand>()).Concat(
                      predicate?.ArtifactDemands ?? (IReadOnlyList<ArtifactDemand>)Array.Empty<ArtifactDemand>()))
@@ -4599,7 +4618,7 @@ public sealed class LoadOrderService : IDisposable
                             return w is null ? null : view.GetRecord(sess!, w.Value.WinnerPlugin, fk);
                         }
                         : null,
-                    predicate.NeedsContainment ? fk => view.ParentOf(fk) : null);
+                    parentOf: null);   // refused above: this file's containment is not in the active order's map
             }
             var seen = new HashSet<FormKey>();
             foreach (var rec in ov.EnumerateMajorRecords())
@@ -9007,7 +9026,8 @@ public sealed record LoadOrderStatusData(
     string ProfileName,         // the ACTIVE profile (instance mode: MO2's selected_profile; explicit: the dir name) — captured under the gate, not re-derived at render
     string? InstanceDir,        // the resolved MO2 instance folder houseCARL is pointed at; null ⇒ explicit-paths / unconfigured mode
     IReadOnlyDictionary<string, string> ExcludedPlugins,
-    string? Epoch = null);      // the resolver's current build fingerprint (SPEC §2.1.1) — the status line names it so a caller can match responses/artifacts to the build; nullable like every other carrier
+    string? Epoch = null,       // the resolver's current build fingerprint (SPEC §2.1.1) — the status line names it so a caller can match responses/artifacts to the build; nullable like every other carrier
+    int ContainedRecordCount = 0);  // children this build recorded a containing record for — the '*parent' map's size, declared in band per SPEC §2.1 rather than left for a user to discover as memory
 
 /// <summary>The data behind housecarl_update_status: MO2's own local Nexus update cache read from meta.ini, with no
 /// network. <see cref="Entries"/> is one row per Nexus-linked mod (installed vs newest version, modid, enabled state);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4111,7 +4111,8 @@ public sealed class LoadOrderService : IDisposable
                             var w = view.ResolveWinner(fk);
                             return w is null ? null : view.GetRecord(sess, w.Value.WinnerPlugin, fk);
                         }
-                        : null);
+                        : null,
+                    predicate.NeedsContainment ? fk => view.ParentOf(fk) : null);
                 var seenSet = new HashSet<FormKey>();
                 foreach (var fk in formidSet!)
                 {
@@ -4201,7 +4202,8 @@ public sealed class LoadOrderService : IDisposable
                         var w = view.ResolveWinner(fk);
                         return w is null ? null : view.GetRecord(winnerSession!, w.Value.WinnerPlugin, fk);
                     }
-                    : null);
+                    : null,
+                predicate.NeedsContainment ? fk => view.ParentOf(fk) : null);
             // where_source=winner needs one body per CANDIDATE, not per record in the order, and fetching them one
             // at a time is a whole-overlay walk each (#251). So the scan buffers a CHUNK of candidates off the one
             // scoped stream, gathers that chunk's winner bodies a plugin at a time — one enumeration per distinct
@@ -4576,7 +4578,8 @@ public sealed class LoadOrderService : IDisposable
                             var w = view.ResolveWinner(fk);
                             return w is null ? null : view.GetRecord(sess!, w.Value.WinnerPlugin, fk);
                         }
-                        : null);
+                        : null,
+                    predicate.NeedsContainment ? fk => view.ParentOf(fk) : null);
             }
             var seen = new HashSet<FormKey>();
             foreach (var rec in ov.EnumerateMajorRecords())

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2376,8 +2376,9 @@ public sealed class LoadOrderService : IDisposable
 
         // materialise while the session (overlay) is open; the *parent hop climbs the index's containment map and
         // fetches the containing record's winner body through the same session
-        var record = ReadEngine.ReadFields(rec, fields, depth, containerHint, ContainmentIndex.ReadHop(view, session));
-        record = AnnotateOwnedChildContent(record, rec, view, session, fk, source, unionMemo, out var childFields);   // the additive union (or the index-only note), display-only
+        var hop = ContainmentIndex.ReadHop(view, session);
+        var record = ReadEngine.ReadFields(rec, fields, depth, containerHint, hop);
+        record = AnnotateOwnedChildContent(record, rec, view, session, fk, source, unionMemo, out var childFields, hop);   // the additive union (or the index-only note), display-only
         if (resolveNames) record = AnnotateLinks(record, view, session, linkMemo ?? new());   // identity of every FormLink token, display-only, on the same open session
         var touching = conflictTree ? view.TouchingPlugins(fk) : null;
         return new ReadOutcome(fk, record, source, winner.Value.WinnerPlugin, winner.Value.OverrideDepth, touching, null)
@@ -2426,50 +2427,97 @@ public sealed class LoadOrderService : IDisposable
     /// <para>Display-only: it rides <see cref="FieldValue.Display"/>, never the round-trip
     /// <see cref="FieldValue.Token"/>, so it is invisible to the write surface, the read-proof oracle and the
     /// conflict diff, and reaches every render through that one carrier.</para></summary>
+    /// <param name="parentOf">The read's own <c>*parent</c> hop, so a row read off a CONTAINING record is judged
+    /// against that record. Without it, '<c>*parent.Temporary</c>' on a placed reference would report the winner
+    /// cell's contents unannotated while '<c>Temporary</c>' on the cell itself annotates them — two spellings of
+    /// one question disagreeing, which is the silently wrong answer this note exists to prevent.</param>
     static RecordFields AnnotateOwnedChildContent(RecordFields rf, IMajorRecordGetter body,
                                                   LoadOrderResolver.IndexView view,
                                                   LoadOrderResolver.OverlaySession session, FormKey fk, string source,
                                                   ChildUnionMemo? memo,
-                                                  out IReadOnlyDictionary<string, ChildUnion?>? annotated)
+                                                  out IReadOnlyDictionary<string, ChildUnion?>? annotated,
+                                                  Func<IMajorRecordGetter, (IMajorRecordGetter? Parent, string? Why)>? parentOf = null)
     {
         annotated = null;
-        // Empty for all but three record types, so this is where the overwhelming majority of reads leave, before
-        // any index lookup.
-        var owning = OwnedChildContent.Fields(body);
-        if (owning.Count == 0) return rf;
-
-        // Which of the lines THIS read produced are those fields. A depth>=2 read emits the same summary line at the
-        // bare field path before expanding its children, so the annotation lands in one place either way.
-        List<int>? hits = null;
+        // Group this read's rows by how many '*parent' hops their path opens with: each group is judged against the
+        // record its rows were actually read off. A hopless read is the whole of one group, which is every read but
+        // a containment one.
+        Dictionary<int, List<int>>? byHops = null;
         for (int i = 0; i < rf.Fields.Count; i++)
-            if (owning.ContainsKey(rf.Fields[i].Path)) (hits ??= new List<int>()).Add(i);
-        if (hits is null) return rf;
-
-        // Narrowed to the fields this read emitted: the union opens a body per touching plugin, and assembling a
-        // worldspace's cells for a read that asked for EditorID would be a cost nobody asked for.
-        var wanted = new Dictionary<string, OwnedChildShape>(hits.Count, StringComparer.Ordinal);
-        foreach (var i in hits) wanted[rf.Fields[i].Path] = owning[rf.Fields[i].Path];
-
-        IReadOnlyDictionary<string, ChildUnion>? unions = null;
-        if (memo is not null) unions = memo.Union(fk, () => OwnedChildUnion.Compute(view, session, fk, source, body, wanted));
-        else if (view.TouchingPlugins(fk) is not { Count: > 1 }) return rf;   // sole toucher: its own body IS the whole story
-        if (memo is not null && unions is null) return rf;                    // same, on the union lane
-        var others = unions is null ? view.TouchingPlugins(fk)!.Count - 1 : 0;
-
-        var rebuilt = new List<FieldValue>(rf.Fields);
-        // The ANNOTATED paths and their unions travel with the outcome, because the render decides its
-        // response-level clause off the fields it actually emitted — a path that never reaches the medium (a cap
-        // hit inside the field loop, a truncated json array, a manifest-only spill) must not earn a clause. A NULL
-        // value is the index-only tier: annotated, but by a lane that did not open the other bodies.
-        var map = new Dictionary<string, ChildUnion?>(hits.Count, StringComparer.Ordinal);
-        foreach (var i in hits)
         {
-            var u = unions?[rebuilt[i].Path];
-            // These fields are containers and owned records; the only other producer of Display is the flags
-            // decode, which fires on [Flags] enum leaves alone — so there is no annotation here to displace.
-            rebuilt[i] = rebuilt[i] with { Display = u is null ? ReadSentences.NotReadNote(others) : ReadSentences.UnionNote(u) };
-            map[rebuilt[i].Path] = u;
+            var segs = rf.Fields[i].Path.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var (hops, err) = ContainmentIndex.SplitHops(segs, rf.Fields[i].Path);
+            if (err is not null) continue;   // a misspelled hop already carries its own refusal note
+            (byHops ??= new Dictionary<int, List<int>>()).TryGetValue(hops, out var g);
+            (byHops[hops] = g ?? new List<int>()).Add(i);
         }
+        if (byHops is null) return rf;
+
+        List<FieldValue>? rebuilt = null;
+        Dictionary<string, ChildUnion?>? map = null;
+        foreach (var (hops, rows) in byHops)
+        {
+            // Climb to the record this group's rows were read on. A hop that cannot be taken annotates nothing —
+            // the rows themselves already carry the reason.
+            var on = body; var onKey = fk;
+            bool reached = true;
+            for (int h = 0; h < hops && reached; h++)
+            {
+                var (parent, _) = parentOf?.Invoke(on) ?? (null, null);
+                if (parent is null) reached = false; else { on = parent; onKey = parent.FormKey; }
+            }
+            if (!reached) continue;
+
+            // Empty for all but three record types, so this is where the overwhelming majority of reads leave,
+            // before any index lookup.
+            var owning = OwnedChildContent.Fields(on);
+            if (owning.Count == 0) continue;
+
+            // Which of the lines THIS read produced are those fields — matched on the path BELOW the hops, since
+            // that is the part read on `on`. A depth>=2 read emits the same summary line at the bare field path
+            // before expanding its children, so the annotation lands in one place either way.
+            List<(int Row, string Field)>? hits = null;
+            foreach (var i in rows)
+            {
+                var below = hops == 0 ? rf.Fields[i].Path
+                          : string.Join(".", rf.Fields[i].Path.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)[hops..]);
+                if (owning.ContainsKey(below)) (hits ??= new List<(int, string)>()).Add((i, below));
+            }
+            if (hits is null) continue;
+
+            // Narrowed to the fields this read emitted: the union opens a body per touching plugin, and assembling a
+            // worldspace's cells for a read that asked for EditorID would be a cost nobody asked for.
+            var wanted = new Dictionary<string, OwnedChildShape>(hits.Count, StringComparer.Ordinal);
+            foreach (var (_, field) in hits) wanted[field] = owning[field];
+
+            // A hopped group was read off the CONTAINING record's winner body, so that is the subject the union is
+            // assembled against; a hopless group is the read's own source.
+            var onSource = hops == 0 ? source : view.ResolveWinner(onKey)?.WinnerPlugin;
+            if (onSource is null) continue;
+
+            IReadOnlyDictionary<string, ChildUnion>? unions = null;
+            if (memo is not null) unions = memo.Union(onKey, () => OwnedChildUnion.Compute(view, session, onKey, onSource, on, wanted));
+            else if (view.TouchingPlugins(onKey) is not { Count: > 1 }) continue;   // sole toucher: its own body IS the whole story
+            if (memo is not null && unions is null) continue;                       // same, on the union lane
+            var others = unions is null ? view.TouchingPlugins(onKey)!.Count - 1 : 0;
+
+            rebuilt ??= new List<FieldValue>(rf.Fields);
+            // The ANNOTATED paths and their unions travel with the outcome, because the render decides its
+            // response-level clause off the fields it actually emitted — a path that never reaches the medium (a cap
+            // hit inside the field loop, a truncated json array, a manifest-only spill) must not earn a clause. A NULL
+            // value is the index-only tier: annotated, but by a lane that did not open the other bodies. The key is
+            // the row's DISPLAY path, hops and all, because that is what the render matches against.
+            map ??= new Dictionary<string, ChildUnion?>(StringComparer.Ordinal);
+            foreach (var (i, field) in hits)
+            {
+                var u = unions?[field];
+                // These fields are containers and owned records; the only other producer of Display is the flags
+                // decode, which fires on [Flags] enum leaves alone — so there is no annotation here to displace.
+                rebuilt[i] = rebuilt[i] with { Display = u is null ? ReadSentences.NotReadNote(others) : ReadSentences.UnionNote(u) };
+                map[rebuilt[i].Path] = u;
+            }
+        }
+        if (rebuilt is null) return rf;
         annotated = map;
         return rf with { Fields = rebuilt };
     }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2651,6 +2651,7 @@ public sealed class LoadOrderService : IDisposable
         using var session = p.Resolver.OpenSession();
         var tree = p.View.ResolveTree(session, fk);
         if (tree is null) return null;
+        var hop = ContainmentIndex.ReadHop(p.View, session);   // '*parent' on fields= — this lane holds the index, so it answers
 
         // The precise owned-child tier: which providers declare children per child-bearing field, asked of bodies
         // already open for the diff below, so it costs no extra fetch. Rationale and narrowing rules:
@@ -2666,7 +2667,7 @@ public sealed class LoadOrderService : IDisposable
         var nodes = new List<ConflictNodeView>(tree.Nodes.Count);
         foreach (var n in tree.Nodes)
         {
-            nodes.Add(new ConflictNodeView(n.Plugin, ReadEngine.ReadFields(n.Record, fields, ConflictDiffDepth)));   // materialise while open
+            nodes.Add(new ConflictNodeView(n.Plugin, ReadEngine.ReadFields(n.Record, fields, ConflictDiffDepth, parentOf: hop)));   // materialise while open
             foreach (var f in wanted)
             {
                 // Null means "could not look", never "declares nothing": a body dropped in silence would render as
@@ -3211,6 +3212,10 @@ public sealed class LoadOrderService : IDisposable
                               out string? armStatement, out bool covers, out string? error, out PoleInfo? offOrderArm)
     {
         error = null; covers = true; offOrderArm = null;
+        // '*parent' on fields=: every in-order arm below reads through this captured view and open session, so the
+        // hop answers on them exactly as it does on a plain read. The off-order arm carries no index and keeps the
+        // note saying so.
+        var hop = ContainmentIndex.ReadHop(view, session);
         switch (spec.Kind)
         {
             case PoleKind.Winner:
@@ -3223,7 +3228,7 @@ public sealed class LoadOrderService : IDisposable
                     var body = view.GetRecord(session, w.Value.WinnerPlugin, fk);
                     if (body is null)
                         return new PoleReading(null, null, null, $"the winner body of {fk} could not be read from '{w.Value.WinnerPlugin}'.");
-                    return new PoleReading(ReadEngine.ReadFields(body, fields, ConflictDiffDepth),
+                    return new PoleReading(ReadEngine.ReadFields(body, fields, ConflictDiffDepth, parentOf: hop),
                                            new DiffPole(w.Value.WinnerPlugin, "winner (active order)", true,
                                                         RecordNaming.StripOverlay(body.GetType().Name), body.EditorID), null, null);
                 };
@@ -3253,7 +3258,7 @@ public sealed class LoadOrderService : IDisposable
                         return new PoleReading(null, null, null, $"the previous provider '{refPlugin}' of {fk} could not be read.");
                     // Mid-stack subject: what sits above is surfaced as neutral fact, never advice.
                     IReadOnlyList<string>? above = idx < touchers.Count - 1 ? touchers.Skip(idx + 1).ToList() : null;
-                    return new PoleReading(ReadEngine.ReadFields(body, fields, ConflictDiffDepth),
+                    return new PoleReading(ReadEngine.ReadFields(body, fields, ConflictDiffDepth, parentOf: hop),
                                            new DiffPole(refPlugin, $"previous provider (immediately below '{subjectPlugin}')", true,
                                                         RecordNaming.StripOverlay(body.GetType().Name), body.EditorID), above, null);
                 };
@@ -3286,7 +3291,7 @@ public sealed class LoadOrderService : IDisposable
                                     ? $"Touched by (active order, winner last): {string.Join(", ", touchers)}."
                                     : "No active plugin touches it either."));
                         }
-                        return new PoleReading(ReadEngine.ReadFields(body, fields, ConflictDiffDepth),
+                        return new PoleReading(ReadEngine.ReadFields(body, fields, ConflictDiffDepth, parentOf: hop),
                                                new DiffPole(arm.Plugin, arm.Where, true,
                                                             RecordNaming.StripOverlay(body.GetType().Name), body.EditorID), null, null);
                     };
@@ -3327,6 +3332,7 @@ public sealed class LoadOrderService : IDisposable
                                      out string? armStatement, out bool covers, out string? error)
     {
         error = null;
+        var hop = ContainmentIndex.ReadHop(view, session);   // both overlay arms read through the order's own index
         var state = (spec.OverlayState ?? "post").Trim().ToLowerInvariant();
         if (state is not ("pre" or "post"))
         {
@@ -3346,7 +3352,7 @@ public sealed class LoadOrderService : IDisposable
                 if (w is null) return new PoleReading(null, null, null, UnresolvedFormId(view, fk));
                 var body = view.GetRecord(session, w.Value.WinnerPlugin, fk);
                 if (body is null) return new PoleReading(null, null, null, $"the winner body of {fk} could not be read from '{w.Value.WinnerPlugin}'.");
-                return new PoleReading(ReadEngine.ReadFields(body, fields, ConflictDiffDepth),
+                return new PoleReading(ReadEngine.ReadFields(body, fields, ConflictDiffDepth, parentOf: hop),
                                        new DiffPole(w.Value.WinnerPlugin, "skypatcher overlay (pre) = winner", true,
                                                     RecordNaming.StripOverlay(body.GetType().Name), body.EditorID), null, null);
             };
@@ -3396,7 +3402,7 @@ public sealed class LoadOrderService : IDisposable
                     var w = view.ResolveWinner(fk);
                     var body = w is null ? null : view.GetRecord(session, w.Value.WinnerPlugin, fk);
                     if (body is not null)
-                        return postMemo[fk] = new PoleReading(ReadEngine.ReadFields(body, fields, ConflictDiffDepth),
+                        return postMemo[fk] = new PoleReading(ReadEngine.ReadFields(body, fields, ConflictDiffDepth, parentOf: hop),
                                                new DiffPole(w!.Value.WinnerPlugin,
                                                             "skypatcher overlay (post) = winner — type not SkyPatcher-patchable, the layer cannot touch it",
                                                             true, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID), null, null);
@@ -3404,7 +3410,7 @@ public sealed class LoadOrderService : IDisposable
                 return postMemo[fk] = new PoleReading(null, null, null, r.Error);
             }
             int applied = r.Folders.Where(f => f.Result is not null).Sum(f => f.Result!.Applied.Count);
-            var post = ReadEngine.ReadFields(r.Copy!, fields, ConflictDiffDepth);
+            var post = ReadEngine.ReadFields(r.Copy!, fields, ConflictDiffDepth, parentOf: hop);
             return postMemo[fk] = new PoleReading(post,
                 new DiffPole(r.WinnerPlugin!, $"skypatcher overlay (post) — {applied} op(s) applied onto the winner", true,
                              post.Type, r.EditorId), null, null);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2374,7 +2374,9 @@ public sealed class LoadOrderService : IDisposable
                 $"Touched by (load order, winner last): {string.Join(", ", touchers)}.");
         }
 
-        var record = ReadEngine.ReadFields(rec, fields, depth, containerHint);   // materialise while the session (overlay) is open
+        // materialise while the session (overlay) is open; the *parent hop climbs the index's containment map and
+        // fetches the containing record's winner body through the same session
+        var record = ReadEngine.ReadFields(rec, fields, depth, containerHint, ContainmentIndex.ReadHop(view, session));
         record = AnnotateOwnedChildContent(record, rec, view, session, fk, source, unionMemo, out var childFields);   // the additive union (or the index-only note), display-only
         if (resolveNames) record = AnnotateLinks(record, view, session, linkMemo ?? new());   // identity of every FormLink token, display-only, on the same open session
         var touching = conflictTree ? view.TouchingPlugins(fk) : null;
@@ -3486,7 +3488,7 @@ public sealed class LoadOrderService : IDisposable
                     continue;
                 }
             }
-            var record = ReadEngine.ReadFields(bodyToRead!, fields, depth, containerHint);
+            var record = ReadEngine.ReadFields(bodyToRead!, fields, depth, containerHint, ContainmentIndex.ReadHop(view, session));
             if (resolveNames) record = AnnotateLinks(record, view, session, overlayLinkMemo ??= new LinkMemo());
             var ok = (new ReadOutcome(fk, record, winner.Value.WinnerPlugin, winner.Value.WinnerPlugin,
                                       winner.Value.OverrideDepth, null, null)
@@ -3694,7 +3696,25 @@ public sealed class LoadOrderService : IDisposable
                         if (!link.FormKey.IsNull && seen.Add(link.FormKey)) list.Add(link.FormKey);
                 return list;
             }
-            var (links, n) = ReadEngine.CollectLinksAt(body, segs);
+            // The '*parent' containment step: hop to the record that CONTAINS this one, then read the rest of the
+            // path there. A path that is nothing but hops IS the edge — the parent is what the walk crosses to.
+            int hops = 0;
+            while (hops < segs.Length && string.Equals(segs[hops], ContainmentIndex.ParentToken, StringComparison.OrdinalIgnoreCase)) hops++;
+            for (int i = 0; i < hops; i++)
+            {
+                var pk = view.ParentOf(body.FormKey);
+                if (pk is null)
+                {
+                    note = $"(no record contains this {TypeOf(body)} — containment runs from these properties only: {ContainmentIndex.ChildBearingSurface()})";
+                    return new List<FormKey>();
+                }
+                if (i == hops - 1 && hops == segs.Length) return new List<FormKey> { pk.Value };
+                var up = Fetch(pk.Value);
+                if (up is null) { note = $"(the containing record {pk.Value} would not fetch)"; return new List<FormKey>(); }
+                body = up;
+            }
+
+            var (links, n) = ReadEngine.CollectLinksAt(body, hops == 0 ? segs : segs[hops..]);
             note = n;
             return links ?? new List<FormKey>();
         }

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Text;
 using System.Text.Json;
 using ModelContextProtocol.Server;

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -2055,6 +2055,9 @@ public static class RecordsTools
         {
             int open = seg.IndexOf('[');
             if (open < 0 || !seg.EndsWith("]", StringComparison.Ordinal)) continue;
+            // A quantifier on the containment step is that grammar's mistake, not a projection one — leave it to
+            // the read walk's shared check, so where= and project.fields refuse it in the same sentence.
+            if (HousecarlCore.ContainmentIndex.IsParentStep(seg[..open])) continue;
             var key = seg[(open + 1)..^1];
             if (key.Length > 0 && key[0] == '*') return $"[{key}]";
         }

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Text;
 using System.Text.Json;
 using ModelContextProtocol.Server;
@@ -34,7 +34,7 @@ public static class RecordsTools
         [Description("The form: 'identity' (FormID -> type/editorid/name/winner — the labeling form; needs formids=) | 'summary' (identity plus winner/override-depth header facts — the default) | 'fields' (named field values; takes fields= and depth=) | 'rows' (a LIST field folded to ONE LINE PER ELEMENT — the compact per-row view: takes fields= naming the list (index one element, 'Conditions[0]', to fold just that one), and depth= (default 4). Each line is the element's own summary plus every sub-field the read FOUND; only ABSENT optionals are omitted, which is what turns a 40-row condition stack from ~1,000 lines into 40. A declared-but-null link is kept — an empty slot is a fact. A named field that is not a list fails loud) | 'everything' (the full record body; takes depth=) | 'aggregate' (a counted table; takes group_by=) | 'delta' (subject vs reference, differences only — source= is the subject, versus= the reference; takes fields= to narrow) | 'tree' (every provider of each record in priority order, winner last, each diffed against the reference pole — default the winner; takes fields=. On a record type that OWNS child records — a cell's placed references, a topic's INFO lines, a worldspace's cells — it also states, per such field, which providers DECLARE children there (a COLLECTION field) or how many do (a SINGULAR one, e.g. Cell.Landscape), and says so when none do) | 'info_order' (DIAL topics only: the effective MERGED INFO sequence across every touching plugin — the order the game walks, with MOVED annotations; the 'why does the wrong line play' diagnostic) | 'chain' (a walk's own paths, endpoints and cycles rather than the records it reached; needs walk=, and carries the NPC-template inheritance report and the reverse MGEF carrier rows).")]
         public string? form { get; set; }
 
-        [Description("fields/rows forms: dotted field paths to read, e.g. [\"BasicStats.Damage\", \"Keywords\", \"Effects\"]. Index a list/dict element with BRACKETS ('Effects[0].Data.Magnitude'). On the rows form these name the LIST(S) to fold, one line per element. where='s quantifier tokens are not read here: [*any]/[*all]/[*none] fold to a boolean, which is not a row, and [*] / [*count] as a PROJECTION are not built yet — both are refused by name.")]
+        [Description("fields/rows forms: dotted field paths to read, e.g. [\"BasicStats.Damage\", \"Keywords\", \"Effects\"]. Index a list/dict element with BRACKETS ('Effects[0].Data.Magnitude'). A path may LEAD with the containment step '*parent' — the record that CONTAINS this one, which group nesting makes invisible to references= ('*parent.EditorID' is an INFO's owning DIAL; '*parent.*parent.EditorID' a placed reference's worldspace) — and it chains. On the rows form these name the LIST(S) to fold, one line per element. where='s quantifier tokens are not read here: [*any]/[*all]/[*none] fold to a boolean, which is not a row, and [*] / [*count] as a PROJECTION are not built yet — both are refused by name.")]
         public string[]? fields { get; set; }
 
         [Description("fields/rows/everything forms: expansion depth for list/dict/substruct CONTENTS (default 1, or 4 on the rows form, where a shallower read renders every element as a bare type). THIS is the expansion knob: fields=[\"Effects\"], depth=4 reaches every effect's Magnitude/Area/Duration — no hand-written index guessing.")]
@@ -52,10 +52,10 @@ public static class RecordsTools
     /// call's own SELECT.</summary>
     public sealed class RecordsWalk
     {
-        [Description("Link-bearing field paths that start the walk from each seed, e.g. [\"HeadParts\", \"WornArmor\"]. Omit for every link on the seed.")]
+        [Description("Link-bearing field paths that start the walk from each seed, e.g. [\"HeadParts\", \"WornArmor\"]. '*parent' crosses the containment edge instead — the record that CONTAINS the seed (a REFR from a crash log to its CELL; '*parent.*parent' to the worldspace). Omit for every link on the seed.")]
         public string[]? seed_paths { get; set; }
 
-        [Description("The link path followed at every LATER hop. \"*\" (default) walks every link — full closure. A named path restricts to one chain, e.g. \"Template\" for NPC template inheritance.")]
+        [Description("The link path followed at every LATER hop. \"*\" (default) walks every link — full closure. A named path restricts to one chain, e.g. \"Template\" for NPC template inheritance, or \"*parent\" to climb containment.")]
         public string? follow { get; set; }
 
         [Description("'forward' (default) — what the seeds point AT (cheap: each hop is one link resolve). 'reverse' — what points AT the seeds; depth 1 only (reverse is a bounded scan; transitive reverse is refused naming the reverse-reference index as the future capability). The general reverse spelling on this surface IS references= (same construct); walk.direction='reverse' serves the typed MGEF lane — magic-effect seeds get per-carrier magnitude/area/duration (types= narrows the carrier types; walk.max_nodes bounds each seed's carrier rows; limit=/offset= window the SEEDS).")]
@@ -104,7 +104,11 @@ public static class RecordsTools
          "[*any]/[*all]/[*none] fold the elements into a boolean, [*count] into their number, and [*all] is " +
          "vacuously true on an empty list; a quantified step COSTS the list's length (per-candidate work times the " +
          "number of elements) and, where its sub-path carries '->', one winner fetch PER ELEMENT — " +
-         "'Temporary[*any]->…' on a dense cell is hundreds of fetches per candidate, presence 'VirtualMachineAdapter " +
+         "'Temporary[*any]->…' on a dense cell is hundreds of fetches per candidate; the CONTAINMENT step " +
+         "'*parent' — the record that CONTAINS this one, " +
+         "which group nesting makes invisible to references=: '*parent.EditorID = GreetingsTopic' is an INFO's " +
+         "owning DIAL, '*parent.*parent.EditorID = Tamriel' a placed reference's worldspace; it LEADS a path and " +
+         "chains, presence 'VirtualMachineAdapter " +
          "exists', membership 'formid not in @<file>' / 'Race in [XXXXXX:A.esm, YYYYYY:B.esm]' (list entries " +
          "separate on commas/newlines with brackets and quotes stripped — a value that itself contains a comma " +
          "or bracket is not expressible in a list; test it with '='), ONE '->' link step " +

--- a/src/housecarl-mcp/StatusTools.cs
+++ b/src/housecarl-mcp/StatusTools.cs
@@ -85,6 +85,10 @@ static class StatusWire
         if (d.MaxPlugins > 0) sb.Append(" [capped at MaxPlugins=").Append(d.MaxPlugins).Append(']');
         if (d.Epoch is not null) sb.Append("  epoch=").Append(d.Epoch);   // the current build's fingerprint — bulk responses stamp the build they read, matched against this
         sb.Append('\n');
+        // The containment map's size, in band: it is built on every index build for the '*parent' step whether or
+        // not the user ever spells one, so its cost is stated here rather than discovered as memory.
+        sb.Append("containment: ").Append(d.ContainedRecordCount.ToString("N0", System.Globalization.CultureInfo.InvariantCulture))
+          .Append(" child record(s) mapped to a containing record (the '*parent' step reads this)\n");
         if (d.ProfileChanged)
             sb.Append("[!] the profile changed mid-call and a refresh is still pending — houseCARL re-reads it " +
                       "automatically on the next tool call (lazy refresh; no restart needed).\n");


### PR DESCRIPTION
Containment becomes the second edge kind beside the form link, spelled `*parent`. DIAL→INFO, CELL→REFR/ACHR and WRLD→CELL ownership is group nesting, so `references=` correctly returns nothing for it and the child body names no owner — only a NavigationMesh does, at `Data.Parent`. The index build therefore captures it: `LoadOrderResolver.BuildIndex` swaps its flat `EnumerateMajorRecords` for `EnumerateMajorRecordContexts`, which yields the identical record set with the containing context attached, climbs group/block contexts to the nearest record ancestor (and stages nothing where the chain holds no record, rather than guessing), and merges one packed child→parent map per plugin, later-wins — the 2,363 children a real order re-parents are what makes per-plugin later-wins the right merge rather than one whole-order map. `*parent` then lands as a value on the axes that already exist: a leading, chaining step on `where=` paths, on `project.fields`, and on a walk's `seed_paths`/`follow`. It is a step, so everything below the hop — the `winner` term, `editorid`, `formid` membership, leaves, quantified steps from #458 — reads the containing record with no second rule. There is no per-record-type parent map anywhere in it: the set is Mutagen's own containment walk, and the refusals name `WriteEngine.ChildBearingProperties` as the reason, derived, so a Mutagen bump grows the reach with no edit here.

Refusals, each one sentence: `*parent` after a field step (it leads a path by definition — the containing record is a property of the record, not of a field value), carrying a quantifier (there is only ever one), with nothing after it, on the left of `->` with nothing after it, and any other `*` token. A record nothing contains is a named no-verdict whose scan rollup says so and names the child-bearing properties — never a silent non-match, and never a null on the read side.

Measured on the live ARR 2.0 order (3,801 plugins, 3.69M records, `parent-in-hand` probe, medians of three alternating runs): the context walk costs **0.31 s more than the flat walk, 1.04×** (7.91 s → 8.22 s), inside the run-to-run spread, and the packed map retains **77.3 MB** for 2,711,713 distinct children at ~30 B/entry. On the synthetic test fixture (3 plugins) the delta is below timer noise. 1,214 tests (baseline 1,190) and 128/128 probes pass.

Not in this PR: #489's reverse-reference index, which is E1 step 3.

Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)
