### PR TITLE
Gather winner bodies a plugin at a time on where_source=winner

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -181,7 +181,9 @@ saying it sets an expectation their install may contradict. Say what is known, a
 - **A `where_source=winner` scan now says WHY a winner plugin did not give up its record.** A plugin another
   program is holding open reports that, with the error underneath it and the plugin named once as a coverage gap,
   instead of every one of its records reading as a winner the index named that did not re-resolve — a different
-  problem, and not the one the user can act on.
+  problem, and not the one the user can act on. A plugin that opens but whose records cannot be read to the end —
+  it changed on disk since the load order was indexed — reports that instead, and is not described as held open by
+  a program that is holding nothing. Either way the gap is one plugin's: the rest of the scan still answers.
 
 - **Reading a cell's `Persistent`/`Temporary` — or a topic's `Responses`, or a worldspace's `SubCells` — now
   states the additive union the game assembles, not just the read body's own list.** These children are declared

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -169,6 +169,14 @@ saying it sets an expectation their install may contradict. Say what is known, a
   None-property diagnostics read it), and the list's own header keeps its true count. Under `format='json'` a row
   is one entry carrying its folded leaves as `cells`, each with its own value, `link` and count — the values are
   never handed over as a sentence to parse.
+- **A broad `where_source=winner` scan is no longer slower the more records it considers.** Deciding the match on
+  the live winner used to re-read each candidate's winner by walking that plugin's whole record list, once per
+  candidate, so a post-patch audit over a large master could spend minutes doing nothing but re-reading. The
+  winner bodies are now gathered a plugin at a time — one pass per winner plugin however many of its records are
+  wanted — so the cost is bounded by the load order instead of by the number of candidates. On a synthetic order
+  of one 19.2k-record master and nine plugins, an audit of every record the master touches went from 165 s to
+  51 s, which is what the same scan costs with `where_source` left at its default. Same matches, same rows.
+
 - **Reading a cell's `Persistent`/`Temporary` — or a topic's `Responses`, or a worldspace's `SubCells` — now
   states the additive union the game assembles, not just the read body's own list.** These children are declared
   per plugin and the engine assembles a parent's from every plugin that declares any, so a cell whose winner is

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -171,11 +171,17 @@ saying it sets an expectation their install may contradict. Say what is known, a
   never handed over as a sentence to parse.
 - **A broad `where_source=winner` scan is no longer slower the more records it considers.** Deciding the match on
   the live winner used to re-read each candidate's winner by walking that plugin's whole record list, once per
-  candidate, so a post-patch audit over a large master could spend minutes doing nothing but re-reading. The
-  winner bodies are now gathered a plugin at a time — one pass per winner plugin however many of its records are
-  wanted — so the cost is bounded by the load order instead of by the number of candidates. On a synthetic order
-  of one 19.2k-record master and nine plugins, an audit of every record the master touches went from 165 s to
-  51 s, which is what the same scan costs with `where_source` left at its default. Same matches, same rows.
+  candidate, so a post-patch audit over a large master could spend minutes doing nothing but re-reading. The winner
+  bodies are now gathered a chunk of candidates at a time — one pass per winner plugin in the chunk — and a
+  candidate the scoped plugin itself wins is not re-read at all, since the body the scan already streamed IS the
+  winner's. So the cost is bounded by the load order instead of by the number of candidates, and the scan holds one
+  chunk of bodies at a time rather than one per candidate. On a synthetic order of one 19,200-record master and
+  nine plugins, an audit of every record the master touches went from 34 s to 0.4 s, against the 0.2 s the same
+  scan costs with `where_source` left at its default. Same matches, same rows.
+- **A `where_source=winner` scan now says WHY a winner plugin did not give up its record.** A plugin another
+  program is holding open reports that, with the error underneath it and the plugin named once as a coverage gap,
+  instead of every one of its records reading as a winner the index named that did not re-resolve — a different
+  problem, and not the one the user can act on.
 
 - **Reading a cell's `Persistent`/`Temporary` — or a topic's `Responses`, or a worldspace's `SubCells` — now
   states the additive union the game assembles, not just the read body's own list.** These children are declared

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -64,14 +64,31 @@ public readonly record struct RecordStatus(
 /// <summary>A plugin in the load order could not be opened during a scan, although it opened when the index was
 /// built — it was moved, or another program (xEdit, MO2, the running game) is holding it. Thrown from the
 /// plugin-scoped record stream so a scan reports the plugin it could not read rather than skipping it silently.</summary>
-public sealed class PluginUnreadableException : Exception
+public class PluginUnreadableException : Exception
 {
     public string PluginName { get; }
     public PluginUnreadableException(string pluginName, Exception inner)
-        : base($"could not read '{pluginName}': it opened when the load order was indexed but not now — another " +
+        : this(pluginName, inner,
+               $"could not read '{pluginName}': it opened when the load order was indexed but not now — another " +
                "program is probably holding it open. Close that program and run this again. " +
-               $"({inner.GetType().Name}: {inner.Message})", inner)
-        => PluginName = pluginName;
+               $"({inner.GetType().Name}: {inner.Message})") { }
+
+    protected PluginUnreadableException(string pluginName, Exception inner, string message)
+        : base(message, inner) => PluginName = pluginName;
+}
+
+/// <summary>A plugin OPENED but its records could not be walked to the end — the file changed under the index, or
+/// Mutagen cannot step over something in it. A different fault from <see cref="PluginUnreadableException"/> and
+/// worded as one: telling the user to close a program that is holding nothing would send them after the wrong
+/// thing. Reported the same way, as a whole-plugin coverage gap, because a walk that died part-way says nothing
+/// about the records after it.</summary>
+public sealed class PluginUnscannableException : PluginUnreadableException
+{
+    public PluginUnscannableException(string pluginName, Exception inner)
+        : base(pluginName, inner,
+               $"could not finish reading '{pluginName}': it opened, but its records could not be walked to the end " +
+               "— the file has probably changed since the load order was indexed. Run this again, and check the " +
+               $"plugin in xEdit if it repeats. ({inner.GetType().Name}: {inner.Message})") { }
 }
 
 /// <summary>A BASELINE master (Skyrim.esm / Update.esm) is active but cannot be opened. Every written plugin
@@ -1054,7 +1071,9 @@ public sealed class LoadOrderResolver : IDisposable
     /// them cost N walks (#251), while this costs one walk however many are wanted, and stops as soon as it has them
     /// all. <paramref name="getterTypes"/> narrows the walk to the GRUPs those types live in when the caller knows
     /// them; anything the typed walk did not produce falls through to the flat one, per KEY, for the same reason
-    /// <see cref="SeekBody"/> does. A key this plugin does not hold is simply absent from the sink.</summary>
+    /// <see cref="SeekBody"/> does. A key this plugin does not hold is simply absent from the sink. Throws
+    /// <see cref="PluginUnreadableException"/> on a plugin that opened at index-build time but cannot be opened now;
+    /// a fault from the WALK is left as it came, so a caller does not report it as a held-open file.</summary>
     public void CollectRecords(OverlaySession session, string pluginName, IReadOnlyCollection<FormKey> wanted,
                                IReadOnlyList<Type>? getterTypes, IDictionary<FormKey, IMajorRecordGetter> sink)
         => CollectRecords(session, pluginName, wanted, getterTypes, sink, _snap);
@@ -1065,7 +1084,11 @@ public sealed class LoadOrderResolver : IDisposable
         if (wanted.Count == 0) return;
         if (!_nameToIdx.TryGetValue(pluginName, out int idx)) return;
         if (s.Excluded.Contains(idx)) return;                              // excluded plugin — never re-enumerate it (would re-throw)
-        var ov = session.Overlay(idx);
+        ISkyrimModGetter ov;
+        // Only the OPEN is named as unopenable, exactly as RecordsIn and WinnerRecordsOfType name it. A fault from
+        // the walk BELOW is a different problem, and calling it a held-open file would send the user after nothing.
+        try { ov = session.Overlay(idx); }
+        catch (Exception ex) { throw new PluginUnreadableException(_names[idx], ex); }
         var want = wanted as HashSet<FormKey> ?? new HashSet<FormKey>(wanted);
         int got = 0;
         foreach (var fk in want) if (sink.ContainsKey(fk)) got++;          // already in hand from an earlier call

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -1053,7 +1053,7 @@ public sealed class LoadOrderResolver : IDisposable
     /// the caller wants many records from the same plugin: <see cref="GetRecord"/> costs one walk per record, so N of
     /// them cost N walks (#251), while this costs one walk however many are wanted, and stops as soon as it has them
     /// all. <paramref name="getterTypes"/> narrows the walk to the GRUPs those types live in when the caller knows
-    /// them; a typed walk that finds none of the wanted keys falls back to the flat one for the same reason
+    /// them; anything the typed walk did not produce falls through to the flat one, per KEY, for the same reason
     /// <see cref="SeekBody"/> does. A key this plugin does not hold is simply absent from the sink.</summary>
     public void CollectRecords(OverlaySession session, string pluginName, IReadOnlyCollection<FormKey> wanted,
                                IReadOnlyList<Type>? getterTypes, IDictionary<FormKey, IMajorRecordGetter> sink)
@@ -1068,6 +1068,8 @@ public sealed class LoadOrderResolver : IDisposable
         var ov = session.Overlay(idx);
         var want = wanted as HashSet<FormKey> ?? new HashSet<FormKey>(wanted);
         int got = 0;
+        foreach (var fk in want) if (sink.ContainsKey(fk)) got++;          // already in hand from an earlier call
+        if (got == want.Count) return;
         if (getterTypes is { Count: > 0 })
         {
             foreach (var t in getterTypes)
@@ -1077,7 +1079,11 @@ public sealed class LoadOrderResolver : IDisposable
                         sink[rec.FormKey] = rec;
                         if (++got == want.Count) return;
                     }
-            if (got > 0) return;                                           // the typed walk routed; what it did not find, this plugin does not hold
+            // Fall through for whatever is STILL missing, per key. "The typed walk routed something, so what it
+            // did not find is not here" is the inference SeekBody's own doc comment warns against: with two types
+            // where Mutagen routes one and silently routes nothing for the other, the routed type's hits would
+            // otherwise declare the unrouted type's records absent. The flat pass costs the same as SeekBody's
+            // fallback on a miss, and it cannot answer wrong.
         }
         foreach (var rec in ov.EnumerateMajorRecords())
             if (want.Contains(rec.FormKey) && !sink.ContainsKey(rec.FormKey))

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -904,6 +904,12 @@ public sealed class LoadOrderResolver : IDisposable
         public IMajorRecordGetter? GetRecord(OverlaySession session, string pluginName, FormKey fk, Type? getterType = null)
             => _r.GetRecord(session, pluginName, fk, _s, getterType);
 
