### PR TITLE
Bring the check tool description under the 2,048-character cap

### DIFF
--- a/src/housecarl-mcp-tests/PublishedDescriptionBoundTests.cs
+++ b/src/housecarl-mcp-tests/PublishedDescriptionBoundTests.cs
@@ -30,7 +30,6 @@ public sealed class PublishedDescriptionBoundTests
     // Tools whose descriptions are still over the bound, one line each. Each description PR deletes its own line.
     static readonly HashSet<string> StillOversized = new(StringComparer.Ordinal)
     {
-        ToolNames.Check,
         ToolNames.CompactPlugin,
         ToolNames.Create,
         ToolNames.Forward,

--- a/src/housecarl-mcp/CheckTools.cs
+++ b/src/housecarl-mcp/CheckTools.cs
@@ -27,89 +27,39 @@ public static class CheckTools
 {
     [McpServerTool(Name = ToolNames.Check, ReadOnly = true, Title = "Sweep the load order for derived findings"),
      Description(
-         // ---- what it is, and what selects a family ------------------------------------------------
+         // Only what belongs to no single parameter: the purpose, the family roster, one line per axis naming its
+         // parameters, and the cross-tool pointers. Each family's own grammar, cost and boundary lives on the
+         // parameter it is about — those arrive whole, this is cut at 2,048 characters.
          "DERIVED-FINDINGS SWEEP over the load order — one call, several finding FAMILIES, selected by findings=. " +
-         "Read-only; writes nothing. Resolves against the load-order WINNERS, like every other read. Three families: " +
-         "'errors' (load-order integrity), 'scripts' (VMAD script-property binding) and 'dialogue' (dialogue graph " +
-         "validation over SEEDED topics and quests). findings= takes whole families or the classes inside them " +
-         "('dangling', 'missing_masters'; 'unbound_object', 'unbound_scalar', 'unbound', 'bound_null') — naming a " +
-         "class runs its family narrowed to that class; the dialogue family narrows by seeds=, not by class. " +
-         "DEFAULT: findings= omitted runs the ERRORS family alone, and the response STATES which families ran, which " +
-         "registered families did not, and the exact findings= spelling that adds them — the default narrows only " +
-         "because the response says so. It cannot be every family: an unscoped scripts sweep is ~8 minutes on a " +
-         "3800-plugin order (measured), and an unscoped dialogue sweep is refused outright (below). " +
-         // ---- family: errors (harvested from housecarl_check_errors) -------------------------------
-         "ERRORS FAMILY — the data-layer twin of the Creation Kit's 'Check For Errors' / xEdit's error check. For " +
-         "each plugin in scope it walks every record's FormLinks and reports three classes: (1) DANGLING references " +
-         "— a non-null link whose target NO plugin in the ACTIVE order defines; (2) MISSING MASTERS — a master a " +
-         "plugin DECLARES that is not present in the active order (the most common load-order break); (3) PARSE " +
-         "failures — records houseCARL/Mutagen could not read, plus whole plugins the index excluded as unparseable. " +
-         "A scoped name NOT in the active order is resolved on disk (any mod folder — enabled, disabled, or not yet " +
-         "listed in MO2) and swept OFF-ORDER: its own records, links resolved against the active order PLUS the " +
-         "file's own definitions — the pre-enable verify sweep for a patch houseCARL just wrote. BOUNDARY (never a silent claim of more — Q3): it covers the FormLink-resolution / missing-master / " +
-         "parse class. It does NOT verify navmesh or terrain spatial integrity (CRC/grid — a Mutagen-delta " +
-         "residual), does NOT flag a required field left null (a null FormLink is a legal optional, not an error), " +
-         "does NOT list unused-master cleanup (a FormLink scan cannot prove a master is unused), and does NOT " +
-         "link-check an owned item's ownership 'variable' word (a rank/global Mutagen cannot type on an override " +
-         "without a link cache). BASELINE: the base-game masters carry permanent vanilla dangling refs no load order " +
-         "can fix, so the response splits them out of the total and spends limit= on every other plugin FIRST — " +
-         "vanilla cannot crowd mod findings out of the listing. " +
-         // ---- family: scripts (harvested from housecarl_validate_scripts) --------------------------
-         "SCRIPTS FAMILY — catches the silent-None footgun a byte-valid plugin hides: a record whose attached " +
-         "Papyrus script DECLARES a property (e.g. 'Spell Property CallVesyraPower Auto') the record's script data " +
-         "(VMAD) never BINDS, so at runtime it is None and the code that uses it no-ops while the log looks clean " +
-         "(the maximally-misleading 'the function ran, the effect is absent' class — the same as the Creation Kit's " +
-         "auto-add-property bug). For each record carrying a script it reads the attached script's compiled .pex — " +
-         "and every script it EXTENDS — from the load order (loose or BSA), and reports: (1) UNBOUND properties " +
-         "declared but not bound (an object/form type ⇒ None ⇒ the silent no-op, ranked first; an uninitialized " +
-         "scalar ⇒ a 0/false/\"\" default that may be wrong); (2) BOUND-BUT-NULL object properties (advisory — " +
-         "sometimes filled at runtime). BOUNDARY: it checks Auto (CK-editable) properties only, not code-driven full " +
-         "properties; 'unbound may be intentional' (a runtime-filled link), so a finding is a flag to VERIFY; and if " +
-         "a script's .pex is not on disk (uncompiled / not in the order) the attachment is reported UNVERIFIABLE, " +
-         "never passed clean. It has the SAME off-order lane as the errors family: a scoped name not in the active " +
-         "order is swept from its file on disk, so a fresh patch's bindings can be checked BEFORE it is enabled — " +
-         "the .pex chain is still read from the ACTIVE order, so a script shipped only inside the not-yet-enabled " +
-         "mod reads UNVERIFIABLE rather than clean. " +
-         // ---- family: dialogue (harvested from housecarl_validate_dialogue) ------------------------
-         "DIALOGUE FAMILY — a topic's whole graph as the GAME sees it, and it is SEEDED, not swept: seeds= names " +
-         "what to validate and findings=['dialogue'] without it is REFUSED on cost (a whole-order pass is a " +
-         "per-topic graph walk across every touching plugin, and the order this bound was measured on carries " +
-         "82,343 dialogue topics). A seed is a DIAL (one topic), a QUST (EVERY topic that quest owns, plus the " +
-         "quest's own CK-parity subrecords and its .seq, checked once), or a DLVW/DLBR (a record-level CK-parity " +
-         "check — a bare DLVW crashes the CK's Dialogue Views editor). It checks what houseCARL CAN verify at the " +
-         "data layer: the topic is wired to a quest, the branch resolves, the INFO.LinkTo conversation chain has no " +
-         "dangling targets, and no previous-link (PNAM) is dangling — an EMPTY PNAM is NORMAL (vanilla selects among " +
-         "a topic's lines by their conditions, not a previous-link chain), so absence is never flagged; each voiced " +
-         "line's .fuz is on disk and each result script is bound + compiled; non-ASCII characters in the " +
-         "player-facing text (topic name, line prompt, response text) are flagged as likely in-game MOJIBAKE (the " +
-         "CK/Papyrus surface is Windows-1252/ASCII); each line's CTDA conditions are statically checked for a " +
-         "meaningful subset of MALFORMED shapes (a dangling form reference, a dead quest-alias index, an unset Run " +
-         "On reference, GetIsID pointed at a placed instance); and a Start-Game-Enabled quest's .seq is checked for " +
-         "coverage and staleness (without it the quest is dormant on a fresh save and its dialogue never shows). " +
-         "BOUNDARY: it cannot EVALUATE whether a WELL-FORMED condition passes — only the running game can — and it " +
-         "does not check lip-sync or audio content, so 'checks passed' never reads as 'this will play'. NOT HERE: " +
-         "the effective merged INFO order — the sequence the game walks, which line MOVED and which plugin moved it, " +
-         "the answer to 'why does the wrong line play' — is an ordered sequence rather than a finding and lives on " +
-         ToolNames.Records + " project='info_order'. To CREATE dialogue lines use " + ToolNames.Create + "; to inspect " +
-         "one record use " + ToolNames.Records + ". " +
-         // ---- narrowing, shared, with each family's own cost teaching ------------------------------
-         "NARROWING: beyond plugins= it takes a record scope (type= / formids= / editorid_contains=), " +
-         "property_contains= (the scripts family — chasing one property name), a findings= filter, counts_only=true " +
-         "for the totals plus per-family histograms (errors: dangling by TARGET plugin and by SOURCE plugin; " +
-         "scripts: unbound by PROPERTY NAME; dialogue: the totals alone, no per-topic blocks), and format='json'. A script-heavy plugin (~180 scripted records) does " +
-         "not fit a tool result unnarrowed, and limit= alone will not help there because it caps FINDINGS, not the " +
-         "record roster — counts_only=true or a record scope is what does. Narrowing narrows the COUNTS too: they " +
-         "are always the counts for the scope actually swept, and the response says so. exclude= drops named plugins " +
-         "or whole groups (base_masters / implicit) out of the sweep entirely rather than merely accounting for " +
-         "them; it scopes every SWEPT family. The dialogue family is seeded rather than swept, so no plugin scope " +
-         "narrows it — the response says so in that family's own section. " +
-         // ---- the accounting, harvested from both ---------------------------------------------------
-         "Results cap at limit= and max_chars (both overruns explicit, per family): the response states how much of " +
-         "each family's listing it carries, why the rest is absent, and which knob moves it — a capped errors " +
-         "listing NAMES which source plugins lost entries.")]
+         "Read-only; writes nothing. Resolves against the load-order WINNERS, like every other read. " +
+         "ONE surface: which FAMILIES run (findings=) x what they are run over (the SCOPE) x how it reads back " +
+         "(TRANSPORT). " +
+         "FAMILIES: 'errors' (load-order integrity), 'scripts' (VMAD script-property binding) and 'dialogue' " +
+         "(dialogue graph validation over SEEDED topics and quests). findings= takes whole families or the classes " +
+         "inside them, and carries what each family reports, what it does NOT, and what the default runs — omitted, " +
+         "it runs the errors family alone. " +
+         "SCOPE: the two SWEPT families share one — plugins= (off-order files included) / type= / formids= / " +
+         "editorid_contains= / exclude=, plus property_contains= on the scripts family. The dialogue family is " +
+         "SEEDED instead: seeds= names what to validate, and no plugin scope narrows it. Narrowing narrows the " +
+         "COUNTS too: they are always the counts for the scope actually swept, and the response says so. " +
+         "TRANSPORT: counts_only= / format= / limit= / max_chars=. Results cap at limit= and max_chars, both " +
+         "overruns explicit and per family: the response states how much of each family's listing it carries, why " +
+         "the rest is absent, and which knob moves it. " +
+         "NOT HERE: the effective merged INFO order — the sequence the game walks, which line MOVED and which " +
+         "plugin moved it, the answer to 'why does the wrong line play' — is an ordered sequence rather than a " +
+         "finding and lives on " + ToolNames.Records + " project='info_order'. To CREATE dialogue lines use " +
+         ToolNames.Create + "; to inspect one record use " + ToolNames.Records + ".")]
     public static string CheckTool(
         LoadOrderService svc,
-        [Description("Optional. Plugin filenames to sweep (e.g. 'MyMod.esp'). A name not in the active order is resolved on disk (a fresh houseCARL patch, a disabled mod) and swept OFF-ORDER by BOTH swept families — errors and scripts; found nowhere (or in several folders) it is an error. Omit to sweep the WHOLE active order — thorough but heavier; scope to one plugin for a fast, focused check like the CK's per-plugin 'Check For Errors'.")]
+        [Description("Optional. Plugin filenames to sweep (e.g. 'MyMod.esp'). A name not in the active order is " +
+             "resolved on disk — any mod folder, enabled, disabled, or not yet listed in MO2 (a fresh houseCARL " +
+             "patch, a disabled mod) — and swept OFF-ORDER by BOTH swept families, errors and scripts; found " +
+             "nowhere (or in several folders) it is an error. OFF-ORDER means its own records, with links resolved " +
+             "against the active order PLUS the file's own definitions: the pre-enable verify sweep for a patch " +
+             "houseCARL just wrote. On the SCRIPTS family the .pex chain is still read from the ACTIVE order, so a " +
+             "script shipped only inside the not-yet-enabled mod reads UNVERIFIABLE rather than clean. Omit to " +
+             "sweep the WHOLE active order — thorough but heavier; scope to one plugin for a fast, focused check " +
+             "like the CK's per-plugin 'Check For Errors'.")]
             string[]? plugins = null,
         [Description("Optional. Record type to sweep — a 4-char signature ('WEAP') or catalog name ('Weapon'). Applied at the record STREAM, so it is the CHEAPEST scope: skipped records cost nothing (no link walk, no .pex chain read). An unknown type is refused, naming what is expected.")]
             string? type = null,
@@ -133,15 +83,90 @@ public static class CheckTools
              "is the ordinary case and is simply dropped. This does not change what " +
              "counts as the vanilla BASELINE the errors family splits out — that is always Mutagen's own base-master set.")]
             string[]? exclude = null,
