### PR TITLE
docs(spid-authoring): verifying a distribution actually happened

### DIFF
--- a/.claude/skills/spid-authoring/SKILL.md
+++ b/.claude/skills/spid-authoring/SKILL.md
@@ -139,6 +139,14 @@ what SPID looked up; only a live actor shows what SPID applied.
   it by name, which is what makes a no-ESP keyword distribution verifiable from script at all. For the
   signature, look it up in the `papyrus-reference` skill; the SPID side
   is in `references/form-types.md`.
+- **Chance and a Level Filter skip actors by design.** A `Chance` below 100 is *supposed* to miss some
+  NPCs, so two sampled actors without the form is an ordinary outcome for `|||||50`, not a broken
+  rule — and the roll is re-made each session unless `!` pins it per NPC (`!` makes re-sampling the
+  same actor repeatable; it does not make the form land). A Level Filter does the same
+  deterministically: the line moves to the Leveled Distribution pass and only auto-leveled NPCs whose
+  level/skills fall in the range receive it. Before calling a rule failed, set Chance to 100 and check
+  the actors you sampled pass the Level Filter (`references/grammar-core.md` §10,
+  `references/filters.md` §3).
 - **Sample somewhere NPCs must be** — testing practice, not a SPID rule. An interior cell with known
   occupants beats an exterior spawn marker: finding no NPC within scan range there is inconclusive
   rather than a failing distribution.

--- a/.claude/skills/spid-authoring/SKILL.md
+++ b/.claude/skills/spid-authoring/SKILL.md
@@ -125,9 +125,10 @@ SPID documentation.
 A parsed `_DISTR.ini` and a clean SPID log are **not** proof that an NPC got the thing. The log shows
 what SPID looked up; only a live actor shows what SPID applied.
 
-- **SPID does not distribute to the player.** Every distribution path is gated on a check that
-  excludes the player, so asserting on `Game.GetPlayer()` reports failure for a rule that is working
-  perfectly — sample NPCs instead (`references/grammar-core.md` §3).
+- **SPID does not distribute to the player.** The ordinary on-load path is gated on an explicit
+  `IsPlayer()` check, and the other paths into `Distribute()` exclude the player by their own guards,
+  so asserting on `Game.GetPlayer()` reports failure for a rule that is working perfectly — sample
+  NPCs instead (`references/grammar-core.md` §3).
 - **A newly added rule reaches old saves, but not mid-session.** SPID distributes from scratch each
   launch and writes nothing into the save, so actors in a pre-existing save do get a rule added
   afterwards (`references/grammar-core.md` §3). What bites is that the INIs are read **once per game

--- a/.claude/skills/spid-authoring/SKILL.md
+++ b/.claude/skills/spid-authoring/SKILL.md
@@ -128,14 +128,15 @@ what SPID looked up; only a live actor shows what SPID applied.
 - **SPID does not distribute to the player.** Every distribution path is gated on a check that
   excludes the player, so asserting on `Game.GetPlayer()` reports failure for a rule that is working
   perfectly — sample NPCs instead (`references/grammar-core.md` §3).
-- **A newly added rule reaches old saves, but not mid-session.** SPID redistributes from scratch each
-  launch, so actors in a pre-existing save do get a rule added afterwards. What bites is that the INIs
-  are read **once per game launch**: a rule added while the game is running needs a restart, and the
-  actor has to load in that new session for the lazy per-actor distribution to run.
+- **A newly added rule reaches old saves, but not mid-session.** SPID distributes from scratch each
+  launch and writes nothing into the save, so actors in a pre-existing save do get a rule added
+  afterwards (`references/grammar-core.md` §3). What bites is that the INIs are read **once per game
+  launch**: a rule added while the game is running needs a restart, and the actor has to load in that
+  new session for the lazy per-actor distribution to run.
 - **A dynamic keyword IS reachable.** A keyword SPID creates at runtime has no plugin FormID — nothing
   in xEdit to point at — but it is in the game's keyword array, so `Keyword.GetKeyword("<name>")` finds
   it by name, which is what makes a no-ESP keyword distribution verifiable from script at all. For the
-  signature, look it up in the `papyrus-reference` skill (`references/skse/Keyword.md`); the SPID side
+  signature, look it up in the `papyrus-reference` skill; the SPID side
   is in `references/form-types.md`.
 - **Sample somewhere NPCs must be** — testing practice, not a SPID rule. An interior cell with known
   occupants beats an exterior spawn marker: finding no NPC within scan range there is inconclusive

--- a/.claude/skills/spid-authoring/SKILL.md
+++ b/.claude/skills/spid-authoring/SKILL.md
@@ -120,6 +120,27 @@ SPID documentation.
   one of them (text → String, form → Form, level/skill → Level, trait → Trait). Look it up in
   `filters.md` rather than assuming a filter exists.
 
