### PR TITLE
Gather a walk's bodies per hop so a big selection fits in memory

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -39,6 +39,15 @@ saying it sets an expectation their install may contradict. Say what is known, a
   a fresh write, never on an `into=` extend, and not at all on a profile that names no mod at all (a missing
   `modlist.txt`), where an enabled mod folder and an unregistered one cannot be told apart.
 
+- **A `housecarl_records` walk over a big selection now runs, where it used to die with an internal
+  out-of-memory error.** Reading each seed's and each reached node's body walked the whole winning plugin
+  looking for that one record, so the call's cost was the number of seeds times the plugin's record count: a
+  template-chain walk over one large mod's NPCs ran the server out of memory. Every seed now advances one hop
+  at a time and the hop's bodies come from one pass per source plugin, so a walk costs what its seeds cost.
+  The one-call shape — a scan-scoped selection feeding `walk=` — and the two-step shape (`to_file=`, then
+  `formids=["@<path>"]`) now both pay that, and neither is a workaround for the other. A walk still renders
+  the set it reaches under its own node budget, described on `walk.max_nodes`, not under the render bound on
+  `limit=`. A cancel sent by the client stops a walk between hops.
 - **A `housecarl_records` scan now says what its render cost, refuses a render too big to finish, and stops
   when the client sends a cancel.** Reading a record body per rendered row used to walk the whole winning
   plugin for each one, so a projection of a few fields over a big selection could run for tens of minutes with

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -47,9 +47,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
   The one-call shape — a scan-scoped selection feeding `walk=` — and the two-step shape (`to_file=`, then
   `formids=["@<path>"]`) now both pay that, and neither is a workaround for the other. What a walk reaches is
   bounded by its own node budget, described on `walk.max_nodes`, and a seed that has spent that budget now reads
-  nothing further. A reading form that renders the reached set refuses up front when the set is too big to
-  render, naming `project.form='chain'` and narrower seeds; `chain` reads no body per rendered row and is not held
-  to it, though the walk itself still reads one per reached node whatever the form. A cancel sent by the client
+  nothing further. Any reading form that renders the reached set — `summary`, `fields`, `rows`, `everything`,
+  `aggregate` — refuses up front when the set is too big to render, on the forward walk and on both reverse walks,
+  naming that lane's own levers: its seeds, `walk.depth` and `walk.max_nodes` where they move it, and
+  `project.form='chain'` on the two lanes chain can draw. `chain` reads no body per rendered row and is not held to
+  the bound, though the walk itself still reads one per reached node whatever the form. A cancel sent by the client
   stops a walk between hops.
 - **A `housecarl_records` scan now says what its render cost, refuses a render too big to finish, and stops
   when the client sends a cancel.** Reading a record body per rendered row used to walk the whole winning

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -48,8 +48,9 @@ saying it sets an expectation their install may contradict. Say what is known, a
   `formids=["@<path>"]`) now both pay that, and neither is a workaround for the other. What a walk reaches is
   bounded by its own node budget, described on `walk.max_nodes`, and a seed that has spent that budget now reads
   nothing further. A reading form that renders the reached set refuses up front when the set is too big to
-  render, naming `project.form='chain'` and narrower seeds; `chain` itself reads no record body and is not held
-  to it. A cancel sent by the client stops a walk between hops.
+  render, naming `project.form='chain'` and narrower seeds; `chain` reads no body per rendered row and is not held
+  to it, though the walk itself still reads one per reached node whatever the form. A cancel sent by the client
+  stops a walk between hops.
 - **A `housecarl_records` scan now says what its render cost, refuses a render too big to finish, and stops
   when the client sends a cancel.** Reading a record body per rendered row used to walk the whole winning
   plugin for each one, so a projection of a few fields over a big selection could run for tens of minutes with

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -45,9 +45,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
   template-chain walk over one large mod's NPCs ran the server out of memory. Every seed now advances one hop
   at a time and the hop's bodies come from one pass per source plugin, so a walk costs what its seeds cost.
   The one-call shape — a scan-scoped selection feeding `walk=` — and the two-step shape (`to_file=`, then
-  `formids=["@<path>"]`) now both pay that, and neither is a workaround for the other. A walk still renders
-  the set it reaches under its own node budget, described on `walk.max_nodes`, not under the render bound on
-  `limit=`. A cancel sent by the client stops a walk between hops.
+  `formids=["@<path>"]`) now both pay that, and neither is a workaround for the other. What a walk reaches is
+  bounded by its own node budget, described on `walk.max_nodes`, and a seed that has spent that budget now reads
+  nothing further. A reading form that renders the reached set refuses up front when the set is too big to
+  render, naming `project.form='chain'` and narrower seeds; `chain` itself reads no record body and is not held
+  to it. A cancel sent by the client stops a walk between hops.
 - **A `housecarl_records` scan now says what its render cost, refuses a render too big to finish, and stops
   when the client sends a cancel.** Reading a record body per rendered row used to walk the whole winning
   plugin for each one, so a projection of a few fields over a big selection could run for tens of minutes with

--- a/src/housecarl-mcp-tests/RecordsRenderCostTests.cs
+++ b/src/housecarl-mcp-tests/RecordsRenderCostTests.cs
@@ -389,16 +389,18 @@ public sealed class RecordsRenderCostTests
         Assert.True(doc.GetProperty("render_ms").GetInt64() >= 0);
     }
 
-    /// <summary>A walk is measured on what it RENDERS, not on the size of the scan that seeded it: the walk lane
-    /// windows its own rows under its own node budget, so refusing it for the seed count would refuse a call for a
-    /// cost it was never going to pay.</summary>
+    /// <summary>A walk is measured on what it RENDERS — the set it reached — and not on the size of the scan that
+    /// seeded it, which is a different count and a different lane. So the refusal that comes back is the walk
+    /// lane's, naming the walk's own levers, and never the scan window's.</summary>
     [Fact]
-    public void AWalkIsNotRefusedForTheSizeOfItsSeedScan()
+    public void AWalkIsMeasuredOnWhatItReachedAndNotOnItsSeedScan()
     {
         var response = WithBound(10, () =>
             RecordsTools.Records(Svc, types: Weap, walk: new RecordsTools.RecordsWalk(), project: Fields()));
 
-        Assert.DoesNotContain("reads a record body", response);
+        Assert.StartsWith("error:", response);
+        Assert.Contains("project.form='chain'", response);
+        Assert.DoesNotContain("re-scans", response);          // the scan's window is not what moves a walk
     }
 
     /// <summary>The census reads no bodies, so it is not bound by the render's cost.</summary>

--- a/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
+++ b/src/housecarl-mcp-tests/RecordsReverseIndexTests.cs
@@ -353,6 +353,44 @@ public sealed class RecordsReverseIndexTests : RecordsTestBase
                                      walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 1 });
         Served(r, "selection = 2 record(s) (1 referrer(s)");
     }
+
+    // ---- the reached set's render bound, on the two reverse lanes ------------------------------------
+
+    /// <summary>Both reverse walks hand the list lane their whole reached set, so a reading form over either reads
+    /// a body per row exactly as a forward walk's does — and is held to the same bound. The transitive lane's set
+    /// is its shared node budget; the carrier lane's is the seeds times the per-seed budget.</summary>
+    [Fact]
+    public void ATransitiveReverseWalkTooBigToRenderRefuses()
+    {
+        var r = WithBound(1, () =>
+            RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefHop) },
+                                 walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 2 },
+                                 project: Fields("EditorID")));
+        Refused(r, "walk.max_nodes", "walk.depth");
+        // chain refuses on this lane, so the remedy must not send the caller to it as the shape to run first.
+        Assert.DoesNotContain("which is what to run first", r);
+    }
+
+    /// <summary>The carrier lane's own remedy: chain CAN draw this walk, and walk.depth cannot move it because the
+    /// walk reaches nothing past hop 1.</summary>
+    [Fact]
+    public void AReverseCarrierWalkTooBigToRenderRefusesNamingTheChainForm()
+    {
+        var r = WithBound(1, () =>
+            RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefHop) },
+                                 walk: new RecordsTools.RecordsWalk { direction = "reverse", follow = "Effects[].BaseEffect" },
+                                 project: Fields("EditorID")));
+        Refused(r, "project.form='chain'", "walk.max_nodes");
+        Assert.DoesNotContain("walk.depth", r);
+    }
+
+    static string WithBound(int rows, Func<string> call)
+    {
+        var prior = RenderBudget.MaxRenderRows;
+        RenderBudget.MaxRenderRows = rows;
+        try { return call(); }
+        finally { RenderBudget.MaxRenderRows = prior; }
+    }
 }
 
 /// <summary>The index's own lifecycle: what a build costs, that a second call pays nothing, that a plugin whose

