### PR TITLE
Answer an unbounded references= off a lazy reverse-reference index

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -72,6 +72,18 @@ saying it sets an expectation their install may contradict. Say what is known, a
   collection whose elements are owned child records (`Cell.Persistent`) is sent to the record axis rather than handed
   a container call no verb takes. Inside
   a `compose=`'s nested `sets`, the path is named in the `path` slot it belongs to rather than `field_path`.
+- **`references=` no longer needs a bounding `types=`/`plugins=` scope.** "Who references X" over the whole order
+  was refused, so the answer had to be assembled from a scope guess per plugin. It is now one call:
+  `records references=["0006BBD3:Skyrim.esm"]`. The first such call builds a reverse-reference index — one
+  whole-order link-walk, the same walk the dangling sweep runs (measured on a 3,801-plugin order: 24.4 s, 14.7M
+  target→referencer pairs, ~200 MB held) — and the response says what that build cost and carries the index's own
+  freshness key. The index is kept per plugin and keyed on that plugin's path and last-write time, so a plugin you
+  change rebuilds only its own slice (an unchanged order re-checks in milliseconds), and it is never answered from
+  bodies it was not computed from. Nothing else is unbounded: a `where=` or `editorid_contains=` with no scope is
+  still refused, naming the bound. A bounded `references=` is unchanged and still cheaper — it builds no index. The
+  negated spelling `references=["!XXXXXX:Plugin.esp"]` is unbounded too, and keeps its meaning of "does not
+  reference that target", so with no scope its universe is the whole order; the response says so.
+
 - **A path can now step to the record that CONTAINS this one, with `*parent`.** DIAL→INFO, CELL→REFR/ACHR and
   WRLD→CELL ownership is group nesting rather than a form link, so `references=` correctly returns nothing for it
   and the child's own body names no owner — there was no way back from an INFO to its topic, or from a crash log's

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -82,14 +82,19 @@ saying it sets an expectation their install may contradict. Say what is known, a
   bodies it was not computed from. Nothing else is unbounded: a `where=` or `editorid_contains=` with no scope is
   still refused, naming the bound. A bounded `references=` is unchanged and still cheaper — it builds no index.
   The index is kept for as long as the load order it was built from, including across a plugin being ticked or
-  re-sorted in MO2, so that walk is paid once and not once per touch.
+  re-sorted in MO2, so that walk is paid once and not once per touch. `project.group_by='type'` composes with it:
+  the index hands the scan a universe of records whose bodies are read, which is what names each match's type.
 
 - **The orphan sweep: `references=["!XXXXXX:Plugin.esp"]` with no scope now asks which records nothing in the
   order references.** A negated `references=` under a `types=`/`plugins=` scope is unchanged — records in that
   scope that do not link the target. With no scope at all the universe becomes every record nothing references,
   and the named target then excludes any of those that link it; the response states which question it answered.
   The sweep is refused in combination with `form='delta'`/`'tree'`/`'info_order'`, which would compare every one
-  of those records — run it as a plain scan with `to_file=` and re-enter the artifact instead.
+  of those records — run it as a plain scan with `to_file=` and re-enter the artifact instead; an in-order
+  `source=` plugin is a scope like any other, so a negated `references=` under one is that plugin's records and
+  those forms compose with it. Where a plugin cannot be read, the sweep says it is OVER-inclusive by whatever that
+  plugin references — a record only it links is listed as an orphan — which is the opposite of what an unreadable
+  plugin does to the positive question, and the response says which of the two it is telling you.
 
 - **A path can now step to the record that CONTAINS this one, with `*parent`.** DIAL→INFO, CELL→REFR/ACHR and
   WRLD→CELL ownership is group nesting rather than a form link, so `references=` correctly returns nothing for it

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -80,9 +80,16 @@ saying it sets an expectation their install may contradict. Say what is known, a
   freshness key. The index is kept per plugin and keyed on that plugin's path and last-write time, so a plugin you
   change rebuilds only its own slice (an unchanged order re-checks in milliseconds), and it is never answered from
   bodies it was not computed from. Nothing else is unbounded: a `where=` or `editorid_contains=` with no scope is
-  still refused, naming the bound. A bounded `references=` is unchanged and still cheaper — it builds no index. The
-  negated spelling `references=["!XXXXXX:Plugin.esp"]` is unbounded too, and keeps its meaning of "does not
-  reference that target", so with no scope its universe is the whole order; the response says so.
+  still refused, naming the bound. A bounded `references=` is unchanged and still cheaper — it builds no index.
+  The index is kept for as long as the load order it was built from, including across a plugin being ticked or
+  re-sorted in MO2, so that walk is paid once and not once per touch.
+
+- **The orphan sweep: `references=["!XXXXXX:Plugin.esp"]` with no scope now asks which records nothing in the
+  order references.** A negated `references=` under a `types=`/`plugins=` scope is unchanged — records in that
+  scope that do not link the target. With no scope at all the universe becomes every record nothing references,
+  and the named target then excludes any of those that link it; the response states which question it answered.
+  The sweep is refused in combination with `form='delta'`/`'tree'`/`'info_order'`, which would compare every one
+  of those records — run it as a plain scan with `to_file=` and re-enter the artifact instead.
 
 - **A path can now step to the record that CONTAINS this one, with `*parent`.** DIAL→INFO, CELL→REFR/ACHR and
   WRLD→CELL ownership is group nesting rather than a form link, so `references=` correctly returns nothing for it

--- a/src/housecarl-core/EffectChain.cs
+++ b/src/housecarl-core/EffectChain.cs
@@ -106,7 +106,7 @@ public static class EffectChain
                 return FailStamped(
                     $"{mgef} resolves to a {RecordNaming.StripOverlay(mbody.GetType().Name)}, not a MagicEffect — the chain form " +
                     $"needs an MGEF. (To find what references an arbitrary record, use {ToolNames.Records} references=[the FormID] " +
-                    "with types= or plugins= to bound the scan.)");
+                    "— unbounded off the reverse-reference index, or with types= or plugins= for a cheaper bounded scan.)");
             mgefEid = mr.EditorID ?? "<none>";
         }
 

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -121,6 +121,8 @@ public sealed class LoadOrderResolver : IDisposable
     readonly Dictionary<string, int> _nameToIdx;       // plugin filename → index (last copy of a duplicate name wins = priority)
     FileStamp[] _stamps;                               // last-write AND length at the last index build, per path (freshness baseline)
     readonly string? _dataDir;                         // real game-Data folder (Skyrim.esm's dir) — localized-strings fallback source (OpenOverlay)
+    ReverseReferenceIndex? _reverse;                   // lazy, held BESIDE the snapshot so a snapshot swap does not drop it
+    readonly object _reverseGate = new();              // one build at a time; a second caller waits rather than walking the order twice
 
     /// <summary>The real game-Data folder this order resolved, for callers OUTSIDE the session that must open a plugin
     /// through <see cref="OpenOverlay"/> and get the same strings resolution the index reads with. The in-place write's
@@ -914,6 +916,20 @@ public sealed class LoadOrderResolver : IDisposable
         /// <summary>Distinct children this build recorded a containing record for.</summary>
         public int ContainedRecordCount => _s.Containment.Count;
 
+        /// <summary>Every FormKey in the order, in no promised order beyond being stable for one build — the
+        /// universe an unbounded selection starts from when nothing narrows it.</summary>
+        public IEnumerable<FormKey> RecordKeys() => _s.Index.Keys;
+
+        /// <summary>Build the reverse-reference index if nothing has needed it yet, refresh the partitions whose
+        /// plugin bytes changed, and hand back what that cost — see
+        /// <see cref="LoadOrderResolver.EnsureReverseIndex"/>. The index is the resolver's, not this build's, so a
+        /// freshness rebuild between two calls keeps every partition it did not invalidate.</summary>
+        public ReverseReferenceIndex.Refreshed EnsureReverseIndex() => _r.EnsureReverseIndex(_s);
+
+        /// <summary>The reverse-reference index itself, once <see cref="EnsureReverseIndex"/> has built it; null
+        /// before that.</summary>
+        public ReverseReferenceIndex? ReverseIndex => _r.ReverseIndex;
+
         /// <summary>Every FormKey overridden by more than one plugin (the whole-order conflict set).</summary>
         public IEnumerable<FormKey> ConflictKeys() => _s.Overriders.Keys;
 
@@ -1273,6 +1289,25 @@ public sealed class LoadOrderResolver : IDisposable
         _snap = BuildIndex();                                              // ONE reference write — in-flight readers keep their captured build
         return true;
     }
+
+    // ---- The reverse-reference index: lazy, per-plugin, beside the snapshot ----------------
+
+    /// <summary>Build the reverse-reference index if this is the first call that needs it, and bring its per-plugin
+    /// partitions up to date against the files on disk. Held on the RESOLVER, not on the snapshot: the snapshot's
+    /// epoch is order-wide and a snapshot swap would drop the whole index, where this refresh rebuilds only the
+    /// partitions whose own (path, mtime) changed. Returns what the refresh cost and what it holds, for the
+    /// response's accounting.</summary>
+    internal ReverseReferenceIndex.Refreshed EnsureReverseIndex(IndexSnapshot s)
+    {
+        lock (_reverseGate)
+        {
+            _reverse ??= new ReverseReferenceIndex();
+            return _reverse.Refresh(_names, _paths, i => OpenOverlay(_paths[i], _dataDir), s.Excluded);
+        }
+    }
+
+    /// <summary>The current reverse index, or null when nothing has needed it yet.</summary>
+    internal ReverseReferenceIndex? ReverseIndex { get { lock (_reverseGate) return _reverse; } }
 
     /// <summary>The resolver holds NO plugin file handles at rest (only the pure-data index), so there is nothing to
     /// release — Dispose is a no-op, kept so the service can treat a resolver as a disposable resource it builds and

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -1309,6 +1309,17 @@ public sealed class LoadOrderResolver : IDisposable
     /// <summary>The current reverse index, or null when nothing has needed it yet.</summary>
     internal ReverseReferenceIndex? ReverseIndex { get { lock (_reverseGate) return _reverse; } }
 
+    /// <summary>Take over the reverse index of the resolver this one replaces. Ticking a plugin in MO2 rebuilds the
+    /// RESOLVER, not just the snapshot, so without this the index dies on the commonest touch there is and the next
+    /// unbounded call re-walks 3,800 unchanged plugins. The partitions are keyed on (path, mtime), so the next
+    /// refresh keeps every one whose file did not move and builds only the plugins this order added.</summary>
+    public void AdoptReverseIndexFrom(LoadOrderResolver previous)
+    {
+        var carried = previous.ReverseIndex;
+        if (carried is null) return;
+        lock (_reverseGate) _reverse ??= carried;
+    }
+
     /// <summary>The resolver holds NO plugin file handles at rest (only the pure-data index), so there is nothing to
     /// release — Dispose is a no-op, kept so the service can treat a resolver as a disposable resource it builds and
     /// swaps over its lifetime, and so `using var resolver = …` call sites stay valid.</summary>

--- a/src/housecarl-core/ReverseReferenceIndex.cs
+++ b/src/housecarl-core/ReverseReferenceIndex.cs
@@ -18,15 +18,21 @@ namespace HousecarlCore;
 /// <para><b>Partitioned by plugin, keyed on (path, mtime).</b> This is the one place the resolver's existing
 /// freshness machinery does not fit: <c>RefreshIfStale</c> is all-or-nothing and <c>Epoch</c> is order-wide, so an
 /// index hung off the snapshot would die wholesale on every MO2 touch and pay the full walk again. The index is
-/// held BESIDE the snapshot and carried across a snapshot swap; a refresh drops and rebuilds only the partitions
-/// whose own key changed. Stale-and-silent is what the partition key makes structurally impossible.</para>
+/// held BESIDE the snapshot and carried across a snapshot swap AND across a resolver swap; a refresh drops and
+/// rebuilds only the partitions whose own key changed. Stale-and-silent is what the partition key makes
+/// structurally impossible.</para>
+///
+/// <para><b>Generational, so a read is never torn.</b> A refresh builds whole new collections and publishes them
+/// with one field assignment; a reader takes the current generation once and works off it. No reader ever sees a
+/// half-rebuilt order, and no reader takes the build lock.</para>
 ///
 /// <para><b>Plugin-atomic.</b> A plugin whose enumeration throws part-way contributes NO partition content and is
 /// named in the report, so a half-read plugin never leaves partial reverse edges behind and a caller can say the
 /// answer is short rather than call it complete.</para>
 ///
 /// <para><b>Packed.</b> Entries are ulong ((interned mod index &lt;&lt; 32) | FormID), not FormKey: 8 bytes a pair
-/// instead of 24. Pure derived data — no bodies, no file handles at rest.</para>
+/// instead of 24. Pure derived data — no bodies, no file handles at rest. It is resident until the resolver it
+/// hangs off is dropped: there is no eviction policy and no ceiling knob, which is the accepted ruling.</para>
 ///
 /// <para><b>What it is not.</b> Not the position-seek index (a different question), and not reverse over the
 /// runtime layers (SkyPatcher, SPID): plugin FormLinks only, like the sweep it rides.</para></summary>
@@ -35,6 +41,7 @@ public sealed class ReverseReferenceIndex
     sealed class Partition
     {
         public string Path = "";
+        public string Name = "";
         public DateTime Mtime;
         public Dictionary<ulong, ulong[]> ByTarget = new();
         public long Pairs;
@@ -42,31 +49,66 @@ public sealed class ReverseReferenceIndex
         public string? Unreadable;                     // set ⇒ this plugin contributed nothing, and why
     }
 
