### PR TITLE
Name an unreadable sub-field instead of dropping it

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -55,10 +55,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
   one. A client that stops waiting WITHOUT sending a cancel is not something the server can detect — nothing
   in the protocol reports it — which is what the render bound is there for.
 - **A field inside a record that cannot be read now says so, instead of rendering as absent.** Reading a
-  record deeply (`project.depth` of 2 or more) dropped the line for any sub-field whose read threw — a
-  truncated or badly merged plugin, most often — so a field that could not be read looked exactly like a
-  field the record does not carry. It now renders as `(unreadable: <reason>)` on its own line, naming the
-  sub-field and Mutagen's own reason, in every form and format; the sub-fields beside it still read.
+  record deeply (`project.depth` of 2 or more) dropped the line for any sub-field whose read threw — what a
+  truncated or badly merged plugin does to one field — so a field that could not be read looked exactly like
+  a field the record does not carry. It now renders as `(unreadable: <reason>)` on its own line, naming the
+  sub-field and Mutagen's own reason, and the fields beside it still read. `delta` and `tree` name it too:
+  an unreadable field is reported as not compared and leaves the comparison incomplete, so a record carrying
+  one is never called `identical`.
 
 - **Every tool description now fits inside the 2,048 characters Claude Code shows, and the grammar that was
   being cut off lives on the parameters it belongs to.** A description longer than that cap lost its tail on

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -54,6 +54,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
   the server running, and a `to_file=` call stopped that way writes no artifact at all rather than a partial
   one. A client that stops waiting WITHOUT sending a cancel is not something the server can detect — nothing
   in the protocol reports it — which is what the render bound is there for.
+- **A field inside a record that cannot be read now says so, instead of rendering as absent.** Reading a
+  record deeply (`project.depth` of 2 or more) dropped the line for any sub-field whose read threw — a
+  truncated or badly merged plugin, most often — so a field that could not be read looked exactly like a
+  field the record does not carry. It now renders as `(unreadable: <reason>)` on its own line, naming the
+  sub-field and Mutagen's own reason, in every form and format; the sub-fields beside it still read.
+
 - **Every tool description now fits inside the 2,048 characters Claude Code shows, and the grammar that was
   being cut off lives on the parameters it belongs to.** A description longer than that cap lost its tail on
   the way to the model, so predicate languages, source and comparison rules, refusal lists, projection forms

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -59,8 +59,10 @@ saying it sets an expectation their install may contradict. Say what is known, a
   truncated or badly merged plugin does to one field — so a field that could not be read looked exactly like
   a field the record does not carry. It now renders as `(unreadable: <reason>)` on its own line, naming the
   sub-field and Mutagen's own reason, and the fields beside it still read. `delta` and `tree` name it too:
-  an unreadable field is reported as not compared and leaves the comparison incomplete, so a record carrying
-  one is never called `identical`.
+  an unreadable field is reported as not compared, with the reason, and leaves the comparison incomplete, so
+  a record carrying one is never called `identical`. The rest of that record still compares — only the
+  unreadable path and the list it sits in drop out — and such a record is counted as neither differing nor
+  identical but under its own `no_verdict` count.
 
 - **Every tool description now fits inside the 2,048 characters Claude Code shows, and the grammar that was
   being cut off lives on the parameters it belongs to.** A description longer than that cap lost its tail on

--- a/src/housecarl-core/FieldsDiff.cs
+++ b/src/housecarl-core/FieldsDiff.cs
@@ -19,7 +19,8 @@ namespace HousecarlCore;
 ///     emitted: for record types where list order IS the semantics (a DIAL's INFO children decide which
 ///     line plays), a pure reorder must not read as identical. Nested list reordering INSIDE an element is
 ///     not canonicalised — it can over-report as a content delta, never under-report;
-///   • if either side's deep read hit the expansion cap, <see cref="Result.Complete"/> is false: list
+///   • if either side's deep read hit the expansion cap, OR either side carries a leaf it could not read,
+///     <see cref="Result.Complete"/> is false: list
 ///     comparison and one-sided-presence deltas are SUPPRESSED (where the two caps fell would otherwise
 ///     fabricate differences), only value mismatches observed on both sides are reported, and the caller
 ///     must not claim identity beyond what was actually compared.
@@ -27,8 +28,10 @@ namespace HousecarlCore;
 public static class FieldsDiff
 {
     /// <summary>Field-level deltas, preformatted for the conflict-tree render. <see cref="Complete"/> false ⇒
-    /// at least one side's read was truncated at the expansion cap, so an empty <see cref="Deltas"/> must NOT
-    /// be rendered as "identical to winner" — never claim knowledge the comparison doesn't have.
+    /// at least one side's read was truncated at the expansion cap, or carried a leaf that could not be read, so an
+    /// empty <see cref="Deltas"/> must NOT be rendered as "identical to winner" — never claim knowledge the
+    /// comparison doesn't have. An unreadable leaf also gets its own named line in <see cref="Deltas"/>, so that
+    /// case never presents as an empty delta list.
     ///
     /// <para><see cref="AgreedCount"/> + <see cref="AgreedSample"/> are the present-==-winner signal:
     /// how many VALUE LEAVES the node carries that exactly equal the winner's — i.e. ITM-restated fields,
@@ -61,8 +64,10 @@ public static class FieldsDiff
     {
         var tValueLeaves = new HashSet<string>(StringComparer.Ordinal);
         var wValueLeaves = new HashSet<string>(StringComparer.Ordinal);
-        var (tLines, tComplete) = CleanLines(theirs, tValueLeaves);
-        var (wLines, wComplete) = CleanLines(winner, wValueLeaves);
+        var tUnreadable = new HashSet<string>(StringComparer.Ordinal);
+        var wUnreadable = new HashSet<string>(StringComparer.Ordinal);
+        var (tLines, tComplete) = CleanLines(theirs, tValueLeaves, tUnreadable);
+        var (wLines, wComplete) = CleanLines(winner, wValueLeaves, wUnreadable);
         bool complete = tComplete && wComplete;
 
         // Numeric-bracket roots seen on EITHER side (the union, so a 0-item-vs-N-item list is still compared
@@ -90,6 +95,17 @@ public static class FieldsDiff
         }
 
         var deltas = new List<string>();
+
+        // ---- unreadable leaves: a NO-VERDICT, named. The path is out of the comparison above (its note is a
+        //      reason, not a value) and Complete is already false, so the record can never be counted identical;
+        //      the line says WHICH field and on which side, because "the comparison is incomplete" alone does not
+        //      tell a caller where to look.
+        foreach (var path in tUnreadable.Union(wUnreadable).OrderBy(p => p, StringComparer.Ordinal))
+            deltas.Add(tUnreadable.Contains(path) && wUnreadable.Contains(path)
+                ? $"{path}: UNREADABLE on both sides — not compared"
+                : tUnreadable.Contains(path)
+                    ? $"{path}: UNREADABLE here — not compared"
+                    : $"{path}: UNREADABLE in {referenceLabel} — not compared");
 
         // ---- exact-path comparison: scalars, substructs, dict children (bracket = a semantic key) --------
         // On a TRUNCATED comparison the list roots' own summary lines join the exact-path set: a root count
@@ -193,18 +209,25 @@ public static class FieldsDiff
         return null;
     }
 
-    /// <summary>The read's lines minus the expansion-cap sentinel; each value is the round-trippable token or,
-    /// for a non-leaf/absent line, its note. <paramref name="valueLeaves"/> collects the paths that carry a real
-    /// VALUE (<c>HasValue</c>) — the only lines an agreement count may consider, so a container summary line
-    /// ("[3 item(s)]") or an absent/null-link note is never miscounted as a present field. Complete=false iff the
-    /// expansion-cap sentinel was present.</summary>
-    static (List<(string path, string val)> lines, bool complete) CleanLines(RecordFields rf, HashSet<string> valueLeaves)
+    /// <summary>The read's lines minus the expansion-cap sentinel and the UNREADABLE ones; each value is the
+    /// round-trippable token or, for a non-leaf/absent line, its note. <paramref name="valueLeaves"/> collects the
+    /// paths that carry a real VALUE (<c>HasValue</c>) — the only lines an agreement count may consider, so a
+    /// container summary line ("[3 item(s)]") or an absent/null-link note is never miscounted as a present field.
+    /// <paramref name="unreadable"/> collects the paths this side could not read: a fault note is a REASON, not a
+    /// value, so comparing it as one makes two unreadable poles agree and an unreadable-vs-read pair a value
+    /// difference. It leaves the comparison incomplete at that path, exactly as the cap does — Complete is false
+    /// when either was present. Keyed on <see cref="ReadEngine.IsUnreadableNote"/>, not on <c>Readable</c> alone:
+    /// the other Readable=false answer is a no-such-field, which IS knowledge about the record and stays a
+    /// comparable shape difference.</summary>
+    static (List<(string path, string val)> lines, bool complete) CleanLines(RecordFields rf,
+        HashSet<string> valueLeaves, HashSet<string> unreadable)
     {
         var lines = new List<(string, string)>(rf.Fields.Count);
         bool complete = true;
         foreach (var f in rf.Fields)
         {
             if (f.Path == "…") { complete = false; continue; }         // ReadEngine's expansion-cap sentinel
+            if (!f.Readable && ReadEngine.IsUnreadableNote(f.Note)) { unreadable.Add(f.Path); complete = false; continue; }
             if (f.HasValue) valueLeaves.Add(f.Path);
             lines.Add((f.Path, f.HasValue ? f.Token ?? "" : f.Note ?? ""));
         }

--- a/src/housecarl-core/FieldsDiff.cs
+++ b/src/housecarl-core/FieldsDiff.cs
@@ -53,8 +53,12 @@ public static class FieldsDiff
     /// presence bit, so a leaf that EQUALS the winner is counted as agreement (it IS the same modeled value) but
     /// the render never claims the contributor "carries" it as a distinct subrecord — there is no bit to prove
     /// that. The ABSENT render fires only on the explicit sentinels, which only nullable fields produce.</para></summary>
+    /// <param name="NoVerdictCount">How many of <paramref name="Deltas"/> are UNREADABLE no-verdict lines rather
+    /// than value differences. A no-verdict is a THIRD state — the record can be neither counted identical nor
+    /// reported as differing in value — so a caller counting differences subtracts it here rather than re-deriving
+    /// it from the line text, which only this comparison actually knows.</param>
     public sealed record Result(IReadOnlyList<string> Deltas, bool Complete,
-        int AgreedCount, IReadOnlyList<string> AgreedSample);
+        int AgreedCount, IReadOnlyList<string> AgreedSample, int NoVerdictCount);
 
     /// <summary>True when a CleanLines value is a read-engine "no value here" note sentinel — the field is
     /// modeled but the contributor carries nothing (absent optional, or a present-but-null link). Treated as a
@@ -222,7 +226,7 @@ public static class FieldsDiff
         // artifact — suppress it: a partial read must not claim "N fields match the winner". An unreadable leaf
         // does not touch it: every path it counts was read on both sides, and Complete still refuses identity.
         if (capped) { agreedCount = 0; agreedSample.Clear(); }
-        return new Result(deltas, complete, agreedCount, agreedSample);
+        return new Result(deltas, complete, agreedCount, agreedSample, noVerdict.Count);
     }
 
     /// <summary>How many agreed-field paths to keep for the render — a small sample, not the full set (a deep

--- a/src/housecarl-core/FieldsDiff.cs
+++ b/src/housecarl-core/FieldsDiff.cs
@@ -216,9 +216,11 @@ public static class FieldsDiff
     /// <paramref name="unreadable"/> collects the paths this side could not read: a fault note is a REASON, not a
     /// value, so comparing it as one makes two unreadable poles agree and an unreadable-vs-read pair a value
     /// difference. It leaves the comparison incomplete at that path, exactly as the cap does — Complete is false