-        [Description("Optional. Which finding FAMILIES and CLASSES to look for, in one vocabulary. Families: 'errors', 'scripts', 'dialogue'. Classes inside them: 'dangling', 'missing_masters' (errors); 'unbound_object' (HIGH — the silent-None footgun), 'unbound_scalar' (MEDIUM), 'unbound' (both), 'bound_null' (advisory) (scripts). The DIALOGUE family has no class token — it narrows by seeds=, which it requires. A family token means every class in it; a class token runs its family narrowed to that class; naming several runs each. DEFAULT (omitted) = the errors family alone, and the response states what it did not run and how to ask for it. Excluding 'dangling' SKIPS the per-record link walk entirely — that is how you ask 'is any master missing anywhere in my order' without paying for a full sweep. An excluded class renders as 'not checked', never as 0. Unscannable records, scan errors and unverifiable script attachments are ALWAYS reported and cannot be filtered out (a suppressed 'could not read' would read as a clean result).")]
+        [Description("Optional. Which finding FAMILIES and CLASSES to look for, in one vocabulary. Families: " +
+             "'errors', 'scripts', 'dialogue'. Classes inside them: 'dangling', 'missing_masters' (errors); " +
+             "'unbound_object' (HIGH — the silent-None footgun), 'unbound_scalar' (MEDIUM), 'unbound' (both), " +
+             "'bound_null' (advisory) (scripts). The DIALOGUE family has no class token — it narrows by seeds=, " +
+             "which it requires. A family token means every class in it; a class token runs its family narrowed to " +
+             "that class; naming several runs each. DEFAULT (omitted) = the ERRORS family alone, and the response " +
+             "STATES which families ran, which registered families did not, and the exact findings= spelling that " +
+             "adds them — the default narrows only because the response says so. It cannot be every family: an " +
+             "unscoped scripts sweep is ~8 minutes on a 3800-plugin order (measured), and an unscoped dialogue " +
+             "sweep is refused outright (seeds= is required). Excluding 'dangling' SKIPS the per-record link walk " +
+             "entirely — that is how you ask 'is any master missing anywhere in my order' without paying for a full " +
+             "sweep. An excluded class renders as 'not checked', never as 0. Unscannable records, scan errors and " +
+             "unverifiable script attachments are ALWAYS reported and cannot be filtered out (a suppressed 'could " +
+             "not read' would read as a clean result). " +
+             // ---- family: errors (harvested from housecarl_check_errors) -------------------------------
+             "ERRORS FAMILY — the data-layer twin of the Creation Kit's 'Check For Errors' / xEdit's error check. " +
+             "For each plugin in scope it walks every record's FormLinks and reports three classes: (1) DANGLING " +
+             "references — a non-null link whose target NO plugin in the ACTIVE order defines; (2) MISSING MASTERS " +
+             "— a master a plugin DECLARES that is not present in the active order (the most common load-order " +
+             "break); (3) PARSE failures — records houseCARL/Mutagen could not read, plus whole plugins the index " +
+             "excluded as unparseable. BOUNDARY (never a silent claim of more — Q3): it covers the " +
+             "FormLink-resolution / missing-master / parse class. It does NOT verify navmesh or terrain spatial " +
+             "integrity (CRC/grid — a Mutagen-delta residual), does NOT flag a required field left null (a null " +
+             "FormLink is a legal optional, not an error), does NOT list unused-master cleanup (a FormLink scan " +
+             "cannot prove a master is unused), and does NOT link-check an owned item's ownership 'variable' word " +
+             "(a rank/global Mutagen cannot type on an override without a link cache). " +
+             // ---- family: scripts (harvested from housecarl_validate_scripts) --------------------------
+             "SCRIPTS FAMILY — catches the silent-None footgun a byte-valid plugin hides: a record whose attached " +
+             "Papyrus script DECLARES a property (e.g. 'Spell Property CallVesyraPower Auto') the record's script " +
+             "data (VMAD) never BINDS, so at runtime it is None and the code that uses it no-ops while the log " +
+             "looks clean (the maximally-misleading 'the function ran, the effect is absent' class — the same as " +
+             "the Creation Kit's auto-add-property bug). For each record carrying a script it reads the attached " +
+             "script's compiled .pex — and every script it EXTENDS — from the load order (loose or BSA), and " +
+             "reports: (1) UNBOUND properties declared but not bound (an object/form type ⇒ None ⇒ the silent " +
+             "no-op, ranked first; an uninitialized scalar ⇒ a 0/false/\"\" default that may be wrong); (2) " +
+             "BOUND-BUT-NULL object properties (advisory — sometimes filled at runtime). BOUNDARY: it checks Auto " +
+             "(CK-editable) properties only, not code-driven full properties; 'unbound may be intentional' (a " +
+             "runtime-filled link), so a finding is a flag to VERIFY; and if a script's .pex is not on disk " +
+             "(uncompiled / not in the order) the attachment is reported UNVERIFIABLE, never passed clean. It has " +
+             "the SAME off-order lane as the errors family (see plugins=), so a fresh patch's bindings can be " +
+             "checked BEFORE it is enabled. " +
+             // ---- family: dialogue (harvested from housecarl_validate_dialogue) ------------------------
+             "DIALOGUE FAMILY — a topic's whole graph as the GAME sees it, and it is SEEDED, not swept (see " +
+             "seeds=, which it requires). It checks what houseCARL CAN verify at the data layer: the topic is " +
+             "wired to a quest, the branch resolves, the INFO.LinkTo conversation chain has no dangling targets, " +
+             "and no previous-link (PNAM) is dangling — an EMPTY PNAM is NORMAL (vanilla selects among a topic's " +
+             "lines by their conditions, not a previous-link chain), so absence is never flagged; each voiced " +
+             "line's .fuz is on disk and each result script is bound + compiled; non-ASCII characters in the " +
+             "player-facing text (topic name, line prompt, response text) are flagged as likely in-game MOJIBAKE " +
+             "(the CK/Papyrus surface is Windows-1252/ASCII); each line's CTDA conditions are statically checked " +
+             "for a meaningful subset of MALFORMED shapes (a dangling form reference, a dead quest-alias index, an " +
+             "unset Run On reference, GetIsID pointed at a placed instance); and a Start-Game-Enabled quest's .seq " +
+             "is checked for coverage and staleness (without it the quest is dormant on a fresh save and its " +
+             "dialogue never shows). BOUNDARY: it cannot EVALUATE whether a WELL-FORMED condition passes — only " +
+             "the running game can — and it does not check lip-sync or audio content, so 'checks passed' never " +
+             "reads as 'this will play'.")]
             string[]? findings = null,
         [Description("Optional. true = return ONLY the header totals plus each running family's histograms, with no per-plugin or per-record listing. Errors: dangling-by-TARGET-plugin (which plugin the broken refs point INTO — the one absent dependency behind a wall of findings) and dangling-by-SOURCE-plugin (which plugin they come FROM — how much is vanilla baseline and how much your mods introduced). Scripts: unbound-by-PROPERTY-NAME. Dialogue: the totals and the unreachable-seed roster alone, no per-topic blocks — a seed nobody could reach bounds the answer rather than sitting inside it, so this does not silence it. The cheap before/after-a-fix comparison; totals stay exact (never limit-capped) and limit= caps the histogram ROWS instead.")]
             bool counts_only = false,
         [Description("Optional. 'text' (default) or 'json' — the machine-readable twin carrying the same data, sectioned per family, with the totals/capped/truncated accounting in-band.")]
             string? format = null,
