### PR TITLE
Walk the reverse direction to any depth

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -28,6 +28,15 @@ saying it sets an expectation their install may contradict. Say what is known, a
   `housecarl_load_order_status` lists them all. `housecarl_check` states the sentence once, at the top of the
   response, so a dialogue-only check — the one family that carries no epoch — says it too; each swept family
   carries the flag and the plugin count beside its own `epoch`, the same fact its text head states.
+- **`housecarl_records` walks the reverse direction to any depth.** `walk={"direction":"reverse","depth":N}`
+  under a reading form now answers "what points at the seeds, and what points at that" — every link at every
+  hop, off the reverse-reference index, with no bounding `types=`/`plugins=` scope; the depth>1 refusal is gone.
+  The response names the count reached at each hop, empty hops included, and says which hops it did not need to
+  walk, so a walk that ran out of referrers reads as exhausted rather than as a silent stop. The index's own
+  accounting — the one-time build cost, its per-plugin freshness key, and any plugin the walk could not read —
+  rides this lane exactly as it rides `references=`. `form='chain'` still selects the typed MGEF carrier lane
+  (per-carrier magnitude/area/duration); it follows the effect link at every hop, so it reaches nothing past
+  hop 1 and now says the empty hops instead of answering a deeper call with a depth-1 answer.
 
 - **`housecarl_asset_status` and `housecarl_place` take `format='json'`.** Both answered text only, so a caller
   reading them from a script parsed prose. The json document carries the same data as the text render: for

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -44,11 +44,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
   link, `follow="Effects[].BaseEffect"` is the typed MGEF carrier walk (per-carrier magnitude/area/duration,
   `types=` narrowing the carrier types), which follows the effect link at every hop and so reaches nothing past
   hop 1 — said out loud when a depth was asked for. The form then only picks the view, as it does forward:
-  `'chain'` renders the walk's rows and a reading form consumes the same reached set. One declared exception
-  keeps the existing carrier spelling working: `form='chain'` with `follow` unset means the carrier walk,
-  because the transitive walk expands one shared frontier and has no per-seed path for `chain` to draw;
-  `form='chain'` with `follow="*"` refuses and names both alternatives. Any other `follow` on reverse refuses
-  naming the two the index can serve. `walk.max_nodes` says which reading it spends: per seed on the carrier
+  `'chain'` renders the walk's rows and a reading form consumes the same reached set. No default `follow`
+  implies a walk under any form: `form='chain'` on a reverse walk with `follow` unset now refuses and names
+  both follows the index can serve, and says that `chain` has no per-seed path to draw for the transitive
+  walk; `form='chain'` with `follow="*"` refuses as before. A reverse `chain` call — including the one the
+  retired `housecarl_effect_chain` redirect teaches — therefore says `follow="Effects[].BaseEffect"`. Any
+  other `follow` on reverse refuses naming the two the index can serve. `walk.max_nodes` says which reading it spends: per seed on the carrier
   walk, one shared budget across every seed and hop on the transitive walk.
 
 - **`housecarl_asset_status` and `housecarl_place` take `format='json'`.** Both answered text only, so a caller

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -34,9 +34,22 @@ saying it sets an expectation their install may contradict. Say what is known, a
   The response names the count reached at each hop, empty hops included, and says which hops it did not need to
   walk, so a walk that ran out of referrers reads as exhausted rather than as a silent stop. The index's own
   accounting — the one-time build cost, its per-plugin freshness key, and any plugin the walk could not read —
-  rides this lane exactly as it rides `references=`. `form='chain'` still selects the typed MGEF carrier lane
-  (per-carrier magnitude/area/duration); it follows the effect link at every hop, so it reaches nothing past
-  hop 1 and now says the empty hops instead of answering a deeper call with a depth-1 answer.
+  rides this lane exactly as it rides `references=`. The reached set is verified against the body the walk
+  judges — the load-order winner — so a record whose winner dropped the link is not reported and not expanded,
+  and the walk and `references=` answer the same question the same way; the response says how many index
+  candidates that check dropped. A hop the `walk.max_nodes` budget ended is marked as cut rather than reading
+  as a hop that reached nothing.
+- **`walk.follow` is legal on `direction='reverse'`, and it is what picks the reverse walk.** `follow` names
+  the edges a walk crosses, backwards as well as forwards: unset or `"*"` is the transitive walk over every
+  link, `follow="Effects[].BaseEffect"` is the typed MGEF carrier walk (per-carrier magnitude/area/duration,
+  `types=` narrowing the carrier types), which follows the effect link at every hop and so reaches nothing past
+  hop 1 — said out loud when a depth was asked for. The form then only picks the view, as it does forward:
+  `'chain'` renders the walk's rows and a reading form consumes the same reached set. One declared exception
+  keeps the existing carrier spelling working: `form='chain'` with `follow` unset means the carrier walk,
+  because the transitive walk expands one shared frontier and has no per-seed path for `chain` to draw;
+  `form='chain'` with `follow="*"` refuses and names both alternatives. Any other `follow` on reverse refuses
+  naming the two the index can serve. `walk.max_nodes` says which reading it spends: per seed on the carrier
+  walk, one shared budget across every seed and hop on the transitive walk.
 
 - **`housecarl_asset_status` and `housecarl_place` take `format='json'`.** Both answered text only, so a caller
   reading them from a script parsed prose. The json document carries the same data as the text render: for

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -37,8 +37,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
   rides this lane exactly as it rides `references=`. The reached set is verified against the body the walk
   judges — the load-order winner — so a record whose winner dropped the link is not reported and not expanded,
   and the walk and `references=` answer the same question the same way; the response says how many index
-  candidates that check dropped. A hop the `walk.max_nodes` budget ended is marked as cut rather than reading
-  as a hop that reached nothing.
+  candidates that check dropped, and names each cause with its own count — a winner that does not carry the
+  link, a winning plugin that could not be read (a coverage gap, not a verdict), a deleted winner, or no
+  resolvable winner — counting each record once however many hops name it. One record that cannot be read
+  costs that record, never the walk. A hop the `walk.max_nodes` budget ended is marked as cut rather than
+  reading as a hop that reached nothing, and a walk that stopped because it reached `walk.depth` with records
+  still to expand says so instead of reading as a complete answer.
 - **`walk.follow` is legal on `direction='reverse'`, and it is what picks the reverse walk.** `follow` names
   the edges a walk crosses, backwards as well as forwards: unset or `"*"` is the transitive walk over every
   link, `follow="Effects[].BaseEffect"` is the typed MGEF carrier walk (per-carrier magnitude/area/duration,
@@ -49,7 +53,9 @@ saying it sets an expectation their install may contradict. Say what is known, a
   both follows the index can serve, and says that `chain` has no per-seed path to draw for the transitive
   walk; `form='chain'` with `follow="*"` refuses as before. A reverse `chain` call — including the one the
   retired `housecarl_effect_chain` redirect teaches — therefore says `follow="Effects[].BaseEffect"`. Any
-  other `follow` on reverse refuses naming the two the index can serve. `walk.max_nodes` says which reading it spends: per seed on the carrier
+  other `follow` on reverse refuses naming the two the index can serve. A seed the carrier walk could not read
+  is named under a reading form too, not only under `chain`, so an answer covering some of the seeds never
+  reads as one covering all of them. `walk.max_nodes` says which reading it spends: per seed on the carrier
   walk, one shared budget across every seed and hop on the transitive walk.
 
 - **`housecarl_asset_status` and `housecarl_place` take `format='json'`.** Both answered text only, so a caller

--- a/src/housecarl-core/ReverseReferenceIndex.cs
+++ b/src/housecarl-core/ReverseReferenceIndex.cs
@@ -336,6 +336,41 @@ public static class ReverseSelection
         return index.Orphans(view.RecordKeys());
     }
 
+    /// <summary>One hop of a transitive reverse walk: the records reached at this distance from the seeds, first
+    /// arrival wins. An EMPTY hop is a fact and is kept in the list, so a walk that ran out of referrers says so
+    /// rather than trailing off.</summary>
+    public sealed record Hop(int Depth, IReadOnlyList<FormKey> Reached);
+
+    /// <summary>The transitive reverse walk: who references the seeds, then who references those, hop after hop.
+    /// The follow rule — every link — is the same at every hop, which is what <c>depth</c> means here and
+    /// everywhere. Records already reached are not re-reported and not re-expanded, so a reference cycle
+    /// terminates. <paramref name="maxNodes"/> bounds the TOTAL reached across all hops; a breach keeps what was
+    /// proved, stops there, and sets <paramref name="capped"/> so the response can say the cut happened.</summary>
+    public static IReadOnlyList<Hop> Transitive(ReverseReferenceIndex index, IReadOnlyList<FormKey> seeds,
+                                                int depth, int maxNodes, out bool capped)
+    {
+        capped = false;
+        var hops = new List<Hop>();
+        var visited = new HashSet<FormKey>(seeds);
+        IReadOnlyList<FormKey> frontier = seeds;
+        int reached = 0;
+        for (int d = 1; d <= depth; d++)
+        {
+            var next = new List<FormKey>();
+            foreach (var k in index.ReferencersOf(frontier))
+            {
+                if (!visited.Add(k)) continue;
+                if (reached >= maxNodes) { capped = true; break; }
+                next.Add(k);
+                reached++;
+            }
+            hops.Add(new Hop(d, next));
+            if (capped || next.Count == 0) break;
+            frontier = next;
+        }
+        return hops;
+    }
+
     /// <summary>The sentence a caller gets for the negated-only unbounded form: its universe is the orphan set, not
     /// the whole order and not the same question a bounded negated <c>references=</c> asks. Declared, never
     /// discovered.</summary>

--- a/src/housecarl-core/ReverseReferenceIndex.cs
+++ b/src/housecarl-core/ReverseReferenceIndex.cs
@@ -348,8 +348,9 @@ public static class ReverseSelection
     /// terminates. The index answers in CANDIDATES, so <paramref name="verify"/> re-tests each one against the body
     /// the caller means to judge — the same second step <c>references=</c> takes — and a candidate that fails it is
     /// neither reported nor expanded, so a dropped link cannot seed a false subtree. <paramref name="maxNodes"/>
-    /// bounds the TOTAL reached across all hops; the budget is tested BEFORE the node is consumed, so a raised
-    /// budget on a retry sees the same graph, and the hop the cut landed on is marked
+    /// bounds the TOTAL reached across all hops; the budget is tested BEFORE the candidate is verified or
+    /// consumed, so a spent budget bounds the body reads as well as the reach, a raised budget on a retry sees
+    /// the same graph, and the hop the cut landed on is marked
     /// <see cref="Hop.Cut"/> rather than reading as a hop that reached nothing.</summary>
     public static IReadOnlyList<Hop> Transitive(ReverseReferenceIndex index, IReadOnlyList<FormKey> seeds,
                                                 int depth, int maxNodes,
@@ -368,8 +369,10 @@ public static class ReverseSelection
             foreach (var k in index.ReferencersOf(frontier))
             {
                 if (visited.Contains(k)) continue;
-                if (verify is not null && !verify(k, frontierSet)) continue;
+                // The budget is spent before the candidate is verified, so a spent budget stops the body reads
+                // too — verification has no ordering effect, so a raised budget on a retry still sees this graph.
                 if (reached >= maxNodes) { capped = true; cut = true; break; }
+                if (verify is not null && !verify(k, frontierSet)) continue;
                 visited.Add(k);
                 next.Add(k);
                 reached++;

--- a/src/housecarl-core/ReverseReferenceIndex.cs
+++ b/src/housecarl-core/ReverseReferenceIndex.cs
@@ -338,16 +338,22 @@ public static class ReverseSelection
 
     /// <summary>One hop of a transitive reverse walk: the records reached at this distance from the seeds, first
     /// arrival wins. An EMPTY hop is a fact and is kept in the list, so a walk that ran out of referrers says so
-    /// rather than trailing off.</summary>
-    public sealed record Hop(int Depth, IReadOnlyList<FormKey> Reached);
+    /// rather than trailing off — unless <paramref name="Cut"/>, which says the node budget ended this hop and its
+    /// count is a prefix, not a finding.</summary>
+    public sealed record Hop(int Depth, IReadOnlyList<FormKey> Reached, bool Cut);
 
     /// <summary>The transitive reverse walk: who references the seeds, then who references those, hop after hop.
     /// The follow rule — every link — is the same at every hop, which is what <c>depth</c> means here and
     /// everywhere. Records already reached are not re-reported and not re-expanded, so a reference cycle
-    /// terminates. <paramref name="maxNodes"/> bounds the TOTAL reached across all hops; a breach keeps what was
-    /// proved, stops there, and sets <paramref name="capped"/> so the response can say the cut happened.</summary>
+    /// terminates. The index answers in CANDIDATES, so <paramref name="verify"/> re-tests each one against the body
+    /// the caller means to judge — the same second step <c>references=</c> takes — and a candidate that fails it is
+    /// neither reported nor expanded, so a dropped link cannot seed a false subtree. <paramref name="maxNodes"/>
+    /// bounds the TOTAL reached across all hops; the budget is tested BEFORE the node is consumed, so a raised
+    /// budget on a retry sees the same graph, and the hop the cut landed on is marked
+    /// <see cref="Hop.Cut"/> rather than reading as a hop that reached nothing.</summary>
     public static IReadOnlyList<Hop> Transitive(ReverseReferenceIndex index, IReadOnlyList<FormKey> seeds,
-                                                int depth, int maxNodes, out bool capped)
+                                                int depth, int maxNodes,
+                                                Func<FormKey, IReadOnlySet<FormKey>, bool>? verify, out bool capped)
     {
         capped = false;
         var hops = new List<Hop>();
@@ -356,15 +362,19 @@ public static class ReverseSelection
         int reached = 0;
         for (int d = 1; d <= depth; d++)
         {
+            var frontierSet = new HashSet<FormKey>(frontier);
             var next = new List<FormKey>();
+            bool cut = false;
             foreach (var k in index.ReferencersOf(frontier))
             {
-                if (!visited.Add(k)) continue;
-                if (reached >= maxNodes) { capped = true; break; }
+                if (visited.Contains(k)) continue;
+                if (verify is not null && !verify(k, frontierSet)) continue;
+                if (reached >= maxNodes) { capped = true; cut = true; break; }
+                visited.Add(k);
                 next.Add(k);
                 reached++;
             }
-            hops.Add(new Hop(d, next));
+            hops.Add(new Hop(d, next, cut));
             if (capped || next.Count == 0) break;
             frontier = next;
         }

--- a/src/housecarl-mcp-tests/RecordsComparisonFormTests.cs
+++ b/src/housecarl-mcp-tests/RecordsComparisonFormTests.cs
@@ -13,6 +13,8 @@ public sealed class RecordsComparisonFormTests : RecordsTestBase
 
     static RecordsTools.RecordsProject Delta => new() { form = "delta" };
     static RecordsTools.RecordsProject Chain => new() { form = "chain" };
+    /// <summary>The typed MGEF carrier walk, said outright: no follow is implied under the chain form.</summary>
+    const string CarrierFollow = "Effects[].BaseEffect";
 
     string DeltaVsPrevious(Mutagen.Bethesda.Plugins.FormKey rec, string subject) =>
         RecordsTools.Records(Svc, formids: new[] { Fid(rec) }, source: Plugin(subject),
@@ -121,7 +123,7 @@ public sealed class RecordsComparisonFormTests : RecordsTestBase
     public void ReverseMgefLane_TheCarriersOfThisEffectWithTheMatchingEntrysPayload()
     {
         var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefA) },
-                                     walk: new RecordsTools.RecordsWalk { direction = "reverse" }, project: Chain);
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", follow = CarrierFollow }, project: Chain);
         Served(r, "HcRecSpellA");
         Assert.DoesNotContain("HcRecSpellB", r);
     }