-    /// when either was present. Keyed on <see cref="ReadEngine.IsUnreadableNote"/>, not on <c>Readable</c> alone:
-    /// the other Readable=false answer is a no-such-field, which IS knowledge about the record and stays a
-    /// comparable shape difference.</summary>
+    /// when either was present. Keyed on <c>Readable</c>, which carries the fault by construction, with ONE
+    /// carve-out: a no-such-field (<see cref="ReadEngine.IsNoSuchFieldNote"/>) IS knowledge about the record and
+    /// stays a comparable shape difference. Testing the fault note's prose instead would cover only the getter
+    /// throw and let the walk's other fault notes — an FLOI it cannot read, a <c>*parent</c> hop it cannot
+    /// take — back in as comparable values.</summary>
     static (List<(string path, string val)> lines, bool complete) CleanLines(RecordFields rf,
         HashSet<string> valueLeaves, HashSet<string> unreadable)
     {
@@ -227,7 +229,7 @@ public static class FieldsDiff
         foreach (var f in rf.Fields)
         {
             if (f.Path == "…") { complete = false; continue; }         // ReadEngine's expansion-cap sentinel
-            if (!f.Readable && ReadEngine.IsUnreadableNote(f.Note)) { unreadable.Add(f.Path); complete = false; continue; }
+            if (!f.Readable && !ReadEngine.IsNoSuchFieldNote(f.Note)) { unreadable.Add(f.Path); complete = false; continue; }
             if (f.HasValue) valueLeaves.Add(f.Path);
             lines.Add((f.Path, f.HasValue ? f.Token ?? "" : f.Note ?? ""));
         }

--- a/src/housecarl-core/FieldsDiff.cs
+++ b/src/housecarl-core/FieldsDiff.cs
@@ -20,10 +20,14 @@ namespace HousecarlCore;
 ///     line plays), a pure reorder must not read as identical. Nested list reordering INSIDE an element is
 ///     not canonicalised — it can over-report as a content delta, never under-report;
 ///   • if either side's deep read hit the expansion cap, OR either side carries a leaf it could not read,
-///     <see cref="Result.Complete"/> is false: list
-///     comparison and one-sided-presence deltas are SUPPRESSED (where the two caps fell would otherwise
-///     fabricate differences), only value mismatches observed on both sides are reported, and the caller
-///     must not claim identity beyond what was actually compared.
+///     <see cref="Result.Complete"/> is false and the caller must not claim identity beyond what was actually
+///     compared. What gets suppressed differs by cause, because the two are not alike. A CAP makes the whole
+///     line set unreliable — where it fell decides which lines exist — so list comparison and
+///     one-sided-presence deltas are suppressed RECORD-WIDE. An UNREADABLE leaf removes exactly one known
+///     path, so suppression is scoped to that path and everything under it (and, where it sits inside a
+///     positional list, to that list's element comparison, whose fingerprints it would otherwise skew): the
+///     rest of the record still compares in full, and a differing list beside an unreadable scalar is still
+///     reported.
 /// </summary>
 public static class FieldsDiff
 {
@@ -39,8 +43,9 @@ public static class FieldsDiff
     /// identically (an ITM override) was indistinguishable from one that simply doesn't carry it. Counts only
     /// exact-path value leaves read on BOTH sides (never container summaries, never a side's <c>(absent)</c> /
     /// <c>(null link)</c> sentinel — an absent field is NOT an agreement). <see cref="AgreedSample"/> is up to a
-    /// few of those paths for the render. Both are 0/empty on a truncated comparison — the agreed set, like the
-    /// one-sided deltas, would be a where-the-cap-fell artifact.</para>
+    /// few of those paths for the render. Both are 0/empty on a CAPPED comparison — the agreed set, like the
+    /// one-sided deltas, would be a where-the-cap-fell artifact. An unreadable leaf leaves them standing: every
+    /// path they count was really read on both sides.</para>
     ///
     /// <para><b>Honest limit:</b> per-field presence is reliable only for NULLABLE fields, whose absence the
     /// read engine surfaces as a distinct <c>(absent)</c> / <c>(null link)</c> note. Non-nullable scalars grouped
@@ -64,11 +69,20 @@ public static class FieldsDiff
     {
         var tValueLeaves = new HashSet<string>(StringComparer.Ordinal);
         var wValueLeaves = new HashSet<string>(StringComparer.Ordinal);
-        var tUnreadable = new HashSet<string>(StringComparer.Ordinal);
-        var wUnreadable = new HashSet<string>(StringComparer.Ordinal);
-        var (tLines, tComplete) = CleanLines(theirs, tValueLeaves, tUnreadable);
-        var (wLines, wComplete) = CleanLines(winner, wValueLeaves, wUnreadable);
-        bool complete = tComplete && wComplete;
+        var tUnreadable = new Dictionary<string, string>(StringComparer.Ordinal);
+        var wUnreadable = new Dictionary<string, string>(StringComparer.Ordinal);
+        var (tLines, tCapped) = CleanLines(theirs, tValueLeaves, tUnreadable);
+        var (wLines, wCapped) = CleanLines(winner, wValueLeaves, wUnreadable);
+        bool capped = tCapped || wCapped;
+        var noVerdict = tUnreadable.Keys.Union(wUnreadable.Keys).OrderBy(p => p, StringComparer.Ordinal).ToList();
+        bool complete = !capped && noVerdict.Count == 0;
+
+        // A path is OUT of the comparison when it, or a path it hangs under, could not be read on either side:
+        // the faulting side carries no line there and none below it, so comparing would report the other side's
+        // lines as a one-sided difference that is not one. Scoped to those paths only — a cap is the wholesale
+        // case, and it is handled separately.
+        bool Suppressed(string p) => noVerdict.Any(s => p.StartsWith(s, StringComparison.Ordinal)
+                                                     && (p.Length == s.Length || p[s.Length] is '.' or '['));
 
         // Numeric-bracket roots seen on EITHER side (the union, so a 0-item-vs-N-item list is still compared
         // as elements), then split DICT-vs-LIST by the read engine's in-band container marker: a numeric-KEYED
@@ -94,25 +108,42 @@ public static class FieldsDiff
             if (seen && !dict) listRoots.Add(root);
         }
 
+        // The roots whose ELEMENTS are still compared: none on a cap, and not one holding an unreadable leaf —
+        // a missing line inside an element changes that element's fingerprint, which would report it (and the
+        // reference's) as one-sided content. The others compare as usual.
+        var comparedRoots = new HashSet<string>(StringComparer.Ordinal);
+        if (!capped)
+            foreach (var root in listRoots)
+                if (!Suppressed(root) && !noVerdict.Any(s => ListRoot(s) == root)) comparedRoots.Add(root);
+
         var deltas = new List<string>();
 
         // ---- unreadable leaves: a NO-VERDICT, named. The path is out of the comparison above (its note is a
         //      reason, not a value) and Complete is already false, so the record can never be counted identical;
         //      the line says WHICH field and on which side, because "the comparison is incomplete" alone does not
         //      tell a caller where to look.
-        foreach (var path in tUnreadable.Union(wUnreadable).OrderBy(p => p, StringComparer.Ordinal))
-            deltas.Add(tUnreadable.Contains(path) && wUnreadable.Contains(path)
-                ? $"{path}: UNREADABLE on both sides — not compared"
-                : tUnreadable.Contains(path)
-                    ? $"{path}: UNREADABLE here — not compared"
-                    : $"{path}: UNREADABLE in {referenceLabel} — not compared");
+        foreach (var path in noVerdict)
+        {
+            bool t = tUnreadable.TryGetValue(path, out var tn), w = wUnreadable.TryGetValue(path, out var wn);
+            var side = t && w ? "on both sides" : t ? "here" : $"in {referenceLabel}";
+            deltas.Add($"{path}: UNREADABLE {side} — not compared{Why(t, tn, w, wn)}");
+        }
+
+        // The read's own reason travels with the line: one of these reasons ("read the record through the load
+        // order instead") is itself the remedy, and "not compared" alone leaves a caller nothing to act on.
+        string Why(bool t, string? tn, bool w, string? wn)
+        {
+            if (t && w && !string.Equals(tn, wn, StringComparison.Ordinal)) return $" (here {tn}, {referenceLabel} {wn})";
+            var note = t ? tn : wn;
+            return string.IsNullOrEmpty(note) ? "" : " " + note;
+        }
 
         // ---- exact-path comparison: scalars, substructs, dict children (bracket = a semantic key) --------
-        // On a TRUNCATED comparison the list roots' own summary lines join the exact-path set: a root count
-        // token read on BOTH sides is a real, cap-independent read, so a count delta still surfaces even
-        // though element comparison is suppressed.
-        var tScalar = ExactPathLines(tLines, listRoots, includeListRootSummaries: !complete);
-        var wScalar = ExactPathLines(wLines, listRoots, includeListRootSummaries: !complete);
+        // Where element comparison is suppressed, that root's own summary line joins the exact-path set: a root
+        // count token read on BOTH sides is a real read either way, so a count delta still surfaces. Suppressed
+        // paths are out of both maps, so neither side reports the other's lines under them.
+        var tScalar = ExactPathLines(tLines, listRoots, comparedRoots, Suppressed);
+        var wScalar = ExactPathLines(wLines, listRoots, comparedRoots, Suppressed);
         int agreedCount = 0;
         var agreedSample = new List<string>();
         foreach (var (path, val) in tScalar)
@@ -151,48 +182,46 @@ public static class FieldsDiff
                     if (agreedSample.Count < AgreedSampleCap) agreedSample.Add(path);
                 }
             }
-            // One-sided presence is only a delta when BOTH sides were fully read: on a truncated side a
-            // missing line is an artifact of WHERE its cap fell, not of content — reporting it would
-            // FABRICATE a difference.
-            else if (complete) deltas.Add($"{path}={val} ({referenceLabel} has no {path})");   // shape difference (e.g. another ConditionData arm)
+            // One-sided presence is only a delta when neither side was CAPPED: on a capped side a missing line
+            // is an artifact of WHERE the cap fell, not of content — reporting it would FABRICATE a difference.
+            // An unreadable leaf needs no guard here: its path, and everything under it, is out of both maps.
+            else if (!capped) deltas.Add($"{path}={val} ({referenceLabel} has no {path})");   // shape difference (e.g. another ConditionData arm)
         }
-        if (complete)
+        if (!capped)
             foreach (var (path, wv) in wScalar)
                 if (!tScalar.ContainsKey(path)) deltas.Add($"{path} only in {referenceLabel}: {wv}");
 
-        // ---- positional lists: order-insensitive whole-element multiset comparison. SKIPPED entirely on a
-        //      truncated comparison — a cap landing mid-list fabricates one-sided elements and wrong counts;
-        //      the renderer surfaces the truncation instead. -----------------------------------------------
-        if (complete)
+        // ---- positional lists: order-insensitive whole-element multiset comparison. Only the roots still being
+        //      compared: a cap landing mid-list fabricates one-sided elements and wrong counts, and so does an
+        //      unreadable leaf inside an element; the renderer surfaces both. ---------------------------------
+        foreach (var root in comparedRoots.OrderBy(r => r, StringComparer.Ordinal))
         {
-            foreach (var root in listRoots.OrderBy(r => r, StringComparer.Ordinal))
+            var tElems = ElementsOf(tLines, root);
+            var wElems = ElementsOf(wLines, root);
+            var (onlyT, onlyW) = MultisetDiff(tElems, wElems);
+            if (onlyT.Count == 0 && onlyW.Count == 0)
             {
-                var tElems = ElementsOf(tLines, root);
-                var wElems = ElementsOf(wLines, root);
-                var (onlyT, onlyW) = MultisetDiff(tElems, wElems);
-                if (onlyT.Count == 0 && onlyW.Count == 0)
-                {
-                    // Equal multisets ⇒ same CONTENTS. For most list fields order is noise, but for some it IS the
-                    // semantics — a DIAL's INFO children decide which line the game plays, so a pure reorder is the
-                    // whole delta and folding it into "no delta" would report such a record identical to the winner.
-                    // ElementsOf returns elements in positional order, so an ordered fingerprint-sequence mismatch
-                    // IS a reorder. Type-agnostic on purpose: over-reporting a noise reorder is the safe direction.
-                    //
-                    // SIBLING DETECTOR: DialogueInfoOrder.RelativeOrderChanges answers the finer "WHICH elements
-                    // moved" (an LCS pass) for a DIAL's N-plugin merge against its origin, feeding validate_dialogue.
-                    // This one answers the coarser "did this list get reordered at all". Separate by granularity and
-                    // call site, but a change to reorder semantics here should consider that one too, and vice versa.
-                    if (!tElems.Select(e => e.Fingerprint).SequenceEqual(wElems.Select(e => e.Fingerprint)))
-                        deltas.Add($"{root}: same {tElems.Count} item(s), ORDER DIFFERS from {referenceLabel}");
-                    continue;
-                }
-                deltas.Add(DescribeListDelta(root, tElems.Count, wElems.Count, onlyT, onlyW, referenceLabel));
+                // Equal multisets ⇒ same CONTENTS. For most list fields order is noise, but for some it IS the
+                // semantics — a DIAL's INFO children decide which line the game plays, so a pure reorder is the
+                // whole delta and folding it into "no delta" would report such a record identical to the winner.
+                // ElementsOf returns elements in positional order, so an ordered fingerprint-sequence mismatch
+                // IS a reorder. Type-agnostic on purpose: over-reporting a noise reorder is the safe direction.
+                //
+                // SIBLING DETECTOR: DialogueInfoOrder.RelativeOrderChanges answers the finer "WHICH elements
+                // moved" (an LCS pass) for a DIAL's N-plugin merge against its origin, feeding validate_dialogue.
+                // This one answers the coarser "did this list get reordered at all". Separate by granularity and
+                // call site, but a change to reorder semantics here should consider that one too, and vice versa.
+                if (!tElems.Select(e => e.Fingerprint).SequenceEqual(wElems.Select(e => e.Fingerprint)))
+                    deltas.Add($"{root}: same {tElems.Count} item(s), ORDER DIFFERS from {referenceLabel}");
+                continue;
             }
+            deltas.Add(DescribeListDelta(root, tElems.Count, wElems.Count, onlyT, onlyW, referenceLabel));
         }
 
-        // On a truncated comparison the agreed set, like the one-sided deltas, would be a where-the-cap-fell
-        // artifact — suppress it: a partial read must not claim "N fields match the winner".
-        if (!complete) { agreedCount = 0; agreedSample.Clear(); }
+        // On a CAPPED comparison the agreed set, like the one-sided deltas, would be a where-the-cap-fell
+        // artifact — suppress it: a partial read must not claim "N fields match the winner". An unreadable leaf
+        // does not touch it: every path it counts was read on both sides, and Complete still refuses identity.
+        if (capped) { agreedCount = 0; agreedSample.Clear(); }
         return new Result(deltas, complete, agreedCount, agreedSample);
     }
 
