### PR TITLE
Fix two silent wrong answers on the records lane

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -139,6 +139,17 @@ saying it sets an expectation their install may contradict. Say what is known, a
   both halves now ends with the near-miss suggestion, so a typo or a guessed `.esp`/`.esl` extension names the
   plugin you meant.
 
+- **A `types=` filter naming one arm of an abstract record group — `GlobalShort`, `GlobalFloat`, `GameSettingInt` and
+  every other Mutagen arm — now answers over that arm alone.** It returned the whole group instead: the plugin
+  enumeration seeks the record group, which for these types holds every arm of it, and the load-order scan trusted
+  the seek. Nothing said the filter had widened, so a count taken over one arm was a count over all of them. Check an
+  answer you took before this by re-running the same call and comparing the totals; the group's own name (`GLOB`,
+  `GMST`) still returns every arm, as it always did.
+- **A `plugins=`-scoped `fields` scan written with `to_file=` now carries the scoped-vs-winner note in its manifest.**
+  The rows hold each match's scoped plugin's own field values, and the three inline transports all say so; the
+  artifact said nothing, so a value read back out of the file later — a defining esp's damage rather than the live
+  winner's — came with nothing attached naming which body it was. The note is the same sentence the inline renders
+  state, on line 1 of the file.
 - **`housecarl_skse` now carries the same transport every other tool has: `format='json'`, `limit=`/`offset=` paging,
   and an in-band accounting line on every answer.** `format='json'` returns the machine-readable twin of whichever
   family ran — the same census, the same rows, the same numbers, in named fields, plus the family that ran and the two

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -141,10 +141,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 - **A `types=` filter naming one arm of an abstract record group — `GlobalShort`, `GlobalFloat`, `GameSettingInt` and
   every other Mutagen arm — now answers over that arm alone.** It returned the whole group instead: the plugin
-  enumeration seeks the record group, which for these types holds every arm of it, and the load-order scan trusted
-  the seek. Nothing said the filter had widened, so a count taken over one arm was a count over all of them. Check an
-  answer you took before this by re-running the same call and comparing the totals; the group's own name (`GLOB`,
-  `GMST`) still returns every arm, as it always did.
+  enumeration seeks the record group, which for these types holds every arm of it, and the scans trusted the seek.
+  Nothing said the filter had widened, so a count taken over one arm was a count over all of them. This covers
+  `housecarl_check_errors` with `type=` too, on an active plugin and on an off-order file alike — its findings and its
+  per-plugin tallies were the whole group's, and with a group name resolving to several arms each record was walked
+  once per arm. Check an answer you took before this by re-running the same call and comparing the totals; the group's
+  own name (`GLOB`, `GMST`) still returns every arm, as it always did.
 - **A `plugins=`-scoped `fields` scan written with `to_file=` now carries the scoped-vs-winner note in its manifest.**
   The rows hold each match's scoped plugin's own field values, and the three inline transports all say so; the
   artifact said nothing, so a value read back out of the file later — a defining esp's damage rather than the live

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -1093,12 +1093,11 @@ public sealed class LoadOrderResolver : IDisposable
             }
             try
             {
-                foreach (var t in getterTypes)
-                    foreach (var rec in ov.EnumerateMajorRecords(t, throwIfUnknown: true))
-                        // A typed enumeration seeks the GRUP, which for an abstract group (Global, GameSetting) holds
-                        // every arm of it — so an arm's own type is re-checked here rather than trusted from the seek.
-                        if (t.IsInstanceOfType(rec) && s.Index.TryGetValue(rec.FormKey, out var e) && e.winner == i)   // this overlay's instance wins
-                            yield return (rec.FormKey, e.count, rec);
+                // RecordArms is the shared arm re-check: a typed enumeration seeks the GRUP, which for an abstract
+                // group (Global, GameSetting) holds every arm of it.
+                foreach (var rec in RecordArms.OfTypes(ov, getterTypes))
+                    if (s.Index.TryGetValue(rec.FormKey, out var e) && e.winner == i)   // this overlay's instance wins
+                        yield return (rec.FormKey, e.count, rec);
             }
             finally { (ov as IDisposable)?.Dispose(); }
         }