@@ -130,7 +132,7 @@ public sealed class RecordsComparisonFormTests : RecordsTestBase
     public void ReverseWithANonMgefSeedFailsLoudNamingTheType_NeverASilentZeroCarriers()
     {
         var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.Weapons[0]) },
-                                     walk: new RecordsTools.RecordsWalk { direction = "reverse" }, project: Chain);
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", follow = CarrierFollow }, project: Chain);
         Assert.Contains("error", r);
         Assert.True(r.Contains("MagicEffect") || r.Contains("MGEF"), "the refusal names the required type");
     }
@@ -141,7 +143,7 @@ public sealed class RecordsComparisonFormTests : RecordsTestBase
     public void ReverseDepthOnTheCarrierLaneNamesTheEmptyHopsRatherThanStoppingSilently()
     {
         var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefA) },
-                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 3 }, project: Chain);
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 3, follow = CarrierFollow }, project: Chain);
         Served(r, "hop 2: 0", "hop 3: 0", "not a magic effect");
     }
 
@@ -151,7 +153,7 @@ public sealed class RecordsComparisonFormTests : RecordsTestBase
     public void TheCarrierLaneWithNoDepthAskedPrintsNoHopCensus()
     {
         var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefA) },
-                                     walk: new RecordsTools.RecordsWalk { direction = "reverse" }, project: Chain);
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", follow = CarrierFollow }, project: Chain);
         Assert.False(r.StartsWith("error:", StringComparison.Ordinal), r);
         Assert.DoesNotContain("hop 2: 0", r);
         Assert.DoesNotContain("hop 16", r);
@@ -217,7 +219,7 @@ public sealed class RecordsComparisonFormTests : RecordsTestBase
     {
         var art = W.Scratch("results", "carriers.jsonl");
         var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefA) },
-                                     walk: new RecordsTools.RecordsWalk { direction = "reverse" }, to_file: art,
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", follow = CarrierFollow }, to_file: art,
                                      project: Chain);
         Assert.True(File.Exists(art));
         Assert.Contains(art, r);
@@ -250,7 +252,7 @@ public sealed class RecordsComparisonFormTests : RecordsTestBase
     [Fact]
     public void ReReview_LimitWindowsTheSeedsOnly_BothCarriersOfTheOneSeedRender() =>
         Served(RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefA) },
-                                    walk: new RecordsTools.RecordsWalk { direction = "reverse" }, limit: 1, project: Chain),
+                                    walk: new RecordsTools.RecordsWalk { direction = "reverse", follow = CarrierFollow }, limit: 1, project: Chain),
                "HcRecSpellA", "HcRecSpellC");
 
     // ---- json envelopes and fields_source compositions -------------------------------------------------

--- a/src/housecarl-mcp-tests/RecordsComparisonFormTests.cs
+++ b/src/housecarl-mcp-tests/RecordsComparisonFormTests.cs
@@ -135,11 +135,15 @@ public sealed class RecordsComparisonFormTests : RecordsTestBase
         Assert.True(r.Contains("MagicEffect") || r.Contains("MGEF"), "the refusal names the required type");
     }
 
+    /// <summary>The carrier lane follows the effect link at every hop, so a depth past 1 reaches nothing — and the
+    /// response says the empty hops rather than answering a depth-3 call with a depth-1 answer and no word.</summary>
     [Fact]
-    public void ReverseDepthGreaterThanOneRefusesNamingTheReverseReferenceIndexAsTheFutureCapability() =>
-        Refused(RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefA) },
-                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 3 }, project: Chain),
-                "reverse-reference index");
+    public void ReverseDepthOnTheCarrierLaneNamesTheEmptyHopsRatherThanStoppingSilently()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefA) },
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 3 }, project: Chain);
+        Served(r, "hop 2: 0", "hop 3: 0", "not a magic effect");
+    }
 
     [Fact]
     public void InfoOrderOnANonDial_IsATypedPerItemRefusalTeachingTheQuestFanOutComposition() =>

--- a/src/housecarl-mcp-tests/RecordsComparisonFormTests.cs
+++ b/src/housecarl-mcp-tests/RecordsComparisonFormTests.cs
@@ -145,6 +145,18 @@ public sealed class RecordsComparisonFormTests : RecordsTestBase
         Served(r, "hop 2: 0", "hop 3: 0", "not a magic effect");
     }
 
+    /// <summary>A plain carrier call asked for no depth, so it is told none: the default 16 must not print fifteen
+    /// empty hops and a paragraph answering a question nobody asked.</summary>
+    [Fact]
+    public void TheCarrierLaneWithNoDepthAskedPrintsNoHopCensus()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefA) },
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse" }, project: Chain);
+        Assert.False(r.StartsWith("error:", StringComparison.Ordinal), r);
+        Assert.DoesNotContain("hop 2: 0", r);
+        Assert.DoesNotContain("hop 16", r);
+    }
+
     [Fact]
     public void InfoOrderOnANonDial_IsATypedPerItemRefusalTeachingTheQuestFanOutComposition() =>
         Served(RecordsTools.Records(Svc, formids: new[] { Fid(W.Weapons[0]) }, project: Form("info_order")),

--- a/src/housecarl-mcp-tests/RecordsRemedyRepairTests.cs
+++ b/src/housecarl-mcp-tests/RecordsRemedyRepairTests.cs
@@ -109,7 +109,7 @@ public sealed class RecordsRemedyRepairTests : RecordsTestBase
     public void ACappedCarrierListNamesWalkMaxNodes_LimitWindowsTheSeedsAndWouldBeANoOp()
     {
         var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefA) }, project: Form("chain"),
-                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", max_nodes = 1 });
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", follow = "Effects[].BaseEffect", max_nodes = 1 });
         Served(r, "raise walk.max_nodes");
         Assert.DoesNotContain("raise limit=", r);
     }

--- a/src/housecarl-mcp-tests/RecordsRetiredNameRemedyTests.cs
+++ b/src/housecarl-mcp-tests/RecordsRetiredNameRemedyTests.cs
@@ -25,7 +25,7 @@ public sealed class RecordsRetiredNameRemedyTests : IDisposable
     string Mgef => RecordsWorld.Fid(_w.MgefA);
 
     static RecordsTools.RecordsProject Chain => new() { form = "chain" };
-    static RecordsTools.RecordsWalk Reverse => new() { direction = "reverse" };
+    static RecordsTools.RecordsWalk Reverse => new() { direction = "reverse", follow = "Effects[].BaseEffect" };
 
     /// <summary>Every name the redirect table calls retired, so the population grows with the table.</summary>
     static IEnumerable<string> RetiredNames() => AliasTable.AllRetiredTools.Select(r => r.Old);

--- a/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
+++ b/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
@@ -126,6 +126,55 @@ public sealed class RecordsReverseIndexTests : RecordsTestBase
     public void AnUnboundedReferencesWithAWhereIsStillRefused() =>
         Refused(RecordsTools.Records(Svc, references: new[] { Fid(W.MgefA) },
                                      where: new[] { "EditorID = HcRecSpellA" }), "types=");
+
+    // ---- the transitive reverse walk (walk.direction='reverse' under a reading form) -------------------
+
+    /// <summary>Depth repeats the follow rule at every hop: hop 1 is what links the seed, hop 2 what links those.
+    /// MgefHop &lt;- SpellHop &lt;- ListHop, so the second hop is the one that proves transitivity.</summary>
+    [Fact]
+    public void AReverseWalkAtDepthTwoReachesTheSecondHopReferrer()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefHop) },
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 2 });
+        Served(r, "HcRecSpellHop", "HcRecListHop", "hop 1: 1", "hop 2: 1");
+    }
+
+    /// <summary>Depth 1 is the same walk with one hop: the second-hop referrer is NOT in it, so the depth is doing
+    /// the work rather than the lane reaching everything and calling it a depth.</summary>
+    [Fact]
+    public void AReverseWalkAtDepthOneStopsAtTheFirstHop()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefHop) },
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 1 });
+        Served(r, "HcRecSpellHop", "hop 1: 1");
+        Assert.DoesNotContain("HcRecListHop", r);
+    }
+
+    /// <summary>An exhausted walk says which hops it did not need to walk, so a depth-6 call that ran out at hop 3
+    /// reads as exhausted rather than as a silent stop.</summary>
+    [Fact]
+    public void AReverseWalkThatRunsOutOfReferrersSaysSo()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefHop) },
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 6 });
+        Served(r, "hop 3: 0", "nothing left to expand");
+    }
+
+    /// <summary>The index's accounting rides this lane too — the build cost, the freshness key and the coverage
+    /// disclosures are true of the walk's answer exactly as they are of a references= answer.</summary>
+    [Fact]
+    public void TheIndexAccountingRidesTheReverseWalk() =>
+        Served(RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefHop) },
+                                    walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 2 }),
+               "reverse-reference index", "key=");
+
+    /// <summary>types= narrows the typed carrier lane's carrier types; this lane reaches every type, so the pair
+    /// refuses with the re-entry spelling named rather than filtering something else.</summary>
+    [Fact]
+    public void TypesOnTheTransitiveReverseWalkRefusesNamingTheReEntrySpelling() =>
+        Refused(RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefHop) }, types: new[] { "Spell" },
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 2 }),
+                "to_file");
 }
 
 /// <summary>The index's own lifecycle: what a build costs, that a second call pays nothing, that a plugin whose

--- a/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
+++ b/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
@@ -199,6 +199,16 @@ public sealed class RecordsReverseIndexTests : RecordsTestBase
         Assert.DoesNotContain("HcRecListHop", r);
     }
 
+    /// <summary>A failed seed is said on the reading form too: one good seed must not make a half answer read as a
+    /// whole one.</summary>
+    [Fact]
+    public void TheCarrierReadingFormSaysASeedFailed()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefHop), Fid(W.SpellHop) },
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", follow = "Effects[].BaseEffect" });
+        Served(r, "HcRecSpellHop", "1 seed(s) failed and contributed no carriers");
+    }
+
     /// <summary>A follow the reverse index cannot serve refuses naming the two it can, rather than being ignored
     /// and answering a different question.</summary>
     [Fact]

--- a/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
+++ b/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
@@ -279,6 +279,18 @@ public sealed class RecordsReverseIndexTests : RecordsTestBase
                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 1 }),
                "whose winner does not carry the link");
 
+    /// <summary>A spent budget stops the work, not just the reach: HcRecListHop fills a budget of 1, and the
+    /// candidate behind it (HcRecListDropped) is never read, so it is not verified and not counted as a drop.
+    /// </summary>
+    [Fact]
+    public void ASpentBudgetStopsVerifyingTheCandidatesBehindIt()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.SpellHop) },
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 1, max_nodes = 1 });
+        Served(r, "HcRecListHop");
+        Assert.DoesNotContain("index candidate(s) were dropped", r);
+    }
+
     /// <summary>One candidate on two frontiers is one drop: HcRecListDropped is named at hop 1 and again at hop 2,
     /// and the drop line counts records, not verification failures.</summary>
     [Fact]

--- a/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
+++ b/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
@@ -216,6 +216,28 @@ public sealed class RecordsReverseIndexTests : RecordsTestBase
                                      project: new RecordsTools.RecordsProject { form = "chain" }),
                 "Effects[].BaseEffect");
 
+    /// <summary>No default follow implies a walk under any form: chain on a reverse walk with follow unset refuses
+    /// naming both follows the index serves, rather than quietly meaning the carrier one.</summary>
+    [Fact]
+    public void ChainOnAReverseWalkWithFollowUnsetRefusesNamingBothFollows()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefHop) },
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse" },
+                                     project: new RecordsTools.RecordsProject { form = "chain" });
+        Refused(r, "Effects[].BaseEffect");
+        Assert.Contains("\"*\"", r);
+        Assert.DoesNotContain("HcRecSpellHop", r);
+    }
+
+    /// <summary>The same call with the carrier follow said outright is served, so the refusal above is about the
+    /// missing follow and not about the chain form on reverse.</summary>
+    [Fact]
+    public void TheSameChainCallWithTheCarrierFollowSaidOutrightIsServed() =>
+        Served(RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefHop) },
+                                    walk: new RecordsTools.RecordsWalk { direction = "reverse", follow = "Effects[].BaseEffect" },
+                                    project: new RecordsTools.RecordsProject { form = "chain" }),
+               "HcRecSpellHop");
+
     /// <summary>A bad direction is taught the follow that picks the reverse walk, not the deleted depth-1 rule.
     /// </summary>
     [Fact]