@@ -213,27 +242,29 @@ public static class FieldsDiff
     /// round-trippable token or, for a non-leaf/absent line, its note. <paramref name="valueLeaves"/> collects the
     /// paths that carry a real VALUE (<c>HasValue</c>) — the only lines an agreement count may consider, so a
     /// container summary line ("[3 item(s)]") or an absent/null-link note is never miscounted as a present field.
-    /// <paramref name="unreadable"/> collects the paths this side could not read: a fault note is a REASON, not a
+    /// <paramref name="unreadable"/> collects the paths this side could not read, each with the read's own reason
+    /// for the no-verdict line to carry: a fault note is a REASON, not a
     /// value, so comparing it as one makes two unreadable poles agree and an unreadable-vs-read pair a value
-    /// difference. It leaves the comparison incomplete at that path, exactly as the cap does — Complete is false
-    /// when either was present. Keyed on <c>Readable</c>, which carries the fault by construction, with ONE
+    /// difference. Returns whether this side hit the expansion CAP, which the caller keeps apart from the
+    /// unreadable paths: both clear Complete, but one is a whole unreliable line set and the other is a known
+    /// path. Keyed on <c>Readable</c>, which carries the fault by construction, with ONE
     /// carve-out: a no-such-field (<see cref="ReadEngine.IsNoSuchFieldNote"/>) IS knowledge about the record and
     /// stays a comparable shape difference. Testing the fault note's prose instead would cover only the getter
     /// throw and let the walk's other fault notes — an FLOI it cannot read, a <c>*parent</c> hop it cannot
     /// take — back in as comparable values.</summary>
-    static (List<(string path, string val)> lines, bool complete) CleanLines(RecordFields rf,
-        HashSet<string> valueLeaves, HashSet<string> unreadable)
+    static (List<(string path, string val)> lines, bool capped) CleanLines(RecordFields rf,
+        HashSet<string> valueLeaves, Dictionary<string, string> unreadable)
     {
         var lines = new List<(string, string)>(rf.Fields.Count);
-        bool complete = true;
+        bool capped = false;
         foreach (var f in rf.Fields)
         {
-            if (f.Path == "…") { complete = false; continue; }         // ReadEngine's expansion-cap sentinel
-            if (!f.Readable && !ReadEngine.IsNoSuchFieldNote(f.Note)) { unreadable.Add(f.Path); complete = false; continue; }
+            if (f.Path == "…") { capped = true; continue; }            // ReadEngine's expansion-cap sentinel
+            if (!f.Readable && !ReadEngine.IsNoSuchFieldNote(f.Note)) { unreadable[f.Path] = f.Note ?? ""; continue; }
             if (f.HasValue) valueLeaves.Add(f.Path);
             lines.Add((f.Path, f.HasValue ? f.Token ?? "" : f.Note ?? ""));
         }
-        return (lines, complete);
+        return (lines, capped);
     }
 
     /// <summary>The path's OUTERMOST positional-list root — the prefix before its first NUMERIC bracket — or
@@ -257,17 +288,18 @@ public static class FieldsDiff
 
     /// <summary>Exact-path map of every line OUTSIDE positional-list content: scalars, substructs, dict
     /// children and dict-root summaries (a dict bracket is a semantic key — numeric or not — so exact-path is
-    /// the correct comparison), excluding only positional-list content and the list roots' own summary lines
-    /// (subsumed by the element comparison — including the 0-item side, whose only trace IS its summary).</summary>
+    /// the correct comparison), excluding positional-list content, the summary lines of the roots whose elements
+    /// ARE compared (subsumed by that comparison — including the 0-item side, whose only trace IS its summary),
+    /// and any path <paramref name="suppressed"/> names as out of the comparison.</summary>
     static Dictionary<string, string> ExactPathLines(List<(string path, string val)> lines,
-        HashSet<string> listRoots, bool includeListRootSummaries = false)
+        HashSet<string> listRoots, HashSet<string> comparedRoots, Func<string, bool> suppressed)
     {
         var map = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (var (path, val) in lines)
         {
             var root = ListRoot(path);
             bool positionalContent = root is not null && listRoots.Contains(root);
-            if (!positionalContent && (includeListRootSummaries || !listRoots.Contains(path)))
+            if (!positionalContent && !comparedRoots.Contains(path) && !suppressed(path))
                 map[path] = val;
         }
         return map;

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -558,13 +558,24 @@ public static class ReadEngine
 
     static FieldValue Fault(string path, Exception ex) => Fault(path, Reason(ex));
 
+    /// <summary>Recurse into ONE child under the same isolation its getter has: a throw anywhere beneath it — the
+    /// child's own token emit, its element count, a grandchild's getter — names THAT child's path and the sibling
+    /// walk carries on. Unwinding to the caller instead would drop every sibling after it (each reading as absent)
+    /// and pin a second line on the parent's own path, which both row folds then discard.</summary>
+    static void ExpandChild(object? val, Type declaredType, object parent, string childPath, int depth,
+                            List<FieldValue> sink, ref int budget)
+    {
+        try { Expand(val, declaredType, parent, childPath, depth, sink, ref budget); }
+        catch (Exception ex) { Emit(sink, ref budget, Fault(childPath, ex)); }
+    }
+
     /// <summary>Recursively emit <paramref name="val"/> at <paramref name="path"/>: a value leaf → its token;
     /// a link → its note (not opened); a container/substruct → an identity-enriched summary line, then (while
     /// depth allows) one child line per element (bracketed) or sub-field (dotted), each recursed at depth-1.
-    /// <para>A sub-field that cannot be read gets its own "(unreadable …)" line — the same sentence and the same
-    /// Readable=false the depth-1 read emits — and the walk carries on with its siblings. It is never skipped: a
-    /// dropped line is indistinguishable from an absent optional, which would make an unreadable field read as
-    /// evidence that nothing is there.</para></summary>
+    /// <para>A child that cannot be read — its getter, or anything under it (see <see cref="ExpandChild"/>) — gets
+    /// its own "(unreadable …)" line, the same sentence and the same Readable=false the depth-1 read emits, and the
+    /// walk carries on with its siblings. It is never skipped: a dropped line is indistinguishable from an absent
+    /// optional, which would make an unreadable field read as evidence that nothing is there.</para></summary>
     static void Expand(object? val, Type declaredType, object parent, string path, int depth, List<FieldValue> sink, ref int budget)
     {
         if (budget < 0) return;
@@ -619,7 +630,7 @@ public static class ReadEngine
                 var et = entry.GetType();
                 var key = et.GetProperty("Key", BindingFlags.Public | BindingFlags.Instance)?.GetValue(entry);
                 var ev = et.GetProperty("Value", BindingFlags.Public | BindingFlags.Instance)?.GetValue(entry);
-                Expand(ev, ev?.GetType() ?? typeof(object), val, $"{path}[{key}]", childDepth, sink, ref budget);
+                ExpandChild(ev, ev?.GetType() ?? typeof(object), val, $"{path}[{key}]", childDepth, sink, ref budget);
             }
         }
         else if (WriteEngine.GenderedInterface(val.GetType()) is not null)
@@ -642,7 +653,7 @@ public static class ReadEngine
                 object? arm;
                 try { arm = armProp.GetValue(val); }
                 catch (Exception ex) { Emit(sink, ref budget, Fault($"{path}[{g}]", ex)); continue; }
-                Expand(arm, armProp.PropertyType, val, $"{path}[{g}]", childDepth, sink, ref budget);
+                ExpandChild(arm, armProp.PropertyType, val, $"{path}[{g}]", childDepth, sink, ref budget);
             }
         }
         else if (val is System.Collections.IEnumerable seq and not string)
@@ -651,7 +662,7 @@ public static class ReadEngine
             foreach (var item in seq)
             {
                 if (budget < 0) return;
-                Expand(item, item?.GetType() ?? typeof(object), val, $"{path}[{i}]", childDepth, sink, ref budget);
+                ExpandChild(item, item?.GetType() ?? typeof(object), val, $"{path}[{i}]", childDepth, sink, ref budget);
                 i++;
             }
         }
@@ -685,7 +696,7 @@ public static class ReadEngine
                 object? fv;
                 try { fv = prop.GetValue(val); }
                 catch (Exception ex) { Emit(sink, ref budget, Fault($"{path}.{fname}", ex)); continue; }
-                Expand(fv, prop.PropertyType, val, $"{path}.{fname}", childDepth, sink, ref budget);
+                ExpandChild(fv, prop.PropertyType, val, $"{path}.{fname}", childDepth, sink, ref budget);
             }
         }
     }

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -276,18 +276,25 @@ public static class ReadEngine
     //  THE READ PRIMITIVE — navigate a path read-only, emit the leaf token.
     // ======================================================================
 
-    /// <summary>The opening of every note the read walk emits for a FAULT — "(unreadable: &lt;reason&gt;)". Public
-    /// because <c>Readable=false</c> covers TWO answers, and a consumer that must separate them (the conflict diff
-    /// treats a fault as incomparable but a no-such-field as a shape difference) has to test the class of note
-    /// rather than keep its own copy of the sentence.</summary>
+    /// <summary>The opening of the note a getter throw emits — "(unreadable: &lt;reason&gt;)". One of several fault
+    /// notes the walk can emit; a consumer separating faults from the other <c>Readable=false</c> answer tests
+    /// <see cref="IsNoSuchFieldNote"/>, not this prefix.</summary>
     public const string UnreadablePrefix = "(unreadable: ";
 
     /// <summary>The ONE spelling of a read-fault note, so the sentence cannot drift between the walks that emit it.</summary>
     static string UnreadableNote(string reason) => $"{UnreadablePrefix}{reason})";
 
-    /// <summary>Is this note a read FAULT (as opposed to a no-such-field, the other <c>Readable=false</c> answer)?</summary>
-    public static bool IsUnreadableNote(string? note) =>
-        note is not null && note.StartsWith(UnreadablePrefix, StringComparison.Ordinal);
+    /// <summary>The opening of the NO-SUCH-FIELD note. Public because <c>Readable=false</c> covers two answers and
+    /// only one of them is comparable: every other <c>Readable=false</c> line is a fault of some class (a getter
+    /// throw, an FLOI the walk cannot read, a <c>*parent</c> hop that could not be taken), while this one is
+    /// knowledge about the record — it has no such field — and the conflict diff still compares it as a shape
+    /// difference.</summary>
+    public const string NoFieldPrefix = "(no field ";
+
+    /// <summary>Is this note the no-such-field answer (as opposed to a read fault, every other
+    /// <c>Readable=false</c> line)?</summary>
+    public static bool IsNoSuchFieldNote(string? note) =>
+        note is not null && note.StartsWith(NoFieldPrefix, StringComparison.Ordinal);
 
     /// <summary>The reason an unreadable note reports. A getter's own throw comes back from reflection wrapped in a
     /// <see cref="TargetInvocationException"/> whose message ("Exception has been thrown by the target of an
@@ -435,9 +442,9 @@ public static class ReadEngine
         if (ownerIsCollection)
         {
             var pf = precedingField ?? "<field>";
-            return $"(no field '{segName}': '{pf}' is a list/dict — {ListHopRemedy(owner, segName, pf, trailing)})";
+            return $"{NoFieldPrefix}'{segName}': '{pf}' is a list/dict — {ListHopRemedy(owner, segName, pf, trailing)})";
         }
-        return $"(no field {segName})";
+        return $"{NoFieldPrefix}{segName})";
     }
 
     /// <summary>What to actually DO about a path that dotted THROUGH a list/dict — checked against the element

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -276,6 +276,19 @@ public static class ReadEngine
     //  THE READ PRIMITIVE — navigate a path read-only, emit the leaf token.
     // ======================================================================
 
+    /// <summary>The opening of every note the read walk emits for a FAULT — "(unreadable: &lt;reason&gt;)". Public
+    /// because <c>Readable=false</c> covers TWO answers, and a consumer that must separate them (the conflict diff
+    /// treats a fault as incomparable but a no-such-field as a shape difference) has to test the class of note
+    /// rather than keep its own copy of the sentence.</summary>
+    public const string UnreadablePrefix = "(unreadable: ";
+
+    /// <summary>The ONE spelling of a read-fault note, so the sentence cannot drift between the walks that emit it.</summary>
+    static string UnreadableNote(string reason) => $"{UnreadablePrefix}{reason})";
+
+    /// <summary>Is this note a read FAULT (as opposed to a no-such-field, the other <c>Readable=false</c> answer)?</summary>
+    public static bool IsUnreadableNote(string? note) =>
+        note is not null && note.StartsWith(UnreadablePrefix, StringComparison.Ordinal);
+
     /// <summary>The reason an unreadable note reports. A getter's own throw comes back from reflection wrapped in a
     /// <see cref="TargetInvocationException"/> whose message ("Exception has been thrown by the target of an
     /// invocation") names nothing a caller can act on, so the note carries the inner exception's message instead.</summary>
@@ -313,7 +326,7 @@ public static class ReadEngine
             }
             return EmitToken(leaf.GetValue(current), leaf.PropertyType, current);
         }
-        catch (Exception ex) { return LeafRead.Unreadable($"(unreadable: {Reason(ex)})"); }
+        catch (Exception ex) { return LeafRead.Unreadable(UnreadableNote(Reason(ex))); }
     }
 
     /// <summary>The FormKeys on a record's <c>Keywords</c> list — the ONE keyword walk, shared by the SkyPatcher