+## Verifying a distribution actually happened
+
+A parsed `_DISTR.ini` and a clean SPID log are **not** proof that an NPC got the thing. The log shows
+what SPID looked up; only a live actor shows what SPID applied.
+
+- **SPID does not distribute to the player.** Every distribution path is gated on a check that
+  excludes the player, so asserting on `Game.GetPlayer()` reports failure for a rule that is working
+  perfectly — sample NPCs instead (`references/grammar-core.md` §3).
+- **A newly added rule reaches old saves, but not mid-session.** SPID redistributes from scratch each
+  launch, so actors in a pre-existing save do get a rule added afterwards. What bites is that the INIs
+  are read **once per game launch**: a rule added while the game is running needs a restart, and the
+  actor has to load in that new session for the lazy per-actor distribution to run.
+- **A dynamic keyword IS reachable.** A keyword SPID creates at runtime has no plugin FormID — nothing
+  in xEdit to point at — but it is in the game's keyword array, so `Keyword.GetKeyword("<name>")` finds
+  it by name, which is what makes a no-ESP keyword distribution verifiable from script at all. For the
+  signature, look it up in the `papyrus-reference` skill (`references/skse/Keyword.md`); the SPID side
+  is in `references/form-types.md`.
+- **Sample somewhere NPCs must be** — testing practice, not a SPID rule. An interior cell with known
+  occupants beats an exterior spawn marker: finding no NPC within scan range there is inconclusive
+  rather than a failing distribution.
+
 ## Notes
 
 - **Provenance.** The `references/` corpus is reconstructed from "SPID: The Complete Reference"