@@ -1128,11 +1127,9 @@ public sealed class LoadOrderResolver : IDisposable
             catch (Exception ex) { throw new PluginUnreadableException(_names[i], ex); }
             try
             {
-                // The arm re-check is the one WinnerRecordsOfType does, for the same reason: a typed enumeration over an
-                // abstract group's arm seeks the whole GRUP.
                 IEnumerable<IMajorRecordGetter> recs = getterTypes is null
                     ? ov.EnumerateMajorRecords()
-                    : getterTypes.SelectMany(t => ov.EnumerateMajorRecords(t, throwIfUnknown: true).Where(t.IsInstanceOfType));
+                    : RecordArms.OfTypes(ov, getterTypes);   // the shared arm re-check
                 foreach (var rec in recs)
                     if (s.Index.TryGetValue(rec.FormKey, out var e))
                         yield return (rec.FormKey, e.count, rec, _names[i]);   // _names[i] = this scoped plugin's filename (the source body)

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -1095,7 +1095,9 @@ public sealed class LoadOrderResolver : IDisposable
             {
                 foreach (var t in getterTypes)
                     foreach (var rec in ov.EnumerateMajorRecords(t, throwIfUnknown: true))
-                        if (s.Index.TryGetValue(rec.FormKey, out var e) && e.winner == i)   // this overlay's instance wins
+                        // A typed enumeration seeks the GRUP, which for an abstract group (Global, GameSetting) holds
+                        // every arm of it — so an arm's own type is re-checked here rather than trusted from the seek.
+                        if (t.IsInstanceOfType(rec) && s.Index.TryGetValue(rec.FormKey, out var e) && e.winner == i)   // this overlay's instance wins
                             yield return (rec.FormKey, e.count, rec);
             }
             finally { (ov as IDisposable)?.Dispose(); }
@@ -1126,9 +1128,11 @@ public sealed class LoadOrderResolver : IDisposable
             catch (Exception ex) { throw new PluginUnreadableException(_names[i], ex); }
             try
             {
+                // The arm re-check is the one WinnerRecordsOfType does, for the same reason: a typed enumeration over an
+                // abstract group's arm seeks the whole GRUP.
                 IEnumerable<IMajorRecordGetter> recs = getterTypes is null
                     ? ov.EnumerateMajorRecords()
-                    : getterTypes.SelectMany(t => ov.EnumerateMajorRecords(t, throwIfUnknown: true));
+                    : getterTypes.SelectMany(t => ov.EnumerateMajorRecords(t, throwIfUnknown: true).Where(t.IsInstanceOfType));
                 foreach (var rec in recs)
                     if (s.Index.TryGetValue(rec.FormKey, out var e))
                         yield return (rec.FormKey, e.count, rec, _names[i]);   // _names[i] = this scoped plugin's filename (the source body)

--- a/src/housecarl-core/RecordArms.cs
+++ b/src/housecarl-core/RecordArms.cs
@@ -1,0 +1,21 @@
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// The one typed record enumeration every scan and sweep lane goes through.
+///
+/// <para>Mutagen's <c>EnumerateMajorRecords(Type)</c> SEEKS THE GRUP the type lives in, and an abstract group
+/// (GLOB → GlobalShort / GlobalInt / GlobalFloat; GMST → its own arms) is one GRUP holding every arm of it. So a
+/// filter naming one arm gets handed the whole group, and a filter naming several arms gets each record once per
+/// arm. Either way the answer is wider than the filter and nothing says so — the failure this class exists to make
+/// impossible to reintroduce lane by lane. The arm is re-checked per record, in this one place.</para>
+/// </summary>
+public static class RecordArms
+{
+    /// <summary>Every record in <paramref name="ov"/> of any of <paramref name="getterTypes"/>, each yielded once,
+    /// under its own arm. throwIfUnknown is belt-and-braces — resolved types are always real.</summary>
+    public static IEnumerable<IMajorRecordGetter> OfTypes(ISkyrimModGetter ov, IReadOnlyList<Type> getterTypes)
+        => getterTypes.SelectMany(t => ov.EnumerateMajorRecords(t, throwIfUnknown: true).Where(t.IsInstanceOfType));
+}

--- a/src/housecarl-core/SweepScope.cs
+++ b/src/housecarl-core/SweepScope.cs
@@ -1,5 +1,6 @@
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
 
 namespace HousecarlCore;
 
@@ -50,7 +51,8 @@ public sealed class SweepScope
     public bool IsEmpty => Formids is null && EditorIdContains is null && Types is null;
 
     /// <summary>Does this record fall inside the scope? <see cref="Types"/> is NOT re-tested here — it is applied at the
-    /// stream, so a body reaching this call is already of a scoped type.</summary>
+    /// stream, and every stream a sweep reads (<c>RecordsIn</c> and the off-order overlay alike) narrows through
+    /// <see cref="RecordArms"/>, which re-checks the arm. So a body reaching this call is already of a scoped type.</summary>
     public bool Matches(FormKey fk, IMajorRecordGetter body)
     {
         if (Formids is not null && !Formids.Contains(fk)) return false;
@@ -78,10 +80,12 @@ public sealed class SweepScope
 
     /// <summary>An OFF-ORDER file's record stream, type-scoped when the caller asked for one — the overlay
     /// counterpart of <c>RecordsIn</c>'s getter-type filter, so a <c>type=</c> scope costs nothing per skipped
-    /// record on that lane either. One home, because both sweep families walk an off-order file the same way.</summary>
-    public static IEnumerable<IMajorRecordGetter> RecordsFrom(IModGetter ov, SweepScope? scope)
+    /// record on that lane either. One home, because both sweep families walk an off-order file the same way.
+    /// Through <see cref="RecordArms"/>, the same arm re-check the in-order lanes go through: without it an arm scope
+    /// (<c>type='GlobalShort'</c>) would sweep and count the whole GRUP here.</summary>
+    public static IEnumerable<IMajorRecordGetter> RecordsFrom(ISkyrimModGetter ov, SweepScope? scope)
         => scope?.Types is { Count: > 0 } types
-            ? types.SelectMany(t => ov.EnumerateMajorRecords(t, throwIfUnknown: true)).Cast<IMajorRecordGetter>()
+            ? RecordArms.OfTypes(ov, types)
             : ov.EnumerateMajorRecords();
 }
 

--- a/src/housecarl-mcp-tests/RecordsArtifactScopedNoteTests.cs
+++ b/src/housecarl-mcp-tests/RecordsArtifactScopedNoteTests.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// The scoped-vs-winner field-source note on a <c>to_file=</c> artifact. The three inline transports all warn that a
+/// <c>plugins=</c>-scoped fields scan is showing each match's scoped plugin's own values rather than the live winner;
+/// the artifact carries the same values and is read later with no conversation attached, so it has to carry the same
+/// sentence. Its home is the manifest — line 1, the row set's one header, and what a re-entering caller reads first.
+/// </summary>
+[Trait("tier", "integration")]
+public sealed class RecordsArtifactScopedNoteTests : ArtifactTestBase, IClassFixture<ArtifactFixture>
+{
+    public RecordsArtifactScopedNoteTests(ArtifactFixture f) : base(f) { }
+
+    static RecordsTools.RecordsProject Damage => new() { form = "fields", fields = new[] { "BasicStats.Damage" } };
+
+    RecordsTools.RecordsScope Master => new() { names = new[] { W.MasterName } };
+
+    /// <summary>The note the INLINE json answer to the same call carries — read off the product rather than spelled
+    /// here, so the artifact is pinned to the inline wording and the two cannot drift.</summary>
+    string InlineNote(string? fieldsSource = null)
+    {
+        var json = Je(RecordsTools.Records(Svc, types: new[] { "WEAP" }, plugins: Master, project: Damage,
+                                           fields_source: fieldsSource, format: "json"));
+        return json.GetProperty("notes").EnumerateArray().Select(n => n.GetString()!)
+                   .Single(n => n.Contains("field values", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ToFile_TheManifestCarriesTheScopedFieldsNoteTheInlineRendersCarry()
+    {
+        var art = Art("scoped-note.jsonl");
+        RecordsTools.Records(Svc, types: new[] { "WEAP" }, plugins: Master, project: Damage, to_file: art);
+
+        var notes = ManifestOf(art).Notes;
+        Assert.NotNull(notes);
+        Assert.Contains(InlineNote(), notes!);
+    }
+
+    /// <summary>The note is a 4-way matrix over the two poles, so the artifact must state the arm this call is on —
+    /// not a fixed sentence that happens to be right on the default.</summary>
+    [Fact]
+    public void ToFile_TheManifestNoteFollowsTheDisplayPole()
+    {
+        var art = Art("scoped-note-winner.jsonl");
+        RecordsTools.Records(Svc, types: new[] { "WEAP" }, plugins: Master, project: Damage,
+                             fields_source: "winner", to_file: art);
+
+        Assert.Contains(InlineNote("winner"), ManifestOf(art).Notes!);
+    }
+
+    /// <summary>No scoped bodies, no note: an unscoped scan reads the winner, and a sentence saying otherwise would
+    /// be a warning about something that did not happen.</summary>
+    [Fact]
+    public void ToFile_AnUnscopedScanCarriesNoScopedFieldsNote()
+    {
+        var art = Art("scoped-note-none.jsonl");
+        RecordsTools.Records(Svc, types: new[] { "WEAP" }, project: Damage, to_file: art);
+
+        var notes = ManifestOf(art).Notes ?? Array.Empty<string>();
+        Assert.DoesNotContain(notes, n => n.Contains("field values", StringComparison.Ordinal));
+    }
+
+    /// <summary>A summary artifact carries no field values at all, so it is owed no field-source note.</summary>
+    [Fact]
+    public void ToFile_ASummaryArtifactCarriesNoScopedFieldsNote()
+    {
+        var art = Art("scoped-note-summary.jsonl");
+        RecordsTools.Records(Svc, types: new[] { "WEAP" }, plugins: Master, to_file: art);
+
+        var notes = ManifestOf(art).Notes ?? Array.Empty<string>();
+        Assert.DoesNotContain(notes, n => n.Contains("field values", StringComparison.Ordinal));
+    }
+}

--- a/src/housecarl-mcp-tests/RecordsTypeArmTests.cs
+++ b/src/housecarl-mcp-tests/RecordsTypeArmTests.cs
@@ -60,6 +60,31 @@ public sealed class RecordsTypeArmTests
         Assert.DoesNotContain(TypeArmWorld.Float1, r, StringComparison.Ordinal);
     }
 
+    /// <summary>The errors sweep's off-order lane runs a third enumeration of its own, so it needs the same arm
+    /// re-check: without it a <c>type='GlobalShort'</c> sweep of a file holding no GlobalShort walks and counts the
+    /// whole GLOB group. <c>BaseMastersSwept</c> is what that lane's examined set reaches — a swept off-order base
+    /// master is listed there, one whose every record the scope filtered out is not.</summary>
+    [Fact]
+    public void AnArmTypeFilterOnTheOffOrderSweepExaminesThatArmAlone()
+    {
+        var swept = _w.Svc.CheckErrors(new[] { TypeArmWorld.OffOrderName }, 1000, type: "GlobalShort");
+
+        Assert.Null(swept.Error);
+        Assert.Contains(TypeArmWorld.OffOrderName, swept.OffOrderScanned!);   // the file WAS located and opened
+        Assert.Empty(swept.BaseMastersSwept!);                                // and nothing in it was examined
+    }
+
+    /// <summary>The control: the arm the file does hold IS examined, so the assertion above is a filter working
+    /// rather than the off-order lane failing to reach the records at all.</summary>
+    [Fact]
+    public void TheArmTheOffOrderFileHoldsIsExamined()
+    {
+        var swept = _w.Svc.CheckErrors(new[] { TypeArmWorld.OffOrderName }, 1000, type: "GlobalFloat");
+
+        Assert.Null(swept.Error);
+        Assert.Contains(TypeArmWorld.OffOrderName, swept.BaseMastersSwept!);
+    }
+
     /// <summary>The whole abstract group is still addressable by its own name — narrowing the arms must not narrow
     /// the group.</summary>
     [Fact]

--- a/src/housecarl-mcp-tests/RecordsTypeArmTests.cs
+++ b/src/housecarl-mcp-tests/RecordsTypeArmTests.cs
@@ -1,0 +1,74 @@
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// A type filter naming one ARM of an abstract group (GlobalShort, GameSettingInt) answers over that arm alone.
+/// Mutagen's typed enumeration seeks the GRUP, which for an abstract group is every arm of it, so the scan lane has
+/// to re-check the arm on each record — otherwise the answer is the whole group with a corrupted denominator and
+/// nothing saying the filter widened.
+/// </summary>
+[Collection("type-arms")]
+[Trait("tier", "integration")]
+public sealed class RecordsTypeArmTests
+{
+    readonly TypeArmWorld _w;
+    public RecordsTypeArmTests(TypeArmFixture f) => _w = f.W;
+
+    [Fact]
+    public void AnArmTypeFilterOnTheInOrderScanReturnsThatArmAlone()
+    {
+        var r = RecordsTools.Records(_w.Svc, types: new[] { "GlobalShort" });
+
+        Assert.Contains(TypeArmWorld.Short1, r, StringComparison.Ordinal);
+        Assert.Contains(TypeArmWorld.Short2, r, StringComparison.Ordinal);
+        Assert.DoesNotContain(TypeArmWorld.Int1, r, StringComparison.Ordinal);
+        Assert.DoesNotContain(TypeArmWorld.Float1, r, StringComparison.Ordinal);
+    }
+
+    /// <summary>A second arm of the same group, so the filter is known to select rather than to happen to keep the
+    /// first arm's records.</summary>
+    [Fact]
+    public void TheOtherArmOfTheSameGroupSelectsItsOwnRecords()
+    {
+        var r = RecordsTools.Records(_w.Svc, types: new[] { "GlobalFloat" });
+
+        Assert.Contains(TypeArmWorld.Float1, r, StringComparison.Ordinal);
+        Assert.DoesNotContain(TypeArmWorld.Short1, r, StringComparison.Ordinal);
+        Assert.DoesNotContain(TypeArmWorld.Int1, r, StringComparison.Ordinal);
+    }
+
+    /// <summary>The same shape on a second abstract group, so the fix is not one type's special case.</summary>
+    [Fact]
+    public void AGameSettingArmFilterAnswersOverThatArmAlone()
+    {
+        var r = RecordsTools.Records(_w.Svc, types: new[] { "GameSettingInt" });
+
+        Assert.Contains(TypeArmWorld.GmstInt, r, StringComparison.Ordinal);
+        Assert.DoesNotContain(TypeArmWorld.GmstFloat, r, StringComparison.Ordinal);
+    }
+
+    /// <summary>The plugin-scoped lane runs its own enumeration, so it needs the same arm re-check.</summary>
+    [Fact]
+    public void AnArmTypeFilterOnThePluginScopedScanReturnsThatArmAlone()
+    {
+        var r = RecordsTools.Records(_w.Svc, types: new[] { "GlobalShort" },
+                                     plugins: new RecordsTools.RecordsScope { names = new[] { _w.MasterName } });
+
+        Assert.Contains(TypeArmWorld.Short1, r, StringComparison.Ordinal);
+        Assert.DoesNotContain(TypeArmWorld.Float1, r, StringComparison.Ordinal);
+    }
+
+    /// <summary>The whole abstract group is still addressable by its own name — narrowing the arms must not narrow
+    /// the group.</summary>
+    [Fact]
+    public void TheAbstractGroupNameStillAnswersOverEveryArm()
+    {
+        var r = RecordsTools.Records(_w.Svc, types: new[] { "GLOB" });
+
+        Assert.Contains(TypeArmWorld.Short1, r, StringComparison.Ordinal);
+        Assert.Contains(TypeArmWorld.Int1, r, StringComparison.Ordinal);
+        Assert.Contains(TypeArmWorld.Float1, r, StringComparison.Ordinal);
+    }
+}

--- a/src/housecarl-mcp-tests/TypeArmWorld.cs
+++ b/src/housecarl-mcp-tests/TypeArmWorld.cs
@@ -1,0 +1,98 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlGenerator;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// A world of ABSTRACT-GROUP records only: one GLOB group holding all three of Mutagen's concrete arms
+/// (GlobalShort / GlobalInt / GlobalFloat) and one GMST group holding two of its own. Mutagen models these groups as
+/// an abstract base with concrete subclasses, so a type filter naming an arm is the only case where the resolved
+/// getter type is narrower than the GRUP a typed enumeration seeks.
+///
+/// <para>Its own world: the shared records and bulk worlds carry no globals, and adding any would move counts their
+/// tests assert.</para>
+/// </summary>
+public sealed class TypeArmWorld : IDisposable
+{
+    public string Root { get; }
+    public string MasterName { get; }
+    public LoadOrderService Svc { get; }
+
+    /// <summary>The two GlobalShort records — what a <c>type='GlobalShort'</c> filter must return, and all it must
+    /// return.</summary>
+    public const string Short1 = "HcArmShortA";
+    public const string Short2 = "HcArmShortB";
+    public const string Int1 = "HcArmInt";
+    public const string Float1 = "HcArmFloat";
+
+    /// <summary>The GMST arms — the same shape on a second abstract group, so the fix is known not to be one type's
+    /// special case.</summary>
+    public const string GmstInt = "HcArmGmstInt";
+    public const string GmstFloat = "HcArmGmstFloat";
+
+    readonly string _priorCorpusPath;
+
+    public TypeArmWorld()
+    {
+        _priorCorpusPath = CorpusRulebook.CorpusPath;
+
+        Root = Path.Combine(Path.GetTempPath(), "hc-typearm-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(Root, "game", "Data"));
+
+        var masterKey = new ModKey("HcArmMaster", ModType.Master);
+        MasterName = masterKey.FileName.String;
+        var master = new SkyrimMod(masterKey, SkyrimRelease.SkyrimSE);
+
+        master.Globals.Add(new GlobalShort(master.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = Short1, Data = 1 });
+        master.Globals.Add(new GlobalShort(master.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = Short2, Data = 2 });
+        master.Globals.Add(new GlobalInt(master.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = Int1, Data = 3 });
+        master.Globals.Add(new GlobalFloat(master.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = Float1, Data = 4.5f });
+
+        master.GameSettings.Add(new GameSettingInt(master.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = GmstInt, Data = 7 });
+        master.GameSettings.Add(new GameSettingFloat(master.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = GmstFloat, Data = 8.5f });
+
+        var instance = Path.Combine(Root, "inst");
+        var modDir = Path.Combine(instance, "mods", "ArmMasterMod");
+        Directory.CreateDirectory(modDir);
+        master.BeginWrite.ToPath(Path.Combine(modDir, MasterName)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+        var genDir = Path.Combine(Root, "corpus-gen");
+        CorpusGenerator.GenerateAll(genDir, Path.Combine(Root, "corpus-ref"));
+        CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json");
+
+        File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(Root, "game").Replace(@"\", @"\\") + ")\r\n");
+        var prof = Path.Combine(instance, "profiles", "Default");
+        Directory.CreateDirectory(prof);
+        File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + MasterName + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*" + MasterName + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n+ArmMasterMod\r\n");
+
+        Svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(Root, "user.json")));
+    }
+
+    public void Dispose()
+    {
+        CorpusRulebook.CorpusPath = _priorCorpusPath;
+        Svc.Dispose();
+        try { Directory.Delete(Root, true); } catch { /* temp cleanup best-effort */ }
+    }
+}
+
+public sealed class TypeArmFixture : IDisposable
+{
+    public TypeArmWorld W { get; } = new();
+    public void Dispose() => W.Dispose();
+}
+
+/// <summary>Its own collection, for the reason the records and bulk ones have theirs:
+/// <c>CorpusRulebook.CorpusPath</c> is a process-global and only one world may own it at a time.</summary>
+[CollectionDefinition("type-arms")]
+public sealed class TypeArmCollection : ICollectionFixture<TypeArmFixture> { }

--- a/src/housecarl-mcp-tests/TypeArmWorld.cs
+++ b/src/housecarl-mcp-tests/TypeArmWorld.cs
@@ -36,6 +36,15 @@ public sealed class TypeArmWorld : IDisposable
     public const string GmstInt = "HcArmGmstInt";
     public const string GmstFloat = "HcArmGmstFloat";
 
+    /// <summary>A plugin FILE on disk that is NOT in the active order — the errors sweep's off-order lane, its own
+    /// record stream. Named for a base-game master because <c>BaseMastersSwept</c> is what exposes that lane's
+    /// "examined" set to a test: a swept off-order base master is listed there, and one whose every record a scope
+    /// filtered out is not. It holds a GlobalFloat and a GlobalInt and deliberately NO GlobalShort, so a
+    /// <c>type='GlobalShort'</c> sweep of it must examine nothing.</summary>
+    public const string OffOrderName = "Update.esm";
+    public const string OffOrderFloat = "HcArmOffFloat";
+    public const string OffOrderInt = "HcArmOffInt";
+
     readonly string _priorCorpusPath;
 
     public TypeArmWorld()
@@ -62,6 +71,16 @@ public sealed class TypeArmWorld : IDisposable
         Directory.CreateDirectory(modDir);
         master.BeginWrite.ToPath(Path.Combine(modDir, MasterName)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
 
+        // The off-order file: written into an ENABLED mod folder but left out of plugins.txt and loadorder.txt, which
+        // is what the errors sweep locates on disk and sweeps as a file.
+        var offKey = new ModKey(Path.GetFileNameWithoutExtension(OffOrderName), ModType.Master);
+        var off = new SkyrimMod(offKey, SkyrimRelease.SkyrimSE);
+        off.Globals.Add(new GlobalFloat(off.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = OffOrderFloat, Data = 1.5f });
+        off.Globals.Add(new GlobalInt(off.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = OffOrderInt, Data = 6 });
+        var offDir = Path.Combine(instance, "mods", "ArmOffOrderMod");
+        Directory.CreateDirectory(offDir);
+        off.BeginWrite.ToPath(Path.Combine(offDir, OffOrderName)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
         var genDir = Path.Combine(Root, "corpus-gen");
         CorpusGenerator.GenerateAll(genDir, Path.Combine(Root, "corpus-ref"));
         CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json");
@@ -73,7 +92,7 @@ public sealed class TypeArmWorld : IDisposable
         Directory.CreateDirectory(prof);
         File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + MasterName + "\r\n");
         File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*" + MasterName + "\r\n");
-        File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n+ArmMasterMod\r\n");
+        File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n+ArmOffOrderMod\r\n+ArmMasterMod\r\n");
 
         Svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(Root, "user.json")));
     }

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -184,7 +184,7 @@ internal static class Artifacts
         // The manifest stamps which tool wrote the artifact; see WriteResolve for why it names records.
         var (manifest, err) = writer.Save(path, ToolNames.Records, query, identity, schema, sort,
                                           q.Groups is not null ? q.Groups.Count : q.Total, q.Epoch ?? "",
-                                          OwnedChildNotes(annotated, annotatedUnioned));
+                                          CrossQueryNotes(q, fields, winnerFields, annotated, annotatedUnioned, levers));
         return err is not null ? (null, err) : (new SpillInfo(path, manifest!, reason), null);
     }
 
