### PR TITLE
Give the S2 tools a format=json lane

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -16,11 +16,13 @@ saying it sets an expectation their install may contradict. Say what is known, a
 - **`housecarl_asset_status` and `housecarl_place` take `format='json'`.** Both answered text only, so a caller
   reading them from a script parsed prose. The json document carries the same data as the text render: for
   `asset_status`, the build-level caveats, one row per path with its winner and full provider chain, and the same
-  eight accounting counters the text line states; for `place`, one row per destination with its source and the
+  eight accounting counters the text line states, under one `accounting` object; for `place`, one row per destination with its source and the
   current VFS winner, and the "a placed file does not win until you enable and sort the mod" step in band. A
   provider is `{name, kind}` — the name alone is what `place`'s `source_provider=` takes, so nothing has to be
   parsed back off the printed token. A whole-call refusal answers a json caller as a document, and a document
-  that hits `max_chars` drops trailing rows, stays valid JSON, and says so.
+  that hits `max_chars` drops trailing rows, stays valid JSON, and says so — `max_chars` bounds the build-level
+  caveats as well as the rows, and the first row always renders, so a small `max_chars` still answers the path
+  that was asked about.
 
 - **`housecarl_merge_plugins` now carries a donor's light (ESL) flag onto the merged plugin where it is valid to.**
   The flag is carried when every donor was light and every merged object id landed inside the light window

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -16,13 +16,18 @@ saying it sets an expectation their install may contradict. Say what is known, a
 - **`housecarl_asset_status` and `housecarl_place` take `format='json'`.** Both answered text only, so a caller
   reading them from a script parsed prose. The json document carries the same data as the text render: for
   `asset_status`, the build-level caveats, one row per path with its winner and full provider chain, and the same
-  eight accounting counters the text line states, under one `accounting` object; for `place`, one row per destination with its source and the
+  eight accounting counters the text line states, under one `accounting` object; for `place`, the same
+  `accounting` object plus `placed`/`failed`, one row per destination with its source and the
   current VFS winner, and the "a placed file does not win until you enable and sort the mod" step in band. A
   provider is `{name, kind}` — the name alone is what `place`'s `source_provider=` takes, so nothing has to be
   parsed back off the printed token. A whole-call refusal answers a json caller as a document, and a document
   that hits `max_chars` drops trailing rows, stays valid JSON, and says so — `max_chars` bounds the build-level
-  caveats as well as the rows, and the first row always renders, so a small `max_chars` still answers the path
-  that was asked about.
+  caveats as well as the rows, each of which carries a `<name>_omitted` count of what was cut, and the first row
+  always renders, so a small `max_chars` still answers the path that was asked about.
+
+- **`housecarl_place` no longer tells you to sort above a winner it did not name.** When `max_chars` cut every row
+  that had a current winner, the enable-and-sort step still said "above the current winner(s) listed above" while
+  the render listed none. It now says the rows were cut and to raise `max_chars` to see which mods they name.
 
 - **`housecarl_merge_plugins` now carries a donor's light (ESL) flag onto the merged plugin where it is valid to.**
   The flag is carried when every donor was light and every merged object id landed inside the light window

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,15 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **`housecarl_asset_status` and `housecarl_place` take `format='json'`.** Both answered text only, so a caller
+  reading them from a script parsed prose. The json document carries the same data as the text render: for
+  `asset_status`, the build-level caveats, one row per path with its winner and full provider chain, and the same
+  eight accounting counters the text line states; for `place`, one row per destination with its source and the
+  current VFS winner, and the "a placed file does not win until you enable and sort the mod" step in band. A
+  provider is `{name, kind}` — the name alone is what `place`'s `source_provider=` takes, so nothing has to be
+  parsed back off the printed token. A whole-call refusal answers a json caller as a document, and a document
+  that hits `max_chars` drops trailing rows, stays valid JSON, and says so.
+
 - **`housecarl_merge_plugins` now carries a donor's light (ESL) flag onto the merged plugin where it is valid to.**
   The flag is carried when every donor was light and every merged object id landed inside the light window
   `0x800–0xFFF`; the report says the output is light, so it need not be opened to find out. Otherwise the flag is

--- a/src/housecarl-mcp-tests/S2JsonLaneTests.cs
+++ b/src/housecarl-mcp-tests/S2JsonLaneTests.cs
@@ -101,13 +101,37 @@ public sealed class AssetStatusJsonLaneTests : IClassFixture<AssetSelectWorld>
         var capped = AssetTools.AssetStatus(_w.Svc, under: many, format: "json", max_chars: 2_000);
         var whole = AssetTools.AssetStatus(_w.Svc, under: many, format: "json");
 
-        var notes = Parse(capped).GetProperty("selector_notes");
+        var root = Parse(capped);
+        var notes = root.GetProperty("selector_notes");
         Assert.True(notes.GetArrayLength() < 400, "the note list was written past max_chars");
-        Assert.Contains("omitted at max_chars=2000", notes[notes.GetArrayLength() - 1].GetString());
+        // The cut is a sibling COUNT, and the array stays pure data — a consumer iterating it never has to
+        // substring-match a prose marker out of the entries, and the two numbers still add up to the whole.
+        int omitted = root.GetProperty("selector_notes_omitted").GetInt32();
+        Assert.Equal(400, notes.GetArrayLength() + omitted);
+        foreach (var n in notes.EnumerateArray()) Assert.DoesNotContain("omitted at max_chars", n.GetString());
         // The cut is real, not cosmetic: the same call unbounded is many times the document.
         Assert.True(capped.Length < whole.Length / 4, $"capped={capped.Length} whole={whole.Length}");
         // Every selector is still COUNTED, whatever the render could show of them.
-        Assert.Equal(400, Parse(capped).GetProperty("accounting").GetProperty("notes").GetInt32());
+        Assert.Equal(400, root.GetProperty("accounting").GetProperty("notes").GetInt32());
+        // A document nothing was dropped from says so too.
+        Assert.Equal(0, Parse(whole).GetProperty("selector_notes_omitted").GetInt32());
+    }
+
+    /// <summary>A document whose CAVEATS were cut reports itself truncated. The accounting counters count rows only,
+    /// so a call that resolved every row it selected but lost caveat entries to the budget would otherwise say
+    /// truncated=false, and a consumer branching on that flag to re-call would conclude nothing was lost.</summary>
+    [Fact]
+    public void ADocumentWhoseCaveatsWereCutSaysItWasTruncated()
+    {
+        var many = Enumerable.Range(0, 400).Select(i => $"meshes/hcnothing{i}/**/*.nif").ToArray();
+
+        var root = Parse(AssetTools.AssetStatus(_w.Svc, under: many, format: "json", max_chars: 2_000));
+
+        // No row was dropped — none was selected — and yet the document is not complete.
+        Assert.Equal(0, root.GetProperty("accounting").GetProperty("truncated").GetInt32());
+        Assert.True(root.GetProperty("selector_notes_omitted").GetInt32() > 0);
+        Assert.True(root.GetProperty("truncated").GetBoolean());
+        Assert.Contains("max_chars=2000", root.GetProperty("truncated_note").GetString());
     }
 
     /// <summary>A whole-call refusal answers a json caller as a document, not as a bare sentence — otherwise the
@@ -137,7 +161,7 @@ public sealed class AssetStatusJsonLaneTests : IClassFixture<AssetSelectWorld>
     public void TheDocumentFitsTheMaxCharsItWasGiven()
     {
         var text = AssetTools.AssetStatus(_w.Svc, under: new[] { AssetSelectWorld.FaceGeomDir },
-                                          format: "json", max_chars: 1_500);
+                                          format: "json", max_chars: 2_000);
 
         var root = Parse(text);
         Assert.True(root.GetProperty("accounting").GetProperty("rendered").GetInt32() > 1);
@@ -145,8 +169,8 @@ public sealed class AssetStatusJsonLaneTests : IClassFixture<AssetSelectWorld>
         // the cap, on the row that was in flight when the budget ran out (the same one-item overshoot the text lane
         // makes), but never past it by the whole accounting block, which is what an unreserved tail costs.
         int tailAt = text.IndexOf("\"accounting\"", StringComparison.Ordinal);
-        Assert.True(tailAt > 0 && tailAt <= 1_500, $"the accounting starts at {tailAt} on max_chars=1500");
-        Assert.True(text.Length - 1_500 < text.Length - tailAt,
+        Assert.True(tailAt > 0 && tailAt <= 2_000, $"the accounting starts at {tailAt} on max_chars=2000");
+        Assert.True(text.Length - 2_000 < text.Length - tailAt,
                     $"the document is {text.Length} chars — over by more than its own tail");
     }
 

--- a/src/housecarl-mcp-tests/S2JsonLaneTests.cs
+++ b/src/housecarl-mcp-tests/S2JsonLaneTests.cs
@@ -273,8 +273,13 @@ public class PlaceJsonRenderTests
 
         Assert.True(root.GetProperty("ok").GetBoolean());
         Assert.Equal("houseCARL - MyFixes", root.GetProperty("mod_folder").GetString());
-        Assert.Equal(3, root.GetProperty("total").GetInt32());
-        Assert.Equal(3, root.GetProperty("rendered").GetInt32());
+        // Under the same `accounting` object asset_status writes: a consumer reads doc.accounting.total on both S2
+        // tools rather than one nested and one flat. placed/failed are the write lane's own siblings of it.
+        var acct = root.GetProperty("accounting");
+        Assert.Equal(3, acct.GetProperty("total").GetInt32());
+        Assert.Equal(3, acct.GetProperty("rendered").GetInt32());
+        Assert.Equal(0, acct.GetProperty("truncated").GetInt32());
+        Assert.False(root.TryGetProperty("total", out _));
         Assert.Equal(2, root.GetProperty("placed").GetInt32());
         Assert.Equal(1, root.GetProperty("failed").GetInt32());
         Assert.False(root.GetProperty("truncated").GetBoolean());
@@ -291,8 +296,8 @@ public class PlaceJsonRenderTests
         var root = Parse(JsonWire.RenderPlaceOutcome(Outcome(ok: 4, failed: 0), 300));
 
         Assert.True(root.GetProperty("truncated").GetBoolean());
-        Assert.True(root.GetProperty("rendered").GetInt32() < 4);
-        Assert.Equal(4, root.GetProperty("total").GetInt32());
+        Assert.True(root.GetProperty("accounting").GetProperty("rendered").GetInt32() < 4);
+        Assert.Equal(4, root.GetProperty("accounting").GetProperty("total").GetInt32());
         Assert.Contains("the WRITE is unaffected", root.GetProperty("truncated_note").GetString());
         Assert.Contains("\"wrote it\" is not \"it wins\"", root.GetProperty("next_step").GetString());
     }
@@ -306,8 +311,45 @@ public class PlaceJsonRenderTests
 
         var row = Assert.Single(root.GetProperty("results").EnumerateArray());
         Assert.Equal("OtherMod (loose)", row.GetProperty("current_winner").GetString());
