### PR TITLE
Stamp the dialogue check with the build it read

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -64,9 +64,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
   `epoch_covers_all_inputs: false` and `epoch_uncovered`, which names the verdicts read off disk rather than off the
   record index: voiced lines (.fuz on disk), the result-script .pex chain, and .seq coverage and staleness. The text
   render states the same stamp and the same three classes on its own line. Compare two responses' `epoch` to know
-  whether the record half changed between them; the named classes are outside that comparison. A refusal — no seeds,
-  or every seed unresolvable — carries the bare `epoch` with no coverage claim beside it, which is what the errors and
-  scripts families' refusals carry.
+  whether the record half changed between them; the named classes are outside that comparison. A call whose every seed
+  was a dialogue view (DLVW) or branch (DLBR) reads nothing off disk, so it stamps `epoch_covers_all_inputs: true` and
+  names no classes. A dialogue-only call refused because every seed was unresolvable carries the bare `epoch` — the
+  build it was decided against — as the errors and scripts families' post-index refusals do; a call with no `seeds=` is
+  refused on the arguments alone before any build is read, and names none, as theirs do not.
 
 - **`housecarl_asset_status` and `housecarl_place` take `format='json'`.** Both answered text only, so a caller
   reading them from a script parsed prose. The json document carries the same data as the text render: for

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -64,7 +64,9 @@ saying it sets an expectation their install may contradict. Say what is known, a
   `epoch_covers_all_inputs: false` and `epoch_uncovered`, which names the verdicts read off disk rather than off the
   record index: voiced lines (.fuz on disk), the result-script .pex chain, and .seq coverage and staleness. The text
   render states the same stamp and the same three classes on its own line. Compare two responses' `epoch` to know
-  whether the record half changed between them; the named classes are outside that comparison.
+  whether the record half changed between them; the named classes are outside that comparison. A refusal — no seeds,
+  or every seed unresolvable — carries the bare `epoch` with no coverage claim beside it, which is what the errors and
+  scripts families' refusals carry.
 
 - **`housecarl_asset_status` and `housecarl_place` take `format='json'`.** Both answered text only, so a caller
   reading them from a script parsed prose. The json document carries the same data as the text render: for

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -58,6 +58,14 @@ saying it sets an expectation their install may contradict. Say what is known, a
   reads as one covering all of them. `walk.max_nodes` says which reading it spends: per seed on the carrier
   walk, one shared budget across every seed and hop on the transitive walk.
 
+- **The dialogue check stamps the build it read, and says what that stamp does not cover.** `housecarl_check
+  findings=["dialogue"]` was the one family answering with no freshness claim at all. It now carries `epoch` — the
+  record build every seed was validated against, one pinned build for the whole call — beside
+  `epoch_covers_all_inputs: false` and `epoch_uncovered`, which names the verdicts read off disk rather than off the
+  record index: voiced lines (.fuz on disk), the result-script .pex chain, and .seq coverage and staleness. The text
+  render states the same stamp and the same three classes on its own line. Compare two responses' `epoch` to know
+  whether the record half changed between them; the named classes are outside that comparison.
+
 - **`housecarl_asset_status` and `housecarl_place` take `format='json'`.** Both answered text only, so a caller
   reading them from a script parsed prose. The json document carries the same data as the text render: for
   `asset_status`, the build-level caveats, one row per path with its winner and full provider chain, and the same

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -26,8 +26,8 @@ saying it sets an expectation their install may contradict. Say what is known, a
   beside the epoch, never inside it, so two builds that differ only in health still compare as different builds.
   A healthy order carries nothing. The sentence names up to ten plugins and counts the rest —
   `housecarl_load_order_status` lists them all. `housecarl_check` states the sentence once, at the top of the
-  response, so a dialogue-only check — the one family that carries no epoch — says it too; each swept family
-  carries the flag and the plugin count beside its own `epoch`, the same fact its text head states.
+  response, so a dialogue-only check says it too; each family carries the flag and the plugin count beside its own
+  `epoch`, the same fact its text head states.
 - **`housecarl_records` walks the reverse direction to any depth.** `walk={"direction":"reverse","depth":N}`
   under a reading form now answers "what points at the seeds, and what points at that" — every link at every
   hop, off the reverse-reference index, with no bounding `types=`/`plugins=` scope; the depth>1 refusal is gone.