-        [Description("Optional. Max findings to list per family (default 1000). The TRUE totals are always reported; over the cap the response says so, and for the errors family says how many plugins lost entries, names the ones that lost the most (a count each), and states how many it did not name. Master-table findings and unverifiable notes are outside this cap, never trimmed by it; on the SCRIPTS family a note repeating one already reported for the same script class is collapsed to a count instead, so a disabled mod's unreadable scripts cannot fill the listing (a note that names no script class is never collapsed — the record is its only identity). Under counts_only=true this caps the histogram ROWS instead. For the DIALOGUE family it caps how many SEEDS one call expands, and the response names how many it did not reach.")]
+        [Description("Optional. Max findings to list per family (default 1000). The TRUE totals are always " +
+             "reported; over the cap the response says so, and for the errors family says how many plugins lost " +
+             "entries, names the ones that lost the most (a count each), and states how many it did not name. " +
+             "BASELINE: the base-game masters carry permanent vanilla dangling refs no load order can fix, so the " +
+             "response splits them out of the total and spends limit= on every other plugin FIRST — vanilla cannot " +
+             "crowd mod findings out of the listing. Master-table findings and unverifiable notes are outside this " +
+             "cap, never trimmed by it; on the SCRIPTS family a note repeating one already reported for the same " +
+             "script class is collapsed to a count instead, so a disabled mod's unreadable scripts cannot fill the " +
+             "listing (a note that names no script class is never collapsed — the record is its only identity). A " +
+             "script-heavy plugin (~180 scripted records) does not fit a tool result unnarrowed, and limit= alone " +
+             "will not help there because it caps FINDINGS, not the record roster — counts_only=true or a record " +
+             "scope is what does. Under counts_only=true this caps the histogram ROWS instead. For the DIALOGUE " +
+             "family it caps how many SEEDS one call expands, and the response names how many it did not reach.")]
             int limit = 1000,