-        Assert.Equal(1, root.GetProperty("rendered").GetInt32());
+        Assert.Equal(1, root.GetProperty("accounting").GetProperty("rendered").GetInt32());
         Assert.True(root.GetProperty("truncated").GetBoolean());
+    }
+
+    /// <summary>next_step is true of the document it ships in. When max_chars cut every contended row, the sentence
+    /// cannot point at "the current winner(s) listed above" — the document names none — and it must not say nothing
+    /// else provides the path either, because something does. It says the rows were cut.</summary>
+    [Fact]
+    public void TheEnableStepNeverCitesAWinnerTheDocumentDropped()
+    {
+        // Row 0 is uncontended; the contended rows are further down, where a small cap cannot reach them.
+        var results = new List<PlaceResult> { new("meshes/hc/first.nif", true, 42, "SomeMod (loose)", null, null) };
+        for (int i = 0; i < 40; i++)
+            results.Add(new PlaceResult($"meshes/hc/ok{i}.nif", true, 42, "SomeMod (loose)", "OtherMod (loose)", null));
+        var o = new PlaceOutcome(results, @"C:\mods\houseCARL - MyFixes", Array.Empty<string>(), null, null);
+
+        var root = Parse(JsonWire.RenderPlaceOutcome(o, 1));
+
+        Assert.Equal(1, root.GetProperty("accounting").GetProperty("rendered").GetInt32());
+        var step = root.GetProperty("next_step").GetString()!;
+        Assert.DoesNotContain("listed above", step);
+        Assert.DoesNotContain("Nothing else provided", step);
+        Assert.Contains("max_chars cut the row(s) naming them", step);
+        // The whole list rendered still points at the rows, because they are there to point at.
+        Assert.Contains("listed above", Parse(JsonWire.RenderPlaceOutcome(o, 80_000)).GetProperty("next_step").GetString());
+    }
+
+    /// <summary>An outcome-level refusal is the SAME document shape as a tool-level one: {ok, error, epoch}. Two
+    /// refusal doors on one tool that write two shapes make a consumer reading doc["epoch"] throw on one of them.</summary>
+    [Fact]
+    public void BothOfPlacesRefusalDoorsWriteTheSameDocumentShape()
+    {
+        var fromOutcome = Parse(JsonWire.RenderPlaceOutcome(PlaceOutcome.Fail("no assets to place."), 80_000));
+        var fromToolLayer = Parse(JsonWire.RenderError("no assets to place.", null));
+
+        Assert.False(fromOutcome.GetProperty("ok").GetBoolean());
+        Assert.Equal(JsonValueKind.Null, fromOutcome.GetProperty("epoch").ValueKind);
+        Assert.Equal(fromToolLayer.EnumerateObject().Select(p => p.Name),
+                     fromOutcome.EnumerateObject().Select(p => p.Name));
     }
 
     [Fact]

--- a/src/housecarl-mcp-tests/S2JsonLaneTests.cs
+++ b/src/housecarl-mcp-tests/S2JsonLaneTests.cs
@@ -1,0 +1,169 @@
+using System.Text.Json;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>The S2 tools' TRANSPORT lane (#542, SPEC §2.1): asset_status and place both answer format='json' with
+/// the same data the text render carries and the accounting in band. A surface missing one of the uniform axes is a
+/// bug, so these arms hold each tool's json document against the same facts its text twin states.</summary>
+[Trait("tier", "integration")]
+public sealed class AssetStatusJsonLaneTests : IClassFixture<AssetSelectWorld>
+{
+    readonly AssetSelectWorld _w;
+    public AssetStatusJsonLaneTests(AssetSelectWorld w) => _w = w;
+
+    static JsonElement Parse(string s) => JsonDocument.Parse(s).RootElement;
+
+    /// <summary>The document carries the winner and the whole provider chain as data — the provider NAME on its own,
+    /// which is the token place's source_provider= takes, rather than the text lane's printed "name" (kind).</summary>
+    [Fact]
+    public void TheJsonLaneCarriesTheWinnerAndProviderChainAsData()
+    {
+        var contested = _w.Rel("0002.nif");
+        var root = Parse(AssetTools.AssetStatus(_w.Svc, new[] { contested }, format: "json"));
+
+        var row = root.GetProperty("results")[0];
+        Assert.Equal(contested, row.GetProperty("path").GetString());
+        Assert.True(row.GetProperty("exists").GetBoolean());
+        var data = _w.Svc.AssetStatus(new[] { contested });
+        var hit = Assert.Single(data.Results).Hit!;
+        Assert.Equal(hit.Winner!.Source, row.GetProperty("winner").GetProperty("name").GetString());
+        Assert.Equal(hit.Providers.Count, row.GetProperty("providers").GetArrayLength());
+        foreach (var (p, i) in hit.Providers.Select((p, i) => (p, i)))
+            Assert.Equal(p.Source, row.GetProperty("providers")[i].GetProperty("name").GetString());
+        // The name alone, never the display token: a consumer must not have to parse " (loose)" back off it.
+        Assert.DoesNotContain("(loose)", row.GetProperty("winner").GetProperty("name").GetString());
+    }
+
+    /// <summary>The same eight counters the text accounting line states, so a json consumer pages by the document
+    /// instead of by prose it might miss.</summary>
+    [Fact]
+    public void TheJsonLaneCarriesTheSameAccountingTheTextLaneStates()
+    {
+        var root = Parse(AssetTools.AssetStatus(_w.Svc, under: new[] { AssetSelectWorld.FaceGeomDir },
+                                                limit: 2, format: "json"));
+
+        Assert.Equal(AssetSelectWorld.FaceGeomFiles, root.GetProperty("total").GetInt32());
+        Assert.Equal(2, root.GetProperty("rendered").GetInt32());
+        Assert.Equal(0, root.GetProperty("skipped").GetInt32());
+        Assert.Equal(AssetSelectWorld.FaceGeomFiles - 2, root.GetProperty("capped").GetInt32());
+        Assert.Equal(0, root.GetProperty("truncated_rows").GetInt32());
+        Assert.False(root.GetProperty("truncated").GetBoolean());
+        // The next page is measured off what was rendered, and carries the limit, exactly as the text advice does.
+        Assert.Equal(2, root.GetProperty("next_limit").GetInt32());
+        Assert.Equal(2, root.GetProperty("next_offset").GetInt32());
+    }
+
+    /// <summary>A cut document stays valid JSON and says it was cut — the text lane's answer is a cut StringBuilder,
+    /// which is the one thing the json lane must not do.</summary>
+    [Fact]
+    public void ACutJsonDocumentIsStillValidJsonAndSaysItWasCut()
+    {
+        var text = AssetTools.AssetStatus(_w.Svc, under: new[] { AssetSelectWorld.FaceGeomDir },
+                                          format: "json", max_chars: 300);
+
+        var root = Parse(text);   // parses, or the render cut mid-document
+        Assert.True(root.GetProperty("truncated").GetBoolean());
+        Assert.True(root.GetProperty("truncated_rows").GetInt32() > 0);
+        Assert.Contains("max_chars=300", root.GetProperty("truncated_note").GetString());
+    }
+
+    /// <summary>A whole-call refusal answers a json caller as a document, not as a bare sentence — otherwise the
+    /// json lane is a degraded mode exactly where the caller most needs to branch.</summary>
+    [Fact]
+    public void ARefusalAnswersAJsonCallerAsADocument()
+    {
+        var root = Parse(AssetTools.AssetStatus(_w.Svc, Array.Empty<string>(), format: "json"));
+
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Contains("both empty", root.GetProperty("error").GetString());
+    }
+
+    /// <summary>An unrecognized format is named rather than falling through to text on a typo.</summary>
+    [Fact]
+    public void AnUnrecognizedFormatIsRefusedByName()
+    {
+        var text = AssetTools.AssetStatus(_w.Svc, new[] { _w.Rel("0001.nif") }, format: "jsonn");
+
+        Assert.Contains("format='jsonn' is not recognized", text);
+    }
+
+    /// <summary>place's own refusal takes the same shape through the same door.</summary>
+    [Fact]
+    public void PlaceRefusesAJsonCallerWithADocumentToo()
+    {
+        var root = Parse(PlaceTools.Place(_w.Svc, new[] { new PlaceTarget() }, format: "json"));
+
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Contains("exactly one of formid or path", root.GetProperty("error").GetString());
+    }
+}
+
+/// <summary>place's json document at the render seam, against the same outcomes its text twin is held to: the
+/// accounting in band, and the two things a caller cannot act without surviving a cap that cuts the list.</summary>
+[Trait("tier", "unit")]
+public class PlaceJsonRenderTests
+{
+    static PlaceOutcome Outcome(int ok, int failed) => new(
+        Enumerable.Range(0, ok)
+            .Select(i => new PlaceResult($"meshes/hc/ok{i}.nif", true, 42, "SomeMod (loose)", "OtherMod (loose)", null))
+            .Concat(Enumerable.Range(0, failed)
+                .Select(i => new PlaceResult($"meshes/hc/bad{i}.nif", false, 0, null, null, "nothing supplies this path")))
+            .ToList(),
+        @"C:\mods\houseCARL - MyFixes", Array.Empty<string>(), null, null);
+
+    static JsonElement Parse(string s) => JsonDocument.Parse(s).RootElement;
+
+    [Fact]
+    public void EveryDocumentCarriesTheAccountingAndTheEnableAndSortStep()
+    {
+        var root = Parse(JsonWire.RenderPlaceOutcome(Outcome(ok: 2, failed: 1), 80_000));
+
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("houseCARL - MyFixes", root.GetProperty("mod_folder").GetString());
+        Assert.Equal(3, root.GetProperty("total").GetInt32());
+        Assert.Equal(3, root.GetProperty("rendered").GetInt32());
+        Assert.Equal(2, root.GetProperty("placed").GetInt32());
+        Assert.Equal(1, root.GetProperty("failed").GetInt32());
+        Assert.False(root.GetProperty("truncated").GetBoolean());
+        Assert.Contains("\"wrote it\" is not \"it wins\"", root.GetProperty("next_step").GetString());
+        // A failed row is a per-row error, never the document's discriminant.
+        var bad = root.GetProperty("results")[2];
+        Assert.False(bad.GetProperty("placed").GetBoolean());
+        Assert.Equal("nothing supplies this path", bad.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public void ACutDocumentStaysValidJsonAndKeepsWhatTheCallerMustDoNext()
+    {
+        var root = Parse(JsonWire.RenderPlaceOutcome(Outcome(ok: 4, failed: 0), 300));
+
+        Assert.True(root.GetProperty("truncated").GetBoolean());
+        Assert.True(root.GetProperty("rendered").GetInt32() < 4);
+        Assert.Equal(4, root.GetProperty("total").GetInt32());
+        Assert.Contains("the WRITE is unaffected", root.GetProperty("truncated_note").GetString());
+        Assert.Contains("\"wrote it\" is not \"it wins\"", root.GetProperty("next_step").GetString());
+    }
+
+    [Fact]
+    public void ACallThatPlacedNothingClaimsNoEnableAndSortIsPending()
+    {
+        var root = Parse(JsonWire.RenderPlaceOutcome(Outcome(ok: 0, failed: 2), 80_000));
+
+        Assert.Equal(0, root.GetProperty("placed").GetInt32());
+        Assert.False(root.TryGetProperty("next_step", out _));
+    }
+
+    /// <summary>The document and its text twin say the same thing about the same outcome — the sentence has one home,
+    /// so a json caller is never the one who is not told to enable the mod.</summary>
+    [Fact]
+    public void TheTwoLanesCarryTheSameNextStepSentence()
+    {
+        var o = Outcome(ok: 2, failed: 0);
+
+        var json = Parse(JsonWire.RenderPlaceOutcome(o, 80_000)).GetProperty("next_step").GetString();
+
+        Assert.Contains(json!, PlaceWire.Render(o, 80_000));
+    }
+}

--- a/src/housecarl-mcp-tests/S2JsonLaneTests.cs
+++ b/src/housecarl-mcp-tests/S2JsonLaneTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using HousecarlCore;
 using HousecarlMcp;
 using Xunit;
 
@@ -44,11 +45,17 @@ public sealed class AssetStatusJsonLaneTests : IClassFixture<AssetSelectWorld>
         var root = Parse(AssetTools.AssetStatus(_w.Svc, under: new[] { AssetSelectWorld.FaceGeomDir },
                                                 limit: 2, format: "json"));
 
-        Assert.Equal(AssetSelectWorld.FaceGeomFiles, root.GetProperty("total").GetInt32());
-        Assert.Equal(2, root.GetProperty("rendered").GetInt32());
-        Assert.Equal(0, root.GetProperty("skipped").GetInt32());
-        Assert.Equal(AssetSelectWorld.FaceGeomFiles - 2, root.GetProperty("capped").GetInt32());
-        Assert.Equal(0, root.GetProperty("truncated_rows").GetInt32());
+        // Under ONE accounting object, the shape every §2.1 json lane states them in.
+        var acct = root.GetProperty("accounting");
+        Assert.Equal(AssetSelectWorld.FaceGeomFiles, acct.GetProperty("total").GetInt32());
+        Assert.Equal(2, acct.GetProperty("rendered").GetInt32());
+        Assert.Equal(0, acct.GetProperty("skipped").GetInt32());
+        Assert.Equal(AssetSelectWorld.FaceGeomFiles - 2, acct.GetProperty("capped").GetInt32());
+        Assert.Equal(0, acct.GetProperty("truncated").GetInt32());
+        // The four omissions have four distinct causes and sum to the total, on this lane as on the text one.
+        Assert.Equal(acct.GetProperty("total").GetInt32(),
+                     acct.GetProperty("skipped").GetInt32() + acct.GetProperty("rendered").GetInt32()
+                     + acct.GetProperty("truncated").GetInt32() + acct.GetProperty("capped").GetInt32());
         Assert.False(root.GetProperty("truncated").GetBoolean());
         // The next page is measured off what was rendered, and carries the limit, exactly as the text advice does.
         Assert.Equal(2, root.GetProperty("next_limit").GetInt32());
@@ -65,8 +72,42 @@ public sealed class AssetStatusJsonLaneTests : IClassFixture<AssetSelectWorld>
 
         var root = Parse(text);   // parses, or the render cut mid-document
         Assert.True(root.GetProperty("truncated").GetBoolean());
-        Assert.True(root.GetProperty("truncated_rows").GetInt32() > 0);
+        Assert.True(root.GetProperty("accounting").GetProperty("truncated").GetInt32() > 0);
         Assert.Contains("max_chars=300", root.GetProperty("truncated_note").GetString());
+    }
+
+    /// <summary>The one path the caller asked about is answered however small max_chars is — the text lane's
+    /// "the FIRST item always renders its core answer" rule, which a json lane that checked its budget before the
+    /// first row would drop, handing back an empty results array for a question it had already resolved.</summary>
+    [Fact]
+    public void TheFirstRowRendersHoweverSmallMaxCharsIs()
+    {
+        var root = Parse(AssetTools.AssetStatus(_w.Svc, new[] { _w.Rel("0001.nif") }, format: "json", max_chars: 120));
+
+        var row = Assert.Single(root.GetProperty("results").EnumerateArray());
+        Assert.Equal(_w.Rel("0001.nif"), row.GetProperty("path").GetString());
+        Assert.Equal(1, root.GetProperty("accounting").GetProperty("rendered").GetInt32());
+        Assert.False(root.GetProperty("truncated").GetBoolean());
+    }
+
+    /// <summary>The build-level caveats are bounded by the same max_chars the rows are. Unbounded they are the one
+    /// block max_chars does not reach: a sweep of many selectors that match nothing writes them all before the row
+    /// loop takes its first reading, and every row the caller asked about is then cut.</summary>
+    [Fact]
+    public void TheCaveatBlocksAreCappedByMaxCharsToo()
+    {
+        var many = Enumerable.Range(0, 400).Select(i => $"meshes/hcnothing{i}/**/*.nif").ToArray();
+
+        var capped = AssetTools.AssetStatus(_w.Svc, under: many, format: "json", max_chars: 2_000);
+        var whole = AssetTools.AssetStatus(_w.Svc, under: many, format: "json");
+
+        var notes = Parse(capped).GetProperty("selector_notes");
+        Assert.True(notes.GetArrayLength() < 400, "the note list was written past max_chars");
+        Assert.Contains("omitted at max_chars=2000", notes[notes.GetArrayLength() - 1].GetString());
+        // The cut is real, not cosmetic: the same call unbounded is many times the document.
+        Assert.True(capped.Length < whole.Length / 4, $"capped={capped.Length} whole={whole.Length}");
+        // Every selector is still COUNTED, whatever the render could show of them.
+        Assert.Equal(400, Parse(capped).GetProperty("accounting").GetProperty("notes").GetInt32());
     }
 
     /// <summary>A whole-call refusal answers a json caller as a document, not as a bare sentence — otherwise the
@@ -89,6 +130,26 @@ public sealed class AssetStatusJsonLaneTests : IClassFixture<AssetSelectWorld>
         Assert.Contains("format='jsonn' is not recognized", text);
     }
 