@@ -195,6 +195,22 @@ internal static class Artifacts
     /// tier's note is <see cref="PreciseChildNotes"/>.</summary>
     static IReadOnlyList<string>? OwnedChildNotes(IReadOnlyCollection<string> annotatedFields, bool unioned) =>
         annotatedFields.Count == 0 ? null : new[] { ReadSentences.OwnedChildClause(annotatedFields, unioned) };
+
+    /// <summary>The manifest notes a scan artifact carries: the scoped-vs-winner field-source note the three inline
+    /// transports state, then the owned-child clause. The artifact holds the same values the inline render would have
+    /// shown and is read later with no conversation attached, so the sentence saying WHOSE body those values came
+    /// from has to travel with them. The scoped test is the one the inline renders use, so the two cannot disagree
+    /// about when the note is owed.</summary>
+    static IReadOnlyList<string>? CrossQueryNotes(CrossQueryOutcome q, IReadOnlyList<string>? fields, bool winnerFields,
+                                                  IReadOnlyCollection<string> annotatedFields, bool annotatedUnioned,
+                                                  LeverNames? levers)
+    {
+        var notes = new List<string>();
+        if (fields is { Count: > 0 } && q.Sources is { } sources && sources.Take(q.Keys.Count).Any(s => s is not null))
+            notes.Add(JsonWire.ScopedFieldsNote(winnerFields, q.WhereWinner, levers));
+        if (OwnedChildNotes(annotatedFields, annotatedUnioned) is { } child) notes.AddRange(child);
+        return notes.Count > 0 ? notes : null;
+    }
 
     /// <summary>The precise tier's response-level note for a tree artifact: <see cref="ReadSentences.DeclarersLead"/>
     /// stated once rather than per row, when any row's <c>child_declarers</c> reached the file.</summary>

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -199,14 +199,14 @@ internal static class Artifacts
     /// <summary>The manifest notes a scan artifact carries: the scoped-vs-winner field-source note the three inline
     /// transports state, then the owned-child clause. The artifact holds the same values the inline render would have
     /// shown and is read later with no conversation attached, so the sentence saying WHOSE body those values came
