### PR TITLE
Say why a ci-all run cannot make its fixture directory

### DIFF
--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -176,7 +176,8 @@ public static class CiAll
         foreach (var e in All())
             if (e.Name == name)
             {
-                try { ProbeTemp.Redirect(); rc = e.Run(args); }
+                if (!ProbeTemp.TryRedirect(out var error)) { rc = TempStartFailed(error); return true; }
+                try { rc = e.Run(args); }
                 finally { ProbeTemp.Cleanup(); }
                 return true;
             }
@@ -187,8 +188,16 @@ public static class CiAll
     /// <summary>Run the whole roster under this process's own temp root, and take the fixtures with it.</summary>
     public static int RunAll(string[] args)
     {
-        try { ProbeTemp.Redirect(); return RunRoster(args); }
+        if (!ProbeTemp.TryRedirect(out var error)) return TempStartFailed(error);
+        try { return RunRoster(args); }
         finally { ProbeTemp.Cleanup(); }
+    }
+
+    /// <summary>Report a run that could not make its fixture root, and give the exit code it fails with.</summary>
+    static int TempStartFailed(string? error)
+    {
+        Console.Error.WriteLine("::error::" + error);
+        return 1;
     }
 
     static int RunRoster(string[] args)

--- a/src/housecarl-generator/ProbeTemp.cs
+++ b/src/housecarl-generator/ProbeTemp.cs
@@ -88,6 +88,7 @@ public static class ProbeTemp
     {
         int left = 0;
         string? first = null;
+        Exception? unlistable = null;
 
         try
         {
@@ -100,13 +101,22 @@ public static class ProbeTemp
                 first ??= f;
             }
         }
-        // A temp path that will not list has nothing to sweep and no residue to name: the enumeration is the
-        // only thing here that throws, and the start failure right after it is the run's one sentence.
-        catch { }
+        // Listing temp is the only thing here that throws, and it throws in states the run survives: a temp
+        // this process may traverse and write but not read denies the enumeration while CreateDirectory below
+        // succeeds. Say the sweep could not look rather than count entries it never saw — silence there skips
+        // the sweep every run and lets dead runs' roots pile up with nothing saying why.
+        catch (Exception ex) { unlistable = ex; }
 
         if (left > 0)
             Console.WriteLine($"  (temp sweep left {left} entr{(left == 1 ? "y" : "ies")} from an earlier run under {temp}: {first})");
+        if (unlistable != null) Console.WriteLine($"  ({SweepUnlistable(temp, unlistable)})");
     }
+
+    /// <summary>The one line a run prints when it cannot list temp to sweep the roots earlier runs left.</summary>
+    static string SweepUnlistable(string temp, Exception ex) =>
+        $"temp sweep could not look in {temp} for the roots killed runs leave behind ({ex.Message.TrimEnd()}) — " +
+        "grant this run list access there or point TMP/TEMP at a directory it can read, or those roots go " +
+        "unswept every run";
 
     /// <summary>Read the pid out of an <c>hc-&lt;pid&gt;</c> or <c>hc-&lt;pid&gt;-&lt;n&gt;</c> root name.</summary>
     static bool TryReadPid(string name, out int pid)

--- a/src/housecarl-generator/ProbeTemp.cs
+++ b/src/housecarl-generator/ProbeTemp.cs
@@ -44,8 +44,8 @@ public static class ProbeTemp
             ReportLeft(root, left, first);
             root = Path.Combine(temp, $"hc-{Environment.ProcessId}-{n}");
         }
-        // A full or read-only temp volume, or a plain FILE already named hc-<pid> (which Directory.Exists above
-        // does not see), stops the run before any probe: say which path and why, not a stack trace.
+        // A full, read-only or missing temp volume, or a plain FILE already named hc-<pid> (which
+        // Directory.Exists above does not see), stops the run before any probe: say which path and why.
         try { Directory.CreateDirectory(root); }
         catch (Exception ex) { error = StartFailure(root, ex); return false; }
 
@@ -66,7 +66,8 @@ public static class ProbeTemp
     /// <summary>The one sentence a run prints when its fixture root cannot be made.</summary>
     static string StartFailure(string root, Exception ex) =>
         $"could not create the fixture directory {root} this run works in ({ex.Message.TrimEnd()}) — " +
