### PR TITLE
Give each ci-all run its own fixture directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,8 +86,4 @@ dev/
 *.user.json
 houseCARL.user.json
 
-## Probe scratch dirs (compile-probe / import-order-guard end-to-end arms create + delete these in
-## the repo root; a swallowed delete failure must not litter the tree as untracked noise).
-.compile-probe-gen/
-.import-order-probe-gen/
 __pycache__/

--- a/src/housecarl-generator/BsaProbe.cs
+++ b/src/housecarl-generator/BsaProbe.cs
@@ -34,7 +34,7 @@ internal static class BsaProbe
         if (!File.Exists(bsarch)) { Console.WriteLine($"  SKIP  no BSArch at '{bsarch}' (pass its path as arg 1, or set HOUSECARL_BSARCH)"); return 0; }
         if (!File.Exists(bsa)) { Console.WriteLine($"  SKIP  no test archive at '{bsa}' (pass one as arg 2, or set HOUSECARL_TEST_BSA)"); return 0; }
 
-        var work = Path.Combine(Environment.CurrentDirectory, ".bsa-probe");
+        var work = Path.Combine(Path.GetTempPath(), ".bsa-probe");
         var unpacked = Path.Combine(work, "unpacked");            // Mutagen unpack
         var bsarchDir = Path.Combine(work, "bsarch-unpacked");    // BSArch unpack (the parity oracle)
         var repacked = Path.Combine(work, "repacked.bsa");

--- a/src/housecarl-generator/BsaProbe.cs
+++ b/src/housecarl-generator/BsaProbe.cs
@@ -85,7 +85,7 @@ internal static class BsaProbe
             Check(File.Exists(repacked) && new FileInfo(repacked).Length == beforeLen,
                   "non-destructive: the PRIOR archive is left intact after a failed pack");
         }
-        finally { try { Directory.Delete(work, recursive: true); } catch { /* in-dir scratch; non-fatal */ } }
+        finally { try { Directory.Delete(work, recursive: true); } catch { /* temp scratch; non-fatal */ } }
 
         Console.WriteLine();
         Console.WriteLine(fail == 0 ? "================ ALL PASS ================" : $"================ {fail} CHECK(S) FAILED ================");

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -22,8 +22,10 @@ namespace HousecarlGenerator;
 /// runner's canonical corpus, so the check-first probes never validate against a prior probe's deleted temp
 /// corpus; the <c>CODEX_HOME</c> env var is restored, because setup-update-lock-guard nulls it and does not;
 /// and each probe runs in its own try/catch, so a probe that throws fails only itself. Everything else is