--- a/src/housecarl-core/DialogueCheck.cs
+++ b/src/housecarl-core/DialogueCheck.cs
@@ -46,12 +46,11 @@ public sealed record DialogueSeedResult(string Seed, DialogueValidationReport? R
 /// <param name="CountsOnly">the response carries totals and the unreachable-seed roster, and no topic blocks. The
 /// merged tool's own mode applied to this family — a family that ignored it would render a full listing under a
 /// parameter documented to suppress one.</param>
-///
-/// <remarks><b>No EPOCH, deliberately.</b> The two sweep families stamp the record build they read. A dialogue
-/// validation cannot honestly carry that stamp: core pins one view, but half of what it reports — whether a line's
-/// <c>.fuz</c> is on disk, whether a result script's <c>.pex</c> exists — comes off the ASSET substrate, which the
-/// record fingerprint does not cover. A stamp covering half the answer would be a freshness claim the response
-/// cannot support. An honest stamp spanning both substrates is still unowned.</remarks>
+/// <param name="Epoch">the RECORD build every seed was validated against — the one pinned view the whole call reads,
+/// stamped like the sibling families stamp theirs. It names the record build and nothing else: the verdicts taken off
+/// the ASSET substrate (a line's <c>.fuz</c>, a result script's <c>.pex</c> chain, <c>.seq</c> coverage and staleness)
+/// are outside the fingerprint, so both renders write it with <c>epoch_covers_all_inputs: false</c> and name those
+/// classes rather than omitting the stamp. Null only on a refusal, which validated nothing.</param>
 public sealed record DialogueCheckResult(
     IReadOnlyList<DialogueSeedResult> Seeds,
     int TopicsFound,
@@ -60,7 +59,8 @@ public sealed record DialogueCheckResult(
     string? Error = null,
     int Limit = 0,
     int SeedsNamed = 0,
-    bool CountsOnly = false)
+    bool CountsOnly = false,
+    string? Epoch = null)
 {
     public bool Success => Error is null;
 

--- a/src/housecarl-core/DialogueCheck.cs
+++ b/src/housecarl-core/DialogueCheck.cs
@@ -50,7 +50,8 @@ public sealed record DialogueSeedResult(string Seed, DialogueValidationReport? R
 /// stamped like the sibling families stamp theirs. It names the record build and nothing else: the verdicts taken off
 /// the ASSET substrate (a line's <c>.fuz</c>, a result script's <c>.pex</c> chain, <c>.seq</c> coverage and staleness)
 /// are outside the fingerprint, so both renders write it with <c>epoch_covers_all_inputs: false</c> and name those
-/// classes rather than omitting the stamp. Null only on a refusal, which validated nothing.</param>
+/// classes rather than omitting the stamp. A refusal carries the bare stamp — the build it was decided against, with
+/// no coverage claim beside it, which is what the sibling families' refusals carry.</param>
 public sealed record DialogueCheckResult(
     IReadOnlyList<DialogueSeedResult> Seeds,
     int TopicsFound,
@@ -80,6 +81,8 @@ public sealed record DialogueCheckResult(
     /// could not evaluate, not a description of the listing.</summary>
     public int ConditionedInfos => Topics.Sum(x => x.Topic.ConditionedInfoCount);
 
-    public static DialogueCheckResult Fail(string error) =>
-        new(Array.Empty<DialogueSeedResult>(), 0, 0, false, error);
+    /// <summary>The family's refusal, stamped with the build it was decided against — the sibling families stamp
+    /// theirs, and a refusal decided after the view was captured has a build to name.</summary>
+    public static DialogueCheckResult Fail(string error, string? epoch = null) =>
+        new(Array.Empty<DialogueSeedResult>(), 0, 0, false, error) { Epoch = epoch };
 }

--- a/src/housecarl-core/DialogueCheck.cs
+++ b/src/housecarl-core/DialogueCheck.cs
@@ -50,8 +50,8 @@ public sealed record DialogueSeedResult(string Seed, DialogueValidationReport? R
 /// stamped like the sibling families stamp theirs. It names the record build and nothing else: the verdicts taken off
 /// the ASSET substrate (a line's <c>.fuz</c>, a result script's <c>.pex</c> chain, <c>.seq</c> coverage and staleness)
 /// are outside the fingerprint, so both renders write it with <c>epoch_covers_all_inputs: false</c> and name those
-/// classes rather than omitting the stamp. A refusal carries the bare stamp — the build it was decided against, with
-/// no coverage claim beside it, which is what the sibling families' refusals carry.</param>
+/// classes rather than omitting the stamp. Null on a refusal decided before any build was read, which is where the
+/// sibling families leave theirs null too.</param>
 public sealed record DialogueCheckResult(
     IReadOnlyList<DialogueSeedResult> Seeds,
     int TopicsFound,
@@ -81,8 +81,9 @@ public sealed record DialogueCheckResult(
     /// could not evaluate, not a description of the listing.</summary>
     public int ConditionedInfos => Topics.Sum(x => x.Topic.ConditionedInfoCount);
 
-    /// <summary>The family's refusal, stamped with the build it was decided against — the sibling families stamp
-    /// theirs, and a refusal decided after the view was captured has a build to name.</summary>
+    /// <summary>The family's refusal. It carries a stamp only when it was decided AFTER a build was read — the split
+    /// the sibling families keep: a refusal decided on the arguments alone has no build to name, and reading one to
+    /// stamp it would build the index for a call that is about to refuse.</summary>
     public static DialogueCheckResult Fail(string error, string? epoch = null) =>
         new(Array.Empty<DialogueSeedResult>(), 0, 0, false, error) { Epoch = epoch };
 }

--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -242,11 +242,15 @@ public static class DialogueValidate
         return built;
     }
 
-    public static DialogueValidationReport Run(LoadOrderResolver resolver, AssetResolver assets, FormKey fk)
+    /// <param name="pinned">the build to read, when a CALLER has already pinned one — a seed sweep validating several
+    /// records in one response hands its own view down so every seed reads the build the response stamps. Null pins one
+    /// here, which is what a single validation wants.</param>
+    public static DialogueValidationReport Run(LoadOrderResolver resolver, AssetResolver assets, FormKey fk,
+                                               LoadOrderResolver.IndexView? pinned = null)
     {
         try
         {
-            var view = resolver.Capture();                       // pin ONE index build for the whole validation
+            var view = pinned ?? resolver.Capture();             // pin ONE index build for the whole validation
             using var session = resolver.OpenSession();          // one set of overlays, disposed at run end
             var av = assets.Capture();                           // …and ONE asset build, so presence + ReadIncomplete agree
 

--- a/src/housecarl-generator/CheckMergeProbe.cs
+++ b/src/housecarl-generator/CheckMergeProbe.cs
@@ -1539,6 +1539,15 @@ public static class CheckMergeProbe
             && Count(mixedText, "record-level CK-parity check only") == 1,
             $"recordLevel=[{Trim(rlText)}] mixed=[{Trim(mixedText)}]");
 
+        Arm("DIALOGUE-THE-STAMP-DECLARES-ONLY-THE-BOUND-THIS-RESPONSE-HAS: the epoch line names the asset-substrate classes it does not cover only where those checks RAN. A call whose every seed was a DLVW or DLBR answered off the record substrate alone, so its stamp covers the whole answer — an uncovered set beside a boundary saying no voice file or result script was checked would contradict it inside one section",
+            rlText.Contains("it covers every verdict here", StringComparison.Ordinal)
+            && !rlText.Contains("does not cover", StringComparison.Ordinal)
+            && questText.Contains("does not cover: voiced lines (.fuz on disk)", StringComparison.Ordinal)
+            && !questText.Contains("it covers every verdict here", StringComparison.Ordinal)
+            // The mixed call reached a quest, so the graph checks ran and the bound is named.
+            && mixedText.Contains("does not cover: voiced lines (.fuz on disk)", StringComparison.Ordinal),
+            $"recordLevel=[{Trim(rlText)}] quest=[{Trim(questText)}]");
+
         // …and the json transport states the same, off the same value — one computation, two transports.
         bool rlJson;
         try
@@ -1559,7 +1568,13 @@ public static class CheckMergeProbe
                      && Strings(Arr(At(Arr(questFam, "seeds"), 0), "checks_run"))
                             .SequenceEqual(new[] { "record_parity", "topic_graph" })
                      && Str(questFam, "boundary") is { } qb
-                     && qb.Contains("LinkTo and previous-link targets", StringComparison.Ordinal);
+                     && qb.Contains("LinkTo and previous-link targets", StringComparison.Ordinal)
+                     // The coverage keys fork on the same value: a record-substrate-only answer claims full coverage
+                     // and names no classes, a quest names the three it read off disk.
+                     && Bool(fam, "epoch_covers_all_inputs") == true
+                     && Arr(fam, "epoch_uncovered") is null
+                     && Bool(questFam, "epoch_covers_all_inputs") == false
+                     && Strings(Arr(questFam, "epoch_uncovered")).Length == 3;
         }
         catch { rlJson = false; }
         Arm("DIALOGUE-THE-KIND-AWARE-VERDICT-AND-BOUNDARY-ARE-THE-SAME-IN-JSON: the record-level boundary and the seed's own CK-parity verdict read the same value in both transports — the sentence is composed once and stated whole by each, which is the rule the first fold of this defect broke by patching one site",

--- a/src/housecarl-generator/CheckMergeProbe.cs
+++ b/src/housecarl-generator/CheckMergeProbe.cs
@@ -1683,32 +1683,42 @@ public static class CheckMergeProbe
     /// <summary>Drive the real <c>DialogueSweep.Run</c> with a stub validator: <c>000A01</c> is a quest owning
     /// <see cref="Topics"/> topics, and every other resolvable seed is a named miss.</summary>
     static DialogueCheckResult DialogueSweep_Run(IReadOnlyList<string>? seeds, int limit)
-        => DialogueSweep.Run(fk => fk.ID == 0x000A01 || fk.ModKey.Name == "A" ? QuestReport(fk)
-                                 : DialogueValidationReport.ForError(fk, "no DIAL, QUST, DLVW or DLBR with this FormID is in the active order"),
-                             PluginQualified, seeds, limit);
+        => DialogueSweep.Run(() => Bind(fk => fk.ID == 0x000A01 || fk.ModKey.Name == "A" ? QuestReport(fk)
+                                 : DialogueValidationReport.ForError(fk, "no DIAL, QUST, DLVW or DLBR with this FormID is in the active order")),
+                             seeds, limit);
+
+    /// <summary>The stub binding every dialogue fixture runs through: the stub validator, the plugin-qualified parse,
+    /// and a FIXED stamp — so the epoch line and its coverage keys are inside every shape the matrix sweeps, at a
+    /// width that does not move between runs.</summary>
+    static DialogueSweep.Binding Bind(Func<FormKey, DialogueValidationReport> validate)
+        => new(validate, PluginQualified, ProbeEpoch);
+
+    /// <summary>A stamp of the width a real one has (16 hex characters), so a shape measured here is the shape a real
+    /// call renders.</summary>
+    const string ProbeEpoch = "7af654ddc8af948e";
 
     /// <summary>A sweep whose every reached seed is a RECORD-LEVEL kind — a DLVW and a DLBR, both passing. Neither
     /// owns an INFO list, so neither runs any of the graph, voice, script or condition checks; what the response
     /// says about them, and what its boundary claims on their behalf, is round-3 finding A1's subject.</summary>
     static DialogueCheckResult RecordLevelFixture()
-        => DialogueSweep.Run(fk => RecordLevelReport(fk, fk.ID == 0x000E01 ? "view" : "branch", Array.Empty<DialogueIssue>()),
-                             PluginQualified, new[] { "000E01:HcCm.esp", "000E02:HcCm.esp" }, 1000);
+        => DialogueSweep.Run(() => Bind(fk => RecordLevelReport(fk, fk.ID == 0x000E01 ? "view" : "branch", Array.Empty<DialogueIssue>())),
+                             new[] { "000E01:HcCm.esp", "000E02:HcCm.esp" }, 1000);
 
     /// <summary>The same two kinds, both FAILING their parity — the other side of the OK line, so an arm asking for
     /// the verdict cannot pass by finding a sentence that is printed either way.</summary>
     static DialogueCheckResult RecordLevelFailingFixture()
-        => DialogueSweep.Run(fk => RecordLevelReport(fk, fk.ID == 0x000E01 ? "view" : "branch",
+        => DialogueSweep.Run(() => Bind(fk => RecordLevelReport(fk, fk.ID == 0x000E01 ? "view" : "branch",
                                        new[] { new DialogueIssue(DialogueIssueSeverity.Problem,
-                                                   "the DNAM byte subrecord the Creation Kit always writes is absent") }),
-                             PluginQualified, new[] { "000E01:HcCm.esp", "000E02:HcCm.esp" }, 1000);
+                                                   "the DNAM byte subrecord the Creation Kit always writes is absent") })),
+                             new[] { "000E01:HcCm.esp", "000E02:HcCm.esp" }, 1000);
 
     /// <summary>A MIXED sweep: one quest that owns topics, one passing DLVW. The family's boundary can take only
     /// one arm and takes the wide one here — true of the response, and not of the view seed, which is why that seed
     /// carries a record-level scope note of its own.</summary>
     static DialogueCheckResult MixedKindFixture()
-        => DialogueSweep.Run(fk => fk.ID == 0x000A01 ? QuestReport(fk)
-                                 : RecordLevelReport(fk, "view", Array.Empty<DialogueIssue>()),
-                             PluginQualified, new[] { "000A01:HcCm.esp", "000E01:HcCm.esp" }, 1000);
+        => DialogueSweep.Run(() => Bind(fk => fk.ID == 0x000A01 ? QuestReport(fk)
+                                 : RecordLevelReport(fk, "view", Array.Empty<DialogueIssue>())),
+                             new[] { "000A01:HcCm.esp", "000E01:HcCm.esp" }, 1000);
 
     /// <summary>The seed parse these probes drive the sweep with: the plugin-qualified form only, since there is no
     /// load order here to resolve a runtime FormID against.</summary>

--- a/src/housecarl-mcp-tests/DegradedOrderMarkerTests.cs
+++ b/src/housecarl-mcp-tests/DegradedOrderMarkerTests.cs
@@ -11,8 +11,8 @@ namespace HousecarlMcpTests;
 /// build.
 ///
 /// <para>The PR's claim is about every stamped lane, so there is a case per lane: the record read, the scan, the
-/// merged check's per-family heads, the check ROOT (which a dialogue-only call is the only lane to reach), and the
-/// write lane's dry run.</para></summary>
+/// merged check's per-family heads — the dialogue family's among them, on a seed that resolves — the check ROOT
+/// (which a dialogue-only call is the only lane to reach), and the write lane's dry run.</para></summary>
 [Collection("epoch")]
 [Trait("tier", "integration")]
 public sealed class DegradedOrderMarkerTests
@@ -107,6 +107,27 @@ public sealed class DegradedOrderMarkerTests
 
         var text = CheckTools.CheckTool(Svc, findings: new[] { "dialogue" }, seeds: new[] { Fid });
         Assert.Contains("load FAILURE", text);
+    }
+
+    /// <summary>A dialogue call whose seed RESOLVES, so the family renders a head instead of refusing. The head is the
+    /// lane the sibling families are asserted on above, and the one the refusal case cannot reach: it stamps its own
+    /// `epoch`, so it has to carry the flag and the count beside it on json and the clause beside `epoch=` on text.
+    /// </summary>
+    [Fact]
+    public void TheDialogueFamilyHeadCarriesTheMarkerBesideItsOwnStamp()
+    {
+        var seed = $"{W.View.ID:X6}:{W.View.ModKey.FileName}";
+
+        var json = CheckTools.CheckTool(Svc, findings: new[] { "dialogue" }, seeds: new[] { seed }, format: "json");
+        var fam = JsonDocument.Parse(json).RootElement.GetProperty("families").GetProperty("dialogue");
+        Assert.False(string.IsNullOrEmpty(fam.GetProperty("epoch").GetString()));
+        Assert.True(fam.GetProperty("order_degraded").GetBoolean());
+        Assert.Equal(1, fam.GetProperty("order_degraded_plugins").GetInt32());
+        // The sentence stays the root's alone, as it does on the errors family.
+        Assert.False(fam.TryGetProperty("order_degraded_note", out _));
+
+        var text = CheckTools.CheckTool(Svc, findings: new[] { "dialogue" }, seeds: new[] { seed });
+        Assert.Contains($"epoch={Svc.Stats().epoch} · {Clause}", text);
     }
 
     /// <summary>The write lane, on a dry run so the shared world is not touched. A write's stamp is what tells a

--- a/src/housecarl-mcp-tests/DegradedOrderMarkerTests.cs
+++ b/src/housecarl-mcp-tests/DegradedOrderMarkerTests.cs
@@ -96,9 +96,9 @@ public sealed class DegradedOrderMarkerTests
         Assert.Contains("load FAILURE", text);
     }
 
-    /// <summary>A DIALOGUE-ONLY check. That family carries no epoch by design, so before the root marker existed
-    /// this response was silent about an order missing a plugin on both transports — the failure #353 exists to
-    /// end. Its seeds resolve to nothing here, which is a family refusal, not a reason to drop the marker.</summary>
+    /// <summary>A DIALOGUE-ONLY check. Before the root marker existed this response was silent about an order missing
+    /// a plugin on both transports — the failure #353 exists to end. Its seeds resolve to nothing here, which is a
+    /// family refusal, not a reason to drop the marker.</summary>
     [Fact]
     public void ADialogueOnlyCheckStillSaysTheOrderLostPlugins()
     {

--- a/src/housecarl-mcp-tests/DialogueFamilyTests.cs
+++ b/src/housecarl-mcp-tests/DialogueFamilyTests.cs
@@ -201,8 +201,8 @@ public sealed class DialogueFamilyTests
         Assert.Equal(DialogueSweepRender.EpochUncovered,
                      fam.GetProperty("epoch_uncovered").EnumerateArray().Select(e => e.GetString()).ToArray());
 
-        // A refusal carries the BARE stamp, as the sibling families' refusals do (EpochCheckSweepTests.FactE5_6):
-        // the view is pinned before the seeds are read, so there is a build to name, and nothing was covered by it.
+        // A refusal reached AFTER the build was read carries the bare stamp, as the sibling families' post-capture
+        // refusals do (EpochCheckSweepTests.FactE5_6): there is a build to name, and nothing was covered by it.
         var refused = Svc.CheckDialogue(new[] { "not-a-formid" }, 1000);
         Assert.NotNull(refused.Error);
         Assert.Equal(result.Epoch, refused.Epoch);
@@ -211,6 +211,13 @@ public sealed class DialogueFamilyTests
         var refusedJson = JsonWire.RenderCheck(new CheckSweep(DialogueSel(), Dialogue: refused), 20000);
         Assert.Equal(refused.Epoch, JsonDocument.Parse(refusedJson).RootElement.GetProperty("epoch").GetString());
         Assert.DoesNotContain("epoch_covers_all_inputs", refusedJson);
+
+        // …and a refusal decided on the ARGUMENTS alone names no build, which is the split the siblings keep: it is
+        // answered without reading one, so there is nothing honest to stamp.
+        var unseeded = Svc.CheckDialogue(Array.Empty<string>(), 1000);
+        Assert.NotNull(unseeded.Error);
+        Assert.Null(unseeded.Epoch);
+        Assert.DoesNotContain("epoch=", Wire.RenderCheck(new CheckSweep(DialogueSel(), Dialogue: unseeded), 20000));
     }
 
     /// <summary>Everything AFTER the seed prefix the sweep echoes — the composed refusal itself. The sweep writes

--- a/src/housecarl-mcp-tests/DialogueFamilyTests.cs
+++ b/src/housecarl-mcp-tests/DialogueFamilyTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Mutagen.Bethesda.Skyrim;
 using HousecarlCore;
@@ -174,6 +175,31 @@ public sealed class DialogueFamilyTests
         var byQuestLine = SeedBlock(r, "quest (QUST)");
         Assert.Contains("quest CK-parity: OK", byQuestLine);
         foreach (var sig in pinQuest) Assert.Contains(sig, byQuestLine);
+    }
+
+    // ---- fact V2 --------------------------------------------------------------------------------------
+    // The family stamps the record build every seed was validated against, and DECLARES the bound rather than
+    // omitting the stamp: both transports name the three verdict classes the record fingerprint does not describe.
+
+    [Fact]
+    public void FactV2_TheStampDeclaresItsBound()
+    {
+        var result = Svc.CheckDialogue(new[] { Fid(W.Topic) }, 1000);
+        Assert.Null(result.Error);
+        Assert.False(string.IsNullOrEmpty(result.Epoch));
+
+        var text = Wire.RenderCheck(new CheckSweep(DialogueSel(), Dialogue: result), 20000);
+        Served(text, $"epoch={result.Epoch}", "does not cover");
+        foreach (var cls in DialogueSweepRender.EpochUncovered) Assert.Contains(cls, text);
+
+        var fam = JsonDocument.Parse(JsonWire.RenderCheck(new CheckSweep(DialogueSel(), Dialogue: result), 20000))
+                              .RootElement.GetProperty("families")
+                              .GetProperty(SweepFamilySelection.Token(SweepFamily.Dialogue));
+        Assert.Equal(result.Epoch, fam.GetProperty("epoch").GetString());
+        // The stamp is a record-build claim only, so the coverage flag is false and the uncovered set says over what.
+        Assert.False(fam.GetProperty("epoch_covers_all_inputs").GetBoolean());
+        Assert.Equal(DialogueSweepRender.EpochUncovered,
+                     fam.GetProperty("epoch_uncovered").EnumerateArray().Select(e => e.GetString()).ToArray());
     }
 
     /// <summary>Everything AFTER the seed prefix the sweep echoes — the composed refusal itself. The sweep writes

--- a/src/housecarl-mcp-tests/DialogueFamilyTests.cs
+++ b/src/housecarl-mcp-tests/DialogueFamilyTests.cs
@@ -200,6 +200,17 @@ public sealed class DialogueFamilyTests
         Assert.False(fam.GetProperty("epoch_covers_all_inputs").GetBoolean());
         Assert.Equal(DialogueSweepRender.EpochUncovered,
                      fam.GetProperty("epoch_uncovered").EnumerateArray().Select(e => e.GetString()).ToArray());
+
+        // A refusal carries the BARE stamp, as the sibling families' refusals do (EpochCheckSweepTests.FactE5_6):
+        // the view is pinned before the seeds are read, so there is a build to name, and nothing was covered by it.
+        var refused = Svc.CheckDialogue(new[] { "not-a-formid" }, 1000);
+        Assert.NotNull(refused.Error);
+        Assert.Equal(result.Epoch, refused.Epoch);
+        Assert.Contains($"epoch={refused.Epoch}",
+                        Wire.RenderCheck(new CheckSweep(DialogueSel(), Dialogue: refused), 20000));
+        var refusedJson = JsonWire.RenderCheck(new CheckSweep(DialogueSel(), Dialogue: refused), 20000);
+        Assert.Equal(refused.Epoch, JsonDocument.Parse(refusedJson).RootElement.GetProperty("epoch").GetString());
+        Assert.DoesNotContain("epoch_covers_all_inputs", refusedJson);
     }
 
     /// <summary>Everything AFTER the seed prefix the sweep echoes — the composed refusal itself. The sweep writes