-        [Description("Optional. The DIALOGUE family only, and required by it: the topics and quests to validate, as FormIDs ('0F1AC1:Skyrim.esm' — 6 hex digits, a colon, then the defining master's filename). A DIAL validates one topic; a QUST validates EVERY topic that quest owns (plus the quest's own CK-parity subrecords and its .seq, checked once); a DLVW or DLBR runs a record-level CK-parity check. This family is SEEDED, not swept — plugins=/type=/formids=/editorid_contains=/exclude= do not scope it — and findings=['dialogue'] with no seeds is REFUSED on cost, never widened to the whole order. limit= caps how many seeds one call expands.")]
+        [Description("Optional. The DIALOGUE family only, and required by it: the topics and quests to validate, " +
+             "as FormIDs ('0F1AC1:Skyrim.esm' — 6 hex digits, a colon, then the defining master's filename). A " +
+             "DIAL validates one topic; a QUST validates EVERY topic that quest owns (plus the quest's own " +
+             "CK-parity subrecords and its .seq, checked once); a DLVW or DLBR runs a record-level CK-parity check " +
+             "— a bare DLVW crashes the CK's Dialogue Views editor. This family is SEEDED, not swept — " +
+             "plugins=/type=/formids=/editorid_contains=/exclude= do not scope it — and findings=['dialogue'] with " +
+             "no seeds is REFUSED on cost, never widened to the whole order (a whole-order pass is a per-topic " +
+             "graph walk across every touching plugin, and the order this bound was measured on carries 82,343 " +
+             "dialogue topics). limit= caps how many seeds one call expands.")]
             string[]? seeds = null,
         [Description("Optional. Max characters before the response stops with an explicit notice. 0 = the server default (~80k). The budget is DIVIDED among the families that ran and their parts, not spent in series — a family that renders second does not inherit what the first one left over. Raise it for a quest that owns many topics.")]
             int max_chars = 0) => Guard.Tool(ToolNames.Check, () =>

--- a/src/housecarl-mcp/CheckTools.cs
+++ b/src/housecarl-mcp/CheckTools.cs
@@ -81,7 +81,7 @@ public static class CheckTools
              "exclusion that removes the whole scope is refused too rather than sweeping nothing in silence. " +
              "A group member that is not in this order " +
              "is the ordinary case and is simply dropped. This does not change what " +
-             "counts as the vanilla BASELINE the errors family splits out — that is always Mutagen's own base-master set.")]
+             "counts as the vanilla BASELINE the errors family splits out (see limit=) — that is always Mutagen's own base-master set.")]
             string[]? exclude = null,
         [Description("Optional. Which finding FAMILIES and CLASSES to look for, in one vocabulary. Families: " +
              "'errors', 'scripts', 'dialogue'. Classes inside them: 'dangling', 'missing_masters' (errors); " +
@@ -92,7 +92,7 @@ public static class CheckTools
              "STATES which families ran, which registered families did not, and the exact findings= spelling that " +
              "adds them — the default narrows only because the response says so. It cannot be every family: an " +
              "unscoped scripts sweep is ~8 minutes on a 3800-plugin order (measured), and an unscoped dialogue " +
-             "sweep is refused outright (seeds= is required). Excluding 'dangling' SKIPS the per-record link walk " +
+             "sweep is refused outright (see seeds=). Excluding 'dangling' SKIPS the per-record link walk " +
              "entirely — that is how you ask 'is any master missing anywhere in my order' without paying for a full " +
              "sweep. An excluded class renders as 'not checked', never as 0. Unscannable records, scan errors and " +
              "unverifiable script attachments are ALWAYS reported and cannot be filtered out (a suppressed 'could " +
@@ -126,8 +126,8 @@ public static class CheckTools
              "checked BEFORE it is enabled. " +
              // ---- family: dialogue (harvested from housecarl_validate_dialogue) ------------------------
              "DIALOGUE FAMILY — a topic's whole graph as the GAME sees it, and it is SEEDED, not swept (see " +
-             "seeds=, which it requires). It checks what houseCARL CAN verify at the data layer: the topic is " +
-             "wired to a quest, the branch resolves, the INFO.LinkTo conversation chain has no dangling targets, " +
+             "seeds=). It checks what houseCARL CAN verify at the data layer: the topic is wired to a quest, the " +
+             "branch resolves, the INFO.LinkTo conversation chain has no dangling targets, " +
              "and no previous-link (PNAM) is dangling — an EMPTY PNAM is NORMAL (vanilla selects among a topic's " +
              "lines by their conditions, not a previous-link chain), so absence is never flagged; each voiced " +
              "line's .fuz is on disk and each result script is bound + compiled; non-ASCII characters in the " +
@@ -147,16 +147,17 @@ public static class CheckTools
         [Description("Optional. Max findings to list per family (default 1000). The TRUE totals are always " +
              "reported; over the cap the response says so, and for the errors family says how many plugins lost " +
              "entries, names the ones that lost the most (a count each), and states how many it did not name. " +
-             "BASELINE: the base-game masters carry permanent vanilla dangling refs no load order can fix, so the " +
-             "response splits them out of the total and spends limit= on every other plugin FIRST — vanilla cannot " +
-             "crowd mod findings out of the listing. Master-table findings and unverifiable notes are outside this " +
-             "cap, never trimmed by it; on the SCRIPTS family a note repeating one already reported for the same " +
-             "script class is collapsed to a count instead, so a disabled mod's unreadable scripts cannot fill the " +
-             "listing (a note that names no script class is never collapsed — the record is its only identity). A " +
-             "script-heavy plugin (~180 scripted records) does not fit a tool result unnarrowed, and limit= alone " +
-             "will not help there because it caps FINDINGS, not the record roster — counts_only=true or a record " +
-             "scope is what does. Under counts_only=true this caps the histogram ROWS instead. For the DIALOGUE " +
-             "family it caps how many SEEDS one call expands, and the response names how many it did not reach.")]
+             "BASELINE (errors family): the base-game masters carry permanent vanilla dangling refs no load order " +
+             "can fix, so the response splits them out of the total and spends limit= on every other plugin FIRST " +
+             "— vanilla cannot crowd mod findings out of the listing. Master-table findings and unverifiable " +
+             "notes are outside this cap, never trimmed by it; on the SCRIPTS family a note repeating one already " +
+             "reported for the same script class is collapsed to a count instead, so a disabled mod's unreadable " +
+             "scripts cannot fill the listing (a note that names no script class is never collapsed — the record " +
+             "is its only identity). A script-heavy plugin (~180 scripted records) does not fit a tool result " +
+             "unnarrowed, and limit= alone will not help there because it caps FINDINGS, not the record roster — " +
+             "counts_only=true or a record scope is what does. Under counts_only=true this caps the histogram " +
+             "ROWS instead. For the DIALOGUE family it caps how many SEEDS one call expands, and the response " +
+             "names how many it did not reach.")]
             int limit = 1000,
         [Description("Optional. The DIALOGUE family only, and required by it: the topics and quests to validate, " +
              "as FormIDs ('0F1AC1:Skyrim.esm' — 6 hex digits, a colon, then the defining master's filename). A " +


### PR DESCRIPTION
`housecarl_check` published a 7,489-character tool description. Claude Code shows the first 2,048 characters of a description and delivers parameter descriptions whole, so the three family taxonomies — what each family reports, its BOUNDARY, its cost — were being described in a part of the text the model never saw. Nothing is deleted here: each paragraph moves into the description of the parameter it is about — the family blocks onto `findings`, the off-order lane onto `plugins`, the seeded refusal and the seed kinds onto `seeds`, the baseline split and the two listing-cost sentences onto `limit` — and where the parameter already said the same thing the description's copy is dropped as a duplicate rather than pasted in twice. The description keeps the purpose sentence, the read-only and winner-resolution rules, the family roster, one line per axis naming its parameters, the counts-follow-the-scope rule that governs every scope parameter at once, and the cross-tool pointers. `housecarl_check` comes off the bound test's `StillOversized` list, which now names six tools.

Part of #583.

## Measured on the published tools/list

| | Before | After |
|---|---|---|
| `housecarl_check` description | 7,489 | **1,649** |
| Top-level parameter descriptions | 6,121 | 11,119 |
| All schema descriptions | 6,121 | 11,119 |

The two schema rows are equal because `check` has no object parameters: every one of its twelve inputs is a scalar or a `string[]`, so there are no nested DTO members and no `@file`-style spelling to get wrong.

The description shed 5,840 characters and the schema gained 4,998; the 842-character difference is text the description was repeating from a parameter that already carried it (the class roster, the counts_only histogram detail, `property_contains=`'s scripts-family scoping, `format='json'`, the `exclude=` sentence, the dialogue-is-seeded sentence, and the capped-errors naming rule).

Margin under the cap: 399 characters. The description embeds `ToolNames` three times (`housecarl_records` twice, `housecarl_create` once).

## Harvest

Every sentence of the old description and where it lives now.

| Old description sentence | Now lives in |
|---|---|
| "DERIVED-FINDINGS SWEEP over the load order — one call, several finding FAMILIES, selected by findings=." | kept in description |
| "Read-only; writes nothing." | kept in description |
| "Resolves against the load-order WINNERS, like every other read." | kept in description |
| "Three families: 'errors' (load-order integrity), 'scripts' (VMAD script-property binding) and 'dialogue' (dialogue graph validation over SEEDED topics and quests)." | kept in description (the FAMILIES line) |
| "findings= takes whole families or the classes inside them ('dangling', 'missing_masters'; 'unbound_object', …) — naming a class runs its family narrowed to that class; the dialogue family narrows by seeds=, not by class." | `findings` (already said there, with the class roster and its severities); the description keeps the axis half without the roster |
| "DEFAULT: findings= omitted runs the ERRORS family alone, and the response STATES which families ran, which registered families did not, and the exact findings= spelling that adds them — the default narrows only because the response says so." | `findings` (its weaker "the response states what it did not run and how to ask for it" replaced) |
| "It cannot be every family: an unscoped scripts sweep is ~8 minutes on a 3800-plugin order (measured), and an unscoped dialogue sweep is refused outright (below)." | `findings`; "(below)" repointed to "(seeds= is required)", since there is no longer a section below it |
| "ERRORS FAMILY — the data-layer twin of the Creation Kit's 'Check For Errors' / xEdit's error check." + the three classes it reports (dangling, missing masters, parse failures) | `findings` |
| "A scoped name NOT in the active order is resolved on disk (any mod folder — enabled, disabled, or not yet listed in MO2) and swept OFF-ORDER: its own records, links resolved against the active order PLUS the file's own definitions — the pre-enable verify sweep for a patch houseCARL just wrote." | `plugins`, which carried the short form ("resolved on disk … and swept OFF-ORDER by BOTH swept families"); it gains the mod-folder gloss and what off-order resolution actually means |
| "BOUNDARY (never a silent claim of more — Q3): it covers the FormLink-resolution / missing-master / parse class." + the four does-NOT clauses | `findings` |
| "BASELINE: the base-game masters carry permanent vanilla dangling refs no load order can fix, so the response splits them out of the total and spends limit= on every other plugin FIRST — vanilla cannot crowd mod findings out of the listing." | `limit` — it is one sentence about how limit= is spent, and `exclude` already points at "the vanilla BASELINE the errors family splits out" |
| "SCRIPTS FAMILY — catches the silent-None footgun a byte-valid plugin hides: …" through "… the attachment is reported UNVERIFIABLE, never passed clean." | `findings` |
| "It has the SAME off-order lane as the errors family: a scoped name not in the active order is swept from its file on disk, so a fresh patch's bindings can be checked BEFORE it is enabled" | `findings`, shortened to point at `plugins=` rather than restate the lane there |
| "— the .pex chain is still read from the ACTIVE order, so a script shipped only inside the not-yet-enabled mod reads UNVERIFIABLE rather than clean." | `plugins`, keeping its "on the SCRIPTS family" qualifier — it is false for the errors family, which reads no .pex |
| "DIALOGUE FAMILY — a topic's whole graph as the GAME sees it, and it is SEEDED, not swept" | `findings` (the framing), pointing at `seeds=` |
| "seeds= names what to validate and findings=['dialogue'] without it is REFUSED on cost (a whole-order pass is a per-topic graph walk across every touching plugin, and the order this bound was measured on carries 82,343 dialogue topics)." | `seeds`, which already carried the refusal; it gains the measured cost behind it |
| "A seed is a DIAL (one topic), a QUST (EVERY topic that quest owns, plus the quest's own CK-parity subrecords and its .seq, checked once), or a DLVW/DLBR (a record-level CK-parity check — a bare DLVW crashes the CK's Dialogue Views editor)." | `seeds` (already said there); it gains the "a bare DLVW crashes the CK's Dialogue Views editor" clause |
| "It checks what houseCARL CAN verify at the data layer: …" — the quest wiring, the branch, LinkTo, the PNAM-absence-is-normal rule, .fuz and result scripts, MOJIBAKE, the CTDA shapes, the .seq coverage check | `findings` |
| "BOUNDARY: it cannot EVALUATE whether a WELL-FORMED condition passes — only the running game can — and it does not check lip-sync or audio content, so 'checks passed' never reads as 'this will play'." | `findings` |
| "NOT HERE: the effective merged INFO order — the sequence the game walks, which line MOVED and which plugin moved it, the answer to 'why does the wrong line play' — is an ordered sequence rather than a finding and lives on `housecarl_records` project='info_order'." | kept in description (cross-tool pointer) |
| "To CREATE dialogue lines use `housecarl_create`; to inspect one record use `housecarl_records`." | kept in description (cross-tool pointer) |
| "NARROWING: beyond plugins= it takes a record scope (type= / formids= / editorid_contains=), property_contains= (the scripts family — chasing one property name), a findings= filter, counts_only=true for the totals plus per-family histograms (errors: …; scripts: …; dialogue: …), and format='json'." | kept in description as the SCOPE and TRANSPORT axis lines; the histogram breakdown was already on `counts_only`, the scripts-family scoping already on `property_contains`, and 'json' already on `format` |
| "A script-heavy plugin (~180 scripted records) does not fit a tool result unnarrowed, and limit= alone will not help there because it caps FINDINGS, not the record roster — counts_only=true or a record scope is what does." | `limit` (it is a statement about what limit= cannot do) |
| "Narrowing narrows the COUNTS too: they are always the counts for the scope actually swept, and the response says so." | kept in description — it is true of every scope parameter at once, so it belongs to none of them |
| "exclude= drops named plugins or whole groups (base_masters / implicit) out of the sweep entirely rather than merely accounting for them; it scopes every SWEPT family." | `exclude` (already said there, at more length) |
| "The dialogue family is seeded rather than swept, so no plugin scope narrows it — the response says so in that family's own section." | `exclude` and `seeds` (already said on both); the description's SCOPE line keeps the one-clause form |
| "Results cap at limit= and max_chars (both overruns explicit, per family): the response states how much of each family's listing it carries, why the rest is absent, and which knob moves it" | kept in description (the TRANSPORT line) — it governs `limit` and `max_chars` alike |
| "— a capped errors listing NAMES which source plugins lost entries." | `limit` (already said there, with the count-each and how-many-not-named detail) |

The description gained one thing it did not carry before: the composition sentence — "ONE surface: which FAMILIES run (findings=) x what they are run over (the SCOPE) x how it reads back (TRANSPORT)" — and the three axis headings it introduces. The old text named the parameters in prose under NARROWING; the axis lines make the roster the description's index of them, which is what it is for now that the grammar has moved.

## Test

`src/housecarl-mcp-tests/PublishedDescriptionBoundTests.cs`: the `ToolNames.Check` line comes out of `StillOversized`, and nothing else changes. Ran the class with the line gone and the description untouched — `EveryPublishedDescriptionFitsTheClientsCut(tool: "housecarl_check")` failed at 7,489, which is the first commit here. It passes at 1,649 after the move.

Two existing tests read these descriptions and still pass: `CheckWirePathTests.ThePublishedFindingsSchemaNamesEveryRegisteredFamily` (each family token, quoted, on `findings`) and `CheckExcludeGrammarDescriptionTests`' two — every `exclude=` token named, and `limit=` stating the unverifiable-note collapse. Nothing in the repo quotes the tool description itself: `grep` for its phrases and for the measured figures in it finds only `CheckTools.cs`, the `SweepFamilies` docstring, and the `82,343` figure in the dialogue refusal sentence (`ReadSentences`), which `CheckMergeProbe` reads off the response, not off a description.

## What was run

```
dotnet build housecarl.sln -c Release          0 errors
dotnet test src/housecarl-mcp-tests -c Release --no-build --filter "tier!=bridge"
    1620 passed, 0 failed
dotnet .../housecarl-generator.dll description-vocab-guard
    64 passed, 0 failed
```

`ci-all` was not run locally (#570 — its probes collide with parallel runs); CI runs it here. No checked-in capture snapshots the descriptions: `src/housecarl-mcp-tests/data/tools-list-2.0.json` holds tool names only. No `plugin/CHANGELOG.md` line — the records PR's entry covers this wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