-    /// from has to travel with them. The scoped test is the one the inline renders use, so the two cannot disagree
-    /// about when the note is owed.</summary>
+    /// from has to travel with them. The scoped test is <see cref="JsonWire.AnyScopedFieldRow"/> — the very function
+    /// the inline renders call, not a copy of it — so the two cannot disagree about when the note is owed.</summary>
     static IReadOnlyList<string>? CrossQueryNotes(CrossQueryOutcome q, IReadOnlyList<string>? fields, bool winnerFields,
                                                   IReadOnlyCollection<string> annotatedFields, bool annotatedUnioned,
                                                   LeverNames? levers)
     {
         var notes = new List<string>();
-        if (fields is { Count: > 0 } && q.Sources is { } sources && sources.Take(q.Keys.Count).Any(s => s is not null))
+        if (JsonWire.AnyScopedFieldRow(q, fields))
             notes.Add(JsonWire.ScopedFieldsNote(winnerFields, q.WhereWinner, levers));
         if (OwnedChildNotes(annotatedFields, annotatedUnioned) is { } child) notes.AddRange(child);
         return notes.Count > 0 ? notes : null;

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1086,7 +1086,7 @@ static class JsonWire
             else                                                            // per-match: detail (fields=) or summary
             {
                 bool detail = fields is { Count: > 0 };
-                bool anyScoped = detail && q.Sources is { } ss && ss.Take(q.Keys.Count).Any(s => s is not null);   // any row read from a scoped body
+                bool anyScoped = AnyScopedFieldRow(q, fields);   // the shared test: any row read from a scoped body
                 string? p5 = anyScoped ? ScopedFieldsNote(winnerFields, q.WhereWinner, levers) : null;
                 w.WriteNumber("total", q.Total);
                 w.WriteBoolean("capped", q.Capped);
@@ -1133,6 +1133,15 @@ static class JsonWire
         }
         return Finish(ms);
     }
