### PR TITLE
Read the quantified step in project.fields

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -57,6 +57,14 @@ saying it sets an expectation their install may contradict. Say what is known, a
   is named under a reading form too, not only under `chain`, so an answer covering some of the seeds never
   reads as one covering all of them. `walk.max_nodes` says which reading it spends: per seed on the carrier
   walk, one shared budget across every seed and hop on the transitive walk.
+- **`housecarl_records` reads the quantified step in `project.fields`.** `where=` has taken `[*count]` and the
+  boolean folds for a while; the same tokens are now a projection. `project.fields=["Effects[*count]"]` renders one
+  number per record — how many elements the list holds — and `["Effects[*]"]` one row per element, in the same row
+  shape `project.form='rows'` produces; a sub-path after the token (`"Effects[*].Data.Magnitude"`) renders that leaf
+  per element instead. Under `format='dense'` the extra rows repeat the record's identity columns, and an
+  unquantified column repeats its own cell beside them. `[*any]`/`[*all]`/`[*none]` fold to a boolean, which is not
+  a row, and stay refused here by name. A quantifier on a step that is not a list fails that record with one
+  sentence naming the path, what the step actually holds, and the two ways to read it.
 
 - **`housecarl_asset_status` and `housecarl_place` take `format='json'`.** Both answered text only, so a caller
   reading them from a script parsed prose. The json document carries the same data as the text render: for

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -66,10 +66,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
   a row, and stay refused here by name. A quantifier on a step that is not a list fails that record with one
   sentence naming the path, what the step actually holds, and the two ways to read it. An EMPTY list answers with
   its own summary line under the caller's spelling, so it can never be mistaken for a path that was not asked for,
-  and a read the engine cut short says so beside the shortened rows. Under `format='dense'` a row is keyed by its
-  element index — a sub-path an element does not carry leaves that row's cell empty rather than shifting the next
-  element's value onto it — the ceiling is checked per row, `rows_rendered` counts them, and two different lists in
-  one call are refused by name, since one row cannot be an element of both.
+  and a read the engine cut short says so beside the shortened rows. Under `format='dense'` a row is keyed by the
+  element's own key — its index in a positional list, its dict key in a dict, so a package's `Data` arms keyed 2
+  and 7 are two rows and not eight — and a sub-path an element does not carry leaves that row's cell empty rather
+  than shifting the next element's value onto it. The ceiling is checked per row, `rows_rendered` counts them, and
+  two different lists in one call are refused by name, since one row cannot be an element of both.
 
 - **`housecarl_asset_status` and `housecarl_place` take `format='json'`.** Both answered text only, so a caller
   reading them from a script parsed prose. The json document carries the same data as the text render: for

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -64,7 +64,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
   per element instead. Under `format='dense'` the extra rows repeat the record's identity columns, and an
   unquantified column repeats its own cell beside them. `[*any]`/`[*all]`/`[*none]` fold to a boolean, which is not
   a row, and stay refused here by name. A quantifier on a step that is not a list fails that record with one
-  sentence naming the path, what the step actually holds, and the two ways to read it.
+  sentence naming the path, what the step actually holds, and the two ways to read it. An EMPTY list answers with
+  its own summary line under the caller's spelling, so it can never be mistaken for a path that was not asked for,
+  and a read the engine cut short says so beside the shortened rows. Under `format='dense'` a row is keyed by its
+  element index — a sub-path an element does not carry leaves that row's cell empty rather than shifting the next
+  element's value onto it — the ceiling is checked per row, `rows_rendered` counts them, and two different lists in
+  one call are refused by name, since one row cannot be an element of both.
 
 - **`housecarl_asset_status` and `housecarl_place` take `format='json'`.** Both answered text only, so a caller
   reading them from a script parsed prose. The json document carries the same data as the text render: for

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records;
+using Fold = HousecarlCore.PathFold;   // the fold vocabulary is shared with project.fields — one word list, one meaning
 
 namespace HousecarlCore;
 
@@ -71,12 +72,6 @@ public sealed class FieldPredicateSet
     /// <c>@&lt;absolute path&gt;</c> naming a file of them. Restricted to <c>formid</c> at parse (a named refusal on any
     /// other path) so a future generalization to leaf-value membership is an extension, not a behavior change.</summary>
     enum Op { Eq, Ne, Gt, Ge, Lt, Le, Contains, StartsWith, Has, HasAny, HasNone, Exists, Missing, In, NotIn }
-
-    /// <summary>A path step's declared multiplicity and fold. <see cref="None"/> is an ordinary step;
-    /// <see cref="Set"/> is the bare <c>[*]</c> (the element set — a PROJECT reading, refused in a predicate);
-    /// <see cref="Any"/>/<see cref="All"/>/<see cref="NoneOf"/> fold the elements into a boolean and
-    /// <see cref="Count"/> into their number.</summary>
-    enum Fold { None, Set, Any, All, NoneOf, Count }
 
     /// <summary>One parsed predicate: the split path segments (fed straight to <see cref="ReadEngine.ReadLeaf"/>),
     /// the operator, the raw operand, and — for a numeric operator — the operand pre-parsed to a double (validated
@@ -489,19 +484,10 @@ public sealed class FieldPredicateSet
         for (int i = 0; i < segs.Length; i++)
         {
             var s = segs[i];
-            int open = s.IndexOf('[');
-            if (open < 0 || !s.EndsWith("]", StringComparison.Ordinal)) continue;
-            var key = s[(open + 1)..^1];
-            if (key.Length == 0 || key[0] != '*') continue;
-            if (open == 0)
+            var (bare, f, key) = PathFoldGrammar.Read(s);
+            if (key is null) continue;
+            if (bare.Length == 0)
                 return (segs, null, $"predicate '{raw}': '{s}' has no field name before '[' — a quantifier binds to a list field, e.g. 'Conditions{s}'.");
-            var word = key[1..];
-            var f = word.Length == 0 ? Fold.Set
-                  : word.Equals("any", StringComparison.OrdinalIgnoreCase) ? Fold.Any
-                  : word.Equals("all", StringComparison.OrdinalIgnoreCase) ? Fold.All
-                  : word.Equals("none", StringComparison.OrdinalIgnoreCase) ? Fold.NoneOf
-                  : word.Equals("count", StringComparison.OrdinalIgnoreCase) ? Fold.Count
-                  : Fold.None;
             if (f == Fold.None)
                 return (segs, null, $"predicate '{raw}': '[{key}]' is not a quantifier — the tokens are [*any], [*all], [*none] and [*count].");
             if (f == Fold.Set)
@@ -512,7 +498,7 @@ public sealed class FieldPredicateSet
                 return (segs, null, $"predicate '{raw}': nothing can follow '[*count]' — it yields how MANY elements there are, not an element to step into.");
             if (folds is null) { folds = new Fold[segs.Length]; outSegs = (string[])segs.Clone(); }
             folds[i] = f;
-            outSegs[i] = s[..open];
+            outSegs[i] = bare;
         }
         return (outSegs, folds, null);
     }
@@ -529,10 +515,7 @@ public sealed class FieldPredicateSet
     }
 
     /// <summary>The token a fold is spelled with, for a message.</summary>
-    static string FoldToken(Fold f) => f switch
-    {
-        Fold.Set => "[*]", Fold.Any => "[*any]", Fold.All => "[*all]", Fold.NoneOf => "[*none]", Fold.Count => "[*count]", _ => "",
-    };
+    static string FoldToken(Fold f) => PathFoldGrammar.Token(f);
 
     /// <summary>Parse a generalized (non-formid) membership list: same separators/wrapping as the formid grammar,
     /// but entries are arbitrary VALUE tokens (enum names, numbers, FormKeys) — validated only for non-emptiness.

--- a/src/housecarl-core/PathFold.cs
+++ b/src/housecarl-core/PathFold.cs
@@ -1,0 +1,38 @@
+namespace HousecarlCore;
+
+/// <summary>The quantifier a path step declares — the multiplicity and the fold spelled IN the step, where it
+/// binds. One vocabulary, shared by <c>where=</c>'s predicates and <c>project.fields</c>' projection, so the two
+/// surfaces can never drift on what a token means.</summary>
+public enum PathFold { None, Set, Any, All, NoneOf, Count }
+
+/// <summary>The quantified step's tokenizer. The word list lives here ONCE: every surface that reads a quantifier
+/// reads it through this, so a token added on one side is a token on the other by construction.</summary>
+public static class PathFoldGrammar
+{
+    /// <summary>Split one path segment into its bare field name, the fold its bracket key spells, and that key as
+    /// the caller wrote it. <see cref="PathFold.None"/> with a null key = no quantifier at all;
+    /// <see cref="PathFold.None"/> with a non-null key = a bracket key that begins '*' but is not a quantifier
+    /// word, which each surface names in its own voice.</summary>
+    public static (string Bare, PathFold Fold, string? Key) Read(string seg)
+    {
+        int open = seg.IndexOf('[');
+        if (open < 0 || !seg.EndsWith("]", StringComparison.Ordinal)) return (seg, PathFold.None, null);
+        var key = seg[(open + 1)..^1];
+        if (key.Length == 0 || key[0] != '*') return (seg, PathFold.None, null);
+        var word = key[1..];
+        var fold = word.Length == 0 ? PathFold.Set
+                 : word.Equals("any", StringComparison.OrdinalIgnoreCase) ? PathFold.Any
+                 : word.Equals("all", StringComparison.OrdinalIgnoreCase) ? PathFold.All
+                 : word.Equals("none", StringComparison.OrdinalIgnoreCase) ? PathFold.NoneOf
+                 : word.Equals("count", StringComparison.OrdinalIgnoreCase) ? PathFold.Count
+                 : PathFold.None;
+        return (seg[..open], fold, key);
+    }
+
+    /// <summary>The token a fold is spelled with, for a message.</summary>
+    public static string Token(PathFold f) => f switch
+    {
+        PathFold.Set => "[*]", PathFold.Any => "[*any]", PathFold.All => "[*all]",
+        PathFold.NoneOf => "[*none]", PathFold.Count => "[*count]", _ => "",
+    };
+}

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -193,9 +193,14 @@ public static class ReadEngine
     /// one-level dump of every modeled field. Wraps the internal <see cref="ReadLeaf"/> the round-trip oracle drives,
     /// so the server's reads inherit the read-proof by construction. Per-leaf fault isolation: an unreadable field
     /// names itself in its <see cref="FieldValue.Note"/>, never throws out of the record read.</summary>
+    /// <param name="depths">One depth per entry of <paramref name="paths"/>, when the caller needs them to differ —
+    /// a projection that raises the depth for the paths a quantifier binds to must not expand the others deeper
+    /// than asked, since every path spends the same expansion budget. Null (the default) reads every path at
+    /// <paramref name="depth"/>, which still decides whether the read expands at all.</param>
     public static RecordFields ReadFields(IMajorRecordGetter record, IReadOnlyList<string>? paths = null, int depth = 1,
                                           string? containerHint = DepthExpandHint,
-                                          Func<IMajorRecordGetter, (IMajorRecordGetter? Parent, string? Why)>? parentOf = null)
+                                          Func<IMajorRecordGetter, (IMajorRecordGetter? Parent, string? Why)>? parentOf = null,
+                                          IReadOnlyList<int>? depths = null)
     {
         var typeName = RecordNaming.StripGetterInterface(WriteEngine.PrimaryGetter(record.GetType())?.Name ?? "I?Getter");
         var targets = paths is { Count: > 0 } ? (IEnumerable<string>)paths : ModeledFieldNames(typeName, record.GetType());
@@ -224,12 +229,18 @@ public static class ReadEngine
         else
         {
             int budget = MaxExpandNodes;
+            // Per-path depths only apply when they line up with the paths the caller named; anything else reads at
+            // the one depth, so a mismatched array can never quietly read a path at the wrong depth.
+            var perPath = paths is { Count: > 0 } && depths is not null && depths.Count == paths.Count ? depths : null;
+            int at = 0;
             foreach (var p in targets)
             {
+                int d = perPath is not null ? perPath[at] : depth;
+                at++;
                 var seg = p.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
                 var (on, tail, hopNote) = HopToParent(record, seg, parentOf);
                 if (hopNote is not null) { fields.Add(new FieldValue(p, false, null, hopNote, null, Present: false, Count: null, Readable: false)); continue; }
-                EmitWithDepth(on, string.Join(".", tail), depth, fields, ref budget, p);
+                EmitWithDepth(on, string.Join(".", tail), d, fields, ref budget, p);
             }
         }
         return new RecordFields(typeName, record.FormKey.ToString(), record.EditorID, fields);

--- a/src/housecarl-mcp-tests/RecordsFieldFoldTests.cs
+++ b/src/housecarl-mcp-tests/RecordsFieldFoldTests.cs
@@ -1,0 +1,136 @@
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// The PROJECT half of the quantified step: <c>project.fields</c>' <c>[*count]</c> (one number per record) and
+/// <c>[*]</c> (one row per element), driven end to end through the tool over the fixture's two-effect spell.
+/// </summary>
+[Collection("records")]
+[Trait("tier", "integration")]
+public sealed class RecordsFieldFoldTests : RecordsTestBase
+{
+    public RecordsFieldFoldTests(RecordsFixture f) : base(f) { }
+
+    string Spell(params string[] paths) =>
+        RecordsTools.Records(Svc, formids: new[] { Fid(W.SpellA) }, project: Fields(paths));
+
+    [Fact]
+    public void CountOnAListIsOneNumberPerRecord()
+    {
+        var r = Spell("Effects[*count]");
+        Served(r, "Effects[*count] = 2");
+        // The number, not the list: no element line survives.
+        Assert.DoesNotContain("Effects[0]", r);
+    }
+
+    [Fact]
+    public void CountReadsTheListWithoutOpeningIt()
+    {
+        // A count needs no expansion, so the call costs the depth-1 read even though [*] would force depth 4.
+        var r = RecordsTools.Records(Svc, types: new[] { "SPEL" }, format: "dense", project: Fields("Effects[*count]"));
+        var doc = Je(r);
+        Assert.Equal(new[] { "formid", "runtime_formid", "editorid", "Effects[*count]" },
+                     doc.GetProperty("columns").EnumerateArray().Select(c => c.GetString()).ToArray());
+        var spellA = doc.GetProperty("rows").EnumerateArray().First(x => x[2].GetString() == "HcRecSpellA");
+        Assert.Equal("2", spellA[3].GetString());
+    }
+
+    [Fact]
+    public void TheBareStarIsOneRowPerElement_TheRowsFormsOwnRowShape()
+    {
+        var r = Spell("Effects[*]");
+        Served(r, "Effects[0] = ", "Effects[1] = ");
+        // Each row carries the element's sub-fields inline, exactly as form='rows' renders them.
+        Assert.Contains("Data.Magnitude=5", RowLine(r, "Effects[0]"));
+        Assert.Contains("Data.Magnitude=4", RowLine(r, "Effects[1]"));
+        // And never as lines of their own — that is the whole difference from naming the list.
+        Assert.DoesNotContain("Effects[0].", r);
+    }
+
+    [Fact]
+    public void AQuantifiedPathComposesWithAnOrdinaryOne()
+    {
+        var r = Spell("EditorID", "Effects[*]");
+        Served(r, "EditorID = HcRecSpellA", "Effects[0] = ", "Effects[1] = ");
+    }
+
+    [Fact]
+    public void ASubPathAfterTheTokenIsThatLeafPerElement()
+    {
+        var r = Spell("Effects[*].Data.Magnitude");
+        Served(r, "Effects[0].Data.Magnitude = 5", "Effects[1].Data.Magnitude = 4");
+    }
+
+    [Fact]
+    public void DenseCarriesTheExtraRowsWithTheIdentityColumnsRepeated()
+    {
+        var doc = Je(RecordsTools.Records(Svc, formids: new[] { Fid(W.SpellA) }, types: new[] { "SPEL" },
+                                          format: "dense", project: Fields("EditorID", "Effects[*]")));
+        Assert.Equal(new[] { "formid", "runtime_formid", "editorid", "EditorID", "Effects[*]" },
+                     doc.GetProperty("columns").EnumerateArray().Select(c => c.GetString()).ToArray());
+        var rows = doc.GetProperty("rows").EnumerateArray().ToList();
+        Assert.Equal(2, rows.Count);                                    // one row per effect
+        Assert.Equal(rows[0][0].GetString(), rows[1][0].GetString());   // identity repeated, not omitted
+        Assert.Equal("HcRecSpellA", rows[0][3].GetString());            // the unquantified column repeats too
+        Assert.Equal("HcRecSpellA", rows[1][3].GetString());
+        Assert.Contains("Data.Magnitude=5", rows[0][4].GetString()!);
+        Assert.Contains("Data.Magnitude=4", rows[1][4].GetString()!);
+    }
+
+    [Fact]
+    public void AQuantifierOnANonListPathIsRefusedByName()
+    {
+        var r = Spell("EditorID[*]");
+        Assert.Contains("'EditorID[*]' quantifies a LIST", r);
+        Assert.Contains("'EditorID' on Spell", r);
+        Assert.Contains("drop the quantifier", r);
+    }
+
+    [Fact]
+    public void CountOnANonListPathIsRefusedTheSameWay() =>
+        Assert.Contains("'EditorID[*count]' quantifies a LIST", Spell("EditorID[*count]"));
+
+    [Fact]
+    public void AnAbsentListIsTheReadsAnswerNotAMisuseOfTheToken() =>
+        // No Effects field on a WEAP at all: the read says so under the caller's own spelling.
+        Served(RecordsTools.Records(Svc, formids: new[] { Fid(W.Weapons[1]) }, project: Fields("Effects[*count]")),
+               "Effects[*count]");
+
+    [Fact]
+    public void ABooleanFoldStaysInWhere() =>
+        Refused(Spell("Effects[*any].Data.Magnitude"), "not a row", "where=");
+
+    [Fact]
+    public void ANonQuantifierBracketKeyIsNamedATypo() =>
+        Refused(Spell("Effects[*sum]"), "is not a quantifier");
+
+    [Fact]
+    public void NothingCanFollowCount() =>
+        Refused(Spell("Effects[*count].Data"), "nothing can follow '[*count]'");
+
+    [Fact]
+    public void TwoQuantifiedStepsInOnePathAreRefused() =>
+        Refused(Spell("Effects[*].Conditions[*]"), "quantifies two steps");
+
+    [Fact]
+    public void TheTokenBelongsToTheFieldsForm() =>
+        Refused(RecordsTools.Records(Svc, formids: new[] { Fid(W.SpellA) },
+                    project: new RecordsTools.RecordsProject { form = "rows", fields = new[] { "Effects[*]" } }),
+                "the 'rows' form already folds");
+
+    [Fact]
+    public void DepthOneWouldCollapseTheElementsAway() =>
+        Refused(RecordsTools.Records(Svc, formids: new[] { Fid(W.SpellA) },
+                    project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "Effects[*]" }, depth = 1 }),
+                "Effects[*count]");
+
+    /// <summary>The one rendered line for a row, by its path.</summary>
+    static string RowLine(string response, string path)
+    {
+        var line = response.Split('\n').FirstOrDefault(l => l.TrimStart().StartsWith(path + " = ", StringComparison.Ordinal));
+        Assert.NotNull(line);
+        return line!;
+    }
+}