+        /// <summary>Many records from ONE plugin in ONE enumeration (<see cref="LoadOrderResolver.CollectRecords"/>),
+        /// judged against THIS view's build.</summary>
+        public void CollectRecords(OverlaySession session, string pluginName, IReadOnlyCollection<FormKey> wanted,
+                                   IReadOnlyList<Type>? getterTypes, IDictionary<FormKey, IMajorRecordGetter> sink)
+            => _r.CollectRecords(session, pluginName, wanted, getterTypes, sink, _s);
+
         /// <summary>The master filenames a plugin DECLARES in its header (the master table), in declared order — opens
         /// the overlay, reads the header, disposes — the header parses without enumerating records. Throws
         /// on a name not in the order or excluded this build. The integrity sweep diffs this against the masters a
@@ -1040,6 +1046,45 @@ public sealed class LoadOrderResolver : IDisposable
         catch (Exception ex) { throw new PluginUnreadableException(_names[idx], ex); }
         try { return ov.ModHeader.MasterReferences.Select(m => m.Master.FileName.ToString()).ToList(); }
         finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    /// <summary>The bodies ONE plugin holds for a KNOWN set of FormKeys, gathered in a SINGLE enumeration of that
+    /// plugin and written into <paramref name="sink"/>. The counterpart of <see cref="GetRecord"/> for the case where
+    /// the caller wants many records from the same plugin: <see cref="GetRecord"/> costs one walk per record, so N of
+    /// them cost N walks (#251), while this costs one walk however many are wanted, and stops as soon as it has them
+    /// all. <paramref name="getterTypes"/> narrows the walk to the GRUPs those types live in when the caller knows
+    /// them; a typed walk that finds none of the wanted keys falls back to the flat one for the same reason
+    /// <see cref="SeekBody"/> does. A key this plugin does not hold is simply absent from the sink.</summary>
+    public void CollectRecords(OverlaySession session, string pluginName, IReadOnlyCollection<FormKey> wanted,
+                               IReadOnlyList<Type>? getterTypes, IDictionary<FormKey, IMajorRecordGetter> sink)
+        => CollectRecords(session, pluginName, wanted, getterTypes, sink, _snap);
+
+    void CollectRecords(OverlaySession session, string pluginName, IReadOnlyCollection<FormKey> wanted,
+                        IReadOnlyList<Type>? getterTypes, IDictionary<FormKey, IMajorRecordGetter> sink, IndexSnapshot s)
+    {
+        if (wanted.Count == 0) return;
+        if (!_nameToIdx.TryGetValue(pluginName, out int idx)) return;
+        if (s.Excluded.Contains(idx)) return;                              // excluded plugin — never re-enumerate it (would re-throw)
+        var ov = session.Overlay(idx);
+        var want = wanted as HashSet<FormKey> ?? new HashSet<FormKey>(wanted);
+        int got = 0;
+        if (getterTypes is { Count: > 0 })
+        {
+            foreach (var t in getterTypes)
+                foreach (var rec in ov.EnumerateMajorRecords(t, throwIfUnknown: false))
+                    if (want.Contains(rec.FormKey) && !sink.ContainsKey(rec.FormKey))
+                    {
+                        sink[rec.FormKey] = rec;
+                        if (++got == want.Count) return;
+                    }
+            if (got > 0) return;                                           // the typed walk routed; what it did not find, this plugin does not hold
+        }
+        foreach (var rec in ov.EnumerateMajorRecords())
+            if (want.Contains(rec.FormKey) && !sink.ContainsKey(rec.FormKey))
+            {
+                sink[rec.FormKey] = rec;
+                if (++got == want.Count) return;
+            }
     }
 
     /// <summary>Fetch one record body from one overlay by re-enumerating it into the session. Throws if the overlay

--- a/src/housecarl-core/WinnerBodies.cs
+++ b/src/housecarl-core/WinnerBodies.cs
@@ -1,0 +1,48 @@
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// The live winner's BODY for each of a known set of records (#251).
+///
+/// <para>A scan that decides its match on the winner has the candidate FormKeys in hand before it needs any winner
+/// body, and a plugin's winners are a contiguous fact about that plugin's overlay. So the bodies are gathered by
+/// PLUGIN — one enumeration per distinct winner plugin, however many of its records are wanted — rather than by
+/// record, which is one whole-overlay walk EACH and turns a broad audit into O(candidates x overlay). The order
+/// bounds the total work: every plugin is walked at most once.</para>
+///
+/// <para>Nothing is held past the caller's session: the bodies are backed by the overlays that session has open,
+/// exactly as <see cref="LoadOrderResolver.IndexView.GetRecord"/>'s are, and the map itself is one entry per
+/// CANDIDATE — never one per record in the order.</para>
+/// </summary>
+public static class WinnerBodies
+{
+    /// <summary>The winner body of each candidate, keyed by FormKey. A candidate whose winner cannot be resolved,
+    /// or whose winner plugin does not yield it, is simply ABSENT — the caller decides what an unfetchable winner
+    /// means, because "the index named a winner that did not re-resolve" is a fact it has to report, not one this
+    /// helper may swallow. <paramref name="getterTypes"/> is the caller's own type scope when it has one, which
+    /// narrows each plugin's walk to the GRUPs those types live in.</summary>
+    public static Dictionary<FormKey, IMajorRecordGetter> For(
+        LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session,
+        IReadOnlyCollection<FormKey> candidates, IReadOnlyList<Type>? getterTypes)
+    {
+        var bodies = new Dictionary<FormKey, IMajorRecordGetter>(candidates.Count);
+        if (candidates.Count == 0) return bodies;
+
+        var byPlugin = new Dictionary<string, HashSet<FormKey>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var fk in candidates)
+        {
+            if (view.ResolveWinner(fk) is not { } w) continue;
+            if (!byPlugin.TryGetValue(w.WinnerPlugin, out var set)) byPlugin[w.WinnerPlugin] = set = new HashSet<FormKey>();
+            set.Add(fk);
+        }
+        foreach (var (plugin, wanted) in byPlugin)
+            // A winner plugin that will not OPEN leaves its candidates absent rather than ending the scan, which is
+            // what the per-record fetch this replaces did: each such candidate is then the caller's own
+            // "the index named a winner that did not re-resolve" row, and the rest of the scan still answers.
+            try { view.CollectRecords(session, plugin, wanted, getterTypes, bodies); }
+            catch { /* absent; the caller reports each candidate */ }
+        return bodies;
+    }
+}