-/// per-probe already — Guid-unique temp dirs and explicit-path UserConfigStores — and the class-parents and
-/// decompile caches are per-LoadOrderService-instance, not process statics.</para>
+/// per-probe already — its own fixture directory and an explicit-path UserConfigStore — and the class-parents
+/// and decompile caches are per-LoadOrderService-instance, not process statics. Those fixture directories
+/// carry fixed names, so the run puts them under a per-process temp root (<see cref="ProbeTemp"/>): that is
+/// what keeps two runs at once out of each other's files.</para>
 /// </summary>
 public static class CiAll
 {
@@ -172,12 +174,26 @@ public static class CiAll
     public static bool TryDispatch(string name, string[] args, out int rc)
     {
         foreach (var e in All())
-            if (e.Name == name) { rc = e.Run(args); return true; }
+            if (e.Name == name)
+            {
+                ProbeTemp.Redirect();
+                try { rc = e.Run(args); }
+                finally { ProbeTemp.Cleanup(); }
+                return true;
+            }
         rc = 0;
         return false;
     }
 
+    /// <summary>Run the whole roster under this process's own temp root, and take the fixtures with it.</summary>
     public static int RunAll(string[] args)
+    {
+        ProbeTemp.Redirect();
+        try { return RunRoster(args); }
+        finally { ProbeTemp.Cleanup(); }
+    }
+
+    static int RunRoster(string[] args)
     {
         var probes = Roster;
 

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -176,8 +176,7 @@ public static class CiAll
         foreach (var e in All())
             if (e.Name == name)
             {
-                ProbeTemp.Redirect();
-                try { rc = e.Run(args); }
+                try { ProbeTemp.Redirect(); rc = e.Run(args); }
                 finally { ProbeTemp.Cleanup(); }
                 return true;
             }
@@ -188,8 +187,7 @@ public static class CiAll
     /// <summary>Run the whole roster under this process's own temp root, and take the fixtures with it.</summary>
     public static int RunAll(string[] args)
     {
-        ProbeTemp.Redirect();
-        try { return RunRoster(args); }
+        try { ProbeTemp.Redirect(); return RunRoster(args); }
         finally { ProbeTemp.Cleanup(); }
     }
 

--- a/src/housecarl-generator/CompileProbe.cs
+++ b/src/housecarl-generator/CompileProbe.cs
@@ -59,7 +59,7 @@ internal static class CompileProbe
             var vanilla = Path.Combine(gameRoot!, "Data", "Source", "Scripts");
             Check(Directory.Exists(vanilla), $"vanilla sources derived from compiler dir exist ({vanilla})");
 
-            var work = Path.Combine(Environment.CurrentDirectory, ".compile-probe-gen");
+            var work = Path.Combine(Path.GetTempPath(), ".compile-probe-gen");
             var outDir = Path.Combine(work, "out");
             Directory.CreateDirectory(outDir);
             File.WriteAllText(Path.Combine(work, "HCGood.psc"),
@@ -95,7 +95,7 @@ internal static class CompileProbe
                 Check(!reBad.Success && reBad.PexPath is null, "recompile (now broken): reports failure, no new .pex");
                 Check(File.Exists(pex), "recompile (now broken): the PRIOR .pex is LEFT INTACT (non-destructive)");
             }
-            finally { try { Directory.Delete(work, recursive: true); } catch { /* in-dir scratch; non-fatal */ } }
+            finally { try { Directory.Delete(work, recursive: true); } catch { /* temp scratch; non-fatal */ } }
         }
 
         Console.WriteLine();

--- a/src/housecarl-generator/CompileProbe.cs
+++ b/src/housecarl-generator/CompileProbe.cs
@@ -83,17 +83,26 @@ internal static class CompileProbe
                 // RECOMPILE behaviour (Aaron 2026-06-06): a prior .pex is LEFT in place — a successful recompile updates
                 // it (success = THIS run wrote it, detected by the write-time advancing, NOT by a pre-delete); a FAILED
                 // recompile must NOT destroy the last good build (non-destructive — the user deletes outputs at will).
-                var pex = good.PexPath!;
-                var firstWriteUtc = File.GetLastWriteTimeUtc(pex);
-                var reGood = PapyrusCompile.CompileObject(compiler, "HCGood", imports, outDir);
-                Check(reGood.Success && File.Exists(pex), "recompile (still valid): Success + .pex present");
-                Check(File.GetLastWriteTimeUtc(pex) > firstWriteUtc, "recompile (still valid): .pex rewritten this run (write-time advanced; no pre-delete)");
+                // Without a .pex from the good compile there is nothing to recompile over; say that rather than
+                // dereference the null and report the whole probe as a throw.
+                if (good.PexPath is null)
+                {
+                    Console.WriteLine("  SKIP  recompile checks: the good compile produced no .pex (see the failed check above)");
+                }
+                else
+                {
+                    var pex = good.PexPath;
+                    var firstWriteUtc = File.GetLastWriteTimeUtc(pex);
+                    var reGood = PapyrusCompile.CompileObject(compiler, "HCGood", imports, outDir);
+                    Check(reGood.Success && File.Exists(pex), "recompile (still valid): Success + .pex present");
+                    Check(File.GetLastWriteTimeUtc(pex) > firstWriteUtc, "recompile (still valid): .pex rewritten this run (write-time advanced; no pre-delete)");
 
-                File.WriteAllText(Path.Combine(work, "HCGood.psc"),
-                    "Scriptname HCGood extends Quest\n\nFunction Foo()\n    @@@ broken edit\nEndFunction\n");
-                var reBad = PapyrusCompile.CompileObject(compiler, "HCGood", imports, outDir);
-                Check(!reBad.Success && reBad.PexPath is null, "recompile (now broken): reports failure, no new .pex");
-                Check(File.Exists(pex), "recompile (now broken): the PRIOR .pex is LEFT INTACT (non-destructive)");
+                    File.WriteAllText(Path.Combine(work, "HCGood.psc"),
+                        "Scriptname HCGood extends Quest\n\nFunction Foo()\n    @@@ broken edit\nEndFunction\n");
+                    var reBad = PapyrusCompile.CompileObject(compiler, "HCGood", imports, outDir);
+                    Check(!reBad.Success && reBad.PexPath is null, "recompile (now broken): reports failure, no new .pex");
+                    Check(File.Exists(pex), "recompile (now broken): the PRIOR .pex is LEFT INTACT (non-destructive)");
+                }
             }
             finally { try { Directory.Delete(work, recursive: true); } catch { /* temp scratch; non-fatal */ } }
         }