--- a/src/housecarl-mcp-tests/RecordsFieldFoldTests.cs
+++ b/src/housecarl-mcp-tests/RecordsFieldFoldTests.cs
@@ -210,6 +210,32 @@ public sealed class RecordsFieldFoldTests : RecordsTestBase
         Assert.NotEqual(JsonValueKind.Null, rows[1][4].ValueKind);
     }
 
+    /// <summary>A DICT list is keyed by its own keys, not by a position: a package's two Data arms keyed 2 and 7
+    /// are two rows, not eight with six empty ones, and the count the document reports is the same two.</summary>
+    [Fact]
+    public void ADictListLaysOneRowPerPairAndNotOnePerKeyValue()
+    {
+        var doc = Je(RecordsTools.Records(Svc, formids: new[] { Fid(W.Package) }, types: new[] { "PACK" },
+                                          format: "dense", project: Fields("Data[*]")));
+        var rows = doc.GetProperty("rows").EnumerateArray().ToList();
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(2, doc.GetProperty("rows_rendered").GetInt32());
+        Assert.Contains("HcRecDatumTwo", rows[0][3].GetString()!);
+        Assert.Contains("HcRecDatumSeven", rows[1][3].GetString()!);
+    }
+
+    /// <summary>The key a row is laid on is the bracket segment as text — the one shape that covers a positional
+    /// list and a dict alike.</summary>
+    [Fact]
+    public void AnElementKeyIsTheBracketSegmentItself()
+    {
+        Assert.Equal("0", FoldPlan.ElementKey("Effects[0].Data", "Effects"));
+        Assert.Equal("7", FoldPlan.ElementKey("Data[7]", "Data"));
+        Assert.Equal("Male", FoldPlan.ElementKey("WorldModel[Male]", "WorldModel"));
+        Assert.Null(FoldPlan.ElementKey("Effects", "Effects"));
+        Assert.Null(FoldPlan.ElementKey("Effects.Data", "Effects"));
+    }
+
     [Fact]
     public void TwoDifferentListsCannotShareOneDenseRow() =>
         Refused(RecordsTools.Records(Svc, types: new[] { "SPEL" }, format: "dense",

--- a/src/housecarl-mcp-tests/RecordsFieldFoldTests.cs
+++ b/src/housecarl-mcp-tests/RecordsFieldFoldTests.cs
@@ -66,6 +66,26 @@ public sealed class RecordsFieldFoldTests : RecordsTestBase
         Served(r, "Effects[0].Data.Magnitude = 5", "Effects[1].Data.Magnitude = 4");
     }
 
+    /// <summary>A bracketed index inside the sub-path costs an expansion level of its own, so a depth counted per
+    /// dotted SEGMENT stops the read one level short and the record answers "no element carries it" — a confident
+    /// wrong answer about a field that is right there.</summary>
+    [Fact]
+    public void AnIndexedSubPathIsReadDeepEnoughToReachIt()
+    {
+        Served(Spell("Effects[*].Conditions[0].Data"), "Effects[1].Conditions[0].Data = ");
+        Assert.DoesNotContain("no element of", Spell("Effects[*].Conditions[0].Data"));
+    }
+
+    /// <summary>The same need, at a depth the caller named: the default of 4 covers the shallower spelling, so the
+    /// claim only bites once the caller asks for less than the token needs.</summary>
+    [Fact]
+    public void TheTokensOwnDepthWinsOverALowerOneTheCallerNamed()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.SpellA) },
+                    project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "Effects[*].Conditions[0]" }, depth = 2 });
+        Served(r, "Effects[1].Conditions[0] = ");
+    }
+
     [Fact]
     public void DenseCarriesTheExtraRowsWithTheIdentityColumnsRepeated()
     {

--- a/src/housecarl-mcp-tests/RecordsFieldFoldTests.cs
+++ b/src/housecarl-mcp-tests/RecordsFieldFoldTests.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using HousecarlCore;
 using HousecarlMcp;
 using Xunit;
 
@@ -28,12 +30,13 @@ public sealed class RecordsFieldFoldTests : RecordsTestBase
     [Fact]
     public void CountReadsTheListWithoutOpeningIt()
     {
-        // A count needs no expansion, so the call costs the depth-1 read even though [*] would force depth 4.
-        var r = RecordsTools.Records(Svc, types: new[] { "SPEL" }, format: "dense", project: Fields("Effects[*count]"));
-        var doc = Je(r);
-        Assert.Equal(new[] { "formid", "runtime_formid", "editorid", "Effects[*count]" },
-                     doc.GetProperty("columns").EnumerateArray().Select(c => c.GetString()).ToArray());
-        var spellA = doc.GetProperty("rows").EnumerateArray().First(x => x[2].GetString() == "HcRecSpellA");
+        // The cost claim, on the one fixture that can prove it: the over-budget list truncates the moment it is
+        // expanded, so a count that reports the number WITHOUT that note never opened it.
+        var count = RecordsTools.Records(Svc, formids: new[] { Fid(W.BigList) }, project: Fields("Items[*count]"));
+        Served(count, "Items[*count] = " + (ReadEngine.MaxExpandNodes + 1));
+        Assert.DoesNotContain("expansion truncated", count);
+        var dense = Je(RecordsTools.Records(Svc, types: new[] { "SPEL" }, format: "dense", project: Fields("Effects[*count]")));
+        var spellA = dense.GetProperty("rows").EnumerateArray().First(x => x[2].GetString() == "HcRecSpellA");
         Assert.Equal("2", spellA[3].GetString());
     }
 
@@ -93,10 +96,15 @@ public sealed class RecordsFieldFoldTests : RecordsTestBase
         Assert.Contains("'EditorID[*count]' quantifies a LIST", Spell("EditorID[*count]"));
 
     [Fact]
-    public void AnAbsentListIsTheReadsAnswerNotAMisuseOfTheToken() =>
-        // No Effects field on a WEAP at all: the read says so under the caller's own spelling.
-        Served(RecordsTools.Records(Svc, formids: new[] { Fid(W.Weapons[1]) }, project: Fields("Effects[*count]")),
-               "Effects[*count]");
+    public void AnAbsentListIsTheReadsAnswerNotAMisuseOfTheToken()
+    {
+        // No Effects field on a WEAP at all: the read's own note carries out under the caller's spelling, and the
+        // count is NOT answered with a number — a missing field and an empty list are different answers.
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.Weapons[1]) }, project: Fields("Effects[*count]"));
+        Served(r, "Effects[*count]");
+        Assert.DoesNotContain("Effects[*count] = 0", r);
+        Assert.Contains("no field", Line(r, "Effects[*count]").ToLowerInvariant());
+    }
 
     [Fact]
     public void ABooleanFoldStaysInWhere() =>
@@ -126,11 +134,125 @@ public sealed class RecordsFieldFoldTests : RecordsTestBase
                     project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "Effects[*]" }, depth = 1 }),
                 "Effects[*count]");
 
-    /// <summary>The one rendered line for a row, by its path.</summary>
-    static string RowLine(string response, string path)
+    // ---- what the read said, carried through the fold ------------------------------------------------
+
+    /// <summary>The read's own cut is the case the fold could silently shorten: the elements past
+    /// <c>MaxExpandNodes</c> are missing from the rows, so the note that NAMES the cut has to survive the fold.
+    /// The fixture's over-budget FormList is the only record that reaches it.</summary>
+    [Fact]
+    public void ATruncatedExpansionStillSaysSoBesideTheShortRows()
     {
-        var line = response.Split('\n').FirstOrDefault(l => l.TrimStart().StartsWith(path + " = ", StringComparison.Ordinal));
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.BigList) }, project: Fields("Items[*]"));
+        Served(r, "expansion truncated");
+        // And with the fold's own remedy, not the fields form's: lowering the depth renders no rows at all.
+        Assert.Contains("the fold runs AFTER the read", r);
+    }
+
+    [Fact]
+    public void TheDenseDocumentCarriesTheCutToo()
+    {
+        var doc = Je(RecordsTools.Records(Svc, formids: new[] { Fid(W.BigList) }, types: new[] { "FLST" },
+                                          format: "dense", project: Fields("Items[*]"), max_chars: 400_000));
+        Assert.Contains("expansion truncated", doc.GetProperty("read_note").GetString()!);
+    }
+
+    // ---- an empty list is an answer -----------------------------------------------------------------
+
+    /// <summary>An empty list reads back present with zero elements. The rows form passes its summary line
+    /// through, so this spelling of the same row shape does too — a dropped path would be indistinguishable from
+    /// one that was never asked for.</summary>
+    [Fact]
+    public void AnEmptyListRendersItsOwnLineAndNotNothing()
+    {
+        // Effect 0 carries no conditions; effect 1 does — so the same call proves both halves.
+        Served(Spell("Effects[0].Conditions[*]"), "Effects[0].Conditions[*]");
+        Served(Spell("Effects[1].Conditions[*]"), "Effects[1].Conditions[0]");
+    }
+
+    [Fact]
+    public void CountOnAnEmptyListIsZero() =>
+        Served(Spell("Effects[0].Conditions[*count]"), "Effects[0].Conditions[*count] = 0");
+
+    // ---- dense: a cell belongs to its own element ---------------------------------------------------
+
+    /// <summary>A sub-path column emits no line for an element whose arm does not carry it, so pairing the
+    /// columns by POSITION would sit element 1's value on element 0's row and read as element 0's value.</summary>
+    [Fact]
+    public void ADenseCellSitsBesideItsOwnElementNeverTheNextOne()
+    {
+        var doc = Je(RecordsTools.Records(Svc, formids: new[] { Fid(W.SpellA) }, types: new[] { "SPEL" },
+                                          format: "dense", project: Fields("Effects[*]", "Effects[*].Conditions[0]")));
+        var rows = doc.GetProperty("rows").EnumerateArray().ToList();
+        Assert.Equal(2, rows.Count);
+        Assert.Contains("Data.Magnitude=5", rows[0][3].GetString()!);      // effect 0 — no conditions
+        Assert.Equal(JsonValueKind.Null, rows[0][4].ValueKind);
+        Assert.Contains("Data.Magnitude=4", rows[1][3].GetString()!);      // effect 1 — the only one with a condition
+        Assert.NotEqual(JsonValueKind.Null, rows[1][4].ValueKind);
+    }
+
+    [Fact]
+    public void TwoDifferentListsCannotShareOneDenseRow() =>
+        Refused(RecordsTools.Records(Svc, types: new[] { "SPEL" }, format: "dense",
+                                     project: Fields("Effects[*]", "Keywords[*]")),
+                "different lists", "one call per list");
+
+    /// <summary>The ceiling is a ROW property: one record's element rows are unbounded, so a cap consulted only
+    /// between records lets a single record overrun it.</summary>
+    [Fact]
+    public void DenseCapsTheElementRowsAndNotOnlyTheRecords()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.BigList) }, types: new[] { "FLST" },
+                                     format: "dense", project: Fields("Items[*]"), max_chars: 4000);
+        var doc = Je(r);
+        Assert.True(doc.GetProperty("truncated").GetBoolean());
+        Assert.True(doc.GetProperty("rows").GetArrayLength() < 100, $"rows={doc.GetProperty("rows").GetArrayLength()}");
+        Assert.True(r.Length <= 8000, $"len={r.Length}");
+        // `rendered` counts RECORDS, so the row count is its own number rather than a figure a consumer infers.
+        Assert.Equal(doc.GetProperty("rows").GetArrayLength(), doc.GetProperty("rows_rendered").GetInt32());
+    }
+
+    // ---- one fold, every lane -----------------------------------------------------------------------
+
+    /// <summary>The json document takes the body lane, not the dense render, so it is its own claim.</summary>
+    [Fact]
+    public void TheJsonDocumentCarriesTheSameElementRows()
+    {
+        var doc = Je(RecordsTools.Records(Svc, formids: new[] { Fid(W.SpellA) }, format: "json", project: Fields("Effects[*]")));
+        var paths = doc.GetProperty("records")[0].GetProperty("fields").EnumerateArray()
+                       .Select(f => f.GetProperty("path").GetString()).ToArray();
+        Assert.Equal(new[] { "Effects[0]", "Effects[1]" }, paths);
+    }
+
+    /// <summary>The one rendered line for a row, by its path.</summary>
+    static string RowLine(string response, string path) => Line(response, path + " = ");
+
+    /// <summary>The first rendered line whose own text starts with <paramref name="lead"/>.</summary>
+    static string Line(string response, string lead)
+    {
+        var line = response.Split('\n').FirstOrDefault(l => l.TrimStart().StartsWith(lead, StringComparison.Ordinal));
         Assert.NotNull(line);
         return line!;
+    }
+}
+
+/// <summary>The quantified projection's ARTIFACT lane: a to_file spill takes a different route from the inline
+/// render, and the claim is that both see the same folded fields.</summary>
+[Trait("tier", "integration")]
+public sealed class RecordsFieldFoldArtifactTests : ArtifactTestBase, IClassFixture<ArtifactFixture>
+{
+    public RecordsFieldFoldArtifactTests(ArtifactFixture f) : base(f) { }
+
+    [Fact]
+    public void TheArtifactCarriesTheSameElementRows()
+    {
+        var art = Art("fold-elements.jsonl");
+        RecordsTools.Records(Svc, types: new[] { "SPEL" }, to_file: art,
+                             project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "Effects[*]" } });
+        // The spilled row for the two-effect spell carries the ELEMENT rows and nothing else — not the list's
+        // summary line and not the per-sub-field lines the same depth-4 read would emit unfolded.
+        var row = File.ReadAllLines(art).First(l => l.Contains("HcRecSpellA", StringComparison.Ordinal));
+        var paths = Je(row).GetProperty("fields").EnumerateArray()
+                           .Select(f => f.GetProperty("path").GetString()).ToArray();
+        Assert.Equal(new[] { "Effects[0]", "Effects[1]" }, paths);
     }
 }