--- a/src/housecarl-mcp-tests/EpochWorld.cs
+++ b/src/housecarl-mcp-tests/EpochWorld.cs
@@ -30,6 +30,11 @@ public sealed class EpochWorld : IDisposable
     public LoadOrderService Svc { get; }
     public FormKey Weapon { get; }
 
+    /// <summary>A CK-parity-complete dialogue view in the master: a dialogue seed that RESOLVES on this degraded
+    /// order, so the dialogue family renders a head rather than refusing. DLVW reads nothing off disk, so the head
+    /// it renders is the whole-coverage one.</summary>
+    public FormKey View { get; }
+
     readonly string _priorCorpusPath;
 
     public EpochWorld()
@@ -49,6 +54,9 @@ public sealed class EpochWorld : IDisposable
         var w = master.Weapons.AddNew(); w.EditorID = "HcEpWeapon";
         w.BasicStats = new WeaponBasicStats { Damage = 10, Weight = 1 };
         Weapon = w.FormKey;
+        var view = master.DialogViews.AddNew(); view.EditorID = "HcEpView";
+        DialogueCkParity.ApplyViewDefaults(view);
+        View = view.FormKey;
 
         var old = new SkyrimMod(oldKey, SkyrimRelease.SkyrimSE);
         ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(old, master.Weapons.First()))