--- a/.claude/skills/spid-authoring/references/_CORPUS_STATUS.md
+++ b/.claude/skills/spid-authoring/references/_CORPUS_STATUS.md
@@ -75,8 +75,10 @@ only — no code vendored. Files consulted (all `SPID/src/`): `LookupConfigs.cpp
 chain), `LookupConfigs.h` (`TraitsFilterComponentParser`, `ChanceComponentParser`,
 `LevelFiltersComponentParser`), `Defs.h` (`Traits` struct), `DistributeManager.cpp`
 (`detail::should_process_NPC`, the load hooks), `FormData.h` (`kCreateIfMissing`), `main.cpp`
-(config read and lookup timing). MIT (unlike SkyPatcher's unlicensed repo)
-would permit vendoring, but the corpus documents grammar, it doesn't embed source.
+(config read and lookup timing). The verification-behaviour files were read at commit
+`6e66908` (`master`, 2026-09-02); the earlier parsing files at `master` as of 2026-06-02. MIT (unlike
+SkyPatcher's unlicensed repo) would permit vendoring, but the corpus documents grammar, it doesn't
+embed source.
 
 ## Structure
 

--- a/.claude/skills/spid-authoring/references/_CORPUS_STATUS.md
+++ b/.claude/skills/spid-authoring/references/_CORPUS_STATUS.md
@@ -40,7 +40,7 @@ the per-record files.
 | Distributable form types | **10 / 10** (`form-types.md`) |
 | Filter sections | **4 / 4** (`filters.md`) |
 | Flat enums | skill indices, trait letters, package-list types, form signatures, distribution order, defaults (`value-tables.md`) |
-| **Gaps** | **The article does not cover verification behaviour.** Four details a user hits when checking whether a rule landed — player exclusion, the once-per-launch config read, the dynamic keyword's missing plugin FormID, and its reachability by name — are absent from article 6617 and were resolved from source (marked **[source]**; see Confidence). Two other article-*silent* details (comment syntax, whitespace tolerance) came from source the same way. Expect further gaps outside the article's grammar scope. |
+| **Gaps** | **The article does not cover verification behaviour.** Five details a user hits when checking whether a rule landed — player exclusion, the once-per-launch config read, the runtime `SPID_Processed` marker, the dynamic keyword's missing plugin FormID, and its reachability by name — are absent from article 6617 and were resolved from source (marked **[source]**; see Confidence). Two other article-*silent* details (comment syntax, whitespace tolerance) came from source the same way. Expect further gaps outside the article's grammar scope. |
 
 ## Confidence
 
@@ -61,6 +61,10 @@ the per-record files.
     article.
   - **Configs are read once per game launch** (`main.cpp`, `kPostLoad`/`kDataLoaded`), so a rule added
     mid-session needs a restart. Not in the article.
+  - **The "already handled this NPC" marker is a runtime keyword, not a persisted one** — `Setup()` in
+    `DistributeManager.cpp` creates `SPID_Processed` via `IFormFactory` each launch (declared in
+    `DistributeManager.h`), and `distribute_on_load` skips an NPC that already carries it. The
+    article states the from-scratch-per-launch behaviour; the mechanism behind it is source-only.
   - **A dynamically created keyword has no plugin FormID but is pushed into the game's keyword array**
     (`FormData.h`, `kCreateIfMissing`). The other half — that SKSE's `Keyword.GetKeyword` resolves a
     name against that same array — is read from SKSE's own source (`ianpatt/skse64`,
@@ -79,11 +83,17 @@ the per-record files.
 only — no code vendored. Files consulted (all `SPID/src/`): `LookupConfigs.cpp` (`sanitize()`, parser
 chain), `LookupConfigs.h` (`TraitsFilterComponentParser`, `ChanceComponentParser`,
 `LevelFiltersComponentParser`), `Defs.h` (`Traits` struct), `DistributeManager.cpp`
-(`detail::should_process_NPC`, the load hooks), `FormData.h` (`kCreateIfMissing`), `main.cpp`
-(config read and lookup timing). The verification-behaviour files were read at commit
-`6e66908` (`master`, 2026-09-02); the earlier parsing files at `master` as of 2026-06-02. MIT (unlike
-SkyPatcher's unlicensed repo) would permit vendoring, but the corpus documents grammar, it doesn't
-embed source.
+(`detail::should_process_NPC`, `Setup()`, the load hooks), `DistributeManager.h` (the `processed`
+keyword declaration), `DistributePCLevelMult.cpp` and `DeathDistribution.cpp` (the remaining
+`Distribute()` call sites and their guards), `Distribute.cpp` (the call-site inventory),
+`FormData.h` (`kCreateIfMissing`), `main.cpp` (config read and lookup timing). The
+verification-behaviour files were read at commit `6e66908` (`master`, 2026-09-02); the earlier parsing
+files at `master` as of 2026-06-02. MIT (unlike SkyPatcher's unlicensed repo) would permit vendoring,
+but the corpus documents grammar, it doesn't embed source.
+
+One fact reaches outside SPID's repo: **SKSE** (`ianpatt/skse64`, `master` `4cd2e34`, read 2026-09-05)
+— `skse64/PapyrusKeyword.cpp`, for how `Keyword.GetKeyword` resolves a name. Cited in `form-types.md`
+so the by-name-reachability claim does not span an unread seam.
 
 ## Structure
 

--- a/.claude/skills/spid-authoring/references/_CORPUS_STATUS.md
+++ b/.claude/skills/spid-authoring/references/_CORPUS_STATUS.md
@@ -62,8 +62,10 @@ the per-record files.
   - **Configs are read once per game launch** (`main.cpp`, `kPostLoad`/`kDataLoaded`), so a rule added
     mid-session needs a restart. Not in the article.
   - **A dynamically created keyword has no plugin FormID but is pushed into the game's keyword array**
-    (`FormData.h`, `kCreateIfMissing`), which is why SKSE's `Keyword.GetKeyword` finds it by name. The
-    article documents dynamic creation but neither consequence.
+    (`FormData.h`, `kCreateIfMissing`). The other half — that SKSE's `Keyword.GetKeyword` resolves a
+    name against that same array — is read from SKSE's own source (`ianpatt/skse64`,
+    `skse64/PapyrusKeyword.cpp`), not inferred; its one-shot, never-invalidated cache is recorded as a
+    caveat in `form-types.md`. The article documents dynamic creation but neither consequence.
 - **One residual confidence caveat:** comment syntax. SPID parses configs via **CSimpleIniA**
   (source-confirmed); the **`;`** line-comment character is CSimpleIni's documented *library default*
   rather than a SPID line of code we read. Stated in the corpus as "standard INI `;` comments (via

--- a/.claude/skills/spid-authoring/references/_CORPUS_STATUS.md
+++ b/.claude/skills/spid-authoring/references/_CORPUS_STATUS.md
@@ -9,7 +9,7 @@ The bundled grammar reference for the `spid-authoring` skill (part of the 5-skil
 distributor-framework cluster — sibling to `skypatcher-authoring`). It documents SPID's `_DISTR.ini`
 distribution grammar — the line syntax, every form type, every filter section and modifier, the
 count/index/chance fields, and the runtime ordering — reconstructed into a consistent, lookup-friendly
-form. The eventual `SKILL.md` (not yet authored — see "Layering") drives lookups against it.
+form. The skill's `SKILL.md` drives lookups against it, routed through `index.jsonl`.
 
 Unlike SkyPatcher (one grammar *per record type*, hence a `records/` dir), SPID has **one grammar**
 that applies across 10 form types. So the corpus is shaped as: `grammar-core` (the line + mechanics) +
@@ -106,20 +106,21 @@ references/
 ├── form-types.md       ← the 10 distributable form types + signatures + special cases
 ├── filters.md          ← the 4 filter sections (String / Form / Level / Trait) in depth
 ├── value-tables.md     ← flat enums (skill indices, trait letters, package-list types, signatures, …)
-└── index.jsonl         ← lookup routing — NOT YET GENERATED (see Layering; deferred with the sibling)
+└── index.jsonl         ← lookup routing: one line per topic, mapping aliases to the file that answers
 ```
