### PR TITLE
Read a record with a draft SkyPatcher INI folded into the layer

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -21,7 +21,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
   there. The same pole is legal as `versus=`, so the draft's post state against the plain post state is the
   draft's own effect and nothing else. An undocumented subfolder, a draft whose filename is already placed in
   that folder (which would shadow or be shadowed depending on mod order), and `state: "pre"` with a draft are
-  each refused by name. The draft rides the `formids=` lane; the scan lane still refuses an overlay pole for
+  each refused by name — as are a draft that is itself one of the layer's placed files, whose lines would
+  replay twice, and `ini`/`subfolder` passed on a `{"file"}` pole, where they would otherwise be dropped and
+  that plugin's own record would read as the draft's post state. A refusal is the call's on every form the
+  pole takes, so `counts_only` cannot report it as an error count with the reason nowhere.
+  The draft rides the `formids=` lane; the scan lane still refuses an overlay pole for
   the reason it already gives. Like the rest of the INI layer, a draft sits outside the epoch fingerprint, and
   the response names it on the source arm. Every warning the replay produces for a draft's line — an unknown
   key, an op with no field mapping, a filter it cannot evaluate — now renders beside the answer with the

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,19 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **A SkyPatcher INI can be checked before it is placed in a mod.** `housecarl_records`'s overlay pole takes a
+  draft file: `source={"overlay": "skypatcher", "state": "post", "ini": "<absolute path to a draft .ini>",
+  "subfolder": "weapon"}` reads the record as the game would see it once that draft is placed — the live layer
+  plus the draft, sorted into its type folder by filename among the live files. `subfolder` may be omitted when
+  the draft's parent directory is already the type folder, and the response says the folder was taken from
+  there. The same pole is legal as `versus=`, so the draft's post state against the plain post state is the
+  draft's own effect and nothing else. An undocumented subfolder, a draft whose filename is already placed in
+  that folder (which would shadow or be shadowed depending on mod order), and `state: "pre"` with a draft are
+  each refused by name. The draft rides the `formids=` lane; the scan lane still refuses an overlay pole for
+  the reason it already gives. Like the rest of the INI layer, a draft sits outside the epoch fingerprint, and
+  the response names it on the source arm. Every warning the replay produces for a draft's line — an unknown
+  key, an op with no field mapping, a filter it cannot evaluate — now renders beside the answer with the
+  draft's path as the file name, as it does for a placed INI's lines.
 - **A `housecarl_records` `formids=` read is now held to the render bound on every form that reads a body, and
   says what those bodies cost.** `summary` and `aggregate` read a body per id on this lane exactly as `fields`,
   `rows` and `everything` do — one cheap leaf off each — but only the last three were measured against the bound,

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -25,7 +25,10 @@ saying it sets an expectation their install may contradict. Say what is known, a
   the reason it already gives. Like the rest of the INI layer, a draft sits outside the epoch fingerprint, and
   the response names it on the source arm. Every warning the replay produces for a draft's line — an unknown
   key, an op with no field mapping, a filter it cannot evaluate — now renders beside the answer with the
-  draft's path as the file name, as it does for a placed INI's lines.
+  draft's path as the file name, as it does for a placed INI's lines, on every form that takes the pole.
+  A draft SkyPatcher would not read once placed — one whose filename gates on a plugin that is not in the
+  order, or one in a type switched off in `SkyPatcher.ini`'s `[Patcher]` section — applies nothing, so the
+  post state is the plain winner and the response says which of the two it was.
 - **A `housecarl_records` `formids=` read is now held to the render bound on every form that reads a body, and
   says what those bodies cost.** `summary` and `aggregate` read a body per id on this lane exactly as `fields`,
   `rows` and `everything` do — one cheap leaf off each — but only the last three were measured against the bound,

--- a/src/housecarl-core/SkyPatcherDiscovery.cs
+++ b/src/housecarl-core/SkyPatcherDiscovery.cs
@@ -54,11 +54,15 @@ public static class SkyPatcherDiscovery
         IReadOnlyList<IniFile> Files);
 
     /// <summary>The whole layer: per-folder ordered scans, layer-level notes, and whether the read was
-    /// incomplete (an unreadable archive means an "absent" answer may be wrong).</summary>
+    /// incomplete (an unreadable archive means an "absent" answer may be wrong). <see cref="PatcherToggles"/>
+    /// is the whole <c>SkyPatcher.ini</c> <c>[Patcher]</c> map, not just the toggles the scanned folders used:
+    /// a type with no live INI produces no <see cref="FolderScan"/>, so anything that INVENTS one (a draft
+    /// folded in) needs the toggle for a folder this scan never built.</summary>
     public sealed record LayerScan(
         IReadOnlyList<FolderScan> Folders,
         IReadOnlyList<string> Notes,
-        bool ReadIncomplete);
+        bool ReadIncomplete,
+        IReadOnlyDictionary<string, bool> PatcherToggles);
 
     /// <summary>Per-file INI parse cache — the same cheap freshness discipline the rest of houseCARL
     /// uses, on the same <see cref="FileStamp"/> key. Keyed on the winning loose file's full path; an
@@ -168,7 +172,7 @@ public static class SkyPatcherDiscovery
                 files.OrderBy(f => f.SortKey, StringComparer.OrdinalIgnoreCase).ToList()));
         }
 
-        return new LayerScan(folders, notes, view.ReadIncomplete);
+        return new LayerScan(folders, notes, view.ReadIncomplete, toggles);
     }
 
     /// <summary>The plugin a filename gates on: 'Skyrim.esm.ini' → "Skyrim.esm"; 'myEdits.ini' → null.
@@ -244,6 +248,6 @@ public static class SkyPatcherDiscovery
     /// <summary>Whether a subfolder's patcher is enabled. The toggle token matches the subfolder
     /// case-insensitively for every documented type (npc→NPC, formList→Formlist, encounterzone→
     /// EncounterZone, …), so no hand-kept toggle↔folder table can drift.</summary>
-    static bool ToggleEnabled(Dictionary<string, bool> toggles, string subfolder)
+    public static bool ToggleEnabled(IReadOnlyDictionary<string, bool> toggles, string subfolder)
         => !toggles.TryGetValue(subfolder, out var on) || on;
 }

--- a/src/housecarl-core/SkyPatcherDiscovery.cs
+++ b/src/housecarl-core/SkyPatcherDiscovery.cs
@@ -34,12 +34,15 @@ public static class SkyPatcherDiscovery
 
     /// <summary>One INI in the layer. <see cref="NotApplied"/> is null when the game reads this file;
     /// otherwise it NAMES why it doesn't (BSA-only / plugin-gated off / unreadable). Parsed lines are
-    /// kept either way (an inactive patch is still inspectable).</summary>
+    /// kept either way (an inactive patch is still inspectable). <see cref="LooseFilePath"/> is the
+    /// on-disk path of the winning loose copy, null when there is none (BSA-only) — it is what tells a
+    /// draft apart from the file it would be folded in beside.</summary>
     public sealed record IniFile(
         string RelPath,
         string Subfolder,
         string SortKey,
         string? WinningProvider,
+        string? LooseFilePath,
         IReadOnlyList<string> ShadowedProviders,
         string? GatePlugin,
         string? NotApplied,
@@ -148,7 +151,9 @@ public static class SkyPatcherDiscovery
 
             }
 
-            var file = new IniFile(rel, subfolder, sortKey, winner?.ProviderName, shadowed, GatePluginOf(rel), notApplied, lines);
+            var file = new IniFile(rel, subfolder, sortKey, winner?.ProviderName,
+                                   winner?.Kind == AssetKind.Loose ? winner.LooseFilePath : null,
+                                   shadowed, GatePluginOf(rel), notApplied, lines);
             (byFolder.TryGetValue(subfolder, out var list) ? list : byFolder[subfolder] = new()).Add(file);
 
             if (shadowed.Count > 0)

--- a/src/housecarl-core/SkyPatcherDraft.cs
+++ b/src/housecarl-core/SkyPatcherDraft.cs
@@ -60,7 +60,7 @@ public static class SkyPatcherDraft
             {
                 refusal = $"the draft's filename '{name}' is already live in the '{Subfolder}' folder as '{clash.RelPath}'"
                         + (clash.WinningProvider is null ? "" : $" (from '{clash.WinningProvider}')")
-                        + ", so placing the draft there would shadow that file or be shadowed by it depending on mod order — rename the draft, or nest it under a mod-specific subfolder.";
+                        + ", so placing the draft there would shadow that file or be shadowed by it depending on mod order — give the draft a filename not yet placed in that folder, which is also what decides where it sorts among them.";
                 return live;
             }
 

--- a/src/housecarl-core/SkyPatcherDraft.cs
+++ b/src/housecarl-core/SkyPatcherDraft.cs
@@ -38,6 +38,20 @@ public static class SkyPatcherDraft
             for (int i = 0; i < live.Folders.Count; i++)
                 if (live.Folders[i].Subfolder.Equals(Subfolder, StringComparison.OrdinalIgnoreCase)) { at = i; break; }
 
+            // A draft that IS one of the layer's live files: folding it in would put the same file in the folder
+            // twice and replay every one of its lines twice, a post state the game never produces. The filename
+            // clash below catches this only when the live copy sits flat in the type folder, since a nested one
+            // sorts under 'MyMod\Blades.ini' and no bare filename matches it.
+            var placed = live.Folders.SelectMany(f => f.Files)
+                             .FirstOrDefault(f => f.LooseFilePath is { } p && SamePath(p, IniPath));
+            if (placed is not null)
+            {
+                refusal = $"the draft '{IniPath}' is already placed — it is the file the layer reads as '{placed.RelPath}'"
+                        + (placed.WinningProvider is null ? "" : $" (from '{placed.WinningProvider}')")
+                        + ", so folding it in would replay its lines twice; read it with the plain post state by dropping \"ini\".";
+                return live;
+            }
+
             // Same relative path once placed = the VFS same-path collision: one copy wins by mod order and the
             // other is never read, so which body this call would answer with is not the draft's to decide.
             var clash = at < 0 ? null
@@ -68,7 +82,7 @@ public static class SkyPatcherDraft
                 warnings?.Add($"{IniPath}: the draft is {notApplied} — SkyPatcher would not read it once placed, so this post state is the plain winner.");
             }
 
-            var draft = new SkyPatcherDiscovery.IniFile(IniPath, Subfolder, name, DraftProvider,
+            var draft = new SkyPatcherDiscovery.IniFile(IniPath, Subfolder, name, DraftProvider, IniPath,
                                                         Array.Empty<string>(), gate, notApplied, lines);
 
             // The SkyPatcher.ini [Patcher] toggle for this type. A folder the live scan built carries it already;
@@ -100,6 +114,13 @@ public static class SkyPatcherDraft
                 "so this reads what the game would see once it is placed there.").ToList();
             return new SkyPatcherDiscovery.LayerScan(folders, notes, live.ReadIncomplete, live.PatcherToggles);
         }
+    }
+
+    /// <summary>Two paths naming the same file, compared as the filesystem does here: normalized, case-insensitive.</summary>
+    static bool SamePath(string a, string b)
+    {
+        try { return Path.GetFullPath(a).Equals(Path.GetFullPath(b), StringComparison.OrdinalIgnoreCase); }
+        catch { return false; }
     }
 
     /// <summary>What the draft's provider column says: it comes from no mod, and saying so keeps a render from

--- a/src/housecarl-core/SkyPatcherDraft.cs
+++ b/src/housecarl-core/SkyPatcherDraft.cs
@@ -25,8 +25,9 @@ public static class SkyPatcherDraft
         /// <summary>Fold this draft into a live layer scan: its type folder gains the draft, sorted among the
         /// live files by filename exactly as <see cref="SkyPatcherDiscovery.Scan"/> sorts them. Returns the live
         /// scan unchanged when <paramref name="refusal"/> is set. <paramref name="warnings"/> collects the facts
-        /// a replay would otherwise swallow — a gated-off draft applies nothing, and silence there would read as
-        /// "the draft changes nothing".</summary>
+        /// a replay would otherwise swallow — a gated-off draft, or one in a type the <c>SkyPatcher.ini</c>
+        /// <c>[Patcher]</c> toggles off, applies nothing, and silence there would read as "the draft changes
+        /// nothing".</summary>
         public SkyPatcherDiscovery.LayerScan Fold(SkyPatcherDiscovery.LayerScan live, SkyPatcherCatalog catalog,
                                                   Func<string, bool> pluginPresent, out string? refusal,
                                                   List<string>? warnings = null)
@@ -70,10 +71,20 @@ public static class SkyPatcherDraft
             var draft = new SkyPatcherDiscovery.IniFile(IniPath, Subfolder, name, DraftProvider,
                                                         Array.Empty<string>(), gate, notApplied, lines);
 
+            // The SkyPatcher.ini [Patcher] toggle for this type. A folder the live scan built carries it already;
+            // a folder invented here for a type with no live INI has no scan to carry it, so it is read off the
+            // layer's toggle map — assuming enabled there would read a disabled type as applied.
+            bool folderEnabled = at >= 0
+                ? live.Folders[at].PatchingEnabled
+                : SkyPatcherDiscovery.ToggleEnabled(live.PatcherToggles, Subfolder);
+            if (!folderEnabled)
+                warnings?.Add($"{IniPath}: SkyPatcher.ini disables '{Subfolder}' patching (iEnable…Patching=0) — the DLL skips the whole folder, " +
+                              "so the draft would apply nothing once placed and this post state is the plain winner.");
+
             var folders = new List<SkyPatcherDiscovery.FolderScan>(live.Folders);
             if (at < 0)
             {
-                folders.Add(new SkyPatcherDiscovery.FolderScan(Subfolder, catalog.ForSubfolder(Subfolder), true,
+                folders.Add(new SkyPatcherDiscovery.FolderScan(Subfolder, catalog.ForSubfolder(Subfolder), folderEnabled,
                                                                new List<SkyPatcherDiscovery.IniFile> { draft }));
                 folders = folders.OrderBy(f => f.Subfolder, StringComparer.OrdinalIgnoreCase).ToList();
             }
@@ -87,7 +98,7 @@ public static class SkyPatcherDraft
             var notes = live.Notes.Append(
                 $"the draft INI '{IniPath}' was folded into the '{Subfolder}' folder as '{name}' — it is NOT on disk in a mod, " +
                 "so this reads what the game would see once it is placed there.").ToList();
-            return new SkyPatcherDiscovery.LayerScan(folders, notes, live.ReadIncomplete);
+            return new SkyPatcherDiscovery.LayerScan(folders, notes, live.ReadIncomplete, live.PatcherToggles);
         }
     }
 