--- a/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
+++ b/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
@@ -1,0 +1,197 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlGenerator;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// A world whose point is the SHAPE a walk pays for: many seeds sitting in one plugin that also holds many other
+/// records. A walk's old per-node body read was a whole-plugin seek, so its cost was the seed count TIMES the
+/// plugin's record count; a handful of records in a small plugin cannot show that, and the shared worlds are both.
+/// </summary>
+public sealed class WalkCostWorld : IDisposable
+{
+    /// <summary>NPC seeds, each on the same template chain.</summary>
+    public const int Seeds = 300;
+
+    /// <summary>Distinct items per seed, so a closure walk's first hop reaches records nothing else reaches.</summary>
+    public const int ItemsPerSeed = 3;
+
+    public string Root { get; }
+    public string MasterName { get; }
+    public LoadOrderService Svc { get; }
+
+    readonly string _priorCorpusPath;
+
+    public WalkCostWorld()
+    {
+        _priorCorpusPath = CorpusRulebook.CorpusPath;
+        Root = Path.Combine(Path.GetTempPath(), "hc-walkcost-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(Root, "game", "Data"));
+
+        var masterKey = new ModKey("HcWalkCostMaster", ModType.Master);
+        MasterName = masterKey.FileName.String;
+        var master = new SkyrimMod(masterKey, SkyrimRelease.SkyrimSE);
+
+        var top = master.Npcs.AddNew();
+        top.EditorID = "HcWalkTemplateTop";
+        var mid = master.Npcs.AddNew();
+        mid.EditorID = "HcWalkTemplateMid";
+        mid.Template.SetTo(top);
+        mid.Configuration.TemplateFlags = NpcConfiguration.TemplateFlag.Stats;
+
+        for (int i = 0; i < Seeds; i++)
+        {
+            var n = master.Npcs.AddNew();
+            n.EditorID = "HcWalkSeed" + i;
+            n.Template.SetTo(mid);
+            n.Configuration.TemplateFlags = NpcConfiguration.TemplateFlag.Stats;
+            n.Items = new Noggog.ExtendedList<ContainerEntry>();
+            for (int j = 0; j < ItemsPerSeed; j++)
+            {
+                var item = master.Ammunitions.AddNew();
+                item.EditorID = $"HcWalkItem{i}_{j}";
+                n.Items.Add(new ContainerEntry { Item = new ContainerItem { Item = item.ToLink(), Count = 1 } });
+            }
+        }
+
+        var instance = Path.Combine(Root, "inst");
+        var mods = Path.Combine(instance, "mods");
+        Directory.CreateDirectory(Path.Combine(mods, "WalkCostMod"));
+        master.BeginWrite.ToPath(Path.Combine(mods, "WalkCostMod", MasterName))
+              .WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+        var genDir = Path.Combine(Root, "corpus-gen");
+        CorpusGenerator.GenerateAll(genDir, Path.Combine(Root, "corpus-ref"));
+        CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json");
+
+        File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(Root, "game").Replace(@"\", @"\\") + ")\r\n");
+        var prof = Path.Combine(instance, "profiles", "Default");
+        Directory.CreateDirectory(prof);
+        File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + MasterName + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*" + MasterName + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n+WalkCostMod\r\n");
+
+        Svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(Root, "user.json")));
+    }
+
+    public void Dispose()
+    {
+        CorpusRulebook.CorpusPath = _priorCorpusPath;
+        Svc.Dispose();
+        try { Directory.Delete(Root, true); } catch { /* temp cleanup best-effort */ }
+    }
+}
+
+/// <summary>The shared walk-cost world. One build per collection.</summary>
+public sealed class WalkCostFixture : IDisposable
+{
+    public WalkCostWorld W { get; } = new();
+    public void Dispose() => W.Dispose();
+}
+
+/// <summary>Its own collection: <c>CorpusRulebook.CorpusPath</c> is a process-global and one world owns it at a time.</summary>
+[CollectionDefinition("walk-cost")]
+public sealed class WalkCostCollection : ICollectionFixture<WalkCostFixture> { }
+
+/// <summary>
+/// What a walk over a big selection costs (#556). A scan-scoped selection feeding the chain walk died with an
+/// internal OutOfMemoryException at 2,235 NPC seeds, because the walk read each node's body with the whole-plugin
+/// seek #582 took out of the scan and batch lanes: one walk of the winning plugin per seed and per reached node, so
+/// the call's cost was the seed count times the plugin's record count.
+/// </summary>
+[Collection("walk-cost")]
+[Trait("tier", "integration")]
+public sealed class RecordsWalkCostTests
+{
+    readonly WalkCostWorld _w;
+    public RecordsWalkCostTests(WalkCostFixture f) => _w = f.W;
+
+    LoadOrderService Svc => _w.Svc;
+    static readonly string[] Npc = { "NPC_" };
+    static RecordsTools.RecordsProject Chain() => new() { form = "chain" };
+    RecordsTools.RecordsScope Scope() => new() { names = new[] { _w.MasterName } };
+
+    /// <summary>The template chain, the shape the issue was reported on.</summary>
+    static RecordsTools.RecordsWalk TemplateWalk() =>
+        new() { follow = "Template", seed_paths = new[] { "Template" } };
+
+    // ---- the cost itself ---------------------------------------------------------------------------
+
+    /// <summary>The seeds are known before the walk starts, so their bodies come from one enumeration per source
+    /// plugin. Before, each seed cost a whole-plugin seek of its own.</summary>
+    [Fact]
+    public void AWalkGathersItsSeedBodiesOncePerPluginNotOncePerSeed()
+    {
+        var before = LoadOrderResolver.BodySeeks;
+        var response = RecordsTools.Records(Svc, types: Npc, plugins: Scope(), walk: TemplateWalk(),
+                                            project: Chain(), counts_only: true);
+        var seeks = LoadOrderResolver.BodySeeks - before;
+
+        Assert.Contains($"seeds={WalkCostWorld.Seeds + 2}", response);
+        Assert.True(seeks <= 1, $"{WalkCostWorld.Seeds + 2} walk seeds cost {seeks} per-record plugin walks.");
+    }
+
+    /// <summary>Every seed advances one hop together, so a hop's reached nodes are one gather too. Before, a closure
+    /// walk paid a whole-plugin seek per distinct node as well as per seed — the same call without seed_paths, which
+    /// is how the issue was also reproduced.</summary>
+    [Fact]
+    public void AWalkGathersEachHopsBodiesTogetherNotOnePerNode()
+    {
+        var before = LoadOrderResolver.BodySeeks;
+        var response = RecordsTools.Records(Svc, types: Npc, plugins: Scope(),
+                                            walk: new RecordsTools.RecordsWalk { depth = 1 },
+                                            project: Chain(), counts_only: true);
+        var seeks = LoadOrderResolver.BodySeeks - before;
+
+        Assert.Contains($"reached={WalkCostWorld.Seeds * (WalkCostWorld.ItemsPerSeed + 1) + 1}", response);
+        Assert.True(seeks <= 1, $"a closure walk over {WalkCostWorld.Seeds} seeds cost {seeks} per-record plugin walks.");
+    }
+
+    /// <summary>What the seeks meant in memory. A walk's allocation now scales with the SEEDS, not with the seeds
+    /// times the plugin behind them: 9 MB over these 302 seeds, where the per-node seek spent 240 MB on the same
+    /// call and rose with every record added to the plugin. The bound is allocated bytes, which a run reports
+    /// exactly — no clock, so no flaky timing.</summary>
+    [Fact]
+    public void AWalkCostsWithItsSeedsNotWithThePluginBehindThem()
+    {
+        // The same call once first: the index build and the JIT of everything below are one-time costs of the
+        // process, not of a walk, and measuring them would make the number depend on which test ran first.
+        string Walk() => RecordsTools.Records(Svc, types: Npc, plugins: Scope(), walk: TemplateWalk(),
+                                              project: Chain(), counts_only: true);
+        Walk();
+
+        var before = GC.GetTotalAllocatedBytes(precise: true);
+        Walk();
+        var allocated = GC.GetTotalAllocatedBytes(precise: true) - before;
+
+        const long perSeedCeiling = 128 * 1024;
+        var ceiling = perSeedCeiling * (WalkCostWorld.Seeds + 2);
+        Assert.True(allocated < ceiling,
+                    $"the walk allocated {allocated / 1048576} MB over {WalkCostWorld.Seeds + 2} seeds — past the {ceiling / 1048576} MB this world's seed count allows.");
+    }
+
+    // ---- and it stops when the client stops waiting -------------------------------------------------
+
+    /// <summary>The walk's hop loop honours the call's cancellation token, like every other loop that reads a body
+    /// (#582). Its engine entry took no token at all before.</summary>
+    [Fact]
+    public void AWalkStopsWhenTheClientCancels()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var q = Svc.CrossQuery(Npc, null, null, false, new[] { _w.MasterName }, null, int.MaxValue);
+        Assert.Null(q.Error);
+        var seeds = q.Keys.Select(k => k.ToString()).ToArray();
+
+        Assert.Throws<OperationCanceledException>(() =>
+            Svc.WalkForwardBatch(seeds, new[] { "Template" }, "Template", 16, 2000,
+                                 Array.Empty<(string, bool)>(), null, out _, out _, cts.Token));
+    }
+}

--- a/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
+++ b/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
@@ -116,6 +116,7 @@ public sealed class RecordsWalkCostTests
     LoadOrderService Svc => _w.Svc;
     static readonly string[] Npc = { "NPC_" };
     static RecordsTools.RecordsProject Chain() => new() { form = "chain" };
+    static RecordsTools.RecordsProject Fields() => new() { form = "fields", fields = new[] { "EditorID" } };
     RecordsTools.RecordsScope Scope() => new() { names = new[] { _w.MasterName } };
 
     /// <summary>The template chain, the shape the issue was reported on.</summary>
@@ -204,6 +205,49 @@ public sealed class RecordsWalkCostTests
         Assert.True(seeks <= 1, $"a capped walk cost {seeks} per-record plugin walks.");
     }
 
+    // ---- what the reached set costs to RENDER --------------------------------------------------------
+
+    /// <summary>The walk lane returns above the scan's render bound, because the seed count is not the rendered
+    /// count. The reached count is, so a reading form that consumes the reached set is measured against the same
+    /// bound — otherwise a walk that no longer runs out of memory hands the list lane seeds times walk.max_nodes
+    /// bodies with no ceiling at all. The remedy is the walk's own, not the scan's window.</summary>
+    [Fact]
+    public void AReachedSetTooBigToRenderRefusesNamingTheChainFormAndNarrowerSeeds()
+    {
+        var response = WithBound(10, () =>
+            RecordsTools.Records(Svc, types: Npc, plugins: Scope(), walk: TemplateWalk(), project: Fields()));
+
+        Assert.StartsWith("error:", response);
+        Assert.Contains("project.form='chain'", response);
+        Assert.Contains("walk.max_nodes", response);
+        Assert.Contains("walk.depth", response);
+        Assert.DoesNotContain("re-scans", response);          // the scan's window is not what moves a walk
+        Assert.DoesNotContain("does not combine", response);
+    }
+
+    /// <summary>The chain form stays exempt: it renders the walk's own rows and reads no record body, so the same
+    /// call under the same bound serves.</summary>
+    [Fact]
+    public void TheChainFormIsNotHeldToTheBodyRenderBound()
+    {
+        var response = WithBound(10, () =>
+            RecordsTools.Records(Svc, types: Npc, plugins: Scope(), walk: TemplateWalk(),
+                                 project: Chain(), counts_only: true));
+
+        Assert.DoesNotContain("error:", response);
+        Assert.Contains($"seeds={WalkCostWorld.Seeds + 2}", response);
+    }
+
+    /// <summary>Under the bound nothing changes: the same reading form serves the set the walk reached.</summary>
+    [Fact]
+    public void AReachedSetUnderTheBoundRendersAsBefore()
+    {
+        var response = WithBound(WalkCostWorld.Seeds * 4, () =>
+            RecordsTools.Records(Svc, types: Npc, plugins: Scope(), walk: TemplateWalk(), project: Fields()));
+
+        Assert.DoesNotContain("error:", response);
+    }
+
     // ---- and it stops when the client stops waiting -------------------------------------------------
 
     /// <summary>The engine entry takes the call's token and hands it to the body gather, so a walk cancelled before
@@ -237,6 +281,16 @@ public sealed class RecordsWalkCostTests
     }
 
     // ---- helpers -----------------------------------------------------------------------------------
+
+    /// <summary>Run one call with the named-fields render bound moved, restored whatever happens — building
+    /// 300,000 reachable records to meet the real one is not a test.</summary>
+    static string WithBound(int rows, Func<string> call)
+    {
+        var prior = RenderBudget.MaxRenderRows;
+        RenderBudget.MaxRenderRows = rows;
+        try { return call(); }
+        finally { RenderBudget.MaxRenderRows = prior; }
+    }
 
     /// <summary>Every NPC in the world, as walk seeds.</summary>
     string[] Seeds()

--- a/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
+++ b/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
@@ -206,19 +206,61 @@ public sealed class RecordsWalkCostTests
 
     // ---- and it stops when the client stops waiting -------------------------------------------------
 