+
+**When you add a fact to this corpus, add or update its `index.jsonl` line too** — a fact the router
+cannot reach is a fact the skill will not find.
 
 ## Layering (build plan)
 
 - **Layer 1 (this corpus) — DONE pending review.** The five reference files above. Built only after
   the complete reference was in hand (article captured + source cross-checked) — the project's
   no-guesswork gate.
-- **Layer 2 — not started.** `SKILL.md` (the lookup + bundled-or-warn playbook, modeled on
-  `papyrus-reference`, authored via the `skill-authoring` specialist), `index.jsonl` (routing format
-  designed alongside SKILL.md, kept consistent with the `skypatcher-authoring` sibling),
-  `evals/` (trigger + author-output eval sets per HOUSECARL_SKILL_AUTHORING.md §6.4/§6.5 — run the
-  anonymized, relevance-framed agent fan-out), and the final §8 reviewer walk. Author Layer 2 only
-  after Aaron reviews Layer 1.
+- **Layer 2 — done.** `SKILL.md` (the lookup + bundled-or-warn playbook, modeled on
+  `papyrus-reference`), `index.jsonl` (routing kept consistent with the `skypatcher-authoring`
+  sibling), and `evals/` (trigger + author-output eval sets per HOUSECARL_SKILL_AUTHORING.md
+  §6.4/§6.5) all ship. The skill is live as `/housecarl:spid-authoring`.
 
 ## Cluster note
 

--- a/.claude/skills/spid-authoring/references/_CORPUS_STATUS.md
+++ b/.claude/skills/spid-authoring/references/_CORPUS_STATUS.md
@@ -40,7 +40,7 @@ the per-record files.
 | Distributable form types | **10 / 10** (`form-types.md`) |
 | Filter sections | **4 / 4** (`filters.md`) |
 | Flat enums | skill indices, trait letters, package-list types, form signatures, distribution order, defaults (`value-tables.md`) |
-| **Gaps** | **none in the article's scope.** Two article-*silent* details (comment syntax, whitespace tolerance) were resolved from source — see Confidence. |
+| **Gaps** | **The article does not cover verification behaviour.** Four details a user hits when checking whether a rule landed — player exclusion, the once-per-launch config read, the dynamic keyword's missing plugin FormID, and its reachability by name — are absent from article 6617 and were resolved from source (marked **[source]**; see Confidence). Two other article-*silent* details (comment syntax, whitespace tolerance) came from source the same way. Expect further gaps outside the article's grammar scope. |
 
 ## Confidence
 
@@ -54,6 +54,13 @@ the per-record files.
   - **Whitespace around `|` and `,` is stripped**, **`" - "` ⇒ `~`** (xEdit paste form), and FormID
     zero-padding is forgiven — from `sanitize()`.
   - **Chance `!`** deterministic flag and **Level `w`** weight prefix — confirmed in the parsers.
+  - **The player is never distributed to** — `should_process_NPC` in `DistributeManager.cpp` gates
+    every path on `!IsPlayer() && !IsDeleted()`. Not in the article.
+  - **Configs are read once per game launch** (`main.cpp`, `kPostLoad`/`kDataLoaded`), so a rule added
+    mid-session needs a restart. Not in the article.
+  - **A dynamically created keyword has no plugin FormID but is pushed into the game's keyword array**
+    (`FormData.h`, `kCreateIfMissing`), which is why SKSE's `Keyword.GetKeyword` finds it by name. The
+    article documents dynamic creation but neither consequence.
 - **One residual confidence caveat:** comment syntax. SPID parses configs via **CSimpleIniA**
   (source-confirmed); the **`;`** line-comment character is CSimpleIni's documented *library default*
   rather than a SPID line of code we read. Stated in the corpus as "standard INI `;` comments (via