--- a/src/housecarl-mcp-tests/RecordsFieldFoldTests.cs
+++ b/src/housecarl-mcp-tests/RecordsFieldFoldTests.cs
@@ -231,6 +231,32 @@ public sealed class RecordsFieldFoldTests : RecordsTestBase
         Assert.Equal(doc.GetProperty("rows").GetArrayLength(), doc.GetProperty("rows_rendered").GetInt32());
     }
 
+    // ---- what the read is actually asked for --------------------------------------------------------
+
+    /// <summary>Two columns quantifying ONE list are one read of it: ReadEngine.ReadFields does not de-duplicate
+    /// its targets and spends a single expansion budget across them, so a repeated path walks the list twice on
+    /// that one budget. The unquantified column rides along at the caller's own depth.</summary>
+    [Fact]
+    public void OneListQuantifiedTwiceIsReadOnceAndSiblingsAtTheCallersDepth()
+    {
+        var (plan, err) = FieldFolds.Parse(new[] { "Effects[*]", "Effects[*].Data.Magnitude", "EditorID" });
+        Assert.Null(err);
+        var (paths, depths) = (plan! with { Depth = 4 }).Read();
+        Assert.Equal(new[] { "Effects", "EditorID" }, paths);
+        Assert.Equal(new[] { 4, 1 }, depths);
+    }
+
+    /// <summary>An unquantified column beside a quantified one renders at the caller's own depth, so it is READ at
+    /// that depth too — expanding it to the token's depth spends the shared budget on lines the render throws
+    /// away, and says the read was cut when the caller's own column is one collapsed line.</summary>
+    [Fact]
+    public void AnUnquantifiedColumnIsReadAtTheCallersOwnDepth()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.BigList) }, project: Fields("Items", "Effects[*]"));
+        Served(r, "Items = ");
+        Assert.DoesNotContain("expansion truncated", r);
+    }
+
     // ---- one fold, every lane -----------------------------------------------------------------------
 
     /// <summary>The json document takes the body lane, not the dense render, so it is its own claim.</summary>

--- a/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
+++ b/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
@@ -856,6 +856,18 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
         Assert.Contains("formids=", note);
     }
 
+    /// <summary>A quantified path renders the same rows through a fold of its own, and the clause is about the
+    /// cells those rows carry — so the folded dense branch has to register the annotated field too, or the
+    /// document states the values without the sentence that says what they are.</summary>
+    [Fact]
+    public void ADenseFoldStatesTheSameClauseTheUnfoldedRowsDo()
+    {
+        var doc = JsonDocument.Parse(RecordsTools.Records(Svc, types: new[] { "CELL" }, format: "dense",
+                                     project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "Temporary[*]" } }));
+        var note = doc.RootElement.GetProperty("owned_child_note").GetString()!;
+        Assert.Contains("Temporary", NamedFields(note, ReadSentences.NotReadFraming));
+    }
+
     /// <summary>The same cell named by formid IS unioned, so the two lanes differ by what the caller asked for,
     /// not by what is true.</summary>
     [Fact]

--- a/src/housecarl-mcp-tests/RecordsReferenceExclusionTests.cs
+++ b/src/housecarl-mcp-tests/RecordsReferenceExclusionTests.cs
@@ -123,18 +123,19 @@ public sealed class RecordsReferenceExclusionTests : RecordsTestBase
                 "not a row");
 
     [Fact]
-    public void TheProjectionHalfOfTheQuantifiedStepIsRefusedAsUnbuilt_NeverSilentlyMisread() =>
-        Refused(RecordsTools.Records(Svc, types: new[] { "SPEL" },
-                                     project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "Effects[*count]" } }),
-                "not built yet");
+    public void TheProjectionHalfOfTheQuantifiedStepAnswers() =>
+        // The count is a projection now, not a where=-only step; the fold's own behaviour is pinned in
+        // RecordsFieldFoldTests.
+        Served(RecordsTools.Records(Svc, types: new[] { "SPEL" },
+                                    project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "Effects[*count]" } }),
+               "Effects[*count] = 1");
 
     [Fact]
-    public void ANonQuantifierTokenInProjectFieldsIsNamedATypo_NotAnUnbuiltCapability()
+    public void ANonQuantifierTokenInProjectFieldsIsNamedATypo()
     {
         var r = RecordsTools.Records(Svc, types: new[] { "SPEL" },
                                      project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "Effects[*sum].Data.Magnitude" } });
         Assert.Contains("is not a quantifier", r);
-        Assert.DoesNotContain("not built yet", r);
     }
 
     [Fact]

--- a/src/housecarl-mcp-tests/RecordsWorld.cs
+++ b/src/housecarl-mcp-tests/RecordsWorld.cs
@@ -43,6 +43,7 @@ public sealed class RecordsWorld : IDisposable
     public FormKey SpellB { get; }
     public FormKey SpellC { get; }
     public FormKey BigList { get; }
+    public FormKey Package { get; }
     public FormKey NpcParent { get; }
     public FormKey NpcChild { get; }
     // A three-link chain of its own — MgefHop <- SpellHop <- ListHop — so a transitive reverse walk has a second
@@ -158,6 +159,12 @@ public sealed class RecordsWorld : IDisposable
         var bigList = master.FormLists.AddNew(); bigList.EditorID = "HcRecBigList"; BigList = bigList.FormKey;
         for (int i = 0; i < ReadEngine.MaxExpandNodes + 1; i++)
             bigList.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(weapons[i % weapons.Count]));
+
+        // A DICT-shaped list: a package's Data arms are keyed by their own numbers, sparsely — the shape a
+        // positional row key would either pad out with empty rows or pair by column position.
+        var pack = master.Packages.AddNew(); pack.EditorID = "HcRecPack"; Package = pack.FormKey;
+        pack.Data.Add(2, new PackageDataBool { Name = "HcRecDatumTwo" });
+        pack.Data.Add(7, new PackageDataBool { Name = "HcRecDatumSeven" });
 
         var npcParent = master.Npcs.AddNew(); npcParent.EditorID = "HcRecNpcParent"; NpcParent = npcParent.FormKey;
         var npcChild = master.Npcs.AddNew(); npcChild.EditorID = "HcRecNpcChild"; NpcChild = npcChild.FormKey;

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -119,7 +119,7 @@ internal static class Artifacts
         LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields,
         bool resolveNames, bool winnerFields, int depth,
         string path, string reason, IReadOnlyList<KeyValuePair<string, string>> query,
-        LeverNames? levers = null, int rowCap = int.MaxValue)
+        LeverNames? levers = null, int rowCap = int.MaxValue, FoldPlan? fold = null)
     {
         using var writer = new ResultArtifact.Writer();
         string[] schema;
@@ -149,6 +149,7 @@ internal static class Artifacts
                 var o = svc.ResolveReadOn(q, fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false, depth,
                                           resolveNames: resolveNames, linkMemo: linkMemo,
                                           containerHint: (levers ?? LeverNames.Legacy).ContainerHint);   // an artifact row is read by the same caller
+                if (fold is not null) o = fold.Apply(o);   // an artifact row carries the same folded fields the render does
                 if (o.Error is null && o.OwnedChildFields is { } af)   // the rows' labels need their clause on line 1
                 {
                     foreach (var annotatedPath in af.Keys) annotated.Add(annotatedPath);

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -142,13 +142,15 @@ internal static class Artifacts
             schema = new[] { "formid", "runtime_formid", "type", "editorid", "winner", "override_depth", "source", "matches?", "fields" };
             sort = "load-order scan order (deterministic within one epoch)";
             var linkMemo = resolveNames ? new LoadOrderService.LinkMemo() : null;
+            var foldDepths = fold?.Read().Depths;   // the quantified paths' depth, and the caller's own for the rest
             for (int i = 0; i < q.Keys.Count; i++)
             {
                 var fk = q.Keys[i];
                 string? matches = q.MatchedTargets is { } mt && i < mt.Count ? mt[i] : null;
                 var o = svc.ResolveReadOn(q, fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false, depth,
                                           resolveNames: resolveNames, linkMemo: linkMemo,
-                                          containerHint: (levers ?? LeverNames.Legacy).ContainerHint);   // an artifact row is read by the same caller
+                                          containerHint: (levers ?? LeverNames.Legacy).ContainerHint,
+                                          depths: foldDepths);   // an artifact row is read by the same caller
                 if (fold is not null) o = fold.Apply(o);   // an artifact row carries the same folded fields the render does
                 if (o.Error is null && o.OwnedChildFields is { } af)   // the rows' labels need their clause on line 1
                 {

--- a/src/housecarl-mcp/FieldFold.cs
+++ b/src/housecarl-mcp/FieldFold.cs
@@ -4,7 +4,13 @@ namespace HousecarlMcp;
 
 /// <summary>One project.fields path's quantified step: the LIST path the read actually runs, the sub-path after
 /// the quantifier (empty when the token ends the path), and the fold the caller spelled.</summary>
-sealed record FieldFold(string Requested, string Root, string[] Tail, PathFold Fold);
+sealed record FieldFold(string Requested, string Root, string[] Tail, PathFold Fold)
+{
+    /// <summary>How many expansion levels the sub-path adds below one element. A dotted step is one level and a
+    /// bracketed index inside a step is another, because <c>ReadEngine.Expand</c> spends one level on each — so
+    /// 'Conditions[0].Data' is three, not two, and counting segments alone stops the read a level short.</summary>
+    internal int TailLevels => Tail.Sum(s => 1 + s.Count(c => c == '['));
+}
 
 /// <summary>
 /// The PROJECT half of the quantified path step. <c>[*count]</c> on a project.fields path yields ONE number per
@@ -188,11 +194,12 @@ static class FieldFolds
         }
         if (!any) return (null, null);
         // The depth the TOKENS require: an element lives one level under its list, and each sub-path step after
-        // the token is one more. A [*count]-only plan needs no expansion at all — the list's own line carries the
-        // count. The caller's own depth is folded in above this, where it can still be deeper.
+        // the token is one more — a bracketed index in that sub-path being a step of its own. A [*count]-only plan
+        // needs no expansion at all — the list's own line carries the count. The caller's own depth is folded in
+        // above this, where it can still be deeper.
         int need = 1;
         foreach (var f in folds)
-            if (f is { Fold: PathFold.Set }) need = Math.Max(need, 2 + f.Tail.Length);
+            if (f is { Fold: PathFold.Set }) need = Math.Max(need, 2 + f.TailLevels);
         return (new FoldPlan(fields, readPaths, folds, need), null);
     }
 }