-        "free space on the temp volume, or remove whatever is already at that path, then run again.";
+        "free space on the temp volume, remove whatever is already at that path, or point TMP/TEMP at a " +
+        "writable directory, then run again.";
 
     /// <summary>Put the temp directory back and delete the root. A file still held open is reported, not thrown.</summary>
     public static void Cleanup()

--- a/src/housecarl-generator/ProbeTemp.cs
+++ b/src/housecarl-generator/ProbeTemp.cs
@@ -99,7 +99,9 @@ public static class ProbeTemp
                 first ??= f;
             }
         }
-        catch (Exception ex) { left++; first ??= ex.Message; }
+        // A temp path that will not list has nothing to sweep and no residue to name: the enumeration is the
+        // only thing here that throws, and the start failure right after it is the run's one sentence.
+        catch { }
 
         if (left > 0)
             Console.WriteLine($"  (temp sweep left {left} entr{(left == 1 ? "y" : "ies")} from an earlier run under {temp}: {first})");

--- a/src/housecarl-generator/ProbeTemp.cs
+++ b/src/housecarl-generator/ProbeTemp.cs
@@ -13,7 +13,7 @@ namespace HousecarlGenerator;
 ///
 /// <para>The run also stops leaving fixtures behind: the whole root goes at the end, entry by entry so one
 /// file another process still holds open strands only itself. A run that is killed — the bridge test's
-/// 20-minute cap, Ctrl-C, a cancelled CI job — never reaches that, so <see cref="Redirect"/> also drops the
+/// 20-minute cap, Ctrl-C, a cancelled CI job — never reaches that, so <see cref="TryRedirect"/> also drops the
 /// roots whose pid is no longer a live process; residue under our own pid that will not go is reported and
 /// the run takes a fresh sibling root rather than work in another run's fixtures. Nothing here throws: a file
 /// that will not delete is reported and the run's exit code is unaffected — cleanup never turns a run red.</para>
@@ -23,10 +23,12 @@ public static class ProbeTemp
     static string? _root;
     static string? _tmpWas, _tempWas, _tmpdirWas;
 
-    /// <summary>Point this process's temp directory at a root only this process uses, and return it.</summary>
-    public static string Redirect()
+    /// <summary>Point this process's temp directory at a root only this process uses. False with a one-sentence
+    /// reason if that root could not be made — the temp directory is then left exactly where it was.</summary>
+    public static bool TryRedirect(out string? error)
     {
-        if (_root != null) return _root;
+        error = null;
+        if (_root != null) return true;
 
         var temp = Path.GetTempPath();
         SweepDeadRoots(temp);
@@ -42,7 +44,11 @@ public static class ProbeTemp
             ReportLeft(root, left, first);
             root = Path.Combine(temp, $"hc-{Environment.ProcessId}-{n}");
         }
-        Directory.CreateDirectory(root);
+        // A full or read-only temp volume, or a plain FILE already named hc-<pid> (which Directory.Exists above
+        // does not see), stops the run before any probe: say which path and why, not a stack trace.
+        try { Directory.CreateDirectory(root); }
+        catch (Exception ex) { error = StartFailure(root, ex); return false; }
+
         // Set before the redirect below, not after it: a variable that will not take would otherwise leave the
         // process pointed at a root Cleanup no longer knows to remove.
         _root = root;
@@ -54,8 +60,13 @@ public static class ProbeTemp
         Environment.SetEnvironmentVariable("TEMP", root);
         Environment.SetEnvironmentVariable("TMPDIR", root);   // what GetTempPath reads off Windows
 
-        return root;
+        return true;
     }
+
+    /// <summary>The one sentence a run prints when its fixture root cannot be made.</summary>
+    static string StartFailure(string root, Exception ex) =>
+        $"could not create the fixture directory {root} this run works in ({ex.Message.TrimEnd()}) — " +
+        "free space on the temp volume, or remove whatever is already at that path, then run again.";
 
     /// <summary>Put the temp directory back and delete the root. A file still held open is reported, not thrown.</summary>
     public static void Cleanup()