-    readonly Dictionary<string, Partition> _byPlugin = new(StringComparer.OrdinalIgnoreCase);
-    readonly List<string> _order = new();              // plugin names in priority order — what makes a candidate list deterministic
-    readonly Dictionary<ModKey, int> _modToIdx = new();
-    readonly List<ModKey> _idxToMod = new();
+    /// <summary>One published, immutable state of the index. Everything a read touches lives here, so a read takes
+    /// the field once and is consistent for its whole run even while a refresh builds the next one.</summary>
+    sealed class Generation
+    {
+        // Keyed on the plugin PATH, not its filename: the resolver's order is addressed by position and tolerates
+        // two entries sharing a filename (last copy wins = priority), so a filename key would silently drop the
+        // lower-priority copy's edges and re-walk both plugins on every call.
+        public Dictionary<string, Partition> ByPath = new(StringComparer.OrdinalIgnoreCase);
+        public List<string> Order = new();             // partition paths in priority order — what makes a candidate list deterministic
+        public Dictionary<ModKey, int> ModToIdx = new();
+        public List<ModKey> IdxToMod = new();
+        public string Key = "";
+
+        Lazy<HashSet<ulong>>? _referenced;
+
+        /// <summary>Every target something in the order links, as one set — the orphan question answered in a
+        /// lookup rather than a scan over every partition. Built on first ask and thrown away with the
+        /// generation.</summary>
+        public HashSet<ulong> Referenced =>
+            (_referenced ??= new Lazy<HashSet<ulong>>(BuildReferenced, LazyThreadSafetyMode.ExecutionAndPublication)).Value;
+
+        HashSet<ulong> BuildReferenced()
+        {
+            var set = new HashSet<ulong>();
+            foreach (var path in Order)
+                if (ByPath.TryGetValue(path, out var p))
+                    foreach (var t in p.ByTarget.Keys) set.Add(t);
+            return set;
+        }
+
+        public bool TryPack(FormKey k, out ulong packed)
+        {
+            if (!ModToIdx.TryGetValue(k.ModKey, out int i)) { packed = 0; return false; }
+            packed = ((ulong)(uint)i << 32) | k.ID;
+            return true;
+        }
+
+        public FormKey Unpack(ulong packed) => new(IdxToMod[(int)(packed >> 32)], (uint)packed);
+    }
+
+    volatile Generation _gen = new();
 
     /// <summary>Plugins with a partition in this index.</summary>
-    public int PartitionCount => _byPlugin.Count;
+    public int PartitionCount => _gen.ByPath.Count;
 
     /// <summary>Distinct (target, plugin) slots — one per target a plugin links at all.</summary>
-    public int TargetSlotCount => _byPlugin.Values.Sum(p => p.ByTarget.Count);
+    public int TargetSlotCount => _gen.ByPath.Values.Sum(p => p.ByTarget.Count);
 
     /// <summary>Distinct (target, referencing record) pairs held.</summary>
-    public long PairCount => _byPlugin.Values.Sum(p => p.Pairs);
+    public long PairCount => _gen.ByPath.Values.Sum(p => p.Pairs);
 
     /// <summary>What the index holds, to the nearest useful order of magnitude: eight bytes a pair plus the
     /// per-target slot overhead of the dictionaries. Reported, not enforced — there is no ceiling knob.</summary>
     public long ApproxBytes => PairCount * 8 + (long)TargetSlotCount * 40;
 
-    /// <summary>Does anything in the order link to this record? The whole of the orphan question.</summary>
+    /// <summary>Does anything in the order link to this record? The whole of the orphan question, in one lookup.</summary>
     public bool HasAnyReferencer(FormKey target)
     {
-        if (!TryPack(target, out var pt)) return false;
-        foreach (var name in _order)
-            if (_byPlugin.TryGetValue(name, out var p) && p.ByTarget.ContainsKey(pt)) return true;
-        return false;
+        var g = _gen;
+        return g.TryPack(target, out var pt) && g.Referenced.Contains(pt);
     }
 
     /// <summary>Every record that links to ANY of these targets, deduped, in load order then plugin-enumeration
@@ -75,17 +117,18 @@ public sealed class ReverseReferenceIndex
     /// still decides on the body it means to judge (a later override may have dropped it).</summary>
     public IReadOnlyList<FormKey> ReferencersOf(IReadOnlyList<FormKey> targets)
     {
+        var g = _gen;
         var packed = new List<ulong>(targets.Count);
-        foreach (var t in targets) if (TryPack(t, out var pt)) packed.Add(pt);
+        foreach (var t in targets) if (g.TryPack(t, out var pt)) packed.Add(pt);
         var seen = new HashSet<ulong>();
         var outp = new List<FormKey>();
-        foreach (var name in _order)
+        foreach (var path in g.Order)
         {
-            if (!_byPlugin.TryGetValue(name, out var p)) continue;
+            if (!g.ByPath.TryGetValue(path, out var p)) continue;
             foreach (var pt in packed)
                 if (p.ByTarget.TryGetValue(pt, out var arr))
                     foreach (var r in arr)
-                        if (seen.Add(r)) outp.Add(Unpack(r));
+                        if (seen.Add(r)) outp.Add(g.Unpack(r));
         }
         return outp;
     }
@@ -96,57 +139,86 @@ public sealed class ReverseReferenceIndex
                                    long ApproxBytes, IReadOnlyList<string> Unreadable, int UnscannableRecords,
                                    string Key)
     {
-        /// <summary>The one accounting line, or null when this call changed nothing and so paid nothing.</summary>
-        public string? Note => Rebuilt == 0 ? null
-            : $"reverse-reference index: built {Rebuilt} plugin partition(s) in {ElapsedMs} ms "
-              + $"({Pairs} target→referencer pairs over {TargetSlots} target slots, ~{ApproxBytes / (1024 * 1024)} MB held), "
-              + $"key={Key} (per plugin, path+mtime — beside the order-wide epoch, not riding it)."
-              + (Unreadable.Count > 0
-                     ? $" {Unreadable.Count} plugin(s) contributed nothing because the walk could not read them: {string.Join(", ", Unreadable)} — the answer is short by whatever they reference."
-                     : "")
-              + (UnscannableRecords > 0
-                     ? $" {UnscannableRecords} record(s) Mutagen could not parse were excluded from the walk."
-                     : "");
+        /// <summary>The one accounting line. The BUILD clause is only true of the call that paid it; the freshness
+        /// key and the coverage disclosures are true of every answer the index serves, so they are unconditional —
+        /// a cached call that dropped them would read as complete when it is short.</summary>
+        public string Note
+        {
+            get
+            {
+                var sb = new StringBuilder("reverse-reference index: ");
+                sb.Append(Rebuilt > 0 ? $"built {Rebuilt} plugin partition(s) in {ElapsedMs} ms"
+                                      : $"unchanged, {Partitions} plugin partition(s) held");
+                sb.Append($" ({Pairs} target→referencer pairs over {TargetSlots} target slots, ~{ApproxBytes / (1024 * 1024)} MB held), ");
+                sb.Append($"key={Key} (per plugin, path+mtime — beside the order-wide epoch, not riding it).");
+                if (Unreadable.Count > 0)
+                    sb.Append($" {Unreadable.Count} plugin(s) contributed nothing because the walk could not read them: ")
+                      .Append(string.Join(", ", Unreadable))
+                      .Append(" — the answer is short by whatever they reference.");
+                if (UnscannableRecords > 0)
+                    sb.Append($" {UnscannableRecords} record(s) Mutagen could not parse were excluded from the walk.");
+                return sb.ToString();
+            }
+        }
     }
 
     /// <summary>Bring every partition up to date against the files on disk: keep the ones whose (path, mtime) is
-    /// unchanged, rebuild the ones whose is not, drop the ones whose plugin left the order. The opener is the
-    /// resolver's, so one plugin is open at a time and none is held at rest.</summary>
+    /// unchanged, rebuild the ones whose is not, drop the ones whose plugin left the order. The whole result is
+    /// staged in fresh collections and published in one assignment, so a concurrent read sees the old generation
+    /// or the new one and never a mixture. The opener is the resolver's, so one plugin is open at a time and none
+    /// is held at rest.</summary>
     internal Refreshed Refresh(IReadOnlyList<string> names, IReadOnlyList<string> paths,
                                Func<int, ISkyrimModGetter> open, ICollection<int> excluded)
     {
         var sw = Stopwatch.StartNew();
+        var prev = _gen;
+        var next = new Generation
+        {
+            // The mod-key interning carries forward, so a partition retained from the previous generation keeps
+            // meaning what it meant: an index into this list, which only ever grows at the tail.
+            IdxToMod = new List<ModKey>(prev.IdxToMod),
+            ModToIdx = new Dictionary<ModKey, int>(prev.ModToIdx),
+        };
         int rebuilt = 0;
         var unreadable = new List<string>();
-        var live = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        _order.Clear();
         for (int i = 0; i < names.Count; i++)
         {
-            if (excluded.Contains(i)) continue;                    // excluded from the index build; excluded here too
-            var name = names[i];
-            live.Add(name);
-            _order.Add(name);
-            var mtime = SafeMtime(paths[i]);
-            if (_byPlugin.TryGetValue(name, out var have) && have.Path == paths[i] && have.Mtime == mtime)
+            if (excluded.Contains(i))
             {
-                if (have.Unreadable is not null) unreadable.Add(name);
-                continue;                                          // this plugin's bytes are the ones it was built from
+                // Excluded from the snapshot's own index because it could not be opened or parsed. The reverse
+                // walk cannot see it either, so the answer is short by whatever it references — said out loud on
+                // every answer, not only on the call that discovered it.
+                unreadable.Add(names[i]);
+                continue;
             }
-            var built = BuildPartition(paths[i], mtime, () => open(i));
-            _byPlugin[name] = built;
+            var path = paths[i];
+            if (next.ByPath.ContainsKey(path)) continue;           // the same file twice in the order is one partition
+            next.Order.Add(path);
+            var mtime = SafeMtime(path);
+            if (prev.ByPath.TryGetValue(path, out var have) && have.Mtime == mtime)
+            {
+                next.ByPath[path] = have;                          // this plugin's bytes are the ones it was built from
+                if (have.Unreadable is not null) unreadable.Add(have.Name);
+                continue;
+            }
+            int pos = i;
+            var built = BuildPartition(path, names[i], mtime, () => open(pos), next);
+            next.ByPath[path] = built;
             rebuilt++;
-            if (built.Unreadable is not null) unreadable.Add(name);
+            if (built.Unreadable is not null) unreadable.Add(built.Name);
         }
-        foreach (var gone in _byPlugin.Keys.Where(k => !live.Contains(k)).ToList()) _byPlugin.Remove(gone);
+        next.Key = FreshnessKey(next);
+        _gen = next;                                               // one assignment: the generation a reader sees is whole
         sw.Stop();
-        return new Refreshed(_byPlugin.Count, rebuilt, sw.ElapsedMilliseconds, TargetSlotCount, PairCount,
-                             ApproxBytes, unreadable, _byPlugin.Values.Sum(p => p.Unscannable), FreshnessKey());
+        return new Refreshed(next.ByPath.Count, rebuilt, sw.ElapsedMilliseconds,
+                             next.ByPath.Values.Sum(p => p.ByTarget.Count), next.ByPath.Values.Sum(p => p.Pairs),
+                             ApproxBytes, unreadable, next.ByPath.Values.Sum(p => p.Unscannable), next.Key);
     }
 
     /// <summary>One plugin's reverse edges, staged whole and committed only if the enumeration finished.</summary>
-    Partition BuildPartition(string path, DateTime mtime, Func<ISkyrimModGetter> open)
+    Partition BuildPartition(string path, string name, DateTime mtime, Func<ISkyrimModGetter> open, Generation into)
     {
-        var part = new Partition { Path = path, Mtime = mtime };
+        var part = new Partition { Path = path, Name = name, Mtime = mtime };
         ISkyrimModGetter ov;
         try { ov = open(); }
         catch (Exception ex) { part.Unreadable = ex.GetType().Name; return part; }
@@ -162,12 +234,12 @@ public sealed class ReverseReferenceIndex
                     // exclusion the dangling sweep makes, before the walk that would throw on such a body.
                     if (DeletedRecordRule.HasNoLiveBody(rec)) continue;
                     if (rec is not IFormLinkContainerGetter flc) continue;
-                    ulong src = Pack(rec.FormKey);
+                    ulong src = Pack(into, rec.FormKey);
                     foreach (var link in flc.EnumerateFormLinks())
                     {
                         var target = link.FormKey;
                         if (target.IsNull) continue;
-                        ulong pt = Pack(target);
+                        ulong pt = Pack(into, target);
                         if (!acc.TryGetValue(pt, out var list)) acc[pt] = list = new List<ulong>(1);
                         // One record's links arrive together, so the same record linking a target twice is the
                         // tail of this list — deduped without a per-target set.
@@ -194,12 +266,12 @@ public sealed class ReverseReferenceIndex
 
     /// <summary>The index's own freshness key: a digest over every partition's (plugin, mtime). Distinct from the
     /// order-wide epoch by construction — it names which plugin BODIES the reverse edges were computed from.</summary>
-    string FreshnessKey()
+    static string FreshnessKey(Generation g)
     {
         var sb = new StringBuilder();
-        foreach (var name in _order)
-            if (_byPlugin.TryGetValue(name, out var p))
-                sb.Append(name).Append('|').Append(p.Mtime.Ticks).Append('\n');
+        foreach (var path in g.Order)
+            if (g.ByPath.TryGetValue(path, out var p))
+                sb.Append(p.Path).Append('|').Append(p.Mtime.Ticks).Append('\n');
         var hash = System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(sb.ToString()));
         return Convert.ToHexString(hash.AsSpan(0, 4)).ToLowerInvariant();
     }
@@ -209,24 +281,16 @@ public sealed class ReverseReferenceIndex
         try { return File.GetLastWriteTimeUtc(path); } catch { return DateTime.MinValue; }
     }
 