--- a/src/housecarl-mcp/FieldFold.cs
+++ b/src/housecarl-mcp/FieldFold.cs
@@ -1,0 +1,151 @@
+using HousecarlCore;
+
+namespace HousecarlMcp;
+
+/// <summary>One project.fields path's quantified step: the LIST path the read actually runs, the sub-path after
+/// the quantifier (empty when the token ends the path), and the fold the caller spelled.</summary>
+sealed record FieldFold(string Requested, string Root, string[] Tail, PathFold Fold);
+
+/// <summary>
+/// The PROJECT half of the quantified path step. <c>[*count]</c> on a project.fields path yields ONE number per
+/// record — how many elements the list holds. <c>[*]</c> yields ONE row per element: the row shape the 'rows'
+/// form produces, which is why the fold itself is <see cref="RowProjection"/>'s and not a second one, and why a
+/// sub-path after the token (<c>Effects[*].Data.Magnitude</c>) is one line per element instead.
+///
+/// <para>The tokens are read through <see cref="PathFoldGrammar"/>, the same tokenizer <c>where=</c> parses with,
+/// so a token means one thing on both surfaces. What differs is which folds each side accepts: a set is not a
+/// boolean and a boolean is not a row, so each surface refuses the other's folds by name.</para>
+/// </summary>
+sealed record FoldPlan(IReadOnlyList<string> Requested, string[] ReadPaths, FieldFold?[] Folds, int Depth)
+{
+    /// <summary>Does any path render per-element rows — the reading that needs the list opened.</summary>
+    internal bool RendersElements => Folds.Any(f => f is { Fold: PathFold.Set });
+
+    /// <summary>The first quantified path, for a refusal that has to name one.</summary>
+    internal FieldFold First => Folds.First(f => f is not null)!;
+
+    /// <summary>One record's lines, grouped per REQUESTED path and in the caller's own order: a quantified path
+    /// contributes its count cell or its element rows, an ordinary path the lines the read emitted for it.
+    /// Grouped rather than flat because the columnar render needs to know which column varies per element.</summary>
+    internal (IReadOnlyList<FieldValue>[]? Columns, string? Error) Columns(RecordFields rec)
+    {
+        var setRoots = Folds.Where(f => f is { Fold: PathFold.Set }).Select(f => f!.Root).Distinct(StringComparer.Ordinal)
+                            .OrderByDescending(r => r.Length).ToList();
+        // The element rows come from the 'rows' fold itself, run over the same lines — so a row here and a row
+        // under form='rows' are the same row, never two renderings of one idea.
+        var rows = setRoots.Count > 0 ? RowProjection.Fold(rec.Fields, setRoots, Depth) : rec.Fields;
+
+        var cols = new IReadOnlyList<FieldValue>[ReadPaths.Length];
+        for (int i = 0; i < ReadPaths.Length; i++)
+        {
+            if (Folds[i] is not { } fold) { cols[i] = Lines(rec.Fields, ReadPaths[i]); continue; }
+            var head = rec.Fields.FirstOrDefault(f => f.Path == fold.Root);
+            // An absent or unreadable list is the READ's answer, not a misuse of the token: it carries out under
+            // the caller's own spelling. A root that resolved to something with no elements at all IS a misuse,
+            // and it fails the record by name.
+            if (head is null || !head.Present || !head.Readable)
+            {
+                cols[i] = new[] { (head ?? new FieldValue(fold.Root, false, null, ReadEngine.AbsentNote, Present: false)) with { Path = fold.Requested } };
+                continue;
+            }
+            if (head.Count is null) return (null, NotAList(rec, fold, head));
+            cols[i] = fold.Fold == PathFold.Count
+                ? new[] { new FieldValue(fold.Requested, true, head.Count.Value.ToString(), null) }
+                : Elements(rows, rec.Fields, fold).ToList();
+        }
+        return (cols, null);
+    }
+
+    /// <summary>One outcome with its fields folded — a failed read has no body and passes through.</summary>
+    internal ReadOutcome Apply(ReadOutcome o)
+    {
+        if (o.Record is null) return o;
+        var (cols, error) = Columns(o.Record);
+        return error is null ? o with { Record = o.Record with { Fields = cols!.SelectMany(c => c).ToList() } }
+                             : o with { Record = null, Error = error };
+    }
+
+    internal IReadOnlyList<ReadOutcome> Apply(IReadOnlyList<ReadOutcome> outcomes)
+        => outcomes.Select(Apply).ToList();
+
+    /// <summary>The rows a <c>[*]</c> path contributes: the folded element line per element when the token ends
+    /// the path, else that element's own sub-path line. Emission order IS element order, since the read walks a
+    /// list in order.</summary>
+    static IEnumerable<FieldValue> Elements(IReadOnlyList<FieldValue> rows, IReadOnlyList<FieldValue> raw, FieldFold fold)
+    {
+        var roots = new[] { fold.Root };
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        if (fold.Tail.Length == 0)
+        {
+            foreach (var f in rows)
+                if (RowProjection.RowKey(f.Path, roots) == f.Path && seen.Add(f.Path))
+                    yield return f;
+            yield break;
+        }
+        var tail = "." + string.Join(".", fold.Tail);
+        foreach (var f in raw)
+            if (RowProjection.RowKey(f.Path, roots) is { } key && f.Path == key + tail && seen.Add(f.Path))
+                yield return f;
+    }
+
+    /// <summary>The lines an ordinary (unquantified) path contributed: its own, plus whatever the depth read
+    /// emitted under it.</summary>
+    static IReadOnlyList<FieldValue> Lines(IReadOnlyList<FieldValue> fields, string path)
+        => fields.Where(f => f.Path == path || RowProjection.IsUnder(f.Path, path)).ToList();
+
+    /// <summary>The sentence a quantifier on a non-list step fails the record with: the caller's path, what the
+    /// step actually holds, and the two ways to read it.</summary>
+    static string NotAList(RecordFields rec, FieldFold fold, FieldValue head)
+        => $"project.fields path '{fold.Requested}' quantifies a LIST, and '{fold.Root}' on {rec.Type} " +
+           $"{(head.HasValue ? "holds a single value" : "is a substruct")} — drop the quantifier to read it, " +
+           "or name a list path (index an element, e.g. 'Effects[0]', to read just that one).";
+}
+
+/// <summary>The projection-side parser for the quantified step.</summary>
+static class FieldFolds
+{
+    /// <summary>Parse project.fields into the paths the READ runs plus the fold each requested path declares, or
+    /// the one-sentence refusal. Null plan = no path carries a quantifier. Every refusal names the caller's own
+    /// path and what to write instead, and the parse runs before any read so a bad token refuses the CALL rather
+    /// than each record.</summary>
+    internal static (FoldPlan? Plan, string? Error) Parse(IReadOnlyList<string> fields)
+    {
+        var readPaths = new string[fields.Count];
+        var folds = new FieldFold?[fields.Count];
+        bool any = false;
+        for (int i = 0; i < fields.Count; i++)
+        {
+            var path = fields[i] ?? "";
+            readPaths[i] = path;
+            var segs = path.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            for (int s = 0; s < segs.Length; s++)
+            {
+                // A quantifier on the containment step is that grammar's mistake, not a projection one — left to
+                // the read walk's shared check, so where= and project.fields refuse it in the same sentence.
+                var (bare, fold, key) = PathFoldGrammar.Read(segs[s]);
+                if (key is null || ContainmentIndex.IsParentStep(bare)) continue;
+                if (folds[i] is not null)
+                    return (null, $"project.fields path '{path}' quantifies two steps, and one row per element of one list is the shape this form renders — quantify the outer step and read the inner list on the row, or name a concrete element of one of them.");
+                if (bare.Length == 0)
+                    return (null, $"project.fields path '{path}': '{segs[s]}' has no field name before '[' — a quantifier binds to a list field, e.g. 'Conditions[*]'.");
+                if (fold == PathFold.None)
+                    return (null, $"project.fields path '{path}': '[{key}]' is not a quantifier — the tokens are [*], [*count], [*any], [*all] and [*none] (the last three fold to a boolean and belong in where=).");
+                if (fold is PathFold.Any or PathFold.All or PathFold.NoneOf)
+                    return (null, $"project.fields path '{path}' folds the elements into a boolean, and a boolean is not a row — use {PathFoldGrammar.Token(fold)} in where= to SELECT the records, and [*] here to read one row per element.");
+                if (fold == PathFold.Count && s != segs.Length - 1)
+                    return (null, $"project.fields path '{path}': nothing can follow '[*count]' — it yields how MANY elements there are, not an element to step into.");
+                folds[i] = new FieldFold(path, string.Join(".", segs[..s].Append(bare)), segs[(s + 1)..], fold);
+                readPaths[i] = folds[i]!.Root;
+                any = true;
+            }
+        }
+        if (!any) return (null, null);
+        // The depth the TOKENS require: an element lives one level under its list, and each sub-path step after
+        // the token is one more. A [*count]-only plan needs no expansion at all — the list's own line carries the
+        // count. The caller's own depth is folded in above this, where it can still be deeper.
+        int need = 1;
+        foreach (var f in folds)
+            if (f is { Fold: PathFold.Set }) need = Math.Max(need, 2 + f.Tail.Length);
+        return (new FoldPlan(fields, readPaths, folds, need), null);
+    }
+}

