### PR TITLE
Bump the plugin version to 2.0.0-beta.1

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "housecarl",
   "displayName": "houseCARL",
-  "version": "1.9.0",
+  "version": "2.0.0-beta.1",
   "description": "Comprehensive data-layer access to your Skyrim SE load order — read any record, author patches into a new plugin, look mods up on Nexus, and look up record schemas, Papyrus signatures, performance reviews, and distributor grammars — in plain English.",
   "author": { "name": "Avick3110" },
   "homepage": "https://github.com/Avick3110/houseCARL",


### PR DESCRIPTION
The plugin manifest still said 1.9.0, so a package built from the default branch would be labelled 1.9.0 with the 2.0 surface inside. This bumps it to `2.0.0-beta.1` so the beta installed on Aaron's PC for the skill-surface audit says what it is in its manifest and zip name. One line; the changelog's `## Unreleased` section is untouched because this is not a release. Ruled 2026-09-05.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