+    /// <summary>The accounting is paid for INSIDE max_chars, as the text twin pays for its accounting line: room for
+    /// the tail is held back before the rows write, so a document that rendered more than its first row fits the cap
+    /// the caller passed rather than overrunning it by the whole accounting block.</summary>
+    [Fact]
+    public void TheDocumentFitsTheMaxCharsItWasGiven()
+    {
+        var text = AssetTools.AssetStatus(_w.Svc, under: new[] { AssetSelectWorld.FaceGeomDir },
+                                          format: "json", max_chars: 1_500);
+
+        var root = Parse(text);
+        Assert.True(root.GetProperty("accounting").GetProperty("rendered").GetInt32() > 1);
+        // The tail BEGINS inside the cap — that is what the reserve buys. The document can still end a little past
+        // the cap, on the row that was in flight when the budget ran out (the same one-item overshoot the text lane
+        // makes), but never past it by the whole accounting block, which is what an unreserved tail costs.
+        int tailAt = text.IndexOf("\"accounting\"", StringComparison.Ordinal);
+        Assert.True(tailAt > 0 && tailAt <= 1_500, $"the accounting starts at {tailAt} on max_chars=1500");
+        Assert.True(text.Length - 1_500 < text.Length - tailAt,
+                    $"the document is {text.Length} chars — over by more than its own tail");
+    }
+
     /// <summary>place's own refusal takes the same shape through the same door.</summary>
     [Fact]
     public void PlaceRefusesAJsonCallerWithADocumentToo()
@@ -97,6 +158,72 @@ public sealed class AssetStatusJsonLaneTests : IClassFixture<AssetSelectWorld>
 
         Assert.False(root.GetProperty("ok").GetBoolean());
         Assert.Contains("exactly one of formid or path", root.GetProperty("error").GetString());
+    }
+}
+
+/// <summary>place's json lane driven END TO END through the tool, not at the render seam: that the tool routes
+/// format='json' to the json renderer at all, and that the withheld set-level pole reaches the document. Its own
+/// fixture instance, because the arm WRITES a mod folder into the world it runs against.</summary>
+[Trait("tier", "integration")]
+public sealed class PlaceJsonServedLaneTests : IClassFixture<AssetSelectWorld>
+{
+    readonly AssetSelectWorld _w;
+    public PlaceJsonServedLaneTests(AssetSelectWorld w) => _w = w;
+
+    /// <summary>A real placement answered as a document: the source is one exact file on disk, which the set-level
+    /// source_provider= cannot apply to — so the pole is withheld, and the row SAYS it was, on this lane as on the
+    /// text one. A caller reading a placed row with the pole silently dropped would believe it was honoured.</summary>
+    [Fact]
+    public void AServedPlaceAnswersAsADocumentAndSaysTheSetPoleWasWithheld()
+    {
+        var onDisk = Path.Combine(_w.Root, "instance", "mods", "FaceBase", _w.Rel("0001.nif"));
+
+        var text = PlaceTools.Place(_w.Svc,
+            new[] { new PlaceTarget { Path = @"meshes\hcjson\served.nif", Source = onDisk } },
+            source_provider: "FaceHigher", format: "json", patch: "JsonServed");
+        var root = JsonDocument.Parse(text).RootElement;   // parses, or format='json' never reached the json renderer
+
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal(1, root.GetProperty("placed").GetInt32());
+        var row = Assert.Single(root.GetProperty("results").EnumerateArray());
+        Assert.True(row.GetProperty("placed").GetBoolean());
+        Assert.True(row.GetProperty("set_provider_withheld").GetBoolean());
+        // Nothing else provides this destination, so the enable-and-sort step says so rather than naming a winner.
+        Assert.Equal(JsonValueKind.Null, row.GetProperty("current_winner").ValueKind);
+        Assert.Contains("\"wrote it\" is not \"it wins\"", root.GetProperty("next_step").GetString());
+    }
+}
+
+/// <summary>asset_status's json document at the render seam, where a build's caveats can be posed directly: the two
+/// ABSENT hedges are two distinct facts with two distinct remedies, and a json consumer must be able to tell which
+/// one applies without re-deriving it.</summary>
+[Trait("tier", "unit")]
+public class AssetStatusJsonHedgeTests
+{
+    static AssetStatusData Absent(bool readIncomplete, bool discoveryIncomplete) => new(
+        new[] { new AssetPathResult("meshes/gone.nif", new AssetHit("meshes/gone.nif", false, null, Array.Empty<AssetProvider>(), false), null) },
+        readIncomplete ? new[] { "HcArch.bsa — unreadable" } : Array.Empty<string>(),
+        readIncomplete,
+        discoveryIncomplete ? new[] { "no Skyrim.ini found; base archives were not scanned" } : Array.Empty<string>(),
+        "Default");
+
+    static JsonElement Row(AssetStatusData d)
+        => JsonDocument.Parse(JsonWire.RenderAssetStatus(d, 80_000)).RootElement.GetProperty("results")[0];
+
+    [Fact]
+    public void TheTwoAbsentHedgesAreStatedApart()
+    {
+        var readOnly_ = Row(Absent(readIncomplete: true, discoveryIncomplete: false));
+        Assert.True(readOnly_.GetProperty("absent_may_be_incomplete_read_failure").GetBoolean());
+        Assert.False(readOnly_.GetProperty("absent_may_be_incomplete_undiscovered_archives").GetBoolean());
+
+        var discoveryOnly = Row(Absent(readIncomplete: false, discoveryIncomplete: true));
+        Assert.False(discoveryOnly.GetProperty("absent_may_be_incomplete_read_failure").GetBoolean());
+        Assert.True(discoveryOnly.GetProperty("absent_may_be_incomplete_undiscovered_archives").GetBoolean());
+
+        var neither = Row(Absent(readIncomplete: false, discoveryIncomplete: false));
+        Assert.False(neither.GetProperty("absent_may_be_incomplete_read_failure").GetBoolean());
+        Assert.False(neither.GetProperty("absent_may_be_incomplete_undiscovered_archives").GetBoolean());
     }
 }
 