--- a/src/housecarl-core/WinnerBodies.cs
+++ b/src/housecarl-core/WinnerBodies.cs
@@ -21,8 +21,9 @@ public static class WinnerBodies
     /// <summary>The winner body of each candidate, keyed by FormKey. A candidate whose winner cannot be resolved,
     /// or whose winner plugin does not yield it, is simply ABSENT — the caller decides what an unfetchable winner
     /// means, because "the index named a winner that did not re-resolve" is a fact it has to report, not one this
-    /// helper may swallow. A winner plugin that will not OPEN is named in <paramref name="unreadable"/> with the
-    /// underlying cause, so the caller reports the held-open file rather than guessing at index staleness.
+    /// helper may swallow. A winner plugin the gather cannot READ is named in <paramref name="unreadable"/> with the
+    /// underlying cause, so the caller reports the held-open file — or the plugin that changed under the index —
+    /// rather than guessing at index staleness.
     /// <paramref name="getterTypes"/> is the caller's own type scope when it has one, which narrows each plugin's
     /// walk to the GRUPs those types live in.</summary>
     public static Dictionary<FormKey, IMajorRecordGetter> For(
@@ -43,13 +44,13 @@ public static class WinnerBodies
         }
         foreach (var (plugin, wanted) in byPlugin)
         {
-            // A winner plugin that will not open leaves its candidates absent rather than ending the scan, which is
-            // what the per-record fetch this replaces did — but the CAUSE travels with it, so a file another program
-            // is holding open reads as that and not as a stale index. An ArgumentException is a named failure about
-            // the request itself (a plugin outside the order), so it is left to the caller's own handler.
+            // A winner plugin the gather cannot read leaves its candidates absent rather than ending the scan, which
+            // is what the per-record fetch this replaces did — but the CAUSE travels with it, and the two causes are
+            // told apart: CollectRecords names an OPEN failure itself, so a file another program is holding open
+            // reads as that, and a fault from the walk after a good open reads as the plugin having changed instead.
             try { view.CollectRecords(session, plugin, wanted, getterTypes, bodies); }
-            catch (ArgumentException) { throw; }
-            catch (Exception ex) { unreadable[plugin] = new PluginUnreadableException(plugin, ex); }
+            catch (PluginUnreadableException ex) { unreadable[plugin] = ex; }
+            catch (Exception ex) { unreadable[plugin] = new PluginUnscannableException(plugin, ex); }
         }
         return bodies;
     }

--- a/src/housecarl-core/WinnerBodies.cs
+++ b/src/housecarl-core/WinnerBodies.cs
@@ -9,24 +9,28 @@ namespace HousecarlCore;
 /// <para>A scan that decides its match on the winner has the candidate FormKeys in hand before it needs any winner
 /// body, and a plugin's winners are a contiguous fact about that plugin's overlay. So the bodies are gathered by
 /// PLUGIN — one enumeration per distinct winner plugin, however many of its records are wanted — rather than by
-/// record, which is one whole-overlay walk EACH and turns a broad audit into O(candidates x overlay). The order
-/// bounds the total work: every plugin is walked at most once.</para>
+/// record, which is one whole-overlay walk EACH and turns a broad audit into O(candidates x overlay).</para>
 ///
-/// <para>Nothing is held past the caller's session: the bodies are backed by the overlays that session has open,
-/// exactly as <see cref="LoadOrderResolver.IndexView.GetRecord"/>'s are, and the map itself is one entry per
-/// CANDIDATE — never one per record in the order.</para>
+/// <para>The caller hands in ONE CHUNK of its candidates at a time, so the map it gets back — and the getters that
+/// map pins — is bounded by the chunk, not by how many records the scan considers. Nothing is held past the
+/// caller's session: the bodies are backed by the overlays that session has open, exactly as
+/// <see cref="LoadOrderResolver.IndexView.GetRecord"/>'s are.</para>
 /// </summary>
 public static class WinnerBodies
 {
     /// <summary>The winner body of each candidate, keyed by FormKey. A candidate whose winner cannot be resolved,
     /// or whose winner plugin does not yield it, is simply ABSENT — the caller decides what an unfetchable winner
     /// means, because "the index named a winner that did not re-resolve" is a fact it has to report, not one this
-    /// helper may swallow. <paramref name="getterTypes"/> is the caller's own type scope when it has one, which
-    /// narrows each plugin's walk to the GRUPs those types live in.</summary>
+    /// helper may swallow. A winner plugin that will not OPEN is named in <paramref name="unreadable"/> with the
+    /// underlying cause, so the caller reports the held-open file rather than guessing at index staleness.
+    /// <paramref name="getterTypes"/> is the caller's own type scope when it has one, which narrows each plugin's
+    /// walk to the GRUPs those types live in.</summary>
     public static Dictionary<FormKey, IMajorRecordGetter> For(
         LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session,
-        IReadOnlyCollection<FormKey> candidates, IReadOnlyList<Type>? getterTypes)
+        IReadOnlyCollection<FormKey> candidates, IReadOnlyList<Type>? getterTypes,
+        out Dictionary<string, PluginUnreadableException> unreadable)
     {
+        unreadable = new Dictionary<string, PluginUnreadableException>(StringComparer.OrdinalIgnoreCase);
         var bodies = new Dictionary<FormKey, IMajorRecordGetter>(candidates.Count);
         if (candidates.Count == 0) return bodies;
 
@@ -38,11 +42,15 @@ public static class WinnerBodies
             set.Add(fk);
         }
         foreach (var (plugin, wanted) in byPlugin)
-            // A winner plugin that will not OPEN leaves its candidates absent rather than ending the scan, which is
-            // what the per-record fetch this replaces did: each such candidate is then the caller's own
-            // "the index named a winner that did not re-resolve" row, and the rest of the scan still answers.
+        {
+            // A winner plugin that will not open leaves its candidates absent rather than ending the scan, which is
+            // what the per-record fetch this replaces did — but the CAUSE travels with it, so a file another program
+            // is holding open reads as that and not as a stale index. An ArgumentException is a named failure about
+            // the request itself (a plugin outside the order), so it is left to the caller's own handler.
             try { view.CollectRecords(session, plugin, wanted, getterTypes, bodies); }
-            catch { /* absent; the caller reports each candidate */ }
+            catch (ArgumentException) { throw; }
+            catch (Exception ex) { unreadable[plugin] = new PluginUnreadableException(plugin, ex); }
+        }
         return bodies;
     }
 }

--- a/src/housecarl-mcp-tests/WinnerSourceScanTests.cs
+++ b/src/housecarl-mcp-tests/WinnerSourceScanTests.cs
@@ -228,6 +228,59 @@ public sealed class WinnerSourceScanTests : IClassFixture<WinnerSourceFixture>
         Assert.DoesNotContain("did not yield the record on winner-source re-fetch", notes);
     }
 
+    /// <summary>A winner plugin that OPENS but cannot be walked to the end is a different fault from one another
+    /// program is holding open, and the gather says so: it isolates the plugin, names the file as changed, and never
+    /// tells the user to close a program that is holding nothing. Nor does the fault escape the gather: a walk that
+    /// throws is one plugin's coverage gap, not the end of the scan.</summary>
+    [Fact]
+    public void AWinnerPluginThatFaultsMidWalkNamesTheChangedFile_NotAHeldOpenOne()
+    {
+        var good = File.ReadAllBytes(_w.MidPath);
+        try
+        {
+            using var resolver = LoadOrderResolver.Build(new[] { _w.MasterPath, _w.LowPath, _w.MidPath });
+            var view = resolver.Capture();
+            OverstateFirstRecordLength(_w.MidPath);                                  // opens; the walk dies part-way
+            using var session = resolver.OpenSession();
+            var bodies = WinnerBodies.For(view, session, new[] { _w.Keys[7] }, null, out var faults);
+            Assert.Empty(bodies);
+            Assert.True(faults.ContainsKey(_w.MidName), string.Join("; ", faults.Values.Select(f => f.Message)));
+            Assert.Contains("could not finish reading", faults[_w.MidName].Message);
+            Assert.DoesNotContain("holding it open", faults[_w.MidName].Message);
+        }
+        finally { File.WriteAllBytes(_w.MidPath, good); }
+    }
+
+    /// <summary>Give the file's first WEAP record a length running off the end of its group: the mod header still
+    /// parses, so the plugin opens, and the record walk faults on the first record it steps over.</summary>
+    static void OverstateFirstRecordLength(string path)
+    {
+        var b = File.ReadAllBytes(path);
+        int at = -1;
+        for (int i = 8; i + 8 <= b.Length && at < 0; i++)
+            if (b[i] == 'W' && b[i + 1] == 'E' && b[i + 2] == 'A' && b[i + 3] == 'P'
+                && !(b[i - 8] == 'G' && b[i - 7] == 'R' && b[i - 6] == 'U' && b[i - 5] == 'P'))   // not the group's label
+                at = i;
+        Assert.True(at > 0, "no WEAP record header in the fixture plugin");
+        BitConverter.GetBytes(0x00FF_FFF0u).CopyTo(b, at + 4);
+        File.WriteAllBytes(path, b);
+    }
+
+    /// <summary>A plugin outside the load order is not a throw out of the gather: <c>CollectRecords</c> returns
+    /// silently for one, exactly as <c>GetRecord</c> does, so the only ArgumentException that could ever come out of
+    /// here is one Mutagen raised mid-walk for a single plugin — which belongs to that plugin, not to the whole
+    /// scan.</summary>
+    [Fact]
+    public void APluginOutsideTheOrderLeavesTheGatherEmptyRatherThanThrowing()
+    {
+        using var resolver = LoadOrderResolver.Build(new[] { _w.MasterPath, _w.LowPath });      // Mid is NOT in this order
+        var view = resolver.Capture();
+        using var session = resolver.OpenSession();
+        var sink = new Dictionary<FormKey, IMajorRecordGetter>();
+        view.CollectRecords(session, _w.MidName, new[] { _w.Keys[7] }, null, sink);
+        Assert.Empty(sink);
+    }
+
     /// <summary>The typed gather decides its flat fallback per KEY, not per plugin. Handed a type that covers only
     /// some of the wanted keys, it must still answer with the rest: Mutagen's typed enumeration routes nothing at
     /// all for a type it does not model, so "the typed walk found something, therefore what it missed is not here"