--- a/src/housecarl-core/SkyPatcherDraft.cs
+++ b/src/housecarl-core/SkyPatcherDraft.cs
@@ -1,0 +1,136 @@
+namespace HousecarlCore;
+
+/// <summary>
+/// DRAFT INI: fold one not-yet-placed SkyPatcher INI into the discovered layer, so a record can be read
+/// as the game would see it once the draft is placed in a mod. A draft is a file anywhere on disk plus
+/// the type subfolder it would be placed in; everything after that is the live layer's own machinery,
+/// unchanged — the <c>Plugin.esp.ini</c> filename gate, the ordinal sort within the type folder, the
+/// per-line warnings. The draft's file NAME in the layer is its full path, so every warning the replay
+/// produces for one of its lines names the draft rather than a Data-relative path that does not exist.
+///
+/// <para><b>No shadowing.</b> A draft whose filename collides with a live INI at the same relative path
+/// is refused: once placed, one of the two would win the VFS and which one depends on mod order, so the
+/// answer would not be the draft's.</para>
+/// </summary>
+public static class SkyPatcherDraft
+{
+    /// <summary>A validated draft: the file, the type folder it would sit in, and whether that folder was
+    /// taken from the file's parent directory rather than named — which the arm line says out loud.</summary>
+    public sealed record Plan(string IniPath, string Subfolder, bool SubfolderInferred)
+    {
+        /// <summary>The arm clause a response leads with, so the answer always names the draft it included.</summary>
+        public string Arm => $"the draft INI '{IniPath}' placed in the '{Subfolder}' folder"
+                           + (SubfolderInferred ? " (subfolder taken from the draft's parent directory)" : "");
+
+        /// <summary>Fold this draft into a live layer scan: its type folder gains the draft, sorted among the
+        /// live files by filename exactly as <see cref="SkyPatcherDiscovery.Scan"/> sorts them. Returns the live
+        /// scan unchanged when <paramref name="refusal"/> is set. <paramref name="warnings"/> collects the facts
+        /// a replay would otherwise swallow — a gated-off draft applies nothing, and silence there would read as
+        /// "the draft changes nothing".</summary>
+        public SkyPatcherDiscovery.LayerScan Fold(SkyPatcherDiscovery.LayerScan live, SkyPatcherCatalog catalog,
+                                                  Func<string, bool> pluginPresent, out string? refusal,
+                                                  List<string>? warnings = null)
+        {
+            refusal = null;
+            var name = Path.GetFileName(IniPath);
+            int at = -1;
+            for (int i = 0; i < live.Folders.Count; i++)
+                if (live.Folders[i].Subfolder.Equals(Subfolder, StringComparison.OrdinalIgnoreCase)) { at = i; break; }
+
+            // Same relative path once placed = the VFS same-path collision: one copy wins by mod order and the
+            // other is never read, so which body this call would answer with is not the draft's to decide.
+            var clash = at < 0 ? null
+                : live.Folders[at].Files.FirstOrDefault(f => f.SortKey.Equals(name, StringComparison.OrdinalIgnoreCase));
+            if (clash is not null)
+            {
+                refusal = $"the draft's filename '{name}' is already live in the '{Subfolder}' folder as '{clash.RelPath}'"
+                        + (clash.WinningProvider is null ? "" : $" (from '{clash.WinningProvider}')")
+                        + ", so placing the draft there would shadow that file or be shadowed by it depending on mod order — rename the draft, or nest it under a mod-specific subfolder.";
+                return live;
+            }
+
+            IReadOnlyList<SkyPatcherLine> lines;
+            try { lines = SkyPatcherParse.ParseFile(File.ReadAllText(IniPath)); }
+            catch (Exception ex)
+            {
+                refusal = $"the draft '{IniPath}' could not be read: {ex.Message}";
+                return live;
+            }
+
+            // The filename gate applies to the draft as to any file: '<Plugin>.esp.ini' loads only when that
+            // plugin is active.
+            var gate = SkyPatcherDiscovery.GatePluginOf(name);
+            string? notApplied = null;
+            if (gate is not null && !pluginPresent(gate))
+            {
+                notApplied = $"filename-gated on plugin '{gate}', which is not in the active load order";
+                warnings?.Add($"{IniPath}: the draft is {notApplied} — SkyPatcher would not read it once placed, so this post state is the plain winner.");
+            }
+
+            var draft = new SkyPatcherDiscovery.IniFile(IniPath, Subfolder, name, DraftProvider,
+                                                        Array.Empty<string>(), gate, notApplied, lines);
+
+            var folders = new List<SkyPatcherDiscovery.FolderScan>(live.Folders);
+            if (at < 0)
+            {
+                folders.Add(new SkyPatcherDiscovery.FolderScan(Subfolder, catalog.ForSubfolder(Subfolder), true,
+                                                               new List<SkyPatcherDiscovery.IniFile> { draft }));
+                folders = folders.OrderBy(f => f.Subfolder, StringComparer.OrdinalIgnoreCase).ToList();
+            }
+            else
+            {
+                var files = folders[at].Files.Append(draft)
+                                             .OrderBy(f => f.SortKey, StringComparer.OrdinalIgnoreCase).ToList();
+                folders[at] = folders[at] with { Files = files };
+            }
+
+            var notes = live.Notes.Append(
+                $"the draft INI '{IniPath}' was folded into the '{Subfolder}' folder as '{name}' — it is NOT on disk in a mod, " +
+                "so this reads what the game would see once it is placed there.").ToList();
+            return new SkyPatcherDiscovery.LayerScan(folders, notes, live.ReadIncomplete);
+        }
+    }
+
+    /// <summary>What the draft's provider column says: it comes from no mod, and saying so keeps a render from
+    /// naming a mod folder that does not have it.</summary>
+    public const string DraftProvider = "the draft (not placed in a mod)";
+
+    /// <summary>Validate a draft pole expression into a <see cref="Plan"/>. Returns the refusal sentence, or null
+    /// on success. <paramref name="subfolder"/> may be null, in which case the file's parent directory name is
+    /// used when it is a documented type folder and the call is refused when it is not.</summary>
+    public static string? Prepare(string? iniPath, string? subfolder, SkyPatcherCatalog catalog, out Plan? plan)
+    {
+        plan = null;
+        var path = (iniPath ?? "").Trim();
+        if (path.Length == 0)
+            return "the draft INI path is empty — give the absolute path to the .ini file the draft would be placed as.";
+        if (!Path.IsPathRooted(path))
+            return $"the draft INI path '{path}' is relative, and there is no directory to resolve it against — give the absolute path to the file.";
+        try { path = Path.GetFullPath(path); }
+        catch (Exception ex) { return $"the draft INI path '{path}' is not a usable path: {ex.Message}"; }
+        if (!path.EndsWith(".ini", StringComparison.OrdinalIgnoreCase))
+            return $"the draft '{path}' is not a .ini file — SkyPatcher reads only .ini files from its type folders.";
+        if (!File.Exists(path))
+            return $"there is no file at '{path}' — the draft is read from disk, so it has to exist before it can be checked.";
+
+        var asked = subfolder?.Trim();
+        bool inferred = string.IsNullOrEmpty(asked);
+        if (inferred)
+        {
+            asked = Path.GetFileName(Path.GetDirectoryName(path)?.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)) ?? "";
+            if (catalog.ForSubfolder(asked) is null)
+                return $"the SkyPatcher type folder for the draft was taken from its parent directory '{asked}', which is not a documented SkyPatcher record type " +
+                       $"(not in the grammar reference; verify the folder name or the reference version) — name the folder with \"subfolder\". The documented folders are: {Documented(catalog)}.";
+        }
+        else if (catalog.ForSubfolder(asked!) is null)
+            return $"subfolder '{asked}' is not a documented SkyPatcher record type (not in the grammar reference; verify the folder name or the reference version). " +
+                   $"The documented folders are: {Documented(catalog)}.";
+
+        // The catalog's own spelling, so a draft folder matches a live one case for case.
+        plan = new Plan(path, catalog.ForSubfolder(asked!)!.Subfolder, inferred);
+        return null;
+    }
+
+    static string Documented(SkyPatcherCatalog catalog)
+        => string.Join(", ", catalog.Records.Select(r => r.Subfolder).OrderBy(s => s, StringComparer.OrdinalIgnoreCase));
+}

--- a/src/housecarl-core/SkyPatcherDraft.cs
+++ b/src/housecarl-core/SkyPatcherDraft.cs
@@ -30,7 +30,7 @@ public static class SkyPatcherDraft
         /// nothing".</summary>
         public SkyPatcherDiscovery.LayerScan Fold(SkyPatcherDiscovery.LayerScan live, SkyPatcherCatalog catalog,
                                                   Func<string, bool> pluginPresent, out string? refusal,
-                                                  List<string>? warnings = null)
+                                                  SkyPatcherOverlay.WarningSink? warnings = null)
         {
             refusal = null;
             var name = Path.GetFileName(IniPath);

--- a/src/housecarl-core/SkyPatcherOverlay.cs
+++ b/src/housecarl-core/SkyPatcherOverlay.cs
@@ -133,13 +133,14 @@ public static class SkyPatcherOverlay
         var applied = new List<SkyPatcherAppliedOp>();
         var directives = new List<SkyPatcherDirective>();
         var warnings = new List<string>();
-        var dedupe = new HashSet<string>(StringComparer.Ordinal);   // layer-fact warnings (e.g. a keyword not in the order) fire once, not per line
+        var warn = new FilterWarnings(warnings);
         int matched = 0, unresolvedSkips = 0;
 
         foreach (var line in lines)
         {
             if (line.Parsed.Kind != SkyPatcherLineKind.Patch) continue;
             var where = $"{line.File}:{line.LineNumber}";
+            warn.At(line.File, where);
             if (line.Parsed.Note is { } parseNote)
                 warnings.Add($"{where}: parse note — {parseNote}");
 
@@ -172,7 +173,7 @@ public static class SkyPatcherOverlay
             if (ops.Count == 0) continue;   // a line with no operation does nothing
 
             // ---- evaluate the filters against THIS record (unsupported ⇒ loud skip). ----
-            var verdict = EvaluateFilters(mutableRecord, fk, editorId, recordCatalog, fieldMap, filters, resolver, warnings, dedupe);
+            var verdict = EvaluateFilters(mutableRecord, fk, editorId, recordCatalog, fieldMap, filters, resolver, warn);
             if (verdict == FilterVerdict.Unresolved)
             {
                 unresolvedSkips++;
@@ -244,10 +245,24 @@ public static class SkyPatcherOverlay
         "filterByMgefs", "filterByAlternateTextures",
     };
 
+    /// <summary>Where the filter evaluators put their warnings. Every one is prefixed with the file and line being
+    /// evaluated, as the op-side warnings already are: without it two INIs raising the same filter warning produce
+    /// the same string, and a draft's cannot be told from a placed file's. The dedupe key is scoped to the file, so
+    /// a filter no evaluator handles is named once per INI rather than once per line.</summary>
+    sealed class FilterWarnings
+    {
+        readonly List<string> _out;
+        readonly HashSet<string> _seen = new(StringComparer.Ordinal);
+        string _file = "", _where = "";
+        public FilterWarnings(List<string> sink) => _out = sink;
+        public void At(string file, string where) { _file = file; _where = where; }
+        public void Add(string key, string text) { if (_seen.Add(_file + "|" + key)) _out.Add($"{_where}: {text}"); }
+    }
+
     static FilterVerdict EvaluateFilters(object record, FormKey fk, string? editorId,
         SkyPatcherRecordCatalog recordCatalog, RecordMap? fieldMap,
         IReadOnlyList<(SkyPatcherSegment seg, SkyPatcherKeyClass cls)> filters, IFormResolver resolver,
-        List<string> warnings, HashSet<string> dedupe)
+        FilterWarnings warn)
     {
         var mutagenRecordType = fieldMap?.RecordType;
 
@@ -312,7 +327,7 @@ public static class SkyPatcherOverlay
                 any = true; continue;
             }
 
-            var verdict = EvaluateOneFilter(record, fk, editorId, cls, seg, conn, fieldMap, resolver, warnings, dedupe);
+            var verdict = EvaluateOneFilter(record, fk, editorId, cls, seg, conn, fieldMap, resolver, warn);
             if (verdict != FilterVerdict.Match) return verdict;
             any = true;
         }