--- a/src/housecarl-mcp/FieldFold.cs
+++ b/src/housecarl-mcp/FieldFold.cs
@@ -16,7 +16,7 @@ sealed record FieldFold(string Requested, string Root, string[] Tail, PathFold F
 /// so a token means one thing on both surfaces. What differs is which folds each side accepts: a set is not a
 /// boolean and a boolean is not a row, so each surface refuses the other's folds by name.</para>
 /// </summary>
-sealed record FoldPlan(IReadOnlyList<string> Requested, string[] ReadPaths, FieldFold?[] Folds, int Depth)
+sealed record FoldPlan(IReadOnlyList<string> Requested, string[] ReadPaths, FieldFold?[] Folds, int Depth, int CallerDepth = 1)
 {
     /// <summary>Does any path render per-element rows — the reading that needs the list opened.</summary>
     internal bool RendersElements => Folds.Any(f => f is { Fold: PathFold.Set });
@@ -24,13 +24,20 @@ sealed record FoldPlan(IReadOnlyList<string> Requested, string[] ReadPaths, Fiel
     /// <summary>The first quantified path, for a refusal that has to name one.</summary>
     internal FieldFold First => Folds.First(f => f is not null)!;
 
+    /// <summary>The distinct LIST paths a <c>[*]</c> binds to — one row per element is one list's reading, so a
+    /// render that flattens the rows has to know when a call names two.</summary>
+    internal IReadOnlyList<string> SetRoots =>
+        Folds.Where(f => f is { Fold: PathFold.Set }).Select(f => f!.Root).Distinct(StringComparer.Ordinal).ToList();
+
     /// <summary>One record's lines, grouped per REQUESTED path and in the caller's own order: a quantified path
     /// contributes its count cell or its element rows, an ordinary path the lines the read emitted for it.
-    /// Grouped rather than flat because the columnar render needs to know which column varies per element.</summary>
-    internal (IReadOnlyList<FieldValue>[]? Columns, string? Error) Columns(RecordFields rec)
+    /// Grouped rather than flat because the columnar render needs to know which column varies per element.
+    /// <paramref name="Carried"/> is what the read said that no column claims — the expansion-truncation note
+    /// above all: the fold runs after the read, so a cut the read named must survive the fold or the answer is
+    /// short with nothing saying so.</summary>
+    internal (IReadOnlyList<FieldValue>[]? Columns, IReadOnlyList<FieldValue> Carried, string? Error) Columns(RecordFields rec)
     {
-        var setRoots = Folds.Where(f => f is { Fold: PathFold.Set }).Select(f => f!.Root).Distinct(StringComparer.Ordinal)
-                            .OrderByDescending(r => r.Length).ToList();
+        var setRoots = SetRoots.OrderByDescending(r => r.Length).ToList();
         // The element rows come from the 'rows' fold itself, run over the same lines — so a row here and a row
         // under form='rows' are the same row, never two renderings of one idea.
         var rows = setRoots.Count > 0 ? RowProjection.Fold(rec.Fields, setRoots, Depth) : rec.Fields;
@@ -38,30 +45,45 @@ sealed record FoldPlan(IReadOnlyList<string> Requested, string[] ReadPaths, Fiel
         var cols = new IReadOnlyList<FieldValue>[ReadPaths.Length];
         for (int i = 0; i < ReadPaths.Length; i++)
         {
-            if (Folds[i] is not { } fold) { cols[i] = Lines(rec.Fields, ReadPaths[i]); continue; }
+            if (Folds[i] is not { } fold) { cols[i] = Lines(rec.Fields, ReadPaths[i], CallerDepth); continue; }
             var head = rec.Fields.FirstOrDefault(f => f.Path == fold.Root);
             // An absent or unreadable list is the READ's answer, not a misuse of the token: it carries out under
-            // the caller's own spelling. A root that resolved to something with no elements at all IS a misuse,
-            // and it fails the record by name.
+            // the caller's own spelling. Only a root that is not a list at all is a misuse, and that fails the
+            // record by name.
             if (head is null || !head.Present || !head.Readable)
             {
                 cols[i] = new[] { (head ?? new FieldValue(fold.Root, false, null, ReadEngine.AbsentNote, Present: false)) with { Path = fold.Requested } };
                 continue;
             }
-            if (head.Count is null) return (null, NotAList(rec, fold, head));
-            cols[i] = fold.Fold == PathFold.Count
-                ? new[] { new FieldValue(fold.Requested, true, head.Count.Value.ToString(), null) }
-                : Elements(rows, rec.Fields, fold).ToList();
+            if (head.Count is null) return (null, Array.Empty<FieldValue>(), NotAList(rec, fold, head));
+            if (fold.Fold == PathFold.Count)
+            {
+                cols[i] = new[] { new FieldValue(fold.Requested, true, head.Count.Value.ToString(), null) };
+                continue;
+            }
+            var elems = Elements(rows, rec.Fields, fold).ToList();
+            // No element row is still an ANSWER and never an empty column: an empty list carries its own summary
+            // line out under the caller's spelling — the same line form='rows' passes through — and a sub-path no
+            // element carries says that in one note. A dropped path would read as never asked for.
+            cols[i] = elems.Count > 0 ? elems
+                    : head.Count.Value == 0 ? new[] { head with { Path = fold.Requested } }
+                    : new[] { new FieldValue(fold.Requested, false, null, NoElement(fold, head.Count.Value)) };
         }
-        return (cols, null);
+        var claimed = new HashSet<string>(cols.SelectMany(c => c).Select(f => f.Path), StringComparer.Ordinal);
+        // What no column claims and no requested path covers: the read's own truncation note, restated by the
+        // rows fold when one ran. It rides out beside the columns rather than being dropped with them.
+        var carried = (setRoots.Count > 0 ? rows : rec.Fields)
+            .Where(f => !claimed.Contains(f.Path) && !ReadPaths.Any(p => f.Path == p || RowProjection.IsUnder(f.Path, p)))
+            .ToList();
+        return (cols, carried, null);
     }
 
     /// <summary>One outcome with its fields folded — a failed read has no body and passes through.</summary>
     internal ReadOutcome Apply(ReadOutcome o)
     {
         if (o.Record is null) return o;
-        var (cols, error) = Columns(o.Record);
-        return error is null ? o with { Record = o.Record with { Fields = cols!.SelectMany(c => c).ToList() } }
+        var (cols, carried, error) = Columns(o.Record);
+        return error is null ? o with { Record = o.Record with { Fields = cols!.SelectMany(c => c).Concat(carried).ToList() } }
                              : o with { Record = null, Error = error };
     }
 
@@ -88,10 +110,33 @@ sealed record FoldPlan(IReadOnlyList<string> Requested, string[] ReadPaths, Fiel
                 yield return f;
     }
 
-    /// <summary>The lines an ordinary (unquantified) path contributed: its own, plus whatever the depth read
-    /// emitted under it.</summary>
-    static IReadOnlyList<FieldValue> Lines(IReadOnlyList<FieldValue> fields, string path)
-        => fields.Where(f => f.Path == path || RowProjection.IsUnder(f.Path, path)).ToList();
+    /// <summary>The lines an ordinary (unquantified) path contributed, at the depth the CALLER asked for: a
+    /// quantifier raises the read's depth for the paths that need it, and an unquantified column beside one must
+    /// still render what it would have rendered alone.</summary>
+    static IReadOnlyList<FieldValue> Lines(IReadOnlyList<FieldValue> fields, string path, int depth)
+        => fields.Where(f => f.Path == path || (RowProjection.IsUnder(f.Path, path) && Levels(f.Path, path) < depth)).ToList();
+
+    /// <summary>How many expansion levels below <paramref name="owner"/> a path sits — one per '.' or '[' step,
+    /// which is the unit project.depth counts.</summary>
+    static int Levels(string path, string owner)
+    {
+        int n = 0;
+        for (int i = owner.Length; i < path.Length; i++) if (path[i] == '.' || path[i] == '[') n++;
+        return n;
+    }
+
+    /// <summary>The element index a folded line carries, or -1 when the path does not index the root.</summary>
+    internal static int ElementIndex(string path, string root)
+    {
+        if (path.Length <= root.Length || path[root.Length] != '[') return -1;
+        int close = path.IndexOf(']', root.Length + 1);
+        return close > 0 && int.TryParse(path.AsSpan(root.Length + 1, close - root.Length - 1), out int n) ? n : -1;
+    }
+
+    /// <summary>The note a sub-path no element carries answers with — the list was read, it holds elements, and
+    /// none of them has that field.</summary>
+    static string NoElement(FieldFold fold, int count)
+        => $"(no element of '{fold.Root}' carries '{string.Join(".", fold.Tail)}' — the list holds {count})";
 
     /// <summary>The sentence a quantifier on a non-list step fails the record with: the caller's path, what the
     /// step actually holds, and the two ways to read it.</summary>

--- a/src/housecarl-mcp/FieldFold.cs
+++ b/src/housecarl-mcp/FieldFold.cs
@@ -83,7 +83,9 @@ sealed record FoldPlan(IReadOnlyList<string> Requested, string[] ReadPaths, Fiel
     {
         if (o.Record is null) return o;
         var (cols, carried, error) = Columns(o.Record);
-        return error is null ? o with { Record = o.Record with { Fields = cols!.SelectMany(c => c).Concat(carried).ToList() } }
+        // The carried note leads: it is what the read did to the columns below it, and a render that hits its own
+        // ceiling part-way down the rows would drop a note written after them.
+        return error is null ? o with { Record = o.Record with { Fields = carried.Concat(cols!.SelectMany(c => c)).ToList() } }
                              : o with { Record = null, Error = error };
     }
 

--- a/src/housecarl-mcp/FieldFold.cs
+++ b/src/housecarl-mcp/FieldFold.cs
@@ -153,12 +153,15 @@ sealed record FoldPlan(IReadOnlyList<string> Requested, string[] Paths, FieldFol
         return n;
     }
 
-    /// <summary>The element index a folded line carries, or -1 when the path does not index the root.</summary>
-    internal static int ElementIndex(string path, string root)
+    /// <summary>The element KEY a folded line carries — the bracket segment just under the root, as text — or null
+    /// when the path does not index the root. Text rather than a number because the read brackets a DICT by its own
+    /// key (a package's Data arms are keyed 2, 7, …, and another list's keys need not be numbers at all), so a
+    /// number would either invent the elements between two keys or fall back to a position.</summary>
+    internal static string? ElementKey(string path, string root)
     {
-        if (path.Length <= root.Length || path[root.Length] != '[') return -1;
+        if (path.Length <= root.Length || path[root.Length] != '[') return null;
         int close = path.IndexOf(']', root.Length + 1);
-        return close > 0 && int.TryParse(path.AsSpan(root.Length + 1, close - root.Length - 1), out int n) ? n : -1;
+        return close > 0 ? path[(root.Length + 1)..close] : null;
     }
 
     /// <summary>The note a sub-path no element carries answers with — the list was read, it holds elements, and

--- a/src/housecarl-mcp/FieldFold.cs
+++ b/src/housecarl-mcp/FieldFold.cs
@@ -22,8 +22,28 @@ sealed record FieldFold(string Requested, string Root, string[] Tail, PathFold F
 /// so a token means one thing on both surfaces. What differs is which folds each side accepts: a set is not a
 /// boolean and a boolean is not a row, so each surface refuses the other's folds by name.</para>
 /// </summary>
-sealed record FoldPlan(IReadOnlyList<string> Requested, string[] ReadPaths, FieldFold?[] Folds, int Depth, int CallerDepth = 1)
+sealed record FoldPlan(IReadOnlyList<string> Requested, string[] Paths, FieldFold?[] Folds, int Depth, int CallerDepth = 1)
 {
+    /// <summary>What the READ is asked for: each distinct path once, with the depth that path's own column needs
+    /// beside it. Distinct because ReadEngine.ReadFields does not de-duplicate its targets and spends ONE expansion
+    /// budget across them, so two columns quantifying the same list would walk it twice and halve what either can
+    /// show. Per-depth because the token raises the depth only for the paths that need it: an unquantified column
+    /// beside a quantified one renders at the caller's own depth, and reading it deeper spends that same budget on
+    /// lines the render then throws away.</summary>
+    internal (string[] Paths, int[] Depths) Read()
+    {
+        var at = new Dictionary<string, int>(StringComparer.Ordinal);
+        var paths = new List<string>(Paths.Length);
+        var depths = new List<int>(Paths.Length);
+        for (int i = 0; i < Paths.Length; i++)
+        {
+            int d = Folds[i] is { Fold: PathFold.Set } ? Depth : CallerDepth;
+            if (at.TryGetValue(Paths[i], out int j)) { depths[j] = Math.Max(depths[j], d); continue; }
+            at[Paths[i]] = paths.Count; paths.Add(Paths[i]); depths.Add(d);
+        }
+        return (paths.ToArray(), depths.ToArray());
+    }
+
     /// <summary>Does any path render per-element rows — the reading that needs the list opened.</summary>
     internal bool RendersElements => Folds.Any(f => f is { Fold: PathFold.Set });
 
@@ -48,10 +68,10 @@ sealed record FoldPlan(IReadOnlyList<string> Requested, string[] ReadPaths, Fiel
         // under form='rows' are the same row, never two renderings of one idea.
         var rows = setRoots.Count > 0 ? RowProjection.Fold(rec.Fields, setRoots, Depth) : rec.Fields;
 
-        var cols = new IReadOnlyList<FieldValue>[ReadPaths.Length];
-        for (int i = 0; i < ReadPaths.Length; i++)
+        var cols = new IReadOnlyList<FieldValue>[Paths.Length];
+        for (int i = 0; i < Paths.Length; i++)
         {
-            if (Folds[i] is not { } fold) { cols[i] = Lines(rec.Fields, ReadPaths[i], CallerDepth); continue; }
+            if (Folds[i] is not { } fold) { cols[i] = Lines(rec.Fields, Paths[i], CallerDepth); continue; }
             var head = rec.Fields.FirstOrDefault(f => f.Path == fold.Root);
             // An absent or unreadable list is the READ's answer, not a misuse of the token: it carries out under
             // the caller's own spelling. Only a root that is not a list at all is a misuse, and that fails the
@@ -79,7 +99,7 @@ sealed record FoldPlan(IReadOnlyList<string> Requested, string[] ReadPaths, Fiel
         // What no column claims and no requested path covers: the read's own truncation note, restated by the
         // rows fold when one ran. It rides out beside the columns rather than being dropped with them.
         var carried = (setRoots.Count > 0 ? rows : rec.Fields)
-            .Where(f => !claimed.Contains(f.Path) && !ReadPaths.Any(p => f.Path == p || RowProjection.IsUnder(f.Path, p)))
+            .Where(f => !claimed.Contains(f.Path) && !Paths.Any(p => f.Path == p || RowProjection.IsUnder(f.Path, p)))
             .ToList();
         return (cols, carried, null);
     }

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1252,6 +1252,8 @@ static class JsonWire
                 int rendered = 0; bool rowsTruncated = false;
                 var childFields = new SortedSet<string>(StringComparer.Ordinal);   // the clause once, over the cells the rows carried
                 bool childUnioned = false;   // which TIER those rows stated — the scan lanes annotate index-only
+                var foldNotes = new SortedSet<string>(StringComparer.Ordinal);   // what the read said that no column carries — the truncation note above all
+                int foldRows = 0;            // rows, which a fold makes ELEMENTS; `rendered` stays records
                 w.WriteStartArray("rows");
                 for (int i = 0; i < q.Keys.Count && !manifestOnly; i++)      // to_file: the rows are the FILE
                 {
@@ -1270,12 +1272,39 @@ static class JsonWire
                             // A quantified path makes the requested paths PER ELEMENT, so the record answers with
                             // one row per element and repeats its identity columns on each. The unquantified
                             // columns keep their own single cell, which is the same cell an unfolded call renders.
-                            var (cols, ferr) = fold.Columns(r);
+                            var (cols, carried, ferr) = fold.Columns(r);
                             if (ferr is not null) { (errors ??= new()).Add((fk.ToString(), ferr)); rendered++; continue; }
+                            // A row is keyed by its ELEMENT INDEX, never by its place in the column: a sub-path
+                            // column skips an element whose arm does not carry it, and by position that cell
+                            // would land beside a different element's row and read as that element's value.
+                            var byIndex = new Dictionary<int, HousecarlCore.FieldValue>?[cols!.Length];
                             int elems = 1;
-                            for (int c = 0; c < cols!.Length; c++) if (fold.Folds[c] is { Fold: HousecarlCore.PathFold.Set }) elems = Math.Max(elems, cols[c].Count);
+                            for (int c = 0; c < cols.Length; c++)
+                            {
+                                if (fold.Folds[c] is not { Fold: HousecarlCore.PathFold.Set } fc) continue;
+                                var map = byIndex[c] = new Dictionary<int, HousecarlCore.FieldValue>();
+                                for (int k = 0; k < cols[c].Count; k++)
+                                {
+                                    int idx = FoldPlan.ElementIndex(cols[c][k].Path, fc.Root);
+                                    map[idx < 0 ? k : idx] = cols[c][k];
+                                }
+                                foreach (var idx in map.Keys) elems = Math.Max(elems, idx + 1);
+                            }
+                            // The owned-child clause is earned per CELL here as it is on the unfolded row below;
+                            // a folded cell's path is the element's, so the column's own list path is the key.
+                            for (int c = 0; c < cols.Length; c++)
+                            {
+                                var owner = fold.Folds[c]?.Root ?? (cols[c].Count > 0 ? cols[c][0].Path : null);
+                                if (owner is not null && o.OwnedChildFields?.ContainsKey(owner) == true) { childFields.Add(owner); childUnioned |= o.OwnedChildUnioned; }
+                            }
+                            foreach (var note in carried) if (note.Note is { } n) foldNotes.Add(n);
+                            bool cut = false;
                             for (int e = 0; e < elems; e++)
                             {
+                                // The cap is per ROW, not per record: one record's element rows are unbounded, so
+                                // a check that only runs between records lets one blow past the caller's ceiling.
+                                w.Flush();
+                                if (ms.Length >= cap) { rowsTruncated = true; cut = true; break; }
                                 w.WriteStartArray();
                                 w.WriteStringValue(r.FormKey);
                                 WriteCell(w, RuntimeCell(o.RuntimeFormId, o.RuntimeFormIdNote));
@@ -1283,15 +1312,16 @@ static class JsonWire
                                 for (int c = 0; c < cols.Length; c++)
                                 {
                                     var col = cols[c];
-                                    var cell = fold.Folds[c] is { Fold: HousecarlCore.PathFold.Set }
-                                        ? (e < col.Count ? col[e] : null)
-                                        : (col.Count > 0 ? col[0] : null);
+                                    var cell = byIndex[c] is { } map ? (map.TryGetValue(e, out var v) ? v : null)
+                                                                     : (col.Count > 0 ? col[0] : null);
                                     WriteCell(w, cell is null ? null : DenseCell(cell));
                                 }
                                 if (anyScoped) WriteCell(w, o.SourcePlugin);
                                 if (hasMatches) WriteCell(w, matches);
                                 w.WriteEndArray();
+                                foldRows++;
                             }
+                            if (cut) break;                                   // a half-written record is not a rendered one
                             rendered++;
                             continue;
                         }
@@ -1335,8 +1365,13 @@ static class JsonWire
                     w.WriteEndArray();
                 }
                 w.WriteNumber("rendered", rendered);
+                // A fold makes a row an ELEMENT, so `rendered` (records) no longer counts the rows: say both.
+                if (fold is not null) w.WriteNumber("rows_rendered", foldRows);
                 w.WriteBoolean("truncated", rowsTruncated);
                 WriteOwnedChildNote(w, childFields, childUnioned);
+                // The read's own note — a truncated expansion above all — belongs to the document whose rows the
+                // fold shortened, or the answer is short with nothing saying so.
+                if (foldNotes.Count > 0) w.WriteString("read_note", string.Join(" ", foldNotes));
                 truncated = rowsTruncated;
             }
             if (spill is not null && q.Error is null) Artifacts.WriteSpillStateJson(w, spill);

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1248,6 +1248,7 @@ static class JsonWire
                 w.WriteEndArray();
 
                 var linkMemo = resolveNames && detail ? new LoadOrderService.LinkMemo() : null;
+                var foldDepths = fold?.Read().Depths;   // the quantified paths' depth, and the caller's own for the rest
                 List<(string Formid, string Error)>? errors = null;
                 int rendered = 0; bool rowsTruncated = false;
                 var childFields = new SortedSet<string>(StringComparer.Ordinal);   // the clause once, over the cells the rows carried
@@ -1264,7 +1265,8 @@ static class JsonWire
                     if (detail)
                     {
                         var o = svc.ResolveReadOn(q, fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false, fold?.Depth ?? 1,
-                                                  resolveNames: resolveNames, linkMemo: linkMemo, containerHint: (levers ?? LeverNames.Legacy).DenseContainerHint);   // dense refuses depth>1 unless a quantifier asks for it; pinned to the scan's build
+                                                  resolveNames: resolveNames, linkMemo: linkMemo, containerHint: (levers ?? LeverNames.Legacy).DenseContainerHint,
+                                                  depths: foldDepths);   // dense refuses depth>1 unless a quantifier asks for it; pinned to the scan's build
                         if (o.Error is not null) { (errors ??= new()).Add((fk.ToString(), o.Error)); rendered++; continue; }
                         var r = o.Record!;
                         if (fold is not null)

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1206,7 +1206,8 @@ static class JsonWire
 
     public static string RenderCrossQueryDense(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, int maxChars, bool resolveNames, bool winnerFields,
                                                SpillState? spill, out bool truncated,
-                                               IReadOnlyList<KeyValuePair<string, string>>? envelope = null, LeverNames? levers = null)
+                                               IReadOnlyList<KeyValuePair<string, string>>? envelope = null, LeverNames? levers = null,
+                                               FoldPlan? fold = null)
     {
         truncated = false;
         int cap = Cap(maxChars);
@@ -1234,7 +1235,7 @@ static class JsonWire
                 if (detail)
                 {
                     w.WriteStringValue("formid"); w.WriteStringValue("runtime_formid"); w.WriteStringValue("editorid");
-                    foreach (var f in fields!) w.WriteStringValue(f);         // cells align positionally: ReadFields returns exactly one value per requested path, in order
+                    foreach (var f in fold?.Requested ?? fields!) w.WriteStringValue(f);   // cells align positionally: one column per REQUESTED path, in order — a quantified path keeps its own spelling
                     // Under a plugins= scope each row's values are SOME scoped plugin's own body, and with 2+ scoped
                     // plugins the caller cannot reconstruct WHICH from the row alone — a defining esp's stale value
                     // then reads as live truth. Carry the provenance per row, exactly like text ("fields (from X):")
@@ -1260,10 +1261,40 @@ static class JsonWire
                     string? matches = q.MatchedTargets is { } mt && i < mt.Count ? mt[i] : null;
                     if (detail)
                     {
-                        var o = svc.ResolveReadOn(q, fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false,
-                                                  resolveNames: resolveNames, linkMemo: linkMemo, containerHint: (levers ?? LeverNames.Legacy).DenseContainerHint);   // dense refuses depth>1, so the hint names the format hop; pinned to the scan's build
+                        var o = svc.ResolveReadOn(q, fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false, fold?.Depth ?? 1,
+                                                  resolveNames: resolveNames, linkMemo: linkMemo, containerHint: (levers ?? LeverNames.Legacy).DenseContainerHint);   // dense refuses depth>1 unless a quantifier asks for it; pinned to the scan's build
                         if (o.Error is not null) { (errors ??= new()).Add((fk.ToString(), o.Error)); rendered++; continue; }
                         var r = o.Record!;
+                        if (fold is not null)
+                        {
+                            // A quantified path makes the requested paths PER ELEMENT, so the record answers with
+                            // one row per element and repeats its identity columns on each. The unquantified
+                            // columns keep their own single cell, which is the same cell an unfolded call renders.
+                            var (cols, ferr) = fold.Columns(r);
+                            if (ferr is not null) { (errors ??= new()).Add((fk.ToString(), ferr)); rendered++; continue; }
+                            int elems = 1;
+                            for (int c = 0; c < cols!.Length; c++) if (fold.Folds[c] is { Fold: HousecarlCore.PathFold.Set }) elems = Math.Max(elems, cols[c].Count);
+                            for (int e = 0; e < elems; e++)
+                            {
+                                w.WriteStartArray();
+                                w.WriteStringValue(r.FormKey);
+                                WriteCell(w, RuntimeCell(o.RuntimeFormId, o.RuntimeFormIdNote));
+                                WriteCell(w, r.EditorId);
+                                for (int c = 0; c < cols.Length; c++)
+                                {
+                                    var col = cols[c];
+                                    var cell = fold.Folds[c] is { Fold: HousecarlCore.PathFold.Set }
+                                        ? (e < col.Count ? col[e] : null)
+                                        : (col.Count > 0 ? col[0] : null);
+                                    WriteCell(w, cell is null ? null : DenseCell(cell));
+                                }
+                                if (anyScoped) WriteCell(w, o.SourcePlugin);
+                                if (hasMatches) WriteCell(w, matches);
+                                w.WriteEndArray();
+                            }
+                            rendered++;
+                            continue;
+                        }
                         w.WriteStartArray();
                         w.WriteStringValue(r.FormKey);
                         WriteCell(w, RuntimeCell(o.RuntimeFormId, o.RuntimeFormIdNote));

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1276,22 +1276,29 @@ static class JsonWire
                             // columns keep their own single cell, which is the same cell an unfolded call renders.
                             var (cols, carried, ferr) = fold.Columns(r);
                             if (ferr is not null) { (errors ??= new()).Add((fk.ToString(), ferr)); rendered++; continue; }
-                            // A row is keyed by its ELEMENT INDEX, never by its place in the column: a sub-path
+                            // A row is keyed by its ELEMENT KEY, never by its place in the column: a sub-path
                             // column skips an element whose arm does not carry it, and by position that cell
-                            // would land beside a different element's row and read as that element's value.
-                            var byIndex = new Dictionary<int, HousecarlCore.FieldValue>?[cols!.Length];
-                            int elems = 1;
+                            // would land beside a different element's row and read as that element's value. The key
+                            // is the bracket segment as TEXT, so a dict list (a package's Data arms, keyed 2 and 7)
+                            // lays two rows rather than eight, six of them empty. Rows come out in key order for a
+                            // positional list and in read order otherwise.
+                            var byKey = new Dictionary<string, HousecarlCore.FieldValue>?[cols!.Length];
+                            var keys = new List<string>();
+                            var seenKeys = new HashSet<string>(StringComparer.Ordinal);
                             for (int c = 0; c < cols.Length; c++)
                             {
                                 if (fold.Folds[c] is not { Fold: HousecarlCore.PathFold.Set } fc) continue;
-                                var map = byIndex[c] = new Dictionary<int, HousecarlCore.FieldValue>();
+                                var map = byKey[c] = new Dictionary<string, HousecarlCore.FieldValue>(StringComparer.Ordinal);
                                 for (int k = 0; k < cols[c].Count; k++)
                                 {
-                                    int idx = FoldPlan.ElementIndex(cols[c][k].Path, fc.Root);
-                                    map[idx < 0 ? k : idx] = cols[c][k];
+                                    var key = FoldPlan.ElementKey(cols[c][k].Path, fc.Root) ?? k.ToString();
+                                    map[key] = cols[c][k];
+                                    if (seenKeys.Add(key)) keys.Add(key);
                                 }
-                                foreach (var idx in map.Keys) elems = Math.Max(elems, idx + 1);
                             }
+                            if (keys.Count > 1 && keys.All(k => int.TryParse(k, out _)))
+                                keys.Sort((x, y) => int.Parse(x).CompareTo(int.Parse(y)));   // a positional list reads in index order whatever order the columns name
+                            int elems = Math.Max(1, keys.Count);   // no set column, or an empty list: still one row
                             // The owned-child clause is earned per CELL here as it is on the unfolded row below;
                             // a folded cell's path is the element's, so the column's own list path is the key.
                             for (int c = 0; c < cols.Length; c++)
@@ -1314,8 +1321,8 @@ static class JsonWire
                                 for (int c = 0; c < cols.Length; c++)
                                 {
                                     var col = cols[c];
-                                    var cell = byIndex[c] is { } map ? (map.TryGetValue(e, out var v) ? v : null)
-                                                                     : (col.Count > 0 ? col[0] : null);
+                                    var cell = byKey[c] is { } map ? (e < keys.Count && map.TryGetValue(keys[e], out var v) ? v : null)
+                                                                   : (col.Count > 0 ? col[0] : null);
                                     WriteCell(w, cell is null ? null : DenseCell(cell));
                                 }
                                 if (anyScoped) WriteCell(w, o.SourcePlugin);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2286,12 +2286,13 @@ public sealed class LoadOrderService : IDisposable
     /// never a silent empty result.</summary>
     public ReadOutcome ResolveRead(FormKey fk, string? plugin, IReadOnlyList<string>? fields, bool conflictTree, int depth = 1,
                                    bool resolveNames = false, LinkMemo? linkMemo = null,
-                                   string? containerHint = ReadEngine.DepthExpandHint)
+                                   string? containerHint = ReadEngine.DepthExpandHint,
+                                   IReadOnlyList<int>? depths = null)
     {
         var resolver = Resolver;
         var view = resolver.Capture();
         return ResolveRead(resolver, view, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint,
-                           new ChildUnionMemo())   // one named record: the union lane
+                           new ChildUnionMemo(), depths: depths)   // one named record: the union lane
                with { Stamp = view.Stamp, Pin = new ViewPin(resolver, view) };   // stamped and pinned here, off the view actually read
     }
 
@@ -2327,7 +2328,8 @@ public sealed class LoadOrderService : IDisposable
                             bool resolveNames = false, LinkMemo? linkMemo = null,
                             string? containerHint = ReadEngine.DepthExpandHint,
                             ChildUnionMemo? unionMemo = null,
-                            LoadOrderResolver.OverlaySession? batchSession = null)
+                            LoadOrderResolver.OverlaySession? batchSession = null,
+                            IReadOnlyList<int>? depths = null)
     {
         // An explicitly-requested plugin excluded this session (unparseable or unopenable) is said so, rather than
         // falling through to a misleading "does not define this record".
@@ -2390,7 +2392,7 @@ public sealed class LoadOrderService : IDisposable
         // materialise while the session (overlay) is open; the *parent hop climbs the index's containment map and
         // fetches the containing record's winner body through the same session
         var hop = ContainmentIndex.ReadHop(view, session);
-        var record = ReadEngine.ReadFields(rec, fields, depth, containerHint, hop);
+        var record = ReadEngine.ReadFields(rec, fields, depth, containerHint, hop, depths);
         record = AnnotateOwnedChildContent(record, rec, view, session, fk, source, unionMemo, out var childFields, hop);   // the additive union (or the index-only note), display-only
         if (resolveNames) record = AnnotateLinks(record, view, session, linkMemo ?? new());   // identity of every FormLink token, display-only, on the same open session
         var touching = conflictTree ? view.TouchingPlugins(fk) : null;
@@ -2645,11 +2647,12 @@ public sealed class LoadOrderService : IDisposable
     internal ReadOutcome ResolveReadOn(CrossQueryOutcome q, FormKey fk, string? plugin, IReadOnlyList<string>? fields,
                                        bool conflictTree, int depth = 1, bool resolveNames = false,
                                        LinkMemo? linkMemo = null,
-                                       string? containerHint = ReadEngine.DepthExpandHint)
+                                       string? containerHint = ReadEngine.DepthExpandHint,
+                                       IReadOnlyList<int>? depths = null)
         => q.Pin is { } p
-            ? ResolveRead(p.Resolver, p.View, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint)
+            ? ResolveRead(p.Resolver, p.View, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint, depths: depths)
               with { Stamp = p.View.Stamp, Pin = p }
-            : ResolveRead(fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint);
+            : ResolveRead(fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint, depths);
 
     /// <summary>The summary twin of <see cref="ResolveReadOn"/> — the conflicts-only lazy fill, pinned to the scan's
     /// build when the outcome carries one.</summary>
@@ -2848,8 +2851,9 @@ public sealed class LoadOrderService : IDisposable
     /// own per-item error.</summary>
     public IReadOnlyList<ReadOutcome> ResolveBatch(IReadOnlyList<string> formids, IReadOnlyList<string>? fields, bool conflictTree, int depth = 1,
                                                    bool resolveNames = false, string? plugin = null,
-                                                   string? containerHint = ReadEngine.DepthExpandHint)
-        => ResolveBatch(formids, fields, conflictTree, depth, resolveNames, plugin, null, out _, out _, containerHint);
+                                                   string? containerHint = ReadEngine.DepthExpandHint,
+                                                   IReadOnlyList<int>? depths = null)
+        => ResolveBatch(formids, fields, conflictTree, depth, resolveNames, plugin, null, out _, out _, containerHint, depths);
 
     /// <summary>The artifact-aware overload: <paramref name="artifactDemand"/> (a formids=@artifact input) is checked
     /// against THIS capture's epoch — the same build that would answer — and a mismatch hands back
@@ -2858,7 +2862,8 @@ public sealed class LoadOrderService : IDisposable
     public IReadOnlyList<ReadOutcome> ResolveBatch(IReadOnlyList<string> formids, IReadOnlyList<string>? fields, bool conflictTree, int depth,
                                                    bool resolveNames, string? plugin, ArtifactDemand? artifactDemand,
                                                    out string? artifactRefusal, out OrderStamp? refusalEpoch,
-                                                   string? containerHint = ReadEngine.DepthExpandHint)
+                                                   string? containerHint = ReadEngine.DepthExpandHint,
+                                                   IReadOnlyList<int>? depths = null)
     {
         artifactRefusal = null; refusalEpoch = null;
         var resolver = Resolver;                // build/refresh once for the batch
@@ -2882,7 +2887,7 @@ public sealed class LoadOrderService : IDisposable
             FormKey fk;
             try { fk = view.ParseFormId(raw); }
             catch (Exception ex) { outcomes.Add(ReadOutcome.Fail(default, $"bad FormID '{raw}': {ex.Message}")); continue; }
-            outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint, unionMemo, batchSession)
+            outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint, unionMemo, batchSession, depths)
                          with { Stamp = view.Stamp, Pin = pin });   // the batch's one build, stamped and pinned per item
         }
         return outcomes;