-    /// <summary>The walk's hop loop honours the call's cancellation token, like every other loop that reads a body
-    /// (#582). Its engine entry took no token at all before.</summary>
+    /// <summary>The engine entry takes the call's token and hands it to the body gather, so a walk cancelled before
+    /// it starts stops in the first gather rather than reading every seed. Its entry took no token at all before.
+    /// The hop loop's own polls are what <see cref="AWalkStopsBetweenHopsWhenTheClientCancels"/> proves.</summary>
     [Fact]
-    public void AWalkStopsWhenTheClientCancels()
+    public void AWalkCancelledBeforeItStartsStopsInTheSeedGather()
     {
         using var cts = new CancellationTokenSource();
         cts.Cancel();
-        var q = Svc.CrossQuery(Npc, null, null, false, new[] { _w.MasterName }, null, int.MaxValue);
-        Assert.Null(q.Error);
-        var seeds = q.Keys.Select(k => k.ToString()).ToArray();
 
         Assert.Throws<OperationCanceledException>(() =>
-            Svc.WalkForwardBatch(seeds, new[] { "Template" }, "Template", 16, 2000,
+            Svc.WalkForwardBatch(Seeds(), new[] { "Template" }, "Template", 16, 2000,
                                  Array.Empty<(string, bool)>(), null, out _, out _, cts.Token));
+    }
+
+    /// <summary>The cancel that arrives once the walk is already running: the hop loop polls between seeds and
+    /// between hops, like every other loop that reads a body (#582). The token is tripped from inside the walk —
+    /// the exclusion list is read once per reached node, so enumerating it cancels after hop 1 has begun — and the
+    /// poll at the top of the next seed's turn is what throws.</summary>
+    [Fact]
+    public void AWalkStopsBetweenHopsWhenTheClientCancels()
+    {
+        using var cts = new CancellationTokenSource();
+        var exclusions = new CancelOnFirstRead(cts);
+
+        Assert.Throws<OperationCanceledException>(() =>
+            Svc.WalkForwardBatch(Seeds(), new[] { "Template" }, "Template", 16, 2000,
+                                 exclusions, null, out _, out _, cts.Token));
+        Assert.True(exclusions.WasRead, "the walk never reached a node, so the hop loop is not what stopped it.");
+    }
+
+    // ---- helpers -----------------------------------------------------------------------------------
+
+    /// <summary>Every NPC in the world, as walk seeds.</summary>
+    string[] Seeds()
+    {
+        var q = Svc.CrossQuery(Npc, null, null, false, new[] { _w.MasterName }, null, int.MaxValue);
+        Assert.Null(q.Error);
+        return q.Keys.Select(k => k.ToString()).ToArray();
+    }
+
+    /// <summary>An empty exclusion list that cancels the moment the walk reads it — which the walk does once per
+    /// node it reaches, inside the hop loop. No production seam: the parameter is a list and this is a list.</summary>
+    sealed class CancelOnFirstRead : IReadOnlyList<(string Match, bool Refuse)>
+    {
+        readonly CancellationTokenSource _cts;
+        public CancelOnFirstRead(CancellationTokenSource cts) => _cts = cts;
+        public bool WasRead { get; private set; }
+        public int Count => 0;
+        public (string Match, bool Refuse) this[int index] => throw new ArgumentOutOfRangeException(nameof(index));
+        public IEnumerator<(string Match, bool Refuse)> GetEnumerator()
+        {
+            WasRead = true;
+            _cts.Cancel();
+            yield break;
+        }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
+++ b/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
@@ -1,4 +1,4 @@
-using Mutagen.Bethesda;
+﻿using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Skyrim;
 using HousecarlCore;
@@ -175,6 +175,33 @@ public sealed class RecordsWalkCostTests
         var ceiling = perSeedCeiling * (WalkCostWorld.Seeds + 2);
         Assert.True(allocated < ceiling,
                     $"the walk allocated {allocated / 1048576} MB over {WalkCostWorld.Seeds + 2} seeds — past the {ceiling / 1048576} MB this world's seed count allows.");
+    }
+
+    /// <summary>A seed at its node budget reads no further. The gather used to take every seed's whole hop frontier
+    /// before the budget was consulted on dequeue, so a walk capped at one node still read — and pinned — every
+    /// link off every seed to keep one of them. The budget now rides into the gather, and the cap itself is
+    /// unchanged: what is listed is reached and proved, and the truncation note still says so.</summary>
+    [Fact]
+    public void ACappedSeedGathersNoBodiesPastItsCap()
+    {
+        var beforeKeys = BodyPrefetch.KeysWanted;
+        var beforeSeeks = LoadOrderResolver.BodySeeks;
+        var response = RecordsTools.Records(Svc, types: Npc, plugins: Scope(),
+                                            walk: new RecordsTools.RecordsWalk { depth = 2, max_nodes = 1 },
+                                            project: Chain(), counts_only: true);
+        var wanted = BodyPrefetch.KeysWanted - beforeKeys;
+        var seeks = LoadOrderResolver.BodySeeks - beforeSeeks;
+
+        // Every seed but the top of the chain proves exactly one node, which is what the cap allows.
+        Assert.Contains($"reached={WalkCostWorld.Seeds + 1}", response);
+        // The seeds themselves, plus at most one body per seed for the one node each may still record. Before the
+        // budget rode into the gather this was the seeds plus their whole first frontier — a template link and
+        // ItemsPerSeed items each.
+        var ceiling = 2 * (WalkCostWorld.Seeds + 2);
+        Assert.True(wanted <= ceiling,
+                    $"a walk capped at one node per seed asked the gather for {wanted} bodies over {WalkCostWorld.Seeds + 2} seeds — past the {ceiling} its caps allow.");
+        // And trimming the gather did not push the walk back onto the per-record seek for what it does read.
+        Assert.True(seeks <= 1, $"a capped walk cost {seeks} per-record plugin walks.");
     }
 
     // ---- and it stops when the client stops waiting -------------------------------------------------

--- a/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
+++ b/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
@@ -272,6 +272,23 @@ public sealed class RecordsWalkCostTests
         Assert.DoesNotContain("does not combine", response);
     }
 
+    /// <summary>Every reading form the walk description names is held to the bound, not just the three that read
+    /// the caller's own field paths: summary and aggregate read a cheap leaf, but they read it off a BODY per row,
+    /// so a walk feeding them the reached set costs the same unbounded render the others do.</summary>
+    [Theory]
+    [InlineData("summary")]
+    [InlineData("aggregate")]
+    public void EveryReadingFormOverTheReachedSetIsHeldToTheBound(string form)
+    {
+        var response = WithBound(10, () =>
+            RecordsTools.Records(Svc, types: Npc, plugins: Scope(), walk: TemplateWalk(),
+                                 project: new RecordsTools.RecordsProject
+                                 { form = form, group_by = form == "aggregate" ? "type" : null }));
+
+        Assert.StartsWith("error:", response);
+        Assert.Contains("project.form='chain'", response);
+    }
+
     /// <summary>A walk is seeded from the formids= lane as well as from a scan, and there the scan terms are not
     /// part of the call at all — so the refusal names the seeds without them, rather than opening on three
     /// parameters the caller did not pass and could not pass alongside formids=.</summary>

--- a/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
+++ b/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
@@ -21,9 +21,16 @@ public sealed class WalkCostWorld : IDisposable
     /// <summary>Distinct items per seed, so a closure walk's first hop reaches records nothing else reaches.</summary>
     public const int ItemsPerSeed = 3;
 
+    /// <summary>Hubs in the revisit fan, and the fresh terminal each hub also carries.</summary>
+    public const int Hubs = 40;
+
     public string Root { get; }
     public string MasterName { get; }
     public LoadOrderService Svc { get; }
+
+    /// <summary>The seed of the revisit fan: a list of <see cref="Hubs"/> hubs that each point back at every hub and
+    /// at one terminal of their own, so hop 2's frontier is half revisits and half records still to reach.</summary>
+    public string RevisitSeed { get; }
 
     readonly string _priorCorpusPath;
 
@@ -58,6 +65,27 @@ public sealed class WalkCostWorld : IDisposable
                 n.Items.Add(new ContainerEntry { Item = new ContainerItem { Item = item.ToLink(), Count = 1 } });
             }
         }
+
+        // The revisit fan: every hub points at every hub (itself included) and at one terminal of its own, so a
+        // closure walk's hop 2 frontier is the hubs again — already visited — ahead of the terminals it can record.
+        var hubs = new List<FormList>(Hubs);
+        for (int i = 0; i < Hubs; i++)
+        {
+            var hub = master.FormLists.AddNew();
+            hub.EditorID = "HcWalkHub" + i;
+            hubs.Add(hub);
+        }
+        for (int i = 0; i < Hubs; i++)
+        {
+            foreach (var other in hubs) hubs[i].Items.Add(new FormLink<ISkyrimMajorRecordGetter>(other.FormKey));
+            var terminal = master.FormLists.AddNew();
+            terminal.EditorID = "HcWalkTerminal" + i;
+            hubs[i].Items.Add(new FormLink<ISkyrimMajorRecordGetter>(terminal.FormKey));
+        }
+        var fanSeed = master.FormLists.AddNew();
+        fanSeed.EditorID = "HcWalkFanSeed";
+        foreach (var hub in hubs) fanSeed.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(hub.FormKey));
+        RevisitSeed = fanSeed.FormKey.ToString();
 
         var instance = Path.Combine(Root, "inst");
         var mods = Path.Combine(instance, "mods");
@@ -203,6 +231,25 @@ public sealed class RecordsWalkCostTests
                     $"a walk capped at one node per seed asked the gather for {wanted} bodies over {WalkCostWorld.Seeds + 2} seeds — past the {ceiling} its caps allow.");
         // And trimming the gather did not push the walk back onto the per-record seek for what it does read.
         Assert.True(seeks <= 1, $"a capped walk cost {seeks} per-record plugin walks.");
+    }
+
+    /// <summary>A key the seed already visited is not gathered. The fill loop screened on the cross-seed set only,
+    /// so a hop whose frontier leads with revisits spent the seed's whole remaining budget on bodies the dequeue
+    /// throws away — and the nodes the seed did record, sitting past that prefix, fell back on the whole-plugin
+    /// seek this walk exists to remove.</summary>
+    [Fact]
+    public void AHopDoesNotSpendItsGatherOnNodesTheSeedAlreadyVisited()
+    {
+        var before = LoadOrderResolver.BodySeeks;
+        var response = RecordsTools.Records(Svc, formids: new[] { _w.RevisitSeed },
+                                            walk: new RecordsTools.RecordsWalk { depth = 2, max_nodes = 2 * WalkCostWorld.Hubs },
+                                            project: Chain(), counts_only: true);
+        var seeks = LoadOrderResolver.BodySeeks - before;
+
+        // The hubs at hop 1, their terminals at hop 2 — the same answer either way; only the cost differed.
+        Assert.Contains($"reached={2 * WalkCostWorld.Hubs}", response);
+        Assert.True(seeks <= 1,
+                    $"a hop whose frontier leads with {WalkCostWorld.Hubs} revisits cost {seeks} per-record plugin walks.");
     }
 
     // ---- what the reached set costs to RENDER --------------------------------------------------------