--- a/src/housecarl-mcp-tests/WinnerSourceScanTests.cs
+++ b/src/housecarl-mcp-tests/WinnerSourceScanTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
 using HousecarlCore;
 using HousecarlGenerator;
@@ -15,7 +16,7 @@ namespace HousecarlMcpTests;
 /// a scan that fetched the wrong plugin's body — or the first declarer's — matches a different set.</summary>
 public sealed class WinnerSourceWorld : IDisposable
 {
-    public const int Weapons = 30;
+    public const int Weapons = 30, Armors = 3;
     public const ushort MasterDamage = 5, LowDamage = 20, MidDamage = 30;
 
     public string Root { get; }
@@ -23,7 +24,13 @@ public sealed class WinnerSourceWorld : IDisposable
     public string MasterName { get; }
     public string LowName { get; }
     public string MidName { get; }
+    public string MasterPath { get; }
+    public string LowPath { get; }
+    public string MidPath { get; }
     public IReadOnlyList<FormKey> Keys { get; }
+    /// <summary>Records of a SECOND type in the same master, so a typed gather can be handed a type that does not
+    /// cover every wanted key.</summary>
+    public IReadOnlyList<FormKey> ArmorKeys { get; }
 
     readonly string _priorCorpusPath;
 
@@ -58,12 +65,25 @@ public sealed class WinnerSourceWorld : IDisposable
             });
         }
         Keys = keys;
-        var masterPath = Path.Combine(masterDir, MasterName);
-        master.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
-        var masterOv = SkyrimMod.CreateFromBinaryOverlay(masterPath, SkyrimRelease.SkyrimSE);
-
-        Write(mods, "LowMod", lowKey, masterOv, 0, 10, LowDamage);
-        Write(mods, "MidMod", midKey, masterOv, 5, 15, MidDamage);
+        var armorKeys = new List<FormKey>();
+        for (int i = 0; i < Armors; i++)
+        {
+            var fk = new FormKey(masterKey, (uint)(0xB00 + i));
+            armorKeys.Add(fk);
+            master.Armors.Add(new Armor(fk, SkyrimRelease.SkyrimSE) { EditorID = "HcWsrcArmo" + i });
+        }
+        ArmorKeys = armorKeys;
+        MasterPath = Path.Combine(masterDir, MasterName);
+        master.BeginWrite.ToPath(MasterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        // Disposed before the fixture leaves the constructor: it is a memory-mapped overlay, and a live handle on the
+        // master would make the temp tree undeletable on Windows, leaking a whole instance per run.
+        var masterOv = SkyrimMod.CreateFromBinaryOverlay(MasterPath, SkyrimRelease.SkyrimSE);
+        try
+        {
+            LowPath = Write(mods, "LowMod", lowKey, masterOv, 0, 10, LowDamage);
+            MidPath = Write(mods, "MidMod", midKey, masterOv, 5, 15, MidDamage);
+        }
+        finally { (masterOv as IDisposable)?.Dispose(); }
 
         var order = new[] { MasterName, LowName, MidName };
         File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + string.Join("\r\n", order) + "\r\n");
@@ -78,7 +98,7 @@ public sealed class WinnerSourceWorld : IDisposable
         Svc.Stats();
     }
 
-    void Write(string mods, string folder, ModKey key, ISkyrimModGetter masterOv, int from, int to, ushort damage)
+    string Write(string mods, string folder, ModKey key, ISkyrimModGetter masterOv, int from, int to, ushort damage)
     {
         var dir = Path.Combine(mods, folder); Directory.CreateDirectory(dir);
         var m = new SkyrimMod(key, SkyrimRelease.SkyrimSE);
@@ -87,7 +107,9 @@ public sealed class WinnerSourceWorld : IDisposable
             var w = m.Weapons.GetOrAddAsOverride(masterOv.Weapons.First(x => x.FormKey == Keys[i]));
             w.BasicStats!.Damage = damage;
         }
-        m.BeginWrite.ToPath(Path.Combine(dir, key.FileName.String)).WithLoadOrder(new[] { masterOv }).Write();
+        var path = Path.Combine(dir, key.FileName.String);
+        m.BeginWrite.ToPath(path).WithLoadOrder(new[] { masterOv }).Write();
+        return path;
     }
 
     public void Dispose()
@@ -106,9 +128,10 @@ public sealed class WinnerSourceFixture : IDisposable
 
 /// <summary>
 /// <c>where_source=winner</c> over a scope whose records win in three different plugins (#251). The winner bodies
-/// are gathered by PLUGIN — one enumeration per distinct winner plugin — instead of one whole-overlay walk per
-/// candidate, so these pin that the batched gather answers with the same set the per-record fetch did: the true
-/// winner's body for every candidate, including the ones the scoped plugin itself wins.
+/// are gathered a chunk of candidates at a time, by PLUGIN — one enumeration per distinct winner plugin in the
+/// chunk — instead of one whole-overlay walk per candidate, so these pin that the batched gather answers with the
+/// same set the per-record fetch did: the true winner's body for every candidate, including the ones the scoped
+/// plugin itself wins, which it takes from the streamed body rather than re-reading.
 /// </summary>
 [Trait("tier", "integration")]
 public sealed class WinnerSourceScanTests : IClassFixture<WinnerSourceFixture>
@@ -118,18 +141,23 @@ public sealed class WinnerSourceScanTests : IClassFixture<WinnerSourceFixture>
 
     const string DamagePath = "BasicStats.Damage";
 
-    string[] Matched(ushort damage, string[]? scope = null)
+    string[] Matched(string comparison, string[]? scope = null, string[]? types = null)
     {
-        var json = RecordsTools.Records(_w.Svc,
-            plugins: new RecordsTools.RecordsScope { names = scope ?? new[] { _w.MasterName } },
-            where: new[] { $"{DamagePath} = {damage}" }, where_source: "winner",
-            project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "EditorID" } },
-            format: "json", max_chars: 200000, limit: 1000);
+        var json = Scan(comparison, scope, types);
         using var doc = JsonDocument.Parse(json);
         Assert.False(doc.RootElement.TryGetProperty("error", out _), json);
         return doc.RootElement.GetProperty("matches").EnumerateArray()
                   .Select(m => m.GetProperty("formid").GetString()!).OrderBy(x => x, StringComparer.Ordinal).ToArray();
     }
+
+    string[] Matched(ushort damage, string[]? scope = null, string[]? types = null) => Matched($"= {damage}", scope, types);
+
+    string Scan(string comparison, string[]? scope = null, string[]? types = null) =>
+        RecordsTools.Records(_w.Svc, types: types,
+            plugins: new RecordsTools.RecordsScope { names = scope ?? new[] { _w.MasterName } },
+            where: new[] { $"{DamagePath} {comparison}" }, where_source: "winner",
+            project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "EditorID" } },
+            format: "json", max_chars: 200000, limit: 1000);
 
     string[] Expected(int from, int to) =>
         Enumerable.Range(from, to - from).Select(i => _w.Keys[i])