@@ -362,7 +375,7 @@ public static class ReadEngine
             if (nav.val is null) return (null, AbsentNote);
             return LinksIn(nav.val, string.Join(".", path));
         }
-        catch (Exception ex) { return (null, $"(unreadable: {Reason(ex)})"); }
+        catch (Exception ex) { return (null, UnreadableNote(Reason(ex))); }
     }
 
     /// <summary>The link-shape half of <see cref="CollectLinksAt"/>, over a value already navigated to — so a
@@ -398,7 +411,7 @@ public static class ReadEngine
             }
             return (keys, null);
         }
-        catch (Exception ex) { return (null, $"(unreadable: {Reason(ex)})"); }
+        catch (Exception ex) { return (null, UnreadableNote(Reason(ex))); }
     }
 
     /// <summary>Navigate a path READ-ONLY to its live value — the quantified step's fan-out source. Same walk
@@ -554,7 +567,7 @@ public static class ReadEngine
     /// <summary>The ONE unreadable line the deep walk emits — same sentence and same structural flags the depth-1
     /// read's <see cref="LeafRead.Unreadable"/> carries, so a nested fault and a top-level one read alike.</summary>
     static FieldValue Fault(string path, string reason) =>
-        new(path, false, null, $"(unreadable: {reason})", Present: false, Readable: false);
+        new(path, false, null, UnreadableNote(reason), Present: false, Readable: false);
 
     static FieldValue Fault(string path, Exception ex) => Fault(path, Reason(ex));
 
@@ -750,7 +763,7 @@ public static class ReadEngine
             }
             return (true, leaf.GetValue(current), leaf.PropertyType, current, null, true);
         }
-        catch (Exception ex) { return (false, null, typeof(object), record, $"(unreadable: {Reason(ex)})", false); }
+        catch (Exception ex) { return (false, null, typeof(object), record, UnreadableNote(Reason(ex)), false); }
     }
 
     /// <summary>Best-effort COMPACT identity of the element a list/dict verb just acted on — the write-verify's

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -281,6 +281,11 @@ public static class ReadEngine
     /// <c>StepIntoElement</c>) but is READ-ONLY — an absent optional substruct is surfaced, never
     /// materialised. Per-leaf fault isolation: any reflection/parse failure names itself and never
     /// throws out, so one Mutagen-unparseable field can't crash a record read.</summary>
+    /// <summary>The reason an unreadable note reports. A getter's own throw comes back from reflection wrapped in a
+    /// <see cref="TargetInvocationException"/> whose message ("Exception has been thrown by the target of an
+    /// invocation") names nothing a caller can act on, so the note carries the inner exception's message instead.</summary>
+    static string Reason(Exception ex) => (ex as TargetInvocationException)?.InnerException?.Message ?? ex.Message;
+
     internal static LeafRead ReadLeaf(object record, string[] path)
     {
         try
@@ -308,7 +313,7 @@ public static class ReadEngine
             }
             return EmitToken(leaf.GetValue(current), leaf.PropertyType, current);
         }
-        catch (Exception ex) { return LeafRead.Unreadable($"(unreadable: {ex.Message})"); }
+        catch (Exception ex) { return LeafRead.Unreadable($"(unreadable: {Reason(ex)})"); }
     }
 
     /// <summary>The FormKeys on a record's <c>Keywords</c> list — the ONE keyword walk, shared by the SkyPatcher
@@ -357,7 +362,7 @@ public static class ReadEngine
             if (nav.val is null) return (null, AbsentNote);
             return LinksIn(nav.val, string.Join(".", path));
         }
-        catch (Exception ex) { return (null, $"(unreadable: {ex.Message})"); }
+        catch (Exception ex) { return (null, $"(unreadable: {Reason(ex)})"); }
     }
 
     /// <summary>The link-shape half of <see cref="CollectLinksAt"/>, over a value already navigated to — so a
@@ -393,7 +398,7 @@ public static class ReadEngine
             }
             return (keys, null);
         }
-        catch (Exception ex) { return (null, $"(unreadable: {ex.Message})"); }
+        catch (Exception ex) { return (null, $"(unreadable: {Reason(ex)})"); }
     }
 
     /// <summary>Navigate a path READ-ONLY to its live value — the quantified step's fan-out source. Same walk
@@ -528,7 +533,9 @@ public static class ReadEngine
     /// per-field fault isolation depth-1 <see cref="ReadLeaf"/> gives: a throw while navigating OR expanding
     /// this one target (an unparseable nested getter, an enumerator that faults mid-list, an ambiguous identity
     /// reflection) names itself "(unreadable …)" and never escapes the record read — so one bad field can't crash
-    /// a whole-record depth dump. Lines already emitted before a mid-expansion fault are real reads and are kept.</summary>
+    /// a whole-record depth dump. Lines already emitted before a mid-expansion fault are real reads and are kept.
+    /// A fault on ONE sub-field is isolated to that sub-field's own line (see <see cref="Expand"/>): the rest of the
+    /// substruct still reads.</summary>
     /// <summary><paramref name="display"/> is how the emitted rows spell the path when it differs from what is
     /// navigated — a <c>*parent</c> hop reads on the parent but the caller asked for '*parent.Responses'.</summary>
     static void EmitWithDepth(object record, string path, int depth, List<FieldValue> sink, ref int budget, string? display = null)
@@ -538,15 +545,26 @@ public static class ReadEngine
         {
             var seg = path.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
             var nav = NavigateValue(record, seg);
-            if (!nav.ok) { Emit(sink, ref budget, new FieldValue(shown, false, null, nav.note, Present: false)); return; }
+            if (!nav.ok) { Emit(sink, ref budget, new FieldValue(shown, false, null, nav.note, Present: false, Readable: nav.readable)); return; }
             Expand(nav.val, nav.type, nav.parent, shown, depth, sink, ref budget);
         }
-        catch (Exception ex) { Emit(sink, ref budget, new FieldValue(shown, false, null, $"(unreadable: {ex.Message})", Present: false)); }
+        catch (Exception ex) { Emit(sink, ref budget, Fault(shown, ex)); }
     }
+
+    /// <summary>The ONE unreadable line the deep walk emits — same sentence and same structural flags the depth-1
+    /// read's <see cref="LeafRead.Unreadable"/> carries, so a nested fault and a top-level one read alike.</summary>
+    static FieldValue Fault(string path, string reason) =>
+        new(path, false, null, $"(unreadable: {reason})", Present: false, Readable: false);
+
+    static FieldValue Fault(string path, Exception ex) => Fault(path, Reason(ex));
 
     /// <summary>Recursively emit <paramref name="val"/> at <paramref name="path"/>: a value leaf → its token;
     /// a link → its note (not opened); a container/substruct → an identity-enriched summary line, then (while
-    /// depth allows) one child line per element (bracketed) or sub-field (dotted), each recursed at depth-1.</summary>
+    /// depth allows) one child line per element (bracketed) or sub-field (dotted), each recursed at depth-1.
+    /// <para>A sub-field that cannot be read gets its own "(unreadable …)" line — the same sentence and the same
+    /// Readable=false the depth-1 read emits — and the walk carries on with its siblings. It is never skipped: a
+    /// dropped line is indistinguishable from an absent optional, which would make an unreadable field read as
+    /// evidence that nothing is there.</para></summary>
     static void Expand(object? val, Type declaredType, object parent, string path, int depth, List<FieldValue> sink, ref int budget)
     {
         if (budget < 0) return;
@@ -614,9 +632,17 @@ public static class ReadEngine
             for (int g = 0; g < WriteEngine.GenderedArmNames.Length; g++)
             {
                 if (budget < 0) return;
-                var armProp = WriteEngine.ResolveProperty(val.GetType(), WriteEngine.GenderedArmNames[g]);
-                object? arm; try { arm = armProp?.GetValue(val); } catch { continue; }
-                Expand(arm, armProp?.PropertyType ?? typeof(object), val, $"{path}[{g}]", childDepth, sink, ref budget);
+                var armName = WriteEngine.GenderedArmNames[g];
+                var armProp = WriteEngine.ResolveProperty(val.GetType(), armName);
+                if (armProp is null)
+                {
+                    Emit(sink, ref budget, Fault($"{path}[{g}]", $"gendered type {RecordNaming.StripOverlay(val.GetType().Name)} has no '{armName}' arm"));
+                    continue;
+                }
+                object? arm;
+                try { arm = armProp.GetValue(val); }
+                catch (Exception ex) { Emit(sink, ref budget, Fault($"{path}[{g}]", ex)); continue; }
+                Expand(arm, armProp.PropertyType, val, $"{path}[{g}]", childDepth, sink, ref budget);
             }
         }
         else if (val is System.Collections.IEnumerable seq and not string)
@@ -647,8 +673,19 @@ public static class ReadEngine
             {
                 if (budget < 0) return;
                 var prop = WriteEngine.ResolveProperty(val.GetType(), fname);
-                object? fv; try { fv = prop?.GetValue(val); } catch { continue; }
-                Expand(fv, prop?.PropertyType ?? typeof(object), val, $"{path}.{fname}", childDepth, sink, ref budget);
+                // The name came off this type's own reflection, so it IS modeled: a resolve miss or a getter throw
+                // is a read FAULT, and the line says so. It never renders as absent — "I could not look" and
+                // "there is nothing there" are different answers.
+                if (prop is null)
+                {
+                    Emit(sink, ref budget, Fault($"{path}.{fname}",
+                        $"{RecordNaming.StripOverlay(val.GetType().Name)} declares '{fname}' but the read walk cannot resolve it"));
+                    continue;
+                }
+                object? fv;
+                try { fv = prop.GetValue(val); }
+                catch (Exception ex) { Emit(sink, ref budget, Fault($"{path}.{fname}", ex)); continue; }
+                Expand(fv, prop.PropertyType, val, $"{path}.{fname}", childDepth, sink, ref budget);
             }
         }
     }
@@ -670,8 +707,11 @@ public static class ReadEngine
 
     /// <summary>Navigate a path READ-ONLY to its target, returning the live value object (+ declared type +
     /// owning parent) for recursion, or a miss note. Same walk as <see cref="ReadLeaf"/> but yields the object
-    /// instead of a token, so the expander can descend into it. Fault-isolated.</summary>
-    static (bool ok, object? val, Type type, object parent, string? note) NavigateValue(object record, string[] path)
+    /// instead of a token, so the expander can descend into it. Fault-isolated.
+    /// <para><c>readable</c> classifies the miss exactly as <see cref="ReadLeaf"/> does — false for a no-such-field
+    /// or a throw, true for a genuinely absent optional — carried structurally so a caller never decides "could not
+    /// look" versus "nothing there" by matching the note's prose.</para></summary>
+    static (bool ok, object? val, Type type, object parent, string? note, bool readable) NavigateValue(object record, string[] path)
     {
         try
         {
@@ -681,23 +721,23 @@ public static class ReadEngine
                 var (segName, segKey) = WriteEngine.ParseSegment(path[i]);
                 var p = WriteEngine.ResolveProperty(current.GetType(), segName);
                 if (p is null) return (false, null, typeof(object), current,
-                    NoFieldNote(current, segName, i > 0 ? WriteEngine.ParseSegment(path[i - 1]).name : null, path[(i + 1)..]));
+                    NoFieldNote(current, segName, i > 0 ? WriteEngine.ParseSegment(path[i - 1]).name : null, path[(i + 1)..]), false);
                 var next = segKey is null ? p.GetValue(current) : WriteEngine.StepIntoElement(current, p, segName, segKey);
-                if (next is null) return (false, null, typeof(object), record, AbsentNote);
+                if (next is null) return (false, null, typeof(object), record, AbsentNote, true);
                 current = next;
             }
             var (leafName, leafKey) = WriteEngine.ParseSegment(path[^1]);
             var leaf = WriteEngine.ResolveProperty(current.GetType(), leafName);
             if (leaf is null) return (false, null, typeof(object), current,
-                NoFieldNote(current, leafName, path.Length >= 2 ? WriteEngine.ParseSegment(path[^2]).name : null));
+                NoFieldNote(current, leafName, path.Length >= 2 ? WriteEngine.ParseSegment(path[^2]).name : null), false);
             if (leafKey is not null)
             {
                 var elem = WriteEngine.StepIntoElement(current, leaf, leafName, leafKey);
-                return (true, elem, elem.GetType(), current, null);
+                return (true, elem, elem.GetType(), current, null, true);
             }
-            return (true, leaf.GetValue(current), leaf.PropertyType, current, null);
+            return (true, leaf.GetValue(current), leaf.PropertyType, current, null, true);
         }
-        catch (Exception ex) { return (false, null, typeof(object), record, $"(unreadable: {ex.Message})"); }
+        catch (Exception ex) { return (false, null, typeof(object), record, $"(unreadable: {Reason(ex)})", false); }
     }
 
     /// <summary>Best-effort COMPACT identity of the element a list/dict verb just acted on — the write-verify's

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -602,9 +602,10 @@ public static class ReadEngine
         var leaf = EmitToken(val, declaredType, parent);
         if (leaf.HasValue) { Emit(sink, ref budget, new FieldValue(path, true, leaf.Token, null, FlagDisplay(leaf))); return; }
         if (val is null) { Emit(sink, ref budget, new FieldValue(path, false, null, leaf.Note, Present: false)); return; }