@@ -2985,7 +2990,8 @@ public sealed class LoadOrderService : IDisposable
         IReadOnlyList<string>? fields, int depth, bool resolveNames,
         ArtifactDemand? artifactDemand,
         out PoleInfo? pole, out string? refusal, out OrderStamp? refusalEpoch,
-        string? containerHint = ReadEngine.DepthExpandHint)
+        string? containerHint = ReadEngine.DepthExpandHint,
+        IReadOnlyList<int>? depths = null)
     {
         pole = null; refusal = null; refusalEpoch = null;
         var resolver = Resolver;
@@ -3021,7 +3027,7 @@ public sealed class LoadOrderService : IDisposable
                 FormKey fk;
                 try { fk = view.ParseFormId(raw); }
                 catch (Exception ex) { outcomes.Add(ReadOutcome.Fail(default, $"bad FormID '{raw}': {ex.Message}")); continue; }
-                outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, false, depth, resolveNames, linkMemo, containerHint, unionMemo, batchSession)
+                outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, false, depth, resolveNames, linkMemo, containerHint, unionMemo, batchSession, depths)
                              with { Stamp = view.Stamp, Pin = pin });
             }
             return outcomes;
@@ -3095,7 +3101,7 @@ public sealed class LoadOrderService : IDisposable
                         with { Stamp = view.Stamp, Pin = pin };
                     continue;
                 }
-                var record = ReadEngine.ReadFields(rec, fields, depth, containerHint);          // materialise while the overlay is open
+                var record = ReadEngine.ReadFields(rec, fields, depth, containerHint, depths: depths);   // materialise while the overlay is open
                 if (resolveNames) record = AnnotateLinks(record, view, session!, linkMemo!);
                 var winner = view.ResolveWinner(fk);                             // winner CONTEXT where the record also lives in the order
                 results[index] = new ReadOutcome(fk, record, plugin, winner?.WinnerPlugin,
@@ -3490,7 +3496,8 @@ public sealed class LoadOrderService : IDisposable
     public IReadOnlyList<ReadOutcome> OverlayPostBatch(
         IReadOnlyList<string> formids, IReadOnlyList<string>? fields, int depth, bool resolveNames,
         ArtifactDemand? demand, out string? refusal, out OrderStamp? refusalEpoch, out OrderStamp? epoch,
-        string? containerHint = ReadEngine.DepthExpandHint)
+        string? containerHint = ReadEngine.DepthExpandHint,
+        IReadOnlyList<int>? depths = null)
     {
         refusal = null; refusalEpoch = null;
         var resolver = Resolver;
@@ -3558,7 +3565,7 @@ public sealed class LoadOrderService : IDisposable
                     continue;
                 }
             }
-            var record = ReadEngine.ReadFields(bodyToRead!, fields, depth, containerHint, ContainmentIndex.ReadHop(view, session));
+            var record = ReadEngine.ReadFields(bodyToRead!, fields, depth, containerHint, ContainmentIndex.ReadHop(view, session), depths);
             if (resolveNames) record = AnnotateLinks(record, view, session, overlayLinkMemo ??= new LinkMemo());
             var ok = (new ReadOutcome(fk, record, winner.Value.WinnerPlugin, winner.Value.WinnerPlugin,
                                       winner.Value.OverrideDepth, null, null)

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -316,7 +316,12 @@ public static class RecordsTools
         }
         var projFields = bodyFields || comparisonForm ? project?.fields : null;
         // The read runs the LIST path a quantifier binds to; the fold puts the caller's own spelling back.
-        var readPaths = foldPlan is null ? projFields : foldPlan.ReadPaths;
+        // The read's own targets: each path once, with the depth that path's column needs. Two columns quantifying
+        // one list are one walk of it, and an unquantified column beside a quantified one is not expanded deeper
+        // than the caller asked — both spend the same expansion budget.
+        string[]? foldReadPaths = null; int[]? readDepths = null;
+        if (foldPlan is not null) (foldReadPaths, readDepths) = foldPlan.Read();
+        var readPaths = foldPlan is null ? projFields : foldReadPaths;
         bool resolveNames = project?.resolve_names ?? false;
         // The lever vocabulary is a function of (tool, FORM), not of the tool alone: the 'everything' form refuses
         // project.fields= by name, so a truncation notice there must not offer it as the way to narrow.
@@ -633,6 +638,9 @@ public static class RecordsTools
                 "summary" or "aggregate" => new[] { "EditorID" },   // cheapest leaf — headers carry the summary facts
                 _ => null,                                          // everything — the full dump
             };
+            // The per-path depths belong to the paths they were computed for; a form that reads something else
+            // (summary's one leaf, everything's full dump) reads at the one depth.
+            var readFieldDepths = ReferenceEquals(readFields, readPaths) ? readDepths : null;
             IReadOnlyList<ReadOutcome> outcomes;
             LoadOrderService.PoleInfo? pole = null;
             if (srcOverlay && !string.Equals(srcSpec.OverlayState ?? "post", "pre", StringComparison.OrdinalIgnoreCase))
@@ -640,7 +648,7 @@ public static class RecordsTools
                 // The overlay post source: every record's winner replayed through the SkyPatcher INI layer, the
                 // replayed body read at the caller's own depth.
                 outcomes = svc.OverlayPostBatch(ids, readFields, depth, resolveNames, demand, out var ovRefusal, out var ovEpoch, out _,
-                                                LeverNames.Records.ContainerHint);
+                                                LeverNames.Records.ContainerHint, readFieldDepths);
                 if (ovRefusal is not null)
                     return json ? JsonWire.RenderError(ovRefusal, ovEpoch)
                                 : "error: " + ovRefusal + Wire.EpochLine(ovEpoch);