@@ -173,33 +201,47 @@ public sealed class WinnerSourceScanTests : IClassFixture<WinnerSourceFixture>
 
     /// <summary>The same answer with a type scope, which narrows each winner plugin's walk to that type's GRUP.</summary>
     [Fact]
-    public void ATypeScopedWinnerSourceScanAnswersTheSameSet()
+    public void ATypeScopedWinnerSourceScanAnswersTheSameSet() =>
+        Assert.Equal(Expected(5, 15), Matched(WinnerSourceWorld.MidDamage, types: new[] { "WEAP" }));
+
+    /// <summary>The gather under the tool: every candidate is judged on its WINNER's body. The scoped master's own
+    /// copy declares the same damage on all thirty, so a filter above it can only match through the gather — the
+    /// fifteen some plugin raises — and no candidate may go unscannable on the way.</summary>
+    [Fact]
+    public void EveryCandidateIsJudgedOnItsWinnersBody_NotTheScopedPluginsCopy()
     {
-        var json = RecordsTools.Records(_w.Svc, types: new[] { "WEAP" },
-            plugins: new RecordsTools.RecordsScope { names = new[] { _w.MasterName } },
-            where: new[] { $"{DamagePath} = {WinnerSourceWorld.MidDamage}" }, where_source: "winner",
-            project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "EditorID" } },
-            format: "json", max_chars: 200000, limit: 1000);
-        using var doc = JsonDocument.Parse(json);
-        Assert.Equal(Expected(5, 15),
-                     doc.RootElement.GetProperty("matches").EnumerateArray()
-                        .Select(m => m.GetProperty("formid").GetString()!).OrderBy(x => x, StringComparer.Ordinal).ToArray());
+        Assert.Equal(Expected(0, 15), Matched($"> {WinnerSourceWorld.MasterDamage}"));
+        Assert.DoesNotContain("did not yield the record", Scan($"> {WinnerSourceWorld.MasterDamage}"));
     }
 
-    /// <summary>The gather itself, under the tool: every candidate's winner body, in one enumeration per winner
-    /// plugin. Its answer must be the winner's body — the damage each record's winner declares — for all thirty.</summary>
+    /// <summary>A winner plugin another program is holding open says THAT, with the underlying cause, rather than
+    /// reporting the index as stale — the two are different problems and only one of them the user can act on.</summary>
     [Fact]
-    public void EveryCandidateGetsItsOwnWinnersBody_NotSomeOtherPluginsCopy()
+    public void AWinnerPluginHeldOpenNamesTheHeldFile_NotAStaleIndex()
     {
-        for (int i = 0; i < WinnerSourceWorld.Weapons; i++)
-        {
-            ushort expected = i < 5 ? WinnerSourceWorld.LowDamage
-                            : i < 15 ? WinnerSourceWorld.MidDamage
-                            : WinnerSourceWorld.MasterDamage;
-            var one = RecordsTools.Records(_w.Svc, formids: new[] { _w.Keys[i].ToString() },
-                                           project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { DamagePath } },
-                                           max_chars: 20000);
-            Assert.Contains($"{DamagePath} = {expected}", one);
-        }
+        using var hold = new FileStream(_w.MidPath, FileMode.Open, FileAccess.Read, FileShare.None);
+        var json = Scan($"= {WinnerSourceWorld.MidDamage}");
+        using var doc = JsonDocument.Parse(json);
+        var notes = string.Join(" ", doc.RootElement.GetProperty("notes").EnumerateArray().Select(n => n.GetString()));
+        Assert.Contains($"could not read '{_w.MidName}'", notes);
+        Assert.Contains("being used by another process", notes);
+        Assert.DoesNotContain("did not yield the record on winner-source re-fetch", notes);
+    }
+
+    /// <summary>The typed gather decides its flat fallback per KEY, not per plugin. Handed a type that covers only
+    /// some of the wanted keys, it must still answer with the rest: Mutagen's typed enumeration routes nothing at
+    /// all for a type it does not model, so "the typed walk found something, therefore what it missed is not here"
+    /// turns a record the plugin holds into a silent absence.</summary>
+    [Fact]
+    public void ATypedGatherFallsThroughForAWantedKeyThatTypeDoesNotCover()
+    {
+        using var resolver = LoadOrderResolver.Build(new[] { _w.MasterPath, _w.LowPath, _w.MidPath });
+        var view = resolver.Capture();
+        using var session = resolver.OpenSession();
+        var sink = new Dictionary<FormKey, IMajorRecordGetter>();
+        view.CollectRecords(session, _w.MasterName,
+                            new[] { _w.Keys[20], _w.ArmorKeys[0] }, new[] { typeof(IWeaponGetter) }, sink);
+        Assert.Contains(_w.Keys[20], sink.Keys);
+        Assert.Contains(_w.ArmorKeys[0], sink.Keys);
     }
 }