@@ -325,23 +340,22 @@ public static class SkyPatcherOverlay
     /// CREATED object's keywords, not its own). Anything else is Unresolved — loud skip upstream.</summary>
     static FilterVerdict EvaluateOneFilter(object record, FormKey fk, string? editorId,
         SkyPatcherKeyClass cls, SkyPatcherSegment seg, string conn, RecordMap? fieldMap,
-        IFormResolver resolver, List<string> warnings, HashSet<string> dedupe)
+        IFormResolver resolver, FilterWarnings warn)
     {
         var spec = fieldMap?.Filters.GetValueOrDefault(cls.BaseKey);
         if (spec is { IsUnmapped: true })
         {
-            if (dedupe.Add($"fu:{cls.BaseKey}"))
-                warnings.Add($"filter '{cls.BaseKey}' has no static evaluation — {spec.Unmapped}");
+            warn.Add($"fu:{cls.BaseKey}", $"filter '{cls.BaseKey}' has no static evaluation — {spec.Unmapped}");
             return FilterVerdict.Unresolved;
         }
         if (spec is not null)
-            return EvaluateSpec(record, cls, seg, conn, spec, fieldMap!, resolver, warnings, dedupe);
+            return EvaluateSpec(record, cls, seg, conn, spec, fieldMap!, resolver, warn);
 
         switch (cls.BaseKey)
         {
             case "filterByKeywords":
             case "restrictToKeywords":   // post-match narrowing; for ONE record that's the same verdict
-                return KeywordVerdict(ReadEngine.KeywordKeys(record), seg, cls.BaseKey, conn, resolver, warnings, dedupe);
+                return KeywordVerdict(ReadEngine.KeywordKeys(record), seg, cls.BaseKey, conn, resolver, warn);
 
             case "filterByEditorIdContains":
                 return ContainsVerdict(seg, conn, editorId ?? "") ? FilterVerdict.Match : FilterVerdict.NoMatch;
@@ -360,8 +374,7 @@ public static class SkyPatcherOverlay
                 if (resolver.WinnerPluginOf(fk) is { } winner
                     && seg.Values.Any(v => v.Raw.Equals(winner, StringComparison.OrdinalIgnoreCase)) != inSet)
                 {
-                    if (dedupe.Add($"mn:{fk}"))
-                        warnings.Add($"filterByModNames{conn}: the record's defining master ('{origin}') and winning override ('{winner}') disagree on membership — which one the DLL tests is unverified, so whether the line applies is UNRESOLVED.");
+                    warn.Add($"mn:{fk}", $"filterByModNames{conn}: the record's defining master ('{origin}') and winning override ('{winner}') disagree on membership — which one the DLL tests is unverified, so whether the line applies is UNRESOLVED.");
                     return FilterVerdict.Unresolved;
                 }
                 bool ok = conn is "Excluded" or "Exclude" ? !inSet : inSet;
@@ -382,15 +395,13 @@ public static class SkyPatcherOverlay
                 // in the Excluded spelling; any other connective is unresolved, never guessed.
                 if (conn is not ("Excluded" or "Exclude"))
                 {
-                    if (dedupe.Add($"ovc:{cls.BaseKey}{conn}"))
-                        warnings.Add($"filter '{cls.BaseKey}{conn}' — only the Excluded spelling is documented; whether this connective yields or selects is UNRESOLVED.");
+                    warn.Add($"ovc:{cls.BaseKey}{conn}", $"filter '{cls.BaseKey}{conn}' — only the Excluded spelling is documented; whether this connective yields or selects is UNRESOLVED.");
                     return FilterVerdict.Unresolved;
                 }
                 var winner = resolver.WinnerPluginOf(fk);
                 if (winner is null)
                 {
-                    if (dedupe.Add($"ov:{fk}"))
-                        warnings.Add($"modNamesLastOverridden{conn}: could not resolve the winning override plugin of {fk} — whether the line yields is UNRESOLVED.");
+                    warn.Add($"ov:{fk}", $"modNamesLastOverridden{conn}: could not resolve the winning override plugin of {fk} — whether the line yields is UNRESOLVED.");
                     return FilterVerdict.Unresolved;
                 }
                 bool hit = seg.Values.Any(v => v.Raw.Equals(winner, StringComparison.OrdinalIgnoreCase));
@@ -402,19 +413,18 @@ public static class SkyPatcherOverlay
                 // Effects array's BaseEffect links. (On the magicEffect folder filterByMgefs is the
                 // PRIMARY filter and never reaches here.)
                 var mine = EntryKeys(record, new[] { "Effects" }, "BaseEffect");
-                return FormSetVerdict(mine, seg, cls.BaseKey, conn, "MagicEffect", resolver, warnings, dedupe);
+                return FormSetVerdict(mine, seg, cls.BaseKey, conn, "MagicEffect", resolver, warn);
             }
             case "filterByAlternateTextures":
             {
                 // Items carrying a given texture set: the model's alternate-texture entries' NewTexture.
                 var mine = EntryKeys(record, new[] { "Model", "AlternateTextures" }, "NewTexture");
-                return FormSetVerdict(mine, seg, cls.BaseKey, conn, "TextureSet", resolver, warnings, dedupe);
+                return FormSetVerdict(mine, seg, cls.BaseKey, conn, "TextureSet", resolver, warn);
             }
             default:
                 // Neither built-in nor mapped — a coverage gap the filtermap guard should have caught;
                 // named here too so a stale plugin build can't skip silently.
-                if (dedupe.Add($"nf:{cls.BaseKey}"))
-                    warnings.Add($"filter '{cls.BaseKey}' has no evaluation (neither built-in nor in the filter map) — whether lines carrying it apply is UNRESOLVED (a coverage gap; report it).");
+                warn.Add($"nf:{cls.BaseKey}", $"filter '{cls.BaseKey}' has no evaluation (neither built-in nor in the filter map) — whether lines carrying it apply is UNRESOLVED (a coverage gap; report it).");
                 return FilterVerdict.Unresolved;
         }
     }
@@ -423,7 +433,7 @@ public static class SkyPatcherOverlay
 
     static FilterVerdict EvaluateSpec(object record, SkyPatcherKeyClass cls, SkyPatcherSegment seg,
         string conn, FilterSpec spec, RecordMap fieldMap, IFormResolver resolver,
-        List<string> warnings, HashSet<string> dedupe)
+        FilterWarnings warn)
     {
         bool excluded = conn is "Excluded" or "Exclude";
         switch (spec.Eval)
@@ -438,7 +448,7 @@ public static class SkyPatcherOverlay
                 foreach (var v in seg.Values)
                 {
                     var k = ResolveFormValue(v, spec.FormType, resolver);
-                    if (k is null) { WarnUnresolvableForm(v, cls.BaseKey, conn, spec, warnings, dedupe); continue; }
+                    if (k is null) { WarnUnresolvableForm(v, cls.BaseKey, conn, spec, warn); continue; }
                     matched |= current.Any(t => string.Equals(t, k.Value.ToString(), StringComparison.OrdinalIgnoreCase));
                 }
                 return (excluded ? !matched : matched) ? FilterVerdict.Match : FilterVerdict.NoMatch;
@@ -448,8 +458,8 @@ public static class SkyPatcherOverlay
                 var segs = SplitPath(spec.Paths[0]);
                 var mine = spec.KeyPath is null ? TryFormLinkKeys(record, segs) : EntryKeys(record, segs, spec.KeyPath);
                 if (spec.EidSubstring)
-                    return EidAwareListVerdict(mine, seg, cls.BaseKey, conn, spec, resolver, warnings, dedupe);
-                return FormSetVerdict(mine, seg, cls.BaseKey, conn, spec.FormType, resolver, warnings, dedupe);
+                    return EidAwareListVerdict(mine, seg, cls.BaseKey, conn, spec, resolver, warn);
+                return FormSetVerdict(mine, seg, cls.BaseKey, conn, spec.FormType, resolver, warn);
             }
             case SkyPatcherFilterEval.EnumEquals:
             {
@@ -468,8 +478,7 @@ public static class SkyPatcherOverlay
                     var member = spec.ValueMap?.GetValueOrDefault(v.Raw) ?? v.Raw;
                     if (enumType is not null && !TryParseEnumMember(enumType, member, out _))
                     {
-                        if (dedupe.Add($"ee:{cls.BaseKey}:{v.Raw}"))
-                            warnings.Add($"filter '{cls.BaseKey}' — '{v.Raw}' is not a {enumType.Name} member (no valueMap match either); whether the line applies is UNRESOLVED.");
+                        warn.Add($"ee:{cls.BaseKey}:{v.Raw}", $"filter '{cls.BaseKey}' — '{v.Raw}' is not a {enumType.Name} member (no valueMap match either); whether the line applies is UNRESOLVED.");
                         return FilterVerdict.Unresolved;
                     }
                     if (current is not null && string.Equals(current, member, StringComparison.OrdinalIgnoreCase)) matched = true;
@@ -482,13 +491,12 @@ public static class SkyPatcherOverlay
                 bool? want = ParseBoolToken(raw);
                 if (want is null)
                 {
-                    if (dedupe.Add($"fb:{cls.BaseKey}:{raw}"))
-                        warnings.Add($"filter '{cls.BaseKey}={raw}' — not a boolean; whether the line applies is UNRESOLVED.");
+                    warn.Add($"fb:{cls.BaseKey}:{raw}", $"filter '{cls.BaseKey}={raw}' — not a boolean; whether the line applies is UNRESOLVED.");
                     return FilterVerdict.Unresolved;
                 }
                 var (bits, enumType) = FlagLeaf(record, spec.Paths[0]);
                 if (enumType is null || !TryParseEnumMember(enumType, spec.Flag!, out var bit))
-                    return UnresolvedLeaf(cls.BaseKey, spec.Paths[0], warnings, dedupe);
+                    return UnresolvedLeaf(cls.BaseKey, spec.Paths[0], warn);
                 bool set = (bits & bit) != 0;
                 if (spec.Invert) set = !set;
                 return set == want.Value ? FilterVerdict.Match : FilterVerdict.NoMatch;
@@ -496,15 +504,14 @@ public static class SkyPatcherOverlay
             case SkyPatcherFilterEval.FlagAnyOf:
             {
                 var (bits, enumType) = FlagLeaf(record, spec.Paths[0]);
-                if (enumType is null) return UnresolvedLeaf(cls.BaseKey, spec.Paths[0], warnings, dedupe);
+                if (enumType is null) return UnresolvedLeaf(cls.BaseKey, spec.Paths[0], warn);
                 var hits = new List<bool>();
                 foreach (var v in seg.Values)
                 {
                     var member = spec.ValueMap?.GetValueOrDefault(v.Raw) ?? v.Raw;
                     if (!TryParseEnumMember(enumType, member, out var bit))
                     {
-                        if (dedupe.Add($"fa:{cls.BaseKey}:{v.Raw}"))
-                            warnings.Add($"filter '{cls.BaseKey}' — flag '{v.Raw}' is not a member of the {spec.Paths[0]} enum (no valueMap match either); whether the line applies is UNRESOLVED.");
+                        warn.Add($"fa:{cls.BaseKey}:{v.Raw}", $"filter '{cls.BaseKey}' — flag '{v.Raw}' is not a member of the {spec.Paths[0]} enum (no valueMap match either); whether the line applies is UNRESOLVED.");
                         return FilterVerdict.Unresolved;
                     }
                     hits.Add((bits & bit) != 0);
@@ -519,8 +526,7 @@ public static class SkyPatcherOverlay
                 else if (raw.Equals("male", StringComparison.OrdinalIgnoreCase)) female = false;
                 else
                 {
-                    if (dedupe.Add($"g:{raw}"))
-                        warnings.Add($"filter '{cls.BaseKey}={raw}' — expected male|female; whether the line applies is UNRESOLVED.");
+                    warn.Add($"g:{raw}", $"filter '{cls.BaseKey}={raw}' — expected male|female; whether the line applies is UNRESOLVED.");
                     return FilterVerdict.Unresolved;
                 }
                 // A TRAITS-templated NPC takes its gender from the TEMPLATE actor — the own-record
@@ -530,13 +536,12 @@ public static class SkyPatcherOverlay
                 var (tBits, tType) = FlagLeaf(record, "Configuration.TemplateFlags");
                 if (tType is not null && TryParseEnumMember(tType, "Traits", out var traitsBit) && (tBits & traitsBit) != 0)
                 {
-                    if (dedupe.Add($"gt:{cls.BaseKey}"))
-                        warnings.Add($"filter '{cls.BaseKey}' — this NPC templates its TRAITS (gender comes from the template actor, not this record); whether the line applies is UNRESOLVED.");
+                    warn.Add($"gt:{cls.BaseKey}", $"filter '{cls.BaseKey}' — this NPC templates its TRAITS (gender comes from the template actor, not this record); whether the line applies is UNRESOLVED.");
                     return FilterVerdict.Unresolved;
                 }
                 var (bits, enumType) = FlagLeaf(record, spec.Paths[0]);
                 if (enumType is null || !TryParseEnumMember(enumType, "Female", out var bit))
-                    return UnresolvedLeaf(cls.BaseKey, spec.Paths[0], warnings, dedupe);
+                    return UnresolvedLeaf(cls.BaseKey, spec.Paths[0], warn);
                 return ((bits & bit) != 0) == female ? FilterVerdict.Match : FilterVerdict.NoMatch;
             }
             case SkyPatcherFilterEval.PcLevelMult:
@@ -545,8 +550,7 @@ public static class SkyPatcherOverlay
                 bool? want = ParseBoolToken(raw);
                 if (want is null)
                 {
-                    if (dedupe.Add($"pl:{cls.BaseKey}:{raw}"))
-                        warnings.Add($"filter '{cls.BaseKey}={raw}' — not a boolean; whether the line applies is UNRESOLVED.");
+                    warn.Add($"pl:{cls.BaseKey}:{raw}", $"filter '{cls.BaseKey}={raw}' — not a boolean; whether the line applies is UNRESOLVED.");
                     return FilterVerdict.Unresolved;
                 }
                 var (parent, leaf) = Navigate(record, SplitPath(spec.Paths[0]));
@@ -565,8 +569,7 @@ public static class SkyPatcherOverlay
                 var hay = resolver.ReadWinnerLeaf(donor.Value, spec.Paths[0]);
                 if (hay is null)
                 {
-                    if (dedupe.Add($"ds:{cls.BaseKey}:{donor}"))
-                        warnings.Add($"filter '{cls.BaseKey}' — could not read '{spec.Paths[0]}' off {donor}'s winner; whether the line applies is UNRESOLVED.");
+                    warn.Add($"ds:{cls.BaseKey}:{donor}", $"filter '{cls.BaseKey}' — could not read '{spec.Paths[0]}' off {donor}'s winner; whether the line applies is UNRESOLVED.");
                     return FilterVerdict.Unresolved;
                 }
                 return ContainsVerdict(seg, conn, hay) ? FilterVerdict.Match : FilterVerdict.NoMatch;
@@ -578,11 +581,10 @@ public static class SkyPatcherOverlay
                 var mine = resolver.KeywordsOf(donor.Value);
                 if (mine is null)
                 {
-                    if (dedupe.Add($"dk:{cls.BaseKey}:{donor}"))
-                        warnings.Add($"filter '{cls.BaseKey}' — could not read the keywords of {donor}'s winner; whether the line applies is UNRESOLVED.");
+                    warn.Add($"dk:{cls.BaseKey}:{donor}", $"filter '{cls.BaseKey}' — could not read the keywords of {donor}'s winner; whether the line applies is UNRESOLVED.");
                     return FilterVerdict.Unresolved;
                 }
-                return KeywordVerdict(mine, seg, cls.BaseKey, conn, resolver, warnings, dedupe);
+                return KeywordVerdict(mine, seg, cls.BaseKey, conn, resolver, warn);
             }
             case SkyPatcherFilterEval.NumericLess:
             {
@@ -592,8 +594,7 @@ public static class SkyPatcherOverlay
                 var raw = seg.Values.Count > 0 ? seg.Values[0].Raw : "";
                 if (!double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var n))
                 {
-                    if (dedupe.Add($"nl:{cls.BaseKey}:{raw}"))
-                        warnings.Add($"filter '{cls.BaseKey}={raw}' — not a number; whether the line applies is UNRESOLVED.");
+                    warn.Add($"nl:{cls.BaseKey}:{raw}", $"filter '{cls.BaseKey}={raw}' — not a number; whether the line applies is UNRESOLVED.");
                     return FilterVerdict.Unresolved;
                 }
                 return current < n ? FilterVerdict.Match : FilterVerdict.NoMatch;
@@ -608,8 +609,7 @@ public static class SkyPatcherOverlay
                 {
                     if (!int.TryParse(v.Raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var idx) || idx is < 0 or > 31)
                     {
-                        if (dedupe.Add($"bs:{cls.BaseKey}:{v.Raw}"))
-                            warnings.Add($"filter '{cls.BaseKey}' — '{v.Raw}' is not a biped slot INDEX (0–31; slot number − 30); whether the line applies is UNRESOLVED.");
+                        warn.Add($"bs:{cls.BaseKey}:{v.Raw}", $"filter '{cls.BaseKey}' — '{v.Raw}' is not a biped slot INDEX (0–31; slot number − 30); whether the line applies is UNRESOLVED.");
                         return FilterVerdict.Unresolved;
                     }
                     hits.Add((bits & (1UL << idx)) != 0);
@@ -628,8 +628,7 @@ public static class SkyPatcherOverlay
             default:
                 // Unreachable while the FilterSpec parser and this switch agree on the eval kinds —
                 // named anyway so a drift can't skip silently (the same contract every arm honors).
-                if (dedupe.Add($"ue:{cls.BaseKey}"))
-                    warnings.Add($"filter '{cls.BaseKey}' — eval kind '{spec.Eval}' has no evaluator; whether the line applies is UNRESOLVED (report it).");
+                warn.Add($"ue:{cls.BaseKey}", $"filter '{cls.BaseKey}' — eval kind '{spec.Eval}' has no evaluator; whether the line applies is UNRESOLVED (report it).");
                 return FilterVerdict.Unresolved;
         }
     }