@@ -144,6 +271,19 @@ public class PlaceJsonRenderTests
         Assert.Equal(4, root.GetProperty("total").GetInt32());
         Assert.Contains("the WRITE is unaffected", root.GetProperty("truncated_note").GetString());
         Assert.Contains("\"wrote it\" is not \"it wins\"", root.GetProperty("next_step").GetString());
+    }
+
+    /// <summary>However small max_chars is, one row renders: on this document that row is the only place
+    /// current_winner — the mod the caller has to sort the new one above — is stated.</summary>
+    [Fact]
+    public void TheFirstDestinationRowRendersHoweverSmallMaxCharsIs()
+    {
+        var root = Parse(JsonWire.RenderPlaceOutcome(Outcome(ok: 3, failed: 0), 1));
+
+        var row = Assert.Single(root.GetProperty("results").EnumerateArray());
+        Assert.Equal("OtherMod (loose)", row.GetProperty("current_winner").GetString());
+        Assert.Equal(1, root.GetProperty("rendered").GetInt32());
+        Assert.True(root.GetProperty("truncated").GetBoolean());
     }
 
     [Fact]

--- a/src/housecarl-mcp/AssetTools.cs
+++ b/src/housecarl-mcp/AssetTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text;
+using System.Text.Json;
 using ModelContextProtocol.Server;
 
 namespace HousecarlMcp;
@@ -124,9 +125,14 @@ static class AssetWire
     /// <summary>What this response actually did, in the shared TRANSPORT vocabulary
     /// (<see cref="TransportAccounting"/>): the selection total, the window this response rendered, and the four
     /// distinct omissions.</summary>
-    static TransportCounts Tally(AssetStatusData d, int rendered) =>
+    internal static TransportCounts Tally(AssetStatusData d, int rendered) =>
         TransportAccounting.Tally(d.Selected, d.Results.Count, rendered, new RowWindow(d.Offset, d.Limit),
                                   d.SelectorNotes?.Count ?? 0);
+
+    /// <summary>The widest counts this response could state — what the json lane's tail reserve measures.</summary>
+    internal static TransportCounts Widest(AssetStatusData d) =>
+        TransportAccounting.Widest(d.Selected, d.Results.Count, new RowWindow(d.Offset, d.Limit),
+                                   d.SelectorNotes?.Count ?? 0);
 
     /// <summary>The chars held back from max_chars so the accounting block is always affordable.</summary>
     internal static int AccountingReserve(AssetStatusData d) =>

--- a/src/housecarl-mcp/AssetTools.cs
+++ b/src/housecarl-mcp/AssetTools.cs
@@ -27,7 +27,8 @@ public static class AssetTools
          "'meshes/actors/character/facegendata/facegeom/Skyrim.esm' answers for every facegen mesh a master defines, " +
          "with no path list at all. The two select forms compose in one call. An archive that cannot be read, or a " +
          "Skyrim.ini base-archive list that cannot be found, is reported LOUD — so an 'absent' answer is never silently " +
