### PR TITLE
Bring the nif_inspect tool description under the 2,048-character cap

### DIFF
--- a/src/housecarl-mcp-tests/PublishedDescriptionBoundTests.cs
+++ b/src/housecarl-mcp-tests/PublishedDescriptionBoundTests.cs
@@ -34,7 +34,6 @@ public sealed class PublishedDescriptionBoundTests
         ToolNames.CompactPlugin,
         ToolNames.Create,
         ToolNames.Forward,
-        ToolNames.NifInspect,
         ToolNames.NifSet,
         ToolNames.Remove,
     };

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -47,18 +47,19 @@ public static class NifTools
          "SOURCE — mod= (empty = the VFS winner).\n" +
          "PROJECT — sections= (empty = the summary).\n" +
          "TRANSPORT — max_chars=.\n\n" +
-         "Every per-path failure — an unreadable archive, an absent path, a mod= name nothing provides, a mesh the " +
-         "underlying mesh library refuses — is reported LOUD by name on THAT path without aborting the rest; never a " +
-         "silent 'absent' or a half-answer. Read-only: resolves nothing to disk, writes nothing, changes no load " +
-         "order — " + ToolNames.NifSet + " is the write counterpart.")]
+         "A per-path failure — an absent path, a mod= name nothing provides, a mesh the underlying mesh library " +
+         "refuses — is reported LOUD by name on THAT path without aborting the rest; an unreadable archive is named " +
+         "once for the batch; never a silent 'absent' or a half-answer. Read-only: resolves nothing to disk, writes " +
+         "nothing, changes no load order — " + ToolNames.NifSet + " is the write counterpart.")]
     public static string NifInspect(
         LoadOrderService svc,
         [Description("The Data-relative mesh path(s) to inspect, e.g. " +
                      "'meshes\\actors\\character\\facegendata\\facegeom\\Skyrim.esm\\00000007.nif' or " +
                      "'meshes\\armor\\iron\\cuirass_1.nif'. One or many at " + ToolNames.AssetStatus + " parity — a " +
                      "whole facegen sweep's flagged subset is ONE call; inspected in order, results returned in the " +
-                     "same order. Relative to the game's Data folder (forward or back slashes both fine). Optional " +
-                     "only if npc= is passed instead.")]
+                     "same order. Relative to the game's Data folder (forward or back slashes both fine); a " +
+                     "drive-rooted path ('C:\\…') or one carrying a '..' segment is REFUSED on that path by name, " +
+                     "never silently normalized. Optional only if npc= is passed instead.")]
             string[]? mesh_paths = null,
         [Description("Optional. NPC FormID(s) to inspect the FaceGen HEAD MESH of — houseCARL derives each one's " +
                      "'meshes\\actors\\character\\facegendata\\facegeom\\<defining master>\\00<6 hex>.nif' and reads it " +
@@ -97,8 +98,8 @@ public static class NifTools
                      "Naming a MOD reaches that mod's loose files AND its own root archives, whether or not MO2 is " +
                      "loading it, so a donor mod can be read without enabling it; the response then SAYS the game is " +
                      "not loading that copy. '*winner' is the winner pole spelled out. A name that provides no copy " +
-                     "of a given mesh is THAT path's own named miss, listing the providers that do; the rest of the " +
-                     "batch still reads. Applies to every mesh " +
+                     "of a given mesh is THAT path's own named miss, listing the providers that do where any do; the " +
+                     "rest of the batch still reads. Applies to every mesh " +
                      "in the batch. Empty = the winner.")]
             string mod = "",
         [Description("Optional. Max characters before the output is cut with an explicit notice — one cap over the " +

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -26,42 +26,39 @@ public static class NifTools
 
     [McpServerTool(Name = ToolNames.NifInspect, ReadOnly = true, Title = "Inspect the data values inside one or many Skyrim meshes (.nif)"),
      Description(
-         "Read the DATA VALUES inside one or many Skyrim meshes (.nif) at the data layer, beneath NifSkope. Resolve each " +
-         "Data-relative path in mesh_paths through Mod Organizer 2's virtual file system to the copy the game actually uses " +
-         "(loose beats BSA; among BSAs the later-loaded plugin wins) and report, per mesh: its header version + whether it is a Skyrim SE " +
-         "stream; the block census (every block type and count); any UNKNOWN blocks (named + preserved, never silently " +
-         "dropped); and per shape — the shape name, the NiAVObject flags (hex, decoded by deviation from the type's " +
-         "documented default plus the 0x80000 bit) and scale, the BSDismember body-part " +
-         "partitions (decoded to their SBP_* names), the alpha property (decoded blend / test / threshold), the SHADER " +
-         "property (block type, the shader TYPE enum — SkinTint / FaceTint / HairTint / EnvironmentMap / Parallax / … — " +
-         "the SLSF1+SLSF2 flags decoded to their names, and the lighting values on a Skyrim-layout shader — emissive " +
-         "colour and multiple, glossiness, specular strength and colour, alpha. Anything not reported is NAMED, with " +
-         "its reason: the library stubs that accessor for that block type, or the mesh reads as another game's " +
-         "layout, where houseCARL declines the group rather than interpret the ones that survive the layout change " +
-         "and guess at the rest), the embedded " +
-         "texture-set paths with their semantic slot names where the shader determines them, and the bone list; plus the node tree and the header string table. Use it to answer 'what " +
-         "shapes / bones / textures / partitions / alpha does this mesh have', 'does this mesh glow / use soft lighting / " +
-         "subsurface skin / env-mapping', to read a facegen mesh's baked shape names " +
-         "and tint path, to check a skeleton's bone names, or to see a dark-face mesh's flags/alpha/partitions — the " +
-         "asset-INTERNAL companion to " + ToolNames.AssetStatus + " (which mod wins) once you know the winning file. Pass " +
-         "mesh_paths = one or more paths (asset_status parity — a whole facegen sweep's flagged subset is ONE call, one " +
-         "load-order resolution for the batch); results return in input order, and a failing path is reported LOUD on THAT " +
-         "path without aborting the rest. Pass npc = one or more NPC FormIDs to inspect their FaceGen HEAD MESHES without " +
-         "working the path out yourself — houseCARL derives each facegeom .nif from the FormID (the folder is the plugin " +
-         "that DEFINES the NPC, never the winner) and reads it as one more member of the same batch. Output is a " +
-         "SUMMARY per mesh by default (header + census + shape names); pass sections to expand ('shapes','partitions','alpha'," +
-         "'paths','shader','strings','nodes','bones', or 'all'). Pass mod= to inspect a specific provider instead of the winner; " +
-         "sections, mod and max_chars apply to the whole batch. An " +
-         "unreadable archive, an absent path, or a mesh the underlying mesh library refuses is " +
-         "reported LOUD by name — never a silent 'absent' or a half-answer. Read-only: resolves nothing to disk, writes " +
-         "nothing, changes no load order. Scope: data values only; it does not read or edit geometry / visual content.")]
+         "Read the DATA VALUES inside one or many Skyrim meshes (.nif) at the data layer, beneath NifSkope — ONE " +
+         "surface: which meshes (SELECT) x whose copy (SOURCE) x how much of each mesh (PROJECT) compose in a single " +
+         "call.\n\n" +
+         "Every Data-relative path — typed in mesh_paths, or derived from an npc= FormID — resolves through Mod " +
+         "Organizer 2's virtual file system to the copy the game actually uses (loose beats BSA; among BSAs the " +
+         "later-loaded plugin wins), with ONE load-order resolution for the whole batch.\n\n" +
+         "WHAT A READ SEES, per mesh: the header version + whether it is a Skyrim SE stream; the block census (every " +
+         "block type and count); any UNKNOWN blocks (named + preserved, never silently dropped); and the shape names " +
+         "— that is the default summary. sections= expands it to each shape's flags, scale, partitions, alpha, shader " +
+         "and texture-set paths, its bone list, the node tree and the header string table. Scope: data values only; " +
+         "it does not read or edit geometry / visual content.\n\n" +
+         "Use it to answer 'what shapes / bones / textures / partitions / alpha does this mesh have', 'does this mesh " +
+         "glow / use soft lighting / subsurface skin / env-mapping', to read a facegen mesh's baked shape names and " +
+         "tint path, to check a skeleton's bone names, or to see a dark-face mesh's flags/alpha/partitions — the " +
+         "asset-INTERNAL companion to " + ToolNames.AssetStatus + " (which mod wins) once you know the winning " +
+         "file.\n\n" +
+         "Each axis's grammar is on its own parameters:\n" +
+         "SELECT — mesh_paths= | npc=; one of the two is required, and the two compose into one batch.\n" +
+         "SOURCE — mod= (empty = the VFS winner).\n" +
+         "PROJECT — sections= (empty = the summary).\n" +
+         "TRANSPORT — max_chars=.\n\n" +
+         "Every per-path failure — an unreadable archive, an absent path, a mod= name nothing provides, a mesh the " +
+         "underlying mesh library refuses — is reported LOUD by name on THAT path without aborting the rest; never a " +
+         "silent 'absent' or a half-answer. Read-only: resolves nothing to disk, writes nothing, changes no load " +
+         "order — " + ToolNames.NifSet + " is the write counterpart.")]
     public static string NifInspect(
         LoadOrderService svc,
         [Description("The Data-relative mesh path(s) to inspect, e.g. " +
                      "'meshes\\actors\\character\\facegendata\\facegeom\\Skyrim.esm\\00000007.nif' or " +
-                     "'meshes\\armor\\iron\\cuirass_1.nif'. One or many; inspected in order, results returned in the same " +
-                     "order. Relative to the game's Data folder (forward or back slashes both fine). Optional only if " +
-                     "npc= is passed instead.")]
+                     "'meshes\\armor\\iron\\cuirass_1.nif'. One or many at " + ToolNames.AssetStatus + " parity — a " +
+                     "whole facegen sweep's flagged subset is ONE call; inspected in order, results returned in the " +
+                     "same order. Relative to the game's Data folder (forward or back slashes both fine). Optional " +
+                     "only if npc= is passed instead.")]
             string[]? mesh_paths = null,
         [Description("Optional. NPC FormID(s) to inspect the FaceGen HEAD MESH of — houseCARL derives each one's " +
                      "'meshes\\actors\\character\\facegendata\\facegeom\\<defining master>\\00<6 hex>.nif' and reads it " +
@@ -69,13 +66,27 @@ public static class NifTools
                      "'XXXXXX:Plugin.esp', or the runtime form the game/console prints ('FE012800', '0501A51A'). " +
                      "The FOLDER is the plugin that DEFINES the NPC, never the conflict winner. Derived paths are " +
                      "inspected AFTER any mesh_paths, in the order given; mesh_paths and npc may be passed together, " +
-                     "and one of the two is required.")]
+                     "and one of the two is required. A FormID that will not PARSE refuses the whole call, naming it, " +
+                     "before any mesh is read; once a path is derived it fails like any other — on that path alone.")]
             string[]? npc = null,
         [Description("Optional. Which detail sections to show beyond the summary — any of 'shapes', 'partitions', 'alpha', " +
                      "'paths', 'shader', 'strings', 'nodes', 'bones', or 'all'. Comma-, space-, or JSON-array-separated (e.g. " +
-                     "[\"shapes\",\"shader\"]). There is NO 'textures' section — a mesh's embedded texture-set slot paths " +
-                     "appear under 'shapes' (per-shape detail) and 'paths'. 'shader' is the per-shape shader property: " +
-                     "block type, shader TYPE enum, decoded SLSF1/SLSF2 flag names, and the lighting values that are readable. " +
+                     "[\"shapes\",\"shader\"]). What each adds — per shape, except 'nodes' and 'strings', which are " +
+                     "per mesh: 'shapes' the shape " +
+                     "name, the NiAVObject flags (hex, decoded by deviation from the type's documented default plus " +
+                     "the 0x80000 bit) and scale, with that shape's partitions, alpha, texture-set paths and bones " +
+                     "inline; 'partitions' the BSDismember body-part partitions (decoded to their SBP_* names); " +
+                     "'alpha' the alpha property (decoded blend / test / threshold); 'paths' the embedded texture-set " +
+                     "paths with their semantic slot names where the shader determines them; 'shader' the SHADER " +
+                     "property (block type, the shader TYPE enum — SkinTint / FaceTint / HairTint / EnvironmentMap / " +
+                     "Parallax / … — the SLSF1+SLSF2 flags decoded to their names, and the lighting values on a " +
+                     "Skyrim-layout shader — emissive colour and multiple, glossiness, specular strength and colour, " +
+                     "alpha. Anything not reported is NAMED, with its reason: the library stubs that accessor for " +
+                     "that block type, or the mesh reads as another game's layout, where houseCARL declines the group " +
+                     "rather than interpret the ones that survive the layout change and guess at the rest); 'bones' " +
+                     "the bone list; 'nodes' the node tree, each node with the same flag decode; 'strings' the header " +
+                     "string table. There is NO 'textures' section — a mesh's embedded texture-set slot paths " +
+                     "appear under 'shapes' (per-shape detail) and 'paths'. " +
                      "Applies to every mesh in the batch; " +
                      "unrecognized tokens are reported loud, and an all-unrecognized sections= is an error (never a " +
                      "silent fallback to the summary). Empty = summary only (header + block census + shape names).")]