@@ -649,9 +648,9 @@ public static class SkyPatcherOverlay
     /// <summary>The keyword-family verdict — <see cref="FormSetVerdict"/> scoped to Keyword. Null set ⇒
     /// the type has no keyword list we can read (unresolved).</summary>
     static FilterVerdict KeywordVerdict(IReadOnlyList<FormKey>? mine, SkyPatcherSegment seg,
-        string baseKey, string conn, IFormResolver resolver, List<string> warnings, HashSet<string> dedupe)
+        string baseKey, string conn, IFormResolver resolver, FilterWarnings warn)
         => mine is null ? FilterVerdict.Unresolved
-            : FormSetVerdict(mine, seg, baseKey, conn, "Keyword", resolver, warnings, dedupe, noun: "keyword");
+            : FormSetVerdict(mine, seg, baseKey, conn, "Keyword", resolver, warn, noun: "keyword");
 
     /// <summary>List-membership verdict for a set of the record's own attached forms (keywords, mgefs,
     /// alternate textures, factions, recipe ingredients…): bare = ALL listed present, Or = any,
@@ -661,7 +660,7 @@ public static class SkyPatcherOverlay
     /// e.g. SLA_KillerHeels) — and makes the bare-AND unsatisfiable.</summary>
     static FilterVerdict FormSetVerdict(IReadOnlyList<FormKey> mine, SkyPatcherSegment seg,
         string baseKey, string conn, string? formType, IFormResolver resolver,
-        List<string> warnings, HashSet<string> dedupe, string noun = "form")
+        FilterWarnings warn, string noun = "form")
     {
         var wanted = new List<FormKey>();
         int unresolved = 0;
@@ -671,8 +670,7 @@ public static class SkyPatcherOverlay
             if (k is null)
             {
                 unresolved++;
-                if (dedupe.Add($"fs:{baseKey}:{v.Raw}"))
-                    warnings.Add($"{noun} '{v.Raw}' (in a {baseKey}{conn}) resolves to nothing in the active order — treated as attached to no record.");
+                warn.Add($"fs:{baseKey}:{v.Raw}", $"{noun} '{v.Raw}' (in a {baseKey}{conn}) resolves to nothing in the active order — treated as attached to no record.");
             }
             else wanted.Add(k.Value);
         }
@@ -685,7 +683,7 @@ public static class SkyPatcherOverlay
     /// EditorID (resolver lookup).</summary>
     static FilterVerdict EidAwareListVerdict(IReadOnlyList<FormKey> mine, SkyPatcherSegment seg,
         string baseKey, string conn, FilterSpec spec, IFormResolver resolver,
-        List<string> warnings, HashSet<string> dedupe)
+        FilterWarnings warn)
     {
         var eids = new Lazy<List<string>>(() => mine
             .Select(k => resolver.EditorIdOf(k) ?? "")
@@ -775,10 +773,9 @@ public static class SkyPatcherOverlay
 
     /// <summary>The named-warning Unresolved for a flag/enum leaf that can't be resolved on this record
     /// — every Unresolved return owes a per-filter warning (the line-level skip message points at it).</summary>
-    static FilterVerdict UnresolvedLeaf(string baseKey, string path, List<string> warnings, HashSet<string> dedupe)
+    static FilterVerdict UnresolvedLeaf(string baseKey, string path, FilterWarnings warn)
     {
-        if (dedupe.Add($"ul:{baseKey}:{path}"))
-            warnings.Add($"filter '{baseKey}' — could not resolve '{path}' (or its member) on this record; whether the line applies is UNRESOLVED.");
+        warn.Add($"ul:{baseKey}:{path}", $"filter '{baseKey}' — could not resolve '{path}' (or its member) on this record; whether the line applies is UNRESOLVED.");
         return FilterVerdict.Unresolved;
     }
 
@@ -788,10 +785,9 @@ public static class SkyPatcherOverlay
          : null;
 
     static void WarnUnresolvableForm(SkyPatcherValue v, string baseKey, string conn, FilterSpec spec,
-        List<string> warnings, HashSet<string> dedupe)
+        FilterWarnings warn)
     {
-        if (dedupe.Add($"fe:{baseKey}:{v.Raw}"))
-            warnings.Add($"form '{v.Raw}' (in a {baseKey}{conn}) resolves to nothing in the active order{(spec.FormType is null ? "" : $" among {spec.FormType} winners")} — treated as matching no record.");
+        warn.Add($"fe:{baseKey}:{v.Raw}", $"form '{v.Raw}' (in a {baseKey}{conn}) resolves to nothing in the active order{(spec.FormType is null ? "" : $" among {spec.FormType} winners")} — treated as matching no record.");
     }
 
     static bool ContainsVerdict(SkyPatcherSegment seg, string conn, string haystack)

--- a/src/housecarl-core/SkyPatcherOverlay.cs
+++ b/src/housecarl-core/SkyPatcherOverlay.cs
@@ -35,6 +35,35 @@ namespace HousecarlCore;
 /// </summary>
 public static class SkyPatcherOverlay
 {
+    /// <summary>
+    /// One call's collector for the replay's warnings, across every record it replays. A warning names the record
+    /// it was raised for, so one INI line yields a DIFFERENT string per record and a batch of N records raises N
+    /// of them — while a render shows at most <see cref="Cap"/>. So the sink keeps that many and counts the rest:
+    /// membership is a hash lookup, and neither the kept list nor the seen set grows with the batch.
+    /// <para>Past the cap the seen set stops growing, so <see cref="Overflow"/> counts further warnings rather
+    /// than further DISTINCT ones — a number for "there were more", which is all it is ever rendered as.</para>
+    /// </summary>
+    public sealed class WarningSink
+    {
+        /// <summary>How many warnings are kept for rendering; the rest are counted.</summary>
+        public const int Cap = 20;
+
+        readonly HashSet<string> _seen = new(StringComparer.Ordinal);
+        readonly List<string> _kept = new();
+
+        /// <summary>The warnings a render lists, in the order they were first raised.</summary>
+        public IReadOnlyList<string> Kept => _kept;
+
+        /// <summary>How many further warnings were raised beyond <see cref="Kept"/>.</summary>
+        public int Overflow { get; private set; }
+
+        public void Add(string warning)
+        {
+            if (_kept.Count < Cap) { if (_seen.Add(warning)) _kept.Add(warning); return; }
+            if (!_seen.Contains(warning)) Overflow++;
+        }
+    }
+
     /// <summary>Everything the overlay needs from the load order, kept behind an interface so the
     /// engine itself stays testable off fixtures (the service implements this over the live resolver).</summary>
     public interface IFormResolver

--- a/src/housecarl-generator/SkyPatcherConflictsProbe.cs
+++ b/src/housecarl-generator/SkyPatcherConflictsProbe.cs
@@ -36,7 +36,7 @@ public static class SkyPatcherConflictsProbe
 
         SkyPatcherDiscovery.IniFile Ini(string name, params string[] lines) => new(
             RelPath: $"SKSE\\Plugins\\SkyPatcher\\weapon\\{name}", Subfolder: "weapon", SortKey: name,
-            WinningProvider: "TestMod", ShadowedProviders: Array.Empty<string>(), GatePlugin: null,
+            WinningProvider: "TestMod", LooseFilePath: null, ShadowedProviders: Array.Empty<string>(), GatePlugin: null,
             NotApplied: null, Lines: lines.Select(SkyPatcherParse.ParseLine).ToList());
 
         const string target = "Skyrim.esm|12EB7";          // 012EB7:Skyrim.esm

--- a/src/housecarl-mcp-tests/RecordsSkyPatcherDraftTests.cs
+++ b/src/housecarl-mcp-tests/RecordsSkyPatcherDraftTests.cs
@@ -1,0 +1,113 @@
+using System.Text.Json;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>The draft-INI value on the SkyPatcher overlay pole: a file not yet placed in a mod, folded into the
+/// live layer so the record reads as the game would see it once the draft is placed.</summary>
+[Collection("records")]
+[Trait("tier", "integration")]
+public sealed class RecordsSkyPatcherDraftTests : RecordsTestBase
+{
+    public RecordsSkyPatcherDraftTests(RecordsFixture f) : base(f) { }
+
+    static RecordsTools.RecordsProject Damage => new() { form = "fields", fields = new[] { "BasicStats.Damage" } };
+    static RecordsTools.RecordsProject DamageDelta => new() { form = "delta", fields = new[] { "BasicStats.Damage" } };
+
+    /// <summary>A draft INI on disk, outside any mod, and the pole that folds it in.</summary>
+    string Draft(string dir, string file, string body)
+    {
+        var path = W.Scratch(dir, file);
+        File.WriteAllText(path, body);
+        return path;
+    }
+
+    static JsonElement DraftPole(string ini, string? subfolder = null, string state = "post") =>
+        Je("{\"overlay\": \"skypatcher\", \"state\": \"" + state + "\", \"ini\": " + JsonSerializer.Serialize(ini)
+           + (subfolder is null ? "" : ", \"subfolder\": \"" + subfolder + "\"") + "}");
+
+    string ReadW0(JsonElement pole) =>
+        RecordsTools.Records(Svc, formids: new[] { Fid(W.Weapons[0]) }, source: pole, project: Damage);
+
+    [Fact]
+    public void ADraftThatSetsALeafIsReadInThePostState()
+    {
+        var ini = Draft("draft-set", "MyWeapons.ini", "filterByWeapons=HcRecW0:attackDamage=123\r\n");
+        Served(ReadW0(DraftPole(ini, "weapon")), "BasicStats.Damage = 123", ini);
+    }
+
+    [Fact]
+    public void TheSubfolderIsTakenFromTheDraftsParentDirectoryAndTheArmSaysSo()
+    {
+        var ini = Draft("weapon", "Inferred.ini", "filterByWeapons=HcRecW0:attackDamage=77\r\n");
+        Served(ReadW0(DraftPole(ini)), "BasicStats.Damage = 77", "parent directory");
+    }
+
+    /// <summary>The composition the skill's verify step wants: the draft's post state against the plain post state
+    /// is the draft's own effect and nothing else.</summary>
+    [Fact]
+    public void TheDraftsPostVersusThePlainPostIsTheDraftsOwnEffect()
+    {
+        var ini = Draft("draft-delta", "Delta.ini", "filterByWeapons=HcRecW0:attackDamage=140\r\n");
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.Weapons[0]) }, source: DraftPole(ini, "weapon"),
+                                     versus: Overlay("post"), project: DamageDelta);
+        Served(r, "BasicStats.Damage", "140", "1 difference");
+    }
+
+    [Fact]
+    public void ADraftLineWithAnUnknownKeyWarnsAndNamesTheDraftsPath()
+    {
+        var ini = Draft("draft-typo", "Typo.ini", "filterByWeapons=HcRecW0:attakDamage=5\r\n");
+        Served(ReadW0(DraftPole(ini, "weapon")), ini, "not in the SkyPatcher reference");
+    }
+
+    /// <summary>A draft named for a plugin that is not in the order would never be read once placed, so the post
+    /// state is the plain winner and the response says why rather than reading as "the draft changes nothing".</summary>
+    [Fact]
+    public void ADraftGatedOnAnInactivePluginIsNotAppliedAndSaysSo()
+    {
+        var ini = Draft("draft-gate", "NotHere.esp.ini", "filterByWeapons=HcRecW0:attackDamage=131\r\n");
+        var r = ReadW0(DraftPole(ini, "weapon"));
+        Served(r, "not in the active load order");
+        Assert.DoesNotContain("BasicStats.Damage = 131", r);
+    }
+
+    [Fact]
+    public void AnUndocumentedSubfolderIsRefusedNamingTheDocumentedFolders()
+    {
+        var ini = Draft("draft-sub", "Bad.ini", "filterByWeapons=HcRecW0:attackDamage=1\r\n");
+        Refused(ReadW0(DraftPole(ini, "weapons")), "weapons", "documented folders are");
+    }
+
+    [Fact]
+    public void ASubfolderThatCannotBeInferredIsRefusedAskingForOne()
+    {
+        var ini = Draft("draft-nofolder", "Loose.ini", "filterByWeapons=HcRecW0:attackDamage=1\r\n");
+        Refused(ReadW0(DraftPole(ini)), "subfolder");
+    }
+
+    [Fact]
+    public void TheDraftIsRefusedOnThePreState()
+    {
+        var ini = Draft("draft-pre", "Pre.ini", "filterByWeapons=HcRecW0:attackDamage=1\r\n");
+        Refused(ReadW0(DraftPole(ini, "weapon", state: "pre")), "\"post\"");
+    }
+
+    [Fact]
+    public void ADraftWhoseFilenameIsAlreadyPlacedIsRefused()
+    {
+        var ini = Draft("draft-clash", RecordsWorld.LiveSkyPatcherIni, "filterByWeapons=HcRecW0:attackDamage=1\r\n");
+        Refused(ReadW0(DraftPole(ini, "weapon")), RecordsWorld.LiveSkyPatcherIni, "shadow");
+    }
+
+    [Fact]
+    public void AMissingDraftFileIsRefused() =>
+        Refused(ReadW0(DraftPole(W.Scratch("draft-missing", "Gone.ini"), "weapon")), "no file at");
+
+    [Fact]
+    public void ASubfolderWithNoDraftIsRefusedByName() =>
+        Refused(RecordsTools.Records(Svc, formids: new[] { Fid(W.Weapons[0]) },
+                                     source: Je("{\"overlay\": \"skypatcher\", \"state\": \"post\", \"subfolder\": \"weapon\"}"),
+                                     project: Damage), "\"ini\"");
+}

