### PR TITLE
Bring the nif_set tool description under the 2,048-character cap

### DIFF
--- a/src/housecarl-mcp-tests/PublishedDescriptionBoundTests.cs
+++ b/src/housecarl-mcp-tests/PublishedDescriptionBoundTests.cs
@@ -32,7 +32,6 @@ public sealed class PublishedDescriptionBoundTests
     {
         ToolNames.CompactPlugin,
         ToolNames.Forward,
-        ToolNames.NifSet,
     };
 
     public static IEnumerable<object[]> EveryPublishedTool() =>

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -176,36 +176,57 @@ public static class NifTools
     [McpServerTool(Name = ToolNames.NifSet, Title = "Write a whitelisted data value into a Skyrim mesh (.nif)"),
      Description(
          "Write ONE whitelisted DATA VALUE into a Skyrim SE mesh (.nif) at the data layer, beneath NifSkope — then VERIFY " +
-         "the edit before anything lands. Resolve the Data-relative mesh_path through Mod Organizer 2's VFS to the winning " +
-         "copy (or mod=), apply the op, and pass it two offset-immune verification gates (only the block/value the op " +
-         "claims to touch changed; a reload re-reads the new value; census + SE-stream intact) — a failure writes NOTHING " +
-         "and says why. The ops (op=): rename_shape / rename_node (retitle a baked shape/node — the HDPT-EDID facegen " +
-         "case), set_flags (NiAVObject flags on a shape/node — the 0x80000 head/hair-class bit), set_scale, set_partition " +
-         "(a BSDismember body-part id — pass body_part_id [+ partition_index]), set_alpha (alpha_flags word and/or " +
-         "alpha_threshold — the hair 0x12ED / hairline 0x12EE class), set_path (swap an asset reference, TWO addressing " +
-         "forms: with texture_slot + path it swaps that BSShaderTextureSet slot on the named shape — e.g. the FaceTint " +
-         "slot 6 or skin slots 0/1; with NO texture_slot it swaps the HEADER STRING target names for path — the " +
-         "material (.bgsm), .tri / BODYTRI and physics-xml refs that sections=strings lists), set_shader_value (a shader LIGHTING value — " +
-         "pass shader_value + value: glossiness, specular_strength, specular_color, emissive_color, emissive_multiple, " +
-         "alpha; the plastic-looking armour or over-bright glow fix. NOT set_alpha — that is the separate NiAlphaProperty). " +
-         "target= is the shape or node NAME the op edits " +
-         "(from " + ToolNames.NifInspect + "). By DEFAULT the verified mesh is written into a NEW houseCARL MO2 mod folder at the " +
-         "same path (originals untouched) — enable it and sort it ABOVE the current winner so the edit wins; a BSA-packed " +
-         "source becomes a loose winning override this way. in_place=true instead OVERWRITES the winning LOOSE file where " +
-         "it sits (opt-in; rides the per-file consent handshake, needs acknowledge=true, NO backup). Only edits " +
-         "data VALUES — never geometry / vertices / the .dds pixels. Refuses loud (Q3): a non-SE mesh, a target it can't " +
-         "find or that's ambiguous, an op that doesn't apply, or any verification miss.")]
+         "the edit before anything lands. ONE surface: which mesh (SELECT) x whose copy (SOURCE) x what to change (the " +
+         "ACT) x WHERE it lands (the LANE) compose in a single call. The WRITE counterpart to " + ToolNames.NifInspect +
+         ", which reads the values this edits — the facegen head-mesh repairs are its canonical use; to make a DIFFERENT " +
+         "existing copy win instead of editing one, use " + ToolNames.Place + ".\n\n" +
+         "Resolve the Data-relative mesh_path through Mod Organizer 2's VFS to the winning copy (or mod=), apply the op, " +
+         "and pass it two offset-immune verification gates (only the block/value the op claims to touch changed; a reload " +
+         "re-reads the new value; census + SE-stream intact) — a failure writes NOTHING and says why. Every refusal is " +
+         "loud and named (Q3), never a silent half-write.\n\n" +
+         "By DEFAULT the verified mesh is written into a NEW houseCARL MO2 mod folder at the same path (originals " +
+         "untouched) — enable it and sort it ABOVE the current winner so the edit wins; a BSA-packed source becomes a " +
+         "loose winning override this way. in_place=true instead OVERWRITES the winning LOOSE file where it sits (opt-in; " +
+         "rides the per-file consent handshake, needs acknowledge=true, NO backup). Only edits data VALUES — never " +
+         "geometry / vertices / the .dds pixels.\n\n" +
+         "Each axis's grammar is on its own parameters:\n" +
+         "SELECT — mesh_path= (which mesh) x target= (what inside it the op edits).\n" +
+         "SOURCE — mod= (empty = the VFS winner).\n" +
+         "ACT — op= names the write; its operands are new_name=, flags=, scale=, body_part_id= [+ partition_index=], " +
+         "alpha_flags= / alpha_threshold=, texture_slot= + path=, and shader_value= + value=.\n" +
+         "LANE — patch_name= | into= on the default lane, or in_place= + acknowledge=.")]
     public static string NifSet(
         LoadOrderService svc,
-        [Description("The Data-relative mesh path to edit, e.g. 'meshes\\actors\\character\\facegendata\\facegeom\\Skyrim.esm\\00000007.nif'.")]
+        [Description("The Data-relative mesh path to edit, e.g. " +
+                     "'meshes\\actors\\character\\facegendata\\facegeom\\Skyrim.esm\\00000007.nif'. Relative to the " +
+                     "game's Data folder (forward or back slashes both fine); a drive-rooted path ('C:\\…') or one " +
+                     "carrying a '..' segment is REFUSED by name, never silently normalized. The mesh it resolves to " +
+                     "must be a Skyrim SE stream (user 12 / stream 100) — a non-SE mesh is refused by name, because a " +
+                     "normalized cross-game (LE / FO4 / Starfield) write is untested.")]
             string mesh_path,
         // Built from OpList, a const so it is legal in an attribute, rather than spelled out: this is the string a
         // caller reads to choose an op, so a stale list here would make a shipped op invisible in the tool schema.
-        [Description("The write op — one of: " + OpList + ".")]
+        [Description("The write op — one of: " + OpList + ". What each one does: rename_shape / rename_node (retitle a " +
+                     "baked shape/node — the HDPT-EDID facegen case), set_flags (NiAVObject flags on a shape/node — the " +
+                     "0x80000 head/hair-class bit), set_scale, set_partition (a BSDismember body-part id — pass " +
+                     "body_part_id [+ partition_index]), set_alpha (alpha_flags word and/or alpha_threshold — the hair " +
+                     "0x12ED / hairline 0x12EE class), set_path (swap an asset reference, TWO addressing forms: with " +
+                     "texture_slot + path it swaps that BSShaderTextureSet slot on the named shape — e.g. the FaceTint " +
+                     "slot 6 or skin slots 0/1; with NO texture_slot it swaps the HEADER STRING target= names for path " +
+                     "— the material (.bgsm), .tri / BODYTRI and physics-xml refs that sections=strings lists), " +
+                     "set_shader_value (a shader LIGHTING value — pass shader_value + value: glossiness, " +
+                     "specular_strength, specular_color, emissive_color, emissive_multiple, alpha; the plastic-looking " +
+                     "armour or over-bright glow fix. NOT set_alpha — that is the separate NiAlphaProperty). An op that " +
+                     "does not APPLY to what target= names — set_partition on a shape carrying no BSDismember skin " +
+                     "instance — is refused by name, with nothing written.")]
             string op,
         [Description("What the op edits, as it currently reads (from " + ToolNames.NifInspect + "). For most ops the NAME of a " +
                      "shape or node; for a rename the OLD name; for set_path WITHOUT texture_slot the header STRING to " +
-                     "replace, exactly as sections=strings prints it (case-sensitive).")]
+                     "replace, exactly as sections=strings prints it (case-sensitive). A target this mesh does not carry " +
+                     "is refused by name with nothing written — no shape or node of that name, or, on the header-string " +
+                     "form, no string reading exactly that. A shape/node name more than one block answers to is refused " +
+                     "as AMBIGUOUS rather than written to the first match; several blocks referencing the SAME header " +
+                     "string are not ambiguous — they all move together.")]
             string target,
         [Description("rename_shape / rename_node: the new name.")] string new_name = "",
         [Description("set_flags: the NiAVObject flags value — hex ('0x800000E') or decimal.")] string flags = "",

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -193,7 +193,8 @@ public static class NifTools
          "SELECT — mesh_path= (which mesh) x target= (what inside it the op edits).\n" +
          "SOURCE — mod= (empty = the VFS winner).\n" +
          "ACT — op= names the write; its operands are new_name=, flags=, scale=, body_part_id= [+ partition_index=], " +