--- a/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
+++ b/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
@@ -290,8 +290,9 @@ public sealed class RecordsWalkCostTests
         Assert.DoesNotContain("where=", response);
     }
 
-    /// <summary>The chain form stays exempt: it renders the walk's own rows and reads no record body, so the same
-    /// call under the same bound serves.</summary>
+    /// <summary>The chain form stays exempt: it renders the walk's own rows and reads no body PER RENDERED ROW, so
+    /// the same call under the same bound serves. The walk still reads one per reached node, which is the cost the
+    /// bound is not measuring.</summary>
     [Fact]
     public void TheChainFormIsNotHeldToTheBodyRenderBound()
     {

--- a/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
+++ b/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
@@ -272,6 +272,24 @@ public sealed class RecordsWalkCostTests
         Assert.DoesNotContain("does not combine", response);
     }
 
+    /// <summary>A walk is seeded from the formids= lane as well as from a scan, and there the scan terms are not
+    /// part of the call at all — so the refusal names the seeds without them, rather than opening on three
+    /// parameters the caller did not pass and could not pass alongside formids=.</summary>
+    [Fact]
+    public void AFormidsSeededWalkIsRefusedWithoutNamingTheScanTerms()
+    {
+        var response = WithBound(10, () =>
+            RecordsTools.Records(Svc, formids: new[] { _w.RevisitSeed },
+                                 walk: new RecordsTools.RecordsWalk { depth = 2 }, project: Fields()));
+
+        Assert.StartsWith("error:", response);
+        Assert.Contains("the seeds you passed", response);
+        Assert.Contains("walk.max_nodes", response);
+        Assert.DoesNotContain("types=", response);
+        Assert.DoesNotContain("plugins=", response);
+        Assert.DoesNotContain("where=", response);
+    }
+
     /// <summary>The chain form stays exempt: it renders the walk's own rows and reads no record body, so the same
     /// call under the same bound serves.</summary>
     [Fact]

--- a/src/housecarl-mcp/BodyPrefetch.cs
+++ b/src/housecarl-mcp/BodyPrefetch.cs
@@ -30,6 +30,12 @@ internal static class BodyPrefetch
     /// <summary>The first row of the chunk row <paramref name="i"/> falls in.</summary>
     internal static int ChunkStart(int i) => i / ChunkRows * ChunkRows;
 
+    /// <summary>How many record bodies the gather has been asked for in this process — the keys it registers for a
+    /// plugin walk. Counted for the reason <see cref="LoadOrderResolver.BodySeeks"/> is: whether a caller gathered
+    /// only what it can use, or a whole frontier it then threw away, is invisible in the answer and only the cost
+    /// differs, so this is what a test can hold that claim to.</summary>
+    internal static long KeysWanted;
+
     /// <summary>The chunk covering rows <paramref name="start"/> (inclusive) to <paramref name="end"/> (exclusive):
     /// which plugin each row's body comes from, and each plugin's whole share of the chunk, ready to be walked when
     /// a row asks for it. <paramref name="sourceAt"/> names the plugin whose body a row displays, or null for the
@@ -52,6 +58,7 @@ internal static class BodyPrefetch
             set.Add(fk);
             plugins[fk] = plugin;
         }
+        Interlocked.Add(ref KeysWanted, plugins.Count);     // what this caller asked for, whether or not a row reads it
         return new Chunk(view, session, byPlugin, plugins, getterTypes, ct);
     }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4002,7 +4002,9 @@ public sealed class LoadOrderService : IDisposable
                 int took = 0;
                 foreach (var q in s.Frontier)
                 {
-                    if (q.Key.IsNull || !gatherSeen.Add(q.Key)) continue;
+                    // A key this seed already visited is dropped at dequeue, so gathering it would spend a slot on a
+                    // body no row ever shows and push a node the seed DOES record back onto the per-record seek.
+                    if (q.Key.IsNull || s.Visited.Contains(q.Key) || !gatherSeen.Add(q.Key)) continue;
                     frontier.Add(q.Key);
                     if (++took >= room) break;
                 }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -3808,16 +3808,36 @@ public sealed class LoadOrderService : IDisposable
                                         string? TruncationNote, IReadOnlyList<NpcTemplateCategory>? TemplateReport,
                                         string? Error);
 
+    /// <summary>One seed's walk in progress: the rows it has proved and the frontier it has still to enter. The walk
+    /// advances every seed one hop at a time, so a hop's bodies can be gathered together; this holds what used to be
+    /// locals of a per-seed loop.</summary>
+    sealed class WalkSeedState
+    {
+        public FormKey Key;
+        public IMajorRecordGetter Body = null!;
+        public string Type = "";
+        public string Label = "";
+        public List<WalkNodeRow> Nodes = new();
+        public List<string> Cycles = new();
+        public string? Truncation;
+        public HashSet<FormKey> Visited = new();
+        public Queue<(FormKey Key, int Depth, string PulledBy)> Frontier = new();
+    }
+
     /// <summary>The forward walk over the winner link graph, per seed off ONE captured build. The edge unit is the
     /// form link; within-record navigation stays the projection's path grammar. seed_paths scope the FIRST hop
     /// (default: every link); follow scopes every later hop (default "*" is closure via the generic
     /// EnumerateFormLinks, so there is no per-type list; a named path is a restricted chain). Exclusions are data
     /// handed in by the caller: stop prunes and records a boundary, refuse fails the whole call loudly naming the
-    /// seed and pull chain. Caps produce an explicit truncation note, never a silent cut.</summary>
+    /// seed and pull chain. Caps produce an explicit truncation note, never a silent cut.
+    /// <para>Every seed advances one hop together, so each hop's bodies come from one enumeration per source plugin
+    /// (<see cref="BodyPrefetch"/>) rather than the whole-plugin seek per record a demand-driven fetch pays — the
+    /// same gather the scan and batch lanes took in #582. Walking seed by seed made a walk's cost the seed count
+    /// times the winning plugin's record count, which is what ran a 2,235-NPC selection out of memory (#556).</para></summary>
     public IReadOnlyList<WalkSeedResult> WalkForwardBatch(
         IReadOnlyList<string> seeds, IReadOnlyList<string>? seedPaths, string? follow,
         int depth, int maxNodes, IReadOnlyList<(string Match, bool Refuse)> exclusions,
-        ArtifactDemand? demand, out string? refusal, out OrderStamp? epoch)
+        ArtifactDemand? demand, out string? refusal, out OrderStamp? epoch, CancellationToken ct = default)
     {
         refusal = null;
         var resolver = Resolver;
@@ -3845,6 +3865,21 @@ public sealed class LoadOrderService : IDisposable
             IMajorRecordGetter? g = view.ResolveWinner(k) is { } w ? view.GetRecord(session, w.WinnerPlugin, k) : null;
             bodyCache[k] = g;
             return g;
+        }
+        // The hop's bodies, one enumeration per source plugin. A key the gather does not return stays UNCACHED, so
+        // Fetch still raises whatever the per-record read raises: the gather is an optimisation, not an error path.
+        void Prefetch(IReadOnlyList<FormKey> keys)
+        {
+            var wanted = new List<FormKey>();
+            var seen = new HashSet<FormKey>();
+            foreach (var k in keys)
+                if (!k.IsNull && !bodyCache.ContainsKey(k) && seen.Add(k)) wanted.Add(k);
+            for (int i = 0; i < wanted.Count; i += BodyPrefetch.ChunkRows)
+            {
+                int end = Math.Min(i + BodyPrefetch.ChunkRows, wanted.Count);
+                foreach (var (k, b) in BodyPrefetch.Gather(view, session, wanted, i, end, _ => null, null, ct))
+                    bodyCache[k] = b;
+            }
         }
         static string TypeOf(IMajorRecordGetter b) => RecordNaming.StripOverlay(b.GetType().Name);
         List<FormKey> LinksOf(IMajorRecordGetter body, string[]? segs, out string? note)
@@ -3884,32 +3919,44 @@ public sealed class LoadOrderService : IDisposable
             return links ?? new List<FormKey>();
         }
 
-        var results = new List<WalkSeedResult>(seeds.Count);
-        foreach (var raw in seeds)
+        // ---- the seeds: parsed, then gathered together, then started on their first hop ----
+        var rows = new WalkSeedResult?[seeds.Count];
+        var states = new WalkSeedState?[seeds.Count];
+        var seedKeys = new FormKey[seeds.Count];
+        var seedGather = new List<FormKey>(seeds.Count);
+        for (int i = 0; i < seeds.Count; i++)
         {
-            FormKey seedFk;
-            try { seedFk = view.ParseFormId(raw); }
-            catch (Exception ex) { results.Add(new WalkSeedResult(raw?.Trim() ?? "", null, null, Array.Empty<WalkNodeRow>(), Array.Empty<string>(), null, null, $"bad FormID '{raw}': {ex.Message}")); continue; }
+            try { seedKeys[i] = view.ParseFormId(seeds[i]); seedGather.Add(seedKeys[i]); }
+            catch (Exception ex) { rows[i] = new WalkSeedResult(seeds[i]?.Trim() ?? "", null, null, Array.Empty<WalkNodeRow>(), Array.Empty<string>(), null, null, $"bad FormID '{seeds[i]}': {ex.Message}"); }
+        }
+        Prefetch(seedGather);
+
+        for (int i = 0; i < seeds.Count; i++)
+        {
+            if (rows[i] is not null) continue;
+            ct.ThrowIfCancellationRequested();
+            var seedFk = seedKeys[i];
             var seedBody = Fetch(seedFk);
             if (seedBody is null)
             {
                 // Fetch returns null for two conditions and they need different sentences: no winner at all (the
                 // three-cause unresolved sentence), or a named winner whose body did not come back on fetch.
                 var seedWin = view.ResolveWinner(seedFk);
-                results.Add(new WalkSeedResult(seedFk.ToString(), null, null, Array.Empty<WalkNodeRow>(), Array.Empty<string>(), null, null,
+                rows[i] = new WalkSeedResult(seedFk.ToString(), null, null, Array.Empty<WalkNodeRow>(), Array.Empty<string>(), null, null,
                     seedWin is null
                         ? UnresolvedFormId(view, seedFk) + " Nothing to walk from."
-                        : $"the winner body of {seedFk} could not be read from '{seedWin.Value.WinnerPlugin}' — nothing to walk from."));
+                        : $"the winner body of {seedFk} could not be read from '{seedWin.Value.WinnerPlugin}' — nothing to walk from.");
                 continue;
             }
             var seedType = TypeOf(seedBody);
-            var seedLabel = $"{seedType} {seedFk} ({seedBody.EditorID ?? "<no editorid>"})";
-
-            var nodes = new List<WalkNodeRow>();
-            var cycles = new List<string>();
-            string? truncation = null;
-            var visited = new HashSet<FormKey> { seedFk };
-            var queue = new Queue<(FormKey Key, int Depth, string PulledBy)>();
+            var st = new WalkSeedState
+            {
+                Key = seedFk,
+                Body = seedBody,
+                Type = seedType,
+                Label = $"{seedType} {seedFk} ({seedBody.EditorID ?? "<no editorid>"})",
+                Visited = new HashSet<FormKey> { seedFk },
+            };
 
             // First hop: seed_paths (each path's links) or every link on the seed.
             if (seedPaths is { Count: > 0 })
@@ -3920,72 +3967,97 @@ public sealed class LoadOrderService : IDisposable
                     if (segs.Length == 0) continue;
                     var links = LinksOf(seedBody, segs, out var note);
                     if (links.Count == 0 && note is not null)
-                        nodes.Add(new WalkNodeRow($"(seed path '{p}')", null, null, 0, seedLabel, "no links", note));   // a wrong path fails loudly in the rows
-                    foreach (var l in links) queue.Enqueue((l, 1, $"{seedLabel}.{p}"));
+                        st.Nodes.Add(new WalkNodeRow($"(seed path '{p}')", null, null, 0, st.Label, "no links", note));   // a wrong path fails loudly in the rows
+                    foreach (var l in links) st.Frontier.Enqueue((l, 1, $"{st.Label}.{p}"));
                 }
             }
             else
             {
-                foreach (var l in LinksOf(seedBody, null, out _)) queue.Enqueue((l, 1, seedLabel));
+                foreach (var l in LinksOf(seedBody, null, out _)) st.Frontier.Enqueue((l, 1, st.Label));
             }