--- a/src/housecarl-mcp-tests/RecordsSkyPatcherDraftTests.cs
+++ b/src/housecarl-mcp-tests/RecordsSkyPatcherDraftTests.cs
@@ -134,6 +134,17 @@ public sealed class RecordsSkyPatcherDraftTests : RecordsTestBase
         Refused(ReadW0(DraftPole(ini, "weapon")), RecordsWorld.LiveSkyPatcherIni, "shadow");
     }
 
+    /// <summary>The draft keys are a value on the overlay pole. On a {"file"} pole they would be dropped and that
+    /// plugin's own record would read as the draft's post state.</summary>
+    [Fact]
+    public void TheDraftKeysOnAPluginPoleAreRefusedNamingTheOverlayPole()
+    {
+        var ini = Draft("draft-wrong-pole", "Mixed.ini", "filterByWeapons=HcRecW0:attackDamage=1\r\n");
+        Refused(RecordsTools.Records(Svc, formids: new[] { Fid(W.Weapons[0]) },
+                                     source: Je("{\"file\": \"" + W.OverrideName + "\", \"ini\": " + JsonSerializer.Serialize(ini) + "}"),
+                                     project: Damage), "overlay");
+    }
+
     [Fact]
     public void AMissingDraftFileIsRefused() =>
         Refused(ReadW0(DraftPole(W.Scratch("draft-missing", "Gone.ini"), "weapon")), "no file at");

--- a/src/housecarl-mcp-tests/RecordsSkyPatcherDraftTests.cs
+++ b/src/housecarl-mcp-tests/RecordsSkyPatcherDraftTests.cs
@@ -134,6 +134,12 @@ public sealed class RecordsSkyPatcherDraftTests : RecordsTestBase
         Refused(ReadW0(DraftPole(ini, "weapon")), RecordsWorld.LiveSkyPatcherIni, "shadow");
     }
 
+    /// <summary>A draft pointed at a file the layer already reads would be folded in beside it and replay its lines
+    /// twice. A nested live INI sorts under its relative path, so the filename clash above never sees it.</summary>
+    [Fact]
+    public void ADraftThatIsAlreadyPlacedIsRefusedRatherThanFoldedInTwice() =>
+        Refused(ReadW0(DraftPole(W.NestedSkyPatcherIniPath, "weapon")), "already placed", "twice");
+
     /// <summary>The draft keys are a value on the overlay pole. On a {"file"} pole they would be dropped and that
     /// plugin's own record would read as the draft's post state.</summary>
     [Fact]

--- a/src/housecarl-mcp-tests/RecordsSkyPatcherDraftTests.cs
+++ b/src/housecarl-mcp-tests/RecordsSkyPatcherDraftTests.cs
@@ -73,6 +73,19 @@ public sealed class RecordsSkyPatcherDraftTests : RecordsTestBase
         Assert.DoesNotContain("BasicStats.Damage = 131", r);
     }
 
+    /// <summary>A draft in a type the SkyPatcher.ini [Patcher] section switches off is folded into a folder the live
+    /// scan never built — nothing is placed in that type — so the toggle has to be read off the layer rather than
+    /// assumed on: once placed the DLL would skip the whole folder, and the post state stays the plain winner.</summary>
+    [Fact]
+    public void ADraftInATypeToggledOffInSkyPatcherIniAppliesNothingAndSaysSo()
+    {
+        var ini = Draft("draft-toggle", "Armors.ini", "filterByArmors=HcRecA0:damageResist=99\r\n");
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.Armor) }, source: DraftPole(ini, "armor"),
+                                     project: new() { form = "fields", fields = new[] { "ArmorRating" } });
+        Served(r, "disables 'armor' patching");
+        Assert.DoesNotContain("ArmorRating = 99", r);
+    }
+
     [Fact]
     public void AnUndocumentedSubfolderIsRefusedNamingTheDocumentedFolders()
     {

--- a/src/housecarl-mcp-tests/RecordsSkyPatcherDraftTests.cs
+++ b/src/housecarl-mcp-tests/RecordsSkyPatcherDraftTests.cs
@@ -63,6 +63,17 @@ public sealed class RecordsSkyPatcherDraftTests : RecordsTestBase
         Served(ReadW0(DraftPole(ini, "weapon")), ini, "not in the SkyPatcher reference");
     }
 
+    /// <summary>A filter the layer has no evaluation for warns from the filter evaluators rather than the line loop,
+    /// and that warning has to name its file as the rest do: unprefixed it is byte-identical to the one a placed INI
+    /// would raise, so the modder cannot tell which of the two carries the filter.</summary>
+    [Fact]
+    public void AFilterTheLayerCannotEvaluateWarnsWithTheDraftsPathAndLine()
+    {
+        var ini = Draft("draft-filter", "Unmapped.ini",
+                        "filterByWeapons=HcRecW0:filterByHasAmmoFromWeaponList=x:attackDamage=9\r\n");
+        Served(ReadW0(DraftPole(ini, "weapon")), ini + ":1: filter 'filterByHasAmmoFromWeaponList'");
+    }
+
     /// <summary>A draft named for a plugin that is not in the order would never be read once placed, so the post
     /// state is the plain winner and the response says why rather than reading as "the draft changes nothing".</summary>
     [Fact]

--- a/src/housecarl-mcp-tests/RecordsSkyPatcherDraftTests.cs
+++ b/src/housecarl-mcp-tests/RecordsSkyPatcherDraftTests.cs
@@ -142,6 +142,27 @@ public sealed class RecordsSkyPatcherDraftTests : RecordsTestBase
     public void ADraftThatIsAlreadyPlacedIsRefusedRatherThanFoldedInTwice() =>
         Refused(ReadW0(DraftPole(W.NestedSkyPatcherIniPath, "weapon")), "already placed", "twice");
 
+    /// <summary>Whether a draft can be folded at all is a fact about the whole call. Reaching the delta lane as a
+    /// per-record error would leave counts_only, which renders no row text, reporting one error and no reason.</summary>
+    [Fact]
+    public void ADraftTheFoldRefusesRefusesTheDeltaCall()
+    {
+        var ini = Draft("draft-delta-clash", RecordsWorld.LiveSkyPatcherIni, "filterByWeapons=HcRecW0:attackDamage=1\r\n");
+        Refused(RecordsTools.Records(Svc, formids: new[] { Fid(W.Weapons[0]) }, source: DraftPole(ini, "weapon"),
+                                     versus: Overlay("post"), project: DamageDelta, counts_only: true),
+                RecordsWorld.LiveSkyPatcherIni);
+    }
+
+    /// <summary>The tree lane resolves its reference through the same pole reader, so it refuses the same way.</summary>
+    [Fact]
+    public void ADraftTheFoldRefusesRefusesTheTreeCall()
+    {
+        var ini = Draft("draft-tree-clash", RecordsWorld.LiveSkyPatcherIni, "filterByWeapons=HcRecW0:attackDamage=1\r\n");
+        Refused(RecordsTools.Records(Svc, formids: new[] { Fid(W.Weapons[0]) }, versus: DraftPole(ini, "weapon"),
+                                     project: DamageTree, counts_only: true),
+                RecordsWorld.LiveSkyPatcherIni);
+    }
+
     /// <summary>The draft keys are a value on the overlay pole. On a {"file"} pole they would be dropped and that
     /// plugin's own record would read as the draft's post state.</summary>
     [Fact]

--- a/src/housecarl-mcp-tests/RecordsSkyPatcherDraftTests.cs
+++ b/src/housecarl-mcp-tests/RecordsSkyPatcherDraftTests.cs
@@ -127,11 +127,13 @@ public sealed class RecordsSkyPatcherDraftTests : RecordsTestBase
         Refused(ReadW0(DraftPole(ini, "weapon", state: "pre")), "\"post\"");
     }
 
+    /// <summary>The remedy has to be one the pole can express: a nested placement cannot be named on it, so the
+    /// refusal asks for a filename that is not yet placed instead.</summary>
     [Fact]
     public void ADraftWhoseFilenameIsAlreadyPlacedIsRefused()
     {
         var ini = Draft("draft-clash", RecordsWorld.LiveSkyPatcherIni, "filterByWeapons=HcRecW0:attackDamage=1\r\n");
-        Refused(ReadW0(DraftPole(ini, "weapon")), RecordsWorld.LiveSkyPatcherIni, "shadow");
+        Refused(ReadW0(DraftPole(ini, "weapon")), RecordsWorld.LiveSkyPatcherIni, "shadow", "not yet placed");
     }
 
     /// <summary>A draft pointed at a file the layer already reads would be folded in beside it and replay its lines

--- a/src/housecarl-mcp-tests/RecordsSkyPatcherDraftTests.cs
+++ b/src/housecarl-mcp-tests/RecordsSkyPatcherDraftTests.cs
@@ -14,6 +14,7 @@ public sealed class RecordsSkyPatcherDraftTests : RecordsTestBase
 
     static RecordsTools.RecordsProject Damage => new() { form = "fields", fields = new[] { "BasicStats.Damage" } };
     static RecordsTools.RecordsProject DamageDelta => new() { form = "delta", fields = new[] { "BasicStats.Damage" } };
+    static RecordsTools.RecordsProject DamageTree => new() { form = "tree", fields = new[] { "BasicStats.Damage" } };
 
     /// <summary>A draft INI on disk, outside any mod, and the pole that folds it in.</summary>
     string Draft(string dir, string file, string body)
@@ -71,6 +72,25 @@ public sealed class RecordsSkyPatcherDraftTests : RecordsTestBase
         var r = ReadW0(DraftPole(ini, "weapon"));
         Served(r, "not in the active load order");
         Assert.DoesNotContain("BasicStats.Damage = 131", r);
+    }
+
+    /// <summary>The tree form takes an overlay pole as versus= as much as delta does, and a draft's skipped line is
+    /// the same fact there: without it every provider reads as identical to the reference with nothing said.</summary>
+    [Fact]
+    public void ADraftLineTheLayerSkipsIsNamedOnTheTreeFormToo()
+    {
+        var ini = Draft("draft-tree", "TreeTypo.ini", "filterByWeapons=HcRecW0:attakDamage=5\r\n");
+        Served(RecordsTools.Records(Svc, formids: new[] { Fid(W.Weapons[0]) }, versus: DraftPole(ini, "weapon"),
+                                    project: DamageTree), ini, "not in the SkyPatcher reference");
+    }
+
+    /// <summary>The gate warning comes from the fold rather than the replay, so the tree form has to render it too.</summary>
+    [Fact]
+    public void ADraftGatedOnAnInactivePluginSaysSoOnTheTreeFormToo()
+    {
+        var ini = Draft("draft-tree-gate", "AlsoNotHere.esp.ini", "filterByWeapons=HcRecW0:attackDamage=131\r\n");
+        Served(RecordsTools.Records(Svc, formids: new[] { Fid(W.Weapons[0]) }, versus: DraftPole(ini, "weapon"),
+                                    project: DamageTree), "not in the active load order");
     }
 
     /// <summary>A draft in a type the SkyPatcher.ini [Patcher] section switches off is folded into a folder the live

--- a/src/housecarl-mcp-tests/RecordsWorld.cs
+++ b/src/housecarl-mcp-tests/RecordsWorld.cs
@@ -29,6 +29,10 @@ public sealed class RecordsWorld : IDisposable
     /// changes no record's post state; it exists so a draft can be given the same name and collide with it.</summary>
     public const string LiveSkyPatcherIni = "placed.ini";
 
+    /// <summary>The SkyPatcher type this world's SkyPatcher.ini switches off. Nothing is placed in its folder, so
+    /// it is the type whose toggle only a folder INVENTED by a draft fold can consult.</summary>
+    public const string ToggledOffSkyPatcherType = "Armor";
+
     public string MasterName { get; }
     public string MidName { get; }
     public string OverrideName { get; }
@@ -213,6 +217,10 @@ public sealed class RecordsWorld : IDisposable
         var spDir = Path.Combine(ModsDir, "MasterMod", "SKSE", "Plugins", "SkyPatcher", "weapon");
         Directory.CreateDirectory(spDir);
         File.WriteAllText(Path.Combine(spDir, LiveSkyPatcherIni), "; placed, and deliberately patches nothing\r\n");
+        // The [Patcher] toggles, with 'armor' switched off and no live armor folder at all: the type a draft can
+        // be folded into that the DLL would skip wholesale. 'weapon' is left at its default (on).
+        File.WriteAllText(Path.Combine(ModsDir, "MasterMod", "SKSE", "Plugins", "SkyPatcher.ini"),
+            "[Patcher]\r\niEnable" + ToggledOffSkyPatcherType + "Patching=0\r\n");
 
         var genDir = Path.Combine(Root, "corpus-gen");
         CorpusGenerator.GenerateAll(genDir, Path.Combine(Root, "corpus-ref"));

--- a/src/housecarl-mcp-tests/RecordsWorld.cs
+++ b/src/housecarl-mcp-tests/RecordsWorld.cs
@@ -33,6 +33,11 @@ public sealed class RecordsWorld : IDisposable
     /// it is the type whose toggle only a folder INVENTED by a draft fold can consult.</summary>
     public const string ToggledOffSkyPatcherType = "Armor";
 