-         "alpha_flags= / alpha_threshold=, texture_slot= + path=, and shader_value= + value=.\n" +
+         "alpha_flags= / alpha_threshold=, path= [+ texture_slot=] (set_path with no slot is the header-string " +
+         "form), and shader_value= + value=.\n" +
          "LANE — patch_name= | into= on the default lane, or in_place= + acknowledge=.")]
     public static string NifSet(
         LoadOrderService svc,
@@ -226,7 +227,11 @@ public static class NifTools
                      "is refused by name with nothing written — no shape or node of that name, or, on the header-string " +
                      "form, no string reading exactly that. A shape/node name more than one block answers to is refused " +
                      "as AMBIGUOUS rather than written to the first match; several blocks referencing the SAME header " +
-                     "string are not ambiguous — they all move together.")]
+                     "string are not ambiguous — they all move together. Two header strings are refused by redirect " +
+                     "rather than swapped: a shape's or node's NAME is 'not an asset reference — use op=rename_shape " +
+                     "or op=rename_node, which refuse renaming onto a name already in use', and 'the KEY an extra-data " +
+                     "block is looked up by' is refused because swapping it would hide the block from the engine — " +
+                     "pass the block's VALUE instead.")]
             string target,
         [Description("rename_shape / rename_node: the new name.")] string new_name = "",
         [Description("set_flags: the NiAVObject flags value — hex ('0x800000E') or decimal.")] string flags = "",