-    ulong Pack(FormKey k)
+    // Interning happens only on the generation being built, which no reader can see yet.
+    static ulong Pack(Generation g, FormKey k)
     {
-        if (!_modToIdx.TryGetValue(k.ModKey, out int i))
+        if (!g.ModToIdx.TryGetValue(k.ModKey, out int i))
         {
-            _modToIdx[k.ModKey] = i = _idxToMod.Count;
-            _idxToMod.Add(k.ModKey);
+            g.ModToIdx[k.ModKey] = i = g.IdxToMod.Count;
+            g.IdxToMod.Add(k.ModKey);
         }
         return ((ulong)(uint)i << 32) | k.ID;
     }
-
-    bool TryPack(FormKey k, out ulong packed)
-    {
-        if (!_modToIdx.TryGetValue(k.ModKey, out int i)) { packed = 0; return false; }
-        packed = ((ulong)(uint)i << 32) | k.ID;
-        return true;
-    }
-
-    FormKey Unpack(ulong packed) => new(_idxToMod[(int)(packed >> 32)], (uint)packed);
 }
 
 /// <summary>What an UNBOUNDED reverse selection scans. The index turns "who references X" from a refusal into a
@@ -234,30 +298,28 @@ public sealed class ReverseReferenceIndex
 /// means to judge and a later override that dropped the link is not counted.</summary>
 public static class ReverseSelection
 {
-    /// <summary>Which question a NEGATED, unbounded <c>references=</c> asks. Two readings are live and Aaron has
-    /// not ruled between them: <c>false</c> is what the bounded term ships today — "does not reference X", whose
-    /// unbounded universe is therefore every record in the order — and <c>true</c> is the orphan sweep, "referenced
-    /// by nothing anywhere", which the index answers directly and for which the named target is advisory. The index
-    /// carries both; this constant is the switch.</summary>
-    public const bool NegatedMeansUnreferencedByAnything = false;
-
-    /// <summary>The scan universe for an unbounded reverse selection. With targets it is every record some plugin
-    /// links to one of them; with none — the negated-only form — it is the whole order under the shipped reading,
-    /// or only the unreferenced records under the other one.</summary>
+    /// <summary>The scan universe for an unbounded reverse selection. With positive targets it is every record
+    /// some plugin links to one of them. With none — the negated-only form — it is the ORPHAN sweep: every record
+    /// nothing in the order references, which is the unbounded question SPEC §2.2's and §3.2's 2026-09-05
+    /// amendments name for this spelling. The named negated targets still apply after it, as the AND term they are
+    /// everywhere else.</summary>
     public static IReadOnlyList<FormKey> Universe(LoadOrderResolver.IndexView view, ReverseReferenceIndex index,
                                                   IReadOnlyList<FormKey>? references)
     {
         if (references is { Count: > 0 }) return index.ReferencersOf(references);
-        return NegatedMeansUnreferencedByAnything
-            ? view.RecordKeys().Where(k => !index.HasAnyReferencer(k)).ToList()
-            : view.RecordKeys().ToList();
+        var orphans = new List<FormKey>();
+        foreach (var k in view.RecordKeys())
+            if (!index.HasAnyReferencer(k)) orphans.Add(k);
+        return orphans;
     }
 
-    /// <summary>The sentence a caller gets when the unbounded reverse universe is the whole order: it is the
-    /// shipped reading's honest cost, declared rather than discovered.</summary>
-    public static string? WholeOrderNote(IReadOnlyList<FormKey>? references, int universe)
-        => references is { Count: > 0 } || NegatedMeansUnreferencedByAnything ? null
-            : $"a negated references= with no types=/plugins= scope asks which records do NOT link the target, so "
-              + $"its universe is the whole order — {universe} records, each winner body read. Add types= or "
-              + "plugins= if you meant a narrower question.";
+    /// <summary>The sentence a caller gets for the negated-only unbounded form: its universe is the orphan set, not
+    /// the whole order and not the same question a bounded negated <c>references=</c> asks. Declared, never
+    /// discovered.</summary>
+    public static string? UniverseNote(IReadOnlyList<FormKey>? references, int universe)
+        => references is { Count: > 0 } ? null
+            : $"a negated references= with no types=/plugins= scope is the ORPHAN sweep: its universe is the "
+              + $"{universe} record(s) nothing in the order references, and the named target(s) then exclude any of "
+              + "those that link them. A bounded negated references= asks the narrower question instead — records "
+              + "in that scope that do not link the target — so add types= or plugins= if that is what you meant.";
 }

--- a/src/housecarl-core/ReverseReferenceIndex.cs
+++ b/src/housecarl-core/ReverseReferenceIndex.cs
@@ -1,0 +1,263 @@
+using System.Diagnostics;
+using System.Text;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// The reverse edge, whole-order: a target FormKey → the records that carry a FormLink to it. It is what makes
+/// "who references X" answerable without a bounding <c>types=</c> / <c>plugins=</c> scope — the forward direction
+/// resolves one link, the reverse direction has to have been walked already.
+///
+/// <para><b>Lazy.</b> Nothing builds it at startup. The first call that needs it pays the whole-order link-walk —
+/// the same walk the dangling sweep already runs — and the cost is reported in that response's accounting rather
+/// than discovered.</para>
+///
+/// <para><b>Partitioned by plugin, keyed on (path, mtime).</b> This is the one place the resolver's existing
+/// freshness machinery does not fit: <c>RefreshIfStale</c> is all-or-nothing and <c>Epoch</c> is order-wide, so an
+/// index hung off the snapshot would die wholesale on every MO2 touch and pay the full walk again. The index is
+/// held BESIDE the snapshot and carried across a snapshot swap; a refresh drops and rebuilds only the partitions
+/// whose own key changed. Stale-and-silent is what the partition key makes structurally impossible.</para>
+///
+/// <para><b>Plugin-atomic.</b> A plugin whose enumeration throws part-way contributes NO partition content and is
+/// named in the report, so a half-read plugin never leaves partial reverse edges behind and a caller can say the
+/// answer is short rather than call it complete.</para>
+///
+/// <para><b>Packed.</b> Entries are ulong ((interned mod index &lt;&lt; 32) | FormID), not FormKey: 8 bytes a pair
+/// instead of 24. Pure derived data — no bodies, no file handles at rest.</para>
+///
+/// <para><b>What it is not.</b> Not the position-seek index (a different question), and not reverse over the
+/// runtime layers (SkyPatcher, SPID): plugin FormLinks only, like the sweep it rides.</para></summary>
+public sealed class ReverseReferenceIndex
+{
+    sealed class Partition
+    {
+        public string Path = "";
+        public DateTime Mtime;
+        public Dictionary<ulong, ulong[]> ByTarget = new();
+        public long Pairs;
+        public int Unscannable;                        // records whose own link walk threw — excluded and counted
+        public string? Unreadable;                     // set ⇒ this plugin contributed nothing, and why
+    }
+
+    readonly Dictionary<string, Partition> _byPlugin = new(StringComparer.OrdinalIgnoreCase);
+    readonly List<string> _order = new();              // plugin names in priority order — what makes a candidate list deterministic
+    readonly Dictionary<ModKey, int> _modToIdx = new();
+    readonly List<ModKey> _idxToMod = new();
+
+    /// <summary>Plugins with a partition in this index.</summary>
+    public int PartitionCount => _byPlugin.Count;
+
+    /// <summary>Distinct (target, plugin) slots — one per target a plugin links at all.</summary>
+    public int TargetSlotCount => _byPlugin.Values.Sum(p => p.ByTarget.Count);
+
+    /// <summary>Distinct (target, referencing record) pairs held.</summary>
+    public long PairCount => _byPlugin.Values.Sum(p => p.Pairs);
+
+    /// <summary>What the index holds, to the nearest useful order of magnitude: eight bytes a pair plus the
+    /// per-target slot overhead of the dictionaries. Reported, not enforced — there is no ceiling knob.</summary>
+    public long ApproxBytes => PairCount * 8 + (long)TargetSlotCount * 40;
+
+    /// <summary>Does anything in the order link to this record? The whole of the orphan question.</summary>
+    public bool HasAnyReferencer(FormKey target)
+    {
+        if (!TryPack(target, out var pt)) return false;
+        foreach (var name in _order)
+            if (_byPlugin.TryGetValue(name, out var p) && p.ByTarget.ContainsKey(pt)) return true;
+        return false;
+    }
+
+    /// <summary>Every record that links to ANY of these targets, deduped, in load order then plugin-enumeration
+    /// order — deterministic for an unchanged order, which is what lets a caller's offset/limit windows tile. The
+    /// answer is a CANDIDATE set: the index says some plugin's copy of the record carries the link, and the caller
+    /// still decides on the body it means to judge (a later override may have dropped it).</summary>
+    public IReadOnlyList<FormKey> ReferencersOf(IReadOnlyList<FormKey> targets)
+    {
+        var packed = new List<ulong>(targets.Count);
+        foreach (var t in targets) if (TryPack(t, out var pt)) packed.Add(pt);
+        var seen = new HashSet<ulong>();
+        var outp = new List<FormKey>();
+        foreach (var name in _order)
+        {
+            if (!_byPlugin.TryGetValue(name, out var p)) continue;
+            foreach (var pt in packed)
+                if (p.ByTarget.TryGetValue(pt, out var arr))
+                    foreach (var r in arr)
+                        if (seen.Add(r)) outp.Add(Unpack(r));
+        }
+        return outp;
+    }
+
+    /// <summary>What one refresh did, for the response's in-band accounting: the build cost when this call is the
+    /// one that paid it, the per-plugin freshness key, and every plugin the walk could not read.</summary>
+    public sealed record Refreshed(int Partitions, int Rebuilt, long ElapsedMs, int TargetSlots, long Pairs,
+                                   long ApproxBytes, IReadOnlyList<string> Unreadable, int UnscannableRecords,
+                                   string Key)
+    {
+        /// <summary>The one accounting line, or null when this call changed nothing and so paid nothing.</summary>
+        public string? Note => Rebuilt == 0 ? null
+            : $"reverse-reference index: built {Rebuilt} plugin partition(s) in {ElapsedMs} ms "
+              + $"({Pairs} target→referencer pairs over {TargetSlots} target slots, ~{ApproxBytes / (1024 * 1024)} MB held), "
+              + $"key={Key} (per plugin, path+mtime — beside the order-wide epoch, not riding it)."
+              + (Unreadable.Count > 0
+                     ? $" {Unreadable.Count} plugin(s) contributed nothing because the walk could not read them: {string.Join(", ", Unreadable)} — the answer is short by whatever they reference."
+                     : "")
+              + (UnscannableRecords > 0
+                     ? $" {UnscannableRecords} record(s) Mutagen could not parse were excluded from the walk."
+                     : "");
+    }
+
+    /// <summary>Bring every partition up to date against the files on disk: keep the ones whose (path, mtime) is
+    /// unchanged, rebuild the ones whose is not, drop the ones whose plugin left the order. The opener is the
+    /// resolver's, so one plugin is open at a time and none is held at rest.</summary>
+    internal Refreshed Refresh(IReadOnlyList<string> names, IReadOnlyList<string> paths,
+                               Func<int, ISkyrimModGetter> open, ICollection<int> excluded)
+    {
+        var sw = Stopwatch.StartNew();
+        int rebuilt = 0;
+        var unreadable = new List<string>();
+        var live = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        _order.Clear();
+        for (int i = 0; i < names.Count; i++)
+        {
+            if (excluded.Contains(i)) continue;                    // excluded from the index build; excluded here too
+            var name = names[i];
+            live.Add(name);
+            _order.Add(name);
+            var mtime = SafeMtime(paths[i]);
+            if (_byPlugin.TryGetValue(name, out var have) && have.Path == paths[i] && have.Mtime == mtime)
+            {
+                if (have.Unreadable is not null) unreadable.Add(name);
+                continue;                                          // this plugin's bytes are the ones it was built from
+            }
+            var built = BuildPartition(paths[i], mtime, () => open(i));
+            _byPlugin[name] = built;
+            rebuilt++;
+            if (built.Unreadable is not null) unreadable.Add(name);
+        }
+        foreach (var gone in _byPlugin.Keys.Where(k => !live.Contains(k)).ToList()) _byPlugin.Remove(gone);
+        sw.Stop();
+        return new Refreshed(_byPlugin.Count, rebuilt, sw.ElapsedMilliseconds, TargetSlotCount, PairCount,
+                             ApproxBytes, unreadable, _byPlugin.Values.Sum(p => p.Unscannable), FreshnessKey());
+    }
+
+    /// <summary>One plugin's reverse edges, staged whole and committed only if the enumeration finished.</summary>
+    Partition BuildPartition(string path, DateTime mtime, Func<ISkyrimModGetter> open)
+    {
+        var part = new Partition { Path = path, Mtime = mtime };
+        ISkyrimModGetter ov;
+        try { ov = open(); }
+        catch (Exception ex) { part.Unreadable = ex.GetType().Name; return part; }
+        var acc = new Dictionary<ulong, List<ulong>>();
+        int unscannable = 0;
+        try
+        {
+            foreach (var rec in ov.EnumerateMajorRecords())
+            {
+                try
+                {
+                    // A deleted record's content is not live, so none of its links is a real reference — the same
+                    // exclusion the dangling sweep makes, before the walk that would throw on such a body.
+                    if (DeletedRecordRule.HasNoLiveBody(rec)) continue;
+                    if (rec is not IFormLinkContainerGetter flc) continue;
+                    ulong src = Pack(rec.FormKey);
+                    foreach (var link in flc.EnumerateFormLinks())
+                    {
+                        var target = link.FormKey;
+                        if (target.IsNull) continue;
+                        ulong pt = Pack(target);
+                        if (!acc.TryGetValue(pt, out var list)) acc[pt] = list = new List<ulong>(1);
+                        // One record's links arrive together, so the same record linking a target twice is the
+                        // tail of this list — deduped without a per-target set.
+                        if (list.Count == 0 || list[^1] != src) list.Add(src);
+                    }
+                }
+                catch { unscannable++; }
+            }
+        }
+        catch (Exception ex)
+        {
+            // Non-resumable: the enumeration itself died, so what was staged is a fragment. Drop it and say so.
+            part.Unreadable = ex.GetType().Name;
+            return part;
+        }
+        finally { (ov as IDisposable)?.Dispose(); }
+        part.Unscannable = unscannable;
+        part.ByTarget = new Dictionary<ulong, ulong[]>(acc.Count);
+        long pairs = 0;
+        foreach (var (k, v) in acc) { part.ByTarget[k] = v.ToArray(); pairs += v.Count; }
+        part.Pairs = pairs;
+        return part;
+    }
+
+    /// <summary>The index's own freshness key: a digest over every partition's (plugin, mtime). Distinct from the
+    /// order-wide epoch by construction — it names which plugin BODIES the reverse edges were computed from.</summary>
+    string FreshnessKey()
+    {
+        var sb = new StringBuilder();
+        foreach (var name in _order)
+            if (_byPlugin.TryGetValue(name, out var p))
+                sb.Append(name).Append('|').Append(p.Mtime.Ticks).Append('\n');
+        var hash = System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(sb.ToString()));
+        return Convert.ToHexString(hash.AsSpan(0, 4)).ToLowerInvariant();
+    }
+
+    static DateTime SafeMtime(string path)
+    {
+        try { return File.GetLastWriteTimeUtc(path); } catch { return DateTime.MinValue; }
+    }
+
+    ulong Pack(FormKey k)
+    {
+        if (!_modToIdx.TryGetValue(k.ModKey, out int i))
+        {
+            _modToIdx[k.ModKey] = i = _idxToMod.Count;
+            _idxToMod.Add(k.ModKey);
+        }
+        return ((ulong)(uint)i << 32) | k.ID;
+    }
+
+    bool TryPack(FormKey k, out ulong packed)
+    {
+        if (!_modToIdx.TryGetValue(k.ModKey, out int i)) { packed = 0; return false; }
+        packed = ((ulong)(uint)i << 32) | k.ID;
+        return true;
+    }
+
+    FormKey Unpack(ulong packed) => new(_idxToMod[(int)(packed >> 32)], (uint)packed);
+}
+
+/// <summary>What an UNBOUNDED reverse selection scans. The index turns "who references X" from a refusal into a
+/// candidate set; the scan that follows is the existing one, so the verdict still comes from the body the caller
+/// means to judge and a later override that dropped the link is not counted.</summary>
+public static class ReverseSelection
+{
+    /// <summary>Which question a NEGATED, unbounded <c>references=</c> asks. Two readings are live and Aaron has
+    /// not ruled between them: <c>false</c> is what the bounded term ships today — "does not reference X", whose
+    /// unbounded universe is therefore every record in the order — and <c>true</c> is the orphan sweep, "referenced
+    /// by nothing anywhere", which the index answers directly and for which the named target is advisory. The index
+    /// carries both; this constant is the switch.</summary>
+    public const bool NegatedMeansUnreferencedByAnything = false;
+
+    /// <summary>The scan universe for an unbounded reverse selection. With targets it is every record some plugin
+    /// links to one of them; with none — the negated-only form — it is the whole order under the shipped reading,
+    /// or only the unreferenced records under the other one.</summary>
+    public static IReadOnlyList<FormKey> Universe(LoadOrderResolver.IndexView view, ReverseReferenceIndex index,
+                                                  IReadOnlyList<FormKey>? references)
+    {
+        if (references is { Count: > 0 }) return index.ReferencersOf(references);
+        return NegatedMeansUnreferencedByAnything
+            ? view.RecordKeys().Where(k => !index.HasAnyReferencer(k)).ToList()
+            : view.RecordKeys().ToList();
+    }
+
+    /// <summary>The sentence a caller gets when the unbounded reverse universe is the whole order: it is the
+    /// shipped reading's honest cost, declared rather than discovered.</summary>
+    public static string? WholeOrderNote(IReadOnlyList<FormKey>? references, int universe)
+        => references is { Count: > 0 } || NegatedMeansUnreferencedByAnything ? null
+            : $"a negated references= with no types=/plugins= scope asks which records do NOT link the target, so "
+              + $"its universe is the whole order — {universe} records, each winner body read. Add types= or "
+              + "plugins= if you meant a narrower question.";
+}