-         "trusted when the scan was incomplete. Read-only: resolves nothing to disk, writes nothing, changes no load order.")]
+         "trusted when the scan was incomplete. format='json' returns the same data machine-readably, with the same " +
+         "accounting in-band. Read-only: resolves nothing to disk, writes nothing, changes no load order.")]
     public static string AssetStatus(
         LoadOrderService svc,
         [Description("The Data-relative asset path(s) to resolve, e.g. " +
@@ -47,19 +48,28 @@ public static class AssetTools
             int limit = 0,
         [Description("Optional. Where in the selection the rendered window starts, for paging a large under= sweep. 0 = the beginning.")]
             int offset = 0,
+        [Description("TRANSPORT: 'text' (default) | 'json' (the same data, machine-readable, accounting in-band).")]
+            string? format = null,
         [Description("Optional. Max characters before the per-path list is cut with an explicit notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool(ToolNames.AssetStatus, () =>
     {
-        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        // format first, so the unconfigured-MO2 prompt answers a json caller as a document.
+        bool json = Wire.WantsJson(format, out var ferr);
+        if (ferr is not null) return ferr;
+        if (svc.ConfigPromptOrNull() is { } prompt)
+            return json ? JsonWire.RenderError(prompt, null) : prompt;
+        string Refuse(string message) => json ? JsonWire.RenderError(message, null) : "error: " + message;
+
         if ((asset_paths is null || asset_paths.Length == 0) && (under is null || under.Length == 0))
-            return "error: asset_paths and under are both empty. Pass Data-relative asset path(s) in asset_paths " +
-                   "(e.g. 'textures/armor/iron/cuirass_1.dds'), or a Data-relative directory or glob in under " +
-                   "(e.g. 'meshes/actors/character/facegendata/facegeom/Skyrim.esm').";
+            return Refuse("asset_paths and under are both empty. Pass Data-relative asset path(s) in asset_paths " +
+                          "(e.g. 'textures/armor/iron/cuirass_1.dds'), or a Data-relative directory or glob in under " +
+                          "(e.g. 'meshes/actors/character/facegendata/facegeom/Skyrim.esm').");
         // The window's own refusal, from the window: this tool and housecarl_skse answer the same input class, so the
         // sentence is spelled once rather than reworded in two places.
-        if (new RowWindow(offset, limit).Error is { } bad) return bad;
+        if (new RowWindow(offset, limit).Error is { } bad) return Wire.Refuse(json, bad);
         var data = svc.AssetStatus(asset_paths ?? Array.Empty<string>(), under, limit, offset);
-        return AssetWire.Render(data, max_chars > 0 ? max_chars : 80_000);
+        int cap = max_chars > 0 ? max_chars : 80_000;
+        return json ? JsonWire.RenderAssetStatus(data, cap) : AssetWire.Render(data, cap);
     });
 }
 

--- a/src/housecarl-mcp/AssetTools.cs
+++ b/src/housecarl-mcp/AssetTools.cs
@@ -58,7 +58,9 @@ public static class AssetTools
         if (ferr is not null) return ferr;
         if (svc.ConfigPromptOrNull() is { } prompt)
             return json ? JsonWire.RenderError(prompt, null) : prompt;
-        string Refuse(string message) => json ? JsonWire.RenderError(message, null) : "error: " + message;
+        // The read/write surface's one refusal shape, through its one owner: Wire.Refuse strips the prefix for the
+        // json document, so this shorthand only saves the two call sites below from repeating the transport flag.
+        string Refuse(string message) => Wire.Refuse(json, Wire.RefusalPrefix + message);
 
         if ((asset_paths is null || asset_paths.Length == 0) && (under is null || under.Length == 0))
             return Refuse("asset_paths and under are both empty. Pass Data-relative asset path(s) in asset_paths " +

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -228,28 +228,30 @@ static class JsonWire
     }
 
     /// <summary>The json twin of <see cref="BatchRender.AppendLines"/>: a caveat list bounded by the SAME budget the
-    /// row loop is bounded by, cut with the same named marker as a final element. An unbounded list here is a list
-    /// max_chars does not reach — one under= of thousands of selectors writes megabytes before the row loop takes
-    /// its first budget reading, and the rows the caller asked about are then all cut.
-    /// <para><paramref name="cap"/> is what the marker names — the number the caller passed and would raise —
-    /// while <paramref name="budget"/> is what it is measured against.</para></summary>
-    static void WriteCappedStringArray(Utf8JsonWriter w, MemoryStream ms, string name, IReadOnlyList<string> items,
-                                       string itemNoun, int cap, int budget)
+    /// row loop is bounded by. An unbounded list here is a list max_chars does not reach — one under= of thousands of
+    /// selectors writes megabytes before the row loop takes its first budget reading, and the rows the caller asked
+    /// about are then all cut.
+    /// <para>The cut is a sibling <c>&lt;name&gt;_omitted</c> count, not a prose element inside the array — the
+    /// capped-list-plus-count shape <see cref="Wire.ContestedHostsShown"/> already uses. A marker element would be
+    /// handed to a consumer iterating the array as if it were one of the entries, and the array length would stop
+    /// matching the count the accounting states.</para>
+    /// <para>Returns how many entries were omitted, so the caller can say so at the document root.</para></summary>
+    static int WriteCappedStringArray(Utf8JsonWriter w, MemoryStream ms, string name, IReadOnlyList<string> items,
+                                      int budget)
     {
         w.WriteStartArray(name);
         int shown = 0;
         foreach (var s in items)
         {
             // shown > 0: the first line always renders, exactly as it does on the text lane.
-            if (shown > 0 && Over(w, ms, budget))
-            {
-                w.WriteStringValue($"… [{items.Count - shown} more {itemNoun} omitted at max_chars={cap}; raise max_chars to see all]");
-                break;
-            }
+            if (shown > 0 && Over(w, ms, budget)) break;
             w.WriteStringValue(s);
             shown++;
         }
         w.WriteEndArray();
+        int omitted = items.Count - shown;
+        w.WriteNumber(name + "_omitted", omitted);
+        return omitted;
     }
 
     // ---- shared record + field writers --------------------------------------------------------------
@@ -2579,10 +2581,10 @@ static class JsonWire
             // against the same budget its text twin caps against — an under= of thousands of selectors would
             // otherwise write megabytes here before the row loop ever checked the budget.
             w.WriteBoolean("read_incomplete", d.ReadIncomplete);
-            WriteCappedStringArray(w, ms, "bsa_failures", d.BsaFailures, "archive(s)", cap, budget);
-            WriteCappedStringArray(w, ms, "warnings", d.Warnings, "warning(s)", cap, budget);
-            if (d.SelectorNotes is null) w.WriteNull("selector_notes");
-            else WriteCappedStringArray(w, ms, "selector_notes", d.SelectorNotes, "selector(s)", cap, budget);
+            int caveatsOmitted = WriteCappedStringArray(w, ms, "bsa_failures", d.BsaFailures, budget)
+                               + WriteCappedStringArray(w, ms, "warnings", d.Warnings, budget);
+            if (d.SelectorNotes is null) { w.WriteNull("selector_notes"); w.WriteNumber("selector_notes_omitted", 0); }
+            else caveatsOmitted += WriteCappedStringArray(w, ms, "selector_notes", d.SelectorNotes, budget);
 
             w.WriteStartArray("results");
             int rendered = 0;
@@ -2598,8 +2600,10 @@ static class JsonWire
 
             var counts = AssetWire.Tally(d, rendered);
             TransportAccounting.WriteJson(w, counts);
-            w.WriteBoolean("truncated", counts.Truncated > 0);
-            WriteAssetAdvice(w, counts, cap);
+            // The document's own flag, so a consumer branching on it re-calls when ANYTHING was dropped: a caveat
+            // block the budget cut is a loss the row counters cannot see.
+            w.WriteBoolean("truncated", counts.Truncated > 0 || caveatsOmitted > 0);
+            WriteAssetAdvice(w, counts, cap, caveatsOmitted > 0);
             w.WriteEndObject();
         }
         return Finish(ms);
@@ -2609,8 +2613,10 @@ static class JsonWire
     /// page (measured off what was RENDERED, so a consumer paging by these lands on the first path it has not seen),
     /// an offset past the end, and the max_chars cut. Siblings of the <c>accounting</c> object rather than members of
     /// it, because that object is the eight counters and nothing else.</summary>
+    /// <param name="caveatsCut">a caveat block lost entries to the budget — the cut the row counters cannot see.</param>
     /// <param name="everySentence">write them all, whatever the counts say — the widest case the reserve measures.</param>
-    static void WriteAssetAdvice(Utf8JsonWriter w, TransportCounts c, int cap, bool everySentence = false)
+    static void WriteAssetAdvice(Utf8JsonWriter w, TransportCounts c, int cap, bool caveatsCut,
+                                 bool everySentence = false)
     {
         if (everySentence || c.Remaining > 0)
         {
@@ -2619,15 +2625,17 @@ static class JsonWire
         }
         if (everySentence || (c.Remaining == 0 && c.Total > 0 && c.Offset >= c.Total))
             w.WriteString("offset_note", $"offset={c.Offset} is past the end of the selection ({c.Total} path(s)) — the last page starts before it.");
-        if (everySentence || c.Truncated > 0)
+        if (everySentence || c.Truncated > 0 || caveatsCut)
             w.WriteString("truncated_note",
-                $"max_chars={cap} cut trailing resolved path(s) from this document — raise max_chars, or page with limit=/offset=.");
+                $"max_chars={cap} cut content from this document — accounting.truncated names the resolved path(s) " +
+                "dropped and each *_omitted counter the caveat entries; raise max_chars, or page with limit=/offset=.");
     }
 
-    /// <summary>The chars held back from max_chars for the tail this document closes on — the accounting object, the
-    /// truncation flag and every advice sentence. Measured by serializing the WIDEST tail under the response's own
-    /// writer options, so no rendering of it can outgrow its own room (measuring unindented what is written indented
-    /// under-reserves by the whole indentation).</summary>
+    /// <summary>The chars held back from max_chars for what this document writes outside the budgeted body — the
+    /// accounting object, the truncation flag, every advice sentence, and the three caveat <c>_omitted</c> counters,
+    /// which are written after their array has already spent the budget. Measured by serializing the WIDEST tail
+    /// under the response's own writer options, so no rendering of it can outgrow its own room (measuring unindented
+    /// what is written indented under-reserves by the whole indentation).</summary>
     static int AssetTailReserve(AssetStatusData d, int cap)
     {
         var widest = AssetWire.Widest(d);
@@ -2636,9 +2644,13 @@ static class JsonWire
         {
             w.WriteStartObject();
             w.WriteString("before", "");   // the tail is never a document's first member, so it pays the separator one owes
+            // Each block can omit at most its own entries, so its own count is the widest number it can write.
+            w.WriteNumber("bsa_failures_omitted", d.BsaFailures.Count);
+            w.WriteNumber("warnings_omitted", d.Warnings.Count);
+            w.WriteNumber("selector_notes_omitted", d.SelectorNotes?.Count ?? 0);
             TransportAccounting.WriteJson(w, widest);
             w.WriteBoolean("truncated", true);
-            WriteAssetAdvice(w, widest, cap, everySentence: true);
+            WriteAssetAdvice(w, widest, cap, caveatsCut: true, everySentence: true);
             w.WriteEndObject();
         }
         return (int)ms.Length;

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -227,6 +227,31 @@ static class JsonWire
         w.WriteEndArray();
     }
 
+    /// <summary>The json twin of <see cref="BatchRender.AppendLines"/>: a caveat list bounded by the SAME budget the
+    /// row loop is bounded by, cut with the same named marker as a final element. An unbounded list here is a list
+    /// max_chars does not reach — one under= of thousands of selectors writes megabytes before the row loop takes
+    /// its first budget reading, and the rows the caller asked about are then all cut.
+    /// <para><paramref name="cap"/> is what the marker names — the number the caller passed and would raise —
+    /// while <paramref name="budget"/> is what it is measured against.</para></summary>
+    static void WriteCappedStringArray(Utf8JsonWriter w, MemoryStream ms, string name, IReadOnlyList<string> items,
+                                       string itemNoun, int cap, int budget)
+    {
+        w.WriteStartArray(name);
+        int shown = 0;
+        foreach (var s in items)
+        {
+            // shown > 0: the first line always renders, exactly as it does on the text lane.
+            if (shown > 0 && Over(w, ms, budget))
+            {
+                w.WriteStringValue($"… [{items.Count - shown} more {itemNoun} omitted at max_chars={cap}; raise max_chars to see all]");
+                break;
+            }
+            w.WriteStringValue(s);
+            shown++;
+        }
+        w.WriteEndArray();
+    }
+
     // ---- shared record + field writers --------------------------------------------------------------
     /// <summary>Serialize the fields array. Each leaf is <c>{path, value}</c> for a round-trippable leaf (value = the
     /// SAME wire token the text mode emits) or <c>{path, note}</c> for a no-value leaf; the display-only <c>display</c>
@@ -2531,62 +2556,92 @@ static class JsonWire
     /// <para>A provider is <c>{name, kind}</c>, not the printed <c>"Name" (kind)</c> token: the reusable value is
     /// the NAME ALONE, which is what <c>housecarl_place</c>'s <c>source_provider=</c> accepts, so a consumer reads
     /// the field rather than parsing the display token apart.</para>
-    /// <para><c>truncated</c> is the boolean every json document carries; <c>truncated_rows</c> is the text lane's
-    /// <c>truncated=</c> count — how many RESOLVED paths max_chars cut, which the other seven counters need to add
-    /// up against.</para></summary>
+    /// <para>The eight counters ride under one <c>accounting</c> object, written by the SAME composer family the
+    /// text line goes through (<see cref="TransportAccounting"/>), so
+    /// <c>skipped + rendered + truncated + capped == total</c> on both lanes and neither can drift. Room for that
+    /// object and the advice after it is reserved out of max_chars before anything is written, the way the text
+    /// twin reserves its accounting line — so max_chars means the same thing on both lanes. <c>truncated</c> at the
+    /// document root is the boolean every json document carries; <c>accounting.truncated</c> is the count.</para></summary>
     public static string RenderAssetStatus(AssetStatusData d, int maxChars)
     {
         int cap = Cap(maxChars);
+        // The accounting object and the advice after it are priced INSIDE max_chars, as the text twin prices its
+        // accounting line: room for their widest spelling is held back BEFORE the caveats and the rows write, rather
+        // than appended past the cap.
+        int budget = Math.Max(cap - AssetTailReserve(d, cap), 1);
         using var ms = new MemoryStream();
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
             w.WriteStartObject();
             w.WriteString("profile", d.ProfileName.Length > 0 ? d.ProfileName : "(unconfigured)");
             // The caveats lead, as they do in the text render: an ABSENT below is only authoritative when both are
-            // empty, and a document that truncates its rows must not be able to cut the reason away.
+            // empty, and a document that truncates its rows must not be able to cut the reason away. Each is capped
+            // against the same budget its text twin caps against — an under= of thousands of selectors would
+            // otherwise write megabytes here before the row loop ever checked the budget.
             w.WriteBoolean("read_incomplete", d.ReadIncomplete);
-            WriteStringArray(w, "bsa_failures", d.BsaFailures);
-            WriteStringArray(w, "warnings", d.Warnings);
-            WriteNullableStringArray(w, "selector_notes", d.SelectorNotes);
+            WriteCappedStringArray(w, ms, "bsa_failures", d.BsaFailures, "archive(s)", cap, budget);
+            WriteCappedStringArray(w, ms, "warnings", d.Warnings, "warning(s)", cap, budget);
+            if (d.SelectorNotes is null) w.WriteNull("selector_notes");
+            else WriteCappedStringArray(w, ms, "selector_notes", d.SelectorNotes, "selector(s)", cap, budget);
 
             w.WriteStartArray("results");
             int rendered = 0;
-            bool truncated = false;
             foreach (var r in d.Results)
             {
-                if (Over(w, ms, cap)) { truncated = true; break; }
+                // rendered > 0: the FIRST row always renders its core answer, even when the caveats alone exhausted
+                // the budget — the same rule BatchRender makes on the text lane, so a one-path call is answered.
+                if (rendered > 0 && Over(w, ms, budget)) break;
                 WriteAssetRow(w, r, d.ReadIncomplete, d.Warnings.Count > 0);
                 rendered++;
             }
             w.WriteEndArray();
 
-            // The same eight counters the text accounting line states, from the same four causes, so
-            // skipped + rendered + truncated_rows + capped == total on both lanes.
-            w.WriteNumber("total", d.Selected);
-            w.WriteNumber("rendered", rendered);
-            w.WriteNumber("skipped", Math.Min(d.Offset, d.Selected));
-            w.WriteNumber("capped", Math.Max(d.Selected - d.Offset - d.Results.Count, 0));
-            w.WriteNumber("truncated_rows", Math.Max(d.Results.Count - rendered, 0));
-            w.WriteNumber("offset", d.Offset);
-            int remaining = Math.Max(d.Selected - (d.Offset + rendered), 0);
-            w.WriteNumber("remaining", remaining);
-            w.WriteNumber("notes", d.SelectorNotes?.Count ?? 0);
-            w.WriteBoolean("truncated", truncated);
-            // Measured off what was RENDERED, like the text advice: a consumer paging by these lands on the first
-            // path it has not seen, and the limit rides along or the next call resolves the whole remainder.
-            if (remaining > 0)
-            {
-                w.WriteNumber("next_limit", d.Limit > 0 ? d.Limit : AssetWire.DefaultPageLimit);
-                w.WriteNumber("next_offset", d.Offset + rendered);
-            }
-            if (remaining == 0 && d.Selected > 0 && d.Offset >= d.Selected)
-                w.WriteString("offset_note", $"offset={d.Offset} is past the end of the selection ({d.Selected} path(s)) — the last page starts before it.");
-            if (truncated)
-                w.WriteString("truncated_note",
-                    $"max_chars={cap} cut trailing resolved path(s) from this document — raise max_chars, or page with limit=/offset=.");
+            var counts = AssetWire.Tally(d, rendered);
+            TransportAccounting.WriteJson(w, counts);
+            w.WriteBoolean("truncated", counts.Truncated > 0);
+            WriteAssetAdvice(w, counts, cap);
             w.WriteEndObject();
         }
         return Finish(ms);
+    }
+
+    /// <summary>The three conditional sentences the text accounting composes, on the same three conditions: the next
+    /// page (measured off what was RENDERED, so a consumer paging by these lands on the first path it has not seen),
+    /// an offset past the end, and the max_chars cut. Siblings of the <c>accounting</c> object rather than members of
+    /// it, because that object is the eight counters and nothing else.</summary>
+    /// <param name="everySentence">write them all, whatever the counts say — the widest case the reserve measures.</param>
+    static void WriteAssetAdvice(Utf8JsonWriter w, TransportCounts c, int cap, bool everySentence = false)
+    {
+        if (everySentence || c.Remaining > 0)
+        {
+            w.WriteNumber("next_limit", c.NextLimit);
+            w.WriteNumber("next_offset", c.Offset + c.Rendered);
+        }
+        if (everySentence || (c.Remaining == 0 && c.Total > 0 && c.Offset >= c.Total))
+            w.WriteString("offset_note", $"offset={c.Offset} is past the end of the selection ({c.Total} path(s)) — the last page starts before it.");
+        if (everySentence || c.Truncated > 0)
+            w.WriteString("truncated_note",
+                $"max_chars={cap} cut trailing resolved path(s) from this document — raise max_chars, or page with limit=/offset=.");
+    }
+
+    /// <summary>The chars held back from max_chars for the tail this document closes on — the accounting object, the
+    /// truncation flag and every advice sentence. Measured by serializing the WIDEST tail under the response's own
+    /// writer options, so no rendering of it can outgrow its own room (measuring unindented what is written indented
+    /// under-reserves by the whole indentation).</summary>
+    static int AssetTailReserve(AssetStatusData d, int cap)
+    {
+        var widest = AssetWire.Widest(d);
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            w.WriteString("before", "");   // the tail is never a document's first member, so it pays the separator one owes
+            TransportAccounting.WriteJson(w, widest);
+            w.WriteBoolean("truncated", true);
+            WriteAssetAdvice(w, widest, cap, everySentence: true);
+            w.WriteEndObject();
+        }
+        return (int)ms.Length;
     }
 
     static void WriteAssetRow(Utf8JsonWriter w, AssetPathResult r, bool readIncomplete, bool discoveryIncomplete)