+    /// <summary>The on-disk path of a placed SkyPatcher INI nested under a mod-specific subfolder. It patches
+    /// nothing either; it exists so a draft can be pointed at a file the layer already reads, whose sort key is a
+    /// relative path rather than a bare filename.</summary>
+    public string NestedSkyPatcherIniPath { get; }
+
     public string MasterName { get; }
     public string MidName { get; }
     public string OverrideName { get; }
@@ -217,6 +222,9 @@ public sealed class RecordsWorld : IDisposable
         var spDir = Path.Combine(ModsDir, "MasterMod", "SKSE", "Plugins", "SkyPatcher", "weapon");
         Directory.CreateDirectory(spDir);
         File.WriteAllText(Path.Combine(spDir, LiveSkyPatcherIni), "; placed, and deliberately patches nothing\r\n");
+        Directory.CreateDirectory(Path.Combine(spDir, "MyMod"));
+        NestedSkyPatcherIniPath = Path.Combine(spDir, "MyMod", "nested.ini");
+        File.WriteAllText(NestedSkyPatcherIniPath, "; placed under a mod subfolder, and patches nothing either\r\n");
         // The [Patcher] toggles, with 'armor' switched off and no live armor folder at all: the type a draft can
         // be folded into that the DLL would skip wholesale. 'weapon' is left at its default (on).
         File.WriteAllText(Path.Combine(ModsDir, "MasterMod", "SKSE", "Plugins", "SkyPatcher.ini"),

--- a/src/housecarl-mcp-tests/RecordsWorld.cs
+++ b/src/housecarl-mcp-tests/RecordsWorld.cs
@@ -25,6 +25,10 @@ public sealed class RecordsWorld : IDisposable
     public string OldFile { get; }
     public string ModsDir { get; }
 
+    /// <summary>The filename of the one SkyPatcher INI actually placed in a mod. It carries no patch line, so it
+    /// changes no record's post state; it exists so a draft can be given the same name and collide with it.</summary>
+    public const string LiveSkyPatcherIni = "placed.ini";
+
     public string MasterName { get; }
     public string MidName { get; }
     public string OverrideName { get; }
@@ -203,6 +207,12 @@ public sealed class RecordsWorld : IDisposable
         midMod.BeginWrite.ToPath(midFile).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
         ovMod.BeginWrite.ToPath(OverrideFile).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
         oldMod.BeginWrite.ToPath(OldFile).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
+
+        // One placed SkyPatcher INI, comment-only: it gives the layer a real 'weapon' folder for a draft to be
+        // sorted into and a filename for a draft to collide with, while patching nothing.
+        var spDir = Path.Combine(ModsDir, "MasterMod", "SKSE", "Plugins", "SkyPatcher", "weapon");
+        Directory.CreateDirectory(spDir);
+        File.WriteAllText(Path.Combine(spDir, LiveSkyPatcherIni), "; placed, and deliberately patches nothing\r\n");
 
         var genDir = Path.Combine(Root, "corpus-gen");
         CorpusGenerator.GenerateAll(genDir, Path.Combine(Root, "corpus-ref"));

--- a/src/housecarl-mcp-tests/SkyPatcherWarningSinkTests.cs
+++ b/src/housecarl-mcp-tests/SkyPatcherWarningSinkTests.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics;
+using HousecarlCore;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>The overlay replay's warning collector. A warning names the record it was raised for, so one INI line
+/// the layer cannot apply raises a DIFFERENT warning for every record in the batch — and the collector runs once
+/// per record.</summary>
+[Trait("tier", "unit")]
+public sealed class SkyPatcherWarningSinkTests
+{
+    /// <summary>The warnings a record-per-line batch actually produces: one long shared prefix (the same file, the
+    /// same line number) and a per-record tail, which is the worst case for a membership test that compares
+    /// strings.</summary>
+    static string Warning(int i) => new string('x', 180) + i;
+
+    [Fact]
+    public void TheKeptWarningsStopAtTheCapAndTheRestAreCounted()
+    {
+        var sink = new SkyPatcherOverlay.WarningSink();
+        for (int i = 0; i < SkyPatcherOverlay.WarningSink.Cap + 7; i++) sink.Add(Warning(i));
+
+        Assert.Equal(SkyPatcherOverlay.WarningSink.Cap, sink.Kept.Count);
+        Assert.Equal(Warning(0), sink.Kept[0]);
+        Assert.Equal(7, sink.Overflow);
+    }
+
+    [Fact]
+    public void ARepeatedWarningIsKeptOnce()
+    {
+        var sink = new SkyPatcherOverlay.WarningSink();
+        sink.Add(Warning(1));
+        sink.Add(Warning(1));
+        sink.Add(Warning(2));
+
+        Assert.Equal(new[] { Warning(1), Warning(2) }, sink.Kept);
+        Assert.Equal(0, sink.Overflow);
+    }
+
+    /// <summary>Collecting costs the same per warning however many came before it: a batch of 50,000 records under
+    /// an overlay post source hands the sink 50,000 distinct warnings, which is a hash lookup each. Comparing every
+    /// new warning against everything collected so far is 1.25e9 comparisons over a 180-character shared prefix,
+    /// which measures at about nine seconds — this bound is set well under that and well over the hashed cost.</summary>
+    [Fact]
+    public void CollectingOneWarningPerRecordDoesNotGetDearerAsTheBatchGrows()
+    {
+        const int batch = 50_000;
+        var warnings = new string[batch];
+        for (int i = 0; i < batch; i++) warnings[i] = Warning(i);
+        var sink = new SkyPatcherOverlay.WarningSink();
+
+        var sw = Stopwatch.StartNew();
+        foreach (var w in warnings) sink.Add(w);
+        sw.Stop();
+
+        Assert.Equal(batch - SkyPatcherOverlay.WarningSink.Cap, sink.Overflow);
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(3),
+                    $"collecting {batch} distinct warnings took {sw.Elapsed.TotalSeconds:0.##}s — the membership test is growing with the batch");
+    }
+}

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -3494,34 +3494,44 @@ public sealed class LoadOrderService : IDisposable
         // would re-apply every INI line onto the already-mutated copy. One replay per key.
         var postMemo = new Dictionary<FormKey, PoleReading>();
         string? setupError = null;
+        void Setup()
+        {
+            if (scan is not null || setupError is not null) return;
+            try
+            {
+                AssetResolver.AssetView assets;
+                lock (_gate) { assets = Assets.Capture(); }
+                fieldMap = SkyPatcherFieldMap.Load();
+                catalog = SkyPatcherCatalog.Load();
+                scan = SkyPatcherDiscovery.Scan(assets, catalog, view.ContainsPlugin, _skyPatcherParseCache);
+                if (spec.Draft is not null)
+                {
+                    scan = spec.Draft.Fold(scan, catalog, view.ContainsPlugin, out var draftRefusal, overlayWarnings);
+                    if (draftRefusal is not null) { scan = null; setupError = draftRefusal; return; }
+                }
+                scratch = new SkyrimMod(SkyPatcherScratchKey, SkyrimRelease.SkyrimSE);
+                formResolver = new SkyPatcherServiceResolver(this, view, session);
+                linesCache = new Dictionary<string, IReadOnlyList<SkyPatcherOverlay.OrderedLine>>(StringComparer.OrdinalIgnoreCase);
+            }
+            catch (Exception ex)
+            {
+                setupError = $"the SkyPatcher layer could not be discovered for the overlay pole: {ex.Message}";
+            }
+        }
+        // A draft is folded up front rather than on the first record: whether it can be folded at all is a fact
+        // about the whole call, so it refuses by name here. Left to the reader it would reach the delta and tree
+        // lanes as a per-record error, which counts_only renders as a bare error count with the reason nowhere.
+        if (spec.Draft is not null)
+        {
+            Setup();
+            if (setupError is not null) { error = setupError; return (_, _) => new PoleReading(null, null, null, setupError); }
+        }
         return (fk, _) =>
         {
             if (setupError is not null) return new PoleReading(null, null, null, setupError);
             if (postMemo.TryGetValue(fk, out var memoized)) return memoized;
-            if (scan is null)
-            {
-                try
-                {
-                    AssetResolver.AssetView assets;
-                    lock (_gate) { assets = Assets.Capture(); }
-                    fieldMap = SkyPatcherFieldMap.Load();
-                    catalog = SkyPatcherCatalog.Load();
-                    scan = SkyPatcherDiscovery.Scan(assets, catalog, view.ContainsPlugin, _skyPatcherParseCache);
-                    if (spec.Draft is not null)
-                    {
-                        scan = spec.Draft.Fold(scan, catalog, view.ContainsPlugin, out var draftRefusal, overlayWarnings);
-                        if (draftRefusal is not null) { setupError = draftRefusal; return new PoleReading(null, null, null, setupError); }
-                    }
-                    scratch = new SkyrimMod(SkyPatcherScratchKey, SkyrimRelease.SkyrimSE);
-                    formResolver = new SkyPatcherServiceResolver(this, view, session);
-                    linesCache = new Dictionary<string, IReadOnlyList<SkyPatcherOverlay.OrderedLine>>(StringComparer.OrdinalIgnoreCase);
-                }
-                catch (Exception ex)
-                {
-                    setupError = $"the SkyPatcher layer could not be discovered for the overlay pole: {ex.Message}";
-                    return new PoleReading(null, null, null, setupError);
-                }
-            }
+            Setup();
+            if (setupError is not null) return new PoleReading(null, null, null, setupError);
             var r = ReplaySkyPatcher(view, session, scan, catalog!, fieldMap!, scratch!, formResolver!, fk, linesCache);
             CollectOverlayWarnings(r.Folders, overlayWarnings);
             if (r.Error is not null)

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1055,12 +1055,12 @@ public sealed class LoadOrderService : IDisposable
     /// <summary>Carry one replay's warnings (unknown key, unmapped op, unresolved filter, parse note) into the
     /// caller's sink, deduplicated: a line the layer could not apply belongs beside the answer, not in silence.
     /// Each warning already names its own file and line, so a draft's warnings name the draft's path.</summary>
-    static void CollectOverlayWarnings(IReadOnlyList<SkyPatcherFolderOutcome> folders, List<string>? sink)
+    static void CollectOverlayWarnings(IReadOnlyList<SkyPatcherFolderOutcome> folders, SkyPatcherOverlay.WarningSink? sink)
     {
         if (sink is null) return;
         foreach (var f in folders)
             foreach (var w in f.Result?.Warnings ?? Array.Empty<string>())
-                if (!sink.Contains(w)) sink.Add(w);
+                sink.Add(w);
     }
 
     /// <summary>
@@ -3251,7 +3251,7 @@ public sealed class LoadOrderService : IDisposable
         IReadOnlyList<string> formids, PoleSpec subject, PoleSpec reference, IReadOnlyList<string>? fields,
         ArtifactDemand? demand,
         out string? subjectArm, out string? referenceArm, out bool epochCoversAll,
-        out string? refusal, out OrderStamp? epoch, List<string>? overlayWarnings = null)
+        out string? refusal, out OrderStamp? epoch, SkyPatcherOverlay.WarningSink? overlayWarnings = null)
     {
         subjectArm = null; referenceArm = null; epochCoversAll = true; refusal = null;
         var resolver = Resolver;
@@ -3331,7 +3331,7 @@ public sealed class LoadOrderService : IDisposable
     PoleReader MakePoleReader(LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session,
                               PoleSpec spec, IReadOnlyList<string>? fields, IReadOnlyCollection<FormKey>? wanted,
                               out string? armStatement, out bool covers, out string? error, out PoleInfo? offOrderArm,
-                              List<string>? overlayWarnings = null)
+                              SkyPatcherOverlay.WarningSink? overlayWarnings = null)
     {
         error = null; covers = true; offOrderArm = null;
         // '*parent' on fields=: every in-order arm below reads through this captured view and open session, so the
@@ -3452,7 +3452,7 @@ public sealed class LoadOrderService : IDisposable
     PoleReader MakeOverlayPoleReader(LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session,
                                      PoleSpec spec, IReadOnlyList<string>? fields,
                                      out string? armStatement, out bool covers, out string? error,
-                                     List<string>? overlayWarnings = null)
+                                     SkyPatcherOverlay.WarningSink? overlayWarnings = null)
     {
         error = null;
         var hop = ContainmentIndex.ReadHop(view, session);   // both overlay arms read through the order's own index
@@ -3608,7 +3608,7 @@ public sealed class LoadOrderService : IDisposable
         IReadOnlyList<int>? depths = null,
         CancellationToken ct = default,
         SkyPatcherDraft.Plan? draft = null,
-        List<string>? overlayWarnings = null)
+        SkyPatcherOverlay.WarningSink? overlayWarnings = null)
     {
         refusal = null; refusalEpoch = null;
         var resolver = Resolver;

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1052,6 +1052,17 @@ public sealed class LoadOrderService : IDisposable
         return (typeName, winner.Value.WinnerPlugin, body.EditorID, folders, null, copy);
     }
 
+    /// <summary>Carry one replay's warnings (unknown key, unmapped op, unresolved filter, parse note) into the
+    /// caller's sink, deduplicated: a line the layer could not apply belongs beside the answer, not in silence.
+    /// Each warning already names its own file and line, so a draft's warnings name the draft's path.</summary>
+    static void CollectOverlayWarnings(IReadOnlyList<SkyPatcherFolderOutcome> folders, List<string>? sink)
+    {
+        if (sink is null) return;
+        foreach (var f in folders)
+            foreach (var w in f.Result?.Warnings ?? Array.Empty<string>())
+                if (!sink.Contains(w)) sink.Add(w);
+    }
+
     /// <summary>
     /// Scan the whole SkyPatcher layer: every loose INI as the DLL reads it (ordered union, VFS
     /// same-path collisions surfaced, gates and toggles evaluated), plus the INI-vs-INI same-field SET
@@ -3204,8 +3215,10 @@ public sealed class LoadOrderService : IDisposable
     public enum PoleKind { Winner, Named, PreviousProvider, Overlay }
 
     /// <summary>A parsed pole expression — the tool layer parses the wire spelling ("winner", a plugin filename,