--- a/src/housecarl-mcp-tests/WinnerSourceScanTests.cs
+++ b/src/housecarl-mcp-tests/WinnerSourceScanTests.cs
@@ -1,0 +1,205 @@
+using System.Text.Json;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlGenerator;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>An order whose winners are spread across THREE plugins, which is what a winner-source scan has to get
+/// right: a master defining 30 weapons, a first plugin overriding the first ten and a second overriding a middle
+/// ten that overlaps it. So five records win in the first plugin, ten in the second and fifteen in the master, and
+/// a scan that fetched the wrong plugin's body — or the first declarer's — matches a different set.</summary>
+public sealed class WinnerSourceWorld : IDisposable
+{
+    public const int Weapons = 30;
+    public const ushort MasterDamage = 5, LowDamage = 20, MidDamage = 30;
+
+    public string Root { get; }
+    public LoadOrderService Svc { get; }
+    public string MasterName { get; }
+    public string LowName { get; }
+    public string MidName { get; }
+    public IReadOnlyList<FormKey> Keys { get; }
+
+    readonly string _priorCorpusPath;
+
+    public WinnerSourceWorld()
+    {
+        _priorCorpusPath = CorpusRulebook.CorpusPath;
+        Root = Path.Combine(Path.GetTempPath(), "hc-winner-source-" + Guid.NewGuid().ToString("N"));
+        var instance = Path.Combine(Root, "instance");
+        var profiles = Path.Combine(instance, "profiles", "Default");
+        var mods = Path.Combine(instance, "mods");
+        foreach (var d in new[] { profiles, mods, Path.Combine(Root, "game", "Data") }) Directory.CreateDirectory(d);
+        File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(Root, "game").Replace(@"\", @"\\") + ")\r\n");
+
+        var masterKey = new ModKey("HcWsrcBase", ModType.Master);
+        var lowKey = new ModKey("HcWsrcLow", ModType.Plugin);
+        var midKey = new ModKey("HcWsrcMid", ModType.Plugin);
+        MasterName = masterKey.FileName.String; LowName = lowKey.FileName.String; MidName = midKey.FileName.String;
+
+        var keys = new List<FormKey>();
+        var masterDir = Path.Combine(mods, "BaseMod"); Directory.CreateDirectory(masterDir);
+        var master = new SkyrimMod(masterKey, SkyrimRelease.SkyrimSE);
+        for (int i = 0; i < Weapons; i++)
+        {
+            var fk = new FormKey(masterKey, (uint)(0xA00 + i));
+            keys.Add(fk);
+            master.Weapons.Add(new Weapon(fk, SkyrimRelease.SkyrimSE)
+            {
+                EditorID = "HcWsrcWeap" + i,
+                BasicStats = new WeaponBasicStats { Damage = MasterDamage, Value = 10, Weight = 1 },
+            });
+        }
+        Keys = keys;
+        var masterPath = Path.Combine(masterDir, MasterName);
+        master.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        var masterOv = SkyrimMod.CreateFromBinaryOverlay(masterPath, SkyrimRelease.SkyrimSE);
+
+        Write(mods, "LowMod", lowKey, masterOv, 0, 10, LowDamage);
+        Write(mods, "MidMod", midKey, masterOv, 5, 15, MidDamage);
+
+        var order = new[] { MasterName, LowName, MidName };
+        File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + string.Join("\r\n", order) + "\r\n");
+        File.WriteAllText(Path.Combine(profiles, "plugins.txt"), string.Concat(order.Select(n => "*" + n + "\r\n")));
+        File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+MidMod\r\n+LowMod\r\n+BaseMod\r\n");
+
+        var genDir = Path.Combine(Root, "corpus-gen");
+        CorpusGenerator.GenerateAll(genDir, Path.Combine(Root, "corpus-ref"));
+        CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json");
+
+        Svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(Root, "houseCARL.user.json")));
+        Svc.Stats();
+    }
+
+    void Write(string mods, string folder, ModKey key, ISkyrimModGetter masterOv, int from, int to, ushort damage)
+    {
+        var dir = Path.Combine(mods, folder); Directory.CreateDirectory(dir);
+        var m = new SkyrimMod(key, SkyrimRelease.SkyrimSE);
+        for (int i = from; i < to; i++)
+        {
+            var w = m.Weapons.GetOrAddAsOverride(masterOv.Weapons.First(x => x.FormKey == Keys[i]));
+            w.BasicStats!.Damage = damage;
+        }
+        m.BeginWrite.ToPath(Path.Combine(dir, key.FileName.String)).WithLoadOrder(new[] { masterOv }).Write();
+    }
+
+    public void Dispose()
+    {
+        Svc.Dispose();
+        CorpusRulebook.CorpusPath = _priorCorpusPath;
+        try { Directory.Delete(Root, true); } catch { /* temp cleanup best-effort */ }
+    }
+}
+
+public sealed class WinnerSourceFixture : IDisposable
+{
+    public WinnerSourceWorld W { get; } = new();
+    public void Dispose() => W.Dispose();
+}
+
+/// <summary>
+/// <c>where_source=winner</c> over a scope whose records win in three different plugins (#251). The winner bodies
+/// are gathered by PLUGIN — one enumeration per distinct winner plugin — instead of one whole-overlay walk per
+/// candidate, so these pin that the batched gather answers with the same set the per-record fetch did: the true
+/// winner's body for every candidate, including the ones the scoped plugin itself wins.
+/// </summary>
+[Trait("tier", "integration")]
+public sealed class WinnerSourceScanTests : IClassFixture<WinnerSourceFixture>
+{
+    readonly WinnerSourceWorld _w;
+    public WinnerSourceScanTests(WinnerSourceFixture f) => _w = f.W;
+
+    const string DamagePath = "BasicStats.Damage";
+
+    string[] Matched(ushort damage, string[]? scope = null)
+    {
+        var json = RecordsTools.Records(_w.Svc,
+            plugins: new RecordsTools.RecordsScope { names = scope ?? new[] { _w.MasterName } },
+            where: new[] { $"{DamagePath} = {damage}" }, where_source: "winner",
+            project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "EditorID" } },
+            format: "json", max_chars: 200000, limit: 1000);
+        using var doc = JsonDocument.Parse(json);
+        Assert.False(doc.RootElement.TryGetProperty("error", out _), json);
+        return doc.RootElement.GetProperty("matches").EnumerateArray()
+                  .Select(m => m.GetProperty("formid").GetString()!).OrderBy(x => x, StringComparer.Ordinal).ToArray();
+    }
+
+    string[] Expected(int from, int to) =>
+        Enumerable.Range(from, to - from).Select(i => _w.Keys[i])
+                  .Select(fk => fk.ToString()).OrderBy(x => x, StringComparer.Ordinal).ToArray();
+
+    /// <summary>The middle ten win in the LAST plugin, and only those match its damage — a gather that took the
+    /// first declarer, or the scoped body, would answer a different set.</summary>
+    [Fact]
+    public void TheRecordsWonByTheHighestPluginMatchOnThatPluginsBody() =>
+        Assert.Equal(Expected(5, 15), Matched(WinnerSourceWorld.MidDamage));
+
+    /// <summary>The first five are overridden by the low plugin and NOT by the high one, so they win there — the
+    /// gather has to fetch from a second winner plugin in the same scan.</summary>
+    [Fact]
+    public void TheRecordsWonByTheMiddlePluginMatchOnThatOne() =>
+        Assert.Equal(Expected(0, 5), Matched(WinnerSourceWorld.LowDamage));
+
+    /// <summary>And the fifteen nobody overrides win in the MASTER, which is also the scoped plugin: a gather that
+    /// only looked at plugins above the scope would lose half the order.</summary>
+    [Fact]
+    public void TheRecordsNobodyOverridesWinInTheScopedPluginItself() =>
+        Assert.Equal(Expected(15, WinnerSourceWorld.Weapons), Matched(WinnerSourceWorld.MasterDamage));
+
+    /// <summary>Every candidate is accounted for exactly once across the three winner plugins — no record is
+    /// dropped by the gather and none is counted twice.</summary>
+    [Fact]
+    public void TheThreeWinnerPluginsPartitionTheScopeWithNothingLostOrDoubled()
+    {
+        var all = Matched(WinnerSourceWorld.MidDamage).Concat(Matched(WinnerSourceWorld.LowDamage))
+                  .Concat(Matched(WinnerSourceWorld.MasterDamage)).ToArray();
+        Assert.Equal(WinnerSourceWorld.Weapons, all.Length);
+        Assert.Equal(WinnerSourceWorld.Weapons, all.Distinct().Count());
+    }
+
+    /// <summary>A scope spanning several plugins still de-dups to one verdict per record: the winner answer is
+    /// FormKey-intrinsic, so a key touched by two scoped plugins must not match twice.</summary>
+    [Fact]
+    public void AMultiPluginScopeStillAnswersOncePerRecord() =>
+        Assert.Equal(Expected(5, 15),
+                     Matched(WinnerSourceWorld.MidDamage, new[] { _w.MasterName, _w.LowName, _w.MidName }));
+
+    /// <summary>The same answer with a type scope, which narrows each winner plugin's walk to that type's GRUP.</summary>
+    [Fact]
+    public void ATypeScopedWinnerSourceScanAnswersTheSameSet()
+    {
+        var json = RecordsTools.Records(_w.Svc, types: new[] { "WEAP" },
+            plugins: new RecordsTools.RecordsScope { names = new[] { _w.MasterName } },
+            where: new[] { $"{DamagePath} = {WinnerSourceWorld.MidDamage}" }, where_source: "winner",
+            project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "EditorID" } },
+            format: "json", max_chars: 200000, limit: 1000);
+        using var doc = JsonDocument.Parse(json);
+        Assert.Equal(Expected(5, 15),
+                     doc.RootElement.GetProperty("matches").EnumerateArray()
+                        .Select(m => m.GetProperty("formid").GetString()!).OrderBy(x => x, StringComparer.Ordinal).ToArray());
+    }
+
+    /// <summary>The gather itself, under the tool: every candidate's winner body, in one enumeration per winner
+    /// plugin. Its answer must be the winner's body — the damage each record's winner declares — for all thirty.</summary>
+    [Fact]
+    public void EveryCandidateGetsItsOwnWinnersBody_NotSomeOtherPluginsCopy()
+    {
+        for (int i = 0; i < WinnerSourceWorld.Weapons; i++)
+        {
+            ushort expected = i < 5 ? WinnerSourceWorld.LowDamage
+                            : i < 15 ? WinnerSourceWorld.MidDamage
+                            : WinnerSourceWorld.MasterDamage;
+            var one = RecordsTools.Records(_w.Svc, formids: new[] { _w.Keys[i].ToString() },
+                                           project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { DamagePath } },
+                                           max_chars: 20000);
+            Assert.Contains($"{DamagePath} = {expected}", one);
+        }
+    }
+}

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4202,8 +4202,26 @@ public sealed class LoadOrderService : IDisposable
                         return w is null ? null : view.GetRecord(winnerSession!, w.Value.WinnerPlugin, fk);
                     }
                     : null);
+            // where_source=winner needs one body per CANDIDATE, not per record in the order, and fetching them one
+            // at a time is a whole-overlay walk each (#251). The candidate keys are settled by the index-only
+            // filters below, so they are collected in a pre-pass that touches no body, and the winner bodies are
+            // then gathered by plugin — one enumeration per distinct winner plugin, so the whole fetch is bounded
+            // by the order rather than by the candidate count.
+            Dictionary<FormKey, IMajorRecordGetter>? winnerBodies = null;
             try
             {
+                if (whereWinnerActive)
+                {
+                    var candidates = new HashSet<FormKey>();
+                    foreach (var (fk, depth, _, _) in view.RecordsIn(plugins!, types))
+                    {
+                        if (setFilter is not null && !setFilter.Contains(fk)) continue;
+                        if (conflictsOnly && depth <= 1) continue;
+                        if (definedIn && !scopedModKeys!.Contains(fk.ModKey)) continue;
+                        candidates.Add(fk);
+                    }
+                    winnerBodies = WinnerBodies.For(view, winnerSession!, candidates, types);
+                }
                 // Carry the source plugin per record so the render shows the body the scan filtered rather than the
                 // winner: plugins= gives the scoped plugin's filename, type= gives null, meaning the winner.
                 IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body, string? source)> stream =
