### PR TITLE
Correct the ruling date in seven comments from 09-06 to 09-05

### DIFF
--- a/src/housecarl-generator/ExtendResolveProbe.cs
+++ b/src/housecarl-generator/ExtendResolveProbe.cs
@@ -56,7 +56,7 @@ internal static class ExtendResolveProbe
         Console.WriteLine();
         int fail = 0;
         void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
-        // Aaron's ruling (2026-09-06): each extend refusal is ONE sentence. Read as one terminating period and no
+        // Aaron's ruling (2026-09-05): each extend refusal is ONE sentence. Read as one terminating period and no
         // sentence break inside it — a plugin basename's dot is followed by a letter, never by a space.
         static bool OneSentence(string s) =>
             s.EndsWith('.') && !s.AsSpan(0, s.Length - 1).Contains(". ", StringComparison.Ordinal);
@@ -244,7 +244,7 @@ internal static class ExtendResolveProbe
                 Check(r.Error is not null && r.Error.Contains("auto-suffixed if that name is taken", StringComparison.Ordinal),
                       "…and qualifies the name it offers with the auto-suffix, rather than promising a filename");
 
-                // Aaron's ruling (2026-09-06): ONE sentence — what went wrong, then what to try, with the candidates
+                // Aaron's ruling (2026-09-05): ONE sentence — what went wrong, then what to try, with the candidates
                 // named inside it. Every arm below pins the same three properties, so a clause creeping back in on
                 // any one lane reddens: one terminating period, the "try" remedy, and no in-place lane.
                 Check(OneSentence(r.Error ?? ""), $"…and the whole refusal is ONE sentence ({r.Error})");
@@ -402,7 +402,7 @@ internal static class ExtendResolveProbe
                 Check(r.Error is not null && r.Error.Contains(WriteSentences.RemoveNoFreshPatch, StringComparison.Ordinal),
                       "…and the LANE states why there is no create route here (removal needs a patch that already carries it)");
                 // One sentence, and no in-place clause on it: this lane's in-place spelling is the TOOL's, and it
-                // rides the missing-patch= refusal rather than this one (Aaron, 2026-09-06).
+                // rides the missing-patch= refusal rather than this one (Aaron, 2026-09-05).
                 Check(r.Error is not null && OneSentence(r.Error) && !r.Error.Contains("in_place", StringComparison.Ordinal),
                       $"…and the whole refusal is ONE sentence naming no in-place lane ({r.Error})");
 
@@ -423,7 +423,7 @@ internal static class ExtendResolveProbe
             Console.WriteLine("--- 8d3: the remove TOOL's refusal names the lane IT declares ---");
             {
                 // The extend refusal is one sentence about the extend that failed: no in-place clause rides it at
-                // TOOL altitude either, even though this tool has a spelling to hand down (Aaron, 2026-09-06).
+                // TOOL altitude either, even though this tool has a spelling to hand down (Aaron, 2026-09-05).
                 var modern = RemoveTools.Remove(svc, new[] { fid }, into: "GhostRemove");
                 Check(!modern.Contains("in_place", StringComparison.Ordinal) && !modern.Contains("target=", StringComparison.Ordinal),
                       "housecarl_remove's not-found refusal names no in-place lane, and never target=");
@@ -527,7 +527,7 @@ internal static class ExtendResolveProbe
                 Check(File.ReadAllBytes(foreignEsp).SequenceEqual(foreignBefore), "the un-owned plugin is byte-untouched after the refusal");
 
                 // #359: the refusal must not dead-end. In ONE sentence it names the fresh lane's own parameter and
-                // the owned patches to extend instead (Aaron, 2026-09-06).
+                // the owned patches to extend instead (Aaron, 2026-09-05).
                 Check(r.Error is not null && r.Error.Contains("patch= a name no mod folder already uses for a fresh patch", StringComparison.Ordinal),
                       "…the un-owned refusal names the fresh lane's parameter (#359)");
                 Check(r.Error is not null && !r.Error.Contains("patch=\"Foreign\"", StringComparison.Ordinal),

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -8286,7 +8286,7 @@ public sealed class LoadOrderService : IDisposable
                 // beside this folder's inactive "<stem>.esp" is two plugins that cannot both be active (#359). The
                 // in-place lane, the other reading of a name that lands on a foreign folder, is NOT offered here:
                 // this refusal is one sentence about the extend that failed, and the consent-gated lane stays
-                // discoverable on the tool that declares it (Aaron, 2026-09-06).
+                // discoverable on the tool that declares it (Aaron, 2026-09-05).
                 throw new InvalidOperationException(ExtendRefusal(
                     $"mod folder '{cand}' exists but was NOT created by houseCARL (no marker), so writing into it "
                     + "would touch a mod houseCARL doesn't own (originals untouched, Q3)",
@@ -8349,7 +8349,7 @@ public sealed class LoadOrderService : IDisposable
                                            bool ScanFailed);
 
     /// <summary>One extend refusal, composed: what went wrong, then what to try, in ONE sentence with the nearest
-    /// owned patches named inside it (Aaron, 2026-09-06). <paramref name="noFreshRule"/> is a lane's own statement
+    /// owned patches named inside it (Aaron, 2026-09-05). <paramref name="noFreshRule"/> is a lane's own statement
     /// that it has no fresh-write route and why, and <paramref name="fresh"/> is that route where a lane has one;
     /// each is omitted when the lane offers neither. No in-place clause rides here: that lane is discoverable on the
     /// tool that declares it.</summary>


### PR DESCRIPTION
Seven comments in `ExtendResolveProbe.cs` and `LoadOrderService.cs` cite Aaron's rulings as 2026-09-06. Those rulings were made on 2026-09-05; the session that recorded them dated everything a day ahead (the commits carry the real date). Comments only, no behaviour change, no changelog line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)