--- a/src/housecarl-generator/ImportOrderProbe.cs
+++ b/src/housecarl-generator/ImportOrderProbe.cs
@@ -273,7 +273,7 @@ internal static class ImportOrderProbe
         }
         else
         {
-            var work = Path.Combine(Environment.CurrentDirectory, ".import-order-probe-gen");
+            var work = Path.Combine(Path.GetTempPath(), ".import-order-probe-gen");
             var extDir = Path.Combine(work, "ext");
             var outDir = Path.Combine(work, "out");
             Directory.CreateDirectory(extDir); Directory.CreateDirectory(outDir);
@@ -309,7 +309,7 @@ internal static class ImportOrderProbe
                       "an AUTO-DISCOVERED mod's extended copy also beats vanilla" +
                       (auto.Success ? "" : $" (first error: {(auto.Diagnostics.Count > 0 ? auto.Diagnostics[0].ToString() : auto.Stderr.Trim())})"));
             }
-            finally { try { Directory.Delete(work, recursive: true); } catch { /* in-dir scratch; non-fatal */ } }
+            finally { try { Directory.Delete(work, recursive: true); } catch { /* temp scratch; non-fatal */ } }
         }
 
         Console.WriteLine();

--- a/src/housecarl-generator/ProbeTemp.cs
+++ b/src/housecarl-generator/ProbeTemp.cs
@@ -12,8 +12,11 @@ namespace HousecarlGenerator;
 /// spawns inherit the same root.</para>
 ///
 /// <para>The run also stops leaving fixtures behind: the whole root goes at the end, entry by entry so one