@@ -4231,14 +4249,11 @@ public sealed class LoadOrderService : IDisposable
                         IMajorRecordGetter filterBody = body;
                         if (whereWinnerActive)
                         {
-                            var w = view.ResolveWinner(fk);
-                            if (w is null) continue;                              // the key came from the order, so a winner must exist; defensive
-                            var wb = view.GetRecord(winnerSession!, w.Value.WinnerPlugin, fk);
-                            if (wb is null)
+                            if (!winnerBodies!.TryGetValue(fk, out var wb))
                             {
                                 unscannable++;
                                 if (unscannableSamples.Count < 3)
-                                    unscannableSamples.Add($"{fk} — winner '{w.Value.WinnerPlugin}' did not yield the record on winner-source re-fetch");
+                                    unscannableSamples.Add($"{fk} — winner '{view.ResolveWinner(fk)?.WinnerPlugin ?? "?"}' did not yield the record on winner-source re-fetch");
                                 continue;
                             }
                             filterBody = wb;

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4203,30 +4203,28 @@ public sealed class LoadOrderService : IDisposable
                     }
                     : null);
             // where_source=winner needs one body per CANDIDATE, not per record in the order, and fetching them one
-            // at a time is a whole-overlay walk each (#251). The candidate keys are settled by the index-only
-            // filters below, so they are collected in a pre-pass that touches no body, and the winner bodies are
-            // then gathered by plugin — one enumeration per distinct winner plugin, so the whole fetch is bounded
-            // by the order rather than by the candidate count.
-            Dictionary<FormKey, IMajorRecordGetter>? winnerBodies = null;
+            // at a time is a whole-overlay walk each (#251). So the scan buffers a CHUNK of candidates off the one
+            // scoped stream, gathers that chunk's winner bodies a plugin at a time — one enumeration per distinct
+            // winner plugin in the chunk — and drains it before reading on. Gathering the whole candidate set first
+            // would instead hold a key and a pinned getter per candidate for the scan's length, which on a broad
+            // untyped scope is every record in the order; the chunk is the memory bound. A candidate the SCOPED
+            // plugin itself wins needs no gather at all — the streamed body IS the winner's — so on the shape this
+            // is for, a master audited against the order, the gather only touches the records something overrides.
+            const int WinnerGatherChunk = 10_000;
+            // The chunk's rows, filtered by everything that needs no body, each with the winner plugin already
+            // resolved. Held only until the chunk drains.
+            var pending = whereWinnerActive
+                ? new List<(FormKey fk, int depth, IMajorRecordGetter body, string source, string winner)>(WinnerGatherChunk)
+                : null;
+            var faultedWinners = whereWinnerActive ? new HashSet<string>(StringComparer.OrdinalIgnoreCase) : null;
             try
             {
-                if (whereWinnerActive)
-                {
-                    var candidates = new HashSet<FormKey>();
-                    foreach (var (fk, depth, _, _) in view.RecordsIn(plugins!, types))
-                    {
-                        if (setFilter is not null && !setFilter.Contains(fk)) continue;
-                        if (conflictsOnly && depth <= 1) continue;
-                        if (definedIn && !scopedModKeys!.Contains(fk.ModKey)) continue;
-                        candidates.Add(fk);
-                    }
-                    winnerBodies = WinnerBodies.For(view, winnerSession!, candidates, types);
-                }
                 // Carry the source plugin per record so the render shows the body the scan filtered rather than the
                 // winner: plugins= gives the scoped plugin's filename, type= gives null, meaning the winner.
                 IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body, string? source)> stream =
                     hasPlugins ? view.RecordsIn(plugins!, types).Select(x => (fk: x.fk, depth: x.depth, body: x.body, source: (string?)x.source))  // the scoped plugin's own body
                                : view.WinnerRecordsOfType(types!, unreadablePlugins).Select(x => (fk: x.fk, depth: x.depth, body: x.body, source: (string?)null));    // the load-order winner's body
+                bool stopped = false;
                 foreach (var (fk, depth, body, source) in stream)
                 {
                     if (setFilter is not null && !setFilter.Contains(fk)) continue;   // the identity intersection, cheapest first
@@ -4234,30 +4232,67 @@ public sealed class LoadOrderService : IDisposable
                     // defined_in= keeps only records whose origin FormKey is a scoped plugin — a definition, not an
                     // override this plugin merely touches. A FormKey test needing no body, so it runs before the try.
                     if (definedIn && !scopedModKeys!.Contains(fk.ModKey)) continue;
+                    if (!whereWinnerActive)
+                    {
+                        if (!ScanRow(fk, depth, body, source)) { stopped = true; break; }
+                        continue;
+                    }
                     // where_source=winner de-dups up front: the winner verdict is FormKey-intrinsic, so any scoped
                     // copy gives the same answer, and the first scoped copy in stream order supplies the display
-                    // source. The scoped path instead de-dups AFTER the filters — a different rule, below.
-                    if (whereWinnerActive && !seen.Add(fk)) continue;
-                    // Per-record fault isolation: the body tests lazily parse subrecord content, so one record
-                    // Mutagen cannot parse would otherwise abort the whole call as an opaque transport error. Such a
-                    // record is excluded and accounted for in the response, never silently skipped and never guessed
-                    // as a match. The winner re-fetch below is inside the try too, so an unparseable winner is
-                    // accounted the same way.
+                    // source. The scoped path instead de-dups AFTER the filters — a different rule, in ScanRow.
+                    if (!seen.Add(fk)) continue;
+                    // A record the order gives no winner at all is a clean non-match, exactly as the per-record
+                    // fetch treated it — never an unscannable row naming a winner there is none of.
+                    if (view.ResolveWinner(fk) is not { } w) continue;
+                    pending!.Add((fk, depth, body, source!, w.WinnerPlugin));
+                    if (pending.Count == WinnerGatherChunk && !DrainChunk()) { stopped = true; break; }
+                }
+                if (!stopped && whereWinnerActive && pending!.Count > 0) DrainChunk();
+
+                // Fetch one chunk's winner bodies and scan its rows, in stream order. Returns false when the scan
+                // must stop.
+                bool DrainChunk()
+                {
+                    var needed = new List<FormKey>(pending!.Count);
+                    foreach (var p in pending)
+                        if (!string.Equals(p.winner, p.source, StringComparison.OrdinalIgnoreCase)) needed.Add(p.fk);
+                    var bodies = WinnerBodies.For(view, winnerSession!, needed, types, out var faults);
+                    // A winner plugin that would not open is a whole-plugin coverage gap, named once in the response
+                    // rather than only sampled three rows deep.
+                    foreach (var (plugin, fault) in faults)
+                        if (faultedWinners!.Add(plugin)) unreadablePlugins.Add(fault);
+                    bool go = true;
+                    foreach (var p in pending)
+                    {
+                        IMajorRecordGetter filterBody;
+                        if (string.Equals(p.winner, p.source, StringComparison.OrdinalIgnoreCase)) filterBody = p.body;
+                        else if (bodies.TryGetValue(p.fk, out var wb)) filterBody = wb;
+                        else
+                        {
+                            unscannable++;
+                            if (unscannableSamples.Count < 3)
+                                unscannableSamples.Add(faults.TryGetValue(p.winner, out var f)
+                                    ? $"{p.fk} — {f.Message}"
+                                    : $"{p.fk} — winner '{p.winner}' did not yield the record on winner-source re-fetch");
+                            continue;
+                        }
+                        if (!ScanRow(p.fk, p.depth, filterBody, p.source)) { go = false; break; }
+                    }
+                    pending.Clear();
+                    return go;
+                }
+
+                // One row's content filtering, on the body the FILTERS decide on: the live winner
+                // (where_source=winner) or the streamed body. Returns false when the scan must stop.
+                //
+                // Per-record fault isolation: the body tests lazily parse subrecord content, so one record
+                // Mutagen cannot parse would otherwise abort the whole call as an opaque transport error. Such a
+                // record is excluded and accounted for in the response, never silently skipped and never guessed
+                // as a match — including a winner body the gather handed over unparseable.
+                bool ScanRow(FormKey fk, int depth, IMajorRecordGetter filterBody, string? source)
+                {
                     try
                     {
-                        // The body the FILTERS decide on: the live winner (where_source=winner) or the streamed body.
-                        IMajorRecordGetter filterBody = body;
-                        if (whereWinnerActive)
-                        {
-                            if (!winnerBodies!.TryGetValue(fk, out var wb))
-                            {
-                                unscannable++;
-                                if (unscannableSamples.Count < 3)
-                                    unscannableSamples.Add($"{fk} — winner '{view.ResolveWinner(fk)?.WinnerPlugin ?? "?"}' did not yield the record on winner-source re-fetch");
-                                continue;
-                            }
-                            filterBody = wb;
-                        }
                         // Deleted records carry no body to scan (the rule lives in DeletedRecordRule, shared with the
                         // error check and the compact/merge scan): the content filters cannot match one, so it is
                         // excluded as a clean non-match before the scan touches its body — which on the references=
@@ -4267,33 +4302,33 @@ public sealed class LoadOrderService : IDisposable
                         // predicates actually READ body content: the header- and resolution-only terms must see
                         // deleted records exactly as editorid_contains= does.
                         if (DeletedRecordRule.HasNoLiveBody(filterBody)
-                            && (refSet is not null || predicate is { NeedsLiveBody: true })) continue;
+                            && (refSet is not null || predicate is { NeedsLiveBody: true })) return true;
                         if (!string.IsNullOrEmpty(editoridContains)
                             && (filterBody.EditorID is null || filterBody.EditorID.IndexOf(editoridContains, StringComparison.OrdinalIgnoreCase) < 0))
-                            continue;
+                            return true;
                         // references= is a list with OR semantics: a record matches if it links to ANY target. One
                         // EnumerateFormLinks pass collects the intersection, so a multi-target lookup can be
                         // un-merged into which targets each row hit.
                         List<FormKey>? hitTargets = null;
                         if (refSet is not null)
                         {
-                            if (filterBody is not IFormLinkContainerGetter flc) continue;
+                            if (filterBody is not IFormLinkContainerGetter flc) return true;
                             var hitSet = new HashSet<FormKey>();
                             foreach (var l in flc.EnumerateFormLinks()) if (refSet.Contains(l.FormKey)) hitSet.Add(l.FormKey);
-                            if (hitSet.Count == 0) continue;
+                            if (hitSet.Count == 0) return true;
                             if (multiTarget && groups is null) hitTargets = references!.Where(hitSet.Contains).Distinct().ToList();   // in input order; only the match-line path consumes it
                         }
-                        if (refNone is not null && ExcludedByReference(filterBody, refNone)) continue;
+                        if (refNone is not null && ExcludedByReference(filterBody, refNone)) return true;
                         if (predicate is not null && !predicate.Matches(filterBody))    // value filter on the same in-hand body, no extra fetch
                         {
-                            if (predicate.FatalError is not null) break;          // e.g. a numeric op against a non-numeric field — abort and surface it
-                            continue;
+                            if (predicate.FatalError is not null) return false;   // e.g. a numeric op against a non-numeric field — abort and surface it
+                            return true;
                         }
                         // De-dup, since a key can recur across scoped plugins. On the scoped path this runs AFTER the
                         // filters, so the source recorded for a shared key is the first scoped plugin, in plugins=
                         // order, whose own body passed. Under where_source=winner the key was already de-duped up
                         // front, so this is a no-op there.
-                        if (!whereWinnerActive && !seen.Add(fk)) continue;
+                        if (!whereWinnerActive && !seen.Add(fk)) return true;
                         total++;
                         if (groups is not null)                                   // group_by=: aggregate over all matches, no keys or prefill, no limit cap
                         {
@@ -4321,6 +4356,7 @@ public sealed class LoadOrderService : IDisposable
                         if (unscannableSamples.Count < 3)
                             unscannableSamples.Add($"{fk}{(source is null ? "" : $" in {source}")} — {ex.GetType().Name}: {ex.Message}");
                     }
+                    return true;
                 }
             }
             catch (ArgumentException ex) { return CrossQueryOutcome.Fail(ex.Message); } // plugin not in order / unknown type