+            states[i] = st;
+        }
 
-            string? refuseError = null;
-            while (queue.Count > 0 && refuseError is null)
-            {
-                var (key, d, pulledBy) = queue.Dequeue();
-                if (key.IsNull) continue;
-                if (!visited.Add(key))
-                {
-                    // A named-follow walk is a linear chain per seed, so a revisit IS a cycle: recorded and named,
-                    // never looped and never silently stopped. Closure walks dedupe on the visited set instead.
-                    if (followSegs is not null) cycles.Add($"{pulledBy} -> {key} (already on this chain)");
-                    continue;
-                }
-                if (nodes.Count >= maxNodes)
-                {
-                    truncation = $"walk truncated: the {maxNodes}-node cap was reached — what is listed IS reached and proved; raise walk.max_nodes to walk further.";
-                    break;
-                }
-                var body = Fetch(key);
-                if (body is null)
-                {
-                    nodes.Add(new WalkNodeRow(key.ToString(), null, null, d, pulledBy, "kept",
-                                              "unresolved — no active plugin defines this target (a missing endpoint)"));
-                    continue;
-                }
-                var type = TypeOf(body);
-                var excl = exclusions.FirstOrDefault(x => x.Match.Equals(type, StringComparison.OrdinalIgnoreCase));
-                if (excl.Match is not null)
-                {
-                    if (excl.Refuse) { refuseError = $"the walk reached a {type} ({key}, via {pulledBy}) — a node class this call excludes with severity 'refuse'. Nothing is returned for this call."; break; }
-                    nodes.Add(new WalkNodeRow(key.ToString(), type, body.EditorID, d, pulledBy, "kept", $"excluded ({type}, severity stop) — recorded as a boundary, not entered"));
-                    continue;
-                }
-                bool atCap = d >= depth;
-                nodes.Add(new WalkNodeRow(key.ToString(), type, body.EditorID, d, pulledBy,
-                                          atCap ? "kept" : "expanded",
-                                          atCap ? $"at the walk.depth cap ({depth}) — not entered" : null));
-                if (atCap)
-                {
-                    truncation ??= $"walk reached its depth cap ({depth}) on at least one chain — nodes at the cap are recorded, not entered; raise walk.depth to walk deeper.";
-                    continue;
-                }
-                var label = $"{type} {key} ({body.EditorID ?? "<no editorid>"})";
-                foreach (var l in LinksOf(body, followSegs, out _))
-                    if (!l.IsNull) queue.Enqueue((l, d + 1, label));
-            }
-            if (refuseError is not null)
-            {
-                refusal = refuseError;
-                return Array.Empty<WalkSeedResult>();
-            }
+        // ---- the hops: every seed advances one hop together, so the hop's bodies are ONE gather ----
+        // A node at the depth cap is recorded and not entered, so nothing is ever queued past `depth`.
+        for (int d = 1; d <= depth; d++)
+        {
+            ct.ThrowIfCancellationRequested();
+            var frontier = new List<FormKey>();
+            foreach (var s in states)
+                if (s is not null)
+                    foreach (var q in s.Frontier) frontier.Add(q.Key);
+            if (frontier.Count == 0) break;
+            Prefetch(frontier);
 
+            foreach (var st in states)
+            {
+                if (st is null) continue;
+                ct.ThrowIfCancellationRequested();
+                int atLevel = st.Frontier.Count;
+                for (int q = 0; q < atLevel; q++)
+                {
+                    var (key, hop, pulledBy) = st.Frontier.Dequeue();
+                    if (key.IsNull) continue;
+                    if (!st.Visited.Add(key))
+                    {
+                        // A named-follow walk is a linear chain per seed, so a revisit IS a cycle: recorded and named,
+                        // never looped and never silently stopped. Closure walks dedupe on the visited set instead.
+                        if (followSegs is not null) st.Cycles.Add($"{pulledBy} -> {key} (already on this chain)");
+                        continue;
+                    }
+                    if (st.Nodes.Count >= maxNodes)
+                    {
+                        st.Truncation = $"walk truncated: the {maxNodes}-node cap was reached — what is listed IS reached and proved; raise walk.max_nodes to walk further.";
+                        st.Frontier.Clear();
+                        break;
+                    }
+                    var body = Fetch(key);
+                    if (body is null)
+                    {
+                        st.Nodes.Add(new WalkNodeRow(key.ToString(), null, null, hop, pulledBy, "kept",
+                                                     "unresolved — no active plugin defines this target (a missing endpoint)"));
+                        continue;
+                    }
+                    var type = TypeOf(body);
+                    var excl = exclusions.FirstOrDefault(x => x.Match.Equals(type, StringComparison.OrdinalIgnoreCase));
+                    if (excl.Match is not null)
+                    {
+                        // A refuse ends the whole call. Hops run before seeds now, so the sentence names the first
+                        // seed IN SEED ORDER that reaches the class at the SHALLOWEST hop any seed reaches it.
+                        if (excl.Refuse)
+                        {
+                            refusal = $"the walk reached a {type} ({key}, via {pulledBy}) — a node class this call excludes with severity 'refuse'. Nothing is returned for this call.";
+                            return Array.Empty<WalkSeedResult>();
+                        }
+                        st.Nodes.Add(new WalkNodeRow(key.ToString(), type, body.EditorID, hop, pulledBy, "kept", $"excluded ({type}, severity stop) — recorded as a boundary, not entered"));
+                        continue;
+                    }
+                    bool atCap = hop >= depth;
+                    st.Nodes.Add(new WalkNodeRow(key.ToString(), type, body.EditorID, hop, pulledBy,
+                                                 atCap ? "kept" : "expanded",
+                                                 atCap ? $"at the walk.depth cap ({depth}) — not entered" : null));
+                    if (atCap)
+                    {
+                        st.Truncation ??= $"walk reached its depth cap ({depth}) on at least one chain — nodes at the cap are recorded, not entered; raise walk.depth to walk deeper.";
+                        continue;
+                    }
+                    var label = $"{type} {key} ({body.EditorID ?? "<no editorid>"})";
+                    foreach (var l in LinksOf(body, followSegs, out _))
+                        if (!l.IsNull) st.Frontier.Enqueue((l, hop + 1, label));
+                }
+            }
+        }
+
+        var results = new List<WalkSeedResult>(seeds.Count);
+        for (int i = 0; i < seeds.Count; i++)
+        {
+            if (states[i] is not { } st) { results.Add(rows[i]!); continue; }
             IReadOnlyList<NpcTemplateCategory>? templateReport = null;
             if (followSegs is { Length: 1 } && followSegs[0].Equals("Template", StringComparison.OrdinalIgnoreCase)
-                && seedBody is INpcGetter seedNpc)
-                templateReport = NpcTemplateReport(Fetch, seedNpc, seedFk);
-
-            results.Add(new WalkSeedResult(seedFk.ToString(), seedType, seedBody.EditorID, nodes, cycles, truncation, templateReport, null));
+                && st.Body is INpcGetter seedNpc)
+                templateReport = NpcTemplateReport(Fetch, seedNpc, st.Key);
+            results.Add(new WalkSeedResult(st.Key.ToString(), st.Type, st.Body.EditorID, st.Nodes, st.Cycles, st.Truncation, templateReport, null));
         }
         return results;
     }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4066,6 +4066,9 @@ public sealed class LoadOrderService : IDisposable
                     foreach (var l in LinksOf(body, followSegs, out _))
                         if (!l.IsNull) st.Frontier.Enqueue((l, hop + 1, label));
                 }
+                // An empty frontier means this seed is finished — nothing but its own turn ever enqueues into it —
+                // and the results loop reads neither of these, so the bookkeeping goes back now rather than at return.
+                if (st.Frontier.Count == 0) { st.Visited = new(); st.Frontier = new(); }
             }
         }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1,4 +1,4 @@
-using Mutagen.Bethesda.Plugins;
+﻿using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Aspects;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
@@ -3877,8 +3877,11 @@ public sealed class LoadOrderService : IDisposable
             for (int i = 0; i < wanted.Count; i += BodyPrefetch.ChunkRows)
             {
                 int end = Math.Min(i + BodyPrefetch.ChunkRows, wanted.Count);
-                foreach (var (k, b) in BodyPrefetch.Gather(view, session, wanted, i, end, _ => null, null, ct))
-                    bodyCache[k] = b;
+                var chunk = BodyPrefetch.Gather(view, session, wanted, i, end, _ => null, null, ct);
+                // The walk asks for every key it gathered — it already trimmed the frontier to what it can record —
+                // so the chunk's deferred per-plugin walk is forced here rather than left to a render that never comes.
+                for (int k = i; k < end; k++)
+                    if (chunk.Body(wanted[k]) is { } body) bodyCache[wanted[k]] = body;
             }
         }
         static string TypeOf(IMajorRecordGetter b) => RecordNaming.StripOverlay(b.GetType().Name);