@@ -652,7 +660,7 @@ public static class RecordsTools
             else if (srcName is null)
             {
                 if (srcOverlay) Arm("skypatcher overlay (pre) = winner — the body the INI layer starts from");
-                outcomes = svc.ResolveBatch(ids, readFields, false, depth, resolveNames, null, demand, out var refusal, out var refusalEpoch, LeverNames.Records.ContainerHint);
+                outcomes = svc.ResolveBatch(ids, readFields, false, depth, resolveNames, null, demand, out var refusal, out var refusalEpoch, LeverNames.Records.ContainerHint, readFieldDepths);
                 if (refusal is not null)
                     return json ? JsonWire.RenderError(refusal, refusalEpoch)
                                 : "error: " + refusal + Wire.EpochLine(refusalEpoch);
@@ -662,7 +670,7 @@ public static class RecordsTools
             {
                 outcomes = svc.ResolveBatchFromPole(ids, srcName, srcMod, readFields, depth, resolveNames, demand,
                                                     out pole, out var refusal, out var refusalEpoch,
-                                                    LeverNames.Records.ContainerHint);
+                                                    LeverNames.Records.ContainerHint, readFieldDepths);
                 if (refusal is not null)
                     return json ? JsonWire.RenderError(refusal, refusalEpoch)
                                 : "error: " + refusal + Wire.EpochLine(refusalEpoch);
@@ -1389,7 +1397,7 @@ public static class RecordsTools
                 if (srcName is not null)
                 {
                     bodies = svc.ResolveBatchFromPole(keys, srcName, srcMod, bodyFields ? readPaths : null, depth, resolveNames, null,
-                                                      out _, out var bref, out var brefEpoch, LeverNames.Records.ContainerHint);
+                                                      out _, out var bref, out var brefEpoch, LeverNames.Records.ContainerHint, readDepths);
                     // A refusal is judged on the named cause, never on row count: a zero-match scan is an honest
                     // empty result, not a failure.
                     if (bref is not null)
@@ -1404,7 +1412,7 @@ public static class RecordsTools
                     // fields_source="winner" retargets display to the winner as it does on the fields form.
                     var srcs = outcome.Sources;
                     if (winnerFields || srcs is null || srcs.Take(keys.Count).All(s => s is null))
-                        bodies = svc.ResolveBatch(keys, bodyFields ? readPaths : null, false, depth, resolveNames, containerHint: LeverNames.Records.ContainerHint);
+                        bodies = svc.ResolveBatch(keys, bodyFields ? readPaths : null, false, depth, resolveNames, containerHint: LeverNames.Records.ContainerHint, depths: readDepths);
                     else
                     {
                         var byIndex = new ReadOutcome[keys.Count];
@@ -1419,12 +1427,12 @@ public static class RecordsTools
                         }
                         if (winnerIdx.Count > 0)
                         {
-                            var res = svc.ResolveBatch(winnerIdx.Select(i => keys[i]).ToList(), bodyFields ? readPaths : null, false, depth, resolveNames, containerHint: LeverNames.Records.ContainerHint);
+                            var res = svc.ResolveBatch(winnerIdx.Select(i => keys[i]).ToList(), bodyFields ? readPaths : null, false, depth, resolveNames, containerHint: LeverNames.Records.ContainerHint, depths: readDepths);
                             for (int i = 0; i < winnerIdx.Count; i++) byIndex[winnerIdx[i]] = res[i];
                         }
                         foreach (var kv in bySource)
                         {
-                            var res = svc.ResolveBatch(kv.Value.Select(i => keys[i]).ToList(), bodyFields ? readPaths : null, false, depth, resolveNames, kv.Key, LeverNames.Records.ContainerHint);
+                            var res = svc.ResolveBatch(kv.Value.Select(i => keys[i]).ToList(), bodyFields ? readPaths : null, false, depth, resolveNames, kv.Key, LeverNames.Records.ContainerHint, readDepths);
                             for (int i = 0; i < kv.Value.Count; i++) byIndex[kv.Value[i]] = res[i];
                         }
                         bodies = byIndex;
@@ -1649,7 +1657,7 @@ public static class RecordsTools
                 var keys = outcome.Keys.Select(k => k.ToString()).ToList();
                 var bodies = svc.ResolveBatchFromPole(keys, pole.Plugin, srcMod, bodyFields ? readPaths : null,
                                                       depth, resolveNames, null, out _, out var bref, out var brefEpoch,
-                                                      LeverNames.Records.ContainerHint);
+                                                      LeverNames.Records.ContainerHint, readDepths);
                 bodies = FoldRows(bodies);
                 if (bref is not null)
                     return json ? JsonWire.RenderError(bref, brefEpoch)

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -261,6 +261,10 @@ public static class RecordsTools
                 return Wire.Refuse(json, form == "rows"
                     ? $"error: project.fields path '{foldPlan.First.Requested}' quantifies a step, and the 'rows' form already folds the list it names to one line per element — drop the token, or use form='fields' to mix quantified and ordinary paths."
                     : $"error: project.fields path '{foldPlan.First.Requested}' quantifies a step, and the '{form}' form lines its two sides up path for path — drop the token, or read the elements with form='fields'.");