### PR DESCRIPTION
`where_source=winner` decides a scan's match on the live load-order winner rather than on the body the scan streams. It got that winner with `view.GetRecord(session, winnerPlugin, fk)`, which walks the winner plugin's whole record list to find one record. For N candidates that is N walks of a plugin, so the cost grew with the candidate count — on the feature's headline use, a broad post-patch audit, that is minutes of nothing but re-reading, and it is the exact anti-pattern the resolver's own comment thirty lines away warns about.

The candidate keys are settled by index-only filters (`formids=` set intersection, `conflicts_only=`, `defined_in=`), so the scan collects them off the record stream it is already walking and gathers their winner bodies **by plugin** rather than by record: `LoadOrderResolver.CollectRecords` walks one plugin's overlay once and picks every wanted key out of it, stopping as soon as it has them all.

**It gathers one CHUNK of candidates at a time — 10,000 — and drains it before reading on.** Gathering the whole candidate set first would hold a key and a pinned overlay getter per candidate for the scan's whole length, which on `plugins=["Skyrim.esm"]` with no `types=` is every record in the order; the chunk is the memory bound, and the measurement below is what it is worth. Two more things keep the work down: the chunk is filled from the **one** scoped stream the scan already runs, so the scope is walked once rather than twice, and a candidate the **scoped plugin itself wins** is never gathered — the streamed body already IS the winner's, which on the headline shape is most of them. With a `types=` scope in hand each walk is typed as well, and falls through to the flat one for whatever it did not find, per key.

Nothing is held past the scan's own session: the bodies are backed by the overlays it already has open. A winner plugin that will not open leaves its candidates absent and hands back the **reason**, so a file another program is holding open reports that — with the IOException under it, and the plugin named once as a coverage gap — instead of every one of its records reading as index staleness. A record the order gives no winner at all is a clean non-match again, not an unscannable row naming a winner `'?'` that was never fetched.

## Measured

A synthetic order built for this: one master and nine plugins each overriding a 2,000-record slice of it (step 1,800, so the slices overlap and the winners spread across all ten). Three builds against the same bytes — `main`'s per-record fetch, the gather-all this PR first proposed, and the chunked gather it now has. `peak heap` is the highest sampled managed heap during the scan, with gen0 forced small so the sample tracks the live set.

| scan (19,200-record master) | per-record | gather-all | chunked |
|---|---|---|---|
| every record the master touches, `where_source=winner` | 34.0 s | 0.5 s | **0.4 s** |
| the same scan, `where_source` default | 0.1 s | 0.2 s | 0.2 s |
| the nine plugins as the scope, `where_source=winner` | 10.3 s | 0.4 s | **0.2 s** |
| the same scan, `where_source` default | 0.1 s | 0.2 s | 0.2 s |

So the winner-source penalty is gone and the two sources cost the same. The second scope walk the gather-all paid shows up in the 0.5 → 0.4 and 0.4 → 0.2.

The memory bound wants a bigger order, so the same shape at a **200,000-record master** (two samples each):

| 200k master audit | gather-all | chunked |
|---|---|---|
| `where_source=winner` | 2.4 s / 2.5 s, **417.7 MB / 403.4 MB** | 1.7 s / 1.8 s, **214.4 MB / 198.0 MB** |
| `where_source` default (no gather at all) | 1.2 s, 199.3 MB | 1.2 s, 198.9 MB |

The default-source arm is the floor. Gather-all sits ~210 MB above it — about 1.05 KB per candidate, which extrapolates to roughly a gigabyte on the ~1M-record untyped `Skyrim.esm` scope the review named. The chunked gather sits **on** the floor: its live set is one chunk, so at 200k candidates it is the same peak as a scan that fetches no winner bodies, and it does not move with the candidate count.

**The bound, stated:** at most 10,000 buffered rows and at most 10,000 gathered winner bodies are live at once, whatever the scan considers. The trade is that a winner plugin holding candidates in several chunks is enumerated once per chunk; the self-won skip is what keeps that small, since on a master audit the only records gathered at all are the ones something overrides.

## Tests

`WinnerSourceScanTests` is the parity fixture the issue asked for: a master defining 30 weapons, one plugin overriding the first ten and another overriding an overlapping middle ten, so five records win in the first plugin, ten in the second and fifteen in the master itself. A gather that took the first declarer, the scoped body, or only the plugins above the scope answers a different set on each of those arms. Eleven tests pin all three partitions, the de-dup under a multi-plugin scope, the type-scoped walk, a winner plugin another program is holding open, one that opens but faults part-way through its record walk, a plugin outside the order leaving the gather empty rather than throwing, and a typed gather handed a type that does not cover every wanted key.

1416 tests and 128/128 probes pass.

Stacked on #553 (`claude/cell-union`) — that branch's typed seek is in the diff base, and it does not by itself close this: the winner-source call site passed no type, and a typed seek would only be a constant factor over the same per-candidate walk, which is what the issue calls the stopgap.

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)