--- a/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
+++ b/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
@@ -168,13 +168,107 @@ public sealed class RecordsReverseIndexTests : RecordsTestBase
                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 2 }),
                "reverse-reference index", "key=");
 
-    /// <summary>types= narrows the typed carrier lane's carrier types; this lane reaches every type, so the pair
+    /// <summary>types= narrows the typed carrier walk's carrier types; this walk reaches every type, so the pair
     /// refuses with the re-entry spelling named rather than filtering something else.</summary>
     [Fact]
     public void TypesOnTheTransitiveReverseWalkRefusesNamingTheReEntrySpelling() =>
         Refused(RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefHop) }, types: new[] { "Spell" },
                                      walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 2 }),
                 "to_file");
+
+    // ---- follow= is what tells the two reverse walks apart -------------------------------------------
+
+    /// <summary>follow is legal on reverse: it names the edges the walk crosses, which is as meaningful backwards
+    /// as forwards. "*" is the transitive walk, and it reaches the same set the unset spelling does.</summary>
+    [Fact]
+    public void AnExplicitFollowStarOnReverseIsTheTransitiveWalk()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefHop) },
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 2, follow = "*" });
+        Served(r, "HcRecSpellHop", "HcRecListHop", "hop 1: 1", "hop 2: 1");
+    }
+
+    /// <summary>The carrier follow picks the typed MGEF walk under a READING form too, so the form only chooses
+    /// the view: the reached set is the carriers either way.</summary>
+    [Fact]
+    public void TheCarrierFollowUnderAReadingFormConsumesTheCarrierReachedSet()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefHop) },
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", follow = "Effects[].BaseEffect" });
+        Served(r, "HcRecSpellHop");
+        Assert.DoesNotContain("HcRecListHop", r);
+    }
+
+    /// <summary>A follow the reverse index cannot serve refuses naming the two it can, rather than being ignored
+    /// and answering a different question.</summary>
+    [Fact]
+    public void AnUnservableFollowOnReverseRefusesNamingTheTwoItServes() =>
+        Refused(RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefHop) },
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", follow = "Template" }),
+                "Effects[].BaseEffect");
+
+    /// <summary>The transitive walk expands one shared frontier, so it has no per-seed path for chain to draw —
+    /// refused with both the reading forms and the carrier follow named.</summary>
+    [Fact]
+    public void ChainOverTheTransitiveReverseWalkRefusesNamingTheCarrierFollow() =>
+        Refused(RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefHop) },
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", follow = "*" },
+                                     project: new RecordsTools.RecordsProject { form = "chain" }),
+                "Effects[].BaseEffect");
+
+    /// <summary>A bad direction is taught the follow that picks the reverse walk, not the deleted depth-1 rule.
+    /// </summary>
+    [Fact]
+    public void ABadDirectionNoLongerTeachesTheDeletedDepthOneRule()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefHop) },
+                                     walk: new RecordsTools.RecordsWalk { direction = "backward" });
+        Assert.StartsWith("error:", r);
+        Assert.DoesNotContain("depth 1", r);
+    }
+
+    // ---- the candidate set is verified, the budget is honest, the seeds are deduplicated ---------------
+
+    /// <summary>The index names a candidate whose WINNER dropped the link. references= excludes it, and so must
+    /// the walk — the two spellings of one question cannot disagree.</summary>
+    [Fact]
+    public void TheReverseWalkExcludesACandidateWhoseWinnerDroppedTheLink()
+    {
+        var refs = RecordsTools.Records(Svc, references: new[] { Fid(W.SpellHop) });
+        Assert.DoesNotContain("HcRecListDropped", refs);
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.SpellHop) },
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 1 });
+        Served(r, "HcRecListHop", "hop 1: 1");
+        Assert.DoesNotContain("HcRecListDropped", r);
+    }
+
+    /// <summary>And the drop is said out loud rather than left as a count the caller cannot account for.</summary>
+    [Fact]
+    public void TheReverseWalkSaysHowManyIndexCandidatesTheBodyCheckDropped() =>
+        Served(RecordsTools.Records(Svc, formids: new[] { Fid(W.SpellHop) },
+                                    walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 1 }),
+               "index candidate(s) were dropped");
+
+    /// <summary>A hop the node budget ended reads as cut, not as a hop that reached nothing, and a capped walk is
+    /// never also called exhausted.</summary>
+    [Fact]
+    public void ACappedReverseWalkNamesTheCutHopAndIsNotCalledExhausted()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefHop) },
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 6, max_nodes = 1 });
+        Assert.Contains("cut by walk.max_nodes", r);
+        Assert.DoesNotContain("nothing left to expand", r);
+    }
+
+    /// <summary>Two spellings of one seed key are one seed: the selection lists it once.</summary>
+    [Fact]
+    public void RepeatedSeedsAreDeduplicated()
+    {
+        var id = Fid(W.MgefHop);
+        var r = RecordsTools.Records(Svc, formids: new[] { id, id },
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 1 });
+        Served(r, "selection = 2 record(s) (1 referrer(s)");
+    }
 }
 
 /// <summary>The index's own lifecycle: what a build costs, that a second call pays nothing, that a plugin whose

--- a/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
+++ b/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
@@ -279,6 +279,17 @@ public sealed class RecordsReverseIndexTests : RecordsTestBase
                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 1 }),
                "whose winner does not carry the link");
 
+    /// <summary>One candidate on two frontiers is one drop: HcRecListDropped is named at hop 1 and again at hop 2,
+    /// and the drop line counts records, not verification failures.</summary>
+    [Fact]
+    public void ACandidateNamedAtTwoHopsIsDroppedOnce()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefHop) },
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 2 });
+        Served(r, "1 index candidate(s) were dropped");
+        Assert.DoesNotContain("HcRecListDropped", r);
+    }
+
     /// <summary>A hop the node budget ended reads as cut, not as a hop that reached nothing, and a capped walk is
     /// never also called exhausted.</summary>
     [Fact]

--- a/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
+++ b/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
@@ -279,6 +279,27 @@ public sealed class RecordsReverseIndexTests : RecordsTestBase
                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 1 }),
                "whose winner does not carry the link");
 
+    /// <summary>A walk that stopped at walk.depth with the last hop still finding records says so, so a prefix is
+    /// never read as a complete answer — and it is not called exhausted.</summary>
+    [Fact]
+    public void AWalkStoppedByWalkDepthSaysTheCapCutIt()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefHop) },
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 1 });
+        Served(r, "walk.depth=1 was reached");
+        Assert.DoesNotContain("nothing left to expand", r);
+    }
+
+    /// <summary>A walk that genuinely ran out before the cap still says THAT, not the depth clause.</summary>
+    [Fact]
+    public void AWalkThatRanOutBeforeTheCapIsStillCalledExhausted()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefHop) },
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 5 });
+        Served(r, "nothing left to expand");
+        Assert.DoesNotContain("was reached with hop", r);
+    }
+
     /// <summary>A spent budget stops the work, not just the reach: HcRecListHop fills a budget of 1, and the
     /// candidate behind it (HcRecListDropped) is never read, so it is not verified and not counted as a drop.
     /// </summary>

--- a/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
+++ b/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
@@ -271,6 +271,14 @@ public sealed class RecordsReverseIndexTests : RecordsTestBase
                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 1 }),
                "index candidate(s) were dropped");
 
+    /// <summary>The drop line names the cause it actually saw rather than asserting one for all four: this
+    /// candidate's winner dropped the link, and an unreadable winner would have read as a coverage gap.</summary>
+    [Fact]
+    public void TheDropLineNamesTheCauseRatherThanAssertingOne() =>
+        Served(RecordsTools.Records(Svc, formids: new[] { Fid(W.SpellHop) },
+                                    walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 1 }),
+               "whose winner does not carry the link");
+
     /// <summary>A hop the node budget ended reads as cut, not as a hop that reached nothing, and a capped walk is
     /// never also called exhausted.</summary>
     [Fact]

--- a/src/housecarl-mcp-tests/RecordsWorld.cs
+++ b/src/housecarl-mcp-tests/RecordsWorld.cs
@@ -50,6 +50,9 @@ public sealed class RecordsWorld : IDisposable
     public FormKey MgefHop { get; }
     public FormKey SpellHop { get; }
     public FormKey ListHop { get; }
+    // A list that carries SpellHop in the master and drops it in the winning override: the index still names it a
+    // candidate, and both reverse spellings must exclude it.
+    public FormKey ListDropped { get; }
 
     public IReadOnlyList<IMajorRecordGetter> WeaponBodies { get; }
     public IReadOnlyList<IMajorRecordGetter> SpellBodies { get; }
@@ -144,6 +147,8 @@ public sealed class RecordsWorld : IDisposable
         { var e = new Effect(); e.BaseEffect.SetTo(MgefHop); e.Data = new EffectData { Magnitude = 3 }; spellHop.Effects.Add(e); }
         var listHop = master.FormLists.AddNew(); listHop.EditorID = "HcRecListHop"; ListHop = listHop.FormKey;
         listHop.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(SpellHop));
+        var listDropped = master.FormLists.AddNew(); listDropped.EditorID = "HcRecListDropped"; ListDropped = listDropped.FormKey;
+        listDropped.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(SpellHop));
 
         // One element past ReadEngine's expansion budget: the only fixture that reaches the delta form's
         // "TRUNCATED at the cap" sentence (zero deltas AND an incomplete deep read).
@@ -158,6 +163,9 @@ public sealed class RecordsWorld : IDisposable
 
         var ovMod = new SkyrimMod(ovKey, SkyrimRelease.SkyrimSE);
         WriteEngine.GenericGetOrAddAsOverride(ovMod, bigList);   // identical copy — no field changed
+        // The winner drops the link the master's copy carries — the index candidate that neither reverse spelling
+        // may report.
+        ((IFormList)WriteEngine.GenericGetOrAddAsOverride(ovMod, listDropped)).Items.Clear();
         ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(ovMod, master.Weapons.First(w => w.FormKey == weapons[0])))
             .BasicStats = new WeaponBasicStats { Damage = 99, Weight = 1 };
         ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(ovMod, master.Weapons.First(w => w.FormKey == weapons[2])))

--- a/src/housecarl-mcp-tests/RecordsWorld.cs
+++ b/src/housecarl-mcp-tests/RecordsWorld.cs
@@ -147,7 +147,10 @@ public sealed class RecordsWorld : IDisposable
         { var e = new Effect(); e.BaseEffect.SetTo(MgefHop); e.Data = new EffectData { Magnitude = 3 }; spellHop.Effects.Add(e); }
         var listHop = master.FormLists.AddNew(); listHop.EditorID = "HcRecListHop"; ListHop = listHop.FormKey;
         listHop.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(SpellHop));
+        // It carries BOTH links, so a two-hop walk from MgefHop names it a candidate at hop 1 and again at hop 2 —
+        // one record, one drop.
         var listDropped = master.FormLists.AddNew(); listDropped.EditorID = "HcRecListDropped"; ListDropped = listDropped.FormKey;
+        listDropped.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(MgefHop));
         listDropped.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(SpellHop));
 
         // One element past ReadEngine's expansion budget: the only fixture that reaches the delta form's

--- a/src/housecarl-mcp-tests/RecordsWorld.cs
+++ b/src/housecarl-mcp-tests/RecordsWorld.cs
@@ -45,6 +45,11 @@ public sealed class RecordsWorld : IDisposable
     public FormKey BigList { get; }
     public FormKey NpcParent { get; }
     public FormKey NpcChild { get; }
+    // A three-link chain of its own — MgefHop <- SpellHop <- ListHop — so a transitive reverse walk has a second
+    // hop to reach without any existing record gaining a referrer it did not have.
+    public FormKey MgefHop { get; }
+    public FormKey SpellHop { get; }
+    public FormKey ListHop { get; }
 
     public IReadOnlyList<IMajorRecordGetter> WeaponBodies { get; }
     public IReadOnlyList<IMajorRecordGetter> SpellBodies { get; }
@@ -131,6 +136,14 @@ public sealed class RecordsWorld : IDisposable
         { var e = new Effect(); e.BaseEffect.SetTo(MgefA); e.Data = new EffectData { Magnitude = 9 }; spellC.Effects.Add(e); }
         var spellB = master.Spells.AddNew(); spellB.EditorID = "HcRecSpellB"; SpellB = spellB.FormKey;
         { var e = new Effect(); e.BaseEffect.SetTo(MgefB); e.Data = new EffectData { Magnitude = 7 }; spellB.Effects.Add(e); }
+
+        // The reverse chain: nothing here is linked from any record above, so every existing referencer count and
+        // orphan verdict is unchanged.
+        var mgefHop = master.MagicEffects.AddNew(); mgefHop.EditorID = "HcRecMgefHop"; MgefHop = mgefHop.FormKey;
+        var spellHop = master.Spells.AddNew(); spellHop.EditorID = "HcRecSpellHop"; SpellHop = spellHop.FormKey;
+        { var e = new Effect(); e.BaseEffect.SetTo(MgefHop); e.Data = new EffectData { Magnitude = 3 }; spellHop.Effects.Add(e); }
+        var listHop = master.FormLists.AddNew(); listHop.EditorID = "HcRecListHop"; ListHop = listHop.FormKey;
+        listHop.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(SpellHop));
 
         // One element past ReadEngine's expansion budget: the only fixture that reaches the delta form's
         // "TRUNCATED at the cap" sentence (zero deltas AND an incomplete deep read).

--- a/src/housecarl-mcp-tests/WhereGrammarTests.cs
+++ b/src/housecarl-mcp-tests/WhereGrammarTests.cs
@@ -101,7 +101,7 @@ public sealed class WhereGrammarTests
 
     [Fact]
     public void LinkStep_SelectsTheSpellWhoseEffectTargetMatches() =>