--- a/src/housecarl-core/ReverseReferenceIndex.cs
+++ b/src/housecarl-core/ReverseReferenceIndex.cs
@@ -62,13 +62,17 @@ public sealed class ReverseReferenceIndex
         public List<ModKey> IdxToMod = new();
         public string Key = "";
 
-        Lazy<HashSet<ulong>>? _referenced;
+        // Built in the constructor, not on first ask: a `??=` on a shared field is a check-then-assign, so two
+        // concurrent sweeps could each construct one and each hold a ~1.6M-entry set at once.
+        readonly Lazy<HashSet<ulong>> _referenced;
+
+        public Generation() =>
+            _referenced = new Lazy<HashSet<ulong>>(BuildReferenced, LazyThreadSafetyMode.ExecutionAndPublication);
 
         /// <summary>Every target something in the order links, as one set — the orphan question answered in a
         /// lookup rather than a scan over every partition. Built on first ask and thrown away with the
         /// generation.</summary>
-        public HashSet<ulong> Referenced =>
-            (_referenced ??= new Lazy<HashSet<ulong>>(BuildReferenced, LazyThreadSafetyMode.ExecutionAndPublication)).Value;
+        public HashSet<ulong> Referenced => _referenced.Value;
 
         HashSet<ulong> BuildReferenced()
         {
@@ -111,6 +115,21 @@ public sealed class ReverseReferenceIndex
         return g.TryPack(target, out var pt) && g.Referenced.Contains(pt);
     }
 
+    /// <summary>Which of these records nothing in the order links — the orphan sweep. The generation is taken ONCE
+    /// for the whole pass: asked key by key, a refresh landing mid-sweep would judge the early keys against the old
+    /// edges and the late ones against the new, and the freshness key the response cites would name neither
+    /// answer. It also keeps the memoised referenced-set for the whole run instead of rebuilding it at the
+    /// crossing.</summary>
+    public IReadOnlyList<FormKey> Orphans(IEnumerable<FormKey> candidates)
+    {
+        var g = _gen;
+        var referenced = g.Referenced;
+        var outp = new List<FormKey>();
+        foreach (var k in candidates)
+            if (!g.TryPack(k, out var pt) || !referenced.Contains(pt)) outp.Add(k);
+        return outp;
+    }
+
     /// <summary>Every record that links to ANY of these targets, deduped, in load order then plugin-enumeration
     /// order — deterministic for an unchanged order, which is what lets a caller's offset/limit windows tile. The
     /// answer is a CANDIDATE set: the index says some plugin's copy of the record carries the link, and the caller
@@ -139,26 +158,33 @@ public sealed class ReverseReferenceIndex
                                    long ApproxBytes, IReadOnlyList<string> Unreadable, int UnscannableRecords,
                                    string Key)
     {
-        /// <summary>The one accounting line. The BUILD clause is only true of the call that paid it; the freshness
-        /// key and the coverage disclosures are true of every answer the index serves, so they are unconditional —
-        /// a cached call that dropped them would read as complete when it is short.</summary>
-        public string Note
+        /// <summary>The one accounting line, for the question that asks who references a target. The BUILD clause
+        /// is only true of the call that paid it; the freshness key and the coverage disclosures are true of every
+        /// answer the index serves, so they are unconditional — a cached call that dropped them would read as
+        /// complete when it is short.</summary>
+        public string Note => NoteFor(orphanSweep: false);
+
+        /// <summary>The same line, told for the lane that asked. A missing plugin's edges cut BOTH ways and the
+        /// two readings are opposites: the positive question loses referencers, so its answer is short; the orphan
+        /// sweep loses the very edges that would disqualify an orphan, so its answer is over-inclusive — a record
+        /// only the unreadable plugin links is listed as referenced by nothing. Saying "short" there would tell a
+        /// caller the confirmed orphans are confirmed.</summary>
+        public string NoteFor(bool orphanSweep)
         {
-            get
-            {
-                var sb = new StringBuilder("reverse-reference index: ");
-                sb.Append(Rebuilt > 0 ? $"built {Rebuilt} plugin partition(s) in {ElapsedMs} ms"
-                                      : $"unchanged, {Partitions} plugin partition(s) held");
-                sb.Append($" ({Pairs} target→referencer pairs over {TargetSlots} target slots, ~{ApproxBytes / (1024 * 1024)} MB held), ");
-                sb.Append($"key={Key} (per plugin, path+mtime — beside the order-wide epoch, not riding it).");
-                if (Unreadable.Count > 0)
-                    sb.Append($" {Unreadable.Count} plugin(s) contributed nothing because the walk could not read them: ")
-                      .Append(string.Join(", ", Unreadable))
-                      .Append(" — the answer is short by whatever they reference.");
-                if (UnscannableRecords > 0)
-                    sb.Append($" {UnscannableRecords} record(s) Mutagen could not parse were excluded from the walk.");
-                return sb.ToString();
-            }
+            var sb = new StringBuilder("reverse-reference index: ");
+            sb.Append(Rebuilt > 0 ? $"built {Rebuilt} plugin partition(s) in {ElapsedMs} ms"
+                                  : $"unchanged, {Partitions} plugin partition(s) held");
+            sb.Append($" ({Pairs} target→referencer pairs over {TargetSlots} target slots, ~{ApproxBytes / (1024 * 1024)} MB held), ");
+            sb.Append($"key={Key} (per plugin, path+mtime — beside the order-wide epoch, not riding it).");
+            if (Unreadable.Count > 0)
+                sb.Append($" {Unreadable.Count} plugin(s) contributed nothing because the walk could not read them: ")
+                  .Append(string.Join(", ", Unreadable))
+                  .Append(orphanSweep
+                      ? " — the sweep is OVER-inclusive by whatever they reference: a record only they link is listed here as an orphan."
+                      : " — the answer is short by whatever they reference.");
+            if (UnscannableRecords > 0)
+                sb.Append($" {UnscannableRecords} record(s) Mutagen could not parse were excluded from the walk.");
+            return sb.ToString();
         }
     }
 
@@ -307,10 +333,7 @@ public static class ReverseSelection
                                                   IReadOnlyList<FormKey>? references)
     {
         if (references is { Count: > 0 }) return index.ReferencersOf(references);
-        var orphans = new List<FormKey>();
-        foreach (var k in view.RecordKeys())
-            if (!index.HasAnyReferencer(k)) orphans.Add(k);
-        return orphans;
+        return index.Orphans(view.RecordKeys());
     }
 
     /// <summary>The sentence a caller gets for the negated-only unbounded form: its universe is the orphan set, not

--- a/src/housecarl-mcp-tests/RecordsReferenceExclusionTests.cs
+++ b/src/housecarl-mcp-tests/RecordsReferenceExclusionTests.cs
@@ -56,8 +56,12 @@ public sealed class RecordsReferenceExclusionTests : RecordsTestBase
     }
 
     [Fact]
-    public void ANegatedReferenceStillNeedsABoundingScope() =>
-        Refused(RecordsTools.Records(Svc, references: new[] { "!" + Fid(W.MgefA) }), "types=");
+    public void ABoundedNegatedReferenceIsStillTheCheaperCall()
+    {
+        var r = RecordsTools.Records(Svc, types: new[] { "SPEL" }, references: new[] { "!" + Fid(W.MgefA) });
+        Served(r, "HcRecSpellB");
+        Assert.DoesNotContain("reverse-reference index", r);   // a bounded scan never builds it
+    }
 
     [Fact]
     public void ABareBangNamesNoTargetAndIsRefused() =>

--- a/src/housecarl-mcp-tests/RecordsRetiredNameRemedyTests.cs
+++ b/src/housecarl-mcp-tests/RecordsRetiredNameRemedyTests.cs
@@ -145,16 +145,15 @@ public sealed class RecordsRetiredNameRemedyTests : IDisposable
         Assert.False(r.StartsWith("error:", StringComparison.Ordinal), "refused: " + r.Split('\n')[0]);
     }
 
-    /// <summary>Why the sentence says "with types= or plugins=" rather than just naming <c>references=</c>:
-    /// unbounded, the same call is refused. Without this the clause could be dropped and nothing would
-    /// notice.</summary>
+    /// <summary>The other half of the same sentence: unbounded, the call is served off the reverse-reference
+    /// index and says what that build cost.</summary>
     [Fact]
-    public void TheSameRemedyUnbounded_IsRefused_SoTheBoundingClauseIsLoadBearing()
+    public void TheSameRemedyUnbounded_IsServedOffTheIndex()
     {
         var r = RecordsTools.Records(_w.Svc, references: new[] { Weapon });
 
-        Assert.StartsWith("error:", r);
-        Assert.Contains("must be combined with", r);
+        Assert.False(r.StartsWith("error:", StringComparison.Ordinal), "refused: " + r.Split('\n')[0]);
+        Assert.Contains("reverse-reference index", r);
     }
 
     /// <summary>The unscannable-record note sends the caller to <c>records formids=[the FormID]</c>. Made, and