--- a/src/housecarl-mcp-tests/ProbeTempStartTests.cs
+++ b/src/housecarl-mcp-tests/ProbeTempStartTests.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using HousecarlGenerator;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>The sentence a run prints when it cannot make the fixture directory it works in — a full or
+/// read-only temp volume, or a plain file already at that path. The redirect itself cannot be driven from a
+/// test without repointing this process's own temp directory, so the sentence is tested where it is built.
+/// Reflected: the builder is private to the class that owns the redirect.</summary>
+[Trait("tier", "unit")]
+public sealed class ProbeTempStartTests
+{
+    static string StartFailure(string root, Exception ex) => (string)typeof(ProbeTemp)
+        .GetMethod("StartFailure", BindingFlags.NonPublic | BindingFlags.Static)!
+        .Invoke(null, new object[] { root, ex })!;
+
+    [Fact]
+    public void NamesThePathAndTheUnderlyingReason()
+    {
+        var sentence = StartFailure(@"C:\Temp\hc-1234", new IOException("The disk is full."));
+        Assert.Contains(@"C:\Temp\hc-1234", sentence);
+        Assert.Contains("The disk is full.", sentence);
+    }
+
+    [Fact]
+    public void SaysWhatToTry()
+    {
+        var sentence = StartFailure(@"C:\Temp\hc-1234", new IOException("A file with the same name exists."));
+        Assert.Contains("free space", sentence);
+        Assert.Contains("remove", sentence);
+    }
+}

--- a/src/housecarl-mcp-tests/ProbeTempStartTests.cs
+++ b/src/housecarl-mcp-tests/ProbeTempStartTests.cs
@@ -4,9 +4,10 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>The sentence a run prints when it cannot make the fixture directory it works in — a full or
-/// read-only temp volume, or a plain file already at that path. The redirect itself cannot be driven from a
-/// test without repointing this process's own temp directory, so the sentence is tested where it is built.
+/// <summary>The sentence a run prints when it cannot make the fixture directory it works in — a full,
+/// read-only or missing temp volume, or a plain file already at that path. The redirect itself cannot be
+/// driven from a test without repointing this process's own temp directory, so the sentence is tested where
+/// it is built.
 /// Reflected: the builder is private to the class that owns the redirect.</summary>
 [Trait("tier", "unit")]
 public sealed class ProbeTempStartTests
@@ -29,5 +30,6 @@ public sealed class ProbeTempStartTests
         var sentence = StartFailure(@"C:\Temp\hc-1234", new IOException("A file with the same name exists."));
         Assert.Contains("free space", sentence);
         Assert.Contains("remove", sentence);
+        Assert.Contains("TMP/TEMP", sentence);
     }
 }

--- a/src/housecarl-mcp-tests/ProbeTempSweepTests.cs
+++ b/src/housecarl-mcp-tests/ProbeTempSweepTests.cs
@@ -16,6 +16,10 @@ public sealed class ProbeTempSweepTests
         .GetMethod("IsLive", BindingFlags.NonPublic | BindingFlags.Static)!
         .Invoke(null, new object[] { pid })!;
 
+    static string SweepUnlistable(string temp, Exception ex) => (string)typeof(ProbeTemp)
+        .GetMethod("SweepUnlistable", BindingFlags.NonPublic | BindingFlags.Static)!
+        .Invoke(null, new object[] { temp, ex })!;
+
     [Fact]
     public void OwnProcessIsLive() => Assert.True(IsLive(Environment.ProcessId));
 
@@ -29,6 +33,30 @@ public sealed class ProbeTempSweepTests
     {
         var pid = SystemPid();
         Assert.True(IsLive(pid), $"pid {pid} is running, so its root must not be swept");
+    }
+
+    /// <summary>A temp directory this process may traverse and write but not read denies the sweep's
+    /// enumeration while the fixture root is still created, so the run goes green with no start sentence: the
+    /// line about the sweep is then the only thing that says the roots of killed runs are piling up.
+    /// Reflected: the builder is private to the class that owns the sweep.</summary>
+    [Fact]
+    public void UnlistableTempNamesTheDirectoryAndTheReason()
+    {
+        var line = SweepUnlistable(@"C:\Temp", new UnauthorizedAccessException(@"Access to the path 'C:\Temp' is denied."));
+        Assert.Contains(@"C:\Temp", line);
+        Assert.Contains(@"Access to the path 'C:\Temp' is denied.", line);
+        Assert.Contains("could not look", line);
+        Assert.Contains("TMP/TEMP", line);
+    }
+
+    /// <summary>A sweep that could not look is not an entry left behind: the two states have different
+    /// remedies, and counting the first as the second names residue nobody saw.</summary>
+    [Fact]
+    public void UnlistableTempIsNotReportedAsResidue()
+    {
+        var line = SweepUnlistable(@"C:\Temp", new UnauthorizedAccessException("denied"));
+        Assert.DoesNotContain("left 1 entry", line);
+        Assert.DoesNotContain("entries", line);
     }
 
     /// <summary>A pid no process holds, confirmed rather than assumed.</summary>