-        Assert.Equal(new[] { _w.SpellA, _w.SpellC }.ToHashSet(),
+        Assert.Equal(new[] { _w.SpellA, _w.SpellC, _w.SpellHop }.ToHashSet(),
                      Run("Effects->editorid startswith HcRec", _w.SpellBodies, null, Fetch));
 
     [Fact]

--- a/src/housecarl-mcp/AliasTable.cs
+++ b/src/housecarl-mcp/AliasTable.cs
@@ -202,7 +202,7 @@ internal static class AliasTable
         ("housecarl_diff_record",
          "absorbed into " + ToolNames.Records + ": project={\"form\": \"delta\"} — source= is the subject (was plugin_a), versus= the reference (was plugin_b; structured poles carry the mod disambiguator), project.fields narrows the comparison."),
         ("housecarl_effect_chain",
-         "absorbed into " + ToolNames.Records + ": project={\"form\": \"chain\"} with walk={\"direction\": \"reverse\"} and the MGEF in formids= (types= still narrows the carrier types)."),
+         "absorbed into " + ToolNames.Records + ": project={\"form\": \"chain\"} with walk={\"direction\": \"reverse\", \"follow\": \"Effects[].BaseEffect\"} and the MGEF in formids= (types= still narrows the carrier types)."),
         ("housecarl_skypatcher_read",
          "absorbed into " + ToolNames.Records + ": source={\"overlay\": \"skypatcher\", \"state\": \"post\"} reads the post-INI body; pre-vs-post is project={\"form\": \"delta\"} with the two overlay poles."),
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -98,6 +98,15 @@ public sealed class LoadOrderService : IDisposable
     /// resolve.</summary>
     internal LoadOrderResolver.IndexView CaptureView() => Resolver.Capture();
 
+    /// <summary>One captured build together with the resolver it came from, for a lane that has to open an overlay
+    /// session against the same resolver it captured — a session from an adjacent build would fetch bodies the
+    /// view's epoch does not name.</summary>
+    internal ViewPin CapturePin()
+    {
+        var r = Resolver;
+        return new ViewPin(r, r.Capture());
+    }
+
     /// <summary>A FormID door for a tool body with no captured view of its own — see <see cref="FormIdDoor"/>.</summary>
     internal FormIdDoor OpenFormIdDoor() => FormIdDoor.For(this);
 

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -55,16 +55,16 @@ public static class RecordsTools
         [Description("Link-bearing field paths that start the walk from each seed, e.g. [\"HeadParts\", \"WornArmor\"]. '*parent' crosses the containment edge instead — the record that CONTAINS the seed (a REFR from a crash log to its CELL; '*parent.*parent' to the worldspace). Omit for every link on the seed.")]
         public string[]? seed_paths { get; set; }
 
-        [Description("The link path followed at every LATER hop. \"*\" (default) walks every link — full closure. A named path restricts to one chain, e.g. \"Template\" for NPC template inheritance, or \"*parent\" to climb containment.")]
+        [Description("The link path followed at every LATER hop — the edges this walk crosses, in either direction. \"*\" (default) walks every link — full closure. A named path restricts to one chain, e.g. \"Template\" for NPC template inheritance, or \"*parent\" to climb containment. On direction='reverse' the two legal values are \"*\" (unset; the transitive walk over every link, off the reverse-reference index) and \"Effects[].BaseEffect\" (the typed MGEF carrier walk).")]
         public string? follow { get; set; }
 
-        [Description("'forward' (default) — what the seeds point AT (cheap: each hop is one link resolve). 'reverse' — what points AT the seeds, at any depth, needing no bounding scope: it follows EVERY link at every hop, off the reverse-reference index, which is built on the first such call at the cost of one whole-order link-walk and reports that cost in the response. The FORM picks the reverse lane, as it does forward: a reading form (summary/fields/rows/everything/aggregate) consumes the reached set and the response names the count at each hop, empty hops included; form='chain' is the typed MGEF carrier lane instead — magic-effect seeds get per-carrier magnitude/area/duration (types= narrows the carrier types; walk.max_nodes bounds each seed's carrier rows; limit=/offset= window the SEEDS), and it reaches nothing past hop 1 because a carrier is not a magic effect. references= is the same reverse question as one step of SELECT.")]
+        [Description("'forward' (default) — what the seeds point AT (cheap: each hop is one link resolve). 'reverse' — what points AT the seeds, at any depth, needing no bounding scope. walk.follow picks the reverse walk, exactly as it does forward: unset or \"*\" follows EVERY link at every hop off the reverse-reference index, which is built on the first such call at the cost of one whole-order link-walk and reports that cost in the response; follow=\"Effects[].BaseEffect\" is the typed MGEF carrier walk — magic-effect seeds, per-carrier magnitude/area/duration, types= narrowing the carrier types — which reaches nothing past hop 1 because a carrier is not a magic effect. The FORM then only picks the view: 'chain' renders the walk's own rows, a reading form (summary/fields/rows/everything/aggregate) consumes the same reached set. One exception, declared: form='chain' with follow unset means the carrier walk, since the transitive walk has no per-seed path render. references= is the same reverse question as one step of SELECT.")]
         public string? direction { get; set; }
 
         [Description("Maximum hops from a seed (default 16). Nodes AT the cap are recorded, not entered, and the response says the cap cut the walk — never a silent stop.")]
         public int? depth { get; set; }
 
-        [Description("Maximum nodes reached per seed (default 2000, the read-expansion budget). A breach keeps what was proved and says so.")]
+        [Description("The node budget (default 2000, the read-expansion budget). Per seed on a forward walk and on the reverse carrier walk (each seed's carrier rows); ONE budget shared across every seed and every hop on the transitive reverse walk, whose hops are one frontier and not a per-seed expansion. A breach keeps what was proved and says which reading it spent.")]
         public int? max_nodes { get; set; }
 
         [Description("Node classes the walk must not enter, as data: [{\"match\": \"Race\", \"severity\": \"stop\"|\"refuse\"}] — match is the record type name a read reports; stop prunes there (recorded as a boundary), refuse fails the whole call loud.")]
@@ -324,17 +324,22 @@ public static class RecordsTools
         // ---- walk= (the traversal construct) ----
         string walkDirection = "forward";
         int walkDepth = 16, walkMaxNodes = 2000;
+        bool walkDepthAsked = false;
+        // The reverse carrier walk's follow, spelled as SPEC §3.3 spells it. It is the discriminator between the
+        // two reverse walks, so it is one constant read by the validation, the lane and every remedy sentence.
+        const string CarrierFollow = "Effects[].BaseEffect";
         var walkExclusions = new List<(string Match, bool Refuse)>();
         if (walk is not null)
         {
             var dir = walk.direction?.Trim().ToLowerInvariant();
             if (dir is not (null or "" or "forward" or "reverse"))
-                return Wire.Refuse(json, $"error: walk.direction='{walk.direction}' — use 'forward' (what the seeds point at) or 'reverse' (what points at them; depth 1).");
+                return Wire.Refuse(json, $"error: walk.direction='{walk.direction}' — use 'forward' (what the seeds point at) or 'reverse' (what points at them, at any depth; walk.follow picks which reverse edges: \"*\" for every link, \"{CarrierFollow}\" for the typed MGEF carriers).");
             if (!string.IsNullOrEmpty(dir)) walkDirection = dir!;
             if (walk.depth is { } wd)
             {
                 if (wd < 1) return Wire.Refuse(json, $"error: walk.depth={wd} — depth must be >= 1 (hops from the seed).");
                 walkDepth = wd;
+                walkDepthAsked = true;
             }
             if (walk.max_nodes is { } wn)
             {
@@ -352,8 +357,15 @@ public static class RecordsTools
             }
             if (walkDirection == "reverse")
             {
-                if (walk.seed_paths is { Length: > 0 } || walk.exclusions is { Length: > 0 } || walk.follow is not null)
-                    return Wire.Refuse(json, "error: walk.seed_paths/follow/exclusions shape a FORWARD expansion — a reverse walk scans TOWARD the seeds and follows every link at every hop. Drop them.");
+                // seed_paths and exclusions really do shape a forward expansion; follow does not — it names which
+                // edges the walk crosses, which is as meaningful backwards as forwards, so it stays legal here and
+                // is what tells the two reverse walks apart.
+                if (walk.seed_paths is { Length: > 0 } || walk.exclusions is { Length: > 0 })
+                    return Wire.Refuse(json, "error: walk.seed_paths/exclusions shape a FORWARD expansion — a reverse walk scans TOWARD the seeds. Drop them (walk.follow stays: it names the edges this walk crosses).");
+                var revFollow = walk.follow?.Trim();
+                if (!string.IsNullOrEmpty(revFollow) && revFollow != "*"
+                    && !string.Equals(revFollow, CarrierFollow, StringComparison.OrdinalIgnoreCase))
+                    return Wire.Refuse(json, $"error: walk.follow='{walk.follow}' on a reverse walk — the reverse edges come from the reverse-reference index, which holds every link and no per-path breakdown, so the two follows it can serve are \"*\" (every link, the transitive walk) and \"{CarrierFollow}\" (the typed MGEF carriers). To narrow the transitive walk's reach by path, walk with to_file= and re-enter the artifact on a where= over the field.");
             }
             if (references is { Length: > 0 })
                 return Wire.Refuse(json, "error: walk= and references= are the same construct (references= IS the reverse walk at depth 1) — use one spelling per call.");
@@ -365,7 +377,7 @@ public static class RecordsTools
                 return Wire.Refuse(json, "error: walk= composed with where= (filtering the reached set by predicate) — walk with to_file=, then re-enter the artifact on a bounded scan via where=[\"formid in @<file>\", …]; the reached set becomes the scan's identity list.");
         }
         if (form == "chain" && walk is null)
-            return Wire.Refuse(json, "error: the 'chain' form renders a walk's paths — pass walk= (e.g. walk={\"follow\": \"Template\"} over NPC seeds; reverse MGEF carriers: walk={\"direction\": \"reverse\"} with MGEF formids=).");
+            return Wire.Refuse(json, $"error: the 'chain' form renders a walk's paths — pass walk= (e.g. walk={{\"follow\": \"Template\"}} over NPC seeds; reverse MGEF carriers: walk={{\"direction\": \"reverse\", \"follow\": \"{CarrierFollow}\"}} with MGEF formids=).");
 
         // The existing single-pole lanes below drive off the named-pole fields; the richer specs dispatch to the
         // comparison/overlay lanes before reaching them.
@@ -401,14 +413,21 @@ public static class RecordsTools
         // formids= composes with the scan terms: the identity set intersects the scan's selection, or is the
         // universe when it is the only bound. The reverse MGEF walk keeps its own lane, where formids are seeds.
         bool reverseWalk = walk is not null && walkDirection == "reverse";
-        // The reverse direction has two lanes and they are told apart by the FORM, exactly as the forward direction
-        // is: 'chain' is the typed MGEF carrier lane (per-carrier magnitude/area/duration), every reading form
-        // consumes the reached set of the transitive reverse walk off the reverse-reference index.
-        bool reverseCarrier = reverseWalk && form == "chain";
+        // The reverse direction has two walks and walk.follow tells them apart, exactly as it does forward: "*" (or
+        // unset) is the transitive walk over every link off the reverse-reference index, the carrier path is the
+        // typed MGEF walk. The FORM then only picks the view. One declared exception keeps the shipped carrier
+        // spelling working: form='chain' with follow unset means the carrier walk, because the transitive walk —
+        // one shared frontier, not a per-seed expansion — has no per-seed path render for chain to draw.
+        bool followAsked = !string.IsNullOrWhiteSpace(walk?.follow);
+        bool reverseCarrier = reverseWalk
+            && (string.Equals(walk!.follow?.Trim(), CarrierFollow, StringComparison.OrdinalIgnoreCase)
+                || (!followAsked && form == "chain"));
+        if (reverseWalk && form == "chain" && !reverseCarrier)
+            return Wire.Refuse(json, $"error: the 'chain' form renders a walk's own per-seed paths, and the transitive reverse walk (follow=\"*\") expands ONE shared frontier rather than a path per seed, so it has none to draw — read it with a reading form (summary/fields/rows/everything/aggregate) over the reached set, or ask for the typed MGEF carrier chain with walk.follow=\"{CarrierFollow}\".");
         if (reverseWalk && (plugins?.names is { Length: > 0 } || conflicts_only || where is { Length: > 0 }))
             return Wire.Refuse(json, "error: a reverse walk takes formids= (its seeds) and nothing else as a scope — the bounded reverse over other scan terms is the references= spelling.");
         if (reverseWalk && !reverseCarrier && types is { Length: > 0 })