-        // a link (incl. a null FormKey, or an FLOI) is a note, not an openable container/substruct.
+        // a link (incl. a null FormKey, or an FLOI) is a note, not an openable container/substruct. Both flags
+        // travel with it: an FLOI whose mode or index could not be read is a fault, not an absence.
         if (val is IFormLinkGetter || WriteEngine.IsFormLinkOrIndex(Nullable.GetUnderlyingType(declaredType) ?? declaredType))
-        { Emit(sink, ref budget, new FieldValue(path, false, null, leaf.Note, Present: leaf.Present)); return; }
+        { Emit(sink, ref budget, new FieldValue(path, false, null, leaf.Note, Present: leaf.Present, Readable: leaf.Readable)); return; }
 
         // Classify dict-vs-list the SAME way the navigation does (StepIntoElement) — by the GENERIC dictionary
         // interfaces via ClosedInterface, not a separate non-generic System.Collections.IDictionary cast — so the

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -709,8 +709,10 @@ public static class ReadEngine
     /// owning parent) for recursion, or a miss note. Same walk as <see cref="ReadLeaf"/> but yields the object
     /// instead of a token, so the expander can descend into it. Fault-isolated.
     /// <para><c>readable</c> classifies the miss exactly as <see cref="ReadLeaf"/> does — false for a no-such-field
-    /// or a throw, true for a genuinely absent optional — carried structurally so a caller never decides "could not
-    /// look" versus "nothing there" by matching the note's prose.</para></summary>
+    /// or a throw, true for a genuinely absent optional. <c>EmitWithDepth</c> carries it onto the emitted leaf's
+    /// <see cref="FieldValue.Readable"/>, which the rows fold and the conflict diff read structurally instead of
+    /// matching the note's prose. It goes no further: <see cref="NavigateTo"/> drops it, so that wrapper's callers
+    /// still classify from the note text.</para></summary>
     static (bool ok, object? val, Type type, object parent, string? note, bool readable) NavigateValue(object record, string[] path)
     {
         try

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -276,16 +276,16 @@ public static class ReadEngine
     //  THE READ PRIMITIVE — navigate a path read-only, emit the leaf token.
     // ======================================================================
 
-    /// <summary>Read one leaf path off a located record and return its round-trippable token (or a
-    /// sentinel). Navigation mirrors the write engine's path walk (same <c>ResolveProperty</c> /
-    /// <c>StepIntoElement</c>) but is READ-ONLY — an absent optional substruct is surfaced, never
-    /// materialised. Per-leaf fault isolation: any reflection/parse failure names itself and never
-    /// throws out, so one Mutagen-unparseable field can't crash a record read.</summary>
     /// <summary>The reason an unreadable note reports. A getter's own throw comes back from reflection wrapped in a
     /// <see cref="TargetInvocationException"/> whose message ("Exception has been thrown by the target of an
     /// invocation") names nothing a caller can act on, so the note carries the inner exception's message instead.</summary>
     static string Reason(Exception ex) => (ex as TargetInvocationException)?.InnerException?.Message ?? ex.Message;
 
+    /// <summary>Read one leaf path off a located record and return its round-trippable token (or a
+    /// sentinel). Navigation mirrors the write engine's path walk (same <c>ResolveProperty</c> /
+    /// <c>StepIntoElement</c>) but is READ-ONLY — an absent optional substruct is surfaced, never
+    /// materialised. Per-leaf fault isolation: any reflection/parse failure names itself and never
+    /// throws out, so one Mutagen-unparseable field can't crash a record read.</summary>
     internal static LeafRead ReadLeaf(object record, string[] path)
     {
         try

--- a/src/housecarl-mcp-tests/RecordsContainmentTests.cs
+++ b/src/housecarl-mcp-tests/RecordsContainmentTests.cs
@@ -196,7 +196,10 @@ public sealed class RecordsContainmentTests : IClassFixture<OwnedChildFixture>
         var r = RecordsTools.Records(Svc, formids: new[] { OwnedChildWorld.Fid(_w.ReparentedRef) },
                                      source: form == "delta" ? Pole(_w.MidName) : null, versus: Pole(copy),
                                      project: new RecordsTools.RecordsProject { form = form, fields = new[] { "*parent.EditorID" } });
-        Assert.Contains("HcOcCellJ", r);
+        // A hop the off-order arm cannot take is a fault, not a value, so the comparison gives no verdict at that
+        // path and says which side could not read it — the in-order arm being the side that could.
+        Assert.Contains("*parent.EditorID: UNREADABLE in ", r);
+        Assert.DoesNotContain("UNREADABLE on both sides", r);
         Assert.Contains("needs the load-order index", r);
     }
 

--- a/src/housecarl-mcp-tests/RecordsOffOrderPathTests.cs
+++ b/src/housecarl-mcp-tests/RecordsOffOrderPathTests.cs
@@ -81,7 +81,7 @@ public sealed class RecordsOffOrderPathTests : RecordsTestBase
         // The whole composed count line, not the "1 difference" fragment — that fragment is a substring of
         // "11 differences" and would read a wider delta as this one.
         var named = Delta("BasicStats.Damage");
-        Served(named, $"1 difference — each line: {W.MasterName}'s value (reference = {W.OverrideName}):",
+        Served(named, $"1 difference — each value line: {W.MasterName}'s value (reference = {W.OverrideName}):",
                       "BasicStats.Damage=10");
         Assert.Equal(1, CountOf(named, "BasicStats."));
 

--- a/src/housecarl-mcp-tests/RecordsRowsFormTests.cs
+++ b/src/housecarl-mcp-tests/RecordsRowsFormTests.cs
@@ -70,8 +70,8 @@ public sealed class RecordsRowsFormTests : RecordsTestBase
     public void AnUnreadableSubFieldIsNotAnAbsentOne()
     {
         // A read fault must survive the fold: dropping it would report "I could not look" as "nothing is there".
-        // Driven at the fold directly on purpose: ReadEngine.Expand skips a nested property-get fault rather than
-        // emitting an unreadable line, so no read on this lane can produce one — this pins the fold, not the lane.
+        // Driven at the fold directly so the assertion is about the fold alone; the read that produces such a line
+        // is pinned in RecordsUnreadableSubFieldTests.
         var folded = RowProjection.Fold(new[]
         {
             new HousecarlCore.FieldValue("Conditions[0]", false, null, "[ConditionFloat]", Present: true),

--- a/src/housecarl-mcp-tests/RecordsUnreadableSubFieldTests.cs
+++ b/src/housecarl-mcp-tests/RecordsUnreadableSubFieldTests.cs
@@ -89,7 +89,12 @@ public sealed class TruncatedSubFieldWorld : IDisposable
         int grup = Find(bytes, "GRUP", 0);           // the WEAP group header; its own label is "WEAP" at +8,
         int rec = Find(bytes, "WEAP", grup + 24);    // so the record itself is searched for past the header
         int sub = Find(bytes, "DATA", rec + 24);
+        // Every offset below is unchecked arithmetic on these three: a miss (-1) or a DATA that is not the 10-byte
+        // WEAP one still writes a plugin, and the test then fails somewhere far from the cause. Assert the fixture's
+        // assumptions here so a Mutagen layout change fails as itself.
+        Assert.True(grup >= 0 && rec >= 0 && sub >= 0, $"WEAP GRUP/record/DATA not found (grup={grup} rec={rec} sub={sub})");
         int len = BitConverter.ToUInt16(bytes, sub + 4);
+        Assert.Equal(10, len);
         const int Keep = 8;
         int cut = len - Keep;
         BitConverter.GetBytes((ushort)Keep).CopyTo(bytes, sub + 4);

--- a/src/housecarl-mcp-tests/RecordsUnreadableSubFieldTests.cs
+++ b/src/housecarl-mcp-tests/RecordsUnreadableSubFieldTests.cs
@@ -198,6 +198,29 @@ public sealed class RecordsUnreadableSubFieldTests : IClassFixture<TruncatedSubF
     }
 }
 
+/// <summary>A deep read carries the readable bit on a LINK leaf too. A condition target (FormLinkOrIndex) the
+/// emit cannot read is a fault, and a fault that renders with Present=false and Readable=true tells every
+/// consumer reading the bits that nothing is there.</summary>
+[Trait("tier", "unit")]
+public sealed class UnreadableLinkLeafReadTests
+{
+    [Fact]
+    public void AnUnreadableConditionTargetIsNotReadAsAbsent()
+    {
+        var mod = new SkyrimMod(new ModKey("HcFloiRead", ModType.Plugin), SkyrimRelease.SkyrimSE);
+        var mgef = mod.MagicEffects.AddNew();
+        mgef.EditorID = "HcFloiMgef";
+        // Index mode (UseAliases), whose index accessor the emit cannot resolve — the fault EmitFloi reports.
+        mgef.Conditions.Add(new ConditionFloat { Data = new GetInFactionConditionData { UseAliases = true } });
+
+        var f = ReadEngine.ReadFields(mgef, new[] { "Conditions" }, depth: 3).Fields
+                          .Single(x => x.Path == "Conditions[0].Data.Faction");
+
+        Assert.StartsWith("(floi: ", f.Note);
+        Assert.False(f.Readable);
+    }
+}
+
 /// <summary>The pole-symmetric half of the same fact, driven at <see cref="FieldsDiff"/> directly: when BOTH poles
 /// are unreadable at one path there is nothing to compare there, so the record must not be reported identical.
 /// Driven here because one truncated plugin cannot be both poles of a lane call — the shape of the failure belongs

--- a/src/housecarl-mcp-tests/RecordsUnreadableSubFieldTests.cs
+++ b/src/housecarl-mcp-tests/RecordsUnreadableSubFieldTests.cs
@@ -216,6 +216,41 @@ public sealed class RecordsUnreadableSubFieldTests : IClassFixture<TruncatedSubF
     }
 }
 
+/// <summary>The tree form's node line says the comparison was incomplete WHENEVER it was, not only where the
+/// node has no deltas — an unreadable leaf always produces a delta line, so gating the note on an empty delta
+/// list left the normal shape rendering one UNREADABLE line and nothing about what was skipped beside it.
+/// Driven against a hand-built row: the render is the subject, and no fixture makes this node shape.</summary>
+[Trait("tier", "unit")]
+public sealed class TreeIncompleteNoteTests
+{
+    static string Render(params string[] deltas)
+    {
+        var row = new LoadOrderService.TreeRow("000800:A.esm", "Weapon", "HcWeap",
+            new[] { "A.esm", "B.esp" }, "A.esm",
+            new[] { new LoadOrderService.TreeNodeDelta("A.esm", false, true, Array.Empty<string>(), 0, true, null),
+                    new LoadOrderService.TreeNodeDelta("B.esp", true, false, deltas, 0, false, null) },
+            null, Array.Empty<ChildDeclarers>());
+        return RecordsTools.RenderRecordsTree(new[] { row }, 1, 1, 0, false, "records  form=tree", null,
+                                              100_000, null, out _);
+    }
+
+    [Fact]
+    public void ANodeWithDeltasStillSaysTheComparisonWasIncomplete()
+    {
+        var r = Render("BasicStats.Damage: UNREADABLE here — not compared (unreadable: out of range)");
+
+        Assert.Contains("BasicStats.Damage: UNREADABLE here", r);
+        Assert.Contains("the comparison is INCOMPLETE", r);
+    }
+
+    /// <summary>The no-delta node keeps its own note — the only cause left there is the cap.</summary>
+    [Fact]
+    public void ANodeWithNoDeltasStillNamesTheCap()
+    {
+        Assert.Contains("TRUNCATED at the cap", Render());
+    }
+}
+
 /// <summary>A deep read carries the readable bit on a LINK leaf too. A condition target (FormLinkOrIndex) the
 /// emit cannot read is a fault, and a fault that renders with Present=false and Readable=true tells every
 /// consumer reading the bits that nothing is there.</summary>

--- a/src/housecarl-mcp-tests/RecordsUnreadableSubFieldTests.cs
+++ b/src/housecarl-mcp-tests/RecordsUnreadableSubFieldTests.cs
@@ -1,0 +1,164 @@
+using System.Text.Json;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlGenerator;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>A plugin whose single weapon carries a SHORT DATA subrecord: the record opens, its BasicStats
+/// substruct opens, and reading the last field out of that substruct throws inside Mutagen. Two bytes of the
+/// plugin are the whole fixture — the file is written by Mutagen, then DATA's declared length is cut from 10 to
+/// 8 (and the enclosing record and group sizes with it), which is what a truncated or badly merged plugin looks
+/// like on disk. It sits in a switched-OFF mod folder and is read by name, the same off-order lane a caller uses
+/// to look inside a plugin that is not in the order; a clean master holds the active order.</summary>
+public sealed class TruncatedSubFieldWorld : IDisposable
+{
+    public string Root { get; }
+    public LoadOrderService Svc { get; }
+    /// <summary>The plugin holding the weapon whose BasicStats.Damage cannot be read. Value and Weight, which sit
+    /// before the cut, still read.</summary>
+    public string TruncName { get; }
+    public const string WeaponEditorId = "HcTruncWeap";
+    public const int Value = 34;
+
+    static int Find(byte[] b, string sig, int from)
+    {
+        for (int i = from; i + 4 <= b.Length; i++)
+            if (b[i] == sig[0] && b[i + 1] == sig[1] && b[i + 2] == sig[2] && b[i + 3] == sig[3]) return i;
+        return -1;
+    }
+
+    readonly string _priorCorpusPath;
+
+    public TruncatedSubFieldWorld()
+    {
+        // CorpusRulebook.CorpusPath is a process-global: capture before repointing, and restore before the
+        // directory the new value names is deleted.
+        _priorCorpusPath = CorpusRulebook.CorpusPath;
+
+        Root = Path.Combine(Path.GetTempPath(), "hc-truncated-subfield-tests-" + Guid.NewGuid().ToString("N"));
+        var instance = Path.Combine(Root, "instance");
+        var profiles = Path.Combine(instance, "profiles", "Default");
+        var mods = Path.Combine(instance, "mods");
+        foreach (var d in new[] { profiles, mods, Path.Combine(Root, "game", "Data") }) Directory.CreateDirectory(d);
+        File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(Root, "game").Replace(@"\", @"\\") + ")\r\n");
+
+        string P(string folder, ModKey k)
+        {
+            var p = Path.Combine(mods, folder, k.FileName.String);
+            Directory.CreateDirectory(Path.GetDirectoryName(p)!);
+            return p;
+        }
+
+        var cleanKey = new ModKey("HcTruncClean", ModType.Master);
+        var clean = new SkyrimMod(cleanKey, SkyrimRelease.SkyrimSE);
+        clean.Weapons.AddNew().EditorID = "HcCleanWeap";
+        clean.BeginWrite.ToPath(P("CleanMod", cleanKey)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+        var truncKey = new ModKey("HcTrunc", ModType.Plugin);
+        TruncName = truncKey.FileName.String;
+        var m = new SkyrimMod(truncKey, SkyrimRelease.SkyrimSE);
+        var weapon = m.Weapons.AddNew();
+        weapon.EditorID = WeaponEditorId;
+        weapon.BasicStats = new WeaponBasicStats { Damage = 12, Value = Value, Weight = 5.5f };
+        var path = P("TruncMod", truncKey);
+        m.BeginWrite.ToPath(path).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+        // …and now cut two bytes off DATA, so the last field in the struct reads past the end of its own
+        // subrecord. The record, the group and the file all stay internally consistent: nothing but that one
+        // field is broken.
+        var bytes = File.ReadAllBytes(path);
+        int grup = Find(bytes, "GRUP", 0);           // the WEAP group header; its own label is "WEAP" at +8,
+        int rec = Find(bytes, "WEAP", grup + 24);    // so the record itself is searched for past the header
+        int sub = Find(bytes, "DATA", rec + 24);
+        int len = BitConverter.ToUInt16(bytes, sub + 4);
+        const int Keep = 8;
+        int cut = len - Keep;
+        BitConverter.GetBytes((ushort)Keep).CopyTo(bytes, sub + 4);
+        BitConverter.GetBytes(BitConverter.ToUInt32(bytes, rec + 4) - (uint)cut).CopyTo(bytes, rec + 4);
+        BitConverter.GetBytes(BitConverter.ToUInt32(bytes, grup + 4) - (uint)cut).CopyTo(bytes, grup + 4);
+        File.WriteAllBytes(path, bytes[..(sub + 6 + Keep)].Concat(bytes[(sub + 6 + len)..]).ToArray());
+
+        var genDir = Path.Combine(Root, "corpus-gen");
+        CorpusGenerator.GenerateAll(genDir, Path.Combine(Root, "corpus-ref"));
+        CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json");
+
+        File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + cleanKey.FileName + "\r\n");
+        File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + cleanKey.FileName + "\r\n");
+        File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n-TruncMod\r\n+CleanMod\r\n");
+
+        Svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(Root, "houseCARL.user.json")));
+        Svc.Stats();
+    }
+
+    public void Dispose()
+    {
+        CorpusRulebook.CorpusPath = _priorCorpusPath;
+        Svc.Dispose();
+        try { Directory.Delete(Root, true); } catch { /* temp cleanup best-effort */ }
+    }
+}
+
+public sealed class TruncatedSubFieldFixture : IDisposable
+{
+    public TruncatedSubFieldWorld W { get; } = new();
+    public void Dispose() => W.Dispose();
+}
+
+/// <summary>A sub-field that cannot be read says so, on the field, wherever fields are rendered. It is never
+/// dropped: an omitted line and an absent optional are the same thing to a caller, so a swallowed fault reports
+/// "I could not look" as "there is nothing there".</summary>
+[Trait("tier", "integration")]
+public sealed class RecordsUnreadableSubFieldTests : IClassFixture<TruncatedSubFieldFixture>
+{
+    readonly TruncatedSubFieldWorld _w;
+    public RecordsUnreadableSubFieldTests(TruncatedSubFieldFixture f) => _w = f.W;
+
+    string Read(RecordsTools.RecordsProject project, string? format = null) =>
+        RecordsTools.Records(_w.Svc, source: JsonDocument.Parse("\"" + _w.TruncName + "\"").RootElement.Clone(),
+                             types: new[] { "WEAP" }, project: project, format: format);
+
+    static RecordsTools.RecordsProject Stats =>
+        new() { form = "fields", fields = new[] { "BasicStats" }, depth = 2 };
+
+    /// <summary>The fault is isolated to its own line: the sub-field names itself and its reason, and the siblings
+    /// beside it are real reads and are kept.</summary>
+    [Fact]
+    public void TheFieldsFormNamesTheSubFieldAndTheReasonAndKeepsItsSiblings()
+    {
+        var r = Read(Stats);
+        Assert.False(r.StartsWith("error:", StringComparison.Ordinal), r);
+        Assert.Contains("BasicStats.Damage = (unreadable: ", r);
+        Assert.Contains("BasicStats.Value = " + TruncatedSubFieldWorld.Value, r);
+        // The reason is Mutagen's own, not a wrapper's: reflection's "target of an invocation" names nothing.
+        Assert.DoesNotContain("target of an invocation", r);
+    }
+
+    [Fact]
+    public void TheJsonRenderCarriesTheFaultAsThatFieldsOwnNote()
+    {
+        using var doc = JsonDocument.Parse(Read(Stats, "json"));
+        var field = doc.RootElement.GetProperty("records")[0].GetProperty("fields")
+                       .EnumerateArray().Single(f => f.GetProperty("path").GetString() == "BasicStats.Damage");
+        Assert.StartsWith("(unreadable: ", field.GetProperty("note").GetString());
+        Assert.False(field.TryGetProperty("value", out _));
+    }
+
+    /// <summary>A whole-record read is still a whole-record read: every other field answers, and the one that
+    /// could not be read is named among them.</summary>
+    [Fact]
+    public void AnEverythingReadKeepsTheRestOfTheRecordAndStillNamesTheFault()
+    {
+        var r = Read(new RecordsTools.RecordsProject { form = "everything", depth = 2 });
+        Assert.False(r.StartsWith("error:", StringComparison.Ordinal), r);
+        Assert.Contains(TruncatedSubFieldWorld.WeaponEditorId, r);
+        Assert.Contains("BasicStats.Value = " + TruncatedSubFieldWorld.Value, r);
+        Assert.Contains("BasicStats.Damage = (unreadable: ", r);
+    }
+}