### PR DESCRIPTION
Each `ci-all` run works in its own fixture directory under the system temp (#586). Making that directory could still fail — a full, read-only or missing temp volume, or a plain file already named `hc-<pid>`, which the `Directory.Exists` check ahead of it does not see — and the run then died on a raw stack trace out of the generator. `ProbeTemp.Redirect` becomes `TryRedirect(out string? error)`: the `CreateDirectory` call is caught and turned into one sentence naming the path it tried, the reason underneath it, and what to try, and both callers in `CiAll` report it as an `::error::` line and exit 1, the same shape a failed probe gets. Nothing is redirected on that path — the environment variables are set after the directory exists, so a failed start leaves TMP/TEMP/TMPDIR where they were.

Three things came out of review. `SweepDeadRoots` runs first, and in these states `Directory.EnumerateDirectories` throws; its catch-all counted that as one entry left from an earlier run, so every failure here printed a false residue line ahead of the start sentence. That is no longer counted as residue. Making it silent instead was wrong, though: the string-pattern overload lists with `IgnoreInaccessible = false`, so a temp directory this process may traverse and write but not *read* — an ACL granting create and denying list — denies the enumeration while the `CreateDirectory` right after it succeeds. The run then goes green with no start sentence, the sweep is skipped every run, and the roots of killed runs pile up with nothing saying why. A sweep that cannot list its temp now prints one line naming the directory and the reason, worded as a sweep that could not look rather than as entries left behind, and says what to try. The remedy in the start sentence also named only two of the causes: freeing space and removing what is at the path fix a full volume and a plain file, but not a temp location that is missing, read-only or denied, so it now also says to point TMP/TEMP at a writable directory.

Closes #605

Verified from the worktree, rebased on the current base: `dotnet build housecarl.sln -c Release` (0 errors); `dotnet test src/housecarl-mcp-tests -c Release --no-build --filter "tier!=bridge"` — 1696 passed, 0 failed; `ci-all` — 127/127 passed in 1.38 min.

Verified the failures by hand rather than in a test, never touching the real temp. A plain file was written at a path in this session's scratchpad, and the generator was run twice with `TMP`/`TEMP`/`TMPDIR` pointed at that file — once as `ci-all`, once as the single probe `apply-guard`. Both printed exactly one line, `::error::could not create the fixture directory …\faketemp\hc-25180 this run works in (Cannot create '…\faketemp' because a file or directory with the same name already exists.) — free space on the temp volume, remove whatever is already at that path, or point TMP/TEMP at a writable directory, then run again.`, and exited 1. With the three variables pointed at `Z:\nope`, a missing volume, the run prints two true lines and exits 1: the sweep's `  (temp sweep could not look in Z:\nope\ for the roots killed runs leave behind (Could not find a part of the path 'Z:\nope'.) — grant this run list access there or point TMP/TEMP at a directory it can read, or those roots go unswept every run)` and then the start sentence for `Z:\nope\hc-33448`. The list-denied state was reproduced with `icacls <scratch dir> /deny "<user>:(RD)"` and the same three variables pointed at it: `apply-guard` printed that same sweep line naming the scratch directory and `Access to the path … is denied.`, then ran to `80 passed, 0 failed -> PASS` and exit 0 — the run survives, which is exactly why the line has to be there.

The tests cover the two extracted sentence builders, reflected the way `ProbeTempSweepTests` already reflects the sweep's liveness check: the start sentence names the path, the reason and what to try, and the sweep line names the directory, the reason and what to try while not reading as entries left behind. `TryRedirect` itself still cannot be driven from a test without repointing the test process's own temp directory, which is the judgement the #586 fold made and I agree with; the by-hand runs above are what exercise the real path. No CHANGELOG line: this is developer tooling and no user of the shipped plugin sees it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