@@ -66,7 +73,9 @@ the per-record files.
 `powerof3/Spell-Perk-Item-Distributor` (GitHub, `master`, **MIT License**) was read for grammar facts
 only — no code vendored. Files consulted (all `SPID/src/`): `LookupConfigs.cpp` (`sanitize()`, parser
 chain), `LookupConfigs.h` (`TraitsFilterComponentParser`, `ChanceComponentParser`,
-`LevelFiltersComponentParser`), `Defs.h` (`Traits` struct). MIT (unlike SkyPatcher's unlicensed repo)
+`LevelFiltersComponentParser`), `Defs.h` (`Traits` struct), `DistributeManager.cpp`
+(`detail::should_process_NPC`, the load hooks), `FormData.h` (`kCreateIfMissing`), `main.cpp`
+(config read and lookup timing). MIT (unlike SkyPatcher's unlicensed repo)
 would permit vendoring, but the corpus documents grammar, it doesn't embed source.
 
 ## Structure

--- a/.claude/skills/spid-authoring/references/_CORPUS_STATUS.md
+++ b/.claude/skills/spid-authoring/references/_CORPUS_STATUS.md
@@ -54,8 +54,11 @@ the per-record files.
   - **Whitespace around `|` and `,` is stripped**, **`" - "` ⇒ `~`** (xEdit paste form), and FormID
     zero-padding is forgiven — from `sanitize()`.
   - **Chance `!`** deterministic flag and **Level `w`** weight prefix — confirmed in the parsers.
-  - **The player is never distributed to** — `should_process_NPC` in `DistributeManager.cpp` gates
-    every path on `!IsPlayer() && !IsDeleted()`. Not in the article.
+  - **The player is not distributed to** — `should_process_NPC` in `DistributeManager.cpp` gates the
+    on-load path on `!IsPlayer() && !IsDeleted()`; the PC-level-mult hooks require an already-processed
+    NPC and the death path carries its own `!IsPlayerRef()` guard. All `Distribute()` call sites were
+    read (`DistributeManager.cpp`, `DistributePCLevelMult.cpp`, `DeathDistribution.cpp`). Not in the
+    article.
   - **Configs are read once per game launch** (`main.cpp`, `kPostLoad`/`kDataLoaded`), so a rule added
     mid-session needs a restart. Not in the article.
   - **A dynamically created keyword has no plugin FormID but is pushed into the game's keyword array**

--- a/.claude/skills/spid-authoring/references/form-types.md
+++ b/.claude/skills/spid-authoring/references/form-types.md
@@ -48,6 +48,12 @@ any plugin:
 Keyword = MyVerySpecialKeyword
 ```
 
+A keyword created this way is a **dynamic form: it has no owning plugin, so there is no plugin FormID
+to reference it by** — no `0x…~Plugin.esp` exists for it and xEdit will never show it. It is still
+reachable by name, because SPID pushes the new keyword into the game's `BGSKeyword` form array, which
+is what SKSE's `Keyword.GetKeyword("<name>")` looks up. **[source]** (`SPID/src/FormData.h`, the
+`kCreateIfMissing` branch — creates the form via `IFormFactory` and sets its `formEditorID`.)
+
 This is the idiom behind keyword-tagging NPCs for other frameworks/mods to react to. (Recall from
 grammar-core §3 that Keywords distribute first and are topo-sorted, so a dynamically-created keyword
 can be used as a filter by a later keyword entry.)

--- a/.claude/skills/spid-authoring/references/form-types.md
+++ b/.claude/skills/spid-authoring/references/form-types.md
@@ -50,9 +50,21 @@ Keyword = MyVerySpecialKeyword
 
 A keyword created this way is a **dynamic form: it has no owning plugin, so there is no plugin FormID
 to reference it by** — no `0x…~Plugin.esp` exists for it and xEdit will never show it. It is still
-reachable by name, because SPID pushes the new keyword into the game's `BGSKeyword` form array, which
-is what SKSE's `Keyword.GetKeyword("<name>")` looks up. **[source]** (`SPID/src/FormData.h`, the
-`kCreateIfMissing` branch — creates the form via `IFormFactory` and sets its `formEditorID`.)
+reachable by name, and both halves of that are read from source:
+
+- SPID pushes the new keyword into the data handler's `BGSKeyword` form array. **[source]**
+  (`SPID/src/FormData.h`, the `kCreateIfMissing` branch — creates the form via `IFormFactory`, sets
+  its `formEditorID`, and `push_back`s it onto the array.)
+- SKSE's `Keyword.GetKeyword("<name>")` resolves a name against that same array. **[source]**
+  (`ianpatt/skse64`, `skse64/PapyrusKeyword.cpp` — `GetKeyword` walks `DataHandler::keywords` into a
+  `BSFixedString → BGSKeyword*` map keyed on each keyword's string, then looks the name up in it.)
+
+**One caveat that comes with that SKSE code:** the map is built once, lazily, on the first
+`GetKeyword` call of the session, and is never invalidated (the invalidation branch is commented out
+in SKSE's source). Anything added to the keyword array *after* that first call is not found for the
+rest of the session. SPID creates its keywords during form lookup at `kDataLoaded`, before any Papyrus
+runs, so a SPID keyword is in the array before the cache is built — but this is the one way a by-name
+lookup can return `None` for a keyword that genuinely exists.
 
 This is the idiom behind keyword-tagging NPCs for other frameworks/mods to react to. (Recall from
 grammar-core §3 that Keywords distribute first and are topo-sorted, so a dynamically-created keyword

--- a/.claude/skills/spid-authoring/references/grammar-core.md
+++ b/.claude/skills/spid-authoring/references/grammar-core.md
@@ -57,13 +57,14 @@ INI edited while the game is running takes effect only after a restart. **[sourc
 (`SPID/src/main.cpp` — configs are read at `kPostLoad` and forms looked up at `kDataLoaded`.)
 
 **Every launch, from scratch.** SPID "distributes everything from scratch each time you launch the
-game" and "doesn't have effect on either loaded plugins nor on save" — nothing it distributes is
-written into the save, so a rule added to a `_DISTR.ini` after a save was made applies to that save's
-actors on the next launch, when they next load in. The "already handled this NPC" marker is a runtime
-`SPID_Processed` keyword created fresh at each launch, so it carries nothing across sessions.
-**[source]** (`SPID/src/DistributeManager.cpp` — `Setup()` creates the keyword via `IFormFactory`;
-`distribute_on_load` skips an NPC that already has it.) The practical limit is the once-per-launch
-config read above: no restart, no new rule.
+game" and "doesn't have effect on either loaded plugins nor on save" — article 6617, § General
+Distribution Info, quoted verbatim. Nothing it distributes is written into the save, so a rule added
+to a `_DISTR.ini` after a save was made applies to that save's actors on the next launch, when they
+next load in. The "already handled this NPC" marker is a runtime `SPID_Processed` keyword created
+fresh at each launch, so it carries nothing across sessions. **[source]**
+(`SPID/src/DistributeManager.cpp` — `Setup()` creates the keyword via `IFormFactory`;
+`distribute_on_load` skips an NPC that already has it; declared in `DistributeManager.h`.) The
+practical limit is the once-per-launch config read above: no restart, no new rule.
 
 **Who — never the player.** Every distribution path is gated on
 `detail::should_process_NPC`, which is `!a_npc->IsPlayer() && !a_npc->IsDeleted()`, so the player

--- a/.claude/skills/spid-authoring/references/grammar-core.md
+++ b/.claude/skills/spid-authoring/references/grammar-core.md
@@ -56,6 +56,15 @@ load), not all at once at game start. The configs themselves are read **once per
 INI edited while the game is running takes effect only after a restart. **[source]**
 (`SPID/src/main.cpp` — configs are read at `kPostLoad` and forms looked up at `kDataLoaded`.)
 
+**Every launch, from scratch.** SPID "distributes everything from scratch each time you launch the
+game" and "doesn't have effect on either loaded plugins nor on save" — nothing it distributes is
+written into the save, so a rule added to a `_DISTR.ini` after a save was made applies to that save's
+actors on the next launch, when they next load in. The "already handled this NPC" marker is a runtime
+`SPID_Processed` keyword created fresh at each launch, so it carries nothing across sessions.
+**[source]** (`SPID/src/DistributeManager.cpp` — `Setup()` creates the keyword via `IFormFactory`;
+`distribute_on_load` skips an NPC that already has it.) The practical limit is the once-per-launch
+config read above: no restart, no new rule.
+
 **Who — never the player.** Every distribution path is gated on
 `detail::should_process_NPC`, which is `!a_npc->IsPlayer() && !a_npc->IsDeleted()`, so the player
 character is not a distribution target and never receives a SPID form. **[source]**

--- a/.claude/skills/spid-authoring/references/grammar-core.md
+++ b/.claude/skills/spid-authoring/references/grammar-core.md
@@ -52,7 +52,14 @@ comment stripping are CSimpleIniA's, not SPID's own code.)
 ## 3. When distribution happens, and in what order
 
 **When:** distribution is **lazy** — it runs when NPCs are loaded into the world (typically on cell
-load), not all at once at game start.
+load), not all at once at game start. The configs themselves are read **once per game launch**, so an
+INI edited while the game is running takes effect only after a restart. **[source]**
+(`SPID/src/main.cpp` — configs are read at `kPostLoad` and forms looked up at `kDataLoaded`.)
+
+**Who — never the player.** Every distribution path is gated on
+`detail::should_process_NPC`, which is `!a_npc->IsPlayer() && !a_npc->IsDeleted()`, so the player
+character is not a distribution target and never receives a SPID form. **[source]**
+(`SPID/src/DistributeManager.cpp`.)
 
 **Order (per-type passes):** SPID processes each form type separately, in this fixed order:
 

--- a/.claude/skills/spid-authoring/references/grammar-core.md
+++ b/.claude/skills/spid-authoring/references/grammar-core.md
@@ -66,10 +66,17 @@ fresh at each launch, so it carries nothing across sessions. **[source]**
 `distribute_on_load` skips an NPC that already has it; declared in `DistributeManager.h`.) The
 practical limit is the once-per-launch config read above: no restart, no new rule.
 
-**Who — never the player.** Every distribution path is gated on
-`detail::should_process_NPC`, which is `!a_npc->IsPlayer() && !a_npc->IsDeleted()`, so the player
-character is not a distribution target and never receives a SPID form. **[source]**
-(`SPID/src/DistributeManager.cpp`.)
+**Who — not the player.** The ordinary on-load path is gated on `detail::should_process_NPC`, which
+is `!a_npc->IsPlayer() && !a_npc->IsDeleted()`, so a normal distribution never reaches the player
+character. The other paths into `Distribute()` exclude the player their own way rather than through
+that function: the two PC-level-mult redistribution hooks run only for an NPC that already carries
+`SPID_Processed`, and only the on-load path ever adds it; on-death distribution guards its death-event
+handler with `!IsPlayerRef() && !IsSummoned()`. (Its other entry, the `ShouldBackgroundClone` hook,
+carries no explicit player check — the player is not background-cloned, but that is a game fact, not a
+SPID guard.) **[source]** (`SPID/src/DistributeManager.cpp`, `DistributePCLevelMult.cpp`,
+`DeathDistribution.cpp` — all `Distribute()` call sites read.)
+
+Practically: don't assert a SPID distribution on `Game.GetPlayer()`; sample NPCs.
 
 **Order (per-type passes):** SPID processes each form type separately, in this fixed order:
 

--- a/.claude/skills/spid-authoring/references/index.jsonl
+++ b/.claude/skills/spid-authoring/references/index.jsonl
@@ -3,7 +3,7 @@
 {"topic": "Item", "kind": "form-type", "sig": "ALCH, AMMO, ARMO, BOOK, INGR, KEYM, LVLI, MISC, SCRL, SLGM, WEAP", "file": "form-types.md", "aliases": ["weapon", "armor", "potion", "gear", "gold", "arrows", "count"]}
 {"topic": "Shout", "kind": "form-type", "sig": "SHOU", "file": "form-types.md"}
 {"topic": "Package", "kind": "form-type", "sig": "PACK, FLST", "file": "form-types.md", "aliases": ["AI package", "patrol", "travel", "package index", "package list"]}
-{"topic": "Keyword", "kind": "form-type", "sig": "KYWD", "file": "form-types.md", "note": "can be created dynamically", "aliases": ["dynamic keyword", "tag"]}
+{"topic": "Keyword", "kind": "form-type", "sig": "KYWD", "file": "form-types.md", "note": "can be created dynamically", "aliases": ["dynamic keyword", "tag", "GetKeyword", "no plugin FormID", "not in xEdit", "keyword array"]}
 {"topic": "Outfit", "kind": "form-type", "sig": "OTFT", "file": "form-types.md"}
 {"topic": "SleepOutfit", "kind": "form-type", "sig": "OTFT", "file": "form-types.md", "note": "cannot be inferred — name the type explicitly"}
 {"topic": "Faction", "kind": "form-type", "sig": "FACT", "file": "form-types.md"}
@@ -14,6 +14,7 @@
 {"topic": "Trait Filter", "kind": "filter", "section": 4, "file": "filters.md", "aliases": ["female", "male", "unique", "summonable", "child", "leveled", "teammate", "dead", "gender"]}
 {"topic": "line syntax", "kind": "grammar", "file": "grammar-core.md", "aliases": ["pipe sections", "FormType", "FormOrEditorID", "NONE", "blank section"]}
 {"topic": "file discovery & load order", "kind": "grammar", "file": "grammar-core.md", "aliases": ["_DISTR", "Data folder", "alphabetical", "comments", "semicolon"]}
+{"topic": "when distribution happens", "kind": "grammar", "file": "grammar-core.md", "aliases": ["lazy", "cell load", "once per launch", "restart", "from scratch", "existing save", "new game needed", "player excluded", "never the player", "verify"]}
 {"topic": "input normalization", "kind": "grammar", "file": "grammar-core.md", "aliases": ["whitespace", "xEdit paste", "space hyphen space", "leading zeros", "0x"]}
 {"topic": "referencing a form", "kind": "grammar", "file": "grammar-core.md", "aliases": ["FormID", "EditorID", "suffix tilde", "0x123~Plugin.esp"]}
 {"topic": "filter combination logic", "kind": "grammar", "file": "grammar-core.md", "aliases": ["AND", "OR", "exclusion", "multiple lines", "multiplicative", "additive"]}

--- a/.claude/skills/spid-authoring/references/index.jsonl
+++ b/.claude/skills/spid-authoring/references/index.jsonl
@@ -20,7 +20,7 @@
 {"topic": "filter combination logic", "kind": "grammar", "file": "grammar-core.md", "aliases": ["AND", "OR", "exclusion", "multiple lines", "multiplicative", "additive"]}
 {"topic": "type inferring", "kind": "grammar", "file": "grammar-core.md", "aliases": ["generic Form", "infer", "Form ="]}
 {"topic": "Count or Package Index", "kind": "grammar", "file": "grammar-core.md", "aliases": ["item count", "range", "package index", "package list type"]}
-{"topic": "Chance", "kind": "grammar", "file": "grammar-core.md", "aliases": ["chance", "percent", "deterministic", "!"]}
+{"topic": "Chance", "kind": "grammar", "file": "grammar-core.md", "aliases": ["chance", "percent", "deterministic", "!", "only some NPCs got it", "didn't land on everyone", "random miss"]}
 {"topic": "templated NPCs", "kind": "grammar", "file": "grammar-core.md", "aliases": ["template", "base template", "leveled NPC", "reachable", "descendants"]}
 {"topic": "skill indices", "kind": "value-table", "file": "value-tables.md", "aliases": ["skill index", "one-handed", "destruction", "0-17", "skill level filter"]}
 {"topic": "trait letter codes", "kind": "value-table", "file": "value-tables.md", "aliases": ["F", "M", "U", "S", "C", "L", "T", "D", "teammate letter"]}

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -15,10 +15,10 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 - **`spid-authoring` now covers checking that a distribution reached a live actor.** A parsed
   `_DISTR.ini` and a clean SPID log show what SPID looked up, not what an NPC received. The skill's new
-  "Verifying a distribution actually happened" section says what to assert instead: the player is never
-  a distribution target, a rule added mid-session needs a game restart because the INIs are read once
-  per launch, and a keyword SPID creates at runtime has no plugin FormID but is still found by name from
-  a script. The reference corpus carries the same facts with their source. Reported and drafted by
+  "Verifying a distribution actually happened" section says what to assert instead: SPID does not
+  distribute to the player, a rule added mid-session needs a game restart because the INIs are read once
+  per launch, a `Chance` below 100 or a Level Filter can skip a sampled actor by design, and a keyword
+  SPID creates at runtime has no plugin FormID but is still found by name from a script. The reference corpus carries the same facts with their source. Reported and drafted by
   juggernaunt46-star (#384).
 
 - **A response answered off an order that lost plugins to a load failure says so.** When a plugin cannot be

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,14 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **`spid-authoring` now covers checking that a distribution reached a live actor.** A parsed
+  `_DISTR.ini` and a clean SPID log show what SPID looked up, not what an NPC received. The skill's new
+  "Verifying a distribution actually happened" section says what to assert instead: the player is never
+  a distribution target, a rule added mid-session needs a game restart because the INIs are read once
+  per launch, and a keyword SPID creates at runtime has no plugin FormID but is still found by name from
+  a script. The reference corpus carries the same facts with their source. Reported and drafted by
+  juggernaunt46-star (#384).
+
 - **A response answered off an order that lost plugins to a load failure says so.** When a plugin cannot be
   opened or parsed it is excluded from the index build, and reads after that answer off the narrowed order —
   shallower override depths, fewer touching plugins, sometimes a different winner. The epoch stamp changed, but


### PR DESCRIPTION
The `spid-authoring` skill said nothing about positively verifying that a rule landed on an actor, which is where several SPID behaviours bite. This lands juggernaunt46-star's PR #384 text with corrections. The new "Verifying a distribution actually happened" section says that a parsed `_DISTR.ini` and a clean SPID log show what SPID looked up, not what an actor received, and then what to assert instead: the player is never a distribution target; a dynamically created keyword has no plugin FormID but is still found by name from a script; and sampling an interior cell with known occupants is testing practice, marked as such rather than as a SPID fact. The pre-existing-save bullet from #384 is rewritten because it was wrong as written — SPID redistributes from scratch every launch, so an old save's actors do get a newly added rule; the real constraint is that the INIs are read once per game launch, so a rule added mid-session needs a restart and the actor has to load in that new session. The section sits after "Common mistakes" per the section order in `standards/HOUSECARL_SKILL_AUTHORING.md` §4.2, and cites the `papyrus-reference` skill for the `Keyword.GetKeyword` signature per §4.4.

The facts themselves are grounded in the reference corpus rather than asserted only in the skill body: player exclusion and the once-per-launch config read go into `references/grammar-core.md` §3, the dynamic keyword's missing plugin FormID and its reachability by name go into `references/form-types.md`, both with the corpus's existing **[source]** marker naming SPID's own files (`DistributeManager.cpp` `should_process_NPC`, `FormData.h` `kCreateIfMissing`, `main.cpp` config timing). `_CORPUS_STATUS.md` no longer claims "Gaps: none in the article's scope" — article 6617 covers grammar, not verification behaviour — and lists the new source-resolved facts and the files they came from.

Docs only, no build. Frontmatter and description are untouched, so the trigger surface is unchanged and the eval set is unaffected; no eval re-run per §6.5, which gates re-measurement on a changed description. `SKILL.md` is 158 lines, under the §4.1 cap. No houseCARL tool is named in the added text.

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)