@@ -3983,12 +3986,29 @@ public sealed class LoadOrderService : IDisposable
         for (int d = 1; d <= depth; d++)
         {
             ct.ThrowIfCancellationRequested();
+            // The gather is bounded by what each seed can still RECORD, not by the size of its frontier: a seed
+            // whose node budget is spent reads nothing more, and a seed near its cap reads only what it can still
+            // admit. A key left out stays uncached, which is the contract Prefetch already runs on, so the cap
+            // itself is still enforced below — recorded and not entered, with the same sentence.
             var frontier = new List<FormKey>();
+            var gatherSeen = new HashSet<FormKey>();
+            bool pending = false;
             foreach (var s in states)
-                if (s is not null)
-                    foreach (var q in s.Frontier) frontier.Add(q.Key);
-            if (frontier.Count == 0) break;
-            Prefetch(frontier);
+            {
+                if (s is null || s.Frontier.Count == 0) continue;
+                pending = true;
+                int room = maxNodes - s.Nodes.Count;
+                if (room <= 0) continue;                                  // at its cap: its turn below records the cut
+                int took = 0;
+                foreach (var q in s.Frontier)
+                {
+                    if (q.Key.IsNull || !gatherSeen.Add(q.Key)) continue;
+                    frontier.Add(q.Key);
+                    if (++took >= room) break;
+                }
+            }
+            if (!pending) break;
+            if (frontier.Count > 0) Prefetch(frontier);
 
             foreach (var st in states)
             {

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -169,6 +169,9 @@ public static class RecordsTools
         }
         bool comparisonForm = form is "delta" or "tree";
         bool bodyFields = form is "fields" or "rows";   // the two forms that read the caller's own field paths
+        // Every reading form reads a body per row: summary and aggregate one cheap leaf, fields/rows the caller's
+        // paths, everything the whole record. This is the set a derived selection's render bound is measured over.
+        bool bodyForm = bodyFields || form is "summary" or "everything" or "aggregate";
         // Sub-parameters exist only inside their forms; a stray one is refused by name, so the caller learns the
         // form-scoping rule instead of getting a silently ignored knob.
         if (project?.fields is { Length: > 0 } && !bodyFields && !comparisonForm)
@@ -908,7 +911,7 @@ public static class RecordsTools
             // walk.max_nodes rows, each one a body read by the list lane. Same two lanes as the scan's bound, its
             // own remedy, since the scan window is not what moves a walk. form='chain' stays exempt and returned
             // above: it renders the walk's own rows, so it pays no SECOND body read on top of the walk's own.
-            if ((bodyFields || form == "everything") && !counts_only
+            if (bodyForm && !counts_only
                 && RenderBudget.Refuse(combined.Count, form == "everything", RenderBudget.WalkRemedy) is { } walkTooBig)
                 return Wire.Refuse(json, walkTooBig, wEpoch);
 

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -848,7 +848,7 @@ public static class RecordsTools
             // Forward: one engine batch, one captured build. The chain form renders it; every other form
             // consumes the reached set — seeds included, and the render says so — through the normal lanes.
             var rows = svc.WalkForwardBatch(ids, walk!.seed_paths, walk.follow, walkDepth, walkMaxNodes,
-                                            walkExclusions, demand, out var wRefusal, out var wEpoch);
+                                            walkExclusions, demand, out var wRefusal, out var wEpoch, ct);
             if (wRefusal is not null)
                 return json ? JsonWire.RenderError(wRefusal, wEpoch) : "error: " + wRefusal + Wire.EpochLine(wEpoch);
             if (SeamTear(wEpoch) is { } wTear)

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -64,7 +64,7 @@ public static class RecordsTools
         [Description("Maximum hops from a seed (default 16). Nodes AT the cap are recorded, not entered, and the response says the cap cut the walk — never a silent stop.")]
         public int? depth { get; set; }
 
-        [Description("The node budget (default 2000, the read-expansion budget). Per seed on a forward walk and on the reverse carrier walk (each seed's carrier rows); ONE budget shared across every seed and every hop on the transitive reverse walk, whose hops are one frontier and not a per-seed expansion. A breach keeps what was proved and says which reading it spent. A reading form (summary/fields/rows/everything/aggregate) then renders the whole reached set — seeds times this budget at the worst — and reads a body per row, so it is held to the same render bound a scan is and refuses up front naming project.form='chain', which lists the same set without reading a body per rendered row (the walk reads one per reached node whatever the form).")]
+        [Description("The node budget (default 2000, the read-expansion budget). Per seed on a forward walk and on the reverse carrier walk (each seed's carrier rows); ONE budget shared across every seed and every hop on the transitive reverse walk, whose hops are one frontier and not a per-seed expansion. A breach keeps what was proved and says which reading it spent. A reading form (summary/fields/rows/everything/aggregate) then renders the whole reached set — seeds times this budget at the worst — and reads a body per row, so it is held to the same render bound a scan is on EVERY walk lane, and refuses up front naming that lane's own levers: its seeds, this budget, and — on the forward and carrier walks, the two chain can draw — project.form='chain', which lists the same set without reading a body per rendered row (the walk reads one per reached node whatever the form).")]
         public int? max_nodes { get; set; }
 
         [Description("Node classes the walk must not enter, as data: [{\"match\": \"Race\", \"severity\": \"stop\"|\"refuse\"}] — match is the record type name a read reports; stop prunes there (recorded as a boundary), refuse fails the whole call loud.")]
@@ -730,6 +730,12 @@ public static class RecordsTools
                 }
                 if (rev.Capped)
                     headerLine += $"\n[!] the walk.max_nodes budget ({walkMaxNodes}, one budget shared across every seed and hop on this lane) was reached — what is listed IS reached and proved, and the hop it cut is marked; raise walk.max_nodes to walk further.";
+                // The reached set's render bound, the same one the forward walk pays: this lane hands the list lane
+                // its whole reached set and every reading form reads a body per row. Its own remedy, because chain
+                // refuses on this walk and the scan terms are refused on it too.
+                if (bodyForm && !counts_only
+                    && RenderBudget.Refuse(rev.Selection.Count, form == "everything", RenderBudget.ReverseTransitiveRemedy) is { } revTooBig)
+                    return Wire.Refuse(json, revTooBig, rev.Stamp);
                 expectEpoch = rev.Epoch;
                 formids = rev.Selection.ToArray();
                 walk = null;
@@ -813,6 +819,12 @@ public static class RecordsTools
                         headerLine += $"\n[!] {seedErrs2} seed(s) failed and contributed no carriers — run form='chain' to see each seed's outcome.";
                     if (cappedSeeds > 0)
                         headerLine += $"\n[!] {cappedSeeds} seed(s) hit the walk.max_nodes carrier bound ({walkMaxNodes}, per seed on this lane) — the selection is a prefix of the {carrierTotal} carrier(s) reached; raise walk.max_nodes.";
+                    // The reached set's render bound, the same one the forward walk pays: seeds times the per-seed
+                    // carrier budget at the worst, each row a body read by the list lane. walk.depth is not among
+                    // its levers, because this walk reaches nothing past hop 1.
+                    if (bodyForm && !counts_only
+                        && RenderBudget.Refuse(carrierSel.Count, form == "everything", RenderBudget.ReverseCarrierRemedy) is { } carrierTooBig)
+                        return Wire.Refuse(json, carrierTooBig, epochR);
                     expectEpoch = epochR?.Epoch;
                     formids = carrierSel.ToArray();
                     walk = null;

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -64,7 +64,7 @@ public static class RecordsTools
         [Description("Maximum hops from a seed (default 16). Nodes AT the cap are recorded, not entered, and the response says the cap cut the walk — never a silent stop.")]
         public int? depth { get; set; }
 
-        [Description("The node budget (default 2000, the read-expansion budget). Per seed on a forward walk and on the reverse carrier walk (each seed's carrier rows); ONE budget shared across every seed and every hop on the transitive reverse walk, whose hops are one frontier and not a per-seed expansion. A breach keeps what was proved and says which reading it spent. A reading form (summary/fields/rows/everything/aggregate) then renders the whole reached set — seeds times this budget at the worst — and reads a body per row, so it is held to the same render bound a scan is and refuses up front naming project.form='chain', which lists the same set without reading a body.")]
+        [Description("The node budget (default 2000, the read-expansion budget). Per seed on a forward walk and on the reverse carrier walk (each seed's carrier rows); ONE budget shared across every seed and every hop on the transitive reverse walk, whose hops are one frontier and not a per-seed expansion. A breach keeps what was proved and says which reading it spent. A reading form (summary/fields/rows/everything/aggregate) then renders the whole reached set — seeds times this budget at the worst — and reads a body per row, so it is held to the same render bound a scan is and refuses up front naming project.form='chain', which lists the same set without reading a body per rendered row (the walk reads one per reached node whatever the form).")]
         public int? max_nodes { get; set; }
 
         [Description("Node classes the walk must not enter, as data: [{\"match\": \"Race\", \"severity\": \"stop\"|\"refuse\"}] — match is the record type name a read reports; stop prunes there (recorded as a boundary), refuse fails the whole call loud.")]
@@ -907,7 +907,7 @@ public static class RecordsTools
             // scan's bound below the walk lane exempts a walk; the REACHED count is it — up to seeds x
             // walk.max_nodes rows, each one a body read by the list lane. Same two lanes as the scan's bound, its
             // own remedy, since the scan window is not what moves a walk. form='chain' stays exempt and returned
-            // above: it renders the walk's own rows, not the records' bodies.
+            // above: it renders the walk's own rows, so it pays no SECOND body read on top of the walk's own.
             if ((bodyFields || form == "everything") && !counts_only
                 && RenderBudget.Refuse(combined.Count, form == "everything", RenderBudget.WalkRemedy) is { } walkTooBig)
                 return Wire.Refuse(json, walkTooBig, wEpoch);

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Text;
 using System.Text.Json;
 using ModelContextProtocol.Server;
@@ -64,7 +64,7 @@ public static class RecordsTools
         [Description("Maximum hops from a seed (default 16). Nodes AT the cap are recorded, not entered, and the response says the cap cut the walk — never a silent stop.")]
         public int? depth { get; set; }
 
-        [Description("The node budget (default 2000, the read-expansion budget). Per seed on a forward walk and on the reverse carrier walk (each seed's carrier rows); ONE budget shared across every seed and every hop on the transitive reverse walk, whose hops are one frontier and not a per-seed expansion. A breach keeps what was proved and says which reading it spent.")]
+        [Description("The node budget (default 2000, the read-expansion budget). Per seed on a forward walk and on the reverse carrier walk (each seed's carrier rows); ONE budget shared across every seed and every hop on the transitive reverse walk, whose hops are one frontier and not a per-seed expansion. A breach keeps what was proved and says which reading it spent. A reading form (summary/fields/rows/everything/aggregate) then renders the whole reached set — seeds times this budget at the worst — and reads a body per row, so it is held to the same render bound a scan is and refuses up front naming project.form='chain', which lists the same set without reading a body.")]
         public int? max_nodes { get; set; }
 
         [Description("Node classes the walk must not enter, as data: [{\"match\": \"Race\", \"severity\": \"stop\"|\"refuse\"}] — match is the record type name a read reports; stop prunes there (recorded as a boundary), refuse fails the whole call loud.")]