--- a/src/housecarl-mcp-tests/RecordsUnreadableSubFieldTests.cs
+++ b/src/housecarl-mcp-tests/RecordsUnreadableSubFieldTests.cs
@@ -196,6 +196,24 @@ public sealed class RecordsUnreadableSubFieldTests : IClassFixture<TruncatedSubF
         // The reading it must NOT give: the reference's 12 asserted as a difference from a value never read.
         Assert.DoesNotContain("BasicStats.Damage=(unreadable", r);
     }
+
+    string Delta(bool countsOnly) => RecordsTools.Records(_w.Svc, formids: new[] { _w.WeaponFid },
+        source: JsonDocument.Parse("\"" + _w.TruncName + "\"").RootElement.Clone(),
+        versus: JsonDocument.Parse("\"" + _w.CleanName + "\"").RootElement.Clone(),
+        project: new RecordsTools.RecordsProject { form = "delta" }, counts_only: countsOnly);
+
+    /// <summary>A no-verdict is a THIRD state, not a difference: this record restates every field the reference
+    /// carries and differs in none, so counting the UNREADABLE line as a difference would report a difference
+    /// nobody read.</summary>
+    [Fact]
+    public void ANoVerdictIsCountedApartFromValueDifferences()
+    {
+        Assert.Contains("differing=0 identical=0 no_verdict=1", Delta(countsOnly: true));
+
+        var r = Delta(countsOnly: false);
+        Assert.Contains("1 field that could not be read", r);
+        Assert.DoesNotContain("1 difference —", r);
+    }
 }
 
 /// <summary>A deep read carries the readable bit on a LINK leaf too. A condition target (FormLinkOrIndex) the

--- a/src/housecarl-mcp-tests/RecordsUnreadableSubFieldTests.cs
+++ b/src/housecarl-mcp-tests/RecordsUnreadableSubFieldTests.cs
@@ -240,7 +240,49 @@ public sealed class UnreadableLeafComparisonTests
                                    Rec(new FieldValue("EditorID", true, "HcWeap", null), Unreadable("BasicStats.Damage")));
 
         Assert.False(d.Complete);
-        Assert.Contains("BasicStats.Damage: UNREADABLE on both sides — not compared", d.Deltas);
+        Assert.Contains(d.Deltas, x => x.StartsWith("BasicStats.Damage: UNREADABLE on both sides — not compared (unreadable: ", StringComparison.Ordinal));
+    }
+
+    static FieldValue List(string path, int n) =>
+        new(path, false, null, $"[list: {n} item(s)]", Present: true, Count: n);
+
+    /// <summary>What an unreadable leaf costs is its own path, not the record: the rest still compares, so a
+    /// differing list beside an unreadable scalar is still reported. Complete stays false, so nothing claims
+    /// identity.</summary>
+    [Fact]
+    public void ADifferingListBesideAnUnreadableLeafIsStillCompared()
+    {
+        var d = FieldsDiff.Compare(
+            Rec(Unreadable("BasicStats.Damage"), List("Keywords", 2),
+                new FieldValue("Keywords[0]", true, "000AAA:A.esm", null),
+                new FieldValue("Keywords[1]", true, "000BBB:A.esm", null)),
+            Rec(new FieldValue("BasicStats.Damage", true, "12", null), List("Keywords", 2),
+                new FieldValue("Keywords[0]", true, "000AAA:A.esm", null),
+                new FieldValue("Keywords[1]", true, "000CCC:A.esm", null)));
+
+        Assert.False(d.Complete);
+        Assert.Contains(d.Deltas, x => x.StartsWith("BasicStats.Damage: UNREADABLE here — not compared (unreadable: ", StringComparison.Ordinal));
+        Assert.Contains(d.Deltas, x => x.StartsWith("Keywords: ", StringComparison.Ordinal));
+        // …and the winner's readable value at the unreadable path is not reported as one-sided presence.
+        Assert.DoesNotContain(d.Deltas, x => x.Contains("BasicStats.Damage", StringComparison.Ordinal)
+                                          && !x.Contains("UNREADABLE", StringComparison.Ordinal));
+    }
+
+    /// <summary>An unreadable leaf INSIDE a list element takes that list's element comparison down with it — the
+    /// missing line changes the element's fingerprint — and nothing else: a second list still compares.</summary>
+    [Fact]
+    public void AnUnreadableLeafInsideAnElementSuppressesOnlyThatList()
+    {
+        var d = FieldsDiff.Compare(
+            Rec(List("Conditions", 1), new FieldValue("Conditions[0].ComparisonValue", true, "1", null),
+                Unreadable("Conditions[0].Data.Reference"),
+                List("Keywords", 1), new FieldValue("Keywords[0]", true, "000AAA:A.esm", null)),
+            Rec(List("Conditions", 1), new FieldValue("Conditions[0].ComparisonValue", true, "2", null),
+                new FieldValue("Conditions[0].Data.Reference", true, "000FFF:A.esm", null),
+                List("Keywords", 1), new FieldValue("Keywords[0]", true, "000BBB:A.esm", null)));
+
+        Assert.Contains(d.Deltas, x => x.StartsWith("Keywords: ", StringComparison.Ordinal));
+        Assert.DoesNotContain(d.Deltas, x => x.StartsWith("Conditions: ", StringComparison.Ordinal));
     }
 
     /// <summary>A fault the walk spells some other way — an FLOI whose mode or index it could not read — is a
@@ -255,7 +297,7 @@ public sealed class UnreadableLeafComparisonTests
                                    Rec(new FieldValue("EditorID", true, "HcWeap", null), floi));
 
         Assert.False(d.Complete);
-        Assert.Contains("Conditions[0].Data.Reference: UNREADABLE on both sides — not compared", d.Deltas);
+        Assert.Contains(d.Deltas, x => x.StartsWith("Conditions[0].Data.Reference: UNREADABLE on both sides — not compared (floi: ", StringComparison.Ordinal));
     }
 
     /// <summary>A no-such-field is the OTHER Readable=false answer and stays comparable: it says something true

--- a/src/housecarl-mcp-tests/RecordsUnreadableSubFieldTests.cs
+++ b/src/housecarl-mcp-tests/RecordsUnreadableSubFieldTests.cs
@@ -14,7 +14,8 @@ namespace HousecarlMcpTests;
 /// plugin are the whole fixture — the file is written by Mutagen, then DATA's declared length is cut from 10 to
 /// 8 (and the enclosing record and group sizes with it), which is what a truncated or badly merged plugin looks
 /// like on disk. It sits in a switched-OFF mod folder and is read by name, the same off-order lane a caller uses