-/// file another process still holds open strands only itself. A file that will not delete is reported and the
-/// run's exit code is unaffected — cleanup never turns a green run red.</para>
+/// file another process still holds open strands only itself. A run that is killed — the bridge test's
+/// 20-minute cap, Ctrl-C, a cancelled CI job — never reaches that, so <see cref="Redirect"/> also drops the
+/// roots whose pid is no longer a live process; residue under our own pid that will not go is reported and
+/// the run takes a fresh sibling root rather than work in another run's fixtures. Nothing here throws: a file
+/// that will not delete is reported and the run's exit code is unaffected — cleanup never turns a run red.</para>
 /// </summary>
 public static class ProbeTemp
 {
@@ -25,9 +28,20 @@ public static class ProbeTemp
     {
         if (_root != null) return _root;
 
-        var root = Path.Combine(Path.GetTempPath(), "hc-" + Environment.ProcessId);
-        // A root under this pid can only be residue from a dead process: no live process shares our pid.
-        if (Directory.Exists(root)) Remove(root);
+        var temp = Path.GetTempPath();
+        SweepDeadRoots(temp);
+
+        // A root under this pid can only be residue from a dead process: no live process shares our pid. If any
+        // of it will not go, say so and take a fresh sibling — a run inside fixtures it failed to empty is the
+        // collision this class exists to remove, and silent.
+        var root = Path.Combine(temp, "hc-" + Environment.ProcessId);
+        for (int n = 2; Directory.Exists(root); n++)
+        {
+            var (left, first) = Remove(root);
+            if (left == 0) break;
+            ReportLeft(root, left, first);
+            root = Path.Combine(temp, $"hc-{Environment.ProcessId}-{n}");
+        }
         Directory.CreateDirectory(root);
 
         _tmpWas = Environment.GetEnvironmentVariable("TMP");
@@ -51,32 +65,82 @@ public static class ProbeTemp
         Environment.SetEnvironmentVariable("TMPDIR", _tmpdirWas);
 
         var (left, first) = Remove(_root);
-        if (left > 0)
-            Console.WriteLine($"  (temp cleanup left {left} entr{(left == 1 ? "y" : "ies")} in {_root}: {first})");
+        if (left > 0) ReportLeft(_root, left, first);
         _root = null;
     }
 
-    /// <summary>Delete a directory's contents and then itself, counting what would not go.</summary>
+    /// <summary>Drop the roots of runs that were killed before their own cleanup ran: their pid is no longer live.</summary>
+    static void SweepDeadRoots(string temp)
+    {
+        int left = 0;
+        string? first = null;
+
+        try
+        {
+            foreach (var dir in Directory.EnumerateDirectories(temp, "hc-*"))
+            {
+                if (!TryReadPid(Path.GetFileName(dir), out var pid)) continue;
+                if (pid == Environment.ProcessId || IsLive(pid)) continue;
+                var (l, f) = Remove(dir);
+                left += l;
+                first ??= f;
+            }
+        }
+        catch (Exception ex) { left++; first ??= ex.Message; }
+
+        if (left > 0)
+            Console.WriteLine($"  (temp sweep left {left} entr{(left == 1 ? "y" : "ies")} from an earlier run under {temp}: {first})");
+    }
+
+    /// <summary>Read the pid out of an <c>hc-&lt;pid&gt;</c> or <c>hc-&lt;pid&gt;-&lt;n&gt;</c> root name.</summary>
+    static bool TryReadPid(string name, out int pid)
+    {
+        pid = 0;
+        if (name.Length <= 3) return false;
+        var text = name.AsSpan(3);
+        var dash = text.IndexOf('-');
+        if (dash >= 0) text = text[..dash];
+        return int.TryParse(text, out pid);
+    }
+
+    static bool IsLive(int pid)
+    {
+        try { using var p = System.Diagnostics.Process.GetProcessById(pid); return !p.HasExited; }
+        catch { return false; }
+    }
+
+    static void ReportLeft(string dir, int left, string? first) =>
+        Console.WriteLine($"  (temp cleanup left {left} entr{(left == 1 ? "y" : "ies")} in {dir}: {first})");
+
+    /// <summary>Delete a directory's contents and then itself, counting what would not go. Never throws.</summary>
     static (int Left, string? FirstError) Remove(string dir)
     {
         int left = 0;
         string? first = null;
 
-        foreach (var entry in Directory.EnumerateFileSystemEntries(dir))
+        try
         {
-            try
+            // The walk itself can fail — a child process recreating a directory under us, or the root going
+            // while we read it — so it is inside the try with the deletes, not outside it.
+            foreach (var entry in Directory.EnumerateFileSystemEntries(dir))
             {
-                if (Directory.Exists(entry)) Directory.Delete(entry, recursive: true);
-                else File.Delete(entry);
-            }
-            catch (Exception ex)
-            {
-                left++;
-                first ??= ex.Message;
+                try
+                {
+                    if (Directory.Exists(entry)) Directory.Delete(entry, recursive: true);
+                    else File.Delete(entry);
+                }
+                catch (Exception ex)
+                {
+                    left++;
+                    first ??= ex.Message;
+                }
             }
         }
+        catch (DirectoryNotFoundException) { return (0, null); }   // the root went while we walked it: nothing is left
+        catch (Exception ex) { left++; first ??= ex.Message; }
 
         try { Directory.Delete(dir, recursive: true); }
+        catch (DirectoryNotFoundException) { }
         catch (Exception ex) when (left > 0) { first ??= ex.Message; }
         catch (Exception ex) { left++; first ??= ex.Message; }
 

--- a/src/housecarl-generator/ProbeTemp.cs
+++ b/src/housecarl-generator/ProbeTemp.cs
@@ -103,10 +103,15 @@ public static class ProbeTemp
         return int.TryParse(text, out pid);
     }
 
+    /// <summary>Whether a pid still belongs to a process. Only a definite "no such process" counts as dead.</summary>
     static bool IsLive(int pid)
     {
-        try { using var p = System.Diagnostics.Process.GetProcessById(pid); return !p.HasExited; }
-        catch { return false; }
+        // A process we cannot inspect — one at a higher integrity level, a transient permission error — counts
+        // as live: leaving its root behind is residue the next run picks up, deleting it is a live run's
+        // fixtures going mid-run. HasExited is not consulted; reaching it needs a handle we may not get.
+        try { System.Diagnostics.Process.GetProcessById(pid).Dispose(); return true; }
+        catch (ArgumentException) { return false; }
+        catch { return true; }
     }
 
     static void ReportLeft(string dir, int left, string? first) =>

--- a/src/housecarl-generator/ProbeTemp.cs
+++ b/src/housecarl-generator/ProbeTemp.cs
@@ -134,7 +134,9 @@ public static class ProbeTemp
                     if (Directory.Exists(entry)) Directory.Delete(entry, recursive: true);
                     else File.Delete(entry);
                 }