-            return Wire.Refuse(json, "error: types= narrows the CARRIER types of the typed MGEF lane (form='chain'), and this reverse walk reaches records of every type — walk with to_file= and re-enter the artifact via formids=[\"@<file>\"] with types= to keep only the types you want.");
+            return Wire.Refuse(json, $"error: types= narrows the CARRIER types of the typed MGEF walk (walk.follow=\"{CarrierFollow}\"), and this reverse walk follows every link and reaches records of every type — walk with to_file= and re-enter the artifact via formids=[\"@<file>\"] with types= to keep only the types you want.");
         if (reverseWalk && !hasFormids)
             return Wire.Refuse(json, reverseCarrier
                 ? "error: the reverse walk needs its seeds — pass formids= (the MGEF(s) whose carriers to trace)."
@@ -669,9 +688,9 @@ public static class RecordsTools
 
         // ================================================================================================
         //  WALK lane — forward walks expand the winner link graph (the chain form renders the paths; any other
-        //  form consumes the reached set as its selection). Reverse splits on the same form line: chain is the
-        //  typed MGEF lane tracing carriers with their per-hit payload, every reading form is the transitive
-        //  reverse walk off the reverse-reference index.
+        //  form consumes the reached set as its selection). Reverse splits on walk.follow, not on the form: "*" is
+        //  the transitive walk off the reverse-reference index, the carrier path is the typed MGEF walk, and each
+        //  hands its reached set to the same two views.
         // ================================================================================================
         string WalkLane(string[] ids, HousecarlCore.ArtifactDemand? demand, string? echoSrc)
         {
@@ -698,17 +717,21 @@ public static class RecordsTools
                 if (SeamTear(rev.Epoch) is { } rTear)
                     return json ? JsonWire.RenderError(rTear, rev.Epoch) : "error: " + rTear;
                 // Every hop is named with its count, empty ones included: a walk that ran out of referrers says so
-                // on the response instead of trailing off, so an empty hop 2 is visible and not silent.
-                var hopLine = string.Join(", ", rev.Hops.Select(h => $"hop {h.Depth}: {h.Reached.Count}"));
-                if (rev.Hops.Count < walkDepth)
+                // on the response instead of trailing off, so an empty hop 2 is visible and not silent. A hop the
+                // budget ended says 'cut' instead, so a prefix is never read as a finding, and the exhaustion
+                // clause is only told of a walk that actually ran out.
+                var hopLine = string.Join(", ", rev.Hops.Select(h => $"hop {h.Depth}: {h.Reached.Count}{(h.Cut ? " (cut by walk.max_nodes)" : "")}"));
+                if (!rev.Capped && rev.Hops.Count < walkDepth)
                     hopLine += $" (nothing left to expand, so hops {rev.Hops.Count + 1}–{walkDepth} were not walked)";
-                int reachedRev = rev.Selection.Count - ids.Length;
+                int reachedRev = rev.Selection.Count - rev.Seeds;
                 envelope.Add(new("walk", $"reverse (every link) depth={walkDepth} — {hopLine}; selection = the {rev.Selection.Count} record(s) the walk reached (seeds included)"));
                 if (rev.IndexNote is not null) envelope.Add(new("reverse_index", rev.IndexNote));
                 headerLine += $"\nwalk=reverse (every link) depth={walkDepth}: {hopLine} — selection = {rev.Selection.Count} record(s) ({reachedRev} referrer(s), seeds included)";
                 if (rev.IndexNote is not null) headerLine += "\n" + rev.IndexNote;
+                if (rev.Dropped > 0)
+                    headerLine += $"\n{rev.Dropped} index candidate(s) were dropped: the index says some plugin's copy carries the link, and the body this walk judges — the load-order winner — does not, so they are not reached and were not expanded (the same second step references= takes).";
                 if (rev.Capped)
-                    headerLine += $"\n[!] the walk.max_nodes budget ({walkMaxNodes}) was reached — what is listed IS reached and proved; raise walk.max_nodes to walk further.";
+                    headerLine += $"\n[!] the walk.max_nodes budget ({walkMaxNodes}, one budget shared across every seed and hop on this lane) was reached — what is listed IS reached and proved, and the hop it cut is marked; raise walk.max_nodes to walk further.";
                 expectEpoch = rev.Epoch;
                 formids = rev.Selection.ToArray();
                 walk = null;
@@ -750,21 +773,50 @@ public static class RecordsTools
                 // The census separates written rows from the true total and names capped seeds, so the artifact
                 // and its census cannot disagree and a walk.max_nodes cut is always declared.
                 int carrierRows = results.Sum(r => r.Result.Error is null ? r.Result.Rows.Count : 0);
-                // This lane follows the effect link at every hop, and a carrier is not a magic effect — so hop 2
-                // and beyond reach nothing. Said out loud when a depth was asked for, never a silent stop.
-                var carrierHops = $"hop 1: {carrierRows}";
-                if (walkDepth > 1)
-                    carrierHops += string.Concat(Enumerable.Range(2, walkDepth - 1).Select(d => $", hop {d}: 0"))
-                                 + " — the carrier lane follows the effect link at every hop and a carrier is not a magic effect, so nothing is reached past hop 1; the transitive reverse over every link is walk={\"direction\":\"reverse\"} under a reading form.";
-                envelope.Add(new("walk", $"reverse, depth={walkDepth} — the typed MGEF carrier lane; {carrierHops}"));
-                headerLine += "\nwalk=reverse (per seed: every SPEL/ENCH/ALCH/SCRL/INGR applying it, with the MATCHING entry's magnitude/area/duration — reported AS AUTHORED; conditions are not evaluated, so a row means 'defines it at this strength', not 'it will fire')";
-                if (walkDepth > 1) headerLine += $"\n{carrierHops}";
                 int carrierTotal = results.Sum(r => r.Result.Error is null ? r.Result.Total : 0);
                 int cappedSeeds = results.Count(r => r.Result.Error is null && r.Result.Capped);
                 int seedErrs2 = results.Count(r => r.Result.Error is not null);
+                // This walk follows the effect link at every hop, and a carrier is not a magic effect — so hop 2
+                // and beyond reach nothing. Said out loud only when a depth was actually asked for, never off the
+                // default, and the hop census counts what hop 1 REACHED (the total), not what got printed.
+                var carrierHops = $"hop 1: {carrierTotal}";
+                if (walkDepthAsked && walkDepth > 1)
+                    carrierHops += string.Concat(Enumerable.Range(2, walkDepth - 1).Select(d => $", hop {d}: 0"))
+                                 + $" — walk.follow=\"{CarrierFollow}\" crosses the effect link at every hop and a carrier is not a magic effect, so nothing is reached past hop 1; the transitive reverse over every link is the same call with follow=\"*\".";
+                envelope.Add(new("walk", $"reverse follow={CarrierFollow} depth={walkDepth} — the typed MGEF carrier walk; {carrierHops}"));
+                headerLine += "\nwalk=reverse (per seed: every SPEL/ENCH/ALCH/SCRL/INGR applying it, with the MATCHING entry's magnitude/area/duration — reported AS AUTHORED; conditions are not evaluated, so a row means 'defines it at this strength', not 'it will fire')";
+                if (walkDepthAsked && walkDepth > 1) headerLine += $"\n{carrierHops}";
+                // A reading form consumes this walk's reached set — the carrier records — exactly as it consumes a
+                // forward walk's, so the form picks the view and never the walk.
+                if (form != "chain")
+                {
+                    var carrierSel = new List<string>(ids.Length + carrierRows);
+                    var carrierSeen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var r in results)
+                    {
+                        if (r.Result.Error is not null) continue;
+                        if (carrierSeen.Add(r.Seed)) carrierSel.Add(r.Seed);
+                        foreach (var row in r.Result.Rows)
+                        {
+                            var key = row.Carrier.ToString();
+                            if (carrierSeen.Add(key)) carrierSel.Add(key);
+                        }
+                    }
+                    if (carrierSel.Count == 0)
+                        return json ? JsonWire.RenderError($"the reverse carrier walk reached nothing readable ({seedErrs2} seed error(s) — run form='chain' to see each seed's outcome).", epochR)
+                                    : $"error: the reverse carrier walk reached nothing readable ({seedErrs2} seed error(s) — run form='chain' to see each seed's outcome)." + (epochR is not null ? $"\nepoch={epochR}" : "");
+                    envelope.Add(new("selection", $"the {carrierSel.Count} record(s) the carrier walk reached (seeds included)"));
+                    headerLine += $"\nwalk: selection = {carrierSel.Count} reached record(s) (seeds included)";
+                    if (cappedSeeds > 0)
+                        headerLine += $"\n[!] {cappedSeeds} seed(s) hit the walk.max_nodes carrier bound ({walkMaxNodes}, per seed on this lane) — the selection is a prefix of the {carrierTotal} carrier(s) reached; raise walk.max_nodes.";
+                    expectEpoch = epochR;
+                    formids = carrierSel.ToArray();
+                    walk = null;
+                    return ListLane();
+                }
                 var revCounts = new[] { KvI("seeds", results.Count), KvI("carrier_rows", carrierRows), KvI("carrier_total", carrierTotal), KvI("capped_seeds", cappedSeeds), KvI("errors", seedErrs2) };
                 if (cappedSeeds > 0)
-                    headerLine += $"\n[!] {cappedSeeds} seed(s) hit the walk.max_nodes carrier bound ({walkMaxNodes}) — their rows are a prefix of carrier_total; raise walk.max_nodes.";
+                    headerLine += $"\n[!] {cappedSeeds} seed(s) hit the walk.max_nodes carrier bound ({walkMaxNodes}, per seed on this lane) — their rows are a prefix of carrier_total; raise walk.max_nodes.";
                 if (counts_only)
                     return json
                         ? JsonWire.RenderNamedCounts(envelope, revCounts, epochR)

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -714,9 +714,9 @@ public static class RecordsTools
                 // is — so the per-hop census is the only thing this lane renders of its own.
                 var rev = ReverseWalkBatch.Run(svc, ids, walkDepth, walkMaxNodes, demand);
                 if (rev.Refusal is not null)
-                    return json ? JsonWire.RenderError(rev.Refusal, rev.Epoch) : "error: " + rev.Refusal + (rev.Epoch is not null ? $"\nepoch={rev.Epoch}" : "");
-                if (SeamTear(rev.Epoch) is { } rTear)
-                    return json ? JsonWire.RenderError(rTear, rev.Epoch) : "error: " + rTear;
+                    return json ? JsonWire.RenderError(rev.Refusal, rev.Stamp) : "error: " + rev.Refusal + Wire.EpochLine(rev.Stamp);
+                if (SeamTear(rev.Stamp) is { } rTear)
+                    return json ? JsonWire.RenderError(rTear, rev.Stamp) : "error: " + rTear;
                 // Every hop is named with its count, empty ones included: a walk that ran out of referrers says so
                 // on the response instead of trailing off, so an empty hop 2 is visible and not silent. A hop the
                 // budget ended says 'cut' instead, so a prefix is never read as a finding, and the exhaustion
@@ -819,7 +819,7 @@ public static class RecordsTools
                     }
                     if (carrierSel.Count == 0)
                         return json ? JsonWire.RenderError($"the reverse carrier walk reached nothing readable ({seedErrs2} seed error(s) — run form='chain' to see each seed's outcome).", epochR)