+            // dense lays ONE row per element, and two different lists share no element to lay a row on: the text
+            // render names each cell's own path, dense does not, so a paired row would read as one element's.
+            if (foldPlan is not null && dense && foldPlan.SetRoots is { Count: > 1 } roots)
+                return Wire.Refuse(json, $"error: format='dense' lays one row per element, and '{roots[0]}' and '{roots[1]}' are different lists — one row cannot be an element of both. Quantify one of them and read the other as an ordinary path, or make one call per list.");
         }
         if (project?.depth is { } dv)
         {
@@ -303,7 +307,13 @@ public static class RecordsTools
         int depth = project?.depth is { } d && d > 0 ? d : (form == "rows" || foldsElements ? RowProjection.DefaultDepth : 1);
         // A sub-path after [*] names exactly what to read, so reaching it is the token's own requirement rather
         // than expansion the caller has to budget for.
-        if (foldPlan is not null) { depth = Math.Max(depth, foldPlan.Depth); foldPlan = foldPlan with { Depth = depth }; }
+        // CallerDepth is what an UNQUANTIFIED column beside a quantified one renders at: the token raises the
+        // read's depth for the paths that need it, and a sibling path must not expand deeper for that reason.
+        if (foldPlan is not null)
+        {
+            depth = Math.Max(depth, foldPlan.Depth);
+            foldPlan = foldPlan with { Depth = depth, CallerDepth = project?.depth is { } cd && cd > 0 ? cd : 1 };
+        }
         var projFields = bodyFields || comparisonForm ? project?.fields : null;
         // The read runs the LIST path a quantifier binds to; the fold puts the caller's own spelling back.
         var readPaths = foldPlan is null ? projFields : foldPlan.ReadPaths;
@@ -1289,9 +1299,12 @@ public static class RecordsTools
             // The reverse-reference index's accounting belongs to the response whatever consumes the scan. The two
             // CrossQuery renderers read it off the outcome themselves; every form BELOW renders its own pipeline's
             // response and would drop it, so it rides their header and envelope. One place, so no form forgets.
+            // The forms whose bodies the batch lane below renders: the note rides their envelope, so the gate
+            // and the lane read ONE condition and cannot drift on which forms those are.
+            bool bodyLaneForm = form == "everything" || form == "rows"
+                             || (form == "fields" && (scopePlusPole || (foldPlan is not null && !dense)));
             if (outcome.ReverseIndexNote is not null && outcome.Error is null && outcome.Groups is null
-                && (walk is not null || comparisonForm || form == "info_order"
-                    || ((form == "everything" || (form == "fields" && scopePlusPole)) && !counts_only)))
+                && (walk is not null || comparisonForm || form == "info_order" || (bodyLaneForm && !counts_only)))
             {
                 envelope.Add(new("reverse_index", outcome.ReverseIndexNote));
                 headerLine += "\n" + outcome.ReverseIndexNote;
@@ -1369,8 +1382,7 @@ public static class RecordsTools
             // The rows form always takes this lane: its fold is over a body read, and the scan render fills
             // detail rows of its own that never pass through it. A quantified fields path folds the same way, so
             // it takes the lane too — except under dense, whose own render carries the per-element rows.
-            if ((form == "everything" || form == "rows" || (form == "fields" && (scopePlusPole || (foldPlan is not null && !dense))))
-                && !counts_only && outcome.Error is null && outcome.Groups is null)
+            if (bodyLaneForm && !counts_only && outcome.Error is null && outcome.Groups is null)
             {
                 var keys = outcome.Keys.Select(k => k.ToString()).ToList();
                 IReadOnlyList<ReadOutcome> bodies;
@@ -1682,7 +1694,7 @@ public static class RecordsTools
             SpillState? spill = null;
             if (wantFile && outcome.Error is null)
             {
-                var (sp, aerr) = Artifacts.WriteCrossQuery(svc, outcome, null, false, false, 1, toFile!, "to_file", Echo(), LeverNames.Records, fold: foldPlan);
+                var (sp, aerr) = Artifacts.WriteCrossQuery(svc, outcome, null, false, false, 1, toFile!, "to_file", Echo(), LeverNames.Records);
                 if (aerr is not null)
                     return fmt is Wire.QueryFormat.Text ? "error: " + aerr : JsonWire.RenderError(aerr, outcome.Stamp);
                 spill = SpillState.Spilled(sp!, manifestOnly: true);
@@ -1699,7 +1711,7 @@ public static class RecordsTools
             if (spill is null && truncated && outcome.Error is null)
             {
                 var path = ResultsStore.NextPath(ToolNames.Records, outcome.Epoch ?? "none");
-                var (sp, aerr) = Artifacts.WriteCrossQuery(svc, outcome, null, false, false, 1, path, "ceiling", Echo(), LeverNames.Records, fold: foldPlan);
+                var (sp, aerr) = Artifacts.WriteCrossQuery(svc, outcome, null, false, false, 1, path, "ceiling", Echo(), LeverNames.Records);
                 if (aerr is not null) ResultsStore.Release(path);
                 rendered = Render(aerr is null ? SpillState.Spilled(sp!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
             }

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -34,7 +34,7 @@ public static class RecordsTools
         [Description("The form: 'identity' (FormID -> type/editorid/name/winner — the labeling form; needs formids=) | 'summary' (identity plus winner/override-depth header facts — the default) | 'fields' (named field values; takes fields= and depth=) | 'rows' (a LIST field folded to ONE LINE PER ELEMENT — the compact per-row view: takes fields= naming the list (index one element, 'Conditions[0]', to fold just that one), and depth= (default 4). Each line is the element's own summary plus every sub-field the read FOUND; only ABSENT optionals are omitted, which is what turns a 40-row condition stack from ~1,000 lines into 40. A declared-but-null link is kept — an empty slot is a fact. A named field that is not a list fails loud) | 'everything' (the full record body; takes depth=) | 'aggregate' (a counted table; takes group_by=) | 'delta' (subject vs reference, differences only — source= is the subject, versus= the reference; takes fields= to narrow) | 'tree' (every provider of each record in priority order, winner last, each diffed against the reference pole — default the winner; takes fields=. On a record type that OWNS child records — a cell's placed references, a topic's INFO lines, a worldspace's cells — it also states, per such field, which providers DECLARE children there (a COLLECTION field) or how many do (a SINGULAR one, e.g. Cell.Landscape), and says so when none do) | 'info_order' (DIAL topics only: the effective MERGED INFO sequence across every touching plugin — the order the game walks, with MOVED annotations; the 'why does the wrong line play' diagnostic) | 'chain' (a walk's own paths, endpoints and cycles rather than the records it reached; needs walk=, and carries the NPC-template inheritance report and the reverse MGEF carrier rows).")]
         public string? form { get; set; }
 
-        [Description("fields/rows forms: dotted field paths to read, e.g. [\"BasicStats.Damage\", \"Keywords\", \"Effects\"]. Index a list/dict element with BRACKETS ('Effects[0].Data.Magnitude'). A path may LEAD with the containment step '*parent' — the record that CONTAINS this one, which group nesting makes invisible to references= ('*parent.EditorID' is an INFO's owning DIAL; '*parent.*parent.EditorID' a placed reference's worldspace) — and it chains. On the rows form these name the LIST(S) to fold, one line per element. where='s quantifier tokens are not read here: [*any]/[*all]/[*none] fold to a boolean, which is not a row, and [*] / [*count] as a PROJECTION are not built yet — both are refused by name.")]
+        [Description("fields/rows forms: dotted field paths to read, e.g. [\"BasicStats.Damage\", \"Keywords\", \"Effects\"]. Index a list/dict element with BRACKETS ('Effects[0].Data.Magnitude'). A path may LEAD with the containment step '*parent' — the record that CONTAINS this one, which group nesting makes invisible to references= ('*parent.EditorID' is an INFO's owning DIAL; '*parent.*parent.EditorID' a placed reference's worldspace) — and it chains. On the rows form these name the LIST(S) to fold, one line per element. On the fields form a step may be QUANTIFIED: 'Effects[*count]' is one number per record (how many elements), 'Effects[*]' one row per element in the rows form's own row shape, and 'Effects[*].Data.Magnitude' that leaf per element — under format='dense' the extra rows repeat the record's identity columns. [*any]/[*all]/[*none] fold to a boolean, which is not a row: they belong in where= and are refused here by name.")]
         public string[]? fields { get; set; }
 
         [Description("fields/rows/everything forms: expansion depth for list/dict/substruct CONTENTS (default 1, or 4 on the rows form, where a shallower read renders every element as a bare type). THIS is the expansion knob: fields=[\"Effects\"], depth=4 reaches every effect's Magnitude/Area/Duration — no hand-written index guessing.")]
@@ -148,6 +148,8 @@ public static class RecordsTools
          "line — the element's own summary plus each sub-field the read found, ABSENT optionals omitted. Auditing a " +
          "40-row condition stack (project.fields=[\"Conditions\"]) is one call, not an index probe per row; an indexed path " +
          "(project.fields=[\"Conditions[0]\"]) folds that one element, and a field that is not a list is refused by name. " +
+         "On form='fields' a path may QUANTIFY its step instead: '[*count]' is the element count as one cell, '[*]' one " +
+         "row per element (the same row shape), and dense repeats the identity columns across those rows. " +
          "COMPARISONS (form='delta'/'tree'): a delta reads the SUBJECT (source=) and a REFERENCE (versus=) and " +
          "returns only what differs — each delta line shows the subject's value with the reference's labeled by its " +
          "plugin; versus=\"previous_provider\" answers 'what did this plugin change relative to what sat beneath " +
@@ -244,21 +246,22 @@ public static class RecordsTools
         // null or blank one is bad input and is named as such rather than reaching the fold.
         if (form == "rows" && project?.fields is { } rowFields && Array.FindIndex(rowFields, p => string.IsNullOrWhiteSpace(p)) is var badAt && badAt >= 0)
             return Wire.Refuse(json, $"error: project.fields[{badAt}] is empty — the 'rows' form folds the list each entry names, so every entry must be a field path (e.g. [\"Conditions\"]).");
-        // The quantifier tokens are where='s, not a projection's — refused by name here so a caller who tries one
-        // gets the rule rather than an unreadable-field note from the read walk.
+        // The quantified step's PROJECT half: [*count] is one number per record, [*] one row per element. The
+        // parse runs here, before any read, so a bad token refuses the call rather than each record.
+        FoldPlan? foldPlan = null;
         if (project?.fields is { Length: > 0 } pf)
-            foreach (var path in pf)
-                if (QuantifierToken(path) is { } qt)
-                {
-                    var qtl = qt.ToLowerInvariant();
-                    // A token outside the vocabulary is a typo, not a capability that is coming — say so in the
-                    // parser's own words, so where= and project.fields judge the same token the same way.
-                    if (qtl is not ("[*]" or "[*count]" or "[*any]" or "[*all]" or "[*none]"))
-                        return Wire.Refuse(json, $"error: project.fields path '{path}': '{qt}' is not a quantifier — the tokens are [*], [*count], [*any], [*all] and [*none] (the last three fold to a boolean and belong in where=).");
-                    return Wire.Refuse(json, qtl is "[*any]" or "[*all]" or "[*none]"
-                        ? $"error: project.fields path '{path}' folds the elements into a boolean, and a boolean is not a row — use {qt} in where= to SELECT the records, and name a concrete element ('Effects[0].Data.Magnitude') or the list itself to read one."
-                        : $"error: project.fields path '{path}' uses '{qt}', which is a where= step today — the projection half of the quantified step (a row per element, and the element count as a cell) is not built yet. Name a concrete element ('Effects[0].Data.Magnitude') or the list itself, which renders as a summary with project.depth.");
-                }
+        {
+            var (plan, foldErr) = FieldFolds.Parse(pf);
+            if (foldErr is not null) return Wire.Refuse(json, "error: " + foldErr);
+            foldPlan = plan;
+            // The quantifier belongs to the form that reads a path as a projection. The comparison forms line
+            // their two sides up path for path, and the rows form already folds the list it names, so a token
+            // there is refused by name rather than accepted and dropped.
+            if (foldPlan is not null && form != "fields")
+                return Wire.Refuse(json, form == "rows"
+                    ? $"error: project.fields path '{foldPlan.First.Requested}' quantifies a step, and the 'rows' form already folds the list it names to one line per element — drop the token, or use form='fields' to mix quantified and ordinary paths."
+                    : $"error: project.fields path '{foldPlan.First.Requested}' quantifies a step, and the '{form}' form lines its two sides up path for path — drop the token, or read the elements with form='fields'.");
+        }
         if (project?.depth is { } dv)
         {
             // Any explicit depth is form-scoped — the rule must not depend on the value, or depth:1 is accepted
@@ -272,6 +275,9 @@ public static class RecordsTools
             // depth=1 collapses the list to a count, so the rows form would answer with no rows at all.
             if (dv == 1 && form == "rows")
                 return Wire.Refuse(json, "error: project.depth=1 collapses a list to a count, and the 'rows' form renders its elements — pass depth >= 2 (2 shows each element's type, the default 4 reaches its sub-fields), or use form='fields' for the collapsed line.");
+            // Same reading at the same knob: a [*] path renders elements, which depth 1 collapses away.
+            if (dv == 1 && foldPlan?.Folds.FirstOrDefault(f => f is { Fold: PathFold.Set }) is { } setAt)
+                return Wire.Refuse(json, $"error: project.depth=1 collapses a list to a count, and '{setAt.Requested}' renders its elements — pass depth >= 2 (2 shows each element's type, the default 4 reaches its sub-fields), or use '{setAt.Root}[*count]' for the number of them.");
         }
         if (project?.group_by is not null && form != "aggregate")
             return Wire.Refuse(json, $"error: project.group_by belongs to the 'aggregate' form only (got form='{form}'). Set project.form='aggregate', or drop group_by.");
@@ -293,16 +299,25 @@ public static class RecordsTools
             return Wire.Refuse(json, $"error: project.resolve_names annotates field values and belongs to the 'fields'/'rows'/'everything' forms (got form='{form}').");
         // The rows form's default is its own: at depth 1 every element renders as a bare arm type, which is the
         // gap the form exists to close. Its cost is per-row TEXT, not per-row lines — the fold is one line either way.
-        int depth = project?.depth is { } d && d > 0 ? d : (form == "rows" ? RowProjection.DefaultDepth : 1);
+        bool foldsElements = foldPlan?.RendersElements ?? false;
+        int depth = project?.depth is { } d && d > 0 ? d : (form == "rows" || foldsElements ? RowProjection.DefaultDepth : 1);
+        // A sub-path after [*] names exactly what to read, so reaching it is the token's own requirement rather
+        // than expansion the caller has to budget for.
+        if (foldPlan is not null) { depth = Math.Max(depth, foldPlan.Depth); foldPlan = foldPlan with { Depth = depth }; }
         var projFields = bodyFields || comparisonForm ? project?.fields : null;
+        // The read runs the LIST path a quantifier binds to; the fold puts the caller's own spelling back.
+        var readPaths = foldPlan is null ? projFields : foldPlan.ReadPaths;
         bool resolveNames = project?.resolve_names ?? false;
         // The lever vocabulary is a function of (tool, FORM), not of the tool alone: the 'everything' form refuses
         // project.fields= by name, so a truncation notice there must not offer it as the way to narrow.
         var formLevers = form == "everything" ? LeverNames.Records.WithoutFieldSelector() : LeverNames.Records;
         // The rows form IS the fields form plus this fold, applied wherever a lane produces bodies — so the
-        // render, the artifact and the json document all see the same folded rows.
+        // render, the artifact and the json document all see the same folded rows. A quantified project.fields
+        // path rides the same seam, for the same reason.
         IReadOnlyList<ReadOutcome> FoldRows(IReadOnlyList<ReadOutcome> read)
-            => form == "rows" ? RowProjection.Apply(read, projFields!, depth) : read;
+            => form == "rows" ? RowProjection.Apply(read, projFields!, depth)
+             : foldPlan is not null ? foldPlan.Apply(read)
+             : read;
 
         // ---- SOURCE: the pole grammar (source = the subject; versus = the comparison reference) ----
         // ParsePole has no transport in scope, so its refusals take their shape here.
@@ -604,7 +619,7 @@ public static class RecordsTools
             // paths; everything passes null to dump the modeled fields.
             IReadOnlyList<string>? readFields = form switch
             {
-                "fields" or "rows" => projFields,
+                "fields" or "rows" => readPaths,
                 "summary" or "aggregate" => new[] { "EditorID" },   // cheapest leaf — headers carry the summary facts
                 _ => null,                                          // everything — the full dump
             };
@@ -1352,14 +1367,16 @@ public static class RecordsTools
             // ---- form=everything on a scan: selection here, bodies via the batch lane, window-bounded.
             // counts_only skips the body lane entirely — its census is the scan render below. ----
             // The rows form always takes this lane: its fold is over a body read, and the scan render fills
-            // detail rows of its own that never pass through it.
-            if ((form == "everything" || form == "rows" || (form == "fields" && scopePlusPole)) && !counts_only && outcome.Error is null && outcome.Groups is null)
+            // detail rows of its own that never pass through it. A quantified fields path folds the same way, so
+            // it takes the lane too — except under dense, whose own render carries the per-element rows.
+            if ((form == "everything" || form == "rows" || (form == "fields" && (scopePlusPole || (foldPlan is not null && !dense))))
+                && !counts_only && outcome.Error is null && outcome.Groups is null)
             {
                 var keys = outcome.Keys.Select(k => k.ToString()).ToList();
                 IReadOnlyList<ReadOutcome> bodies;
                 if (srcName is not null)
                 {
-                    bodies = svc.ResolveBatchFromPole(keys, srcName, srcMod, bodyFields ? projFields : null, depth, resolveNames, null,
+                    bodies = svc.ResolveBatchFromPole(keys, srcName, srcMod, bodyFields ? readPaths : null, depth, resolveNames, null,
                                                       out _, out var bref, out var brefEpoch, LeverNames.Records.ContainerHint);
                     // A refusal is judged on the named cause, never on row count: a zero-match scan is an honest
                     // empty result, not a failure.
@@ -1375,7 +1392,7 @@ public static class RecordsTools
                     // fields_source="winner" retargets display to the winner as it does on the fields form.
                     var srcs = outcome.Sources;
                     if (winnerFields || srcs is null || srcs.Take(keys.Count).All(s => s is null))
-                        bodies = svc.ResolveBatch(keys, bodyFields ? projFields : null, false, depth, resolveNames, containerHint: LeverNames.Records.ContainerHint);
+                        bodies = svc.ResolveBatch(keys, bodyFields ? readPaths : null, false, depth, resolveNames, containerHint: LeverNames.Records.ContainerHint);
                     else
                     {
                         var byIndex = new ReadOutcome[keys.Count];
@@ -1390,12 +1407,12 @@ public static class RecordsTools
                         }
                         if (winnerIdx.Count > 0)
                         {
-                            var res = svc.ResolveBatch(winnerIdx.Select(i => keys[i]).ToList(), bodyFields ? projFields : null, false, depth, resolveNames, containerHint: LeverNames.Records.ContainerHint);
+                            var res = svc.ResolveBatch(winnerIdx.Select(i => keys[i]).ToList(), bodyFields ? readPaths : null, false, depth, resolveNames, containerHint: LeverNames.Records.ContainerHint);
                             for (int i = 0; i < winnerIdx.Count; i++) byIndex[winnerIdx[i]] = res[i];
                         }
                         foreach (var kv in bySource)
                         {
-                            var res = svc.ResolveBatch(kv.Value.Select(i => keys[i]).ToList(), bodyFields ? projFields : null, false, depth, resolveNames, kv.Key, LeverNames.Records.ContainerHint);
+                            var res = svc.ResolveBatch(kv.Value.Select(i => keys[i]).ToList(), bodyFields ? readPaths : null, false, depth, resolveNames, kv.Key, LeverNames.Records.ContainerHint);
                             for (int i = 0; i < kv.Value.Count; i++) byIndex[kv.Value[i]] = res[i];
                         }
                         bodies = byIndex;
@@ -1454,7 +1471,7 @@ public static class RecordsTools
             SpillState? spill = null;
             if (wantFile && outcome.Error is null)
             {
-                var (s, aerr) = Artifacts.WriteCrossQuery(svc, outcome, projFields, resolveNames, winnerFields, depth, toFile!, "to_file", Echo(), LeverNames.Records);
+                var (s, aerr) = Artifacts.WriteCrossQuery(svc, outcome, readPaths, resolveNames, winnerFields, depth, toFile!, "to_file", Echo(), LeverNames.Records, fold: foldPlan);
                 if (aerr is not null)
                     return fmt is Wire.QueryFormat.Text ? "error: " + aerr : JsonWire.RenderError(aerr, outcome.Stamp);
                 spill = SpillState.Spilled(s!, manifestOnly: true);
@@ -1464,7 +1481,7 @@ public static class RecordsTools
             var qLevers = projFields is { Length: > 0 } ? LeverNames.Records : LeverNames.Records.WithNothingToDrop();
             string Render(SpillState? sp, out bool trunc) => fmt switch
             {
-                Wire.QueryFormat.Dense when groupBy is null => JsonWire.RenderCrossQueryDense(svc, outcome, projFields, max_chars, resolveNames, winnerFields, sp, out trunc, envelope, qLevers),
+                Wire.QueryFormat.Dense when groupBy is null => JsonWire.RenderCrossQueryDense(svc, outcome, readPaths, max_chars, resolveNames, winnerFields, sp, out trunc, envelope, qLevers, foldPlan),
                 Wire.QueryFormat.Dense or Wire.QueryFormat.Json => JsonWire.RenderCrossQuery(svc, outcome, projFields, max_chars, resolveNames, winnerFields, depth, sp, out trunc, envelope, qLevers),
                 _ => headerLine + "\n" + Wire.RenderCrossQuery(svc, outcome, projFields, max_chars, resolveNames, winnerFields, depth, sp, out trunc, qLevers),
             };
@@ -1472,7 +1489,7 @@ public static class RecordsTools
             if (spill is null && truncated && outcome.Error is null)
             {
                 var path = ResultsStore.NextPath(ToolNames.Records, outcome.Epoch ?? "none");
-                var (s, aerr) = Artifacts.WriteCrossQuery(svc, outcome, projFields, resolveNames, winnerFields, depth, path, "ceiling", Echo(), LeverNames.Records);
+                var (s, aerr) = Artifacts.WriteCrossQuery(svc, outcome, readPaths, resolveNames, winnerFields, depth, path, "ceiling", Echo(), LeverNames.Records, fold: foldPlan);
                 if (aerr is not null) ResultsStore.Release(path);
                 rendered = Render(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
             }
@@ -1618,7 +1635,7 @@ public static class RecordsTools
             if (form is ("fields" or "rows" or "everything") && !counts_only && outcome.Error is null && outcome.Groups is null)
             {
                 var keys = outcome.Keys.Select(k => k.ToString()).ToList();
-                var bodies = svc.ResolveBatchFromPole(keys, pole.Plugin, srcMod, bodyFields ? projFields : null,
+                var bodies = svc.ResolveBatchFromPole(keys, pole.Plugin, srcMod, bodyFields ? readPaths : null,
                                                       depth, resolveNames, null, out _, out var bref, out var brefEpoch,
                                                       LeverNames.Records.ContainerHint);
                 bodies = FoldRows(bodies);
@@ -1665,7 +1682,7 @@ public static class RecordsTools
             SpillState? spill = null;
             if (wantFile && outcome.Error is null)
             {
-                var (sp, aerr) = Artifacts.WriteCrossQuery(svc, outcome, null, false, false, 1, toFile!, "to_file", Echo(), LeverNames.Records);
+                var (sp, aerr) = Artifacts.WriteCrossQuery(svc, outcome, null, false, false, 1, toFile!, "to_file", Echo(), LeverNames.Records, fold: foldPlan);
                 if (aerr is not null)
                     return fmt is Wire.QueryFormat.Text ? "error: " + aerr : JsonWire.RenderError(aerr, outcome.Stamp);
                 spill = SpillState.Spilled(sp!, manifestOnly: true);
@@ -1682,7 +1699,7 @@ public static class RecordsTools
             if (spill is null && truncated && outcome.Error is null)
             {
                 var path = ResultsStore.NextPath(ToolNames.Records, outcome.Epoch ?? "none");
-                var (sp, aerr) = Artifacts.WriteCrossQuery(svc, outcome, null, false, false, 1, path, "ceiling", Echo(), LeverNames.Records);
+                var (sp, aerr) = Artifacts.WriteCrossQuery(svc, outcome, null, false, false, 1, path, "ceiling", Echo(), LeverNames.Records, fold: foldPlan);
                 if (aerr is not null) ResultsStore.Release(path);
                 rendered = Render(aerr is null ? SpillState.Spilled(sp!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
             }
@@ -2187,24 +2204,6 @@ public static class RecordsTools
         foreach (var (key, count) in rows.Select(r => (r.Key, r.Value)))
             sb.Append("  ").Append(count.ToString().PadLeft(6)).Append("  ").Append(key).Append('\n');
         return sb.ToString();
-    }
-
-    /// <summary>The first quantifier token in a projection path, or null — a bracket key beginning '*', spelled back
-    /// as the caller wrote it so the refusal names their own token.</summary>
-    static string? QuantifierToken(string? path)
-    {
-        if (string.IsNullOrEmpty(path)) return null;
-        foreach (var seg in path.Split('.'))
-        {
-            int open = seg.IndexOf('[');
-            if (open < 0 || !seg.EndsWith("]", StringComparison.Ordinal)) continue;
-            // A quantifier on the containment step is that grammar's mistake, not a projection one — leave it to
-            // the read walk's shared check, so where= and project.fields refuse it in the same sentence.
-            if (HousecarlCore.ContainmentIndex.IsParentStep(seg[..open])) continue;
-            var key = seg[(open + 1)..^1];
-            if (key.Length > 0 && key[0] == '*') return $"[{key}]";
-        }
-        return null;
     }
 
     /// <summary>references= @file expansion with the negation sigil carried across it: '!@&lt;path&gt;' excludes every

--- a/src/housecarl-mcp/RowProjection.cs
+++ b/src/housecarl-mcp/RowProjection.cs
@@ -132,14 +132,14 @@ static class RowProjection
     }
 
     /// <summary>Is <paramref name="path"/> a strict sub-field or element of <paramref name="owner"/>.</summary>
-    static bool IsUnder(string path, string owner) =>
+    internal static bool IsUnder(string path, string owner) =>
         path.Length > owner.Length && path.StartsWith(owner, StringComparison.Ordinal)
         && (path[owner.Length] == '.' || path[owner.Length] == '[');
 
     /// <summary>The element path a line belongs to — a requested root plus the first bracketed segment after it,
     /// or the root itself when the caller already indexed one element — or null when the line is the list's own
     /// summary, a non-list field, or the truncation note.</summary>
-    static string? RowKey(string path, IReadOnlyList<string> roots)
+    internal static string? RowKey(string path, IReadOnlyList<string> roots)
     {
         foreach (var r in roots)
         {


### PR DESCRIPTION
`where=` has taken the quantifier tokens since E1; the projection half was refused as unbuilt. This adds it: `project.fields=["Effects[*count]"]` renders one number per record (the element count of that list), and `["Effects[*]"]` renders one row per element in the same row shape `project.form='rows'` produces — the fold IS `RowProjection`'s, so a row here and a row under the rows form are the same row rather than two renderings of one idea. A sub-path after the token (`"Effects[*].Data.Magnitude"`) renders that leaf per element instead. Under `format='dense'` the extra rows repeat the record's identity columns, and an unquantified column repeats its own cell beside them; the text and json lanes take the existing body lane, so the render, the artifact and the json document all see the same folded fields.

The token vocabulary moved into `PathFoldGrammar` in core and `FieldPredicate` now reads through it, so `where=` and `project.fields` cannot drift on what a token means — the SELECT half's tokenizer is reused, not copied. `[*any]`/`[*all]`/`[*none]` fold to a boolean, which is not a row, and stay refused here by name; a quantifier on a step that is not a list fails that record with one sentence naming the path, what the step actually holds, and the two ways to read it.

Tests: `RecordsFieldFoldTests` covers the count on a list, the bare `[*]` in the rows shape and in dense, the sub-path form, composition with an ordinary path, and every refusal. Full suite green (1537), `ci-all` 128/128.

Closes #458