-                catch (Exception ex)
+                // An entry another sweep deleted between our walk and our delete is the outcome we wanted, not
+                // residue: counting it makes a run report a root that is in fact gone, and take a fresh sibling.
+                catch (Exception ex) when (ex is not (DirectoryNotFoundException or FileNotFoundException))
                 {
                     left++;
                     first ??= ex.Message;

--- a/src/housecarl-generator/ProbeTemp.cs
+++ b/src/housecarl-generator/ProbeTemp.cs
@@ -1,0 +1,85 @@
+namespace HousecarlGenerator;
+
+/// <summary>
+/// The fixture root a probe run works under: one directory per process, removed when the run ends.
+///
+/// <para>Probes name their own fixture directories — <c>hc-inplace-guard</c>, <c>hc-mo2instance-probe</c> and
+/// ~50 more — off <see cref="Path.GetTempPath"/>. Those names are fixed, so two runs at once used to open the
+/// same directory and fail each other on file-in-use. Rather than rewrite every call site (and leave the next
+/// probe free to add another fixed path), this points the PROCESS at its own temp directory before any probe
+/// runs: <c>Path.GetTempPath()</c> then answers <c>%TEMP%\hc-&lt;pid&gt;\</c>, every probe's path lands under
+/// it, and two processes cannot name the same directory because their pids differ. Child processes a probe
+/// spawns inherit the same root.</para>
+///
+/// <para>The run also stops leaving fixtures behind: the whole root goes at the end, entry by entry so one
+/// file another process still holds open strands only itself. A file that will not delete is reported and the
+/// run's exit code is unaffected — cleanup never turns a green run red.</para>
+/// </summary>
+public static class ProbeTemp
+{
+    static string? _root;
+    static string? _tmpWas, _tempWas, _tmpdirWas;
+
+    /// <summary>Point this process's temp directory at a root only this process uses, and return it.</summary>
+    public static string Redirect()
+    {
+        if (_root != null) return _root;
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-" + Environment.ProcessId);
+        // A root under this pid can only be residue from a dead process: no live process shares our pid.
+        if (Directory.Exists(root)) Remove(root);
+        Directory.CreateDirectory(root);
+
+        _tmpWas = Environment.GetEnvironmentVariable("TMP");
+        _tempWas = Environment.GetEnvironmentVariable("TEMP");
+        _tmpdirWas = Environment.GetEnvironmentVariable("TMPDIR");
+        Environment.SetEnvironmentVariable("TMP", root);
+        Environment.SetEnvironmentVariable("TEMP", root);
+        Environment.SetEnvironmentVariable("TMPDIR", root);   // what GetTempPath reads off Windows
+
+        _root = root;
+        return root;
+    }
+
+    /// <summary>Put the temp directory back and delete the root. A file still held open is reported, not thrown.</summary>
+    public static void Cleanup()
+    {
+        if (_root is null) return;
+
+        Environment.SetEnvironmentVariable("TMP", _tmpWas);
+        Environment.SetEnvironmentVariable("TEMP", _tempWas);
+        Environment.SetEnvironmentVariable("TMPDIR", _tmpdirWas);
+
+        var (left, first) = Remove(_root);
+        if (left > 0)
+            Console.WriteLine($"  (temp cleanup left {left} entr{(left == 1 ? "y" : "ies")} in {_root}: {first})");
+        _root = null;
+    }
+
+    /// <summary>Delete a directory's contents and then itself, counting what would not go.</summary>
+    static (int Left, string? FirstError) Remove(string dir)
+    {
+        int left = 0;
+        string? first = null;
+
+        foreach (var entry in Directory.EnumerateFileSystemEntries(dir))
+        {
+            try
+            {
+                if (Directory.Exists(entry)) Directory.Delete(entry, recursive: true);
+                else File.Delete(entry);
+            }
+            catch (Exception ex)
+            {
+                left++;
+                first ??= ex.Message;
+            }
+        }
+
+        try { Directory.Delete(dir, recursive: true); }
+        catch (Exception ex) when (left > 0) { first ??= ex.Message; }
+        catch (Exception ex) { left++; first ??= ex.Message; }
+
+        return (left, first);
+    }
+}

--- a/src/housecarl-generator/ProbeTemp.cs
+++ b/src/housecarl-generator/ProbeTemp.cs
@@ -43,6 +43,9 @@ public static class ProbeTemp
             root = Path.Combine(temp, $"hc-{Environment.ProcessId}-{n}");
         }
         Directory.CreateDirectory(root);