--- a/src/housecarl-mcp/CheckOutcome.cs
+++ b/src/housecarl-mcp/CheckOutcome.cs
@@ -106,8 +106,8 @@ internal sealed class CheckOutcome
     internal string? Epoch => _s.Epoch;
 
     /// <summary>The plugins the order this call answered from had lost to a load failure — see
-    /// <see cref="CheckSweep.OrderExcluded"/>. Stated at the response root, so every lane of a check says it,
-    /// including a dialogue-only one that carries no epoch.</summary>
+    /// <see cref="CheckSweep.OrderExcluded"/>. Stated at the response root, so every lane of a check says it once
+    /// whichever families ran.</summary>
     internal IReadOnlyList<string> OrderExcluded => _s.OrderExcluded;
 
     /// <summary><c>findings=</c> was omitted, so <see cref="Ran"/> is the default rather than a caller's choice.

--- a/src/housecarl-mcp/CheckSweepRender.cs
+++ b/src/housecarl-mcp/CheckSweepRender.cs
@@ -48,10 +48,9 @@ internal sealed record CheckSweep(
 
     /// <summary>The plugins the order this call answered from had LOST to a load failure, captured once before any
     /// family was dispatched and checked afterwards against every family's own stamp, so this really is the build
-    /// the whole response describes. A response-level fact, not a family's: the dialogue family carries no epoch by design
-    /// (see <see cref="DialogueCheckResult"/>), so a dialogue-only call has no family stamp to hang it off and would
-    /// otherwise be silent about an order missing plugins (#353). Empty on a healthy order and on a call refused
-    /// before the order was read.</summary>
+    /// the whole response describes. A response-level fact, not a family's: it is one claim about the build every
+    /// family read, so it is stated once at the root rather than assembled from whichever families happened to run
+    /// (#353). Empty on a healthy order and on a call refused before the order was read.</summary>
     internal IReadOnlyList<string> OrderExcluded => Order?.ExcludedPlugins ?? Array.Empty<string>();
 
     /// <summary>Does this family have a result to render?</summary>

--- a/src/housecarl-mcp/CheckSweepRender.cs
+++ b/src/housecarl-mcp/CheckSweepRender.cs
@@ -41,9 +41,10 @@ internal sealed record CheckSweep(
         _ => null,
     };
 
-    /// <summary>The epoch any family stamped, for a refusal render. Either family will do: a call whose families
-    /// stamped different builds refuses through <see cref="OrderSeamError"/> and never reaches here.</summary>
-    internal string? Epoch => Errors?.Epoch ?? Scripts?.Epoch;
+    /// <summary>The epoch any family stamped, for a refusal render. Any family will do: a call whose families
+    /// stamped different builds refuses through <see cref="OrderSeamError"/> and never reaches here. The dialogue
+    /// family is read here too, so a dialogue-only refusal is stamped like its siblings' are.</summary>
+    internal string? Epoch => Errors?.Epoch ?? Scripts?.Epoch ?? Dialogue?.Epoch;
 
     /// <summary>The plugins the order this call answered from had LOST to a load failure, captured once before any
     /// family was dispatched and checked afterwards against every family's own stamp, so this really is the build

--- a/src/housecarl-mcp/CheckTools.cs
+++ b/src/housecarl-mcp/CheckTools.cs
@@ -168,8 +168,7 @@ public static class CheckTools
         // for an answer that is identical both times — and the two cannot disagree about which names resolved.
         var offOrderMemo = new SweepOffOrderMemo();
         // The order every family below answers from, captured once so the response root can say whether it had lost
-        // plugins — the dialogue family carries no epoch, so this is the only lane that can state it for a
-        // dialogue-only call (#353).
+        // plugins once for the whole call, rather than leaving the fact to whichever families ran (#353).
         var order = svc.CaptureView().Stamp;
         ErrorCheckResult? errors = null;
         ScriptCheckResult? scripts = null;

--- a/src/housecarl-mcp/DialogueSweep.cs
+++ b/src/housecarl-mcp/DialogueSweep.cs
@@ -9,24 +9,34 @@ namespace HousecarlMcp;
 /// <c>plugins=</c> and <c>exclude=</c> do not scope this family, and the response says so.</summary>
 internal static class DialogueSweep
 {
-    /// <summary>Validate each seed and tally the result.</summary>
-    /// <param name="validate">the per-seed validation — the service's own <c>ValidateDialogue</c>, passed in so this
+    /// <summary>What this sweep needs off the load order, pinned to one build: the per-seed validation, the seed
+    /// parse and the stamp that names that build. Taken together so the three cannot come off different builds.
+    /// </summary>
+    /// <param name="Validate">the per-seed validation — the service's own dialogue validation, passed in so this
     /// class needs nothing of the service but the one call it makes.</param>
+    /// <param name="ParseFormId">the seed parse, pinned to the same build.</param>
+    /// <param name="Epoch">that build's stamp.</param>
+    internal readonly record struct Binding(Func<FormKey, DialogueValidationReport> Validate,
+                                            Func<string?, FormKey> ParseFormId,
+                                            string Epoch);
+
+    /// <summary>Validate each seed and tally the result.</summary>
+    /// <param name="bind">pins the build and hands back what this sweep reads it through. Called only once the seed
+    /// list has been found non-empty, so a call refused on its arguments alone never builds the index — the rule
+    /// <see cref="SweepSharedInput"/> states, and the reason the no-seeds refusal names no build. Every refusal
+    /// reached after this ran carries the stamp, as the sibling families' post-capture refusals do.</param>
     /// <param name="seeds">the FormIDs the caller named. Null or empty refuses, never widens: an empty scope read as
     /// "the whole order" would run a whole-order dialogue sweep.</param>
     /// <param name="limit">how many seeds this call may expand. Over it, the extra seeds are not validated and the
     /// response states how many and which knob moves them.</param>
     /// <param name="countsOnly">carry the totals and the unreachable-seed roster, and no topic blocks.</param>
-    /// <param name="epoch">the record build every seed was validated against, stamped onto the result — and onto the
-    /// refusals too, as the sibling families stamp theirs: the caller pins the view before this runs, so a refusal
-    /// decided here still names the build it was decided against.</param>
-    internal static DialogueCheckResult Run(Func<FormKey, DialogueValidationReport> validate,
-                                            Func<string?, FormKey> parseFormId,
-                                            IReadOnlyList<string>? seeds, int limit, bool countsOnly = false,
-                                            string? epoch = null)
+    internal static DialogueCheckResult Run(Func<Binding> bind,
+                                            IReadOnlyList<string>? seeds, int limit, bool countsOnly = false)
     {
         var named = (seeds ?? Array.Empty<string>()).Where(s => !string.IsNullOrWhiteSpace(s)).ToArray();
-        if (named.Length == 0) return DialogueCheckResult.Fail(ReadSentences.DialogueNeedsSeeds, epoch);
+        if (named.Length == 0) return DialogueCheckResult.Fail(ReadSentences.DialogueNeedsSeeds);
+
+        var (validate, parseFormId, epoch) = bind();
 
         var results = new List<DialogueSeedResult>();
         int topics = 0, problems = 0;

--- a/src/housecarl-mcp/DialogueSweep.cs
+++ b/src/housecarl-mcp/DialogueSweep.cs
@@ -17,9 +17,12 @@ internal static class DialogueSweep
     /// <param name="limit">how many seeds this call may expand. Over it, the extra seeds are not validated and the
     /// response states how many and which knob moves them.</param>
     /// <param name="countsOnly">carry the totals and the unreachable-seed roster, and no topic blocks.</param>
+    /// <param name="epoch">the record build every seed was validated against, stamped onto the result. Left off the
+    /// refusals, as the sibling families leave it off theirs: a family that validated nothing has no build to claim.</param>
     internal static DialogueCheckResult Run(Func<FormKey, DialogueValidationReport> validate,
                                             Func<string?, FormKey> parseFormId,
-                                            IReadOnlyList<string>? seeds, int limit, bool countsOnly = false)
+                                            IReadOnlyList<string>? seeds, int limit, bool countsOnly = false,
+                                            string? epoch = null)
     {
         var named = (seeds ?? Array.Empty<string>()).Where(s => !string.IsNullOrWhiteSpace(s)).ToArray();
         if (named.Length == 0) return DialogueCheckResult.Fail(ReadSentences.DialogueNeedsSeeds);
@@ -68,7 +71,7 @@ internal static class DialogueSweep
                 string.Join(" ", results.Select(r => $"{r.Seed}: {r.Refusal}."))));
 
         return new DialogueCheckResult(results, topics, problems, readIncomplete, Limit: limit,
-                                       SeedsNamed: named.Length, CountsOnly: countsOnly);
+                                       SeedsNamed: named.Length, CountsOnly: countsOnly, Epoch: epoch);
     }
 
     /// <summary>Every finding one report carries, at both levels. Counted off the report rather than off what