### PR DESCRIPTION
`housecarl_nif_set` published a 2,116-character tool description. Claude Code shows the first 2,048 characters of a description and delivers parameter descriptions whole, so the tail — the whitelist of ops, the lane rules, and the refusal roster — sat in a part of the text the model never saw. Nothing is deleted: each paragraph moves into the description of the parameter it is about, and where the parameter already said the same thing the description's copy is dropped as a duplicate rather than pasted in twice. The description keeps the purpose sentence, the resolve/apply/verify contract, the two-lane write model, the scope sentence, the composition sentence, one line per axis naming its parameters, and the cross-tool pointers. `housecarl_nif_set`'s line comes out of `StillOversized`, so the bound now holds it. Only the `nif_set` region of `NifTools.cs` is touched; `nif_inspect` merged in #594 and is untouched.

Part of #583.

## Measured on the published tools/list

| | Before | After |
|---|---|---|
| `housecarl_nif_set` description | 2,116 | **1,830** |
| Its nineteen parameter descriptions | 3,149 | 5,395 |

The description shed 286 characters and the parameters gained 2,246. The description sheds more than 286 of its own text — the ops roster alone is ~950 — and spends most of that back on the composition sentence and the four axis lines, which it did not carry before.

## Harvest

Every sentence of the old description and where it lives now.