@@ -573,7 +573,7 @@ public static class RecordsTools
             // whole-record refusal and to_file= point at. Checked before any body is read, and counts_only pays it
             // too: this lane reads the list whatever it renders, where the scan lane's census reads no bodies.
             if ((bodyFields || form == "everything") && !walkDerived
-                && RenderBudget.Refuse(ids.Length, form == "everything", listSelection: true) is { } listTooBig)
+                && RenderBudget.Refuse(ids.Length, form == "everything", RenderBudget.ListRemedy) is { } listTooBig)
                 return Wire.Refuse(json, listTooBig);
 
             // ---- summary / fields / everything / aggregate: batch bodies off the source pole. ----
@@ -902,6 +902,16 @@ public static class RecordsTools
             if (combined.Count == 0)
                 return json ? JsonWire.RenderError($"the walk reached nothing readable ({seedErrs} seed error(s) — run form='chain' to see each seed's outcome).", wEpoch)
                             : $"error: the walk reached nothing readable ({seedErrs} seed error(s) — run form='chain' to see each seed's outcome)." + Wire.EpochLine(wEpoch);
+
+            // ---- the reached set's own render bound. The seed scan's count was never this count, which is why the
+            // scan's bound below the walk lane exempts a walk; the REACHED count is it — up to seeds x
+            // walk.max_nodes rows, each one a body read by the list lane. Same two lanes as the scan's bound, its
+            // own remedy, since the scan window is not what moves a walk. form='chain' stays exempt and returned
+            // above: it renders the walk's own rows, not the records' bodies.
+            if ((bodyFields || form == "everything") && !counts_only
+                && RenderBudget.Refuse(combined.Count, form == "everything", RenderBudget.WalkRemedy) is { } walkTooBig)
+                return Wire.Refuse(json, walkTooBig, wEpoch);
+
             envelope.Add(new("walk", $"forward{(walk.follow is { } f3 ? $" follow={f3}" : " (closure)")} depth={walkDepth} — selection = the {combined.Count} record(s) the walk reached (seeds included{(seedErrs > 0 ? $"; {seedErrs} seed error(s), listed via form='chain'" : "")})"));
             headerLine += $"\nwalk: selection = {combined.Count} reached record(s) (seeds included)";
             expectEpoch = wEpoch?.Epoch;
@@ -1288,7 +1298,7 @@ public static class RecordsTools
             // timeout (#582). Checked before any body is read, so the caller learns the shape instead of waiting,
             // and BELOW the walk lane, which returned above: a walk renders the set it reaches under its own node
             // budget, not the seed scan this count is of, so measuring it here would refuse a call for a cost it
-            // was never going to pay.
+            // was never going to pay. The walk lane measures its own reached count against the same bound.
             // The two lanes are measured separately: a named-fields row reads the paths it was given, an
             // 'everything' row materialises the whole record, and the two are two orders of magnitude apart.
             if ((bodyFields || form == "everything") && !counts_only

--- a/src/housecarl-mcp/RenderBudget.cs
+++ b/src/housecarl-mcp/RenderBudget.cs
@@ -98,6 +98,24 @@ internal static class RenderBudget
         "so limit= and offset= window the render and not the walk. project.form='chain' lists the same reached set " +
         "without reading a body per rendered row, which is what to run first.";
 
+    /// <summary>What moves the REVERSE CARRIER walk's row count. Its seeds are formids= and its budget is per seed,
+    /// so walk.depth is not a lever — the walk reaches nothing past hop 1.</summary>
+    internal const string ReverseCarrierRemedy =
+        "pass fewer formids= seeds, or lower walk.max_nodes (the per-seed carrier " +
+        "bound), until the set the walk reaches fits — the rows are the carriers it reached, seeds included, so " +
+        "limit= and offset= window the render and not the walk. types= narrows the carrier types, and " +
+        "project.form='chain' lists the same reached set without reading a body per rendered row, which is what to " +
+        "run first.";
+
+    /// <summary>What moves the TRANSITIVE REVERSE walk's row count. project.form='chain' is not a lever here: that
+    /// walk expands one shared frontier and has no per-seed path to draw, which is why chain refuses on it.</summary>
+    internal const string ReverseTransitiveRemedy =
+        "pass fewer formids= seeds, or lower walk.depth or walk.max_nodes " +
+        "(one budget shared across every seed and hop on this lane), until the set the walk reaches fits — the rows " +
+        "are what the walk reached, seeds included, so limit= and offset= window the render and not the walk. " +
+        "project.form='chain' is not a lever here: this walk expands one shared frontier and has no per-seed path " +
+        "for chain to draw.";
+
     /// <summary>The refusal for a render over its lane's bound, or null when it fits. One sentence for the cost, one
     /// for the shapes that fit, each carrying the caveat that decides between them. <paramref name="wholeRecord"/>
     /// is the <c>form='everything'</c> lane, whose row is a whole record and whose bound is therefore its own —

--- a/src/housecarl-mcp/RenderBudget.cs
+++ b/src/housecarl-mcp/RenderBudget.cs
@@ -89,13 +89,14 @@ internal static class RenderBudget
 
     /// <summary>What moves a WALK's row count. The rows are what the walk REACHED, not what the scan selected, so
     /// the scan window is the wrong lever: the seeds, the walk's own caps, or the chain form, which lists the same
-    /// reached set without reading a body. The seeds are named without the scan terms, because a walk is reached
-    /// from the formids= lane too and there they are not part of the call.</summary>
+    /// reached set without reading a body PER RENDERED ROW — the walk reads one per reached node whatever the form,
+    /// so chain saves the render's read and not the walk's. The seeds are named without the scan terms, because a
+    /// walk is reached from the formids= lane too and there they are not part of the call.</summary>
     internal const string WalkRemedy =
         "narrow the seeds you passed, or lower walk.depth or " +
         "walk.max_nodes, until the set the walk reaches fits — the rows are what the walk reached, seeds included, " +
         "so limit= and offset= window the render and not the walk. project.form='chain' lists the same reached set " +
-        "without reading a body, which is what to run first.";
+        "without reading a body per rendered row, which is what to run first.";
 
     /// <summary>The refusal for a render over its lane's bound, or null when it fits. One sentence for the cost, one
     /// for the shapes that fit, each carrying the caveat that decides between them. <paramref name="wholeRecord"/>

--- a/src/housecarl-mcp/RenderBudget.cs
+++ b/src/housecarl-mcp/RenderBudget.cs
@@ -70,14 +70,39 @@ internal static class RenderBudget
         return ms >= 60_000 ? $"about {ms / 60_000:F0} minutes" : $"about {ms / 1000:F0} seconds";
     }
 
+    /// <summary>What moves a SCAN's row count: the scan terms, or a window over them. Each remedy opens with its own
+    /// verb in lower case; <see cref="Refuse"/> capitalises it when the sentence starts there.</summary>
+    internal const string ScanRemedy =
+        "narrow the scan terms (types=, plugins=, where=), or take the selection " +
+        "in windows with limit= and offset= — offset= re-scans the selection from the start, so a window costs " +
+        "more the further in it is. to_file= captures the COMPLETE selection rather than a window, so it renders " +
+        "every row and does not combine with offset=: narrow the scan until the whole set fits, then write it in " +
+        "one call.";
+
+    /// <summary>What moves the <c>formids=</c> lane's row count. It has no scan terms to narrow, and it reads a body
+    /// for every id it was handed BEFORE the render window applies, so paging the same call does not lower its
+    /// cost.</summary>
+    internal const string ListRemedy =
+        "pass fewer formids= entries: this lane reads a body for EVERY id in the " +
+        "list before limit= and offset= window the render, so paging the same list does not lower what it costs. " +
+        "Re-enter a big artifact a slice at a time, or narrow the selection that wrote it.";
+
+    /// <summary>What moves a WALK's row count. The rows are what the walk REACHED, not what the scan selected, so
+    /// the scan window is the wrong lever: the seeds, the walk's own caps, or the chain form, which lists the same
+    /// reached set without reading a body.</summary>
+    internal const string WalkRemedy =
+        "narrow the seeds (types=, plugins=, where=), or lower walk.depth or " +
+        "walk.max_nodes, until the set the walk reaches fits — the rows are what the walk reached, seeds included, " +
+        "so limit= and offset= window the render and not the walk. project.form='chain' lists the same reached set " +
+        "without reading a body, which is what to run first.";
+
     /// <summary>The refusal for a render over its lane's bound, or null when it fits. One sentence for the cost, one
     /// for the shapes that fit, each carrying the caveat that decides between them. <paramref name="wholeRecord"/>
     /// is the <c>form='everything'</c> lane, whose row is a whole record and whose bound is therefore its own —
     /// and whose first remedy is naming the fields, since that is what moves it between the two.
-    /// <para><paramref name="listSelection"/> is the <c>formids=</c> lane, whose remedy differs in kind: it has no
-    /// scan terms to narrow, and it reads a body for every id it was handed BEFORE the render window applies, so
-    /// paging the same call does not lower its cost.</para></summary>
-    internal static string? Refuse(int rows, bool wholeRecord, bool listSelection = false)
+    /// <paramref name="remedy"/> is the second sentence's lever, defaulting to the scan's — the lanes whose levers
+    /// differ in kind pass their own (<see cref="ListRemedy"/>, <see cref="WalkRemedy"/>).</summary>
+    internal static string? Refuse(int rows, bool wholeRecord, string? remedy = null)
     {
         int bound = wholeRecord ? MaxWholeRecordRows : MaxRenderRows;
         if (rows <= bound) return null;
@@ -88,14 +113,7 @@ internal static class RenderBudget
               $"row too but costs a fraction of a whole-record read, and is bounded at {MaxRenderRows:N0} rows. Or "
             : $"error: this call renders {rows:N0} rows and each one reads a record body — {Projected(rows, false)} of " +
               $"render, past the {bound:N0}-row bound one call is given (a client stops waiting at 30 minutes). ";
-        return lead + (listSelection
-            ? (wholeRecord ? "pass" : "Pass") + " fewer formids= entries: this lane reads a body for EVERY id in the " +
-              "list before limit= and offset= window the render, so paging the same list does not lower what it costs. " +
-              "Re-enter a big artifact a slice at a time, or narrow the selection that wrote it."
-            : (wholeRecord ? "narrow" : "Narrow") + " the scan terms (types=, plugins=, where=), or take the selection " +
-              "in windows with limit= and offset= — offset= re-scans the selection from the start, so a window costs " +
-              "more the further in it is. to_file= captures the COMPLETE selection rather than a window, so it renders " +
-              "every row and does not combine with offset=: narrow the scan until the whole set fits, then write it in " +
-              "one call.");
+        var lever = remedy ?? ScanRemedy;
+        return lead + (wholeRecord ? lever : char.ToUpperInvariant(lever[0]) + lever[1..]);
     }
 }

--- a/src/housecarl-mcp/RenderBudget.cs
+++ b/src/housecarl-mcp/RenderBudget.cs
@@ -89,9 +89,10 @@ internal static class RenderBudget
 
     /// <summary>What moves a WALK's row count. The rows are what the walk REACHED, not what the scan selected, so
     /// the scan window is the wrong lever: the seeds, the walk's own caps, or the chain form, which lists the same