+
+    /// <summary>Is the scoped-vs-winner field-source note owed at all? True when a <c>fields=</c> detail render
+    /// actually carried at least one row read from a scoped plugin's OWN body. Every render that states the note —
+    /// the two json lanes, the inline text render, and the scan artifact's manifest — asks HERE, so the four agreeing
+    /// is structural rather than four copies of one line that happen to match today. A <c>group_by=</c> outcome
+    /// answers false outright: it renders counts, not rows, and fills no per-key sources.</summary>
+    internal static bool AnyScopedFieldRow(CrossQueryOutcome q, IReadOnlyList<string>? fields)
+        => q.Groups is null && fields is { Count: > 0 }
+           && q.Sources is { } sources && sources.Take(q.Keys.Count).Any(s => s is not null);
 
     /// <summary>The scoped-vs-winner field-source note, one of a 4-way matrix over (winner_fields=, where_source=).
     /// <paramref name="whereWinner"/> is true when the MATCH decided on the live winner, and the note must then not
@@ -1183,7 +1192,7 @@ static class JsonWire
             else
             {
                 bool detail = fields is { Count: > 0 };
-                bool anyScoped = detail && q.Sources is { } ss && ss.Take(q.Keys.Count).Any(s => s is not null);   // any row read from a scoped body
+                bool anyScoped = AnyScopedFieldRow(q, fields);   // the shared test: any row read from a scoped body
                 w.WriteNumber("total", q.Total);
                 w.WriteBoolean("capped", q.Capped);
                 WriteNullable(w, "epoch", q.Epoch);                           // offset= windows tile ONLY within one epoch

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -238,7 +238,7 @@ static class Wire
         if (q.Groups is not null) return RenderCrossQueryGroups(q, cap, spill, out truncated);   // group_by= → a count table, not per-match lines
         bool detail = fields is { Count: > 0 };          // expand matches, vs. one-line summaries
         var linkMemo = resolveNames && detail ? new LoadOrderService.LinkMemo() : null;   // one link cache across all rendered matches
-        bool anyScoped = detail && q.Sources is { } ss && ss.Take(q.Keys.Count).Any(s => s is not null);   // a plugins= scope shows a plugin's OWN body
+        bool anyScoped = JsonWire.AnyScopedFieldRow(q, fields);   // the shared test: a plugins= scope shows a plugin's OWN body
         var sb = new StringBuilder();
         sb.Append("scan: ").Append(q.Total).Append(q.Total == 1 ? " match" : " matches");
         if (q.ScopeLabel is not null) sb.Append(" DEFINED IN ").Append(q.ScopeLabel);   // explicit scope — NOT the 'touches' default


### PR DESCRIPTION
Two silent-wrong-answer bugs on the records lane. Both returned or wrote something that read as an answer to the question asked and was an answer to a different one.

**#527 — a concrete-arm type filter returned the whole abstract group.** `types=["GlobalShort"]` and `types=["GlobalFloat"]` both returned the identical whole-GLOB set, mixed, with nothing saying the filter had widened. `ResolveTypeFilter` maps the arm to `IGlobalShortGetter` correctly; the in-order scan then hands that type to Mutagen's `EnumerateMajorRecords`, which seeks the GRUP — and for an abstract group the GRUP is every arm of it. The off-order lane already re-checks the arm per record (`LoadOrderService.cs`, `types.Any(t => t.IsInstanceOfType(rec))`); the two in-order enumerations in `LoadOrderResolver.cs` — `WinnerRecordsOfType` and the plugin-scoped `RecordsIn` — now do the same. The group's own name (`GLOB`, `GMST`) still resolves to every arm.

**#449 — `to_file=` artifact rows carried scoped field values without the scoped-vs-winner note.** The text, json and dense renders all state which body a `plugins=`-scoped fields scan read its values from; the artifact carried the same values and said nothing, so the number came back out of the file later with nothing attached naming its source. The note now rides the manifest — line 1, what a re-entering caller reads first — from `JsonWire.ScopedFieldsNote`, the same composer and the same "any row read from a scoped body" test the inline renders use, so the four-way (`fields_source=`, `where_source=`) matrix cannot drift between the two.

**#448 — not folded: already fixed on `main`.** The refusal the issue asks for landed in 64a730b ("dense refuses a depth it cannot render, instead of dropping it") with three tests in `RecordsScanRefusalRepairTests.cs`. `RecordsTools.cs` refuses `format='dense'` with `project.depth > 1` by name on the scan lane, and the list lane's own dense refusal covers the other half. Verified on this branch: those tests pass. The issue can be closed as done rather than by this PR, which is why there is no `Closes #448` here.

New tests, each failing on the tree before its fix: `RecordsTypeArmTests` over a new `TypeArmWorld` (a GLOB group of all three arms and a GMST group of two) covers both arms of a group selecting their own records, a second abstract group, the plugin-scoped lane, and the group name still returning everything — 4 of its 5 failed before the fix. `RecordsArtifactScopedNoteTests` covers the note on the manifest, the display-pole arm, and the two cases owed no note — 2 of its 4 failed before the fix.

Closes #527
Closes #449

Stacked on #555 (`claude/skse-transport`), which this branch is based on and targets.

Build, `tier!=bridge` tests (1219 passed) and `ci-all` green.