--- a/src/housecarl-mcp/DialogueSweep.cs
+++ b/src/housecarl-mcp/DialogueSweep.cs
@@ -17,15 +17,16 @@ internal static class DialogueSweep
     /// <param name="limit">how many seeds this call may expand. Over it, the extra seeds are not validated and the
     /// response states how many and which knob moves them.</param>
     /// <param name="countsOnly">carry the totals and the unreachable-seed roster, and no topic blocks.</param>
-    /// <param name="epoch">the record build every seed was validated against, stamped onto the result. Left off the
-    /// refusals, as the sibling families leave it off theirs: a family that validated nothing has no build to claim.</param>
+    /// <param name="epoch">the record build every seed was validated against, stamped onto the result — and onto the
+    /// refusals too, as the sibling families stamp theirs: the caller pins the view before this runs, so a refusal
+    /// decided here still names the build it was decided against.</param>
     internal static DialogueCheckResult Run(Func<FormKey, DialogueValidationReport> validate,
                                             Func<string?, FormKey> parseFormId,
                                             IReadOnlyList<string>? seeds, int limit, bool countsOnly = false,
                                             string? epoch = null)
     {
         var named = (seeds ?? Array.Empty<string>()).Where(s => !string.IsNullOrWhiteSpace(s)).ToArray();
-        if (named.Length == 0) return DialogueCheckResult.Fail(ReadSentences.DialogueNeedsSeeds);
+        if (named.Length == 0) return DialogueCheckResult.Fail(ReadSentences.DialogueNeedsSeeds, epoch);
 
         var results = new List<DialogueSeedResult>();
         int topics = 0, problems = 0;
@@ -68,7 +69,7 @@ internal static class DialogueSweep
         // family answers with one refusal rather than a section of nothing.
         if (results.Count > 0 && results.All(r => r.Report is null))
             return DialogueCheckResult.Fail(string.Format(ReadSentences.DialogueNoSeedResolved, results.Count,
-                string.Join(" ", results.Select(r => $"{r.Seed}: {r.Refusal}."))));
+                string.Join(" ", results.Select(r => $"{r.Seed}: {r.Refusal}."))), epoch);
 
         return new DialogueCheckResult(results, topics, problems, readIncomplete, Limit: limit,
                                        SeedsNamed: named.Length, CountsOnly: countsOnly, Epoch: epoch);