-                                    : $"error: the reverse carrier walk reached nothing readable ({seedErrs2} seed error(s) — run form='chain' to see each seed's outcome)." + (epochR is not null ? $"\nepoch={epochR}" : "");
+                                    : $"error: the reverse carrier walk reached nothing readable ({seedErrs2} seed error(s) — run form='chain' to see each seed's outcome)." + Wire.EpochLine(epochR);
                     // A seed that failed contributed no carriers, and the reading form says so: a partial answer
                     // over some of the seeds must never read as an answer over all of them.
                     envelope.Add(new("selection", $"the {carrierSel.Count} record(s) the carrier walk reached (seeds included)"
@@ -829,7 +829,7 @@ public static class RecordsTools
                         headerLine += $"\n[!] {seedErrs2} seed(s) failed and contributed no carriers — run form='chain' to see each seed's outcome.";
                     if (cappedSeeds > 0)
                         headerLine += $"\n[!] {cappedSeeds} seed(s) hit the walk.max_nodes carrier bound ({walkMaxNodes}, per seed on this lane) — the selection is a prefix of the {carrierTotal} carrier(s) reached; raise walk.max_nodes.";
-                    expectEpoch = epochR;
+                    expectEpoch = epochR?.Epoch;
                     formids = carrierSel.ToArray();
                     walk = null;
                     return ListLane();

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -55,10 +55,10 @@ public static class RecordsTools
         [Description("Link-bearing field paths that start the walk from each seed, e.g. [\"HeadParts\", \"WornArmor\"]. '*parent' crosses the containment edge instead — the record that CONTAINS the seed (a REFR from a crash log to its CELL; '*parent.*parent' to the worldspace). Omit for every link on the seed.")]
         public string[]? seed_paths { get; set; }
 
-        [Description("The link path followed at every LATER hop — the edges this walk crosses, in either direction. \"*\" (default) walks every link — full closure. A named path restricts to one chain, e.g. \"Template\" for NPC template inheritance, or \"*parent\" to climb containment. On direction='reverse' the two legal values are \"*\" (unset; the transitive walk over every link, off the reverse-reference index) and \"Effects[].BaseEffect\" (the typed MGEF carrier walk).")]
+        [Description("The link path followed at every LATER hop — the edges this walk crosses, in either direction. \"*\" (default) walks every link — full closure. A named path restricts to one chain, e.g. \"Template\" for NPC template inheritance, or \"*parent\" to climb containment. On direction='reverse' the two legal values are \"*\" (the default under a reading form; the transitive walk over every link, off the reverse-reference index) and \"Effects[].BaseEffect\" (the typed MGEF carrier walk) — under project.form='chain' there is no default and one of the two is said outright.")]
         public string? follow { get; set; }
 
-        [Description("'forward' (default) — what the seeds point AT (cheap: each hop is one link resolve). 'reverse' — what points AT the seeds, at any depth, needing no bounding scope. walk.follow picks the reverse walk, exactly as it does forward: unset or \"*\" follows EVERY link at every hop off the reverse-reference index, which is built on the first such call at the cost of one whole-order link-walk and reports that cost in the response; follow=\"Effects[].BaseEffect\" is the typed MGEF carrier walk — magic-effect seeds, per-carrier magnitude/area/duration, types= narrowing the carrier types — which reaches nothing past hop 1 because a carrier is not a magic effect. The FORM then only picks the view: 'chain' renders the walk's own rows, a reading form (summary/fields/rows/everything/aggregate) consumes the same reached set. One exception, declared: form='chain' with follow unset means the carrier walk, since the transitive walk has no per-seed path render. references= is the same reverse question as one step of SELECT.")]
+        [Description("'forward' (default) — what the seeds point AT (cheap: each hop is one link resolve). 'reverse' — what points AT the seeds, at any depth, needing no bounding scope. walk.follow picks the reverse walk, exactly as it does forward: \"*\" (or, under a reading form, unset) follows EVERY link at every hop off the reverse-reference index, which is built on the first such call at the cost of one whole-order link-walk and reports that cost in the response; follow=\"Effects[].BaseEffect\" is the typed MGEF carrier walk — magic-effect seeds, per-carrier magnitude/area/duration, types= narrowing the carrier types — which reaches nothing past hop 1 because a carrier is not a magic effect. The FORM then only picks the view and never implies a walk: 'chain' renders the walk's own rows, a reading form (summary/fields/rows/everything/aggregate) consumes the same reached set. Under form='chain' walk.follow is REQUIRED — chain can only draw the carrier walk's per-seed paths, and the transitive walk expands one shared frontier with no path per seed, so an unset follow refuses naming both rather than picking one. references= is the same reverse question as one step of SELECT.")]
         public string? direction { get; set; }
 
         [Description("Maximum hops from a seed (default 16). Nodes AT the cap are recorded, not entered, and the response says the cap cut the walk — never a silent stop.")]
@@ -415,13 +415,14 @@ public static class RecordsTools
         bool reverseWalk = walk is not null && walkDirection == "reverse";
         // The reverse direction has two walks and walk.follow tells them apart, exactly as it does forward: "*" (or
         // unset) is the transitive walk over every link off the reverse-reference index, the carrier path is the
-        // typed MGEF walk. The FORM then only picks the view. One declared exception keeps the shipped carrier
-        // spelling working: form='chain' with follow unset means the carrier walk, because the transitive walk —
-        // one shared frontier, not a per-seed expansion — has no per-seed path render for chain to draw.
+        // typed MGEF walk. The FORM then only picks the view, and never implies a walk: under 'chain' the follow is
+        // said outright, because the transitive walk — one shared frontier, not a per-seed expansion — has no
+        // per-seed path render for chain to draw, so a default would silently mean the other walk.
         bool followAsked = !string.IsNullOrWhiteSpace(walk?.follow);
         bool reverseCarrier = reverseWalk
-            && (string.Equals(walk!.follow?.Trim(), CarrierFollow, StringComparison.OrdinalIgnoreCase)
-                || (!followAsked && form == "chain"));
+            && string.Equals(walk!.follow?.Trim(), CarrierFollow, StringComparison.OrdinalIgnoreCase);
+        if (reverseWalk && form == "chain" && !followAsked)
+            return Wire.Refuse(json, $"error: no default follow implies a walk, so a reverse 'chain' call names the edges it crosses — walk.follow=\"{CarrierFollow}\" is the typed MGEF carrier walk, which chain renders, and walk.follow=\"*\" is every link, which chain cannot render because the transitive walk expands one shared frontier and has no per-seed path to draw (read that one with summary/fields/rows/everything/aggregate).");
         if (reverseWalk && form == "chain" && !reverseCarrier)
             return Wire.Refuse(json, $"error: the 'chain' form renders a walk's own per-seed paths, and the transitive reverse walk (follow=\"*\") expands ONE shared frontier rather than a path per seed, so it has none to draw — read it with a reading form (summary/fields/rows/everything/aggregate) over the reached set, or ask for the typed MGEF carrier chain with walk.follow=\"{CarrierFollow}\".");
         if (reverseWalk && (plugins?.names is { Length: > 0 } || conflicts_only || where is { Length: > 0 }))

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -58,7 +58,7 @@ public static class RecordsTools
         [Description("The link path followed at every LATER hop. \"*\" (default) walks every link — full closure. A named path restricts to one chain, e.g. \"Template\" for NPC template inheritance, or \"*parent\" to climb containment.")]
         public string? follow { get; set; }
 
-        [Description("'forward' (default) — what the seeds point AT (cheap: each hop is one link resolve). 'reverse' — what points AT the seeds; depth 1 only (transitive reverse is not wired to the reverse-reference index on this lane yet, so depth>1 is still refused). The general reverse spelling on this surface IS references=, which needs no bounding scope; walk.direction='reverse' serves the typed MGEF lane — magic-effect seeds get per-carrier magnitude/area/duration (types= narrows the carrier types; walk.max_nodes bounds each seed's carrier rows; limit=/offset= window the SEEDS).")]
+        [Description("'forward' (default) — what the seeds point AT (cheap: each hop is one link resolve). 'reverse' — what points AT the seeds, at any depth, needing no bounding scope: it follows EVERY link at every hop, off the reverse-reference index, which is built on the first such call at the cost of one whole-order link-walk and reports that cost in the response. The FORM picks the reverse lane, as it does forward: a reading form (summary/fields/rows/everything/aggregate) consumes the reached set and the response names the count at each hop, empty hops included; form='chain' is the typed MGEF carrier lane instead — magic-effect seeds get per-carrier magnitude/area/duration (types= narrows the carrier types; walk.max_nodes bounds each seed's carrier rows; limit=/offset= window the SEEDS), and it reaches nothing past hop 1 because a carrier is not a magic effect. references= is the same reverse question as one step of SELECT.")]
         public string? direction { get; set; }
 
         [Description("Maximum hops from a seed (default 16). Nodes AT the cap are recorded, not entered, and the response says the cap cut the walk — never a silent stop.")]
@@ -352,12 +352,8 @@ public static class RecordsTools
             }
             if (walkDirection == "reverse")
             {
-                if (walk.depth is > 1)
-                    return Wire.Refuse(json, "error: walk.direction='reverse' with depth>1 is a TRANSITIVE reverse lookup — the reverse-reference index that answers it now ships, but this walk lane is not wired to it yet, so it is refused rather than run as a scan-of-scans. Depth-1 reverse: references= (no bounding scope needed), or MGEF seeds under form='chain' for the typed carrier lane.");
                 if (walk.seed_paths is { Length: > 0 } || walk.exclusions is { Length: > 0 } || walk.follow is not null)
-                    return Wire.Refuse(json, "error: walk.seed_paths/follow/exclusions shape a FORWARD expansion — a reverse walk scans TOWARD the seeds. Drop them.");
-                if (form != "chain")
-                    return Wire.Refuse(json, "error: the reverse walk's general spelling on this surface IS references= (the same construct, depth 1, and it needs no bounding scope) — walk.direction='reverse' serves form='chain' with MGEF seeds (per-carrier magnitude/area/duration).");
+                    return Wire.Refuse(json, "error: walk.seed_paths/follow/exclusions shape a FORWARD expansion — a reverse walk scans TOWARD the seeds and follows every link at every hop. Drop them.");
             }
             if (references is { Length: > 0 })
                 return Wire.Refuse(json, "error: walk= and references= are the same construct (references= IS the reverse walk at depth 1) — use one spelling per call.");
@@ -405,10 +401,18 @@ public static class RecordsTools
         // formids= composes with the scan terms: the identity set intersects the scan's selection, or is the
         // universe when it is the only bound. The reverse MGEF walk keeps its own lane, where formids are seeds.
         bool reverseWalk = walk is not null && walkDirection == "reverse";
+        // The reverse direction has two lanes and they are told apart by the FORM, exactly as the forward direction
+        // is: 'chain' is the typed MGEF carrier lane (per-carrier magnitude/area/duration), every reading form
+        // consumes the reached set of the transitive reverse walk off the reverse-reference index.
+        bool reverseCarrier = reverseWalk && form == "chain";
         if (reverseWalk && (plugins?.names is { Length: > 0 } || conflicts_only || where is { Length: > 0 }))
-            return Wire.Refuse(json, "error: the reverse MGEF walk takes formids= (the effects) and optionally types= (narrowing the carrier types) — the general bounded reverse over other scan terms is the references= spelling.");
+            return Wire.Refuse(json, "error: a reverse walk takes formids= (its seeds) and nothing else as a scope — the bounded reverse over other scan terms is the references= spelling.");
+        if (reverseWalk && !reverseCarrier && types is { Length: > 0 })
+            return Wire.Refuse(json, "error: types= narrows the CARRIER types of the typed MGEF lane (form='chain'), and this reverse walk reaches records of every type — walk with to_file= and re-enter the artifact via formids=[\"@<file>\"] with types= to keep only the types you want.");
         if (reverseWalk && !hasFormids)
-            return Wire.Refuse(json, "error: the reverse walk needs its seeds — pass formids= (the MGEF(s) whose carriers to trace).");
+            return Wire.Refuse(json, reverseCarrier
+                ? "error: the reverse walk needs its seeds — pass formids= (the MGEF(s) whose carriers to trace)."
+                : "error: the reverse walk needs its seeds — pass formids= (the record(s) whose referrers to trace).");
         // The lane, decided once and read wherever a remedy sentence depends on which lane will run. The dispatch
         // below reads this same value, so a refusal cannot disagree with the lane it is refusing for.
         bool scanLane = hasScan && !reverseWalk;
@@ -665,8 +669,9 @@ public static class RecordsTools
 
         // ================================================================================================
         //  WALK lane — forward walks expand the winner link graph (the chain form renders the paths; any other
-        //  form consumes the reached set as its selection); the reverse walk is the typed MGEF lane, tracing
-        //  carriers with their per-hit payload.
+        //  form consumes the reached set as its selection). Reverse splits on the same form line: chain is the
+        //  typed MGEF lane tracing carriers with their per-hit payload, every reading form is the transitive
+        //  reverse walk off the reverse-reference index.
         // ================================================================================================
         string WalkLane(string[] ids, HousecarlCore.ArtifactDemand? demand, string? echoSrc)
         {
@@ -682,7 +687,35 @@ public static class RecordsTools
                 return e;
             }
 
-            if (walkDirection == "reverse")
+            if (reverseWalk && !reverseCarrier)
+            {
+                // The transitive reverse walk: every link, at every hop, off the reverse-reference index. The
+                // reached set is the selection the ordinary reading forms then consume, exactly as a forward walk's
+                // is — so the per-hop census is the only thing this lane renders of its own.
+                var rev = ReverseWalkBatch.Run(svc, ids, walkDepth, walkMaxNodes, demand);
+                if (rev.Refusal is not null)
+                    return json ? JsonWire.RenderError(rev.Refusal, rev.Epoch) : "error: " + rev.Refusal + (rev.Epoch is not null ? $"\nepoch={rev.Epoch}" : "");
+                if (SeamTear(rev.Epoch) is { } rTear)
+                    return json ? JsonWire.RenderError(rTear, rev.Epoch) : "error: " + rTear;
+                // Every hop is named with its count, empty ones included: a walk that ran out of referrers says so
+                // on the response instead of trailing off, so an empty hop 2 is visible and not silent.
+                var hopLine = string.Join(", ", rev.Hops.Select(h => $"hop {h.Depth}: {h.Reached.Count}"));
+                if (rev.Hops.Count < walkDepth)
+                    hopLine += $" (nothing left to expand, so hops {rev.Hops.Count + 1}–{walkDepth} were not walked)";
+                int reachedRev = rev.Selection.Count - ids.Length;
+                envelope.Add(new("walk", $"reverse (every link) depth={walkDepth} — {hopLine}; selection = the {rev.Selection.Count} record(s) the walk reached (seeds included)"));
+                if (rev.IndexNote is not null) envelope.Add(new("reverse_index", rev.IndexNote));
+                headerLine += $"\nwalk=reverse (every link) depth={walkDepth}: {hopLine} — selection = {rev.Selection.Count} record(s) ({reachedRev} referrer(s), seeds included)";
+                if (rev.IndexNote is not null) headerLine += "\n" + rev.IndexNote;
+                if (rev.Capped)
+                    headerLine += $"\n[!] the walk.max_nodes budget ({walkMaxNodes}) was reached — what is listed IS reached and proved; raise walk.max_nodes to walk further.";
+                expectEpoch = rev.Epoch;
+                formids = rev.Selection.ToArray();
+                walk = null;
+                return ListLane();
+            }
+
+            if (reverseCarrier)
             {
                 // The typed MGEF lane: each seed must resolve to a MagicEffect, and a non-MGEF seed fails loud
                 // per item rather than reading as '0 carriers'.
@@ -714,11 +747,18 @@ public static class RecordsTools
                     return json ? JsonWire.RenderError(dref, epochR) : "error: " + dref + Wire.EpochLine(epochR);
                 }
                 Arm("winner (carriers are the load-order-effective versions)");
-                envelope.Add(new("walk", "reverse, depth 1 — the typed MGEF carrier lane"));
-                headerLine += "\nwalk=reverse (per seed: every SPEL/ENCH/ALCH/SCRL/INGR applying it, with the MATCHING entry's magnitude/area/duration — reported AS AUTHORED; conditions are not evaluated, so a row means 'defines it at this strength', not 'it will fire')";
                 // The census separates written rows from the true total and names capped seeds, so the artifact
                 // and its census cannot disagree and a walk.max_nodes cut is always declared.
                 int carrierRows = results.Sum(r => r.Result.Error is null ? r.Result.Rows.Count : 0);
+                // This lane follows the effect link at every hop, and a carrier is not a magic effect — so hop 2
+                // and beyond reach nothing. Said out loud when a depth was asked for, never a silent stop.
+                var carrierHops = $"hop 1: {carrierRows}";
+                if (walkDepth > 1)
+                    carrierHops += string.Concat(Enumerable.Range(2, walkDepth - 1).Select(d => $", hop {d}: 0"))
+                                 + " — the carrier lane follows the effect link at every hop and a carrier is not a magic effect, so nothing is reached past hop 1; the transitive reverse over every link is walk={\"direction\":\"reverse\"} under a reading form.";
+                envelope.Add(new("walk", $"reverse, depth={walkDepth} — the typed MGEF carrier lane; {carrierHops}"));
+                headerLine += "\nwalk=reverse (per seed: every SPEL/ENCH/ALCH/SCRL/INGR applying it, with the MATCHING entry's magnitude/area/duration — reported AS AUTHORED; conditions are not evaluated, so a row means 'defines it at this strength', not 'it will fire')";
+                if (walkDepth > 1) headerLine += $"\n{carrierHops}";
                 int carrierTotal = results.Sum(r => r.Result.Error is null ? r.Result.Total : 0);
                 int cappedSeeds = results.Count(r => r.Result.Error is null && r.Result.Capped);
                 int seedErrs2 = results.Count(r => r.Result.Error is not null);

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -724,6 +724,10 @@ public static class RecordsTools
                 var hopLine = string.Join(", ", rev.Hops.Select(h => $"hop {h.Depth}: {h.Reached.Count}{(h.Cut ? " (cut by walk.max_nodes)" : "")}"));
                 if (!rev.Capped && rev.Hops.Count < walkDepth)
                     hopLine += $" (nothing left to expand, so hops {rev.Hops.Count + 1}–{walkDepth} were not walked)";
+                // The other way a walk ends: it reached walk.depth with the last hop still finding records, so what
+                // that hop reached was recorded and not expanded. Said out loud, or a prefix reads as a finding.
+                else if (!rev.Capped && rev.Hops.Count > 0 && rev.Hops[^1].Reached.Count > 0)
+                    hopLine += $" (walk.depth={walkDepth} was reached with hop {walkDepth} still finding records, so they were recorded and not expanded — raise walk.depth to walk further)";
                 int reachedRev = rev.Selection.Count - rev.Seeds;
                 envelope.Add(new("walk", $"reverse (every link) depth={walkDepth} — {hopLine}; selection = the {rev.Selection.Count} record(s) the walk reached (seeds included)"));
                 if (rev.IndexNote is not null) envelope.Add(new("reverse_index", rev.IndexNote));

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -729,8 +729,18 @@ public static class RecordsTools
                 if (rev.IndexNote is not null) envelope.Add(new("reverse_index", rev.IndexNote));
                 headerLine += $"\nwalk=reverse (every link) depth={walkDepth}: {hopLine} — selection = {rev.Selection.Count} record(s) ({reachedRev} referrer(s), seeds included)";
                 if (rev.IndexNote is not null) headerLine += "\n" + rev.IndexNote;
-                if (rev.Dropped > 0)
-                    headerLine += $"\n{rev.Dropped} index candidate(s) were dropped: the index says some plugin's copy carries the link, and the body this walk judges — the load-order winner — does not, so they are not reached and were not expanded (the same second step references= takes).";
+                if (rev.Dropped.Total > 0)
+                {
+                    // Each cause is named with its own count: an unreadable winner is a coverage gap and a dropped
+                    // link is a verdict, and one sentence for both would tell a caller the wrong thing about half
+                    // of them.
+                    var causes = new List<string>(4);
+                    if (rev.Dropped.NoLink > 0) causes.Add($"{rev.Dropped.NoLink} whose winner does not carry the link");
+                    if (rev.Dropped.Unreadable > 0) causes.Add($"{rev.Dropped.Unreadable} whose winning plugin could not be read — a coverage gap, not a verdict");
+                    if (rev.Dropped.NoLiveBody > 0) causes.Add($"{rev.Dropped.NoLiveBody} whose winner is deleted or carries no links");
+                    if (rev.Dropped.NoWinner > 0) causes.Add($"{rev.Dropped.NoWinner} with no resolvable winner");
+                    headerLine += $"\n{rev.Dropped.Total} index candidate(s) were dropped — the index names a plugin copy that carries the link, and this walk judges the load-order winner (the same second step references= takes): {string.Join("; ", causes)}. None of them was reached or expanded.";
+                }
                 if (rev.Capped)
                     headerLine += $"\n[!] the walk.max_nodes budget ({walkMaxNodes}, one budget shared across every seed and hop on this lane) was reached — what is listed IS reached and proved, and the hop it cut is marked; raise walk.max_nodes to walk further.";
                 expectEpoch = rev.Epoch;

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -820,8 +820,13 @@ public static class RecordsTools
                     if (carrierSel.Count == 0)
                         return json ? JsonWire.RenderError($"the reverse carrier walk reached nothing readable ({seedErrs2} seed error(s) — run form='chain' to see each seed's outcome).", epochR)
                                     : $"error: the reverse carrier walk reached nothing readable ({seedErrs2} seed error(s) — run form='chain' to see each seed's outcome)." + (epochR is not null ? $"\nepoch={epochR}" : "");
-                    envelope.Add(new("selection", $"the {carrierSel.Count} record(s) the carrier walk reached (seeds included)"));
+                    // A seed that failed contributed no carriers, and the reading form says so: a partial answer
+                    // over some of the seeds must never read as an answer over all of them.
+                    envelope.Add(new("selection", $"the {carrierSel.Count} record(s) the carrier walk reached (seeds included)"
+                                                  + (seedErrs2 > 0 ? $"; {seedErrs2} seed error(s), listed via form='chain'" : "")));
                     headerLine += $"\nwalk: selection = {carrierSel.Count} reached record(s) (seeds included)";
+                    if (seedErrs2 > 0)
+                        headerLine += $"\n[!] {seedErrs2} seed(s) failed and contributed no carriers — run form='chain' to see each seed's outcome.";
                     if (cappedSeeds > 0)
                         headerLine += $"\n[!] {cappedSeeds} seed(s) hit the walk.max_nodes carrier bound ({walkMaxNodes}, per seed on this lane) — the selection is a prefix of the {carrierTotal} carrier(s) reached; raise walk.max_nodes.";
                     expectEpoch = epochR;

--- a/src/housecarl-mcp/ReverseWalkBatch.cs
+++ b/src/housecarl-mcp/ReverseWalkBatch.cs
@@ -59,8 +59,11 @@ public static class ReverseWalkBatch
             var w = view.ResolveWinner(candidate);
             if (w is null) { dropped++; return false; }
             IMajorRecordGetter? body;
+            // Any throw out of the lazy overlay seek — an unreadable plugin, a malformed subrecord — is a
+            // coverage gap on that one record, counted and skipped, never the end of the whole walk. The same
+            // rule references= keeps.
             try { body = view.GetRecord(session, w.Value.WinnerPlugin, candidate); }
-            catch (PluginUnreadableException) { dropped++; return false; }
+            catch (Exception) { dropped++; return false; }
             if (body is null || DeletedRecordRule.HasNoLiveBody(body) || body is not IFormLinkContainerGetter flc)
             {
                 dropped++;

--- a/src/housecarl-mcp/ReverseWalkBatch.cs
+++ b/src/housecarl-mcp/ReverseWalkBatch.cs
@@ -1,5 +1,6 @@
 using HousecarlCore;
 using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
 
 namespace HousecarlMcp;
 
@@ -12,35 +13,66 @@ namespace HousecarlMcp;
 public static class ReverseWalkBatch
 {
     /// <summary>What one reverse walk produced: the per-hop reached sets (an empty hop is kept and reported), the
-    /// selection the reading forms consume, the index's own accounting line, and the build the whole answer was
-    /// read from.</summary>
+    /// selection the reading forms consume, the count of index candidates the body check dropped, the index's own
+    /// accounting line, and the build the whole answer was read from.</summary>
     public sealed record Result(IReadOnlyList<ReverseSelection.Hop> Hops, IReadOnlyList<string> Selection,
-                                bool Capped, string? IndexNote, string? Epoch, string? Refusal);
+                                int Seeds, bool Capped, int Dropped, string? IndexNote, string? Epoch,
+                                string? Refusal);
 
     /// <summary>Run the walk from these seeds. Every seed is parsed against the captured build, so a bad FormID is
     /// a refusal naming it rather than a seed that silently reaches nothing.</summary>
     public static Result Run(LoadOrderService svc, IReadOnlyList<string> seeds, int depth, int maxNodes,
                              ArtifactDemand? demand)
     {
-        var view = svc.CaptureView();
+        var pin = svc.CapturePin();
+        var view = pin.View;
         var epoch = view.Epoch;
         if (demand is not null && demand.Epoch != epoch)
-            return new Result(Array.Empty<ReverseSelection.Hop>(), Array.Empty<string>(), false, null, epoch,
+            return new Result(Array.Empty<ReverseSelection.Hop>(), Array.Empty<string>(), 0, false, 0, null, epoch,
                               LoadOrderService.ArtifactEpochMismatch(demand, epoch));
 
+        // Seeds are deduplicated: two spellings of one key (a runtime FormID and its ID:Plugin form) parse to the
+        // same FormKey, and the selection the reading forms consume must list it once.
         var seedKeys = new List<FormKey>(seeds.Count);
+        var seedSeen = new HashSet<FormKey>();
         foreach (var raw in seeds)
         {
-            try { seedKeys.Add(view.ParseFormId(raw)); }
+            FormKey fk;
+            try { fk = view.ParseFormId(raw); }
             catch (Exception ex)
             {
-                return new Result(Array.Empty<ReverseSelection.Hop>(), Array.Empty<string>(), false, null, epoch,
+                return new Result(Array.Empty<ReverseSelection.Hop>(), Array.Empty<string>(), 0, false, 0, null, epoch,
                                   $"bad FormID '{raw}': {ex.Message} — every seed of a reverse walk must parse before the walk starts.");
             }
+            if (seedSeen.Add(fk)) seedKeys.Add(fk);
         }
 
         var built = view.EnsureReverseIndex();
-        var hops = ReverseSelection.Transitive(view.ReverseIndex!, seedKeys, depth, maxNodes, out var capped);
+        int dropped = 0;
+        using var session = pin.Resolver.OpenSession();
+        // The index answers in candidates — it says SOME plugin's copy carries the link. references= then re-tests
+        // each candidate against the body it judges, and so does this: a record whose winner dropped the link is
+        // neither listed nor expanded, so the two spellings of the reverse question cannot disagree and a false
+        // hop-1 node cannot seed a false subtree.
+        bool Verify(FormKey candidate, IReadOnlySet<FormKey> frontier)
+        {
+            var w = view.ResolveWinner(candidate);
+            if (w is null) { dropped++; return false; }
+            IMajorRecordGetter? body;
+            try { body = view.GetRecord(session, w.Value.WinnerPlugin, candidate); }
+            catch (PluginUnreadableException) { dropped++; return false; }
+            if (body is null || DeletedRecordRule.HasNoLiveBody(body) || body is not IFormLinkContainerGetter flc)
+            {
+                dropped++;
+                return false;
+            }
+            foreach (var l in flc.EnumerateFormLinks())
+                if (frontier.Contains(l.FormKey)) return true;
+            dropped++;
+            return false;
+        }
+
+        var hops = ReverseSelection.Transitive(view.ReverseIndex!, seedKeys, depth, maxNodes, Verify, out var capped);
 
         // Seeds first, then each hop in order: the selection reads in walk order, and the render says the seeds
         // are in it.
@@ -49,6 +81,6 @@ public static class ReverseWalkBatch
         foreach (var hop in hops)
             foreach (var k in hop.Reached) selection.Add(k.ToString());
 
-        return new Result(hops, selection, capped, built.Note, epoch, null);
+        return new Result(hops, selection, seedKeys.Count, capped, dropped, built.Note, epoch, null);
     }
 }

--- a/src/housecarl-mcp/ReverseWalkBatch.cs
+++ b/src/housecarl-mcp/ReverseWalkBatch.cs
@@ -1,0 +1,54 @@
+using HousecarlCore;
+using Mutagen.Bethesda.Plugins;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// The transitive reverse walk — "what points at the seeds, and what points at that" — served off the
+/// reverse-reference index. The forward direction has the body in hand and resolves one link per hop; the reverse
+/// direction has to have been walked already, which is what the index is, so this lane is a lookup per hop rather
+/// than a scan of scans. The follow rule is every link, at every hop, which is what depth= means everywhere.
+/// </summary>
+public static class ReverseWalkBatch
+{
+    /// <summary>What one reverse walk produced: the per-hop reached sets (an empty hop is kept and reported), the
+    /// selection the reading forms consume, the index's own accounting line, and the build the whole answer was
+    /// read from.</summary>
+    public sealed record Result(IReadOnlyList<ReverseSelection.Hop> Hops, IReadOnlyList<string> Selection,
+                                bool Capped, string? IndexNote, string? Epoch, string? Refusal);
+
+    /// <summary>Run the walk from these seeds. Every seed is parsed against the captured build, so a bad FormID is
+    /// a refusal naming it rather than a seed that silently reaches nothing.</summary>
+    public static Result Run(LoadOrderService svc, IReadOnlyList<string> seeds, int depth, int maxNodes,
+                             ArtifactDemand? demand)
+    {
+        var view = svc.CaptureView();
+        var epoch = view.Epoch;
+        if (demand is not null && demand.Epoch != epoch)
+            return new Result(Array.Empty<ReverseSelection.Hop>(), Array.Empty<string>(), false, null, epoch,
+                              LoadOrderService.ArtifactEpochMismatch(demand, epoch));
+
+        var seedKeys = new List<FormKey>(seeds.Count);
+        foreach (var raw in seeds)
+        {
+            try { seedKeys.Add(view.ParseFormId(raw)); }
+            catch (Exception ex)
+            {
+                return new Result(Array.Empty<ReverseSelection.Hop>(), Array.Empty<string>(), false, null, epoch,
+                                  $"bad FormID '{raw}': {ex.Message} — every seed of a reverse walk must parse before the walk starts.");
+            }
+        }
+
+        var built = view.EnsureReverseIndex();
+        var hops = ReverseSelection.Transitive(view.ReverseIndex!, seedKeys, depth, maxNodes, out var capped);
+
+        // Seeds first, then each hop in order: the selection reads in walk order, and the render says the seeds
+        // are in it.
+        var selection = new List<string>(seedKeys.Count);
+        foreach (var k in seedKeys) selection.Add(k.ToString());
+        foreach (var hop in hops)
+            foreach (var k in hop.Reached) selection.Add(k.ToString());
+
+        return new Result(hops, selection, capped, built.Note, epoch, null);
+    }
+}

--- a/src/housecarl-mcp/ReverseWalkBatch.cs
+++ b/src/housecarl-mcp/ReverseWalkBatch.cs
@@ -25,8 +25,12 @@ public static class ReverseWalkBatch
     /// selection the reading forms consume, the index candidates the body check dropped and why, the index's own
     /// accounting line, and the build the whole answer was read from.</summary>
     public sealed record Result(IReadOnlyList<ReverseSelection.Hop> Hops, IReadOnlyList<string> Selection,
-                                int Seeds, bool Capped, DropCensus Dropped, string? IndexNote, string? Epoch,
-                                string? Refusal);
+                                int Seeds, bool Capped, DropCensus Dropped, string? IndexNote, OrderStamp? Stamp,
+                                string? Refusal)
+    {
+        /// <summary>The build's fingerprint alone, for the places that compare epochs rather than render them.</summary>
+        public string? Epoch => Stamp?.Epoch;
+    }
 
     /// <summary>Run the walk from these seeds. Every seed is parsed against the captured build, so a bad FormID is
     /// a refusal naming it rather than a seed that silently reaches nothing.</summary>
@@ -35,10 +39,10 @@ public static class ReverseWalkBatch
     {
         var pin = svc.CapturePin();
         var view = pin.View;
-        var epoch = view.Epoch;
-        if (demand is not null && demand.Epoch != epoch)
-            return new Result(Array.Empty<ReverseSelection.Hop>(), Array.Empty<string>(), 0, false, DropCensus.Empty, null, epoch,
-                              LoadOrderService.ArtifactEpochMismatch(demand, epoch));
+        var stamp = view.Stamp;
+        if (demand is not null && demand.Epoch != stamp.Epoch)
+            return new Result(Array.Empty<ReverseSelection.Hop>(), Array.Empty<string>(), 0, false, DropCensus.Empty, null, stamp,
+                              LoadOrderService.ArtifactEpochMismatch(demand, stamp.Epoch));
 
         // Seeds are deduplicated: two spellings of one key (a runtime FormID and its ID:Plugin form) parse to the
         // same FormKey, and the selection the reading forms consume must list it once.
@@ -50,7 +54,7 @@ public static class ReverseWalkBatch
             try { fk = view.ParseFormId(raw); }
             catch (Exception ex)
             {
-                return new Result(Array.Empty<ReverseSelection.Hop>(), Array.Empty<string>(), 0, false, DropCensus.Empty, null, epoch,
+                return new Result(Array.Empty<ReverseSelection.Hop>(), Array.Empty<string>(), 0, false, DropCensus.Empty, null, stamp,
                                   $"bad FormID '{raw}': {ex.Message} — every seed of a reverse walk must parse before the walk starts.");
             }
             if (seedSeen.Add(fk)) seedKeys.Add(fk);
@@ -114,6 +118,6 @@ public static class ReverseWalkBatch
             foreach (var k in hop.Reached) selection.Add(k.ToString());
 
         return new Result(hops, selection, seedKeys.Count, capped,
-                          new DropCensus(noLink.Count, unreadable, noLiveBody, noWinner), built.Note, epoch, null);
+                          new DropCensus(noLink.Count, unreadable, noLiveBody, noWinner), built.Note, stamp, null);
     }
 }

--- a/src/housecarl-mcp/ReverseWalkBatch.cs
+++ b/src/housecarl-mcp/ReverseWalkBatch.cs
@@ -57,7 +57,14 @@ public static class ReverseWalkBatch
         }
 
         var built = view.EnsureReverseIndex();