--- a/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
+++ b/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
@@ -1,0 +1,121 @@
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>The unbounded reverse question — <c>references=</c> with no <c>types=</c>/<c>plugins=</c> scope —
+/// answered off the reverse-reference index, driven through the tool.</summary>
+[Collection("records")]
+[Trait("tier", "integration")]
+public sealed class RecordsReverseIndexTests : RecordsTestBase
+{
+    public RecordsReverseIndexTests(RecordsFixture f) : base(f) { }
+
+    [Fact]
+    public void AnUnboundedReferencesFindsEveryReferencerWithNoScope()
+    {
+        var r = RecordsTools.Records(Svc, references: new[] { Fid(W.MgefA) });
+        Served(r, "HcRecSpellA", "HcRecSpellC");
+        Assert.DoesNotContain("HcRecSpellB", r);
+    }
+
+    [Fact]
+    public void AnUnboundedReferencesOverTwoTargetsUnionsThem()
+    {
+        var r = RecordsTools.Records(Svc, references: new[] { Fid(W.MgefA), Fid(W.MgefB) });
+        Served(r, "HcRecSpellA", "HcRecSpellB", "HcRecSpellC");
+    }
+
+    [Fact]
+    public void AnUnboundedReferencesOnATargetNothingLinksMatchesNothing()
+    {
+        var r = RecordsTools.Records(Svc, references: new[] { Fid(W.SpellB) });
+        Assert.False(r.StartsWith("error:", StringComparison.Ordinal), r);
+        Assert.DoesNotContain("HcRecSpell", r);
+    }
+
+    [Fact]
+    public void AnUnboundedNegatedReferencesKeepsTheRecordsThatDoNotLinkTheTarget()
+    {
+        var r = RecordsTools.Records(Svc, references: new[] { "!" + Fid(W.MgefA) });
+        Served(r, "HcRecSpellB");
+        Assert.DoesNotContain("HcRecSpellA", r);
+        Assert.DoesNotContain("HcRecSpellC", r);
+    }
+
+    [Fact]
+    public void AnUnboundedWhereIsStillRefusedNamingTheBound() =>
+        Refused(RecordsTools.Records(Svc, where: new[] { "EditorID = HcRecSpellA" }), "where=");
+
+    [Fact]
+    public void AnUnboundedReferencesWithAWhereIsStillRefused() =>
+        Refused(RecordsTools.Records(Svc, references: new[] { Fid(W.MgefA) },
+                                     where: new[] { "EditorID = HcRecSpellA" }), "types=");
+}
+
+/// <summary>The index's own lifecycle: what a build costs, that a second call pays nothing, and that a plugin
+/// whose bytes changed rebuilds only its own slice. Each test owns its world, because the accounting these assert
+/// on is "what THIS call did" and a shared world would have been indexed by whichever test ran first.</summary>
+[Trait("tier", "integration")]
+public sealed class ReverseIndexLifecycleTests
+{
+    [Fact]
+    public void TheFirstUnboundedCallReportsTheBuildAndItsPerPluginFreshnessKey()
+    {
+        using var w = new RecordsWorld();
+        var r = RecordsTools.Records(w.Svc, references: new[] { RecordsWorld.Fid(w.MgefA) });
+        Assert.Contains("reverse-reference index", r);
+        Assert.Contains("key=", r);
+        Assert.Contains("partition", r);
+    }
+
+    [Fact]
+    public void ANegatedUnboundedReferencesDeclaresThatItsUniverseIsTheWholeOrder()
+    {
+        using var w = new RecordsWorld();
+        var r = RecordsTools.Records(w.Svc, references: new[] { "!" + RecordsWorld.Fid(w.MgefA) });
+        Assert.Contains("whole order", r);
+    }
+
+    [Fact]
+    public void TheIndexIsBuiltOnceAndASecondCallRebuildsNothing()
+    {
+        using var w = new RecordsWorld();
+        var first = w.Svc.CaptureView().EnsureReverseIndex();
+        Assert.True(first.Rebuilt > 0);
+        Assert.True(first.Partitions > 1, "the world must hold more than one plugin for the partition claim to mean anything");
+        var second = w.Svc.CaptureView().EnsureReverseIndex();
+        Assert.Equal(0, second.Rebuilt);
+        Assert.Equal(first.Partitions, second.Partitions);
+        Assert.Equal(first.Key, second.Key);
+    }
+
+    [Fact]
+    public void AChangedPluginRebuildsOnlyItsOwnPartition()
+    {
+        using var w = new RecordsWorld();
+        var first = w.Svc.CaptureView().EnsureReverseIndex();
+        File.SetLastWriteTimeUtc(w.OverrideFile, DateTime.UtcNow.AddHours(1));
+        var after = w.Svc.CaptureView().EnsureReverseIndex();   // the capture rebuilds the SNAPSHOT; the index must not follow it wholesale
+        Assert.Equal(1, after.Rebuilt);
+        Assert.Equal(first.Partitions, after.Partitions);
+        Assert.NotEqual(first.Key, after.Key);
+    }
+
+    [Fact]
+    public void TheIndexSurvivesASnapshotSwapAndStillAnswers()
+    {
+        using var w = new RecordsWorld();
+        var before = RecordsTools.Records(w.Svc, references: new[] { RecordsWorld.Fid(w.MgefA) });
+        Served(before, "HcRecSpellA");
+        File.SetLastWriteTimeUtc(w.OverrideFile, DateTime.UtcNow.AddHours(1));
+        var after = RecordsTools.Records(w.Svc, references: new[] { RecordsWorld.Fid(w.MgefA) });
+        Served(after, "HcRecSpellA", "HcRecSpellC");
+    }
+
+    static void Served(string response, params string[] mustName)
+    {
+        Assert.False(response.StartsWith("error:", StringComparison.Ordinal), response);
+        foreach (var s in mustName) Assert.Contains(s, response);
+    }
+}

--- a/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
+++ b/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
@@ -1,3 +1,4 @@
+using HousecarlCore;
 using HousecarlMcp;
 using Xunit;
 
@@ -43,6 +44,57 @@ public sealed class RecordsReverseIndexTests : RecordsTestBase
         Assert.DoesNotContain("HcRecSpellC", r);
     }
 
+    /// <summary>SPEC §2.2's and §3.2's 2026-09-05 amendments read the unbounded negated spelling as the orphan
+    /// sweep, so a record something DOES reference is outside the universe however the target reads.</summary>
+    [Fact]
+    public void AnUnboundedNegatedReferencesIsTheOrphanSweep()
+    {
+        var r = RecordsTools.Records(Svc, references: new[] { "!" + Fid(W.SpellB) }, limit: 500);
+        Assert.False(r.StartsWith("error:", StringComparison.Ordinal), r);
+        Assert.Contains("ORPHAN sweep", r);
+        Assert.Contains("HcRecSpellA", r);            // nothing links a spell — an orphan
+        Assert.DoesNotContain("HcRecMgefFire", r);    // two spells link it — not an orphan
+        Assert.DoesNotContain("HcRecNpcParent", r);   // the child's Template links it — not an orphan
+    }
+
+    /// <summary>The orphan sweep's universe is millions of records on a real order, and the comparison forms
+    /// consume every match uncapped — so the pair is refused with the bound named.</summary>
+    [Fact]
+    public void TheOrphanSweepIsRefusedUnderAComparisonForm() =>
+        Refused(RecordsTools.Records(Svc, references: new[] { "!" + Fid(W.MgefA) }, project: Form("tree")),
+                "orphan sweep");
+
+    /// <summary>A positive unbounded references= is NOT the sweep — its universe is what links the target — so the
+    /// same forms compose with it.</summary>
+    [Fact]
+    public void APositiveUnboundedReferencesStillComposesWithAComparisonForm()
+    {
+        var r = RecordsTools.Records(Svc, references: new[] { Fid(W.MgefA) }, project: Form("tree"));
+        Assert.False(r.StartsWith("error:", StringComparison.Ordinal), r);
+    }
+
+    /// <summary>Every form that consumes the scan as a SELECTION renders the index's accounting — otherwise a
+    /// 24-second build and a coverage gap go unmentioned because the response came from another pipeline.</summary>
+    [Theory]
+    [InlineData("everything")]
+    [InlineData("tree")]
+    public void TheIndexAccountingRidesTheDerivedForms(string form)
+    {
+        var r = RecordsTools.Records(Svc, references: new[] { Fid(W.MgefA) }, project: Form(form));
+        Assert.False(r.StartsWith("error:", StringComparison.Ordinal), r);
+        Assert.Contains("reverse-reference index", r);
+        Assert.Contains("key=", r);
+    }
+
+    [Fact]
+    public void TheIndexAccountingRidesTheJsonLane()
+    {
+        var r = RecordsTools.Records(Svc, references: new[] { Fid(W.MgefA) }, format: "json");
+        Assert.Contains("\"notes\"", r);
+        Assert.Contains("reverse-reference index", r);
+        Assert.Contains("key=", r);
+    }
+
     [Fact]
     public void AnUnboundedWhereIsStillRefusedNamingTheBound() =>
         Refused(RecordsTools.Records(Svc, where: new[] { "EditorID = HcRecSpellA" }), "where=");
@@ -53,9 +105,10 @@ public sealed class RecordsReverseIndexTests : RecordsTestBase
                                      where: new[] { "EditorID = HcRecSpellA" }), "types=");
 }
 
-/// <summary>The index's own lifecycle: what a build costs, that a second call pays nothing, and that a plugin
-/// whose bytes changed rebuilds only its own slice. Each test owns its world, because the accounting these assert
-/// on is "what THIS call did" and a shared world would have been indexed by whichever test ran first.</summary>
+/// <summary>The index's own lifecycle: what a build costs, that a second call pays nothing, that a plugin whose
+/// bytes changed rebuilds only its own slice, and that neither a snapshot swap nor a RESOLVER swap drops it. Each
+/// test owns its world, because the accounting these assert on is "what THIS call did" and a shared world would
+/// have been indexed by whichever test ran first.</summary>
 [Trait("tier", "integration")]
 public sealed class ReverseIndexLifecycleTests
 {
@@ -69,12 +122,26 @@ public sealed class ReverseIndexLifecycleTests
         Assert.Contains("partition", r);
     }
 
+    /// <summary>The build clause is only true of the call that paid it; the freshness key is true of every answer
+    /// the index serves. A cached call that dropped the key would read as unindexed.</summary>
     [Fact]
-    public void ANegatedUnboundedReferencesDeclaresThatItsUniverseIsTheWholeOrder()
+    public void ACachedCallStillCarriesTheFreshnessKey()
+    {
+        using var w = new RecordsWorld();
+        RecordsTools.Records(w.Svc, references: new[] { RecordsWorld.Fid(w.MgefA) });
+        var second = RecordsTools.Records(w.Svc, references: new[] { RecordsWorld.Fid(w.MgefA) });
+        Assert.Contains("reverse-reference index: unchanged", second);
+        Assert.Contains("key=", second);
+        Assert.DoesNotContain("built ", second);
+    }
+
+    [Fact]
+    public void ANegatedUnboundedReferencesDeclaresThatItIsTheOrphanSweep()
     {
         using var w = new RecordsWorld();
         var r = RecordsTools.Records(w.Svc, references: new[] { "!" + RecordsWorld.Fid(w.MgefA) });
-        Assert.Contains("whole order", r);
+        Assert.Contains("ORPHAN sweep", r);
+        Assert.Contains("nothing in the order references", r);
     }
 
     [Fact]
@@ -102,20 +169,156 @@ public sealed class ReverseIndexLifecycleTests
         Assert.NotEqual(first.Key, after.Key);
     }
 
+    /// <summary>A target FormKey is master-qualified and independent of the partition that carries the link, so a
+    /// touched MASTER invalidates its own partition and nothing else — and the answers other partitions hold about
+    /// its records still stand.</summary>
     [Fact]
-    public void TheIndexSurvivesASnapshotSwapAndStillAnswers()
+    public void AMasterMtimeChangeRebuildsOnlyTheMasterAndKeepsEveryAnswerAboutIt()
     {
         using var w = new RecordsWorld();
         var before = RecordsTools.Records(w.Svc, references: new[] { RecordsWorld.Fid(w.MgefA) });
-        Served(before, "HcRecSpellA");
-        File.SetLastWriteTimeUtc(w.OverrideFile, DateTime.UtcNow.AddHours(1));
-        var after = RecordsTools.Records(w.Svc, references: new[] { RecordsWorld.Fid(w.MgefA) });
-        Served(after, "HcRecSpellA", "HcRecSpellC");
+        Assert.Contains("HcRecSpellA", before);
+        File.SetLastWriteTimeUtc(Path.Combine(w.ModsDir, "MasterMod", w.MasterName), DateTime.UtcNow.AddHours(1));
+        var after = w.Svc.CaptureView().EnsureReverseIndex();
+        Assert.Equal(1, after.Rebuilt);
+        Assert.Contains("HcRecSpellA", RecordsTools.Records(w.Svc, references: new[] { RecordsWorld.Fid(w.MgefA) }));
     }
 