--- a/src/housecarl-mcp/DialogueSweepRender.cs
+++ b/src/housecarl-mcp/DialogueSweepRender.cs
@@ -56,7 +56,9 @@ internal static class DialogueSweepRender
         sb.Append(string.Format(ReadSentences.DialogueCounts, d.SeedsValidated, d.SeedsReached, d.TopicsFound,
                                 d.FindingsFound));
         if (o.Sweep.Dialogue?.Epoch is { } epoch)
-            sb.Append(string.Format(ReadSentences.DialogueEpochBound, epoch, string.Join(", ", EpochUncovered)));
+            sb.Append(UncoveredBy(d) is { Length: > 0 } unc
+                          ? string.Format(ReadSentences.DialogueEpochBound, epoch, string.Join(", ", unc))
+                          : string.Format(ReadSentences.DialogueEpochWhole, epoch));
         if (d.CountsOnly) sb.Append(ReadSentences.DialogueCountsOnly);
     }
 
@@ -69,6 +71,14 @@ internal static class DialogueSweepRender
         ReadSentences.DialogueUncoveredScripts,
         ReadSentences.DialogueUncoveredSeq,
     };
+
+    /// <summary>Which of those classes THIS response actually carried, off the same per-kind table the boundary reads:
+    /// all three verdicts live behind the graph checks, and a call whose every seed was a DLVW or DLBR ran none of
+    /// them. Its answer is record substrate throughout, so the stamp covers all of it and names nothing — otherwise
+    /// the head would caveat voice, script and .seq verdicts the boundary two lines down says were never checked.
+    /// </summary>
+    internal static string[] UncoveredBy(DialogueOutcome d)
+        => d.ChecksRun.HasFlag(DialogueChecks.TopicGraph) ? EpochUncovered : Array.Empty<string>();
 
     /// <summary>The family's rows. Everything here goes through <paramref name="body"/>, so everything here is
     /// refusable and everything refused is accounted for.</summary>
@@ -167,7 +177,7 @@ internal static class DialogueSweepRender
         w.WriteBoolean("seeded_not_swept", true);
         // The stamp in the shape the swept families write, with the bound declared: this family also reports asset
         // verdicts, so it names them rather than claiming the fingerprint covers them.
-        JsonWire.WriteSweepEpoch(w, o.Sweep.Dialogue?.Epoch, o.Sweep.OrderExcluded.Count, null, EpochUncovered);
+        JsonWire.WriteSweepEpoch(w, o.Sweep.Dialogue?.Epoch, o.Sweep.OrderExcluded.Count, null, UncoveredBy(d));
         w.WriteBoolean("counts_only", d.CountsOnly);
         w.WriteNumber("seeds_named", d.SeedsNamed);
         w.WriteNumber("seeds_reached", d.SeedsReached);

--- a/src/housecarl-mcp/DialogueSweepRender.cs
+++ b/src/housecarl-mcp/DialogueSweepRender.cs
@@ -56,9 +56,14 @@ internal static class DialogueSweepRender
         sb.Append(string.Format(ReadSentences.DialogueCounts, d.SeedsValidated, d.SeedsReached, d.TopicsFound,
                                 d.FindingsFound));
         if (o.Sweep.Dialogue?.Epoch is { } epoch)
+        {
+            // The degraded clause sits beside the stamp exactly as the sibling families print it, so all three heads
+            // state the same fact in the same place.
+            var clause = OrderDegraded.Clause(o.Sweep.OrderExcluded.Count);
             sb.Append(UncoveredBy(d) is { Length: > 0 } unc
-                          ? string.Format(ReadSentences.DialogueEpochBound, epoch, string.Join(", ", unc))
-                          : string.Format(ReadSentences.DialogueEpochWhole, epoch));
+                          ? string.Format(ReadSentences.DialogueEpochBound, epoch, clause, string.Join(", ", unc))
+                          : string.Format(ReadSentences.DialogueEpochWhole, epoch, clause));
+        }
         if (d.CountsOnly) sb.Append(ReadSentences.DialogueCountsOnly);
     }
 

--- a/src/housecarl-mcp/DialogueSweepRender.cs
+++ b/src/housecarl-mcp/DialogueSweepRender.cs
@@ -55,8 +55,20 @@ internal static class DialogueSweepRender
         // different quantities under the same word.
         sb.Append(string.Format(ReadSentences.DialogueCounts, d.SeedsValidated, d.SeedsReached, d.TopicsFound,
                                 d.FindingsFound));
+        if (o.Sweep.Dialogue?.Epoch is { } epoch)
+            sb.Append(string.Format(ReadSentences.DialogueEpochBound, epoch, string.Join(", ", EpochUncovered)));
         if (d.CountsOnly) sb.Append(ReadSentences.DialogueCountsOnly);
     }
+
+    /// <summary>The verdict classes this family reports that the record fingerprint does not describe — the ASSET
+    /// substrate half of the answer. Data, read by both transports, so the text sentence and <c>epoch_uncovered</c>
+    /// cannot name different sets.</summary>
+    internal static readonly string[] EpochUncovered =
+    {
+        ReadSentences.DialogueUncoveredVoice,
+        ReadSentences.DialogueUncoveredScripts,
+        ReadSentences.DialogueUncoveredSeq,
+    };
 
     /// <summary>The family's rows. Everything here goes through <paramref name="body"/>, so everything here is
     /// refusable and everything refused is accounted for.</summary>
@@ -153,6 +165,9 @@ internal static class DialogueSweepRender
         var d = o.Dialogue!.Value;
         w.WriteString("scope", ScopeNote(d));
         w.WriteBoolean("seeded_not_swept", true);
+        // The stamp in the shape the swept families write, with the bound declared: this family also reports asset
+        // verdicts, so it names them rather than claiming the fingerprint covers them.
+        JsonWire.WriteSweepEpoch(w, o.Sweep.Dialogue?.Epoch, o.Sweep.OrderExcluded.Count, null, EpochUncovered);
         w.WriteBoolean("counts_only", d.CountsOnly);
         w.WriteNumber("seeds_named", d.SeedsNamed);
         w.WriteNumber("seeds_reached", d.SeedsReached);

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using System.Text.Json;
 using HousecarlCore;
 using Mutagen.Bethesda.Plugins;

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using System.Text.Json;
 using HousecarlCore;
 using Mutagen.Bethesda.Plugins;
@@ -1374,7 +1374,7 @@ static class JsonWire
         bool didDangling = r.Classes.HasFlag(ErrorFindingClass.Dangling);
         bool didMasters = r.Classes.HasFlag(ErrorFindingClass.MissingMasters);
         w.WriteNumber("scanned_plugins", r.PluginsScanned);
-        WriteSweepEpoch(w, r.Epoch, r.ExcludedPlugins, r.OffOrderScanned);   // the swept INDEXED build + whether it covers every swept input
+        WriteSweepEpoch(w, r.Epoch, r.ExcludedPlugins.Count, r.OffOrderScanned);   // the swept INDEXED build + whether it covers every swept input
         // null (not 0) for a class nobody looked for — see the summary.
         if (didDangling) { w.WriteNumber("dangling", r.TotalDangling); w.WriteNumber("unscannable_records", r.TotalUnscannableRecords); }
         else { w.WriteNull("dangling"); w.WriteNull("unscannable_records"); }
@@ -1680,12 +1680,16 @@ static class JsonWire
         return Size(w, ms) - before;
     }
 
-    /// <summary>A swept family's stamp and coverage as data: <c>epoch_covers_all_inputs</c> is false exactly when
-    /// off-order files were swept beside the index, since their content is outside the fingerprint and
-    /// <c>off_order_scanned</c> names them. Both swept families have that lane, so both write it through here.
+    /// <summary>A family's stamp and coverage as data: <c>epoch_covers_all_inputs</c> is false when off-order files
+    /// were swept beside the index, since their content is outside the fingerprint and <c>off_order_scanned</c> names
+    /// them — or when the family also reports verdicts read off another substrate, which <paramref name="uncovered"/>
+    /// names in <c>epoch_uncovered</c>. Every family that stamps writes it through here.
     /// Success path only; a refusal swept nothing and carries the bare stamp.</summary>