-    /// reached set without reading a body.</summary>
+    /// reached set without reading a body. The seeds are named without the scan terms, because a walk is reached
+    /// from the formids= lane too and there they are not part of the call.</summary>
     internal const string WalkRemedy =
-        "narrow the seeds (types=, plugins=, where=), or lower walk.depth or " +
+        "narrow the seeds you passed, or lower walk.depth or " +
         "walk.max_nodes, until the set the walk reaches fits — the rows are what the walk reached, seeds included, " +
         "so limit= and offset= window the render and not the walk. project.form='chain' lists the same reached set " +
         "without reading a body, which is what to run first.";


### PR DESCRIPTION
A `housecarl_records` walk read each seed's and each reached node's body with `LoadOrderResolver.SeekBody` — one enumeration of the whole winning plugin to find one record, the same per-row cost #582 took out of the scan and batch lanes but never out of the walk. A walk's cost was therefore the number of seeds times the winning plugin's record count, in time and in allocation, which is what ran a 2,235-NPC template-chain walk out of memory. The walk now advances every seed one hop together, so each hop's bodies come from one enumeration per source plugin through the same `BodyPrefetch` gather the other lanes use, and a walk costs what its seeds cost. The engine entry also takes the call's `CancellationToken` and polls it per seed and per hop, like every other loop that reads a body.

Closes #556

## The measurement

Synthetic world, one master plugin, NPC seeds on a shared three-deep template chain, walked with `project.form='chain'`. `LoadOrderResolver.BodySeeks` counts the per-record whole-plugin walks; allocation is `GC.GetTotalAllocatedBytes(precise: true)` and the peak is the heap right after the call.

**The cost is the seeds times the plugin, not the seeds.** Holding the walk fixed and growing only the plugin's *other* records moves the per-seek cost in step, which is the whole finding:

| seeds | records in the plugin | seeks | allocated per seek |
|---|---|---|---|
| 402 | ~405 | 402 | 0.33 MB |
| 402 | ~1,605 | 402 | 1.06 MB |
| 402 | ~3,205 | 402 | 2.00 MB |

So the call's total is quadratic when the seeds grow with the plugin they live in — 400 → 132 MB, 1,600 → 1,913 MB, 3,200 → 7,567 MB allocated, with 38 MB / 579 MB / 2,596 MB still on the heap when the call returns. Requiem.esp's 2,235 NPCs in a plugin of that mod's size is well past where a 64-bit process gives up.

**Before and after, same worlds, identical answers** (`seeds=`, `reached=`, `errors=` match to the row in every case):

| the walk | allocated before | allocated after | heap at return, before → after |
|---|---|---|---|
| 400 seeds, template chain | 132 MB | 12 MB | 38 MB → 12 MB |
| 1,600 seeds, template chain | 1,913 MB | 48 MB | 579 MB → 48 MB |
| 3,200 seeds, template chain | 7,567 MB | 98 MB | 2,596 MB → 57 MB |
| 400 seeds, 2,800 unrelated records beside them | 804 MB | 14 MB | 92 MB → 14 MB |
| 800 seeds, closure walk reaching 3,200 distinct nodes | 6,123 MB | 20 MB | 1,362 MB → 20 MB |

Seeks went from `seeds + distinct nodes` to 0 in every one of those, and growth is now linear in the seeds (400 → 12 MB, 1,600 → 48 MB, 3,200 → 98 MB).

**On the issue's own framing.** #556 reads the two-step split (`to_file=`, then `formids=["@file"]`) succeeding at 1,687 seeds as evidence that the blow-up is in the scan-scoped selection feeding the walk. It is not: the two shapes hand `WalkForwardBatch` the same seed list and, measured side by side on every world above, cost the same to within 1% both before and after this change (ratio 1.00). The two-step run survived because it was smaller — 1,687 seeds against 2,235 is a 1.75x difference on a quadratic curve — and because its scan half had already released. The cost was in the walk itself, and it is fixed there, so both shapes now run and neither is a workaround for the other.

## What changed in the walk

The per-seed loop became: parse and gather every seed's body, start each seed's first hop, then advance all seeds one hop at a time, gathering the hop's frontier in `BodyPrefetch.ChunkRows`-sized chunks. Per-seed state (visited set, node rows, cycles, node budget, truncation note) is unchanged and lives on a `WalkSeedState`; results come back in seed order as before. A key the gather does not return stays out of the cache, so the per-record read still raises whatever it always raised — the gather is an optimisation, not a second error path.

**The gather is bounded by the node budget, not by the frontier.** `walk.max_nodes` is consulted on dequeue, so gathering a hop's whole frontier first meant a seed that had already filled its cap still made the call read and pin bodies that never reached a row — the same allocation axis the issue died on. Each seed's remaining budget now rides into the gather: a seed at its cap contributes nothing, a seed near it contributes only what it can still admit. Over 302 seeds capped at one node each, the call asks the gather for 601 bodies where it asked for 1,202. The cap itself is unchanged — a node at the cap is recorded, not entered, with the same truncation sentence.

**A finished seed's bookkeeping goes back at once.** A seed is finished the moment its frontier empties, and the results loop reads neither its visited set nor its queue, so both are released there rather than at return. The old per-seed loop released both when that seed finished; holding all of them for the whole call would have grown with the seed count exactly the way the seek cost did.

One behaviour does shift, and it is in the code comment: an exclusion with `severity='refuse'` ends the whole call, and the sentence now names the first seed in seed order that reaches the excluded class at the shallowest hop any seed reaches it. Before, seeds ran to completion one after another, so an earlier seed's deep refusal outranked a later seed's shallow one. Either way the call refuses and returns nothing; only which seed and chain the sentence quotes can differ.

## The bound on the reached set

A walk that no longer runs out of memory needs something else to stop it. The walk lane returns above the scan's render bound, deliberately, because the seed scan's count is not the rendered count. The **reached** count is: when a body form consumes the walk, the reached set becomes the list lane's `formids` and every row of it reads a record body — up to seeds × `walk.max_nodes` with no ceiling at all once the OOM is gone.

So the reached count is now measured against the same bound, with the same two lanes (a named-fields row and an `everything` row are two orders of magnitude apart), before a single body is read. That holds on every walk lane and for every reading form that consumes the reached set: `summary` and `aggregate` read one cheap leaf, but they read it off a body per row exactly as `fields`, `rows` and `everything` do, and both reverse walks hand the list lane their reached set the same way the forward walk does.

The remedy sentence is the walk's own rather than the scan's, since `limit=`/`offset=` window the render and not the walk, and each lane names only levers that move it: the seeds the caller passed (named without the scan terms, because a walk is seeded from the `formids=` lane too, where those parameters are not part of the call), `walk.depth` and `walk.max_nodes` where they apply, and `project.form='chain'` on the forward and carrier lanes — the two chain can draw. The transitive reverse lane names `walk.depth` instead and says why chain is not a lever there. `form='chain'` itself stays exempt: it renders the walk's own rows, so it pays no second body read on top of the walk's own — the walk reads one per reached node whatever the form, which is what the remedy now says. The sentence lives on `walk.max_nodes`, where the budget it bounds is described; `housecarl_records`'s own description is untouched.

## Tests

`src/housecarl-mcp-tests/RecordsWalkCostTests.cs`, on a `WalkCostWorld` of 300 NPC seeds on one template chain, each carrying 3 items of its own, in a master of ~1,500 records. Tagged `tier=integration`. `BodyPrefetch.KeysWanted` is a new process counter of the bodies the bulk gather has been asked for, for the reason `LoadOrderResolver.BodySeeks` is one: gathering only what a lane can use, or a whole frontier it then throws away, is invisible in the answer.

| test | before | after |
|---|---|---|
| `AWalkGathersItsSeedBodiesOncePerPluginNotOncePerSeed` | fails — 302 per-record plugin walks for 302 seeds | passes (0) |
| `AWalkGathersEachHopsBodiesTogetherNotOnePerNode` | fails — 1,202 per-record plugin walks for a closure walk | passes (0) |
| `AWalkCostsWithItsSeedsNotWithThePluginBehindThem` | fails — allocates 240 MB, past the 37 MB the seed count allows | passes (9 MB) |
| `ACappedSeedGathersNoBodiesPastItsCap` | fails — 1,202 bodies gathered for 302 seeds allowed one node each | passes (601, and no fallback seek) |
| `AWalkCancelledBeforeItStartsStopsInTheSeedGather` | did not compile — the engine entry took no token | passes |
| `AWalkStopsBetweenHopsWhenTheClientCancels` | fails with the hop loop's two polls deleted | passes |
| `AReachedSetTooBigToRenderRefusesNamingTheChainFormAndNarrowerSeeds` | fails — the reached set renders unbounded | passes |
| `TheChainFormIsNotHeldToTheBodyRenderBound` | passes — the chain form is exempt and stays exempt | passes |
| `AReachedSetUnderTheBoundRendersAsBefore` | passes — under the bound nothing changes | passes |
| `AHopDoesNotSpendItsGatherOnNodesTheSeedAlreadyVisited` | fails — 40 per-record plugin walks when a hop's frontier leads with revisits | passes (0) |
| `EveryReadingFormOverTheReachedSetIsHeldToTheBound` (summary, aggregate) | fails — neither form was gated | passes |
| `AFormidsSeededWalkIsRefusedWithoutNamingTheScanTerms` | fails — the refusal opened on `types=`/`plugins=`/`where=` | passes |
| `ATransitiveReverseWalkTooBigToRenderRefuses` | fails — the lane rendered unbounded | passes |
| `AReverseCarrierWalkTooBigToRenderRefusesNamingTheChainForm` | fails — the lane rendered unbounded | passes |

Fail-before was verified in place for each: making the gather budget unbounded, deleting the two hop-loop polls, and neutralising the reached-set bound, each re-run on its own; the numbers in the table are those runs' own messages. The allocation test is bytes, not a clock, so there is no timing assertion to go flaky: it calls the walk once to pay the index build and the JIT, then measures a second identical call and holds it to 128 KB per seed — about 4x above what it now spends and about 6x below what it spent before. Assembly-wide parallelisation is already off, so the process-wide allocation, seek and gather counters are these tests' alone.

The base branch's `AWalkIsNotRefusedForTheSizeOfItsSeedScan` pinned the walk lane as exempt from the render bound. Its claim — a walk is not refused for the size of the scan that seeded it — still holds and is what it still asserts; it is renamed `AWalkIsMeasuredOnWhatItReachedAndNotOnItsSeedScan` and now checks that the refusal it gets is the walk lane's, naming the walk's levers and not the scan window's.

## What was run

From inside `.claude/worktrees/walk-oom`:

```
dotnet build housecarl.sln -c Release
dotnet test src/housecarl-mcp-tests -c Release --no-build --filter "tier!=bridge"
dotnet src/housecarl-generator/bin/Release/net9.0/housecarl-generator.dll ci-all
```

0 build errors, 1,692 tests passed, 0 failed, and `ci-all` 127/127. `housecarl_records`'s own description is untouched and `PublishedDescriptionBoundTests` passes. Nothing was run against the live MO2 instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