-/// to look inside a plugin that is not in the order; a clean master holds the active order.</summary>
+/// to look inside a plugin that is not in the order; the clean master it OVERRIDES holds the active order and is
+/// the reference pole a delta compares it against.</summary>
 public sealed class TruncatedSubFieldWorld : IDisposable
 {
     public string Root { get; }
@@ -22,8 +23,13 @@ public sealed class TruncatedSubFieldWorld : IDisposable
     /// <summary>The plugin holding the weapon whose BasicStats.Damage cannot be read. Value and Weight, which sit
     /// before the cut, still read.</summary>
     public string TruncName { get; }
+    /// <summary>The master that DEFINES the weapon with a whole DATA — the clean pole a delta compares against.</summary>
+    public string CleanName { get; }
+    /// <summary>The weapon, addressed as the master defines it — the FormID both poles carry.</summary>
+    public string WeaponFid { get; }
     public const string WeaponEditorId = "HcTruncWeap";
     public const int Value = 34;
+    public const int Damage = 12;
 
     static int Find(byte[] b, string sig, int from)
     {
@@ -56,19 +62,25 @@ public sealed class TruncatedSubFieldWorld : IDisposable
             return p;
         }
 
+        // The master DEFINES the weapon, cleanly; the truncated plugin OVERRIDES it with the same content. The two
+        // are byte-identical until the cut below, so a delta between them differs in exactly the one field that
+        // cannot be read — and the master doubles as the clean reference pole.
         var cleanKey = new ModKey("HcTruncClean", ModType.Master);
         var clean = new SkyrimMod(cleanKey, SkyrimRelease.SkyrimSE);
-        clean.Weapons.AddNew().EditorID = "HcCleanWeap";
+        CleanName = cleanKey.FileName.String;
+        var cleanWeapon = clean.Weapons.AddNew();
+        cleanWeapon.EditorID = WeaponEditorId;
+        cleanWeapon.BasicStats = new WeaponBasicStats { Damage = Damage, Value = Value, Weight = 5.5f };
+        WeaponFid = $"{cleanWeapon.FormKey.ID:X6}:{cleanWeapon.FormKey.ModKey.FileName}";
         clean.BeginWrite.ToPath(P("CleanMod", cleanKey)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
 
         var truncKey = new ModKey("HcTrunc", ModType.Plugin);
         TruncName = truncKey.FileName.String;
         var m = new SkyrimMod(truncKey, SkyrimRelease.SkyrimSE);
-        var weapon = m.Weapons.AddNew();
-        weapon.EditorID = WeaponEditorId;
-        weapon.BasicStats = new WeaponBasicStats { Damage = 12, Value = Value, Weight = 5.5f };
+        var weapon = m.Weapons.GetOrAddAsOverride(cleanWeapon);
+        weapon.BasicStats = new WeaponBasicStats { Damage = Damage, Value = Value, Weight = 5.5f };
         var path = P("TruncMod", truncKey);
-        m.BeginWrite.ToPath(path).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        m.BeginWrite.ToPath(path).WithLoadOrder(new ISkyrimModGetter[] { clean }).Write();
 
         // …and now cut two bytes off DATA, so the last field in the struct reads past the end of its own
         // subrecord. The record, the group and the file all stay internally consistent: nothing but that one
@@ -160,5 +172,58 @@ public sealed class RecordsUnreadableSubFieldTests : IClassFixture<TruncatedSubF
         Assert.Contains(TruncatedSubFieldWorld.WeaponEditorId, r);
         Assert.Contains("BasicStats.Value = " + TruncatedSubFieldWorld.Value, r);
         Assert.Contains("BasicStats.Damage = (unreadable: ", r);
+    }
+
+    /// <summary>The comparison forms carry the fault too: a field that could not be read is a NO-VERDICT, named as
+    /// its own line and leaving the comparison incomplete — never asserted as a value that differs from the
+    /// reference's, which claims a reading the engine does not have.</summary>
+    [Fact]
+    public void ADeltaNamesTheUnreadableFieldInsteadOfCallingItAValueDifference()
+    {
+        var r = RecordsTools.Records(_w.Svc, formids: new[] { _w.WeaponFid },
+            source: JsonDocument.Parse("\"" + _w.TruncName + "\"").RootElement.Clone(),
+            versus: JsonDocument.Parse("\"" + _w.CleanName + "\"").RootElement.Clone(),
+            project: new RecordsTools.RecordsProject { form = "delta" });
+
+        Assert.False(r.StartsWith("error:", StringComparison.Ordinal), r);
+        Assert.Contains("BasicStats.Damage: UNREADABLE here — not compared", r);
+        Assert.Contains("the comparison is INCOMPLETE", r);
+        // The reading it must NOT give: the reference's 12 asserted as a difference from a value never read.
+        Assert.DoesNotContain("BasicStats.Damage=(unreadable", r);
+    }
+}
+
+/// <summary>The pole-symmetric half of the same fact, driven at <see cref="FieldsDiff"/> directly: when BOTH poles
+/// are unreadable at one path there is nothing to compare there, so the record must not be reported identical.
+/// Driven here because one truncated plugin cannot be both poles of a lane call — the shape of the failure belongs
+/// to the comparison, not to the read.</summary>
+[Trait("tier", "unit")]
+public sealed class UnreadableLeafComparisonTests
+{
+    static RecordFields Rec(params FieldValue[] fields) => new("WEAP", "000800:A.esm", "HcWeap", fields);
+
+    static FieldValue Unreadable(string path) =>
+        new(path, false, null, "(unreadable: out of range)", Present: false, Readable: false);
+
+    [Fact]
+    public void TwoUnreadablePolesAtOnePathAreNotIdentical()
+    {
+        var d = FieldsDiff.Compare(Rec(new FieldValue("EditorID", true, "HcWeap", null), Unreadable("BasicStats.Damage")),
+                                   Rec(new FieldValue("EditorID", true, "HcWeap", null), Unreadable("BasicStats.Damage")));
+
+        Assert.False(d.Complete);
+        Assert.Contains("BasicStats.Damage: UNREADABLE on both sides — not compared", d.Deltas);
+    }
+
+    /// <summary>A no-such-field is the OTHER Readable=false answer and stays comparable: it says something true
+    /// about the record, so two sides that both lack the field still agree on that.</summary>
+    [Fact]
+    public void ANoSuchFieldStillCompares()
+    {
+        var missing = new FieldValue("Nope", false, null, "(no field Nope)", Present: false, Readable: false);
+        var d = FieldsDiff.Compare(Rec(missing), Rec(missing));
+
+        Assert.True(d.Complete);
+        Assert.Empty(d.Deltas);
     }
 }

--- a/src/housecarl-mcp-tests/RecordsUnreadableSubFieldTests.cs
+++ b/src/housecarl-mcp-tests/RecordsUnreadableSubFieldTests.cs
@@ -220,6 +220,21 @@ public sealed class UnreadableLeafComparisonTests
         Assert.Contains("BasicStats.Damage: UNREADABLE on both sides — not compared", d.Deltas);
     }
 
+    /// <summary>A fault the walk spells some other way — an FLOI whose mode or index it could not read — is a
+    /// no-verdict too: what makes a line incomparable is the Readable bit, not the note's prose.</summary>
+    [Fact]
+    public void AnFloiFaultIsNotComparedEither()
+    {
+        var floi = new FieldValue("Conditions[0].Data.Reference", false, null,
+                                  "(floi: form mode, null or unreadable FormKey on FormLinkOrIndex`1)",
+                                  Present: false, Readable: false);
+        var d = FieldsDiff.Compare(Rec(new FieldValue("EditorID", true, "HcWeap", null), floi),
+                                   Rec(new FieldValue("EditorID", true, "HcWeap", null), floi));
+
+        Assert.False(d.Complete);
+        Assert.Contains("Conditions[0].Data.Reference: UNREADABLE on both sides — not compared", d.Deltas);
+    }
+
     /// <summary>A no-such-field is the OTHER Readable=false answer and stays comparable: it says something true
     /// about the record, so two sides that both lack the field still agree on that.</summary>
     [Fact]

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -297,7 +297,7 @@ internal static class Artifacts
             writer.WriteRow((w, ms) => JsonWire.WriteDeltaRow(w, row, ms, int.MaxValue),
                             row.Error is null ? row.Subject?.RecordType : null);
         var (manifest, err) = writer.Save(path, ToolNames.Records, query, "formid",
-                                          new[] { "formid", "type", "editorid", "subject", "reference", "stack_above?", "note?", "complete", "deltas", "delta_count", "agreed_count" },
+                                          new[] { "formid", "type", "editorid", "subject", "reference", "stack_above?", "note?", "complete", "deltas", "delta_count", "no_verdict_count", "agreed_count" },
                                           "input order", rows.Count, epoch ?? "");
         return err is not null ? (null, err) : (new SpillInfo(path, manifest!, reason), null);
     }

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -657,6 +657,9 @@ static class JsonWire
         }
         w.WriteEndArray();
         w.WriteNumber("delta_count", d.Deltas.Count);
+        // How many of those lines are NO-VERDICTS rather than value differences — the third state, so a consumer
+        // counting differences subtracts it instead of matching the line text.
+        w.WriteNumber("no_verdict_count", d.NoVerdictCount);
         if (cut) { w.WriteNumber("deltas_rendered", rendered); w.WriteBoolean("deltas_truncated", true); }
         w.WriteNumber("agreed_count", d.AgreedCount);
         w.WriteEndObject();

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -959,13 +959,17 @@ public static class RecordsTools
             envelope.Add(new("versus", rArm ?? versusSpec!.Label));
             headerLine += $"  versus={rArm ?? versusSpec!.Label}";
             CoverageNote(covers);
-            int differing = rows.Count(x => x.Error is null && x.Diff!.Deltas.Count > 0);
+            // A no-verdict (a field neither side could be compared at) is a THIRD state: it is not a value
+            // difference, so it stays out of `differing`, and it is not identity either — `identical` already
+            // excludes it via Complete. It gets its own count instead of being folded into one of the two.
+            int differing = rows.Count(x => x.Error is null && x.Diff!.Deltas.Count > x.Diff.NoVerdictCount);
             int identical = rows.Count(x => x.Error is null && x.Diff!.Deltas.Count == 0 && x.Diff.Complete);
+            int noVerdict = rows.Count(x => x.Error is null && x.Diff!.NoVerdictCount > 0);
             int errs = rows.Count(x => x.Error is not null);
             if (counts_only)
                 return json
-                    ? JsonWire.RenderNamedCounts(envelope, new[] { KvI("count", rows.Count), KvI("differing", differing), KvI("identical", identical), KvI("errors", errs) }, epoch)
-                    : $"{headerLine}\ncount={rows.Count} differing={differing} identical={identical} errors={errs}" + Wire.EpochLine(epoch);
+                    ? JsonWire.RenderNamedCounts(envelope, new[] { KvI("count", rows.Count), KvI("differing", differing), KvI("identical", identical), KvI("no_verdict", noVerdict), KvI("errors", errs) }, epoch)
+                    : $"{headerLine}\ncount={rows.Count} differing={differing} identical={identical} no_verdict={noVerdict} errors={errs}" + Wire.EpochLine(epoch);
             var winRows = Windowed(rows);
             SpillState? spill = null;
             if (wantFile)
@@ -974,10 +978,10 @@ public static class RecordsTools
                 if (aerr is not null) return json ? JsonWire.RenderError(aerr, epoch) : "error: " + aerr;
                 spill = SpillState.Spilled(s!, manifestOnly: true);
             }
-            var deltaCounts = new[] { KvI("count", rows.Count), KvI("differing", differing), KvI("identical", identical), KvI("errors", errs) };
+            var deltaCounts = new[] { KvI("count", rows.Count), KvI("differing", differing), KvI("identical", identical), KvI("no_verdict", noVerdict), KvI("errors", errs) };
             string Render(SpillState? sp, out bool trunc) => json
                 ? JsonWire.RenderDelta(winRows, max_chars, epoch, envelope, deltaCounts, sp, out trunc)