-        int noLink = 0, unreadable = 0, noLiveBody = 0, noWinner = 0;
+        int unreadable = 0, noLiveBody = 0, noWinner = 0;
+        // Every candidate is judged once, however many frontiers name it: the winner's links are remembered (null
+        // when the winner cannot be judged at all), so the same body is never read twice and each cause counts
+        // records rather than checks. Whether the winner carries a link is frontier-relative, so it is asked again
+        // per hop off the remembered set — a record dropped at hop 1 can still be legitimately reached at hop 2,
+        // and it then leaves the drop count.
+        var linksOf = new Dictionary<FormKey, IReadOnlySet<FormKey>?>();
+        var noLink = new HashSet<FormKey>();
         using var session = pin.Resolver.OpenSession();
         // The index answers in candidates — it says SOME plugin's copy carries the link. references= then re-tests
         // each candidate against the body it judges, and so does this: a record whose winner dropped the link is
@@ -65,23 +72,35 @@ public static class ReverseWalkBatch
         // hop-1 node cannot seed a false subtree.
         bool Verify(FormKey candidate, IReadOnlySet<FormKey> frontier)
         {
-            var w = view.ResolveWinner(candidate);
-            if (w is null) { noWinner++; return false; }
-            IMajorRecordGetter? body;
-            // Any throw out of the lazy overlay seek — an unreadable plugin, a malformed subrecord — is a
-            // coverage gap on that one record, counted and skipped, never the end of the whole walk. The same
-            // rule references= keeps.
-            try { body = view.GetRecord(session, w.Value.WinnerPlugin, candidate); }
-            catch (Exception) { unreadable++; return false; }
-            if (body is null) { unreadable++; return false; }
-            if (DeletedRecordRule.HasNoLiveBody(body) || body is not IFormLinkContainerGetter flc)
+            if (!linksOf.TryGetValue(candidate, out var links))
             {
-                noLiveBody++;
-                return false;
+                links = null;
+                var w = view.ResolveWinner(candidate);
+                if (w is null) noWinner++;
+                else
+                {
+                    IMajorRecordGetter? body = null;
+                    bool threw = false;
+                    // Any throw out of the lazy overlay seek — an unreadable plugin, a malformed subrecord — is a
+                    // coverage gap on that one record, counted and skipped, never the end of the whole walk. The
+                    // same rule references= keeps.
+                    try { body = view.GetRecord(session, w.Value.WinnerPlugin, candidate); }
+                    catch (Exception) { threw = true; }
+                    if (threw || body is null) unreadable++;
+                    else if (DeletedRecordRule.HasNoLiveBody(body) || body is not IFormLinkContainerGetter flc) noLiveBody++;
+                    else
+                    {
+                        var set = new HashSet<FormKey>();
+                        try { foreach (var l in flc.EnumerateFormLinks()) set.Add(l.FormKey); links = set; }
+                        catch (Exception) { unreadable++; }
+                    }
+                }
+                linksOf[candidate] = links;
             }
-            foreach (var l in flc.EnumerateFormLinks())
-                if (frontier.Contains(l.FormKey)) return true;
-            noLink++;
+            if (links is null) return false;
+            foreach (var l in links)
+                if (frontier.Contains(l)) { noLink.Remove(candidate); return true; }
+            noLink.Add(candidate);
             return false;
         }
 