-    /// {file, mod}, "previous_provider", {overlay, state}) into this engine value.</summary>
-    public sealed record PoleSpec(PoleKind Kind, string? Plugin = null, string? Mod = null, string? OverlayState = null)
+    /// {file, mod}, "previous_provider", {overlay, state, ini, subfolder}) into this engine value. <see cref="Draft"/>
+    /// is the not-yet-placed INI an overlay post pole folds into the live layer.</summary>
+    public sealed record PoleSpec(PoleKind Kind, string? Plugin = null, string? Mod = null, string? OverlayState = null,
+                                  SkyPatcherDraft.Plan? Draft = null)
     {
         public static readonly PoleSpec Winner = new(PoleKind.Winner);
         /// <summary>The arm statement a render leads with when the pole is uniform across the batch. PreviousProvider
@@ -3214,7 +3227,7 @@ public sealed class LoadOrderService : IDisposable
         {
             PoleKind.Winner => "winner",
             PoleKind.PreviousProvider => "previous_provider (the provider immediately below the subject, per record)",
-            PoleKind.Overlay => $"skypatcher overlay ({OverlayState})",
+            PoleKind.Overlay => $"skypatcher overlay ({OverlayState})" + (Draft is null ? "" : $", with {Draft.Arm}"),
             _ => Plugin ?? "?",
         };
     }
@@ -3231,12 +3244,14 @@ public sealed class LoadOrderService : IDisposable
     /// comparison can never span two. Subject defaults to winner; reference may be winner, a named plugin (active or
     /// off-order, with off-order files declared outside the epoch fingerprint), or previous_provider, which is
     /// subject-relative. A named pole that does not touch a record is a per-item refusal naming the actual touchers,
-    /// which the caller counts as not_touched. Overlay poles resolve via the SkyPatcher replay.</summary>
+    /// which the caller counts as not_touched. Overlay poles resolve via the SkyPatcher replay, and
+    /// <paramref name="overlayWarnings"/> collects every warning that replay produced so a line the layer could not
+    /// apply is visible beside the answer instead of being swallowed.</summary>
     public IReadOnlyList<DeltaRow> DeltaBatch(
         IReadOnlyList<string> formids, PoleSpec subject, PoleSpec reference, IReadOnlyList<string>? fields,
         ArtifactDemand? demand,
         out string? subjectArm, out string? referenceArm, out bool epochCoversAll,
-        out string? refusal, out OrderStamp? epoch)
+        out string? refusal, out OrderStamp? epoch, List<string>? overlayWarnings = null)
     {
         subjectArm = null; referenceArm = null; epochCoversAll = true; refusal = null;
         var resolver = Resolver;
@@ -3259,9 +3274,9 @@ public sealed class LoadOrderService : IDisposable
         }
 
         // Resolve the uniform arms once (named poles; winner/overlay are per-record but uniform in statement).
-        var sReader = MakePoleReader(view, session, subject, fields, wanted, out subjectArm, out var sCovers, out var sErr, out var sOffOrder);
+        var sReader = MakePoleReader(view, session, subject, fields, wanted, out subjectArm, out var sCovers, out var sErr, out var sOffOrder, overlayWarnings);
         if (sErr is not null) { refusal = "source: " + sErr; return Array.Empty<DeltaRow>(); }
-        var rReader = MakePoleReader(view, session, reference, fields, wanted, out referenceArm, out var rCovers, out var rErr, out _);
+        var rReader = MakePoleReader(view, session, reference, fields, wanted, out referenceArm, out var rCovers, out var rErr, out _, overlayWarnings);
         if (rErr is not null) { refusal = "versus: " + rErr; return Array.Empty<DeltaRow>(); }
         epochCoversAll = sCovers && rCovers;
 
@@ -3315,7 +3330,8 @@ public sealed class LoadOrderService : IDisposable
     /// null otherwise — a uniform fact about the whole call, so a caller can judge it once instead of per record.</summary>
     PoleReader MakePoleReader(LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session,
                               PoleSpec spec, IReadOnlyList<string>? fields, IReadOnlyCollection<FormKey>? wanted,
-                              out string? armStatement, out bool covers, out string? error, out PoleInfo? offOrderArm)
+                              out string? armStatement, out bool covers, out string? error, out PoleInfo? offOrderArm,
+                              List<string>? overlayWarnings = null)
     {
         error = null; covers = true; offOrderArm = null;
         // '*parent' on fields=: every in-order arm below reads through this captured view and open session, so the
@@ -3370,7 +3386,7 @@ public sealed class LoadOrderService : IDisposable
                 };
 
             case PoleKind.Overlay:
-                return MakeOverlayPoleReader(view, session, spec, fields, out armStatement, out covers, out error);
+                return MakeOverlayPoleReader(view, session, spec, fields, out armStatement, out covers, out error, overlayWarnings);
 
             default:   // Named — the one-pole rule: active in the order, else an on-disk file.
                 var (arm, armErr) = ResolvePoleArm(view, spec.Plugin!, spec.Mod);
@@ -3435,7 +3451,8 @@ public sealed class LoadOrderService : IDisposable
     /// IS pre there, which is an answer rather than an error.</summary>
     PoleReader MakeOverlayPoleReader(LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session,
                                      PoleSpec spec, IReadOnlyList<string>? fields,
-                                     out string? armStatement, out bool covers, out string? error)
+                                     out string? armStatement, out bool covers, out string? error,
+                                     List<string>? overlayWarnings = null)
     {
         error = null;
         var hop = ContainmentIndex.ReadHop(view, session);   // both overlay arms read through the order's own index
@@ -3464,8 +3481,9 @@ public sealed class LoadOrderService : IDisposable
             };
         }
 
-        covers = false;   // the INI layer's files are outside the index fingerprint
-        armStatement = "skypatcher overlay (post) — the winner after the SkyPatcher INI layer replays";
+        covers = false;   // the INI layer's files are outside the index fingerprint (a draft INI likewise)
+        armStatement = "skypatcher overlay (post) — the winner after the SkyPatcher INI layer replays"
+                     + (spec.Draft is null ? "" : $", with {spec.Draft.Arm}");
         // The replay context is built lazily once for the whole batch: discovery scan, catalogs, scratch mod, form
         // resolver and per-folder line cache.
         SkyPatcherFieldMap? fieldMap = null; SkyPatcherCatalog? catalog = null;
@@ -3489,6 +3507,11 @@ public sealed class LoadOrderService : IDisposable
                     fieldMap = SkyPatcherFieldMap.Load();
                     catalog = SkyPatcherCatalog.Load();
                     scan = SkyPatcherDiscovery.Scan(assets, catalog, view.ContainsPlugin, _skyPatcherParseCache);
+                    if (spec.Draft is not null)
+                    {
+                        scan = spec.Draft.Fold(scan, catalog, view.ContainsPlugin, out var draftRefusal, overlayWarnings);
+                        if (draftRefusal is not null) { setupError = draftRefusal; return new PoleReading(null, null, null, setupError); }
+                    }
                     scratch = new SkyrimMod(SkyPatcherScratchKey, SkyrimRelease.SkyrimSE);
                     formResolver = new SkyPatcherServiceResolver(this, view, session);
                     linesCache = new Dictionary<string, IReadOnlyList<SkyPatcherOverlay.OrderedLine>>(StringComparer.OrdinalIgnoreCase);
@@ -3500,6 +3523,7 @@ public sealed class LoadOrderService : IDisposable
                 }
             }
             var r = ReplaySkyPatcher(view, session, scan, catalog!, fieldMap!, scratch!, formResolver!, fk, linesCache);
+            CollectOverlayWarnings(r.Folders, overlayWarnings);
             if (r.Error is not null)
             {
                 // An unpatchable type is an answer, not a failure: the layer cannot touch it, so post IS pre.
@@ -3582,7 +3606,9 @@ public sealed class LoadOrderService : IDisposable
         ArtifactDemand? demand, out string? refusal, out OrderStamp? refusalEpoch, out OrderStamp? epoch,
         string? containerHint = ReadEngine.DepthExpandHint,
         IReadOnlyList<int>? depths = null,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        SkyPatcherDraft.Plan? draft = null,
+        List<string>? overlayWarnings = null)
     {
         refusal = null; refusalEpoch = null;
         var resolver = Resolver;
@@ -3615,6 +3641,11 @@ public sealed class LoadOrderService : IDisposable
             refusalEpoch = view.Stamp;
             return Array.Empty<ReadOutcome>();
         }
+        if (draft is not null)
+        {
+            scan = draft.Fold(scan, catalog, view.ContainsPlugin, out var draftRefusal, overlayWarnings);
+            if (draftRefusal is not null) { refusal = draftRefusal; refusalEpoch = view.Stamp; return Array.Empty<ReadOutcome>(); }
+        }
         var linesCache = new Dictionary<string, IReadOnlyList<SkyPatcherOverlay.OrderedLine>>(StringComparer.OrdinalIgnoreCase);
 
         // Per-batch replay memo: the scratch mod is shared across the batch, so a duplicated key's second replay
@@ -3639,6 +3670,7 @@ public sealed class LoadOrderService : IDisposable
                 continue;
             }
             var r = ReplaySkyPatcher(view, session, scan, catalog, fieldMap, scratch, formResolver, fk, linesCache);
+            CollectOverlayWarnings(r.Folders, overlayWarnings);
             IMajorRecordGetter? bodyToRead = r.Copy;
             if (r.Error is not null)
             {

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -3713,11 +3713,13 @@ public sealed class LoadOrderService : IDisposable
     /// <summary>The project=tree batch: per record, the full provider stack (touching list, winner last) with each
     /// provider diffed against the reference pole — the winner by default, or a named plugin, active or off-order
     /// under the one-pole rule, with untouched records refused by naming the touchers. One captured build for
-    /// everything.</summary>
+    /// everything. An overlay reference replays the SkyPatcher INI layer like the delta form's does, so
+    /// <paramref name="overlayWarnings"/> collects that replay's warnings here too.</summary>
     public IReadOnlyList<TreeRow> TreeBatch(
         IReadOnlyList<string> formids, PoleSpec reference, IReadOnlyList<string>? fields,
         ArtifactDemand? demand,
-        out string? referenceArm, out bool epochCoversAll, out string? refusal, out OrderStamp? epoch)
+        out string? referenceArm, out bool epochCoversAll, out string? refusal, out OrderStamp? epoch,
+        SkyPatcherOverlay.WarningSink? overlayWarnings = null)
     {
         referenceArm = null; epochCoversAll = true; refusal = null;
         var resolver = Resolver;
@@ -3744,7 +3746,7 @@ public sealed class LoadOrderService : IDisposable
         PoleReader? refReader = null;
         if (reference.Kind is not PoleKind.Winner)
         {
-            refReader = MakePoleReader(view, session, reference, fields, wantedT, out referenceArm, out var rCovers, out var rErr, out _);
+            refReader = MakePoleReader(view, session, reference, fields, wantedT, out referenceArm, out var rCovers, out var rErr, out _, overlayWarnings);
             if (rErr is not null) { refusal = "versus: " + rErr; return Array.Empty<TreeRow>(); }
             epochCoversAll = rCovers;
         }

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -1020,7 +1020,8 @@ public static class RecordsTools
                 if (srcSpec.Kind != LoadOrderService.PoleKind.Winner)
                     return Wire.Refuse(json, "error: the tree form has no subject — every provider of each record is on the bench, and the pole each is diffed against is versus=. Drop source= (or use form='delta' for a subject-vs-reference comparison).");
                 var rows = svc.TreeBatch(ids, versusSpec!, projFields, demand,
-                                         out var rArm, out var covers, out var refusal, out var epoch);
+                                         out var rArm, out var covers, out var refusal, out var epoch,
+                                         overlayWarnings);
                 if (refusal is not null)
                     return json ? JsonWire.RenderError(refusal, epoch) : "error: " + refusal + Wire.EpochLine(epoch);
                 return TreeResponse(rows, rArm, covers, epoch, Echo());
@@ -1083,6 +1084,7 @@ public static class RecordsTools
             headerLine += $"  versus={refStatement}";
             Arm("every provider of each record (the touching stack, winner last)");
             CoverageNote(covers);
+            StateOverlayWarnings();
             int contested = rows.Count(x => x.Error is null && x.Touchers.Count > 1);
             int errs = rows.Count(x => x.Error is not null);
             if (counts_only)

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -458,13 +458,12 @@ public static class RecordsTools
         // Every warning the SkyPatcher replay produced — a key it does not know, an op it cannot map, a filter it
         // cannot evaluate, a parse note — named beside the answer, each already carrying its own file and line. A
         // draft INI's lines carry the draft's path, so a bad draft line reads where a bad live line does.