@@ -85,10 +96,13 @@ public static class NifTools
                      "shows it INSIDE the double quotes; the kind after them ('loose' / 'BSA') is not part of the name. " +
                      "Naming a MOD reaches that mod's loose files AND its own root archives, whether or not MO2 is " +
                      "loading it, so a donor mod can be read without enabling it; the response then SAYS the game is " +
-                     "not loading that copy. '*winner' is the winner pole spelled out. Applies to every mesh " +
+                     "not loading that copy. '*winner' is the winner pole spelled out. A name that provides no copy " +
+                     "of a given mesh is THAT path's own named miss, listing the providers that do; the rest of the " +
+                     "batch still reads. Applies to every mesh " +
                      "in the batch. Empty = the winner.")]
             string mod = "",
-        [Description("Optional. Max characters before the output is cut with an explicit notice. 0 = the server default (~80k).")]
+        [Description("Optional. Max characters before the output is cut with an explicit notice — one cap over the " +
+                     "WHOLE batch's render, not per mesh. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool(ToolNames.NifInspect, () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;


### PR DESCRIPTION
`housecarl_nif_inspect` published a 3,038-character tool description. Claude Code shows the first 2,048 characters of a description and delivers parameter descriptions whole, so the per-shape detail catalogue — what each section actually renders, the shader property's decoded flag words and lighting values, and the reason any of them goes unreported — sat in a part of the text the model never saw. Nothing is deleted: each paragraph moves into the description of the parameter it is about, and where the parameter already said the same thing the description's copy is dropped as a duplicate rather than pasted in twice. The description keeps the purpose sentence, the VFS resolution rule, what a read can and cannot see, the use-case sentence, the `housecarl_asset_status` pointer, the composition sentence, one line per axis naming its parameters, and the per-path failure rule. `housecarl_nif_inspect`'s line comes out of `StillOversized`, so the bound now holds it. Only the `nif_inspect` region of `NifTools.cs` is touched; `nif_set` is its own PR.

Part of #583.

## Measured on the published tools/list

| | Before | After |
|---|---|---|
| `housecarl_nif_inspect` description | 3,038 | **2,037** |
| Its five parameter descriptions | 2,336 | 3,994 |

(Re-measured after the review fold, which spent 24 of the description's remaining characters and 133 on the parameter side.)

The description shed 1,001 characters and the parameters gained 1,658. Most of the difference is the text the description was repeating from a parameter that already carried it (the `npc=` paragraph in full, the section-token roster, `mod=`'s "instead of the winner" and "applies to the whole batch", input-order results), less the four clauses noted in the table below that the merge adds back on the parameter side.

## Harvest

Every sentence of the old description and where it lives now.

| Old description sentence | Now lives in |
|---|---|
| "Read the DATA VALUES inside one or many Skyrim meshes (.nif) at the data layer, beneath NifSkope." | kept in description (the purpose sentence) |
| "Resolve each Data-relative path in mesh_paths through Mod Organizer 2's virtual file system to the copy the game actually uses (loose beats BSA; among BSAs the later-loaded plugin wins)" | kept in description — widened from "each Data-relative path in mesh_paths" to "typed in mesh_paths, or derived from an npc= FormID", because the rule holds for both branches and the old scoping read as if only mesh_paths resolved |
| "one load-order resolution for the batch" | kept in description (it is a whole-call fact, not a `mesh_paths` one) |
| "report, per mesh: its header version + whether it is a Skyrim SE stream; the block census (every block type and count); any UNKNOWN blocks (named + preserved, never silently dropped)" | kept in description, as what a read sees by default |
| "and per shape — the shape name, the NiAVObject flags (hex, decoded by deviation from the type's documented default plus the 0x80000 bit) and scale" | `sections`, under `'shapes'` — and the same flag decode is named on `'nodes'`, which renders it too |
| "the BSDismember body-part partitions (decoded to their SBP_* names)" | `sections`, under `'partitions'` |
| "the alpha property (decoded blend / test / threshold)" | `sections`, under `'alpha'` |
| "the SHADER property (block type, the shader TYPE enum — SkinTint / FaceTint / HairTint / EnvironmentMap / Parallax / … — the SLSF1+SLSF2 flags decoded to their names, and the lighting values on a Skyrim-layout shader — emissive colour and multiple, glossiness, specular strength and colour, alpha" | `sections`, under `'shader'` — replacing its weaker "block type, shader TYPE enum, decoded SLSF1/SLSF2 flag names, and the lighting values that are readable", which named neither the enum values nor the lighting values |
| "Anything not reported is NAMED, with its reason: the library stubs that accessor for that block type, or the mesh reads as another game's layout, where houseCARL declines the group rather than interpret the ones that survive the layout change and guess at the rest)" | `sections`, kept INSIDE the `'shader'` clause. It is the shader section's caveat, not the tool's: both reasons are `AppendShaderValues`/`BuildShader` behaviour, gated on `IsSkyrimLayout` and on the interface-stub map, so generalising it to every section would claim something the other seven do not do |
| "the embedded texture-set paths with their semantic slot names where the shader determines them" | `sections`, under `'paths'` (and named again on `'shapes'`, which renders them inline per shape — `RenderShapesDetail` and `RenderPaths` share `AppendTexture`) |
| "and the bone list" | `sections`, under `'bones'` |
| "plus the node tree and the header string table" | `sections`, under `'nodes'` and `'strings'` |
| "Use it to answer 'what shapes / bones / textures / partitions / alpha does this mesh have', 'does this mesh glow / use soft lighting / subsurface skin / env-mapping', to read a facegen mesh's baked shape names and tint path, to check a skeleton's bone names, or to see a dark-face mesh's flags/alpha/partitions" | kept in description — the use-case sentence belongs to no one parameter |
| "the asset-INTERNAL companion to housecarl_asset_status (which mod wins) once you know the winning file" | kept in description (the cross-tool pointer) |
| "Pass mesh_paths = one or more paths (asset_status parity — a whole facegen sweep's flagged subset is ONE call" | `mesh_paths` — its "One or many" gains the parity clause and the facegen-sweep example, which is the reason the parameter is set-valued |
| "results return in input order" | `mesh_paths` (already said there: "inspected in order, results returned in the same order") and `npc` (already said there: "Derived paths are inspected AFTER any mesh_paths, in the order given"), so the description's copy is dropped as a duplicate |
| "a failing path is reported LOUD on THAT path without aborting the rest" | kept in description, merged into the one per-path failure sentence below so the rule is stated once |
| "Pass npc = one or more NPC FormIDs to inspect their FaceGen HEAD MESHES without working the path out yourself — houseCARL derives each facegeom .nif from the FormID (the folder is the plugin that DEFINES the NPC, never the winner) and reads it as one more member of the same batch." | `npc` (already said there, in the same words, including "The FOLDER is the plugin that DEFINES the NPC, never the conflict winner") |
| "Output is a SUMMARY per mesh by default (header + census + shape names)" | kept in description ("that is the default summary", after the census and shape-name facts it names) — `sections` keeps its own "Empty = summary only", which is a statement about the empty value rather than about the default output |
| "pass sections to expand ('shapes','partitions','alpha','paths','shader','strings','nodes','bones', or 'all')" | `sections` (already said there, as the token roster) |
| "Pass mod= to inspect a specific provider instead of the winner" | `mod` (already said there: "Inspect a specific provider's copy instead of the VFS winner") |
| "sections, mod and max_chars apply to the whole batch" | `sections` and `mod` (already said there: "Applies to every mesh in the batch") and `max_chars`, whose "one cap over the WHOLE batch's render, not per mesh" is new — it was the one of the three that never said it, and "applies to the batch" means something different for a character cap than for a filter |
| "An unreadable archive, an absent path, or a mesh the underlying mesh library refuses is reported LOUD by name — never a silent 'absent' or a half-answer." | kept in description, as one sentence with the per-path rule above it |
| "Read-only: resolves nothing to disk, writes nothing, changes no load order." | kept in description |
| "Scope: data values only; it does not read or edit geometry / visual content." | kept in description |

Four things the merged text says that the old description did not, each because moving a sentence made its old scope wrong or its list read as exhaustive:

- The failure list is now introduced as "Every per-path failure" and names a fourth case, **a `mod=` name nothing provides**. `NifPick` returns a named per-path miss for a `mod=` value no provider matches (`WriteSentences.PlaceSourceNamedAbsent`, listing the providers that do supply the path), and the old three-item list read as covering every way a path can fail. `mod=` carries the matching clause.
- `npc` says that **a FormID that will not parse refuses the whole call**, before any mesh is read. The per-path sentence above is true of every path once it exists; the `npc` parse is the one failure that is not per-path (`NifInspect` returns the error from the FormID loop, ahead of the batch), so the parameter that owns it says so.
- `sections` says which of its tokens are per shape and which are per mesh, because the moved catalogue is a single list in which `'nodes'` and `'strings'` are not per-shape.
- The description names `housecarl_nif_set` as the write counterpart. The read/write seam is the pair, `nif_set`'s own description already points back at `nif_inspect` for `target=`, and the pointer was reachable from neither direction on this side.

The class-level XML doc on `NifTools` still describes the same surface and needed no repointing; nothing else in `src/` cites this tool's description (`NifSourceLaneProbe`, `NifSectionsProbe`, `NifInspectBatchGuardProbe` and `NifServiceGuardProbe` assert on rendered output, not on description text).

## Test

`src/housecarl-mcp-tests/PublishedDescriptionBoundTests.cs` loses its `ToolNames.NifInspect` line from `StillOversized`, and nothing else.

- With the line gone and the old description in place, `EveryPublishedDescriptionFitsTheClientsCut(tool: "housecarl_nif_inspect")` failed: "housecarl_nif_inspect's published description is 3038 characters; Claude Code shows the first 2048 and drops the rest." 1 failed, 31 passed.
- With the description moved, the class is green and the theory prints `housecarl_nif_inspect: 2013 characters (bound 2048)`.

## What was run

```
dotnet build housecarl.sln -c Release          0 errors
dotnet test src/housecarl-mcp-tests -c Release --no-build --filter "tier!=bridge"
    1620 passed, 0 failed
```

## Review fold (5da34742)

All three review findings held up against the code and all three are folded.

- The archive is out of the per-path list. A BSA that fails at view-build comes back in `NifInspectBatchData.BsaFailures` and renders once through `BatchRender.AppendReadFailures`, while the path itself renders `ABSENT` plus a hedge, so the description now says "an unreadable archive is named once for the batch" separately from the failures reported "on THAT path".
- `mod=` now says "listing the providers that do where any do" — `WriteSentences.PlaceSourceNamedAbsent` skips that clause on an empty provider list, deliberately.
- "Every per-path failure" is now "A per-path failure", so the list reads as examples rather than a complete set, and the case it omitted is named on `mesh_paths` (delivered whole, no cap): a drive-rooted or `..` path is refused on that path by name, never silently normalized (`LoadOrderService.cs` catches the `ArgumentException` from `ResolveForPlacement`).

The description is **2,037** characters after the fold, inside the 2,048 bound.

Both measurements come off the published `tools/list` of the built server over stdio, not off the source literal. `ci-all` was not run locally (#570 — its probes collide with parallel runs); CI runs it here. No CHANGELOG line: the records PR's entry covers the wave and the last PR of it generalises the entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