| Old description sentence | Now lives in |
|---|---|
| "Write ONE whitelisted DATA VALUE into a Skyrim SE mesh (.nif) at the data layer, beneath NifSkope — then VERIFY the edit before anything lands." | kept in description (the purpose sentence) |
| "Resolve the Data-relative mesh_path through Mod Organizer 2's VFS to the winning copy (or mod=), apply the op, and pass it two offset-immune verification gates (only the block/value the op claims to touch changed; a reload re-reads the new value; census + SE-stream intact) — a failure writes NOTHING and says why." | kept in description, word for word. It is the whole-call pipeline, not any one parameter's, and `NifService.Set`'s two gates are the same for every op |
| "The ops (op=): rename_shape / rename_node (retitle a baked shape/node — the HDPT-EDID facegen case), set_flags (… the 0x80000 head/hair-class bit), set_scale, set_partition (… pass body_part_id [+ partition_index]), set_alpha (… the hair 0x12ED / hairline 0x12EE class), set_path (… TWO addressing forms …), set_shader_value (… the plastic-looking armour or over-bright glow fix. NOT set_alpha …)." | `op`, whole and unedited, after its existing "one of: …" roster. This is the whitelist of settable values, which is what `op` is; the per-op teaching (the facegen case, the flag bit, the alpha classes, the two `set_path` forms, the NiAlphaProperty warning) travels with it |
| "target= is the shape or node NAME the op edits (from housecarl_nif_inspect)." | `target` (already said there, and said BETTER: the parameter's version covers the rename's OLD name and `set_path`'s header-string form, which "the shape or node NAME" does not). The description's copy is dropped as the weaker duplicate; the `nif_inspect` pointer it carried is kept at description level as the read counterpart |
| "By DEFAULT the verified mesh is written into a NEW houseCARL MO2 mod folder at the same path (originals untouched) — enable it and sort it ABOVE the current winner so the edit wins; a BSA-packed source becomes a loose winning override this way." | kept in description, word for word (the write model: what is written where, and that it does not win on write) |
| "in_place=true instead OVERWRITES the winning LOOSE file where it sits (opt-in; rides the per-file consent handshake, needs acknowledge=true, NO backup)." | kept in description, word for word (the other half of the write model). `in_place` and `acknowledge` already carry their own longer versions; this is the one-line contrast the model needs to pick a lane at all |
| "Only edits data VALUES — never geometry / vertices / the .dds pixels." | kept in description (the scope sentence) |
| "Refuses loud (Q3):" (the rule itself) | kept in description, as "Every refusal is loud and named (Q3), never a silent half-write" |
| "… a non-SE mesh …" | `mesh_path`, with the version numbers the engine names (`NifService.cs:563` — user 12 / stream 100) and its reason (a normalized cross-game LE / FO4 / Starfield write is untested) |
| "… a target it can't find or that's ambiguous …" | `target` |
| "… an op that doesn't apply …" | `op`, with the case the engine's own docstring gives (`set_partition` on a shape carrying no BSDismember skin instance, `NifService.cs:686`) |
| "… or any verification miss." | kept in description — it is the two gates' own failure, already named in the sentence above it ("a failure writes NOTHING and says why") |

Four things the merged text says that the old description did not, each because moving a sentence made its old scope wrong or left a parameter as the only home for a refusal:

- **The composition sentence and the four axis lines.** `nif_set` had neither. With the ops roster gone from the description, the axis lines are its only index of the parameters, so they name every one: `mesh_path=` and `target=` (SELECT), `mod=` (SOURCE), `op=` and its operand family (ACT), `patch_name=` / `into=` / `in_place=` / `acknowledge=` (LANE). No TRANSPORT line — this tool publishes no `format=` or `max_chars=`.
- **`target` says what "can't find or ambiguous" means on EACH of its two forms.** The moved clause read as one rule, but the header-string form has no ambiguity refusal: `SetHeaderString` swaps every reference to the same string together, deliberately (`NifService.cs:843`), while `ResolveShape`/`ResolveNode`/`ResolveAvObject` refuse a name more than one block answers to. So the parameter names the not-found refusal for both forms and scopes the ambiguity refusal to the shape/node form, and says the multi-reference case is not ambiguous.
- **`mesh_path` names the path-form refusal.** `NifSet` catches the `ArgumentException` from `ResolveForPlacement` and returns "invalid path — …" for a drive-rooted or `..` path (`LoadOrderService.cs:1395`), which is what a caller pasting a full `C:\…` path out of Explorer hits. `nif_inspect`'s `mesh_paths` already says this; the wording here drops "on that path", which is a batch fact and false for `nif_set`'s single path.
- **The description points at `housecarl_place`** for making a different existing copy win rather than editing one, and names `housecarl_nif_inspect` as the read counterpart. #594 added the forward pointer on `nif_inspect`'s side and noted this side reached `nif_inspect` only through `target=`; dropping that sentence as a duplicate would have left the pointer with no home, so it moves up to the description where the pair belongs.

Nothing else in `src/` cites this tool's description: `NifServiceGuardProbe`, `NifSetGuardProbe`, `AliasLayerProbe`, `InPlaceProbe` and `AssetPrefixHintProbe` assert on rendered output and refusal text, not on description strings, and the class-level XML doc on `NifTools` describes `nif_inspect`'s surface and needed no repointing.

## Test

`src/housecarl-mcp-tests/PublishedDescriptionBoundTests.cs` loses its `ToolNames.NifSet` line from `StillOversized`, and nothing else.

- With the line gone and the old description in place, `EveryPublishedDescriptionFitsTheClientsCut(tool: "housecarl_nif_set")` failed: "housecarl_nif_set's published description is 2116 characters; Claude Code shows the first 2048 and drops the rest." 1 failed, 31 passed.
- With the description moved, the class is green (32 passed) and the theory prints `housecarl_nif_set: 1830 characters (bound 2048)`.

Both measurements come off the published `tools/list` of the built server over stdio, not off the source literal.

## What was run

```
dotnet build housecarl.sln -c Release          0 errors
dotnet test src/housecarl-mcp-tests -c Release --no-build --filter "tier!=bridge"
    1620 passed, 0 failed
```

`ci-all` was not run locally (#570 — its probes collide with parallel runs); CI runs it here. No CHANGELOG line: the records PR's entry covers the wave and the last PR of it generalises the entry.


## Review fold

Both blind-review findings were real and are folded in e4bddcfb.

- The ACT line inverted `set_path`'s optionality: `BuildOp` refuses `set_path` with no `path`, and with no `texture_slot` it takes the header-string form, so the line now reads `path= [+ texture_slot=] (set_path with no slot is the header-string form)` — the same bracket style the other optional operand uses, and the header-string form named on the axis line rather than only on `op=`.
- `target=`'s refusal roster read as the complete set for the header-string form but omitted two refusals `SetHeaderString` names on that axis (`NifService.cs:825` and `:832`): a shape's or node's NAME is redirected to `rename_shape` / `rename_node`, and an extra-data block's KEY is refused with "pass the block's VALUE instead". Both are now in the parameter, in the refusal's own words.

Re-measured on the published `tools/list` of the built server: `housecarl_nif_set` is **1,830** characters, inside the 2,048 bound. `dotnet build` 0 errors; `dotnet test --filter "tier!=bridge"` 1620 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