@@ -2612,8 +2667,12 @@ static class JsonWire
         {
             WriteNullableStringArray(w, "prefix_suggestions", r.PrefixSuggestions);
             // The two ways an ABSENT can be wrong, per row rather than only at the top: the text render hedges the
-            // answer where it is read, and a json consumer branching on exists=false needs the same hedge.
-            w.WriteBoolean("absent_may_be_incomplete", readIncomplete || discoveryIncomplete);
+            // answer where it is read, and a json consumer branching on exists=false needs the same hedge. TWO
+            // booleans because they are two distinct hedges with two distinct remedies — an archive that failed to
+            // read (the asset could be inside it) against base archives never discovered (they went unscanned) — and
+            // one OR of them would leave the consumer re-deriving which applies from the top-level pair.
+            w.WriteBoolean("absent_may_be_incomplete_read_failure", readIncomplete);
+            w.WriteBoolean("absent_may_be_incomplete_undiscovered_archives", discoveryIncomplete);
         }
         w.WriteEndObject();
     }
@@ -2660,7 +2719,9 @@ static class JsonWire
             bool truncated = false;
             foreach (var r in o.Results)
             {
-                if (Over(w, ms, cap)) { truncated = true; break; }
+                // rendered > 0: the FIRST row always renders, as it does on the text lane — and on this document it
+                // is the only place current_winner, the mod the caller has to sort above, is stated.
+                if (rendered > 0 && Over(w, ms, cap)) { truncated = true; break; }
                 WritePlaceRow(w, r, modFolder, poleWithheld?.Contains(r.AssetPath) == true);
                 rendered++;
             }

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -2715,6 +2715,9 @@ static class JsonWire
             if (!o.Success)
             {
                 w.WriteString("error", o.Error);
+                // The same three keys RenderError writes: a refusal from the outcome and a refusal from the tool
+                // layer are one shape, so a consumer reading doc["epoch"] on a refusal never throws on one of them.
+                WriteNullable(w, "epoch", null);
                 w.WriteEndObject();
                 w.Flush();          // INSIDE the using — an unflushed refusal renders EMPTY. See RenderPatchOutcome.
                 return Finish(ms);
@@ -2739,8 +2742,12 @@ static class JsonWire
             }
             w.WriteEndArray();
 
-            w.WriteNumber("total", o.Results.Count);
-            w.WriteNumber("rendered", rendered);
+            // The §2.1 counters ride under the same `accounting` object housecarl_asset_status writes, through the
+            // same composer, so a consumer reads doc.accounting.total on both S2 tools. This lane pages nothing, so
+            // the window is the whole list and only max_chars can omit a row. placed/failed are siblings, not
+            // members: that object is the eight shared counters and nothing else.
+            TransportAccounting.WriteJson(w, TransportAccounting.Tally(o.Results.Count, o.Results.Count, rendered,
+                                                                       RowWindow.All, 0));
             w.WriteNumber("placed", placed);
             w.WriteNumber("failed", o.Results.Count - placed);
             w.WriteBoolean("truncated", truncated);
@@ -2752,7 +2759,7 @@ static class JsonWire
             if (o.LeftoverFolder is not null)
                 w.WriteString("leftover_folder_note", PlaceWire.LeftoverNote(o.LeftoverFolder));
             WriteNullable(w, "leftover_folder", o.LeftoverFolder);
-            if (placed > 0) w.WriteString("next_step", PlaceWire.EnableAndSort(o, modFolder));
+            if (placed > 0) w.WriteString("next_step", PlaceWire.EnableAndSort(o, modFolder, rendered));
             w.WriteEndObject();
         }
         return Finish(ms);

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -2525,6 +2525,191 @@ static class JsonWire
         return Finish(ms);
     }
 