+        // Set before the redirect below, not after it: a variable that will not take would otherwise leave the
+        // process pointed at a root Cleanup no longer knows to remove.
+        _root = root;
 
         _tmpWas = Environment.GetEnvironmentVariable("TMP");
         _tempWas = Environment.GetEnvironmentVariable("TEMP");
@@ -51,7 +54,6 @@ public static class ProbeTemp
         Environment.SetEnvironmentVariable("TEMP", root);
         Environment.SetEnvironmentVariable("TMPDIR", root);   // what GetTempPath reads off Windows
 
-        _root = root;
         return root;
     }
 

--- a/src/housecarl-mcp-tests/ProbeTempSweepTests.cs
+++ b/src/housecarl-mcp-tests/ProbeTempSweepTests.cs
@@ -1,0 +1,55 @@
+using System.Diagnostics;
+using System.Reflection;
+using HousecarlGenerator;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>The liveness call behind <see cref="ProbeTemp"/>'s sweep of old fixture roots. It decides whether
+/// an <c>hc-&lt;pid&gt;</c> root is residue from a killed run or the scratch of a run still working in it, so a
+/// wrong answer either leaves a directory behind or deletes a live run's fixtures mid-run. Reflected: the check
+/// is private to the class that owns the sweep.</summary>
+[Trait("tier", "unit")]
+public sealed class ProbeTempSweepTests
+{
+    static bool IsLive(int pid) => (bool)typeof(ProbeTemp)
+        .GetMethod("IsLive", BindingFlags.NonPublic | BindingFlags.Static)!
+        .Invoke(null, new object[] { pid })!;
+
+    [Fact]
+    public void OwnProcessIsLive() => Assert.True(IsLive(Environment.ProcessId));
+
+    [Fact]
+    public void PidNoProcessHoldsIsDead() => Assert.False(IsLive(FreePid()));
+
+    /// <summary>The Windows System process is running, but a run without the rights to open it cannot read
+    /// its exit state. Only "no such process" is evidence of death; everything else leaves the root alone.</summary>
+    [Fact]
+    public void ProcessWeCannotInspectIsLive()
+    {
+        var pid = SystemPid();
+        Assert.True(IsLive(pid), $"pid {pid} is running, so its root must not be swept");
+    }
+
+    /// <summary>A pid no process holds, confirmed rather than assumed.</summary>
+    static int FreePid()
+    {
+        for (int pid = 999_996; pid > 900_000; pid -= 4)
+        {
+            try { Process.GetProcessById(pid).Dispose(); }
+            catch (ArgumentException) { return pid; }
+        }
+        throw new InvalidOperationException("every candidate pid is in use");
+    }
+
+    /// <summary>The System (4) or Idle (0) process: running, and normally not openable.</summary>
+    static int SystemPid()
+    {
+        foreach (var pid in new[] { 4, 0 })
+        {
+            try { Process.GetProcessById(pid).Dispose(); return pid; }
+            catch (ArgumentException) { }
+        }
+        throw new InvalidOperationException("neither pid 4 nor pid 0 is running");
+    }
+}