-                : RenderRecordsDelta(winRows, rows.Count, differing, identical, errs, headerLine, epoch, max_chars, sp, out trunc);
+                : RenderRecordsDelta(winRows, rows.Count, differing, identical, noVerdict, errs, headerLine, epoch, max_chars, sp, out trunc);
             var rendered = Render(spill, out var truncated);
             if (spill is null && truncated)
             {
@@ -1771,7 +1775,8 @@ public static class RecordsTools
     /// <summary>The delta form's text render: header counts, then per record the two pole lines, the stack-above
     /// fact stated neutrally rather than as advice, and the delta-line grammar — where a truncated deep read is
     /// never rendered as 'identical'.</summary>
-    static string RenderRecordsDelta(IReadOnlyList<LoadOrderService.DeltaRow> rows, int total, int differing, int identical, int errors,
+    static string RenderRecordsDelta(IReadOnlyList<LoadOrderService.DeltaRow> rows, int total, int differing, int identical,
+                                     int noVerdict, int errors,
                                      string headerLine, OrderStamp? epoch, int maxChars, SpillState? spill, out bool truncated)
     {
         truncated = false;
@@ -1780,7 +1785,11 @@ public static class RecordsTools
         var sb = new StringBuilder();
         sb.Append(headerLine).Append('\n');
         sb.Append(total).Append(" record(s): ").Append(differing).Append(" differing, ").Append(identical)
-          .Append(" identical, ").Append(errors).Append(" error(s)");
+          .Append(" identical, ");
+        // Named only when there are any: a record with a field neither side could be compared at is in neither of
+        // the two counts above, so leaving it unnamed would make them look like they had lost a record.
+        if (noVerdict > 0) sb.Append(noVerdict).Append(" with a field that could not be read, ");
+        sb.Append(errors).Append(" error(s)");
         if (epoch is not null) sb.Append(Wire.EpochInline(epoch));
         sb.Append('\n');
         int rendered = 0;
@@ -1821,8 +1830,15 @@ public static class RecordsTools
             }
             else
             {
-                sb.Append("  ").Append(d.Deltas.Count).Append(d.Deltas.Count == 1 ? " difference" : " differences")
-                  .Append(" — each line: ").Append(s.LabelVersus(r.Plugin)).Append("'s value (reference = ")
+                // The block heads with the VALUE differences and names the no-verdict lines apart from them: an
+                // UNREADABLE line is explicitly not a value, so counting it as one contradicts the line itself.
+                int values = d.Deltas.Count - d.NoVerdictCount;
+                sb.Append("  ");
+                if (values > 0) sb.Append(values).Append(values == 1 ? " difference" : " differences");
+                if (d.NoVerdictCount > 0)
+                    sb.Append(values > 0 ? " and " : "").Append(d.NoVerdictCount)
+                      .Append(d.NoVerdictCount == 1 ? " field that could not be read" : " fields that could not be read");
+                sb.Append(" — each value line: ").Append(s.LabelVersus(r.Plugin)).Append("'s value (reference = ")
                   .Append(r.LabelVersus(s.Plugin)).Append("):\n");
                 foreach (var delta in d.Deltas)
                 {

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -1861,8 +1861,11 @@ public static class RecordsTools
 
     /// <summary>The tree form's text render: per record the touching list in load order with the winner last,
     /// and each provider's delta against the reference. Same wording rules as the delta form — identical is
-    /// never claimed over a truncated read, list contents compare by content, and reorders are flagged.</summary>
-    static string RenderRecordsTree(IReadOnlyList<LoadOrderService.TreeRow> rows, int total, int contested, int errors,
+    /// never claimed over a truncated read, list contents compare by content, and reorders are flagged.
+    /// Internal so a test can drive it against a hand-built <see cref="LoadOrderService.TreeRow"/>, the same
+    /// reason <see cref="AppendChildDeclarers"/> is: a node shape no fixture produces (an incomplete comparison
+    /// on a record only one in-order plugin touches) has no other way in.</summary>
+    internal static string RenderRecordsTree(IReadOnlyList<LoadOrderService.TreeRow> rows, int total, int contested, int errors,
                                     bool fieldsNarrow, string headerLine, OrderStamp? epoch, int maxChars,
                                     SpillState? spill, out bool truncated)
     {
@@ -1917,10 +1920,15 @@ public static class RecordsTools
                     break;
                 }
                 sb.Append("    ").Append(n.Plugin).Append(n.IsWinner ? " (winner)" : "").Append(": ");
+                // The incompleteness note goes on EVERY incomplete node, not only the one with no deltas: an
+                // unreadable leaf always produces a delta line, so gating it on an empty delta list left the
+                // normal shape saying nothing about what was skipped.
                 if (n.Deltas.Count > 0)
-                    sb.Append(string.Join("; ", n.Deltas)).Append('\n');
+                    sb.Append(string.Join("; ", n.Deltas))
+                      .Append(n.Complete ? "" : " — the comparison is INCOMPLETE: a field could not be read (nothing at or under it was compared), or the deep read hit the cap (which suppresses list-content and one-sided-presence deltas for the whole record)")
+                      .Append('\n');
                 else if (!n.Complete)
-                    sb.Append("no differing fields in what was read, but the deep read was TRUNCATED — not a clean 'identical'.\n");
+                    sb.Append("no differing fields in what was read, but the comparison is INCOMPLETE — the deep read was TRUNCATED at the cap, so this is not a clean 'identical'.\n");
                 else
                     sb.Append(fieldsNarrow
                         ? $"identical to {row.ReferencePlugin} across the fields read ({n.AgreedCount} leaf/leaves agree)\n"

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -1835,7 +1835,7 @@ public static class RecordsTools
                     sb.Append("    - ").Append(delta).Append('\n');
                 }
                 if (!d.Complete)
-                    sb.Append("  note: the comparison is INCOMPLETE — the deep read hit the cap, or a field above could not be read; list-content and one-sided-presence deltas are SUPPRESSED. Narrow with ").Append(LeverNames.Records.Fields).Append(" to compare those in full.\n");
+                    sb.Append("  note: the comparison is INCOMPLETE — a field above could not be read (nothing at or under it was compared), or the deep read hit the cap (which suppresses list-content and one-sided-presence deltas for the whole record). Narrow with ").Append(LeverNames.Records.Fields).Append(" to compare those in full.\n");
             }
             rendered++;
         }

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -1835,7 +1835,7 @@ public static class RecordsTools
                     sb.Append("    - ").Append(delta).Append('\n');
                 }
                 if (!d.Complete)
-                    sb.Append("  note: the deep read was TRUNCATED — list-content and one-sided-presence deltas are SUPPRESSED; narrow with ").Append(LeverNames.Records.Fields).Append(" to compare those in full.\n");
+                    sb.Append("  note: the comparison is INCOMPLETE — the deep read hit the cap, or a field above could not be read; list-content and one-sided-presence deltas are SUPPRESSED. Narrow with ").Append(LeverNames.Records.Fields).Append(" to compare those in full.\n");
             }
             rendered++;
         }


### PR DESCRIPTION
A deep read (`project.depth` 2 or more) expands a substruct by reflecting its fields, and a getter that threw was skipped with `catch { continue; }`, so the sub-field was left out of the result entirely — indistinguishable from a field the record does not carry, which is the silently wrong answer the read surface is not allowed to give. The expansion now emits that sub-field's own line with the same `(unreadable: …)` note and the same `Readable=false` the depth-1 read already emits, and carries on with the siblings, so a batch, a probe or a catalogue keeps every other field on the row. The same treatment covers the two neighbouring silent skips in the same walk (a gendered arm that will not resolve or throws) and the reason is unwrapped out of reflection's `TargetInvocationException`, whose own message names nothing a caller can act on. Where the walk can say which it is — a name that came off the type's own reflection is modelled, so a miss there is a fault and not a coverage gap — it says so outright; #528's "cannot tell not-modelled from a typo" seam is untouched. `NavigateValue` now carries its readable/absent classification structurally rather than leaving the deep path's own fault line claiming `Readable=true`, so no render decides "could not look" versus "nothing there" by matching prose.

The isolation is per CHILD, not per getter: every recursion (substruct field, list element, dict value, gendered arm) goes through `ExpandChild`, which wraps `Expand` in the same try/catch. A fault under one child — its own token emit, its element count, a grandchild's getter — names that child's path and the sibling walk carries on. Unwinding to the caller instead dropped every later sibling (each then reading as absent) and pinned a second line on the parent's own path, which both row folds discard, so the fault could vanish entirely.

And the comparison forms carry it. `FieldsDiff` had no notion of `Readable`: a fault note entered the exact-path map as if it were a token, so two poles unreadable at the same path compared identical (`identical to <ref> (whole record)`), and an unreadable-vs-read pair was reported as a value difference — the engine asserting a reading it does not have. An unreadable leaf is now kept out of the comparison and clears `Complete`, and its path is named as its own delta with the read's own reason (`BasicStats.Damage: UNREADABLE here — not compared (unreadable: …)`), so such a record can be neither counted `identical` nor reported as differing in value: a no-verdict is a third state, carried on `FieldsDiff.Result` and counted as `no_verdict` rather than folded into `differing`. What it suppresses is scoped to that path and everything under it, plus the element comparison of a list it sits inside — a cap, whose whole line set is unreliable, keeps its record-wide suppression, but an unreadable leaf removes exactly one known path and the rest of the record still compares. Both comparison forms say the comparison was incomplete whenever it was, deltas or no deltas.

The two `Readable=false` answers are separated by the bit, not by prose kept per consumer: everything `Readable=false` is a no-verdict except the one comparable answer, a no-such-field (`ReadEngine.NoFieldPrefix` / `ReadEngine.IsNoSuchFieldNote`), which says something true about the record. Keying on the fault note's own prefix instead covered only the getter throw and let the walk's other fault notes — an FLOI it cannot read, a `*parent` hop it cannot take — back in as comparable values.

Closes #560

## A deliberate behaviour change

`ReflectedFieldNames` yields a name and `ResolveProperty` then resolves it; where it returned null, the old walk expanded a null value and the line rendered `(absent)`. It now renders as a fault. That branch is unreachable by construction, which is why the fault is the right answer for it rather than an absence: `ReflectedFieldNames` collects properties off `PrimaryGetter(t)` plus that interface's own interfaces (or, for a substruct, `t` plus its interfaces), and `ResolveProperty(t, name)` searches `t` plus `t.GetInterfaces()` — which is the transitive closure and therefore a superset of the set the name came from. A name that reached the resolve call has a declaration inside the closure being searched. If that ever stops holding it is a fault in the read walk, and saying "the record does not carry this field" would be the silently wrong answer.

## How it renders

Text (`format='text'`, `project.form='fields'`):

```
  BasicStats.Value = 34
  BasicStats.Weight = 5.5
  BasicStats.Damage = (unreadable: Specified argument was out of the range of valid values.)
```

JSON (`format='json'`) — the field object carries the note in place of a value, exactly as a top-level fault does:

```json
{ "path": "BasicStats.Damage", "note": "(unreadable: Specified argument was out of the range of valid values.)" }
```

`rows` (whose fold already keeps a line when `Readable` is false) and `everything` render from the same emitted lines. `delta` and `tree` render from the comparison, which names the path and refuses the identity claim.

## Tests

`src/housecarl-mcp-tests/RecordsUnreadableSubFieldTests.cs`. The fault is a real one, not an injected hook: the world writes a master and an override with Mutagen, then cuts the override's DATA declared length from 10 to 8 (with the enclosing record and group sizes), which is what a truncated or badly merged plugin looks like on disk. The weapon's record opens, its `BasicStats` substruct opens, `Value` and `Weight` read, and `Damage` throws inside Mutagen because it sits past the end of its own subrecord. The plugin is read through the off-order lane out of a switched-off mod folder — a record that faults during the active order's index build excludes its whole plugin, which is separate, already-loud behaviour — and the clean master it overrides is the delta's reference pole.

- `TheFieldsFormNamesTheSubFieldAndTheReasonAndKeepsItsSiblings` — before: no `BasicStats.Damage` line at all, assertion fails. After: passes.
- `TheJsonRenderCarriesTheFaultAsThatFieldsOwnNote` — before: no field object with that path, `Single` throws. After: passes.
- `AnEverythingReadKeepsTheRestOfTheRecordAndStillNamesTheFault` — before: the record's other fields are there but the fault line is missing, assertion fails. After: passes.
- `ADeltaNamesTheUnreadableFieldInsteadOfCallingItAValueDifference` — before: the delta reads `BasicStats.Damage=(unreadable: …)` as a value difference and the comparison claims to be complete, assertion fails. After: passes.
- `UnreadableLeafComparisonTests.TwoUnreadablePolesAtOnePathAreNotIdentical` — the pole-symmetric half, driven at `FieldsDiff` because one truncated plugin cannot be both poles of a lane call. Before: `Complete` is true and there is no delta, so the record renders identical; assertion fails. After: passes. `ANoSuchFieldStillCompares` is its control — the other `Readable=false` answer stays comparable.

New from Aaron's round, in the same file: `ADifferingListBesideAnUnreadableLeafIsStillCompared` and `AnUnreadableLeafInsideAnElementSuppressesOnlyThatList` pin the scoping, `AnFloiFaultIsNotComparedEither` pins the gate on the bit rather than the prose, `UnreadableLinkLeafReadTests.AnUnreadableConditionTargetIsNotReadAsAbsent` pins the readable bit through the deep read's link leaf (an index-mode FLOI, which is a live fault today), `ANoVerdictIsCountedApartFromValueDifferences` pins `differing=0 identical=0 no_verdict=1`, and `TreeIncompleteNoteTests` drives the tree render against a hand-built row for the note beside deltas.

`RecordsRowsFormTests.AnUnreadableSubFieldIsNotAnAbsentOne` carried a comment saying no read could produce such a line; that is no longer true, so it points at the new tests instead.

## Review

Seven findings from the blind review folded, one refuted (an arm in `RecordsWorldLifecycleTests`: nine worlds repoint the process-global corpus path and two have arms there, so a tenth would be one more per-world guard rather than the general arm the suite would actually need). Reasons are on each thread.

Aaron's round: all five folded — the gate keyed on the readable bit, the readable bit carried through the deep read's link leaf, suppression scoped to the unreadable path, the no-verdict counted as its own state, and the tree's incompleteness note moved beside its deltas. The scoped suppression is the judgement call of the five: it restores what this PR had been quieting (a differing list beside an unreadable scalar) and keeps `Complete` false, but reverting to record-wide suppression is a one-line change if that trade is wanted the other way. Reasons are on each thread.

## Run

From the worktree: `dotnet build housecarl.sln -c Release` clean, and `dotnet test src/housecarl-mcp-tests -c Release --no-build --filter "tier!=bridge"` green at 1632 passed. `ci-all` was not run locally (#570); CI runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