+    // ---- housecarl_asset_status (S2 read) -----------------------------------------------------------
+    /// <summary>The machine-readable twin of <see cref="AssetWire"/>'s render — the SAME data: the build-level
+    /// caveats, one row per queried path with its winner and full provider chain, and the §2.1 accounting in-band.
+    /// <para>A provider is <c>{name, kind}</c>, not the printed <c>"Name" (kind)</c> token: the reusable value is
+    /// the NAME ALONE, which is what <c>housecarl_place</c>'s <c>source_provider=</c> accepts, so a consumer reads
+    /// the field rather than parsing the display token apart.</para>
+    /// <para><c>truncated</c> is the boolean every json document carries; <c>truncated_rows</c> is the text lane's
+    /// <c>truncated=</c> count — how many RESOLVED paths max_chars cut, which the other seven counters need to add
+    /// up against.</para></summary>
+    public static string RenderAssetStatus(AssetStatusData d, int maxChars)
+    {
+        int cap = Cap(maxChars);
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            w.WriteString("profile", d.ProfileName.Length > 0 ? d.ProfileName : "(unconfigured)");
+            // The caveats lead, as they do in the text render: an ABSENT below is only authoritative when both are
+            // empty, and a document that truncates its rows must not be able to cut the reason away.
+            w.WriteBoolean("read_incomplete", d.ReadIncomplete);
+            WriteStringArray(w, "bsa_failures", d.BsaFailures);
+            WriteStringArray(w, "warnings", d.Warnings);
+            WriteNullableStringArray(w, "selector_notes", d.SelectorNotes);
+
+            w.WriteStartArray("results");
+            int rendered = 0;
+            bool truncated = false;
+            foreach (var r in d.Results)
+            {
+                if (Over(w, ms, cap)) { truncated = true; break; }
+                WriteAssetRow(w, r, d.ReadIncomplete, d.Warnings.Count > 0);
+                rendered++;
+            }
+            w.WriteEndArray();
+
+            // The same eight counters the text accounting line states, from the same four causes, so
+            // skipped + rendered + truncated_rows + capped == total on both lanes.
+            w.WriteNumber("total", d.Selected);
+            w.WriteNumber("rendered", rendered);
+            w.WriteNumber("skipped", Math.Min(d.Offset, d.Selected));
+            w.WriteNumber("capped", Math.Max(d.Selected - d.Offset - d.Results.Count, 0));
+            w.WriteNumber("truncated_rows", Math.Max(d.Results.Count - rendered, 0));
+            w.WriteNumber("offset", d.Offset);
+            int remaining = Math.Max(d.Selected - (d.Offset + rendered), 0);
+            w.WriteNumber("remaining", remaining);
+            w.WriteNumber("notes", d.SelectorNotes?.Count ?? 0);
+            w.WriteBoolean("truncated", truncated);
+            // Measured off what was RENDERED, like the text advice: a consumer paging by these lands on the first
+            // path it has not seen, and the limit rides along or the next call resolves the whole remainder.
+            if (remaining > 0)
+            {
+                w.WriteNumber("next_limit", d.Limit > 0 ? d.Limit : AssetWire.DefaultPageLimit);
+                w.WriteNumber("next_offset", d.Offset + rendered);
+            }
+            if (remaining == 0 && d.Selected > 0 && d.Offset >= d.Selected)
+                w.WriteString("offset_note", $"offset={d.Offset} is past the end of the selection ({d.Selected} path(s)) — the last page starts before it.");
+            if (truncated)
+                w.WriteString("truncated_note",
+                    $"max_chars={cap} cut trailing resolved path(s) from this document — raise max_chars, or page with limit=/offset=.");
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
+    static void WriteAssetRow(Utf8JsonWriter w, AssetPathResult r, bool readIncomplete, bool discoveryIncomplete)
+    {
+        w.WriteStartObject();
+        w.WriteString("path", r.RelPath);
+        if (r.Error is not null)                                  // a rejected path: drive-rooted, or escaping with '..'
+        {
+            // A per-ROW error, never the document's discriminant: the call succeeded and rendered a row that failed.
+            w.WriteString("error", r.Error);
+            w.WriteEndObject();
+            return;
+        }
+        var hit = r.Hit!;
+        w.WriteNull("error");
+        w.WriteBoolean("exists", hit.Exists);
+        if (hit.Winner is { } win) WriteAssetProvider(w, "winner", win); else w.WriteNull("winner");
+        w.WriteStartArray("providers");
+        foreach (var p in hit.Providers) WriteAssetProvider(w, null, p);
+        w.WriteEndArray();
+        w.WriteBoolean("ambiguous", hit.Ambiguous);
+        if (!hit.Exists)
+        {
+            WriteNullableStringArray(w, "prefix_suggestions", r.PrefixSuggestions);
+            // The two ways an ABSENT can be wrong, per row rather than only at the top: the text render hedges the
+            // answer where it is read, and a json consumer branching on exists=false needs the same hedge.
+            w.WriteBoolean("absent_may_be_incomplete", readIncomplete || discoveryIncomplete);
+        }
+        w.WriteEndObject();
+    }
+
+    /// <summary>One provider. <paramref name="name"/> null writes it as an array element.</summary>
+    static void WriteAssetProvider(Utf8JsonWriter w, string? name, AssetProvider p)
+    {
+        if (name is null) w.WriteStartObject(); else w.WriteStartObject(name);
+        w.WriteString("name", p.Source);
+        w.WriteString("kind", p.Kind == AssetKind.Bsa ? "BSA" : "loose");
+        w.WriteEndObject();
+    }
+
+    // ---- housecarl_place (S2 write) -----------------------------------------------------------------
+    /// <summary>The machine-readable twin of <see cref="PlaceWire"/>'s render — the SAME data on the write
+    /// surface's contract: <c>ok</c> on both outcomes, a refusal is a document, and the "this does not win until
+    /// you enable and sort the mod" instruction rides in-band as <c>next_step</c>. It is written from the same
+    /// helper the text lane calls, because a truncated json document that dropped the instruction would be the
+    /// silently degraded mode json is not allowed to be.</summary>
+    public static string RenderPlaceOutcome(PlaceOutcome o, int maxChars, IReadOnlySet<string>? poleWithheld = null)
+    {
+        int cap = WriteSentences.Cap(maxChars);   // the WRITE budget rule, shared with the text twin
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            w.WriteBoolean("ok", o.Success);
+            if (!o.Success)
+            {
+                w.WriteString("error", o.Error);
+                w.WriteEndObject();
+                w.Flush();          // INSIDE the using — an unflushed refusal renders EMPTY. See RenderPatchOutcome.
+                return Finish(ms);
+            }
+
+            int placed = 0;
+            foreach (var r in o.Results) if (r.Placed) placed++;
+            var modFolder = o.ModFolder is null ? null : Path.GetFileName(o.ModFolder);
+            WriteNullable(w, "mod_folder", modFolder);
+            WriteStringArray(w, "warnings", o.Warnings);
+
+            w.WriteStartArray("results");
+            int rendered = 0;
+            bool truncated = false;
+            foreach (var r in o.Results)
+            {
+                if (Over(w, ms, cap)) { truncated = true; break; }
+                WritePlaceRow(w, r, modFolder, poleWithheld?.Contains(r.AssetPath) == true);
+                rendered++;
+            }
+            w.WriteEndArray();
+
+            w.WriteNumber("total", o.Results.Count);
+            w.WriteNumber("rendered", rendered);
+            w.WriteNumber("placed", placed);
+            w.WriteNumber("failed", o.Results.Count - placed);
+            w.WriteBoolean("truncated", truncated);
+            // Not "raise max_chars to see the rest": the bytes are already on disk, so a re-issue would place again.
+            if (truncated)
+                w.WriteString("truncated_note",
+                    $"the render hit max_chars={cap} and dropped trailing destination rows — the WRITE is unaffected; " +
+                    "raise max_chars and re-read with " + ToolNames.AssetStatus + " rather than placing again.");
+            if (o.LeftoverFolder is not null)
+                w.WriteString("leftover_folder_note", PlaceWire.LeftoverNote(o.LeftoverFolder));
+            WriteNullable(w, "leftover_folder", o.LeftoverFolder);
+            if (placed > 0) w.WriteString("next_step", PlaceWire.EnableAndSort(o, modFolder));
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
+    static void WritePlaceRow(Utf8JsonWriter w, PlaceResult r, string? modFolder, bool poleWithheld)
+    {
+        w.WriteStartObject();
+        w.WriteString("path", r.AssetPath);
+        w.WriteBoolean("placed", r.Placed);
+        WriteNullable(w, "error", r.Error);
+        if (r.Placed)
+        {
+            w.WriteNumber("bytes", r.Bytes);
+            WriteNullable(w, "source", r.SourceDesc);
+            WriteNullable(w, "current_winner", r.CurrentWinner);
+            w.WriteString("winner_note", r.CurrentWinner is not null
+                ? $"{r.CurrentWinner} currently wins the VFS — sort the new mod ABOVE it"
+                : $"nothing else provides this path — once '{modFolder ?? "(the new folder)"}' is enabled, the placed copy wins");
+            // Bytes served out of a mod MO2 does not load are a fact of the SOURCE, and look like any other
+            // placement without it.
+            if (r.SourceOffOrderProvider is { } offOrder)
+                w.WriteString("source_off_order_note", WriteSentences.PlaceSourceOffOrder(offOrder, r.SourceOffOrderOwnerEnabled));
+            WriteNullable(w, "source_off_order_provider", r.SourceOffOrderProvider);
+        }
+        // An input the call carried but this destination could not use is SAID on both lanes, not dropped.
+        w.WriteBoolean("set_provider_withheld", poleWithheld);
+        w.WriteEndObject();
+    }
+
     /// <summary>The voice-coverage report as data (a created dialogue line with no .fuz plays SILENT in game). The
     /// text render's "[!] WILL BE SILENT" becomes <c>fuz_present:false</c> + the path to put the audio at.</summary>
     static void WriteVoiceReport(Utf8JsonWriter w, VoiceReport? report, MemoryStream ms, int cap, ref bool truncated)

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -9313,6 +9313,10 @@ public sealed record PlaceResult(string AssetPath, bool Placed, long Bytes, stri
 public sealed record PlaceOutcome(
     IReadOnlyList<PlaceResult> Results, string? ModFolder, IReadOnlyList<string> Warnings, string? LeftoverFolder, string? Error)
 {
+    /// <summary>Whether the CALL was served at all — not whether every destination placed. A served call with
+    /// failed rows is a success carrying per-row errors, the way every other write outcome reads.</summary>
+    public bool Success => Error is null;
+
     public static PlaceOutcome Fail(string error)
         => new(Array.Empty<PlaceResult>(), null, Array.Empty<string>(), null, error);
 }

--- a/src/housecarl-mcp/PlaceTools.cs
+++ b/src/housecarl-mcp/PlaceTools.cs
@@ -95,10 +95,10 @@ public static class PlaceTools
         return PlaceTargets(svc, assets, source_provider, kind, patch, into, max_chars, json);
     });
 
-    /// <summary>The write surface's one refusal shape, in the transport the caller asked for — the text lane's
-    /// "error: " prefix, or the json refusal document.</summary>
-    static string Refuse(bool json, string message)
-        => json ? JsonWire.RenderError(message, null) : "error: " + message;
+    /// <summary>The one refusal shape, through its one owner — <see cref="Wire.Refuse"/>, which owns the
+    /// <see cref="Wire.RefusalPrefix"/> the json document strips. A shorthand so the call sites below need not repeat
+    /// the prefix and the transport flag both, never a second definition of the shape.</summary>
+    static string Refuse(bool json, string message) => Wire.Refuse(json, Wire.RefusalPrefix + message);
 
     static string PlaceTargets(LoadOrderService svc, PlaceTarget[] assets, string? source_provider,
                                string? kind, string? patch, string? into, int max_chars, bool json)

--- a/src/housecarl-mcp/PlaceTools.cs
+++ b/src/housecarl-mcp/PlaceTools.cs
@@ -59,40 +59,55 @@ public static class PlaceTools
             string? patch = null,
         [Description("LANE: filename of an EXISTING houseCARL patch mod to place into instead of a fresh folder (accumulate across calls). Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
             string? into = null,
+        [Description("TRANSPORT: 'text' (default) | 'json' (the same data, machine-readable, the accounting and the enable+sort instruction in-band).")]
+            string? format = null,
         [Description("TRANSPORT: character ceiling on the per-destination list. Past it, trailing rows are dropped with an explicit notice (never silent); the WRITE is unaffected, and the accounting line and the enable+sort instruction always render. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool(ToolNames.Place, () =>
     {
-        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        // format first, so the unconfigured-MO2 prompt answers a json caller as a document.
+        bool json = Wire.WantsJson(format, out var ferr);
+        if (ferr is not null) return ferr;
+        if (svc.ConfigPromptOrNull() is { } prompt)
+            return json ? JsonWire.RenderError(prompt, null) : prompt;
         if (assets is not { } el || el.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
-            return "error: assets is empty. Pass one or more { path|formid, kind?, source?, source_provider? } destinations.";
+            return Refuse(json, "assets is empty. Pass one or more { path|formid, kind?, source?, source_provider? } destinations.");
         // The strict reader, not the SDK's binder: a member the shape does not declare is refused by name at its
         // element. Dropped silently, a mistyped source_provider would auto-resolve some other provider's copy and
         // read back as a successful place.
         var (items, listErr) = ListParams.Read<PlaceTarget>(el, "assets", "{path|formid, kind?, source?, source_provider?}");
-        if (listErr is not null) return "error: " + listErr;
-        return PlaceTargets(svc, items!, source_provider, kind, patch, into, max_chars);
+        if (listErr is not null) return Refuse(json, listErr);
+        return PlaceTargets(svc, items!, source_provider, kind, patch, into, max_chars, json);
     });
 
     /// <summary>The same call over destinations already read — the seam the probes and tests drive with typed
     /// members, while a real call comes through the strict reader above.</summary>
     internal static string Place(LoadOrderService svc, PlaceTarget[] assets, string? source_provider = null,
-                                 string? kind = null, string? patch = null, string? into = null, int max_chars = 0)
+                                 string? kind = null, string? patch = null, string? into = null,
+                                 string? format = null, int max_chars = 0)
         => Guard.Tool(ToolNames.Place, () =>
     {
-        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        bool json = Wire.WantsJson(format, out var ferr);
+        if (ferr is not null) return ferr;
+        if (svc.ConfigPromptOrNull() is { } prompt)
+            return json ? JsonWire.RenderError(prompt, null) : prompt;
         if (assets is null || assets.Length == 0)
-            return "error: assets is empty. Pass one or more { path|formid, kind?, source?, source_provider? } destinations.";
-        return PlaceTargets(svc, assets, source_provider, kind, patch, into, max_chars);
+            return Refuse(json, "assets is empty. Pass one or more { path|formid, kind?, source?, source_provider? } destinations.");
+        return PlaceTargets(svc, assets, source_provider, kind, patch, into, max_chars, json);
     });
 
+    /// <summary>The write surface's one refusal shape, in the transport the caller asked for — the text lane's
+    /// "error: " prefix, or the json refusal document.</summary>
+    static string Refuse(bool json, string message)
+        => json ? JsonWire.RenderError(message, null) : "error: " + message;
+
     static string PlaceTargets(LoadOrderService svc, PlaceTarget[] assets, string? source_provider,
-                               string? kind, string? patch, string? into, int max_chars)
+                               string? kind, string? patch, string? into, int max_chars, bool json)
     {
         // The set-level slot is validated ONCE, under its own name: attributed to a member it would blame input the
         // caller never wrote there and repeat it per member, and on a set of nothing but path= members, which ignore
         // it, a bad token would never be noticed at all.
         if (ParseSlot(NullIfBlank(kind), out var setKindErr) is null && setKindErr is not null)
-            return "error: " + setKindErr;
+            return Refuse(json, setKindErr);
 
         // Malformed members refuse the WHOLE call (all-or-nothing, like create); placement-time issues
         // (ambiguous/absent/unreadable source) are per-member (the resolver isn't consulted until the place loop).
@@ -114,9 +129,12 @@ public static class PlaceTools
             }
         }
         if (problems.Count > 0)
-            return $"error: refused — {problems.Count} malformed destination(s); nothing placed:\n  - " + string.Join("\n  - ", problems);
+            return Refuse(json, $"refused — {problems.Count} malformed destination(s); nothing placed:\n  - " + string.Join("\n  - ", problems));
 
-        return PlaceWire.Render(svc.PlaceAssets(all, patch, into), max_chars > 0 ? max_chars : 80_000, poleWithheld);
+        var outcome = svc.PlaceAssets(all, patch, into);
+        int cap = max_chars > 0 ? max_chars : 80_000;
+        return json ? JsonWire.RenderPlaceOutcome(outcome, cap, poleWithheld)
+                    : PlaceWire.Render(outcome, cap, poleWithheld);
     }
 
     /// <summary>Map one destination to its placement request(s): path → one request; formid+kind → one request (the
@@ -238,21 +256,29 @@ static class PlaceWire
            .Append(" truncated=").Append(rendered < o.Results.Count ? "true" : "false").Append('\n');
 
         if (o.LeftoverFolder is not null)
-            sb2.Append("note: the fresh folder at '").Append(o.LeftoverFolder)
-               .Append("' holds a partial result — delete it or retry with into=.\n");
+            sb2.Append("note: ").Append(LeftoverNote(o.LeftoverFolder)).Append('\n');
 
-        if (placed > 0)
-        {
-            bool anyContended = false;
-            foreach (var r in o.Results) if (r.Placed && r.CurrentWinner is not null) { anyContended = true; break; }
-            sb2.Append("\nIMPORTANT — \"wrote it\" is not \"it wins\": the placed file(s) do NOT win the VFS yet. Enable the mod '")
-               .Append(modFolder ?? "(the new folder)").Append("' in MO2");
-            sb2.Append(anyContended
-                ? " and SORT it (left pane) ABOVE the current winner(s) listed above. Only then does the placed copy win.\n"
-                : ". Nothing else provided these path(s), so once enabled the placed copy wins (sort it above any mod you later add that also provides them).\n");
-        }
+        if (placed > 0) sb2.Append('\n').Append(EnableAndSort(o, modFolder)).Append('\n');
 
         return sb2.ToString().TrimEnd('\n');
+    }
+
+    /// <summary>A fresh folder kept because the write half-landed, said once for both transports.</summary>
+    internal static string LeftoverNote(string leftoverFolder)
+        => $"the fresh folder at '{leftoverFolder}' holds a partial result — delete it or retry with into=.";
+
+    /// <summary>The instruction a placement is incomplete without: written bytes do not win the VFS until the mod is
+    /// enabled, and sorted above the current winner when one exists. One home, because both transports have to carry
+    /// it verbatim — a json caller told only that the write succeeded would enable nothing.</summary>
+    internal static string EnableAndSort(PlaceOutcome o, string? modFolder)
+    {
+        bool anyContended = false;
+        foreach (var r in o.Results) if (r.Placed && r.CurrentWinner is not null) { anyContended = true; break; }
+        return "IMPORTANT — \"wrote it\" is not \"it wins\": the placed file(s) do NOT win the VFS yet. Enable the mod '"
+             + (modFolder ?? "(the new folder)") + "' in MO2"
+             + (anyContended
+                 ? " and SORT it (left pane) ABOVE the current winner(s) listed above. Only then does the placed copy win."
+                 : ". Nothing else provided these path(s), so once enabled the placed copy wins (sort it above any mod you later add that also provides them).");
     }
 
     static void AppendResult(StringBuilder sb, PlaceResult r, string? modFolder, bool poleWithheld)