### PR DESCRIPTION
Probes name their fixture directories with fixed names, so two `ci-all` runs at once opened the same files and failed each other on file-in-use and access-denied. A run now points its own process at a temp directory named for its pid before any probe starts, so every `Path.GetTempPath()` a probe reaches for lands under a root no other process can name, and deletes that root when the run ends (a file another process still holds open is reported, not thrown, and never changes the exit code). Three probes built their scratch directory from the working directory instead of the temp path, which collided the same way from one checkout; they now build it from the temp path too, so the two ignore rules that existed only to hide those directories are gone. No probe and no assertion changed, and nothing outside the probes referenced any of these paths: the standalone `freshness-capture-guard` step in `.github/workflows/ci.yml` runs through the same dispatch and gets its own root.

A run that is killed never reaches its own cleanup, so the redirect also drops the roots whose pid no process holds — otherwise naming the root for the pid would trade the old fixed names' bounded residue for an unbounded one. Only a definite "no such process" counts as dead: a process the run cannot inspect, such as one at a higher integrity level, keeps its root, because leaving a directory behind is residue the next run picks up while deleting one is a running run's fixtures going mid-run. Residue under our own pid that will not go is reported in the same one line the cleanup uses, and the run takes a fresh sibling root rather than start inside fixtures it failed to empty.

Closes #570

**Reproduction (before the fix).** Two `ci-all` runs started at the same time from one worktree, first attempt, both red: run A failed 10 probes (`import-order-guard`, `inplace-guard`, `nested-create-guard`, `pkcu-regression`, `snapshot-view-guard`, `source-display-guard`, `subclass-remove-guard`, `substruct-nullable-clear-guard`, `upsert-guard`, `verify-loop-guard`) and run B failed 9 (`compile-probe`, `import-order-guard`, `inplace-guard`, `nested-create-guard`, `snapshot-view-guard`, `source-display-guard`, `subclass-remove-guard`, `upsert-guard`, `verify-loop-guard`). The messages name the shared paths directly, e.g. `IOException: The process cannot access the file 'C:\...\Temp\hc-substruct-nullable-clear-guard\corpus-gen\corpus.json' because it is being used by another process` and `IOException: Access to the path 'C:\...\Temp\hc-subclass-remove-guard\A' is denied`.

**Proof.** With the temp root alone, two-at-once dropped to 1 and 2 failures — `import-order-guard` in both and `compile-probe` in one, which is the second collision, on `.import-order-probe-gen` and `.compile-probe-gen` in the checkout root: one run's cleanup deletes the other's scratch mid-compile, and `compile-probe` then dereferences a null `PexPath`. With both commits, two `ci-all` runs at once are 127/127 each, and a run alone is 127/127. That null `PexPath` deref is now guarded too, so the same environmental failure would report the probe's own failed check rather than a throw.

**What was run.** `dotnet build housecarl.sln -c Release`; `dotnet src/housecarl-generator/bin/Release/net9.0/housecarl-generator.dll ci-all` twice concurrently (127/127 each, both exit 0) and once alone (127/127); `dotnet test src/housecarl-mcp-tests -c Release --no-build --filter "tier!=bridge"` (1591 passed, 0 failed). The cleanup reported nothing left behind in any run, and the temp directory holds no `hc-*` fixture directory from them. The sweep of dead runs' roots was checked by planting `hc-999999` — not a possible live pid — and watching a solo run remove it.

**Tests.** The liveness check that decides whether a root is residue or a running run's scratch is pinned by `ProbeTempSweepTests`: a pid no process holds is dead, this process is live, and a running process the run cannot open is live. That third case fails before the fix and passes after. The redirect itself still has no test — the only way to reach it is to call it, which repoints the whole test process's temp directory and then deletes it out from under every other test in that process. The honest proof for the redirect is running `ci-all` twice at once, which is above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