@@ -95,6 +114,6 @@ public static class ReverseWalkBatch
             foreach (var k in hop.Reached) selection.Add(k.ToString());
 
         return new Result(hops, selection, seedKeys.Count, capped,
-                          new DropCensus(noLink, unreadable, noLiveBody, noWinner), built.Note, epoch, null);
+                          new DropCensus(noLink.Count, unreadable, noLiveBody, noWinner), built.Note, epoch, null);
     }
 }

--- a/src/housecarl-mcp/ReverseWalkBatch.cs
+++ b/src/housecarl-mcp/ReverseWalkBatch.cs
@@ -12,11 +12,20 @@ namespace HousecarlMcp;
 /// </summary>
 public static class ReverseWalkBatch
 {
+    /// <summary>Why the body check dropped index candidates, one count per cause: the walk judges the winner, and
+    /// "the winner does not carry the link" is only one of the four ways a candidate fails it. An unreadable
+    /// winner is a coverage gap, not a verdict, so it is never rendered as one.</summary>
+    public sealed record DropCensus(int NoLink, int Unreadable, int NoLiveBody, int NoWinner)
+    {
+        public static readonly DropCensus Empty = new(0, 0, 0, 0);
+        public int Total => NoLink + Unreadable + NoLiveBody + NoWinner;
+    }
+
     /// <summary>What one reverse walk produced: the per-hop reached sets (an empty hop is kept and reported), the
-    /// selection the reading forms consume, the count of index candidates the body check dropped, the index's own
+    /// selection the reading forms consume, the index candidates the body check dropped and why, the index's own
     /// accounting line, and the build the whole answer was read from.</summary>
     public sealed record Result(IReadOnlyList<ReverseSelection.Hop> Hops, IReadOnlyList<string> Selection,
-                                int Seeds, bool Capped, int Dropped, string? IndexNote, string? Epoch,
+                                int Seeds, bool Capped, DropCensus Dropped, string? IndexNote, string? Epoch,
                                 string? Refusal);
 
     /// <summary>Run the walk from these seeds. Every seed is parsed against the captured build, so a bad FormID is
@@ -28,7 +37,7 @@ public static class ReverseWalkBatch
         var view = pin.View;
         var epoch = view.Epoch;
         if (demand is not null && demand.Epoch != epoch)
-            return new Result(Array.Empty<ReverseSelection.Hop>(), Array.Empty<string>(), 0, false, 0, null, epoch,
+            return new Result(Array.Empty<ReverseSelection.Hop>(), Array.Empty<string>(), 0, false, DropCensus.Empty, null, epoch,
                               LoadOrderService.ArtifactEpochMismatch(demand, epoch));
 
         // Seeds are deduplicated: two spellings of one key (a runtime FormID and its ID:Plugin form) parse to the
@@ -41,14 +50,14 @@ public static class ReverseWalkBatch
             try { fk = view.ParseFormId(raw); }
             catch (Exception ex)
             {
-                return new Result(Array.Empty<ReverseSelection.Hop>(), Array.Empty<string>(), 0, false, 0, null, epoch,
+                return new Result(Array.Empty<ReverseSelection.Hop>(), Array.Empty<string>(), 0, false, DropCensus.Empty, null, epoch,
                                   $"bad FormID '{raw}': {ex.Message} — every seed of a reverse walk must parse before the walk starts.");
             }
             if (seedSeen.Add(fk)) seedKeys.Add(fk);
         }
 
         var built = view.EnsureReverseIndex();
-        int dropped = 0;
+        int noLink = 0, unreadable = 0, noLiveBody = 0, noWinner = 0;
         using var session = pin.Resolver.OpenSession();
         // The index answers in candidates — it says SOME plugin's copy carries the link. references= then re-tests
         // each candidate against the body it judges, and so does this: a record whose winner dropped the link is
@@ -57,21 +66,22 @@ public static class ReverseWalkBatch
         bool Verify(FormKey candidate, IReadOnlySet<FormKey> frontier)
         {
             var w = view.ResolveWinner(candidate);
-            if (w is null) { dropped++; return false; }
+            if (w is null) { noWinner++; return false; }
             IMajorRecordGetter? body;
             // Any throw out of the lazy overlay seek — an unreadable plugin, a malformed subrecord — is a
             // coverage gap on that one record, counted and skipped, never the end of the whole walk. The same
             // rule references= keeps.
             try { body = view.GetRecord(session, w.Value.WinnerPlugin, candidate); }
-            catch (Exception) { dropped++; return false; }
-            if (body is null || DeletedRecordRule.HasNoLiveBody(body) || body is not IFormLinkContainerGetter flc)
+            catch (Exception) { unreadable++; return false; }
+            if (body is null) { unreadable++; return false; }
+            if (DeletedRecordRule.HasNoLiveBody(body) || body is not IFormLinkContainerGetter flc)
             {
-                dropped++;
+                noLiveBody++;
                 return false;
             }
             foreach (var l in flc.EnumerateFormLinks())
                 if (frontier.Contains(l.FormKey)) return true;
-            dropped++;
+            noLink++;
             return false;
         }
 
@@ -84,6 +94,7 @@ public static class ReverseWalkBatch
         foreach (var hop in hops)
             foreach (var k in hop.Reached) selection.Add(k.ToString());
 
-        return new Result(hops, selection, seedKeys.Count, capped, dropped, built.Note, epoch, null);
+        return new Result(hops, selection, seedKeys.Count, capped,
+                          new DropCensus(noLink, unreadable, noLiveBody, noWinner), built.Note, epoch, null);
     }
 }


### PR DESCRIPTION
`walk={"direction":"reverse","depth":N}` was refused past depth 1, naming the reverse-reference index as the thing that would answer it. That index shipped in #562, so the refusal is deleted and the walk answers instead. `depth` means the same thing it means everywhere — the follow rule repeated at each hop.

**`walk.follow` picks the reverse walk; the form only picks the view.** `follow` names the edges a walk crosses, which is as meaningful backwards as forwards, so the surface's own "follow shapes a FORWARD expansion" refusal narrows to `seed_paths`/`exclusions`. On reverse:

- `follow` unset or `"*"` — the transitive walk: every link, at every hop, off the index, with no bounding `types=`/`plugins=` scope.
- `follow="Effects[].BaseEffect"` (SPEC §3.3's spelling) — the typed MGEF carrier walk: per-carrier magnitude/area/duration, `types=` narrowing the carrier types. It crosses the effect link at every hop and a carrier is not a magic effect, so it reaches nothing past hop 1 — a consequence of the follow the caller named, not a special case.
- anything else — refused, naming the two the index can serve (it holds every link and no per-path breakdown).

The reached set is then the same under every form for a given follow, and both walks hand their reached set to the same two views: `form='chain'` renders the walk's rows, a reading form consumes the reached set. The carrier walk under a reading form is new here — it used to be chain-only.

**No default follow implies a walk, under any form.** `form='chain'` on a reverse walk with `follow` unset refuses in one sentence naming the two follows the index can serve — `"Effects[].BaseEffect"` for the typed carrier walk, which chain renders, and `"*"` for every link, which chain cannot render because the transitive walk expands one shared frontier and has no per-seed path to draw — and points that reading at a reading form. `form='chain'` with an explicit `follow="*"` keeps its own refusal. So a reverse chain call says its follow outright, including the one the retired `housecarl_effect_chain` redirect teaches, which now carries the token. Aaron's ruling of 2026-09-06: a token means one thing under every form, and the earlier draft's carry-the-old-spelling default is gone.

`walk.max_nodes` now says which reading it spends: per seed on the carrier walk, one budget shared across every seed and every hop on the transitive walk.

**The reached set is verified, not raw candidates.** The index answers in candidates — some plugin's copy carries the link. `references=` re-tests each candidate against the body it judges; so does this walk now, against the load-order winner, and a candidate that fails is neither reported nor expanded, so the two spellings agree and a false hop-1 node cannot seed a false subtree. The response says how many candidates the check dropped.

**The hop census is honest.** The node budget is tested before the node is consumed, so a raised budget on a retry sees the same graph; the hop the cut landed on is marked `(cut by walk.max_nodes)` instead of reading as `hop N: 0`; a capped walk is never also called exhausted; the carrier walk's hop-1 count is the census total, not the rows written; and the empty-hop prose is told only when a depth was actually asked for, never off the default 16. Seeds are deduplicated, so two spellings of one key are one seed.

The traversal itself is `ReverseSelection.Transitive` beside the index it reads, and the lane's batch is a new file rather than another domain in `LoadOrderService.cs`. No new parameter and no new token.

Tests: reverse depth 2 reaches a second-hop referrer and depth 1 does not; an exhausted walk names the hops it did not walk; a capped walk names the cut hop and is not called exhausted; a candidate whose winner dropped the link is excluded by both `references=` and the walk, and the drop is reported; repeated seeds are deduplicated; `follow="*"` is the transitive walk and `follow="Effects[].BaseEffect"` the carrier walk under a reading form; an unservable follow, chain-over-transitive and chain-with-follow-unset all refuse naming the alternatives, and the same chain call with the carrier follow said outright is served; a bad direction no longer teaches the deleted depth-1 rule; a carrier call with no depth prints no hop census. The fixture gains a three-link chain (MgefHop <- SpellHop <- ListHop) and a list whose winning override drops its link.

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)