--- a/src/housecarl-mcp/PlaceTools.cs
+++ b/src/housecarl-mcp/PlaceTools.cs
@@ -258,7 +258,7 @@ static class PlaceWire
         if (o.LeftoverFolder is not null)
             sb2.Append("note: ").Append(LeftoverNote(o.LeftoverFolder)).Append('\n');
 
-        if (placed > 0) sb2.Append('\n').Append(EnableAndSort(o, modFolder)).Append('\n');
+        if (placed > 0) sb2.Append('\n').Append(EnableAndSort(o, modFolder, rendered)).Append('\n');
 
         return sb2.ToString().TrimEnd('\n');
     }
@@ -269,16 +269,28 @@ static class PlaceWire
 
     /// <summary>The instruction a placement is incomplete without: written bytes do not win the VFS until the mod is
     /// enabled, and sorted above the current winner when one exists. One home, because both transports have to carry
-    /// it verbatim — a json caller told only that the write succeeded would enable nothing.</summary>
-    internal static string EnableAndSort(PlaceOutcome o, string? modFolder)
+    /// it verbatim — a json caller told only that the write succeeded would enable nothing.
+    /// <para><paramref name="rendered"/> is how many rows the render actually got onto the page. Rows come out in
+    /// order, so those are the first <paramref name="rendered"/> results — and a contended row max_chars cut cannot
+    /// be pointed at with "listed above", so the sentence says the row was cut instead of naming a winner the
+    /// document never shows.</para></summary>
+    internal static string EnableAndSort(PlaceOutcome o, string? modFolder, int rendered)
     {
-        bool anyContended = false;
-        foreach (var r in o.Results) if (r.Placed && r.CurrentWinner is not null) { anyContended = true; break; }
+        bool anyContended = false, shownContended = false;
+        for (int i = 0; i < o.Results.Count; i++)
+        {
+            if (!(o.Results[i].Placed && o.Results[i].CurrentWinner is not null)) continue;
+            anyContended = true;
+            if (i < rendered) { shownContended = true; break; }
+        }
+        var sort = shownContended
+            ? " and SORT it (left pane) ABOVE the current winner(s) listed above. Only then does the placed copy win."
+            : anyContended
+                ? " and SORT it (left pane) ABOVE the current winner(s) — max_chars cut the row(s) naming them from " +
+                  "this render, so raise max_chars and re-read to see which. Only then does the placed copy win."
+                : ". Nothing else provided these path(s), so once enabled the placed copy wins (sort it above any mod you later add that also provides them).";
         return "IMPORTANT — \"wrote it\" is not \"it wins\": the placed file(s) do NOT win the VFS yet. Enable the mod '"
-             + (modFolder ?? "(the new folder)") + "' in MO2"
-             + (anyContended
-                 ? " and SORT it (left pane) ABOVE the current winner(s) listed above. Only then does the placed copy win."
-                 : ". Nothing else provided these path(s), so once enabled the placed copy wins (sort it above any mod you later add that also provides them).");
+             + (modFolder ?? "(the new folder)") + "' in MO2" + sort;
     }
 
     static void AppendResult(StringBuilder sb, PlaceResult r, string? modFolder, bool poleWithheld)


### PR DESCRIPTION
`housecarl_asset_status` and `housecarl_place` had no `format=json`. SPEC §2.1 makes TRANSPORT uniform across every
tool and calls a surface missing one of the axes a bug, so both tools get the lane through the same shared code every
other tool uses — `Wire.WantsJson` for the parameter, `Wire.Refuse`/`JsonWire.RenderError` for a whole-call refusal, a
`JsonWire` renderer beside the existing twins, `WriteSentences.Cap` for the write budget. No bespoke serializer and no
second budget rule.

**asset_status** (a read document, so no `ok` on a served answer): profile, the build-level caveats
(`read_incomplete`, `bsa_failures`, `warnings`, `selector_notes`) first, then one row per path — `winner` and the
full `providers` chain as `{name, kind}`, `ambiguous`, and for an absent path its `prefix_suggestions` plus the two
hedges the text render prints at the point of use, `absent_may_be_incomplete_read_failure` and
`absent_may_be_incomplete_undiscovered_archives`, kept apart because they are two facts with two remedies. Then the
same eight counters the text accounting line states, under one `accounting` object, so
`skipped + rendered + truncated + capped == total` on both lanes, with `next_limit`/`next_offset` measured off what
was rendered beside it.

The counters come from `AssetWire.Tally` — the composer the text line already goes through — and its `Widest` sizes a
reserve, so the accounting, the caveat blocks and the advice are all paid for INSIDE `max_chars` rather than written
past it. The three caveat blocks are capped and cut with the same named marker the text lane uses (an `under=` of
thousands of selectors is otherwise a block `max_chars` never reaches), and the first row always renders, so a small
`max_chars` still answers the path that was asked about.

A provider is `{name, kind}` rather than the printed `"Name" (loose)` token on purpose: the reusable value is the
name alone, which is what `place`'s `source_provider=` accepts, so a consumer reads a field instead of parsing the
display token apart.

**place** (a write document, so `ok` on both outcomes): the mod folder, warnings, one row per destination with its
bytes, source, `current_winner` and the off-order-source note, plus `set_provider_withheld` — and `next_step`, the
"a placed file does not win until you enable and sort the mod" instruction. That sentence and the leftover-folder
note now have one home each in `PlaceWire`, called by both lanes: a json caller who was told only that the write
succeeded would enable nothing, which is the degraded mode json is not allowed to be. Its row loop renders a first
row whatever `max_chars` says too — that row is the only place `current_winner` is stated.

`truncated` at the document root stays the boolean every json document carries; the text lane's `truncated=N` count
is `accounting.truncated`. A document that hits `max_chars` drops trailing rows and stays valid JSON rather than
cutting a string mid-object.

`PlaceOutcome` gains a `Success` property (`Error is null`) so the `ok` key is written from a write outcome, which
is what `refusal-completeness-guard` requires of every `ok` write in `JsonWire`.

**On #555.** That PR extracts these same counters into a shared `TransportAccounting` with a JSON twin. This PR's
json accounting is written in that shape deliberately — nested `accounting` object, the same eight names in the same
order, `truncated` as the count — so whichever merges second is a mechanical rebase: `AssetWire.WriteJson` becomes a
call to `TransportAccounting.WriteJson`, and `AssetWire.Tally`/`Widest` become `TransportAccounting.Tally`/`Widest`.
After #555 merges, this lane rewires through `TransportAccounting` rather than keeping its own composer.
`next_limit`/`next_offset` and the two advice sentences stay siblings of the object rather than members of it, which
is where a rewire leaves them untouched.

Tests: `S2JsonLaneTests.cs` — nine arms over the real `asset_status` json lane (winner and chain as data, the eight
counters summing to the total, a cut document that still parses, the first row rendering at a tiny `max_chars`, the
caveat blocks capped, the tail landing inside the cap, a refusal document, an unrecognized `format`, and `place`'s
refusal document through the same door), one driving `place` end to end to a SERVED write with a withheld set-level
pole, one at the render seam for the two ABSENT hedges, and five at `place`'s render seam, including the first-row
rule and one holding the `next_step` sentence identical across the two lanes. Suite 1190 passed, `ci-all` 128/128.

Stacked on `claude/strings-remainder` (#549) — review that one first; this PR's base moves to `main` when it merges.

Closes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)