-    static void WriteSweepEpoch(Utf8JsonWriter w, string? epoch, IReadOnlyDictionary<string, string> excluded,
-                                IReadOnlyList<string>? offOrderScanned)
+    /// <param name="excludedCount">how many plugins the build this family read had lost to a load failure — a count,
+    /// because a family whose own result carries no roster still reports the same fact off the response's stamp.</param>
+    internal static void WriteSweepEpoch(Utf8JsonWriter w, string? epoch, int excludedCount,
+                                         IReadOnlyList<string>? offOrderScanned,
+                                         IReadOnlyList<string>? uncovered = null)
     {
         if (epoch is null) return;
         WriteNullable(w, "epoch", epoch);
@@ -1695,12 +1699,14 @@ static class JsonWire
         // one document three times, beside a roster that already names those plugins WITH their reasons — and the
         // fixed part comes out of the budget the findings are listed from. The count is what the family's TEXT
         // head says beside epoch=, so the two transports state the same thing here.
-        if (excluded.Count > 0)
+        if (excludedCount > 0)
         {
             w.WriteBoolean("order_degraded", true);
-            w.WriteNumber("order_degraded_plugins", excluded.Count);
+            w.WriteNumber("order_degraded_plugins", excludedCount);
         }
-        w.WriteBoolean("epoch_covers_all_inputs", offOrderScanned is not { Count: > 0 });
+        w.WriteBoolean("epoch_covers_all_inputs", offOrderScanned is not { Count: > 0 } && uncovered is not { Count: > 0 });
+        // Named only where there are classes to name, so the key is never a caveat over a stamp that covers everything.
+        if (uncovered is { Count: > 0 }) WriteStringArray(w, "epoch_uncovered", uncovered);
     }
 
     /// <summary>A swept family's off-order roster AND the coverage caveat that makes it readable — the same tail
@@ -1904,7 +1910,7 @@ static class JsonWire
         bool didNull = r.Classes.HasFlag(ScriptFindingClass.BoundNull);
 
         w.WriteNumber("scanned_plugins", r.PluginsScanned);
-        WriteSweepEpoch(w, r.Epoch, r.ExcludedPlugins, r.OffOrderScanned);   // the swept INDEXED build + whether it covers every swept input
+        WriteSweepEpoch(w, r.Epoch, r.ExcludedPlugins.Count, r.OffOrderScanned);   // the swept INDEXED build + whether it covers every swept input
         w.WriteNumber("records_with_scripts", r.RecordsWithScripts);
         if (didObject || didScalar) w.WriteNumber("unbound", r.TotalUnbound); else w.WriteNull("unbound");
         if (didObject) w.WriteNumber("unbound_object", r.TotalUnboundObject); else w.WriteNull("unbound_object");

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -50,7 +50,7 @@ static class JsonWire
     }
 
     /// <summary>The marker on its own, for a document that states it at the ROOT rather than beside an epoch — the
-    /// merged check, whose dialogue family carries no epoch to hang it off. Silent on a healthy order.</summary>
+    /// merged check, which states it once for every family it ran. Silent on a healthy order.</summary>
     static void WriteOrderDegraded(Utf8JsonWriter w, IReadOnlyCollection<string>? excluded)
     {
         if (excluded is not { Count: > 0 }) return;

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2309,17 +2309,20 @@ public sealed class LoadOrderService : IDisposable
     /// tallied for one section of a merged response. Deliberately thin — the family's own grammar (seed parse,
     /// cost refusal, seed budget, tally) lives in <see cref="DialogueSweep"/> rather than in this file.</summary>
     public DialogueCheckResult CheckDialogue(IReadOnlyList<string>? seeds, int limit, bool countsOnly = false)
-    {
-        // One resolver and one view for the whole call, the contract the sibling families keep: every seed is validated
-        // against the same build, so the stamp below names the build the response was actually answered from rather
-        // than whichever one the last seed happened to catch.
-        var resolver = Resolver;
-        var view = resolver.Capture();
-        // The seed door is pinned to that same view: a door of its own would capture a second build on the first
-        // runtime FormID, so the seeds could name records from a build other than the one the response stamps.
-        return DialogueSweep.Run(fk => DialogueValidate.Run(resolver, Assets, fk, view),
-                                 FormIdDoor.On(view).Parse, seeds, limit, countsOnly, view.Epoch);
-    }
+        // Bound LAZILY: the sweep calls this only once it has seeds to validate, so a call with no seeds= refuses
+        // without building the index — the rule SweepSharedInput states, and what this family did before it stamped.
+        => DialogueSweep.Run(() =>
+        {
+            // One resolver and one view for the whole call, the contract the sibling families keep: every seed is
+            // validated against the same build, so the stamp names the build the response was actually answered from
+            // rather than whichever one the last seed happened to catch.
+            var resolver = Resolver;
+            var view = resolver.Capture();
+            // The seed door is pinned to that same view: a door of its own would capture a second build on the first
+            // runtime FormID, so the seeds could name records from a build other than the one the response stamps.
+            return new DialogueSweep.Binding(fk => DialogueValidate.Run(resolver, Assets, fk, view),
+                                             FormIdDoor.On(view).Parse, view.Epoch);
+        }, seeds, limit, countsOnly);
 
     /// <summary>The read body, answered entirely off ONE captured view: the excluded-check, the winner and the
     /// touching-plugin list all describe the same build, so a freshness rebuild landing mid-read cannot make a

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2303,17 +2303,21 @@ public sealed class LoadOrderService : IDisposable
     /// a verify step: a mid-run resolve or asset failure rides
     /// <see cref="DialogueValidationReport.CheckError"/>, and a not-in-order or wrong-type input is a named
     /// <see cref="DialogueValidationReport.Error"/>.</summary>
-    // No epoch is stamped: the report is one build's answer, but many of its verdicts come off the ASSET substrate,
-    // outside the record fingerprint — the .pex chain behind each result script, the .fuz checks, and the .seq
-    // staleness verdict, which is a file-mtime comparison no record fingerprint expresses. A record fingerprint here
-    // would claim freshness for verdicts it does not describe.
     public DialogueValidationReport ValidateDialogue(FormKey fk) => DialogueValidate.Run(Resolver, Assets, fk);
 
     /// <summary>The merged <c>check</c> surface's dialogue family: <see cref="ValidateDialogue"/> over a seed list,
     /// tallied for one section of a merged response. Deliberately thin — the family's own grammar (seed parse,
     /// cost refusal, seed budget, tally) lives in <see cref="DialogueSweep"/> rather than in this file.</summary>
     public DialogueCheckResult CheckDialogue(IReadOnlyList<string>? seeds, int limit, bool countsOnly = false)
-        => DialogueSweep.Run(ValidateDialogue, OpenFormIdDoor().Parse, seeds, limit, countsOnly);
+    {
+        // One resolver and one view for the whole call, the contract the sibling families keep: every seed is validated
+        // against the same build, so the stamp below names the build the response was actually answered from rather
+        // than whichever one the last seed happened to catch.
+        var resolver = Resolver;
+        var view = resolver.Capture();
+        return DialogueSweep.Run(fk => DialogueValidate.Run(resolver, Assets, fk, view),
+                                 OpenFormIdDoor().Parse, seeds, limit, countsOnly, view.Epoch);
+    }
 
     /// <summary>The read body, answered entirely off ONE captured view: the excluded-check, the winner and the
     /// touching-plugin list all describe the same build, so a freshness rebuild landing mid-read cannot make a

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2315,8 +2315,10 @@ public sealed class LoadOrderService : IDisposable
         // than whichever one the last seed happened to catch.
         var resolver = Resolver;
         var view = resolver.Capture();
+        // The seed door is pinned to that same view: a door of its own would capture a second build on the first
+        // runtime FormID, so the seeds could name records from a build other than the one the response stamps.
         return DialogueSweep.Run(fk => DialogueValidate.Run(resolver, Assets, fk, view),
-                                 OpenFormIdDoor().Parse, seeds, limit, countsOnly, view.Epoch);
+                                 FormIdDoor.On(view).Parse, seeds, limit, countsOnly, view.Epoch);
     }
 
     /// <summary>The read body, answered entirely off ONE captured view: the excluded-check, the winner and the

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2317,10 +2317,14 @@ public sealed class LoadOrderService : IDisposable
             // validated against the same build, so the stamp names the build the response was actually answered from
             // rather than whichever one the last seed happened to catch.
             var resolver = Resolver;