-    static void Served(string response, params string[] mustName)
+    /// <summary>The (path, mtime) key cannot see an edit that preserves the timestamp. That is the disclosed
+    /// limit of the key, pinned here so the day the key changes shape something notices.</summary>
+    [Fact]
+    public void AnEditThatPreservesTheMtimeIsNotSeen()
     {
-        Assert.False(response.StartsWith("error:", StringComparison.Ordinal), response);
-        foreach (var s in mustName) Assert.Contains(s, response);
+        using var w = new RecordsWorld();
+        var first = w.Svc.CaptureView().EnsureReverseIndex();
+        var stamp = File.GetLastWriteTimeUtc(w.OverrideFile);
+        var bytes = File.ReadAllBytes(w.OverrideFile);
+        File.WriteAllBytes(w.OverrideFile, bytes);
+        File.SetLastWriteTimeUtc(w.OverrideFile, stamp);
+        var after = w.Svc.CaptureView().EnsureReverseIndex();
+        Assert.Equal(0, after.Rebuilt);
+        Assert.Equal(first.Key, after.Key);
+    }
+
+    /// <summary>Ticking a plugin in MO2 replaces the RESOLVER, not just the snapshot. The index carries across, so
+    /// the plugins whose files did not move are not re-walked — the whole point of the partition key.</summary>
+    [Fact]
+    public void ARemovedPluginDropsItsPartitionAndRebuildsNothingElse()
+    {
+        using var w = new RecordsWorld();
+        var first = w.Svc.CaptureView().EnsureReverseIndex();
+        Untick(w, w.MidName);
+        var after = w.Svc.CaptureView().EnsureReverseIndex();
+        Assert.Equal(first.Partitions - 1, after.Partitions);
+        Assert.Equal(0, after.Rebuilt);
+        Assert.Contains("HcRecSpellA", RecordsTools.Records(w.Svc, references: new[] { RecordsWorld.Fid(w.MgefA) }));
+    }
+
+    [Fact]
+    public void AReorderedOrderRebuildsNothingAndStillAnswers()
+    {
+        using var w = new RecordsWorld();
+        var first = w.Svc.CaptureView().EnsureReverseIndex();
+        Order(w, w.MasterName, w.OverrideName, w.MidName);
+        var after = w.Svc.CaptureView().EnsureReverseIndex();
+        Assert.Equal(first.Partitions, after.Partitions);
+        Assert.Equal(0, after.Rebuilt);
+        Assert.Contains("HcRecSpellC", RecordsTools.Records(w.Svc, references: new[] { RecordsWorld.Fid(w.MgefA) }));
+    }
+
+    /// <summary>A plugin the walk cannot read contributes nothing, and the answer is short by whatever it
+    /// references — said on EVERY answer, including the cached ones.</summary>
+    [Fact]
+    public void AnUnreadablePluginIsNamedOnEveryAnswer()
+    {
+        using var w = new RecordsWorld();
+        RecordsTools.Records(w.Svc, references: new[] { RecordsWorld.Fid(w.MgefA) });
+        File.WriteAllBytes(Path.Combine(w.ModsDir, "MidMod", w.MidName), new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
+        var first = RecordsTools.Records(w.Svc, references: new[] { RecordsWorld.Fid(w.MgefA) });
+        Assert.Contains("the answer is short", first);
+        Assert.Contains(w.MidName, first);
+        var second = RecordsTools.Records(w.Svc, references: new[] { RecordsWorld.Fid(w.MgefA) });
+        Assert.Contains("the answer is short", second);
+    }
+
+    /// <summary>Two entries in the order can share a plugin FILENAME, so partitions are keyed on the PATH: a name
+    /// key would overwrite one copy's edges and re-walk both plugins on every single call.</summary>
+    [Fact]
+    public void TwoCopiesOfOneFilenameEachKeepTheirOwnPartition()
+    {
+        using var w = new RecordsWorld();
+        var copyDir = Path.Combine(w.ModsDir, "OldModCopy");
+        Directory.CreateDirectory(copyDir);
+        var copy = Path.Combine(copyDir, w.OldName);
+        File.Copy(w.OldFile, copy);
+
+        using var resolver = LoadOrderResolver.Build(new[]
+        {
+            Path.Combine(w.ModsDir, "MasterMod", w.MasterName), w.OldFile, copy,
+        });
+        var first = resolver.Capture().EnsureReverseIndex();
+        Assert.Equal(3, first.Partitions);
+        Assert.Equal(3, first.Rebuilt);
+        var second = resolver.Capture().EnsureReverseIndex();
+        Assert.Equal(0, second.Rebuilt);            // a filename key would rebuild the duplicate pair forever
+        Assert.Equal(first.Key, second.Key);
+    }
+
+    /// <summary>Reads take no build lock, so a refresh must publish a whole generation rather than mutate the one
+    /// being read: a torn read is either a thrown collection-modified or a silently short referencer set.</summary>
+    [Fact]
+    public void ConcurrentReadsAndRefreshesNeverTearTheIndex()
+    {
+        using var w = new RecordsWorld();
+        var view = w.Svc.CaptureView();
+        view.EnsureReverseIndex();
+        var index = view.ReverseIndex!;
+        var targets = new[] { w.MgefA };
+        var failures = new System.Collections.Concurrent.ConcurrentBag<string>();
+        var stop = false;
+
+        var refresher = Task.Run(() =>
+        {
+            try
+            {
+                for (int i = 0; i < 40; i++)
+                {
+                    File.SetLastWriteTimeUtc(w.OverrideFile, DateTime.UtcNow.AddMinutes(i + 1));
+                    w.Svc.CaptureView().EnsureReverseIndex();
+                }
+            }
+            catch (Exception ex) { failures.Add("refresh: " + ex); }
+            finally { Volatile.Write(ref stop, true); }
+        });
+        var readers = Enumerable.Range(0, 3).Select(_ => Task.Run(() =>
+        {
+            try
+            {
+                while (!Volatile.Read(ref stop))
+                {
+                    if (index.ReferencersOf(targets).Count == 0) failures.Add("a read saw an empty index");
+                    index.HasAnyReferencer(w.MgefA);
+                }
+            }
+            catch (Exception ex) { failures.Add("read: " + ex); }
+        })).ToArray();
+
+        Task.WaitAll(readers.Append(refresher).ToArray());
+        Assert.Empty(failures);
+    }
+
+    /// <summary>Rewrite the profile so the named plugin is no longer active.</summary>
+    static void Untick(RecordsWorld w, string plugin)
+    {
+        var names = new[] { w.MasterName, w.MidName, w.OverrideName }.Where(n => n != plugin).ToArray();
+        Order(w, names);
+    }
+
+    /// <summary>Rewrite the profile's plugin list, in this order.</summary>
+    static void Order(RecordsWorld w, params string[] names)
+    {
+        var prof = Path.Combine(w.Instance, "profiles", "Default");
+        File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + string.Join("\r\n", names) + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "plugins.txt"), string.Join("\r\n", names.Select(n => "*" + n)) + "\r\n");
     }
 }

--- a/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
+++ b/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
@@ -1,5 +1,6 @@
 using HousecarlCore;
 using HousecarlMcp;
+using Mutagen.Bethesda.Plugins;
 using Xunit;
 
 namespace HousecarlMcpTests;
@@ -93,6 +94,28 @@ public sealed class RecordsReverseIndexTests : RecordsTestBase
         Assert.Contains("\"notes\"", r);
         Assert.Contains("reverse-reference index", r);
         Assert.Contains("key=", r);
+    }
+
+    /// <summary>An in-order source= plugin IS a bound — the scan runs with that one plugin as its scope — so the
+    /// sweep refusal must read the scope the scan will actually use, not the plugins= parameter alone.</summary>
+    [Fact]
+    public void ANegatedReferencesUnderAnInOrderSourceIsNotTheSweep()
+    {
+        var r = RecordsTools.Records(Svc, references: new[] { "!" + Fid(W.MgefA) },
+                                     source: Plugin(W.MidName), project: Form("tree"));
+        Assert.DoesNotContain("orphan sweep", r);
+    }
+
+    /// <summary>group_by='type' needs a body-bearing scope. An unbounded references= is one: the index hands the
+    /// scan its universe and every match's body is read, which is what names the type.</summary>
+    [Fact]
+    public void AnUnboundedReferencesGroupsByType()
+    {
+        var r = RecordsTools.Records(Svc, references: new[] { Fid(W.MgefA) },
+                                     project: new RecordsTools.RecordsProject { form = "aggregate", group_by = "type" });
+        Assert.False(r.StartsWith("error:", StringComparison.Ordinal), r);
+        Assert.Contains("reverse-reference index", r);
+        Assert.Contains("Spell", r);
     }
 
     [Fact]
@@ -305,6 +328,67 @@ public sealed class ReverseIndexLifecycleTests
 
         Task.WaitAll(readers.Append(refresher).ToArray());
         Assert.Empty(failures);
+    }
+
+    /// <summary>An unreadable plugin cuts both ways, and the two readings are opposites: the positive question
+    /// loses referencers and is SHORT; the sweep loses the edges that would disqualify an orphan and is
+    /// OVER-inclusive. Telling a sweep its answer is short says the orphans it listed are confirmed.</summary>
+    [Fact]
+    public void TheUnreadableDisclosureIsToldForTheSweepsDirection()
+    {
+        using var w = new RecordsWorld();
+        RecordsTools.Records(w.Svc, references: new[] { RecordsWorld.Fid(w.MgefA) });
+        File.WriteAllBytes(Path.Combine(w.ModsDir, "MidMod", w.MidName), new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
+        var sweep = RecordsTools.Records(w.Svc, references: new[] { "!" + RecordsWorld.Fid(w.MgefA) });
+        Assert.Contains(w.MidName, sweep);
+        Assert.Contains("OVER-inclusive", sweep);
+        Assert.DoesNotContain("the answer is short", sweep);
+        var positive = RecordsTools.Records(w.Svc, references: new[] { RecordsWorld.Fid(w.MgefA) });
+        Assert.Contains("the answer is short", positive);
+        Assert.DoesNotContain("OVER-inclusive", positive);
+    }
+
+    /// <summary>The sweep takes ONE generation for its whole pass. Asked key by key, a refresh landing mid-pass
+    /// would judge the early keys against the old edges and the late ones against the new, and the freshness key
+    /// the response cites would name neither answer.</summary>
+    [Fact]
+    public void TheSweepJudgesEveryKeyAgainstOneGeneration()
+    {
+        using var w = new RecordsWorld();
+        var masterPath = Path.Combine(w.ModsDir, "MasterMod", w.MasterName);
+        using var resolver = LoadOrderResolver.Build(new[] { masterPath, Path.Combine(w.ModsDir, "MidMod", w.MidName) });
+        var view = resolver.Capture();
+        view.EnsureReverseIndex();
+        var index = view.ReverseIndex!;
+        Assert.True(index.HasAnyReferencer(w.MgefA), "two spells link it — the pre-swap generation says so");
+
+        IEnumerable<FormKey> CandidatesThatRefreshMidway()
+        {
+            yield return w.Armor;
+            // Every edge in the order lived in this plugin: the next generation knows of no referencer at all.
+            File.WriteAllBytes(masterPath, new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
+            resolver.Capture().EnsureReverseIndex();
+            yield return w.MgefA;
+        }
+
+        var orphans = index.Orphans(CandidatesThatRefreshMidway());
+        Assert.DoesNotContain(w.MgefA, orphans);
+    }
+
+    /// <summary>Two sweeps at once share one generation's memoised referenced-set rather than each building their
+    /// own, and neither sees a torn one.</summary>
+    [Fact]
+    public void ConcurrentSweepsAgree()
+    {
+        using var w = new RecordsWorld();
+        var view = w.Svc.CaptureView();
+        view.EnsureReverseIndex();
+        var index = view.ReverseIndex!;
+        var keys = view.RecordKeys().ToList();
+        var results = Enumerable.Range(0, 4)
+            .Select(_ => Task.Run(() => index.Orphans(keys).ToList())).ToArray();
+        Task.WaitAll(results);
+        foreach (var t in results) Assert.Equal(results[0].Result, t.Result);
     }
 
     /// <summary>Rewrite the profile so the named plugin is no longer active.</summary>

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1326,11 +1326,12 @@ static class JsonWire
     /// json is never a silently degraded mode next to text. Omitted when there are none.</summary>
     static void WriteNotes(Utf8JsonWriter w, CrossQueryOutcome q, string? extra = null)
     {
-        if (q.PredicateNote is null && q.ScanNote is null && q.WhereSourceNote is null && extra is null) return;
+        if (q.PredicateNote is null && q.ScanNote is null && q.WhereSourceNote is null && q.ReverseIndexNote is null && extra is null) return;
         w.WriteStartArray("notes");
         if (q.PredicateNote is not null) w.WriteStringValue(q.PredicateNote);
         if (q.ScanNote is not null) w.WriteStringValue(q.ScanNote);
         if (q.WhereSourceNote is not null) w.WriteStringValue(q.WhereSourceNote);   // where_source=winner redundancy under a type=-only scope
+        if (q.ReverseIndexNote is not null) w.WriteStringValue(q.ReverseIndexNote);   // the reverse-reference index's build cost + per-plugin freshness key
         if (extra is not null) w.WriteStringValue(extra);   // the scoped-vs-winner fields note
         w.WriteEndArray();
     }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4053,8 +4053,27 @@ public sealed class LoadOrderService : IDisposable
             return CrossQueryOutcome.Fail("a scan needs at least one of: types=, plugins=, formids=, conflicts_only=true, where=, or references=.");
         // A formid set is itself a bound: the scan touches at most those keys, so a body filter over one needs no
         // types= or plugins=.
+        //
+        // An unbounded references= is no longer one of those: the reverse-reference index answers which records
+        // link a target, so the index supplies the scan universe and everything downstream is the ordinary scan.
+        // Every OTHER body filter still needs a bound — the index knows links, not field values.
+        string? reverseNote = null;
+        bool indexUniverse = false;                                    // the scan universe came from the index, not from the caller
         if (bodyFilter && !hasType && !hasPlugins && !hasFormidSet)
-            return CrossQueryOutcome.Fail("where=/references= is a body scan and must be combined with types=, plugins=, or a formids= set to bound it (conflicts_only= alone is not enough — an unbounded body scan over the whole order is refused). A global reverse-reference index is a future capability.");
+        {
+            bool reverseOnly = !hasWhere && string.IsNullOrEmpty(editoridContains);
+            if (!reverseOnly)
+                return CrossQueryOutcome.Fail("where=/editorid_contains= is a body scan and must be combined with types=, plugins=, or a formids= set to bound it (conflicts_only= alone is not enough — an unbounded body scan over the whole order is refused). Only references= is unbounded, off the reverse-reference index.");
+            var built = view.EnsureReverseIndex();
+            var universe = HousecarlCore.ReverseSelection.Universe(view, view.ReverseIndex!, references);
+            var wholeOrder = HousecarlCore.ReverseSelection.WholeOrderNote(references, universe.Count);
+            reverseNote = built.Note is null ? wholeOrder
+                        : wholeOrder is null ? built.Note
+                        : built.Note + " " + wholeOrder;
+            formidSet = universe;
+            hasFormidSet = true;                                       // an empty universe is still the universe: 0 matches, not a refusal
+            indexUniverse = true;
+        }
 
         // defined_in= keeps only records defined in the scoped plugins (by origin FormKey), which is distinct from
         // plugins=, meaning everything a plugin touches. It needs a plugins= scope to mean anything, so it is
@@ -4169,7 +4188,9 @@ public sealed class LoadOrderService : IDisposable
         // than left to read as a clean whole-order scan.
         var unreadablePlugins = new List<PluginUnreadableException>();
 
-        HashSet<FormKey>? setFilter = hasFormidSet ? new HashSet<FormKey>(formidSet!) : null;
+        // Only the type=/plugins= branches consult this, and neither can co-occur with an index-supplied universe —
+        // so the whole-order universe is never copied into a second set.
+        HashSet<FormKey>? setFilter = hasFormidSet && !indexUniverse ? new HashSet<FormKey>(formidSet!) : null;
         // The set-alone branch also owns conflicts_only combined with formidSet, via its in-loop touching-count
         // test: routing that pair to the index-only else-branch would drop every parsed body filter silently.
         if (!hasType && !hasPlugins && hasFormidSet)                          // the formid set ALONE is the universe: per-key winner fetch
@@ -4500,6 +4521,7 @@ public sealed class LoadOrderService : IDisposable
                                      matched, groupRows, groupBy, definedIn ? string.Join(", ", plugins!) : null, offset,
                                      whereWinner, whereSourceNote)
                { Epoch = view.Epoch, Pin = new ViewPin(resolver, view),
+                 ReverseIndexNote = reverseNote,
                  UnreadPlugins = unreadablePlugins.Select(u => u.PluginName).ToList() };
     }
 