-        const int WarningCap = 20;
-        var overlayWarnings = new List<string>();
+        var overlayWarnings = new HousecarlCore.SkyPatcherOverlay.WarningSink();
         void StateOverlayWarnings()
         {
-            if (overlayWarnings.Count == 0) return;
-            var shown = overlayWarnings.Take(WarningCap).ToList();
-            int over = overlayWarnings.Count - shown.Count;
+            var shown = overlayWarnings.Kept;
+            if (shown.Count == 0) return;
+            int over = overlayWarnings.Overflow;
             envelope.Add(new("skypatcher_warnings",
                              string.Join(" | ", shown) + (over > 0 ? $" (+{over} more not listed)" : "")));
             foreach (var w in shown) headerLine += "\n[!] skypatcher: " + w;

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -122,9 +122,9 @@ public static class RecordsTools
             string? where_source = null,
         [Description("SELECT: find records that REFERENCE these FormIDs (reverse, one step; OR over the list, each match names which target(s) it hit). Needs no bounding scope: unbounded it is answered off the reverse-reference index, which is built on the first such call, costs one whole-order link-walk, and reports that cost and its own per-plugin freshness key in the response. A bounded references= — with a types= or plugins= — is unchanged and still cheaper. A '!' before an entry NEGATES it: references=[\"!XXXXXX:A.esm\"] keeps only records that do NOT reference that target, and plain and negated entries in one call compose by AND; the sigil takes the @file spelling too — references=[\"!@C:/work/targets.jsonl\"] excludes every target the file names. A negated entry ALONE with no types=/plugins= scope is the ORPHAN sweep: the universe becomes every record nothing in the order references, and the named target then excludes any of those that link it — bound the call if you meant the narrower question. Accepts [\"@<path>\"] like formids=.")]
             string[]? references = null,
-        [Description("SOURCE decides whose version you read; this is the SUBJECT of the call. Omit or \"winner\" for the load-order winner (the default). A plugin filename (e.g. \"OldPatch.esp\") reads THAT plugin's version WHEREVER the plugin lives — active in your order, or sitting on disk unticked — you do not have to know which, and the response STATES which arm resolved (active, or out-of-load-order and from where); use {\"file\": \"X.esp\", \"mod\": \"<mod folder>\"} when two mods ship the same filename. A plugin found in neither place is refused naming both places searched. A record the named plugin does not touch is refused naming the plugins that DO touch it — never silently absent. {\"overlay\": \"skypatcher\", \"state\": \"pre\"|\"post\"} reads around the SkyPatcher INI layer (post = after it replays). Content read from outside the load order — an off-order file, or the SkyPatcher INI layer — sits OUTSIDE the epoch fingerprint, and the response says so. \"previous_provider\" is a versus= value only — it is measured FROM the subject this parameter names.")]
+        [Description("SOURCE decides whose version you read; this is the SUBJECT of the call. Omit or \"winner\" for the load-order winner (the default). A plugin filename (e.g. \"OldPatch.esp\") reads THAT plugin's version WHEREVER the plugin lives — active in your order, or sitting on disk unticked — you do not have to know which, and the response STATES which arm resolved (active, or out-of-load-order and from where); use {\"file\": \"X.esp\", \"mod\": \"<mod folder>\"} when two mods ship the same filename. A plugin found in neither place is refused naming both places searched. A record the named plugin does not touch is refused naming the plugins that DO touch it — never silently absent. {\"overlay\": \"skypatcher\", \"state\": \"pre\"|\"post\"} reads around the SkyPatcher INI layer (post = after it replays); add \"ini\": \"<absolute path to a draft .ini>\" (with \"subfolder\": the SkyPatcher type folder it would be placed in, or omit it when the draft's parent directory already IS that folder) to read the post state with a draft INI that is not yet in a mod folded into the layer, so a draft can be checked before it is placed. Content read from outside the load order — an off-order file, or the SkyPatcher INI layer — sits OUTSIDE the epoch fingerprint, and the response says so. \"previous_provider\" is a versus= value only — it is measured FROM the subject this parameter names.")]
             JsonElement? source = null,
-        [Description("SOURCE (comparison forms): the REFERENCE pole a delta/tree compares against. Same forms as source= — \"winner\" | a plugin filename | {\"file\", \"mod\"} | {\"overlay\", \"state\"} — plus \"previous_provider\": the plugin immediately below the SUBJECT (whatever source= names) in the record's touching stack, measured FROM THE SUBJECT, never from the winner. Its four cases are all declared: subject=winner → next plugin down; subject mid-stack → still the one below the SUBJECT, with what sits above reported as plain fact (a mid-stack patch is ordinary practice, not judged); subject defines the record → refused naming it (never an empty diff that reads as 'no changes'); subject doesn't touch it → refused naming the actual touchers. REQUIRED when project.form='delta'; defaults to \"winner\" on 'tree'; refused on other forms.")]
+        [Description("SOURCE (comparison forms): the REFERENCE pole a delta/tree compares against. Same forms as source= — \"winner\" | a plugin filename | {\"file\", \"mod\"} | {\"overlay\", \"state\"[, \"ini\", \"subfolder\"]} — plus \"previous_provider\": the plugin immediately below the SUBJECT (whatever source= names) in the record's touching stack, measured FROM THE SUBJECT, never from the winner. Its four cases are all declared: subject=winner → next plugin down; subject mid-stack → still the one below the SUBJECT, with what sits above reported as plain fact (a mid-stack patch is ordinary practice, not judged); subject defines the record → refused naming it (never an empty diff that reads as 'no changes'); subject doesn't touch it → refused naming the actual touchers. REQUIRED when project.form='delta'; defaults to \"winner\" on 'tree'; refused on other forms.")]
             JsonElement? versus = null,
         [Description("The pole field VALUES display from, when it differs from the matching pole: \"winner\" shows the live winner's values on a plugins=-scoped scan (the old winner_fields=true). Display only — where_source= governs matching.")]
             string? fields_source = null,
@@ -455,6 +455,21 @@ public static class RecordsTools
             envelope.Add(new("source", statement));
             headerLine += $"  source={statement}";
         }
+        // Every warning the SkyPatcher replay produced — a key it does not know, an op it cannot map, a filter it
+        // cannot evaluate, a parse note — named beside the answer, each already carrying its own file and line. A
+        // draft INI's lines carry the draft's path, so a bad draft line reads where a bad live line does.
+        const int WarningCap = 20;
+        var overlayWarnings = new List<string>();
+        void StateOverlayWarnings()
+        {
+            if (overlayWarnings.Count == 0) return;
+            var shown = overlayWarnings.Take(WarningCap).ToList();
+            int over = overlayWarnings.Count - shown.Count;
+            envelope.Add(new("skypatcher_warnings",
+                             string.Join(" | ", shown) + (over > 0 ? $" (+{over} more not listed)" : "")));
+            foreach (var w in shown) headerLine += "\n[!] skypatcher: " + w;
+            if (over > 0) headerLine += $"\n[!] skypatcher: {over} further warning(s) not listed.";
+        }
         // When a walk or scan derived the selection this call now reads, the two captures meet at a seam: every
         // downstream form's epoch is compared against the deriving step's, and a divergence refuses loud rather
         // than mixing builds.
@@ -617,14 +632,17 @@ public static class RecordsTools
                 // The overlay post source: every record's winner replayed through the SkyPatcher INI layer, the
                 // replayed body read at the caller's own depth.
                 outcomes = svc.OverlayPostBatch(ids, readFields, depth, resolveNames, demand, out var ovRefusal, out var ovEpoch, out _,
-                                                LeverNames.Records.ContainerHint, readFieldDepths, ct);
+                                                LeverNames.Records.ContainerHint, readFieldDepths, ct,
+                                                draft: srcSpec.Draft, overlayWarnings: overlayWarnings);
                 if (ovRefusal is not null)
                     return json ? JsonWire.RenderError(ovRefusal, ovEpoch)
                                 : "error: " + ovRefusal + Wire.EpochLine(ovEpoch);
-                Arm("skypatcher overlay (post) — the winner after the SkyPatcher INI layer replays");
+                Arm("skypatcher overlay (post) — the winner after the SkyPatcher INI layer replays"
+                    + (srcSpec.Draft is null ? "" : $", with {srcSpec.Draft.Arm}"));
                 envelope.Add(new("epoch_covers_source", "false"));
                 headerLine += "\n(the SkyPatcher INI layer's files are OUTSIDE the epoch fingerprint — an INI edit changes answers " +
                               "without changing the epoch; a record whose type SkyPatcher cannot patch reads as its plain winner)";
+                StateOverlayWarnings();
             }
             else if (srcName is null)
             {
@@ -992,7 +1010,8 @@ public static class RecordsTools
             if (form == "delta")
             {
                 var rows = svc.DeltaBatch(ids, srcSpec, versusSpec!, projFields, demand,
-                                          out var sArm, out var rArm, out var covers, out var refusal, out var epoch);
+                                          out var sArm, out var rArm, out var covers, out var refusal, out var epoch,
+                                          overlayWarnings);
                 if (refusal is not null)
                     return json ? JsonWire.RenderError(refusal, epoch) : "error: " + refusal + Wire.EpochLine(epoch);
                 return DeltaResponse(rows, sArm, rArm, covers, epoch, Echo());
@@ -1018,6 +1037,7 @@ public static class RecordsTools
             envelope.Add(new("versus", rArm ?? versusSpec!.Label));
             headerLine += $"  versus={rArm ?? versusSpec!.Label}";
             CoverageNote(covers);
+            StateOverlayWarnings();
             // A no-verdict (a field neither side could be compared at) is a THIRD state: it is not a value
             // difference, so it stays out of `differing`, and it is not identity either — `identical` already
             // excludes it via Complete. It gets its own count instead of being folded into one of the two.
@@ -1819,7 +1839,25 @@ public static class RecordsTools
                 string? st = e.TryGetProperty("state", out var stEl) && stEl.ValueKind == JsonValueKind.String ? stEl.GetString()!.Trim() : "post";
                 if (!st!.Equals("pre", StringComparison.OrdinalIgnoreCase) && !st.Equals("post", StringComparison.OrdinalIgnoreCase))
                     return $"error: {param}= overlay state '{st}' — use \"pre\" (the winner before the INI layer) or \"post\" (after it; the default).";
-                spec = new LoadOrderService.PoleSpec(LoadOrderService.PoleKind.Overlay, OverlayState: st.ToLowerInvariant());
+                // The draft INI: a file not yet placed in a mod, folded into the layer so it can be checked before
+                // the write. It is a value on this pole, not a mode of its own.
+                if (e.TryGetProperty("ini", out var iniEl) && iniEl.ValueKind != JsonValueKind.String)
+                    return $"error: {param}= overlay \"ini\" is the absolute path to a draft .ini file, as a string.";
+                if (e.TryGetProperty("subfolder", out var subEl) && subEl.ValueKind != JsonValueKind.String)
+                    return $"error: {param}= overlay \"subfolder\" is the SkyPatcher type folder the draft would be placed in, as a string.";
+                string? draftIni = iniEl.ValueKind == JsonValueKind.String ? iniEl.GetString() : null;
+                string? draftSub = subEl.ValueKind == JsonValueKind.String ? subEl.GetString() : null;
+                SkyPatcherDraft.Plan? plan = null;
+                if (draftIni is null && draftSub is not null)
+                    return $"error: {param}= overlay names \"subfolder\" with no \"ini\" — the subfolder says where a DRAFT would be placed, so pass the draft's path as \"ini\" too, or drop \"subfolder\".";
+                if (draftIni is not null)
+                {
+                    if (st.Equals("pre", StringComparison.OrdinalIgnoreCase))
+                        return $"error: {param}= overlay state \"pre\" IS the plain load-order winner, the body the INI layer starts from, so a draft INI cannot change it — read the draft with state \"post\".";
+                    if (SkyPatcherDraft.Prepare(draftIni, draftSub, SkyPatcherCatalog.Load(), out plan) is { } derr)
+                        return $"error: {param}= {derr}";
+                }
+                spec = new LoadOrderService.PoleSpec(LoadOrderService.PoleKind.Overlay, OverlayState: st.ToLowerInvariant(), Draft: plan);
                 return null;
             }
             if (!e.TryGetProperty("file", out var fEl) || fEl.ValueKind != JsonValueKind.String)

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -1861,8 +1861,13 @@ public static class RecordsTools
                 spec = new LoadOrderService.PoleSpec(LoadOrderService.PoleKind.Overlay, OverlayState: st.ToLowerInvariant(), Draft: plan);
                 return null;
             }
+            // The draft keys ride the overlay pole. On a {"file"} pole they have no meaning, and accepting them
+            // would answer with that plugin's own record while the caller read it as the draft's post state.
+            if (e.TryGetProperty("ini", out _) || e.TryGetProperty("subfolder", out _))
+                return $"error: {param}= names \"ini\"/\"subfolder\" without \"overlay\" — a draft INI is a value on the SkyPatcher overlay pole, " +
+                       "so pass {\"overlay\": \"skypatcher\", \"state\": \"post\", \"ini\": \"<absolute path>\", \"subfolder\": \"<type folder>\"}.";
             if (!e.TryGetProperty("file", out var fEl) || fEl.ValueKind != JsonValueKind.String)
-                return $"error: a structured {param}= names the plugin as {{\"file\": \"X.esp\"[, \"mod\": \"<mod folder>\"]}} or the runtime view as {{\"overlay\": \"skypatcher\", \"state\": \"pre\"|\"post\"}}.";
+                return $"error: a structured {param}= names the plugin as {{\"file\": \"X.esp\"[, \"mod\": \"<mod folder>\"]}} or the runtime view as {{\"overlay\": \"skypatcher\", \"state\": \"pre\"|\"post\"[, \"ini\": \"<draft path>\", \"subfolder\": \"<type folder>\"]}}.";
             string? mod = e.TryGetProperty("mod", out var mEl) && mEl.ValueKind == JsonValueKind.String ? mEl.GetString()!.Trim() : null;
             spec = new LoadOrderService.PoleSpec(LoadOrderService.PoleKind.Named, fEl.GetString()!.Trim(), mod);
             return null;


### PR DESCRIPTION
`housecarl_records` could already read a record after the SkyPatcher INI layer replays, but only for INIs discovered under `SKSE\Plugins\SkyPatcher` in an enabled mod — so a draft INI could not be checked until it had been written into a mod folder, which put the skill's verify step after the write instead of before it. This adds one value to the existing overlay pole: `source={"overlay": "skypatcher", "state": "post", "ini": "<absolute path to a draft .ini>", "subfolder": "weapon"}` reads the record as the game would see it once the draft is placed — the live layer plus the draft, sorted into its type folder by filename among the live files with the same ordinal sort discovery uses, and the same `Plugin.esp.ini` filename gate. `subfolder` may be omitted when the draft's parent directory is already a documented type folder, and the arm line says the folder came from there. The pole is legal as `versus=` too, so a draft's post state against the plain post state is the draft's own effect and nothing else. Refusals: an undocumented subfolder (naming the documented list), a filename already placed in that folder (placing it would shadow or be shadowed depending on mod order, so the answer would not be the draft's), `state: "pre"` with a draft, a missing file, and `subfolder` with no `ini`. The scan-lane refusal for an overlay pole is unchanged; the draft rides the `formids=` lane only.

The draft-to-`IniFile` construction and the merge into a `LayerScan` live in a new `src/housecarl-core/SkyPatcherDraft.cs`; the pole parsing sits beside the existing overlay parsing in `RecordsTools.cs`, and `LoadOrderService` only passes the plan through to the two places that discover the layer. One thing had to come with it: the replay's per-line warnings (unknown key, unmapped op, unresolved filter, parse note) went nowhere on the records lane, so a skipped draft line would have read as "the draft changes nothing". They are now collected and rendered beside the answer on both the read and delta lanes, each already carrying its own file and line — which for a draft is the draft's path.

Tests: `RecordsSkyPatcherDraftTests` covers a draft that sets a leaf, the inferred subfolder, the delta composition, an unknown key warning naming the draft, a draft gated on an inactive plugin, and each refusal. `RecordsWorld` gains one comment-only placed INI so the layer has a real type folder and a filename to collide with; it patches nothing, so no existing test changes. Full suite 1778 passed, `ci-all` 127/127.

Closes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)