+            // The asset resolver is taken once here for the same reason, and where the scripts family takes it: the
+            // property re-gates on every read and can rebuild outright, so reading it per seed would let one
+            // response's .fuz and .pex verdicts come off two different asset builds under one tally and one stamp.
+            var assets = Assets;
             var view = resolver.Capture();
             // The seed door is pinned to that same view: a door of its own would capture a second build on the first
             // runtime FormID, so the seeds could name records from a build other than the one the response stamps.
-            return new DialogueSweep.Binding(fk => DialogueValidate.Run(resolver, Assets, fk, view),
+            return new DialogueSweep.Binding(fk => DialogueValidate.Run(resolver, assets, fk, view),
                                              FormIdDoor.On(view).Parse, view.Epoch);
         }, seeds, limit, countsOnly);
 

--- a/src/housecarl-mcp/ReadSentences.cs
+++ b/src/housecarl-mcp/ReadSentences.cs
@@ -700,6 +700,26 @@ internal static class ReadSentences
     internal const string DialogueCounts =
         "{0} of the {1} seed(s) reached were validated, {2} topic(s), {3} finding(s) across them.\n";
 
+    /// <summary>The dialogue family's stamp line: the record build the verdicts were read from, and the classes that
+    /// build does not describe. The stamp is never omitted in place of declaring the bound — an answer with no
+    /// freshness claim at all is less readable than one that says how far its claim reaches.</summary>
+    [MustState("epoch=", "does not cover")]
+    internal const string DialogueEpochBound =
+        "epoch={0} — the record build these verdicts were read from; it does not cover: {1}.\n";
+
+    /// <summary>One of the three verdict classes the record fingerprint does not describe: whether a line's voice file
+    /// is on disk, which is an asset the fingerprint never sees.</summary>
+    [MustState(".fuz")]
+    internal const string DialogueUncoveredVoice = "voiced lines (.fuz on disk)";
+
+    /// <summary>The second uncovered class: the compiled script behind each result fragment.</summary>
+    [MustState(".pex")]
+    internal const string DialogueUncoveredScripts = "result-script .pex chain";
+
+    /// <summary>The third: the .seq verdict, a file-mtime comparison no record fingerprint expresses.</summary>
+    [MustState(".seq")]
+    internal const string DialogueUncoveredSeq = ".seq coverage and staleness";
+
     /// <summary>What <c>counts_only=true</c> leaves out for this family, stated where the listing would have been:
     /// a mode that renders no blocks must say so rather than look like a validation that found nothing.</summary>
     [MustState("counts_only=true", "no per-topic blocks")]

--- a/src/housecarl-mcp/ReadSentences.cs
+++ b/src/housecarl-mcp/ReadSentences.cs
@@ -700,19 +700,20 @@ internal static class ReadSentences
     internal const string DialogueCounts =
         "{0} of the {1} seed(s) reached were validated, {2} topic(s), {3} finding(s) across them.\n";
 
-    /// <summary>The dialogue family's stamp line: the record build the verdicts were read from, and the classes that
-    /// build does not describe. The stamp is never omitted in place of declaring the bound — an answer with no
-    /// freshness claim at all is less readable than one that says how far its claim reaches.</summary>
+    /// <summary>The dialogue family's stamp line: the record build the verdicts were read from, the degraded-order
+    /// clause the sibling families print beside their own stamps, and the classes that build does not describe. The
+    /// stamp is never omitted in place of declaring the bound — an answer with no freshness claim at all is less
+    /// readable than one that says how far its claim reaches.</summary>
     [MustState("epoch=", "does not cover")]
     internal const string DialogueEpochBound =
-        "epoch={0} — the record build these verdicts were read from; it does not cover: {1}.\n";
+        "epoch={0}{1} — the record build these verdicts were read from; it does not cover: {2}.\n";
 
     /// <summary>The same stamp where the call answered off the record substrate alone — every seed a DLVW or DLBR, so
     /// none of the asset-substrate checks ran. It says the stamp covers the whole answer rather than printing an
     /// uncovered set for verdicts this response never produced.</summary>
     [MustState("epoch=", "covers every verdict")]
     internal const string DialogueEpochWhole =
-        "epoch={0} — the record build these verdicts were read from; it covers every verdict here.\n";
+        "epoch={0}{1} — the record build these verdicts were read from; it covers every verdict here.\n";
 
     /// <summary>One of the three verdict classes the record fingerprint does not describe: whether a line's voice file
     /// is on disk, which is an asset the fingerprint never sees.</summary>

--- a/src/housecarl-mcp/ReadSentences.cs
+++ b/src/housecarl-mcp/ReadSentences.cs
@@ -707,6 +707,13 @@ internal static class ReadSentences
     internal const string DialogueEpochBound =
         "epoch={0} — the record build these verdicts were read from; it does not cover: {1}.\n";
 
+    /// <summary>The same stamp where the call answered off the record substrate alone — every seed a DLVW or DLBR, so
+    /// none of the asset-substrate checks ran. It says the stamp covers the whole answer rather than printing an
+    /// uncovered set for verdicts this response never produced.</summary>
+    [MustState("epoch=", "covers every verdict")]
+    internal const string DialogueEpochWhole =
+        "epoch={0} — the record build these verdicts were read from; it covers every verdict here.\n";
+
     /// <summary>One of the three verdict classes the record fingerprint does not describe: whether a line's voice file
     /// is on disk, which is an asset the fingerprint never sees.</summary>
     [MustState(".fuz")]

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -779,7 +779,7 @@ static class Wire
         // refused, and which registered ones were never asked, with the spelling that gets them.
         sb.Append(o.ScopeSentence()).Append('\n');
         // The order this whole call answered from was short of plugins — a response-level fact, so it is stated
-        // here rather than per family: the dialogue family carries no epoch and would otherwise be silent (#353).
+        // here once rather than left to whichever families ran (#353).
         if (o.OrderExcluded.Count > 0)
             sb.Append(OrderDegraded.Sentence(o.OrderExcluded)).Append('\n');
 


### PR DESCRIPTION
The dialogue family of `housecarl_check` was the one section of a merged response with no freshness claim at all: it stamped no epoch, because half its verdicts — whether a line's `.fuz` is on disk, whether a result script's `.pex` chain exists, whether the `.seq` lists the quest and is newer than its plugin — come off the asset substrate, which the record fingerprint does not cover. Omitting the stamp was a worse answer than declaring the bound. `DialogueCheckResult` now carries `Epoch`, taken off one pinned view that `CheckDialogue` captures and hands to every seed's validation, so the stamp names the build the response was actually answered from rather than whichever one the last seed happened to catch. Both renders write it through the shape the errors and scripts families already use: json gets `epoch`, `epoch_covers_all_inputs: false` and `epoch_uncovered` naming the three classes; the text render states the same stamp and the same three classes on its own line. `WriteSweepEpoch` gained the uncovered arm rather than a second writer, and the class names are one array both transports read, so the two cannot name different sets. The "no honest stamp exists" remarks in `DialogueCheck.cs` and `LoadOrderService.cs` are gone — the SPEC sentence they pointed at exists now (§2.1, amended 2026-09-06).

A refusal still carries no stamp: a family that validated nothing has no build to claim, which is what the sibling families do.

Test: `FactV2_TheStampDeclaresItsBound` drives a dialogue check on the shared world and asserts the stamp and the three names in both transports, with the uncovered set read off the same array the render writes.

Closes #396