@@ -9013,6 +9035,10 @@ public sealed record CrossQueryOutcome(
     /// <summary>The captured build the scan ran over. The render stamps it into the in-band accounting so paged
     /// windows are checkably from the same build. Null on the pre-scan refusals.</summary>
     public string? Epoch { get; init; }
+
+    /// <summary>The reverse-reference index's accounting for this call: what a build it triggered cost, the index's
+    /// own per-plugin freshness key, and the whole-order universe declaration. Null when the call did not use it.</summary>
+    public string? ReverseIndexNote { get; init; }
 
     /// <summary>Plugins the winner scan could not open, by filename. A zero-match answer with one of these is bounded
     /// by the lock, not by the filter, and the render must not tell the caller otherwise.</summary>

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2057,6 +2057,10 @@ public sealed class LoadOrderService : IDisposable
                 // The rebuild must carry the explainer too, or a profile change — the very act that creates an
                 // unticked plugin — would silently drop every refusal back to the flat not-found.
                 var rebuilt = LoadOrderResolver.Build(paths, ExplainPluginAbsence);
+                // The reverse-reference index is derived from plugin bytes, not from this snapshot, so it carries
+                // over: a tick in MO2 rebuilds the resolver, and dropping the index there would re-pay the whole
+                // whole-order walk for plugins whose (path, mtime) never changed.
+                rebuilt.AdoptReverseIndexFrom(_resolver);
                 _resolver.Dispose();
                 _resolver = rebuilt;
             }
@@ -4066,10 +4070,10 @@ public sealed class LoadOrderService : IDisposable
                 return CrossQueryOutcome.Fail("where=/editorid_contains= is a body scan and must be combined with types=, plugins=, or a formids= set to bound it (conflicts_only= alone is not enough — an unbounded body scan over the whole order is refused). Only references= is unbounded, off the reverse-reference index.");
             var built = view.EnsureReverseIndex();
             var universe = HousecarlCore.ReverseSelection.Universe(view, view.ReverseIndex!, references);
-            var wholeOrder = HousecarlCore.ReverseSelection.WholeOrderNote(references, universe.Count);
-            reverseNote = built.Note is null ? wholeOrder
-                        : wholeOrder is null ? built.Note
-                        : built.Note + " " + wholeOrder;
+            var universeNote = HousecarlCore.ReverseSelection.UniverseNote(references, universe.Count);
+            // The index's own line rides EVERY answer it serves, not only the call that paid the build: the
+            // freshness key and the unreadable-plugin disclosure are true of a cached answer too.
+            reverseNote = universeNote is null ? built.Note : built.Note + " " + universeNote;
             formidSet = universe;
             hasFormidSet = true;                                       // an empty universe is still the universe: 0 matches, not a refusal
             indexUniverse = true;
@@ -4188,8 +4192,9 @@ public sealed class LoadOrderService : IDisposable
         // than left to read as a clean whole-order scan.
         var unreadablePlugins = new List<PluginUnreadableException>();
 
-        // Only the type=/plugins= branches consult this, and neither can co-occur with an index-supplied universe —
-        // so the whole-order universe is never copied into a second set.
+        // Only the type=/plugins= branches consult this as a pre-filter, and neither can co-occur with an
+        // index-supplied universe — so building it for one would cost a copy of the universe that nothing reads.
+        // (The set-alone branch below still dedupes as it streams; this guard is about the unread pre-filter.)
         HashSet<FormKey>? setFilter = hasFormidSet && !indexUniverse ? new HashSet<FormKey>(formidSet!) : null;
         // The set-alone branch also owns conflicts_only combined with formidSet, via its in-loop touching-count
         // test: routing that pair to the index-only else-branch would drop every parsed body filter silently.

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4072,8 +4072,11 @@ public sealed class LoadOrderService : IDisposable
             var universe = HousecarlCore.ReverseSelection.Universe(view, view.ReverseIndex!, references);
             var universeNote = HousecarlCore.ReverseSelection.UniverseNote(references, universe.Count);
             // The index's own line rides EVERY answer it serves, not only the call that paid the build: the
-            // freshness key and the unreadable-plugin disclosure are true of a cached answer too.
-            reverseNote = universeNote is null ? built.Note : built.Note + " " + universeNote;
+            // freshness key and the unreadable-plugin disclosure are true of a cached answer too. Which lane asked
+            // decides how an unreadable plugin reads — short for the positive question, over-inclusive for the
+            // sweep — so the note is told for the lane.
+            bool orphanSweep = references is not { Count: > 0 };
+            reverseNote = built.NoteFor(orphanSweep) + (universeNote is null ? "" : " " + universeNote);
             formidSet = universe;
             hasFormidSet = true;                                       // an empty universe is still the universe: 0 matches, not a refusal
             indexUniverse = true;

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -264,6 +264,7 @@ static class Wire
         if (q.PredicateNote is not null) sb.Append(q.PredicateNote).Append('\n');   // where= accounting: wrong path / no value
         if (q.ScanNote is not null) sb.Append(q.ScanNote).Append('\n');             // records Mutagen could not parse
         if (q.WhereSourceNote is not null) sb.Append(q.WhereSourceNote).Append('\n');   // where_source=winner is redundant under a type=-only scope
+        if (q.ReverseIndexNote is not null) sb.Append(q.ReverseIndexNote).Append('\n');   // the reverse-reference index's build cost and per-plugin freshness key
         // Under a plugins= scope the per-match fields are the SCOPED plugin's own values, not the live winner's —
         // silently wrong otherwise, so name it once. The helper covers all four winner_fields=/where_source=
         // combinations so the note never claims a scoped-body match the scan did not make, and the json and dense
@@ -338,6 +339,7 @@ static class Wire
         sb.Append('\n');
         if (q.PredicateNote is not null) sb.Append(q.PredicateNote).Append('\n');
         if (q.ScanNote is not null) sb.Append(q.ScanNote).Append('\n');
+        if (q.ReverseIndexNote is not null) sb.Append(q.ReverseIndexNote).Append('\n');
         for (int i = 0; i < groups.Count && !(spill?.ManifestOnly ?? false); i++)   // to_file: rows live in the file
         {
             if (sb.Length >= cap)

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -114,11 +114,15 @@ public static class RecordsTools
          "or bracket is not expressible in a list; test it with '='), ONE '->' link step " +
          "'Perks->editorid startswith REQ_NULL_', and the provenance term 'winner = X.esp' — which records does X " +
          "WIN; that term forces winner resolution over the scanned scope, the same declared cost as any winner " +
-         "scan) | references= (reverse, one step — requires a bounding types=/plugins= scope; the reverse-reference " +
-         "index that would lift the bound is a known future capability. A '!' before an entry NEGATES it — " +
+         "scan) | references= (reverse, one step; needs no bounding scope — unbounded, it is answered off the " +
+         "reverse-reference index, which is built on the first such call, costs one whole-order link-walk, and " +
+         "reports that cost and its own per-plugin freshness key in the response. A bounded references= is " +
+         "unchanged and still cheaper. A '!' before an entry NEGATES it — " +
          "references=[\"!XXXXXX:A.esm\"] keeps only records that do NOT reference that target, and plain and " +
          "negated entries in one call compose by AND; the sigil takes the @file spelling too — " +
-         "references=[\"!@C:/work/targets.jsonl\"] excludes every target the file names). UNION-ARM tip: when a field is one of " +
+         "references=[\"!@C:/work/targets.jsonl\"] excludes every target the file names; an unbounded negated " +
+         "entry ALONE has the whole order as its " +
+         "universe, so bound it unless you mean that). UNION-ARM tip: when a field is one of " +
          "several shapes (an NPC's Configuration.Level is a fixed level OR a PC-level multiplier), a scalar " +
          "predicate on one arm's sub-field doubles as an ARM-PRESENCE test: where=[\"Configuration.Level.LevelMult " +
          ">= 0\"] returns exactly the NPCs on a multiplier. formids= COMPOSES with the scan terms: the identity set " +
@@ -178,7 +182,7 @@ public static class RecordsTools
             string[]? where = null,
         [Description("Which BODY the where= predicates decide the MATCH on: 'scoped' (default — the body the scan streams) or 'winner' (the live load-order winner regardless of scan scope; the post-patch audit answer). Match only — fields_source= independently governs display.")]
             string? where_source = null,
-        [Description("SELECT: find records that REFERENCE these FormIDs (reverse, one step; OR over the list, each match names which target(s) it hit). Requires a bounding types= or plugins= scope — see the cost declaration in the tool description. Accepts [\"@<path>\"] like formids=.")]
+        [Description("SELECT: find records that REFERENCE these FormIDs (reverse, one step; OR over the list, each match names which target(s) it hit). Needs no bounding scope: unbounded it is answered off the reverse-reference index, built on the first such call at the cost of one whole-order link-walk, declared in the response — see the tool description. A bounding types= or plugins= is still cheaper. Accepts [\"@<path>\"] like formids=.")]
             string[]? references = null,
         [Description("SOURCE: whose version to read — the SUBJECT of the call. Omit or \"winner\" for the load-order winner; a plugin filename (e.g. \"OldPatch.esp\") for that plugin's version WHEREVER it lives — active or on disk out of the order (the response states which); {\"file\": \"X.esp\", \"mod\": \"<mod folder>\"} when two mods ship the same filename; {\"overlay\": \"skypatcher\", \"state\": \"pre\"|\"post\"} for the runtime view around the SkyPatcher INI layer (post = after it replays; INI content sits OUTSIDE the epoch fingerprint and the response says so). \"previous_provider\" is a versus= value only — it is measured FROM the subject this parameter names.")]
             JsonElement? source = null,
@@ -996,10 +1000,13 @@ public static class RecordsTools
             // subject, info_order the merge, a walk its re-entered read. The tree has no subject, so the scan's
             // selection statement stays — it is what discloses an off-order or scoped selection universe.
             bool pipelineArms = form == "delta" || form == "info_order" || walk is not null;
-            if (hasBodyFilter && !hasTypes && !hasScope && !hasFormids)
-                return Wire.Refuse(json, "error: where=/references= is a body scan and must be combined with types=, plugins=, or a formids= set to bound the work " +
-                       "(conflicts_only= alone is not enough — an unbounded body scan over the whole order is refused; the " +
-                       "reverse-reference index that would lift this is a known future capability).");
+            // An unbounded references= is answered off the reverse-reference index; every other body filter still
+            // needs a bound, because the index knows links, not field values.
+            bool onlyReverseFilter = where is not { Length: > 0 };
+            if (hasBodyFilter && !hasTypes && !hasScope && !hasFormids && !onlyReverseFilter)
+                return Wire.Refuse(json, "error: where= is a body scan and must be combined with types=, plugins=, or a formids= set to bound the work " +
+                       "(conflicts_only= alone is not enough — an unbounded body scan over the whole order is refused). " +
+                       "Only references= is unbounded, off the reverse-reference index.");
             if (plugins is { defined_in: true } && !hasScope)
                 return Wire.Refuse(json, "error: plugins.defined_in=true keeps records DEFINED in the scoped plugins, so plugins.names must name that scope.");
 

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -58,7 +58,7 @@ public static class RecordsTools
         [Description("The link path followed at every LATER hop. \"*\" (default) walks every link — full closure. A named path restricts to one chain, e.g. \"Template\" for NPC template inheritance, or \"*parent\" to climb containment.")]
         public string? follow { get; set; }
 
-        [Description("'forward' (default) — what the seeds point AT (cheap: each hop is one link resolve). 'reverse' — what points AT the seeds; depth 1 only (reverse is a bounded scan; transitive reverse is refused naming the reverse-reference index as the future capability). The general reverse spelling on this surface IS references= (same construct); walk.direction='reverse' serves the typed MGEF lane — magic-effect seeds get per-carrier magnitude/area/duration (types= narrows the carrier types; walk.max_nodes bounds each seed's carrier rows; limit=/offset= window the SEEDS).")]
+        [Description("'forward' (default) — what the seeds point AT (cheap: each hop is one link resolve). 'reverse' — what points AT the seeds; depth 1 only (transitive reverse is not wired to the reverse-reference index on this lane yet, so depth>1 is still refused). The general reverse spelling on this surface IS references=, which needs no bounding scope; walk.direction='reverse' serves the typed MGEF lane — magic-effect seeds get per-carrier magnitude/area/duration (types= narrows the carrier types; walk.max_nodes bounds each seed's carrier rows; limit=/offset= window the SEEDS).")]
         public string? direction { get; set; }
 
         [Description("Maximum hops from a seed (default 16). Nodes AT the cap are recorded, not entered, and the response says the cap cut the walk — never a silent stop.")]
@@ -120,9 +120,11 @@ public static class RecordsTools
          "unchanged and still cheaper. A '!' before an entry NEGATES it — " +
          "references=[\"!XXXXXX:A.esm\"] keeps only records that do NOT reference that target, and plain and " +
          "negated entries in one call compose by AND; the sigil takes the @file spelling too — " +
-         "references=[\"!@C:/work/targets.jsonl\"] excludes every target the file names; an unbounded negated " +
-         "entry ALONE has the whole order as its " +
-         "universe, so bound it unless you mean that). UNION-ARM tip: when a field is one of " +
+         "references=[\"!@C:/work/targets.jsonl\"] excludes every target the file names. A negated entry ALONE " +
+         "with no types=/plugins= scope is the " +
+         "ORPHAN sweep: the universe becomes every record nothing in the order references, and the named target " +
+         "then excludes any of those that link it — bound the call if you meant the narrower question). " +
+         "UNION-ARM tip: when a field is one of " +
          "several shapes (an NPC's Configuration.Level is a fixed level OR a PC-level multiplier), a scalar " +
          "predicate on one arm's sub-field doubles as an ARM-PRESENCE test: where=[\"Configuration.Level.LevelMult " +
          ">= 0\"] returns exactly the NPCs on a multiplier. formids= COMPOSES with the scan terms: the identity set " +
@@ -351,11 +353,11 @@ public static class RecordsTools
             if (walkDirection == "reverse")
             {
                 if (walk.depth is > 1)
-                    return Wire.Refuse(json, "error: walk.direction='reverse' with depth>1 is a TRANSITIVE reverse lookup — no index exists for it today, so it is refused rather than run as an unbounded scan-of-scans (the reverse-reference index is the known future capability that lifts this). Depth-1 reverse: references= with a bounding types=/plugins=, or MGEF seeds under form='chain' for the typed carrier lane.");
+                    return Wire.Refuse(json, "error: walk.direction='reverse' with depth>1 is a TRANSITIVE reverse lookup — the reverse-reference index that answers it now ships, but this walk lane is not wired to it yet, so it is refused rather than run as a scan-of-scans. Depth-1 reverse: references= (no bounding scope needed), or MGEF seeds under form='chain' for the typed carrier lane.");
                 if (walk.seed_paths is { Length: > 0 } || walk.exclusions is { Length: > 0 } || walk.follow is not null)
                     return Wire.Refuse(json, "error: walk.seed_paths/follow/exclusions shape a FORWARD expansion — a reverse walk scans TOWARD the seeds. Drop them.");
                 if (form != "chain")
-                    return Wire.Refuse(json, "error: the reverse walk's general spelling on this surface IS references= (the same construct, depth 1, bounded by types=/plugins=) — walk.direction='reverse' serves form='chain' with MGEF seeds (per-carrier magnitude/area/duration).");
+                    return Wire.Refuse(json, "error: the reverse walk's general spelling on this surface IS references= (the same construct, depth 1, and it needs no bounding scope) — walk.direction='reverse' serves form='chain' with MGEF seeds (per-carrier magnitude/area/duration).");
             }
             if (references is { Length: > 0 })
                 return Wire.Refuse(json, "error: walk= and references= are the same construct (references= IS the reverse walk at depth 1) — use one spelling per call.");
@@ -1084,6 +1086,13 @@ public static class RecordsTools
                 if (neg!.Count > 0) refNoneFks = neg.Distinct().ToList();
             }
 
+            // The negated-only unbounded spelling selects the whole orphan set — millions of records on a real
+            // order — and the derived forms consume EVERY match uncapped (effLimit below is int.MaxValue for them),
+            // so each match would also be compared, merged or walked. Refused with the bound named, rather than
+            // run. A positive references= is not this: its universe is what links the target.
+            if (refNoneFks is not null && refFks is null && !hasTypes && !hasScope && !hasFormids && derivedSelection)
+                return Wire.Refuse(json, $"error: a negated references= with no types=/plugins=/formids= bound is the orphan sweep — every record nothing in the order references — and the '{form}' form compares or merges EVERY match, uncapped. Add types= or plugins= to bound it, or run the sweep as a plain scan with to_file= and re-enter the artifact via formids=[\"@<file>\"].");
+
             var scanPlugins = scopePlusPole ? plugins!.names : (srcName is not null ? new[] { srcName } : plugins?.names);
             bool definedIn = plugins?.defined_in ?? false;
             // group_by=type names each match's record type, which only a body-bearing scope can supply. The engine
@@ -1144,6 +1153,17 @@ public static class RecordsTools
                 Add("source", srcName ?? (srcSpec.Kind != LoadOrderService.PoleKind.Winner ? srcSpec.Label : null));
                 if (versusSpec is not null) Add("versus", versusSpec.Label);
                 return e;
+            }
+
+            // The reverse-reference index's accounting belongs to the response whatever consumes the scan. The two
+            // CrossQuery renderers read it off the outcome themselves; every form BELOW renders its own pipeline's
+            // response and would drop it, so it rides their header and envelope. One place, so no form forgets.
+            if (outcome.ReverseIndexNote is not null && outcome.Error is null && outcome.Groups is null
+                && (walk is not null || comparisonForm || form == "info_order"
+                    || ((form == "everything" || (form == "fields" && scopePlusPole)) && !counts_only)))
+            {
+                envelope.Add(new("reverse_index", outcome.ReverseIndexNote));
+                headerLine += "\n" + outcome.ReverseIndexNote;
             }
 
             // ---- walk= on a scan: the scan's matches are the seeds and the walk lane takes it from there,

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -1086,27 +1086,31 @@ public static class RecordsTools
                 if (neg!.Count > 0) refNoneFks = neg.Distinct().ToList();
             }
 
+            var scanPlugins = scopePlusPole ? plugins!.names : (srcName is not null ? new[] { srcName } : plugins?.names);
             // The negated-only unbounded spelling selects the whole orphan set — millions of records on a real
             // order — and the derived forms consume EVERY match uncapped (effLimit below is int.MaxValue for them),
             // so each match would also be compared, merged or walked. Refused with the bound named, rather than
-            // run. A positive references= is not this: its universe is what links the target.
-            if (refNoneFks is not null && refFks is null && !hasTypes && !hasScope && !hasFormids && derivedSelection)
+            // run. A positive references= is not this: its universe is what links the target. Read off scanPlugins,
+            // so an in-order source= plugin counts as the scope it is and its one plugin's records are not called
+            // the sweep.
+            if (refNoneFks is not null && refFks is null && !hasTypes && scanPlugins is not { Length: > 0 } && !hasFormids && derivedSelection)
                 return Wire.Refuse(json, $"error: a negated references= with no types=/plugins=/formids= bound is the orphan sweep — every record nothing in the order references — and the '{form}' form compares or merges EVERY match, uncapped. Add types= or plugins= to bound it, or run the sweep as a plain scan with to_file= and re-enter the artifact via formids=[\"@<file>\"].");
 
-            var scanPlugins = scopePlusPole ? plugins!.names : (srcName is not null ? new[] { srcName } : plugins?.names);
             bool definedIn = plugins?.defined_in ?? false;
             // group_by=type names each match's record type, which only a body-bearing scope can supply. The engine
             // refuses it too, in the 1.x spelling (group_by=/type=), so it is pre-checked here in this tool's own
             // levers. Placed on the IN-ORDER lane only — the off-order file scan returned above, where the file's
             // own records ARE the universe and every match has a body — and read off scanPlugins, so an in-order
-            // source= plugin counts as the scope it is.
+            // source= plugin counts as the scope it is. An unbounded references= is body-bearing too: the reverse
+            // index hands the scan a universe of keys, so each match's body is read and can name its type.
             if (form == "aggregate" && walk is null
                 && string.Equals(project!.group_by?.Trim(), "type", StringComparison.OrdinalIgnoreCase)
-                && !hasTypes && scanPlugins is not { Length: > 0 } && formidSet is null)
+                && !hasTypes && scanPlugins is not { Length: > 0 } && formidSet is null
+                && refFks is null && refNoneFks is null)
                 return Wire.Refuse(json, "error: project.group_by='type' counts each match's record TYPE, which only a " +
-                    "body-bearing scope can name — add types=, plugins=, formids=, or an in-order source= plugin. " +
-                    "(where= and references= read bodies too, but each takes one of those as its own bound; 'winner' " +
-                    "and 'defined_in' group without reading a body.)", probeEpoch);
+                    "body-bearing scope can name — add types=, plugins=, formids=, references=, or an in-order source= plugin. " +
+                    "(where= reads bodies too but takes one of those as its own bound; references= brings its own universe " +
+                    "off the reverse-reference index; 'winner' and 'defined_in' group without reading a body.)", probeEpoch);
             // Under walk= the scan only SELECTS the seeds; the aggregate, like every reading form, applies to
             // the reached set after the walk lane re-enters. Grouping the scan itself would label an aggregate
             // of the seeds as the walk's answer.


### PR DESCRIPTION
"Who references X" over the whole order was a refusal: the reverse direction had no index, so `references=` demanded a bounding `types=`/`plugins=` scope and an agent had to guess a scope per plugin. This adds the reverse-reference index — a target-to-referencer map built off the same whole-order link walk the dangling sweep already runs — and makes the unbounded `references=` an answer. It is E1 step 3 and stacks on #558; the diff here is only this step. No vocabulary: two declared cost-refusals become values on axes that already have their spelling, exactly as the accepted E1 design page and SPEC §2.1 / §3.2 amendments of 2026-09-05 describe.

The index is lazy — nothing builds it at startup, and the first call that needs it pays and says what it paid. It is held beside the snapshot rather than on it, partitioned per plugin and keyed on that plugin's `(path, mtime)`, because `RefreshIfStale` is all-or-nothing and `epoch` is order-wide: an index keyed on those would die wholesale on every MO2 touch. A snapshot swap — and, since the review fold, a RESOLVER swap, which is what ticking a plugin in MO2 actually causes — keeps every partition whose key did not change, and a plugin whose bytes changed rebuilds only its own slice. A plugin whose enumeration throws contributes nothing (plugin-atomic, like the winner index) and is named in the accounting, so a short answer never reads as a complete one. The index supplies the scan's *candidate* universe only; the existing scan still reads the body it means to judge, so a later override that dropped the link is not counted as a referencer. Every other body filter keeps its bound — a `where=` or `editorid_contains=` with no scope is still refused, with the sentence reworded to say that only `references=` is unbounded — because the index knows links, not field values.

A refresh publishes a whole new generation of the index in one assignment and readers take it once, so an unbounded call running concurrently with a refresh sees one consistent state and takes no build lock. Partitions are keyed on the plugin path rather than its filename, because the resolver tolerates two entries sharing a name. The accounting line rides every answer the index serves, not only the call that paid the build: the build clause is conditional, the freshness key and the coverage disclosures are not.

**The negated spelling is the orphan sweep, unbounded.** SPEC §2.2's amendment ("`references=` gains a negated spelling … What the reverse-reference index buys it is the *unbounded* question — the orphan sweep") and the design page §4 ("the *unbounded* question ('referenced by nothing anywhere') — the orphan sweep") both read it that way, so that is what ships: with no `types=`/`plugins=`/`formids=` bound, the universe is every record nothing in the order references, and the named target then excludes any of those that link it. A bounded negated `references=` is unchanged — records in that scope that do not link the target — and the response states which of the two questions it answered. `HasAnyReferencer` is now one lookup against a per-generation set of every referenced target, not a scan over every partition. The sweep is refused in combination with `delta`, `tree` and `info_order`, which consume every match uncapped.

**Measured, and above the accepted figure.** On the live ARR 2.0 order (3,801 plugins, 3,214,664 records): first build 24.4 s, 1,655,669 target slots, 14,720,188 target→referencer pairs, ~203 MB measured heap, 0 unreadable plugins, 1 unscannable record; a second call on an unchanged order costs 18 ms and rebuilds nothing. SPEC §3.2's amendment and the design page state ~149 MB (629,069 distinct targets, 1,513,154 (target, plugin) pairs). The shipped index is 36% over that because it holds referencing **records**, not referencing plugins — it has to, to return rows. Memory was accepted flat with no ceiling knob, so this is a documentation delta rather than a blocker; both documents are Aaron's and are not amended here. On the test fixture: 3 partitions, 14 ms, 10 pairs.

**Left, and stated rather than worked around:** the depth > 1 reverse walk. SPEC §3.2's amendment deletes that cost-refusal too, but `walk.direction='reverse'` on this surface is the typed MGEF carrier lane (MGEF seeds, per-carrier payload rows), and the general reverse spelling is `references=` by the lane's own refusal. Making `depth > 1` generic there would mean the same spelling meaning two different things by depth, which is a shape question the design page and the SPEC do not settle. It stays refused, with the refusal now saying truthfully that the index exists and this lane is not wired to it. So this PR ships one of #489's two "What it lifts" entries; say the word and the other lands as its own step.

Part of #489 — the second half of its "What it lifts" list (the depth > 1 reverse walk) is not in this PR, so it does not auto-close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
