### PR TITLE
Check shipped skill pointers and give the Codex tree a skills/ root

### DIFF
--- a/.claude/skills/dialogue-authoring/SKILL.md
+++ b/.claude/skills/dialogue-authoring/SKILL.md
@@ -65,7 +65,7 @@ The Skyrim-specific knowledge lives in the `references/` files — read the one 
 
 The condition / branch / quest references are **hand-curated** (sourced from the CK wiki + Mutagen's record
 model, not the by-construction generator), so they carry a staleness duty — provenance and the re-check
-checklist live in `references/_CORPUS_STATUS.md` (dev-side; not shipped in the plugin).
+checklist live in the corpus status note in the skill's source tree (dev-side; not shipped in the plugin).
 
 ## Read the flow model first
 

--- a/.claude/skills/dialogue-authoring/references/condition-functions.md
+++ b/.claude/skills/dialogue-authoring/references/condition-functions.md
@@ -10,7 +10,8 @@ reference is how you turn the bytes into meaning.
 Run On options, the operators — is taken **by construction from Mutagen** (houseCARL's `mutagen-reference`),
 so it is exactly what `housecarl_read_record` surfaces and what `housecarl_bulk_apply`/`housecarl_set_field`
 compose. The *semantics* — what each function tests, the Run On scoping rules — are from the Creation Kit
-wiki + modding practice (see `_CORPUS_STATUS.md` for provenance and the staleness duty). Confirm any exact
+wiki + modding practice (provenance and the staleness duty live in the corpus status note in the skill's
+source tree; dev-side, not shipped in the plugin). Confirm any exact
 field path or arm name against `mutagen-reference` before composing a write.
 
 ## The shape of a condition (CTDA)

--- a/.claude/skills/dialogue-authoring/references/dialogue-branch.md
+++ b/.claude/skills/dialogue-authoring/references/dialogue-branch.md
@@ -5,7 +5,8 @@ A **Dialogue Branch** is a conversation entry point — the record that makes a 
 branch flags change in-game behavior in ways a record-only glance won't reveal, and one of them
 (`Exclusive`) can silently lock an NPC out of all dialogue.
 
-Field names are Mutagen spellings (by construction from the record model — see `_CORPUS_STATUS.md`); flag
+Field names are Mutagen spellings (by construction from the record model — the corpus status note in the
+skill's source tree records it; dev-side, not shipped in the plugin); flag
 **semantics** are from the Creation Kit wiki. Confirm exact paths against `mutagen-reference`.
 
 ## Fields (Mutagen `DialogBranch`)

--- a/.claude/skills/dialogue-authoring/references/quest-objectives-tab.md
+++ b/.claude/skills/dialogue-authoring/references/quest-objectives-tab.md
@@ -5,7 +5,8 @@ the **journal** the player sees is driven by **objectives** and stage **log entr
 distinct things people conflate — stage number, objective index, and log entry — and conflating them is how
 a journal goes wrong while the dialogue is fine.
 
-Field names are Mutagen spellings (by construction — see `_CORPUS_STATUS.md`); the display/script behavior is
+Field names are Mutagen spellings (by construction — the corpus status note in the skill's source tree
+records it; dev-side, not shipped in the plugin); the display/script behavior is
 from the Creation Kit wiki + practice. Confirm exact paths against `mutagen-reference`.
 
 ## The three things, kept separate

--- a/.claude/skills/kid-authoring/SKILL.md
+++ b/.claude/skills/kid-authoring/SKILL.md
@@ -121,7 +121,8 @@ the reference may be behind and offer to re-derive from the current KID source/d
 
 - **Provenance.** The `references/` corpus is reconstructed from the MIT KID source
   (`powerof3/Keyword-Item-Distributor`, v3.5.0) and the Nexus #55728 description, with forwarded enum
-  values confirmed against `powerof3/CommonLibSSE`. See `references/_CORPUS_STATUS.md`. On a KID version
+  values confirmed against `powerof3/CommonLibSSE`; the corpus status note in the skill's source tree
+  records it (dev-side; not shipped in the plugin). On a KID version
   bump, re-derive before trusting it for new features.
 - **Lookup without authoring.** The same reference answers "what's the spell-type number for Ability",
   "which body slot is 33", or "what archetypes can I filter magic effects by" — open `value-tables.md`;

--- a/.claude/skills/skse-plugin-authoring/references/hooking.md
+++ b/.claude/skills/skse-plugin-authoring/references/hooking.md
@@ -463,7 +463,7 @@ but the verified-*write* wrapper is `ng`-only (po3-dev's `safe_write` is void-on
 any verify teaching to `ng`). The `[[deprecated]]` on the plain form is **opt-in**: it and
 the runtime `AUDIT:` warning are gated behind `REL_AUDIT_UNVERIFIED_PATCHES`, a migration
 switch you add to *find* unverified patches then remove (`Relocation.h:204-207`,
-`VERIFICATION_MIGRATION.md:44-77`) — in a default build the plain form compiles silently. So
+`docs/VERIFICATION_MIGRATION.md:44-77`) — in a default build the plain form compiles silently. So
 the library *offers* verification and *flags* the unverified form under an audit build; it
 does not deprecate it by default.
 

--- a/.claude/skills/skse-plugin-authoring/references/multi-runtime.md
+++ b/.claude/skills/skse-plugin-authoring/references/multi-runtime.md
@@ -17,7 +17,7 @@ the `.psc` surface; never state a Papyrus signature as though it were derived fr
 the C++/Papyrus line is crossed, say so and hand off.
 
 Provenance is cited as `path:line` against the pinned NG corpus (`alandtse/CommonLibVR` @ `8c048b3`, its
-bundled `CLAUDE.md`, the CommonLibSSE-NG wiki, and real plugins OAR / SPID / po3 Papyrus Extender), so a
+bundled `ng/CLAUDE.md`, the CommonLibSSE-NG wiki, and real plugins OAR / SPID / po3 Papyrus Extender), so a
 surprising claim traces back to source.
 
 ## Contents
@@ -43,7 +43,7 @@ index* per runtime.
 > it ABI-incompatible with AE/SE. A naive virtual function call, therefore, cannot work across all runtimes
 > without the plugin being recompiled specifically for VR." — `REL/Relocation.h:979-983`
 
-NG's design goal is a single DLL that works across all supported runtimes (`CLAUDE.md:7`), achieved by
+NG's design goal is a single DLL that works across all supported runtimes (`ng/CLAUDE.md:7`), achieved by
 **never baking a runtime-specific layout into cross-runtime code**. Layout-critical facts (a struct's size,
 a base class, whether a virtual exists at all) are chosen at *compile time* per build preset; offset, slot,
 and feature facts the one DLL must vary are chosen at *load time* via cheap runtime probes that constant-fold
@@ -52,7 +52,7 @@ to nothing in single-runtime builds.
 The trap you must internalize before anything else: a bug written against one layout **compiles clean under
 a single-runtime test preset** and only bites once VR joins the target set. The multi-runtime build — NG
 calls its preset `all`, and its live code path `SKYRIM_CROSS_VR` — is the one that must be green
-(`CLAUDE.md:510-514`). Testing only `se` hides the entire class of bug this reference exists to prevent.
+(`ng/CLAUDE.md:510-514`). Testing only `se` hides the entire class of bug this reference exists to prevent.
 
 ## The footgun catalog
 
@@ -78,10 +78,10 @@ memory / CTD on VR" is the one that ships and crashes a player.
 | 14 | Reaching for `EXCLUSIVE_SKYRIM_FLAT` where SE and AE actually differ | Compiles clean, silently wrong in one of SE/AE | Gate with `EXCLUSIVE_SKYRIM_SE` / `EXCLUSIVE_SKYRIM_AE` when SE ≠ AE — FLAT only means "not VR" |
 | 15 | Mis-ordering the `Relocate` / `RELOCATION_ID` two-arg form | Wrong id/offset on one runtime | 2-arg = `(SE-and-VR shared, AE)`; 3-arg = `(SE, AE, VR)` |
 
-Sources for the rows above: `CLAUDE.md:432-448,480`, `Actor.h:776-778` (#1); `oar/src/Offsets.h:17` (#2);
-`CLAUDE.md:251`, `Common.h:159,186` (#3); `CLAUDE.md:217-241`, `Relocation.h:934-940` (#4);
-`CLAUDE.md:388-404,476-478` (#5); `Common.h:287-334` (#6); `Relocation.h:1000-1003` (#7);
-`oar/src/Conditions.cpp:814` (#8); `CLAUDE.md:253-296` (#9); Lineage section (#10, #11); `ID.h:589-592`
+Sources for the rows above: `ng/CLAUDE.md:432-448,480`, `Actor.h:776-778` (#1); `oar/src/Offsets.h:17` (#2);
+`ng/CLAUDE.md:251`, `Common.h:159,186` (#3); `ng/CLAUDE.md:217-241`, `Relocation.h:934-940` (#4);
+`ng/CLAUDE.md:388-404,476-478` (#5); `Common.h:287-334` (#6); `Relocation.h:1000-1003` (#7);
+`oar/src/Conditions.cpp:814` (#8); `ng/CLAUDE.md:253-296` (#9); Lineage section (#10, #11); `ID.h:589-592`
 (#12); wiki §12,21,185-193 (#13); `Common.h:3-30` (#14); wiki §84,94 (#15).
 
 Three deserve a worked look because copy-paste gets them wrong most often.
@@ -144,7 +144,7 @@ silent-load-failure trap.
 ## Compile-time vs runtime — the decision rule
 
 This is the single most important author judgment, and it decides which of the tools below you reach for
-(`CLAUDE.md:374-377,217-224,419-426`).
+(`ng/CLAUDE.md:374-377,217-224,419-426`).
 
 **Use a preprocessor `#if` (baked per build) when the difference is layout-critical** — it *must* be fixed
 at compile time because it changes the C++ type's shape:
@@ -193,7 +193,7 @@ error is the guardrail.** From `RE/A/Actor.h:776-778`:
 *Demonstrates: the fields exist only in single-runtime builds — the `all` build forces you through the
 accessor.* `PlayerCharacter` mirrors this (`PlayerCharacter.h:999-1003`). NG's own guide states the rule
 and names the error: *"'is not a member of [class]' → Cause: accessing RUNTIME_DATA members directly in
-multi-runtime builds → Solution: Use GetRuntimeData() accessor"* (`CLAUDE.md:480-482`).
+multi-runtime builds → Solution: Use GetRuntimeData() accessor"* (`ng/CLAUDE.md:480-482`).
 
 So `actor->currentProcess` compiles on an `se` preset and dies only in `all` — a single-preset test hides
 the bug. **Author rule: always go through the accessor, even in a single-runtime build, so the plugin stays
@@ -251,19 +251,19 @@ The recurring three-way skeleton is:
 #if defined(EXCLUSIVE_SKYRIM_VR)
     // VR-only shape
 #elif !defined(ENABLE_SKYRIM_VR)
-    // SE/AE-only shape  — use this, NOT a bare #else (CLAUDE.md:296), or it won't compile across all presets
+    // SE/AE-only shape  — use this, NOT a bare #else (ng/CLAUDE.md:296), or it won't compile across all presets
 #else
     // multi-runtime shape
 #endif
 ```
 
 Use `!defined(ENABLE_SKYRIM_VR)` for the SE/AE arm, never a bare `#else` — the bare form fails to compile
-across every preset (`CLAUDE.md:296`, footgun #9's fine print).
+across every preset (`ng/CLAUDE.md:296`, footgun #9's fine print).
 
 ### Pattern 1 — runtime-exclusive virtual functions
 
 **When:** the class has the **same base class** across runtimes but a virtual exists in only one runtime —
-typically a VR-only slot inserted mid-vtable (`CLAUDE.md:163-251`). VR gets a real `virtual`; the
+typically a VR-only slot inserted mid-vtable (`ng/CLAUDE.md:163-251`). VR gets a real `virtual`; the
 multi-runtime build gets a non-virtual placeholder that keeps the C++ vtable identical to SE/AE while
 `RelocateVirtual` does the real dispatch:
 
@@ -306,13 +306,13 @@ VR:    Begin(01) -> End(02) -> Unk_03(03) -> Update(04) -> GetRotation(05)
 
 `TESCameraState.cpp:19-47` proves it: `Update(0x03,0x04)`, `GetRotation(0x04,0x05)`, and so on. Derived
 classes repeat the whole thing — this is the compounding shift the footgun catalog's Actor example walks in
-detail. As `CLAUDE.md:226` puts it: *"Every derived class that overrides functions after a runtime-exclusive
+detail. As `ng/CLAUDE.md:226` puts it: *"Every derived class that overrides functions after a runtime-exclusive
 function MUST implement RelocateVirtual for those functions."*
 
 ### Pattern 2 — runtime-exclusive inheritance
 
 **When:** the class inherits **completely different, incompatible base classes** per runtime
-(`CLAUDE.md:253-301`). Inherit the VR base under VR, the SE/AE base under `!defined(ENABLE_SKYRIM_VR)`, and a
+(`ng/CLAUDE.md:253-301`). Inherit the VR base under VR, the SE/AE base under `!defined(ENABLE_SKYRIM_VR)`, and a
 single most-compatible common base in multi-runtime; then expose `As<Base>()` upcasts that **return
 `nullptr` for the wrong runtime** and otherwise `RelocateMember` to the base's data. The live exemplar is
 `RE::ButtonEvent` (`:12-20,75-81`):
@@ -347,7 +347,7 @@ The same shape covers `HUDMenu : WorldSpaceMenu` (VR) vs `IMenu` (SE/AE), also i
 ### Pattern 3 — chained-inheritance access
 
 **When:** you need a base class's members but reach it through an inheritance *chain that differs per
-runtime* (`CLAUDE.md:303-354`). `ButtonEvent` again — VR walks `ButtonEvent → VRWandEvent → IDEvent`, SE/AE
+runtime* (`ng/CLAUDE.md:303-354`). `ButtonEvent` again — VR walks `ButtonEvent → VRWandEvent → IDEvent`, SE/AE
 casts directly, and multi-runtime has no `IDEvent` edge at all so it relocates (`ButtonEvent.h:88-101`):
 
 ```cpp
@@ -437,7 +437,7 @@ CMake presets set only the `ENABLE_*` trio; `Common.h` derives the rest. The fiv
 
 ### FLAT is "not VR", not "single non-VR runtime" (footgun #14)
 
-The NG `CLAUDE.md` quick-reference table for these defines is a friendly summary that is **lossy in a way
+The `ng/CLAUDE.md` quick-reference table for these defines is a friendly summary that is **lossy in a way
 that produces wrong code** — it omits `EXCLUSIVE_SKYRIM_SE` / `EXCLUSIVE_SKYRIM_AE` and implies a single-SE
 build gets *only* FLAT. It doesn't: `Common.h:12-20` proves single-SE defines both SE and FLAT. Where the
 table and `Common.h` disagree, **`Common.h` wins** — compiled code over hand-written agent notes.
@@ -479,7 +479,7 @@ is frozen: the NG wiki is CharmedBaryon-era prose, useful as documentation, but 
 
 ## Not yet verified in-game
 
-Everything above is grounded in NG's primary source (headers, `.cpp` bodies, the bundled `CLAUDE.md`), and
+Everything above is grounded in NG's primary source (headers, `.cpp` bodies, the bundled `ng/CLAUDE.md`), and
 the `STATIC_ASSERT_SIZE` / `STATIC_ASSERT_OFFSET` backstop proves layout *consistency* per preset at compile
 time. What static source **cannot** prove is that a given offset/slot pair resolves the right member or
 function in a *running* game. Treat these as open until a build-and-load test on each runtime confirms them

--- a/.claude/skills/skse-plugin-authoring/references/plugin-dissection.md
+++ b/.claude/skills/skse-plugin-authoring/references/plugin-dissection.md
@@ -356,7 +356,7 @@ canonical install site — `void Register() { Event::Register(); DETECTION::Regi
 
 This pattern and the static-`func` hook member (lens 3b) go together for a concrete reason: singletons that
 hold engine addresses must use a `static REL::Relocation` — the authority states it plainly, "REL::Relocation
-Must Be Static" (`alandtse-ng CLAUDE.md:432`). The Manager singleton is where that static state lives.
+Must Be Static" (`ng/CLAUDE.md:432`). The Manager singleton is where that static state lives.
 
 **Log anchor.** `InitializeLog()` runs first in `SKSEPlugin_Load`, setting the plugin's log to
 `SKSE::log::log_directory() / <ProjectName>.log` — the name that maps a `.log` in
@@ -495,6 +495,6 @@ Treat them as reliable working assumptions, not proven facts — and never prese
 - **Log path and level.** Whether the log lands at `<ProjectName>.log` and honors the INI `LogLevel` is a
   runtime observation, not a static fact.
 - **Two corpus gaps.** No fully **NG-native worked exemplar** (`SKSEPluginLoad` + `add_commonlibsse_plugin`)
-  exists in the three studied plugins — that idiom is confirmed only in the alandtse NG headers / `CLAUDE.md`,
+  exists in the three studied plugins — that idiom is confirmed only in the alandtse NG headers / `ng/CLAUDE.md`,
   not from a production consumer; and the **CommonLib-as-vcpkg-port** lineage is asserted from the producer
   manifest alone, no consumer exemplar. Where you rely on either, say so.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -70,6 +70,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
   two read-back parameters now carry the same enabling sentence the instructions do, bound and all: a new mod
   loads last, so enabling is the step, while a write into an existing mod keeps that mod's priority.
 
+- **The Codex umbrella skill now ships under a `skills/` root in the package.** In the release zip it is
+  `houseCARL/codex/skills/housecarl/` where it was `houseCARL/codex/housecarl/` — the shape Codex expects, a
+  skill directory that is an immediate child of `skills/`. The installer places it in the same place it always
+  did (`~/.agents/skills/housecarl`), so an install run from `houseCARL-Setup.exe` is unchanged; a copy taken by
+  hand out of the zip comes from the new path.
+
 - **A `housecarl_records` `formids=` read is now held to the render bound on every form that reads a body, and
   says what those bodies cost.** `summary` and `aggregate` read a body per id on this lane exactly as `fields`,
   `rows` and `everything` do — one cheap leaf off each — but only the last three were measured against the bound,

--- a/scripts/build-plugin.ps1
+++ b/scripts/build-plugin.ps1
@@ -155,11 +155,14 @@ foreach ($f in @('.mcp.json','LICENSE','THIRD-PARTY-NOTICES.txt','README.md','CH
 # ---- 7. leak-check the shipped skill trees (excluded files + markdown pointers) ----
 # Runs on both trees before the -PluginTreeOnly return, so CI (which assembles with that switch)
 # runs it too. Two invariants, from dev/DECISIONS.md 2026-09-07 ruling 2: nothing this script
-# excludes may survive into a shipped copy, and every references/<file> a shipped markdown file
-# writes must exist in that same copy and must not be a file this script excludes. The pointer scan
-# reads every .md in the skill, not just SKILL.md - a reference file pointing at a stripped file is
-# the same dead link. It matches either slash and any case, and a backslash pointer is itself a
-# defect (skill pointers are written with forward slashes).
+# excludes may survive into a shipped copy, and every file a shipped markdown file points at must
+# exist in that same copy and must not be a file this script excludes. Both pointer forms are read:
+# the references/<file> hop, and the bare sibling name that most of the corpus uses. The scan reads
+# every .md in the skill, not just SKILL.md - a reference file pointing at a stripped file is the
+# same dead link. It matches either slash and any case, and a backslash pointer is itself a defect
+# (skill pointers are written with forward slashes). This checks that a pointer RESOLVES; the ruling's
+# form half - that a pointer is written as references/<file> - is enforced per skill by the regrade in
+# that skill's rewrite wave, not here.
 Step '7/12' 'Leak-check skills (excluded files + markdown pointers)'
 $skillLeaks = @()
 foreach ($r in $LeakRoots) {
@@ -174,6 +177,9 @@ $pointerFails = @()
 $docCount = 0
 foreach ($r in $SkillRoots) {
   foreach ($skillDir in (Get-ChildItem $r -Directory)) {
+    # every file name this skill ships - what a bare sibling pointer has to resolve to
+    $shipped = @{}
+    Get-ChildItem $skillDir.FullName -Recurse -Force -File | ForEach-Object { $shipped[$_.Name] = $true }
     foreach ($doc in (Get-ChildItem $skillDir.FullName -Recurse -Force -File -Filter '*.md')) {
       $docCount++
       $rel     = ($doc.FullName.Substring($skillDir.FullName.Length).TrimStart('\')) -replace '\\','/'
@@ -194,6 +200,16 @@ foreach ($r in $SkillRoots) {
           $pointerFails += ("{0} ({1}) points at {2}, which this script strips from every shipped copy." -f $skillDir.Name, $rel, $ptr)
         } elseif (-not (Test-Path (Join-Path $skillDir.FullName $ptr))) {
           $pointerFails += ("{0} ({1}) points at {2}, which is not in the shipped copy." -f $skillDir.Name, $rel, $ptr)
+        }
+      }
+      # the bare sibling form, the dominant one in the corpus (a plain value-tables.md, no references/ hop):
+      # it resolves against every name the skill ships. Only .md and .jsonl are candidates - those are the
+      # extensions shipped skill files use, so a bare .json/.ini/.psc name here is a file in the modded game
+      # (OAR's config.json, SPID's _DISTR.ini, a vanilla Form.psc), never a pointer at a sibling document.
+      foreach ($m in [regex]::Matches($docText, '(?<![A-Za-z0-9_./\\-])[A-Za-z0-9_-]+\.(?:md|jsonl)(?![A-Za-z0-9])', 'IgnoreCase')) {
+        if ($m.Value -eq '_CORPUS_STATUS.md') { continue }   # the stripped-file rule above owns this name
+        if (-not $shipped.ContainsKey($m.Value)) {
+          $pointerFails += ("{0} ({1}) points at {2}, which is not in the shipped copy." -f $skillDir.Name, $rel, $m.Value)
         }
       }
     }

--- a/scripts/build-plugin.ps1
+++ b/scripts/build-plugin.ps1
@@ -10,6 +10,7 @@
 
   Outputs (all gitignored build artifacts, reproducible on demand):
       dist/housecarl/                         the plugin tree (what `claude plugin validate` checks)
+      dist/codex/skills/housecarl/            the Codex umbrella skill, under a skills/ root
       dist/houseCARL-Setup.exe                the no-CLI desktop installer
       dist/START-HERE.txt                     friend-facing note (version stamped from plugin.json)
       dist/.claude-plugin/marketplace.json    CLI-install descriptor (local marketplace)
@@ -21,9 +22,10 @@
   After it succeeds, run the validation gate (necessary, not sufficient):
       claude plugin validate ./dist/housecarl --strict
 
-  -PluginTreeOnly assembles just dist/housecarl (skills + plugin files) and stops: no corpus,
-  no server publish, no setup exe, no zip. That is the whole tree `claude plugin validate`
-  reads, and it is what CI runs the real validator against.
+  -PluginTreeOnly assembles just dist/housecarl (skills + plugin files) and the Codex skill tree,
+  runs the skill leak-check over both, and stops: no corpus, no server publish, no setup exe, no
+  zip. dist/housecarl is the whole tree `claude plugin validate` reads, and it is what CI runs the
+  real validator against; the leak-check runs here so CI runs it too.
 
   Reference:
       dev/plans/PLUGIN_BUILD_EXECUTION_2026-06-03.md   (the checklist this implements)
@@ -41,6 +43,8 @@ $PkgRoot      = Join-Path $RepoRoot 'dist'              # package root: ships ho
 $DistRoot     = Join-Path $PkgRoot 'housecarl'          # the plugin tree (what `claude plugin validate` checks)
 $ServerDir    = Join-Path $DistRoot 'server'
 $SkillsDir    = Join-Path $DistRoot 'skills'
+$CodexRoot    = Join-Path $PkgRoot 'codex'              # the Codex bundle root (beside, not inside, the plugin tree)
+$CodexSkills  = Join-Path $CodexRoot 'skills'           # Codex skill dirs are immediate children of a skills/ root
 $PluginSrc    = Join-Path $RepoRoot 'plugin'
 $GeneratedDir = Join-Path $RepoRoot 'generated'
 $CorpusSrc    = Join-Path $GeneratedDir 'corpus.json'
@@ -67,7 +71,7 @@ Write-Host ("Building houseCARL v{0}" -f $Version) -ForegroundColor Green
 # Clean the WHOLE package root, not just dist/housecarl: stale package-root extras (codex/,
 # START-HERE.txt, a previous setup exe) would otherwise survive into the zip - a stale nested
 # codex/codex/ subtree did exactly that at the 1.2.2 build.
-Step '0/11' 'Clean dist/ (package root)'
+Step '0/12' 'Clean dist/ (package root)'
 if (Test-Path $PkgRoot) { Remove-Item $PkgRoot -Recurse -Force }
 New-Item -ItemType Directory -Path $DistRoot -Force | Out-Null
 
@@ -76,7 +80,7 @@ New-Item -ItemType Directory -Path $DistRoot -Force | Out-Null
 if (-not $PluginTreeOnly) {
 
   # ---- 1. regenerate the rulebook (corpus.json + mutagen-reference shards, in sync by construction)
-  Step '1/11' 'Regenerate corpus.json (generator)'
+  Step '1/12' 'Regenerate corpus.json (generator)'
   # Explicit absolute args make this CWD-independent (Program.cs defaults are relative to CWD).
   dotnet run --project $GenProj -c Release -- $GeneratedDir $RefDir
   if ($LASTEXITCODE -ne 0) { throw "generator failed (exit $LASTEXITCODE)" }
@@ -86,7 +90,7 @@ if (-not $PluginTreeOnly) {
   # ---- 2. publish the server (framework-dependent; trimming OFF) -------------
   # -p:Version stamps the plugin.json version into the exe, which ServerInfo reports over MCP
   # (one version home; an unstamped dev build says 0.0.0-dev).
-  Step '2/11' 'Publish server (Release, win-x64, framework-dependent)'
+  Step '2/12' 'Publish server (Release, win-x64, framework-dependent)'
   dotnet publish $McpProj -c Release -r win-x64 --self-contained false -p:Version=$Version -o $ServerDir
   if ($LASTEXITCODE -ne 0) { throw "publish failed (exit $LASTEXITCODE)" }
   $Exe = Join-Path $ServerDir 'housecarl-mcp.exe'
@@ -100,48 +104,102 @@ if (-not $PluginTreeOnly) {
   # Mutagen release its corresponding-source line points at. Both are written here from the publish just
   # made, so neither can drift from what ships; the licence texts stay hand-authored. Both tracked copies
   # (repo root and plugin/) are rewritten from one string, so they stay byte-identical.
-  Step '3/11' 'Write the generated notices regions from the publish output'
+  Step '3/12' 'Write the generated notices regions from the publish output'
   & (Join-Path $PSScriptRoot 'generate-notices.ps1') -PublishDir $ServerDir -RepoRoot $RepoRoot
 
   # ---- 4. corpus beside the exe (the proven #1 requirement) ------------------
   # Reads survive without it via a reflection fallback, but writes + type-filtered queries need it.
-  Step '4/11' 'Copy corpus.json beside the exe'
+  Step '4/12' 'Copy corpus.json beside the exe'
   Copy-Item $CorpusSrc (Join-Path $ServerDir 'corpus.json') -Force
 }
 
-# ---- 5. bundle the 11 skills (exclude evals/ + _CORPUS_STATUS.md; KEEP all .jsonl) ----
-Step '5/11' 'Bundle skills'
+# ---- 5. bundle the skills, both trees (exclude evals/ + _CORPUS_STATUS.md; KEEP all .jsonl) ----
+# The Codex umbrella skill (the $housecarl entry point for Codex) ships at the PACKAGE ROOT, beside -
+# not inside - dist/housecarl/, so the Claude install (which copies the housecarl/ plugin tree
+# wholesale) never picks it up; only the setup utility's Codex path places it. Its skill dir is an
+# immediate child of a skills/ root (dist/codex/skills/housecarl), the shape Codex accepts.
+Step '5/12' 'Bundle skills (plugin tree + Codex umbrella)'
 New-Item -ItemType Directory -Path $SkillsDir -Force | Out-Null
 foreach ($s in $Skills) {
   $src = Join-Path $RepoRoot ".claude\skills\$s"
   if (-not (Test-Path $src)) { throw "skill not found: $src" }
   Copy-Item $src (Join-Path $SkillsDir $s) -Recurse -Force
 }
-# prune dev/QA meta from the copies (index.jsonl + the mutagen shards stay - load-bearing)
-Get-ChildItem $SkillsDir -Directory -Recurse -Filter 'evals' | Remove-Item -Recurse -Force
-Get-ChildItem $SkillsDir -File -Recurse -Filter '_CORPUS_STATUS.md' | Remove-Item -Force
+$CodexSrc = Join-Path $PluginSrc 'codex'
+$SkillRoots = @($SkillsDir)
+if (Test-Path $CodexSrc) {
+  New-Item -ItemType Directory -Path $CodexSkills -Force | Out-Null
+  Get-ChildItem $CodexSrc -Directory | ForEach-Object { Copy-Item $_.FullName $CodexSkills -Recurse -Force }
+  $SkillRoots += $CodexSkills
+}
+# prune dev/QA meta from the copies (index.jsonl + the mutagen shards stay - load-bearing). The eval
+# file is evals/evals.json (dev/DECISIONS.md, 2026-09-07, ruling 3); the whole directory is stripped.
+foreach ($r in $SkillRoots) {
+  Get-ChildItem $r -Directory -Recurse -Filter 'evals' | Remove-Item -Recurse -Force
+  Get-ChildItem $r -File -Recurse -Filter '_CORPUS_STATUS.md' | Remove-Item -Force
+}
 
 # ---- 6. plugin source files ------------------------------------------------
-Step '6/11' 'Copy plugin files'
+Step '6/12' 'Copy plugin files'
 Copy-Item (Join-Path $PluginSrc '.claude-plugin') $DistRoot -Recurse -Force   # -> dist/housecarl/.claude-plugin/plugin.json
 foreach ($f in @('.mcp.json','LICENSE','THIRD-PARTY-NOTICES.txt','README.md','CHANGELOG.md')) {
   Copy-Item (Join-Path $PluginSrc $f) (Join-Path $DistRoot $f) -Force
 }
 
+# ---- 7. leak-check the shipped skill trees (excluded files + SKILL.md pointers) ----
+# Runs on both trees before the -PluginTreeOnly return, so CI (which assembles with that switch)
+# runs it too. Two invariants, from dev/DECISIONS.md 2026-09-07 ruling 2: nothing this script
+# excludes may survive into a shipped copy, and every references/<file> a shipped SKILL.md body
+# writes must exist in that same copy and must not be a file this script excludes.
+Step '7/12' 'Leak-check skills (excluded files + SKILL.md pointers)'
+$skillLeaks = @()
+foreach ($r in $SkillRoots) {
+  $skillLeaks += Get-ChildItem $r -Recurse -Force -File -Filter '_CORPUS_STATUS.md'
+  $skillLeaks += Get-ChildItem $r -Recurse -Force -Directory -Filter 'evals'
+}
+if ($skillLeaks.Count -gt 0) {
+  $skillLeaks | ForEach-Object { Write-Host "  LEAK (excluded file present): $($_.FullName)" -ForegroundColor Red }
+  throw "leak-check failed: excluded files present in dist"
+}
+$pointerFails = @()
+foreach ($r in $SkillRoots) {
+  foreach ($skillDir in (Get-ChildItem $r -Directory)) {
+    $body = Join-Path $skillDir.FullName 'SKILL.md'
+    if (-not (Test-Path $body)) { continue }
+    $bodyText = Get-Content $body -Raw
+    foreach ($m in [regex]::Matches($bodyText, '(?:references|evals)/[A-Za-z0-9_./-]+')) {
+      $ptr  = $m.Value.TrimEnd('.', ',', ';', ':', ')')
+      $leaf = Split-Path $ptr -Leaf
+      if ($ptr.EndsWith('/') -or ($leaf -notmatch '\.')) { continue }   # names the directory, not a file
+      if ($ptr -like 'evals/*' -or $leaf -eq '_CORPUS_STATUS.md') {
+        $pointerFails += ("{0} points at {1}, which this script strips from every shipped copy." -f $skillDir.Name, $ptr)
+      } elseif (-not (Test-Path (Join-Path $skillDir.FullName $ptr))) {
+        $pointerFails += ("{0} points at {1}, which is not in the shipped copy." -f $skillDir.Name, $ptr)
+      }
+    }
+  }
+}
+if ($pointerFails.Count -gt 0) {
+  $pointerFails | Sort-Object -Unique | ForEach-Object { Write-Host "  POINTER: $_" -ForegroundColor Red }
+  throw "leak-check failed: a shipped SKILL.md points at a file that does not ship beside it"
+}
+Write-Host ("skill leak-check clean ({0} skills across {1} tree(s))." -f ($SkillRoots | ForEach-Object { (Get-ChildItem $_ -Directory).Count } | Measure-Object -Sum).Sum, $SkillRoots.Count) -ForegroundColor Green
+
 # The validator's whole input is assembled now. Stop here when only that was asked for.
 if ($PluginTreeOnly) {
   $skillCount = (Get-ChildItem $SkillsDir -Directory).Count
   Write-Host ("`nPlugin tree assembled: {0}   skills: {1}" -f $DistRoot, $skillCount) -ForegroundColor Green
+  Write-Host ("Codex skill tree:      {0}" -f $CodexSkills)
   Write-Host "Server, setup utility and zip were skipped (-PluginTreeOnly)."
   return
 }
 
-# ---- 7. package-root extras (START-HERE note + local marketplace.json) -----
+# ---- 8. package-root extras (START-HERE note + local marketplace.json) -----
 # These live in the PACKAGE ROOT (dist/), beside - not inside - dist/housecarl/, so the leak-check's
 # excluded-file scan (scoped to dist/housecarl) leaves them out, while the dev-path scan (step 9) still
 # covers them. Source: packaging/ (tracked). START-HERE.txt is version-stamped from plugin.json;
 # marketplace.json is the local CLI-install descriptor (`claude plugin marketplace add <this folder>`).
-Step '7/11' 'Package-root extras (START-HERE.txt + marketplace.json + codex umbrella)'
+Step '8/12' 'Package-root extras (START-HERE.txt + marketplace.json)'
 $startHere = (Get-Content (Join-Path $PackagingSrc 'START-HERE.txt') -Raw) -replace '\{\{VERSION\}\}', $Version
 if ($startHere -match '\{\{') { throw "START-HERE.txt has an unresolved {{token}} after substitution" }
 [System.IO.File]::WriteAllText((Join-Path $PkgRoot 'START-HERE.txt'), $startHere, (New-Object System.Text.UTF8Encoding($false)))
@@ -149,13 +207,7 @@ $MpDir = Join-Path $PkgRoot '.claude-plugin'
 New-Item -ItemType Directory -Path $MpDir -Force | Out-Null
 Copy-Item (Join-Path $PackagingSrc 'marketplace.json') (Join-Path $MpDir 'marketplace.json') -Force
 
-# Codex-only umbrella skill (the $housecarl entry point for Codex). Ships at the PACKAGE ROOT
-# (dist/codex/), beside - not inside - dist/housecarl/, so the Claude install (which copies the
-# housecarl/ plugin tree wholesale) never picks it up; only the setup utility's Codex path places it.
-$CodexSrc = Join-Path $PluginSrc 'codex'
-if (Test-Path $CodexSrc) { Copy-Item $CodexSrc (Join-Path $PkgRoot 'codex') -Recurse -Force }
-
-# ---- 8. publish the setup utility into dist/ (beside the plugin) -----------
+# ---- 9. publish the setup utility into dist/ (beside the plugin) -----------
 # houseCARL-Setup.exe: the no-CLI desktop installer a user double-clicks. It copies the plugin into
 # ~/.claude/skills/housecarl/ (desktop auto-loads the skills) and registers the MCP server in
 # ~/.claude.json (desktop spawns it per session). It ships in the PACKAGE ROOT (dist\), beside - not
@@ -165,19 +217,19 @@ if (Test-Path $CodexSrc) { Copy-Item $CodexSrc (Join-Path $PkgRoot 'codex') -Rec
 # framework-dependent SERVER needs (.NET Runtime + ASP.NET Core Runtime - separate installers on
 # Windows) and say exactly which is missing. Trimming is safe HERE (setup uses only the
 # System.Text.Json DOM, no reflection serialization) - the server's trimming ban is untouched.
-Step '8/11' 'Publish the setup utility (houseCARL-Setup.exe) into dist/'
+Step '9/12' 'Publish the setup utility (houseCARL-Setup.exe) into dist/'
 dotnet publish $SetupProj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=true -p:EnableCompressionInSingleFile=true -p:DebugType=None -p:DebugSymbols=false -o $PkgRoot
 if ($LASTEXITCODE -ne 0) { throw "setup-utility publish failed (exit $LASTEXITCODE)" }
 $SetupExe = Join-Path $PkgRoot 'houseCARL-Setup.exe'
 if (-not (Test-Path $SetupExe)) { throw "setup utility not produced at $SetupExe" }
 Write-Host ("houseCARL-Setup.exe: {0:N2} MB" -f ((Get-Item $SetupExe).Length / 1MB))
 
-# ---- 9. leak-check ---------------------------------------------------------
-Step '9/11' 'Leak-check assembled tree'
+# ---- 10. leak-check the server half + the whole package root ----------------
+# The skill trees were leak-checked at step 7 (excluded files + body pointers); this covers what only
+# a full build produces: the published server, and every shipped text file under the package root.
+Step '10/12' 'Leak-check assembled tree'
 $leaks = @()
 $leaks += Get-ChildItem $DistRoot -Recurse -Force -Filter 'appsettings*.json'
-$leaks += Get-ChildItem $DistRoot -Recurse -Force -Filter '_CORPUS_STATUS.md'
-$leaks += Get-ChildItem $DistRoot -Recurse -Force -Directory -Filter 'evals'
 if ($leaks.Count -gt 0) {
   $leaks | ForEach-Object { Write-Host "  LEAK (excluded file present): $($_.FullName)" -ForegroundColor Red }
   throw "leak-check failed: excluded files present in dist"
@@ -204,7 +256,7 @@ Write-Host "leak-check clean." -ForegroundColor Green
 # One zip, single 'houseCARL/' root (so unzipping never scatters files), built from dist/ via the
 # .NET zip API (Compress-Archive can't set a custom root). Lands in release/ - outside dist/, so it
 # never includes itself. FileMode::Create overwrites a same-version zip in place.
-Step '10/11' 'Pack release zip'
+Step '11/12' 'Pack release zip'
 New-Item -ItemType Directory -Path $ReleaseDir -Force | Out-Null
 $ZipPath = Join-Path $ReleaseDir ("houseCARL-{0}.zip" -f $Version)
 Add-Type -AssemblyName System.IO.Compression
@@ -227,7 +279,7 @@ $ZipMB = [math]::Round((Get-Item $ZipPath).Length / 1MB, 2)
 Write-Host ("packed {0} entries -> {1} ({2} MB)" -f $ZipEntryCount, $ZipPath, $ZipMB) -ForegroundColor Green
 
 # ---- 11. summary -----------------------------------------------------------
-Step '11/11' 'Summary'
+Step '12/12' 'Summary'
 $fileCount  = (Get-ChildItem $DistRoot -Recurse -Force -File).Count
 $totalMB    = (Get-ChildItem $DistRoot -Recurse -Force -File | Measure-Object Length -Sum).Sum / 1MB
 $skillCount = (Get-ChildItem $SkillsDir -Directory).Count
@@ -240,7 +292,7 @@ Write-Host ("  manifest:    {0}" -f (Test-Path (Join-Path $DistRoot '.claude-plu
 Write-Host ("  setup util:  {0}   ({1})" -f (Test-Path $SetupExe), (Split-Path $SetupExe -Leaf))
 Write-Host ("  start-here:  {0}" -f (Test-Path (Join-Path $PkgRoot 'START-HERE.txt')))
 Write-Host ("  marketplace: {0}" -f (Test-Path (Join-Path $PkgRoot '.claude-plugin\marketplace.json')))
-Write-Host ("  codex skill: {0}" -f (Test-Path (Join-Path $PkgRoot 'codex\housecarl\SKILL.md')))
+Write-Host ("  codex skill: {0}" -f (Test-Path (Join-Path $CodexSkills 'housecarl\SKILL.md')))
 Write-Host ("Shippable zip:    {0}  ({1} MB, {2} entries)" -f $ZipPath, $ZipMB, $ZipEntryCount)
 Write-Host "`nDONE." -ForegroundColor Green
 Write-Host "Next - validation gate (necessary, not sufficient):" -ForegroundColor Yellow

--- a/scripts/build-plugin.ps1
+++ b/scripts/build-plugin.ps1
@@ -180,7 +180,7 @@ foreach ($r in $SkillRoots) {
       $docText = Get-Content $doc.FullName -Raw
       if (-not $docText) { $pointerFails += ("{0} ships an empty {1}." -f $skillDir.Name, $rel); continue }
       # a references/ or evals/ pointer in any spelling, plus a bare mention of the stripped status note
-      $hits  = @([regex]::Matches($docText, '(?:references|evals)[/\\][A-Za-z0-9_./\\-]+', 'IgnoreCase') | ForEach-Object { $_.Value })
+      $hits  = @([regex]::Matches($docText, '(?<![A-Za-z0-9_./\\-])(?:references|evals)[/\\][A-Za-z0-9_./\\-]+', 'IgnoreCase') | ForEach-Object { $_.Value })
       $hits += @([regex]::Matches($docText, '(?<![A-Za-z0-9_./\\-])_CORPUS_STATUS\.md', 'IgnoreCase') | ForEach-Object { $_.Value })
       foreach ($hit in $hits) {
         $ptr = $hit.TrimEnd('.', ',', ';', ':', ')')

--- a/scripts/build-plugin.ps1
+++ b/scripts/build-plugin.ps1
@@ -146,12 +146,15 @@ foreach ($f in @('.mcp.json','LICENSE','THIRD-PARTY-NOTICES.txt','README.md','CH
   Copy-Item (Join-Path $PluginSrc $f) (Join-Path $DistRoot $f) -Force
 }
 
-# ---- 7. leak-check the shipped skill trees (excluded files + SKILL.md pointers) ----
+# ---- 7. leak-check the shipped skill trees (excluded files + markdown pointers) ----
 # Runs on both trees before the -PluginTreeOnly return, so CI (which assembles with that switch)
 # runs it too. Two invariants, from dev/DECISIONS.md 2026-09-07 ruling 2: nothing this script
-# excludes may survive into a shipped copy, and every references/<file> a shipped SKILL.md body
-# writes must exist in that same copy and must not be a file this script excludes.
-Step '7/12' 'Leak-check skills (excluded files + SKILL.md pointers)'
+# excludes may survive into a shipped copy, and every references/<file> a shipped markdown file
+# writes must exist in that same copy and must not be a file this script excludes. The pointer scan
+# reads every .md in the skill, not just SKILL.md - a reference file pointing at a stripped file is
+# the same dead link. It matches either slash and any case, and a backslash pointer is itself a
+# defect (skill pointers are written with forward slashes).
+Step '7/12' 'Leak-check skills (excluded files + markdown pointers)'
 $skillLeaks = @()
 foreach ($r in $SkillRoots) {
   $skillLeaks += Get-ChildItem $r -Recurse -Force -File -Filter '_CORPUS_STATUS.md'
@@ -162,42 +165,54 @@ if ($skillLeaks.Count -gt 0) {
   throw "leak-check failed: excluded files present in dist"
 }
 $pointerFails = @()
+$docCount = 0
 foreach ($r in $SkillRoots) {
   foreach ($skillDir in (Get-ChildItem $r -Directory)) {
-    $body = Join-Path $skillDir.FullName 'SKILL.md'
-    if (-not (Test-Path $body)) { continue }
-    $bodyText = Get-Content $body -Raw
-    foreach ($m in [regex]::Matches($bodyText, '(?:references|evals)/[A-Za-z0-9_./-]+')) {
-      $ptr  = $m.Value.TrimEnd('.', ',', ';', ':', ')')
-      $leaf = Split-Path $ptr -Leaf
-      if ($ptr.EndsWith('/') -or ($leaf -notmatch '\.')) { continue }   # names the directory, not a file
-      if ($ptr -like 'evals/*' -or $leaf -eq '_CORPUS_STATUS.md') {
-        $pointerFails += ("{0} points at {1}, which this script strips from every shipped copy." -f $skillDir.Name, $ptr)
-      } elseif (-not (Test-Path (Join-Path $skillDir.FullName $ptr))) {
-        $pointerFails += ("{0} points at {1}, which is not in the shipped copy." -f $skillDir.Name, $ptr)
+    foreach ($doc in (Get-ChildItem $skillDir.FullName -Recurse -Force -File -Filter '*.md')) {
+      $docCount++
+      $rel     = ($doc.FullName.Substring($skillDir.FullName.Length).TrimStart('\')) -replace '\\','/'
+      $docText = Get-Content $doc.FullName -Raw
+      if (-not $docText) { $pointerFails += ("{0} ships an empty {1}." -f $skillDir.Name, $rel); continue }
+      # a references/ or evals/ pointer in any spelling, plus a bare mention of the stripped status note
+      $hits  = @([regex]::Matches($docText, '(?:references|evals)[/\\][A-Za-z0-9_./\\-]+', 'IgnoreCase') | ForEach-Object { $_.Value })
+      $hits += @([regex]::Matches($docText, '(?<![A-Za-z0-9_./\\-])_CORPUS_STATUS\.md', 'IgnoreCase') | ForEach-Object { $_.Value })
+      foreach ($hit in $hits) {
+        $ptr = $hit.TrimEnd('.', ',', ';', ':', ')')
+        if ($ptr -match '\\') {
+          $pointerFails += ("{0} ({1}) writes {2} with a backslash; skill pointers use forward slashes." -f $skillDir.Name, $rel, $ptr)
+          continue
+        }
+        $leaf = Split-Path $ptr -Leaf
+        if ($ptr.EndsWith('/') -or ($leaf -notmatch '\.')) { continue }   # names the directory, not a file
+        if ($ptr -like 'evals/*' -or $leaf -eq '_CORPUS_STATUS.md') {
+          $pointerFails += ("{0} ({1}) points at {2}, which this script strips from every shipped copy." -f $skillDir.Name, $rel, $ptr)
+        } elseif (-not (Test-Path (Join-Path $skillDir.FullName $ptr))) {
+          $pointerFails += ("{0} ({1}) points at {2}, which is not in the shipped copy." -f $skillDir.Name, $rel, $ptr)
+        }
       }
     }
   }
 }
 if ($pointerFails.Count -gt 0) {
-  $pointerFails | Sort-Object -Unique | ForEach-Object { Write-Host "  POINTER: $_" -ForegroundColor Red }
-  throw "leak-check failed: a shipped SKILL.md points at a file that does not ship beside it"
+  $pointerFails | Sort-Object -Unique | ForEach-Object { Write-Host "  SKILL DOC: $_" -ForegroundColor Red }
+  throw "leak-check failed: a shipped skill markdown file is empty or points at a file that does not ship beside it"
 }
-Write-Host ("skill leak-check clean ({0} skills across {1} tree(s))." -f ($SkillRoots | ForEach-Object { (Get-ChildItem $_ -Directory).Count } | Measure-Object -Sum).Sum, $SkillRoots.Count) -ForegroundColor Green
+Write-Host ("skill leak-check clean ({0} skills, {1} markdown files, across {2} tree(s))." -f ($SkillRoots | ForEach-Object { (Get-ChildItem $_ -Directory).Count } | Measure-Object -Sum).Sum, $docCount, $SkillRoots.Count) -ForegroundColor Green
 
 # The validator's whole input is assembled now. Stop here when only that was asked for.
 if ($PluginTreeOnly) {
   $skillCount = (Get-ChildItem $SkillsDir -Directory).Count
   Write-Host ("`nPlugin tree assembled: {0}   skills: {1}" -f $DistRoot, $skillCount) -ForegroundColor Green
-  Write-Host ("Codex skill tree:      {0}" -f $CodexSkills)
+  if (Test-Path $CodexSkills) { Write-Host ("Codex skill tree:      {0}" -f $CodexSkills) }
+  else                        { Write-Host "Codex skill tree:      (none - plugin/codex not found)" }
   Write-Host "Server, setup utility and zip were skipped (-PluginTreeOnly)."
   return
 }
 
 # ---- 8. package-root extras (START-HERE note + local marketplace.json) -----
-# These live in the PACKAGE ROOT (dist/), beside - not inside - dist/housecarl/, so the leak-check's
-# excluded-file scan (scoped to dist/housecarl) leaves them out, while the dev-path scan (step 9) still
-# covers them. Source: packaging/ (tracked). START-HERE.txt is version-stamped from plugin.json;
+# These live in the PACKAGE ROOT (dist/), beside - not inside - dist/housecarl/. Step 10 covers them
+# both ways: its excluded-file scan and its dev-path scan each walk the whole package root.
+# Source: packaging/ (tracked). START-HERE.txt is version-stamped from plugin.json;
 # marketplace.json is the local CLI-install descriptor (`claude plugin marketplace add <this folder>`).
 Step '8/12' 'Package-root extras (START-HERE.txt + marketplace.json)'
 $startHere = (Get-Content (Join-Path $PackagingSrc 'START-HERE.txt') -Raw) -replace '\{\{VERSION\}\}', $Version
@@ -211,8 +226,8 @@ Copy-Item (Join-Path $PackagingSrc 'marketplace.json') (Join-Path $MpDir 'market
 # houseCARL-Setup.exe: the no-CLI desktop installer a user double-clicks. It copies the plugin into
 # ~/.claude/skills/housecarl/ (desktop auto-loads the skills) and registers the MCP server in
 # ~/.claude.json (desktop spawns it per session). It ships in the PACKAGE ROOT (dist\), beside - not
-# inside - the housecarl/ plugin tree, so the leak-check (which scans dist\housecarl only) correctly
-# leaves it out of scope. Single-file, SELF-CONTAINED (trimmed + compressed): setup must run on a
+# inside - the housecarl/ plugin tree, so a Claude install (which copies that tree wholesale) never
+# picks it up. Single-file, SELF-CONTAINED (trimmed + compressed): setup must run on a
 # machine with no .NET installed at all, so it can preflight-check the two runtimes the
 # framework-dependent SERVER needs (.NET Runtime + ASP.NET Core Runtime - separate installers on
 # Windows) and say exactly which is missing. Trimming is safe HERE (setup uses only the
@@ -225,11 +240,15 @@ if (-not (Test-Path $SetupExe)) { throw "setup utility not produced at $SetupExe
 Write-Host ("houseCARL-Setup.exe: {0:N2} MB" -f ((Get-Item $SetupExe).Length / 1MB))
 
 # ---- 10. leak-check the server half + the whole package root ----------------
-# The skill trees were leak-checked at step 7 (excluded files + body pointers); this covers what only
-# a full build produces: the published server, and every shipped text file under the package root.
+# The skill trees were leak-checked at step 7 (excluded files + markdown pointers); this covers what
+# only a full build produces: the published server, and every shipped text file under the package
+# root. The excluded-file scan walks the whole package root, so an excluded file that lands outside
+# skills/ - a stray copy under .claude-plugin/, or one a future publish pulls in - is still caught.
 Step '10/12' 'Leak-check assembled tree'
 $leaks = @()
 $leaks += Get-ChildItem $DistRoot -Recurse -Force -Filter 'appsettings*.json'
+$leaks += Get-ChildItem $PkgRoot -Recurse -Force -File -Filter '_CORPUS_STATUS.md'
+$leaks += Get-ChildItem $PkgRoot -Recurse -Force -Directory -Filter 'evals'
 if ($leaks.Count -gt 0) {
   $leaks | ForEach-Object { Write-Host "  LEAK (excluded file present): $($_.FullName)" -ForegroundColor Red }
   throw "leak-check failed: excluded files present in dist"
@@ -252,7 +271,7 @@ if ($pathLeaks.Count -gt 0) {
 }
 Write-Host "leak-check clean." -ForegroundColor Green
 
-# ---- 10. pack the shippable zip ---------------------------------------------
+# ---- 11. pack the shippable zip ---------------------------------------------
 # One zip, single 'houseCARL/' root (so unzipping never scatters files), built from dist/ via the
 # .NET zip API (Compress-Archive can't set a custom root). Lands in release/ - outside dist/, so it
 # never includes itself. FileMode::Create overwrites a same-version zip in place.
@@ -278,7 +297,7 @@ $zipCheck.Dispose()
 $ZipMB = [math]::Round((Get-Item $ZipPath).Length / 1MB, 2)
 Write-Host ("packed {0} entries -> {1} ({2} MB)" -f $ZipEntryCount, $ZipPath, $ZipMB) -ForegroundColor Green
 
-# ---- 11. summary -----------------------------------------------------------
+# ---- 12. summary -----------------------------------------------------------
 Step '12/12' 'Summary'
 $fileCount  = (Get-ChildItem $DistRoot -Recurse -Force -File).Count
 $totalMB    = (Get-ChildItem $DistRoot -Recurse -Force -File | Measure-Object Length -Sum).Sum / 1MB

--- a/scripts/build-plugin.ps1
+++ b/scripts/build-plugin.ps1
@@ -117,7 +117,8 @@ if (-not $PluginTreeOnly) {
 # The Codex umbrella skill (the $housecarl entry point for Codex) ships at the PACKAGE ROOT, beside -
 # not inside - dist/housecarl/, so the Claude install (which copies the housecarl/ plugin tree
 # wholesale) never picks it up; only the setup utility's Codex path places it. Its skill dir is an
-# immediate child of a skills/ root (dist/codex/skills/housecarl), the shape Codex accepts.
+# immediate child of a skills/ root (dist/codex/skills/housecarl), the shape Codex accepts. The whole
+# plugin/codex tree ships - a loose file at its root lands beside skills/, not inside it.
 Step '5/12' 'Bundle skills (plugin tree + Codex umbrella)'
 New-Item -ItemType Directory -Path $SkillsDir -Force | Out-Null
 foreach ($s in $Skills) {
@@ -126,15 +127,20 @@ foreach ($s in $Skills) {
   Copy-Item $src (Join-Path $SkillsDir $s) -Recurse -Force
 }
 $CodexSrc = Join-Path $PluginSrc 'codex'
-$SkillRoots = @($SkillsDir)
+$SkillRoots = @($SkillsDir)   # skill-directory roots: the markdown pointer scan walks these
+$LeakRoots  = @($SkillsDir)   # excluded-file scan: wider, so a loose Codex package file is covered too
 if (Test-Path $CodexSrc) {
   New-Item -ItemType Directory -Path $CodexSkills -Force | Out-Null
-  Get-ChildItem $CodexSrc -Directory | ForEach-Object { Copy-Item $_.FullName $CodexSkills -Recurse -Force }
+  # the whole plugin/codex tree ships: every directory (hidden ones too) as a skill under skills/, and
+  # any loose file at the Codex package root, where a package-level Codex file belongs.
+  Get-ChildItem $CodexSrc -Directory -Force | ForEach-Object { Copy-Item $_.FullName $CodexSkills -Recurse -Force }
+  Get-ChildItem $CodexSrc -File -Force | ForEach-Object { Copy-Item $_.FullName $CodexRoot -Force }
   $SkillRoots += $CodexSkills
+  $LeakRoots  += $CodexRoot
 }
 # prune dev/QA meta from the copies (index.jsonl + the mutagen shards stay - load-bearing). The eval
 # file is evals/evals.json (dev/DECISIONS.md, 2026-09-07, ruling 3); the whole directory is stripped.
-foreach ($r in $SkillRoots) {
+foreach ($r in $LeakRoots) {
   Get-ChildItem $r -Directory -Recurse -Filter 'evals' | Remove-Item -Recurse -Force
   Get-ChildItem $r -File -Recurse -Filter '_CORPUS_STATUS.md' | Remove-Item -Force
 }
@@ -156,7 +162,7 @@ foreach ($f in @('.mcp.json','LICENSE','THIRD-PARTY-NOTICES.txt','README.md','CH
 # defect (skill pointers are written with forward slashes).
 Step '7/12' 'Leak-check skills (excluded files + markdown pointers)'
 $skillLeaks = @()
-foreach ($r in $SkillRoots) {
+foreach ($r in $LeakRoots) {
   $skillLeaks += Get-ChildItem $r -Recurse -Force -File -Filter '_CORPUS_STATUS.md'
   $skillLeaks += Get-ChildItem $r -Recurse -Force -Directory -Filter 'evals'
 }

--- a/scripts/build-plugin.ps1
+++ b/scripts/build-plugin.ps1
@@ -264,11 +264,12 @@ Write-Host ("houseCARL-Setup.exe: {0:N2} MB" -f ((Get-Item $SetupExe).Length / 1
 # ---- 10. leak-check the server half + the whole package root ----------------
 # The skill trees were leak-checked at step 7 (excluded files + markdown pointers); this covers what
 # only a full build produces: the published server, and every shipped text file under the package
-# root. The excluded-file scan walks the whole package root, so an excluded file that lands outside
-# skills/ - a stray copy under .claude-plugin/, or one a future publish pulls in - is still caught.
+# root. All three excluded-file scans walk the whole package root, so an excluded file that lands
+# outside dist/housecarl - a stray copy under .claude-plugin/, or an appsettings.json the setup-utility
+# publish at step 9 drops beside houseCARL-Setup.exe - is still caught.
 Step '10/12' 'Leak-check assembled tree'
 $leaks = @()
-$leaks += Get-ChildItem $DistRoot -Recurse -Force -Filter 'appsettings*.json'
+$leaks += Get-ChildItem $PkgRoot -Recurse -Force -Filter 'appsettings*.json'
 $leaks += Get-ChildItem $PkgRoot -Recurse -Force -File -Filter '_CORPUS_STATUS.md'
 $leaks += Get-ChildItem $PkgRoot -Recurse -Force -Directory -Filter 'evals'
 if ($leaks.Count -gt 0) {

--- a/src/housecarl-generator/SetupSkillPruneProbe.cs
+++ b/src/housecarl-generator/SetupSkillPruneProbe.cs
@@ -53,6 +53,14 @@ internal static class SetupSkillPruneProbe
         string claudeSkills = Path.Combine(home, ".claude", "skills", "housecarl", "skills");
         string codexSkills  = Path.Combine(home, ".agents", "skills");
 
+        // Where the packager puts the umbrella, read out of scripts/build-plugin.ps1 — the same authority the
+        // setup-update-lock probe reads, so the fixture ships it where the installer looks for it.
+        var (codexPkgPath, codexPathWhy) = SetupUpdateLockProbe.CodexPackagePath();
+        Check(codexPkgPath is not null, "packager's Codex umbrella path read from scripts/build-plugin.ps1: " + codexPathWhy);
+        string umbrellaPkgDir = Path.Combine(new[] { pkg }
+            .Concat((codexPkgPath ?? "codex/skills").Split('/'))
+            .Append("housecarl").ToArray());
+
         try
         {
             // ---- a synthetic package shipping three skills ----
@@ -60,7 +68,7 @@ internal static class SetupSkillPruneProbe
             WriteFile(Path.Combine(src, "server", "housecarl-mcp.exe"), "exe");
             foreach (string s in new[] { "kept-one", "kept-two", "dropped-skill" })
                 WriteFile(Path.Combine(src, "skills", s, "SKILL.md"), s);
-            WriteFile(Path.Combine(pkg, "codex", "housecarl", "SKILL.md"), "umbrella");
+            WriteFile(Path.Combine(umbrellaPkgDir, "SKILL.md"), "umbrella");
 
             Console.WriteLine("--- T1: install the three-skill package, then re-install one that ships only two ---");
             var first = SetupProgram.TryInstall(SetupProgram.Target.Both, src, home, home);
@@ -156,7 +164,7 @@ internal static class SetupSkillPruneProbe
             // ---- T7: the umbrella is taken back when the package stops shipping it ----
             Console.WriteLine();
             Console.WriteLine("--- T7: a package that stops shipping the umbrella takes the installed one back ---");
-            Directory.Delete(Path.Combine(pkg, "codex", "housecarl"), recursive: true);
+            Directory.Delete(umbrellaPkgDir, recursive: true);
 
             string noUmbrellaSaid = Capture(() => SetupProgram.TryInstall(SetupProgram.Target.Both, src, home, home));
 

--- a/src/housecarl-generator/SetupUpdateLockProbe.cs
+++ b/src/housecarl-generator/SetupUpdateLockProbe.cs
@@ -46,7 +46,7 @@ internal static class SetupUpdateLockProbe
 
         string root = Path.Combine(Path.GetTempPath(), "hc-setup-lock-" + Guid.NewGuid().ToString("N"));
         string pkg  = Path.Combine(root, "package");   // the unzipped package dir
-        string src  = Path.Combine(pkg, "housecarl");  // pluginSrc (beside it lives codex/housecarl)
+        string src  = Path.Combine(pkg, "housecarl");  // pluginSrc (beside it lives codex/skills/housecarl)
         string home = Path.Combine(root, "home");      // stand-in for the user profile
 
         // The destinations TryInstall computes (mirrored here for the lock-holding + assertions).
@@ -65,7 +65,7 @@ internal static class SetupUpdateLockProbe
             WriteFile(Path.Combine(src, "server", "housecarl-mcp.exe"), exeV1);
             WriteFile(Path.Combine(src, "server", "Mutagen.Bethesda.dll"), new byte[] { 9 }); // a sibling DLL (T4)
             WriteFile(Path.Combine(src, "skills", "demo-skill", "SKILL.md"), "demo");
-            WriteFile(Path.Combine(pkg, "codex", "housecarl", "SKILL.md"), "umbrella");
+            WriteFile(Path.Combine(pkg, "codex", "skills", "housecarl", "SKILL.md"), "umbrella");
 
             // ===================================================== T1: a clean first install succeeds
             Console.WriteLine("--- T1: a clean first install succeeds (pre-flight never false-blocks a fresh machine) ---");

--- a/src/housecarl-generator/SetupUpdateLockProbe.cs
+++ b/src/housecarl-generator/SetupUpdateLockProbe.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using SetupProgram = HousecarlSetup.Program; // alias: the generator's own top-level Program shadows it otherwise
 
 namespace HousecarlGenerator;
@@ -13,8 +14,10 @@ namespace HousecarlGenerator;
 ///
 ///   T1 (control)  a clean first install (no destination exe yet) SUCCEEDS for Claude AND Codex — the
 ///                 pre-flight never false-blocks a fresh machine — and the Codex umbrella skill lands at
-///                 ~/.agents/skills/housecarl, so the packager path and the installer path must agree
-///                 (disagree on either side and the installer's Directory.Exists guard skips the copy).
+///                 ~/.agents/skills/housecarl. Both halves of that path pair are pinned: the fixture the
+///                 installer reads from is the package path READ OUT of scripts/build-plugin.ps1, so a
+///                 packager that moves the umbrella and an installer that does not turn this red instead
+///                 of letting the installer's Directory.Exists guard skip the copy in silence.
 ///   T2 (Claude)   with the installed server exe held open like a running session, the re-install refuses:
 ///                 ServerInUse, RefusedBeforeAnyCopy (the PRE-FLIGHT path, not the catch), a deleted sentinel
 ///                 file is STILL absent (no copy ran), and the held exe is byte-intact.
@@ -59,6 +62,11 @@ internal static class SetupUpdateLockProbe
         // The Codex umbrella's install destination: the packager path and the installer path must agree,
         // or InstallForCodex's Directory.Exists guard skips the copy and says nothing.
         string umbrella  = Path.Combine(home, ".agents", "skills", "housecarl", "SKILL.md");
+        // Where the PACKAGER puts it, read from the packaging script rather than restated here - restating
+        // it would pin the installer against this file's opinion, not against what actually ships.
+        var (codexPkgPath, codexPathWhy) = CodexPackagePath();
+        Check(codexPkgPath is not null, "packager's Codex umbrella path read from " + PackagingScript + ": " + codexPathWhy);
+        string[] codexSegs = (codexPkgPath ?? "codex/skills").Split('/');
 
         byte[] exeV1 = { 1, 1, 1, 1 };
         byte[] exeV2 = { 2, 2, 2, 2 }; // a different "version", so a copy that ran WOULD change the on-disk bytes
@@ -70,7 +78,7 @@ internal static class SetupUpdateLockProbe
             WriteFile(Path.Combine(src, "server", "housecarl-mcp.exe"), exeV1);
             WriteFile(Path.Combine(src, "server", "Mutagen.Bethesda.dll"), new byte[] { 9 }); // a sibling DLL (T4)
             WriteFile(Path.Combine(src, "skills", "demo-skill", "SKILL.md"), "demo");
-            WriteFile(Path.Combine(pkg, "codex", "skills", "housecarl", "SKILL.md"), "umbrella");
+            WriteFile(Path.Combine(new[] { pkg }.Concat(codexSegs).Append("housecarl").Append("SKILL.md").ToArray()), "umbrella");
 
             // ===================================================== T1: a clean first install succeeds
             Console.WriteLine("--- T1: a clean first install succeeds (pre-flight never false-blocks a fresh machine) ---");
@@ -78,7 +86,7 @@ internal static class SetupUpdateLockProbe
             Check(clean.Outcome == SetupProgram.InstallOutcome.Installed, "clean install (Both) => Installed");
             Check(File.Exists(claudeExe), "Claude server exe landed at ~/.claude/skills/housecarl/server");
             Check(File.Exists(codexExe),  "Codex server exe landed under the (test) data dir");
-            Check(File.Exists(umbrella),  "Codex umbrella skill landed at ~/.agents/skills/housecarl");
+            Check(File.Exists(umbrella),  $"Codex umbrella skill packed at {codexPkgPath ?? "codex/skills"}/housecarl landed at ~/.agents/skills/housecarl");
 
             // ===================================================== T2: locked Claude exe => pre-flight refuses, before any copy
             Console.WriteLine();
@@ -122,6 +130,26 @@ internal static class SetupUpdateLockProbe
             ? "================ ALL PASS ================"
             : $"================ {fail} CHECK(S) FAILED ================");
         return fail == 0 ? 0 : 1;
+    }
+
+    /// <summary>The script that assembles the package — the authority on where the Codex umbrella ships.</summary>
+    private const string PackagingScript = "scripts/build-plugin.ps1";
+
+    /// <summary>The Codex skills root the PACKAGER writes, relative to the package root, read out of
+    /// <see cref="PackagingScript"/>'s text ($CodexRoot / $CodexSkills, each a Join-Path of the one above it).
+    /// Read rather than run: the answer is two lines of the script, and running a packaging build to learn it
+    /// would cost minutes. Returns null with a reason when the script cannot be read or either assignment is
+    /// gone — the probe fails on that rather than certifying the path pair from its own restatement.</summary>
+    private static (string? Path, string Why) CodexPackagePath()
+    {
+        if (!File.Exists(PackagingScript))
+            return (null, $"not readable from '{Directory.GetCurrentDirectory()}' — run ci-all from the repo root");
+        string text = File.ReadAllText(PackagingScript);
+        var root  = Regex.Match(text, @"^\s*\$CodexRoot\s*=\s*Join-Path\s+\$PkgRoot\s+'([^']+)'", RegexOptions.Multiline);
+        var skills = Regex.Match(text, @"^\s*\$CodexSkills\s*=\s*Join-Path\s+\$CodexRoot\s+'([^']+)'", RegexOptions.Multiline);
+        if (!root.Success)   return (null, "no '$CodexRoot = Join-Path $PkgRoot ...' assignment found");
+        if (!skills.Success) return (null, "no '$CodexSkills = Join-Path $CodexRoot ...' assignment found");
+        return ($"{root.Groups[1].Value}/{skills.Groups[1].Value}", $"{root.Groups[1].Value}/{skills.Groups[1].Value}");
     }
 
     /// <summary>Open a file the way a running image holds it: readable + share-read, write DENIED — so the

--- a/src/housecarl-generator/SetupUpdateLockProbe.cs
+++ b/src/housecarl-generator/SetupUpdateLockProbe.cs
@@ -140,7 +140,7 @@ internal static class SetupUpdateLockProbe
     /// Read rather than run: the answer is two lines of the script, and running a packaging build to learn it
     /// would cost minutes. Returns null with a reason when the script cannot be read or either assignment is
     /// gone — the probe fails on that rather than certifying the path pair from its own restatement.</summary>
-    private static (string? Path, string Why) CodexPackagePath()
+    internal static (string? Path, string Why) CodexPackagePath()
     {
         if (!File.Exists(PackagingScript))
             return (null, $"not readable from '{Directory.GetCurrentDirectory()}' — run ci-all from the repo root");

--- a/src/housecarl-generator/SetupUpdateLockProbe.cs
+++ b/src/housecarl-generator/SetupUpdateLockProbe.cs
@@ -54,6 +54,9 @@ internal static class SetupUpdateLockProbe
         string claudeDll = Path.Combine(home, ".claude", "skills", "housecarl", "server", "Mutagen.Bethesda.dll");
         string codexExe  = Path.Combine(home, "houseCARL", "server", "housecarl-mcp.exe");
         string sentinel  = Path.Combine(home, ".claude", "skills", "housecarl", "skills", "demo-skill", "SKILL.md");
+        // The Codex umbrella's install destination: the packager path and the installer path must agree,
+        // or InstallForCodex's Directory.Exists guard skips the copy and says nothing.
+        string umbrella  = Path.Combine(home, ".agents", "skills", "housecarl", "SKILL.md");
 
         byte[] exeV1 = { 1, 1, 1, 1 };
         byte[] exeV2 = { 2, 2, 2, 2 }; // a different "version", so a copy that ran WOULD change the on-disk bytes
@@ -73,6 +76,7 @@ internal static class SetupUpdateLockProbe
             Check(clean.Outcome == SetupProgram.InstallOutcome.Installed, "clean install (Both) => Installed");
             Check(File.Exists(claudeExe), "Claude server exe landed at ~/.claude/skills/housecarl/server");
             Check(File.Exists(codexExe),  "Codex server exe landed under the (test) data dir");
+            Check(File.Exists(umbrella),  "Codex umbrella skill landed at ~/.agents/skills/housecarl");
 
             // ===================================================== T2: locked Claude exe => pre-flight refuses, before any copy
             Console.WriteLine();

--- a/src/housecarl-generator/SetupUpdateLockProbe.cs
+++ b/src/housecarl-generator/SetupUpdateLockProbe.cs
@@ -12,7 +12,9 @@ namespace HousecarlGenerator;
 /// ~/.codex, or %LOCALAPPDATA% touched):
 ///
 ///   T1 (control)  a clean first install (no destination exe yet) SUCCEEDS for Claude AND Codex — the
-///                 pre-flight never false-blocks a fresh machine.
+///                 pre-flight never false-blocks a fresh machine — and the Codex umbrella skill lands at
+///                 ~/.agents/skills/housecarl, so the packager path and the installer path must agree
+///                 (disagree on either side and the installer's Directory.Exists guard skips the copy).
 ///   T2 (Claude)   with the installed server exe held open like a running session, the re-install refuses:
 ///                 ServerInUse, RefusedBeforeAnyCopy (the PRE-FLIGHT path, not the catch), a deleted sentinel
 ///                 file is STILL absent (no copy ran), and the held exe is byte-intact.

--- a/src/housecarl-setup/Program.cs
+++ b/src/housecarl-setup/Program.cs
@@ -446,10 +446,11 @@ public static class Program
 
         // Codex-only umbrella skill: the $housecarl entry point (a top-level SKILL.md routing to the
         // helpers + an agents/openai.yaml declaring the MCP-server dependency). It ships beside the plugin
-        // in the package (codex/housecarl), NOT inside it, so the Claude install never sees it. Placed in
-        // ~/.agents/skills/ alongside the helpers - the location a fresh Codex install was confirmed to
-        // scan (the helpers there are discovered and working).
-        string umbrellaSrc = Path.Combine(Path.GetDirectoryName(pluginSrc)!, "codex", "housecarl");
+        // in the package (codex/skills/housecarl, the skill dir an immediate child of a skills/ root), NOT
+        // inside it, so the Claude install never sees it. Placed in ~/.agents/skills/ alongside the helpers
+        // - the location a fresh Codex install was confirmed to scan (the helpers there are discovered and
+        // working).
+        string umbrellaSrc = Path.Combine(Path.GetDirectoryName(pluginSrc)!, "codex", "skills", "housecarl");
         bool shipsUmbrella = Directory.Exists(umbrellaSrc);
         if (shipsUmbrella)
         {


### PR DESCRIPTION
Wave 0 of the skill rewrite: the packager side of three rulings in `dev/DECISIONS.md` dated 2026-09-07. The leak scan in `scripts/build-plugin.ps1` now also checks what the shipped skill markdown points at, in **both** forms a pointer is written: the `references/<file>` hop, and the bare sibling name (`value-tables.md`) that most of the corpus uses. Every pointer a shipped `.md` writes must exist in that same shipped copy, and none may point at a file the packager strips (`evals/`, whose eval file is `evals/evals.json`, and `references/_CORPUS_STATUS.md`). It reads every `.md` under a skill, not only `SKILL.md` — a reference file pointing at a stripped file is the same dead link in the installed plugin — and it matches either slash in any case, with a backslash pointer reported as its own defect since skill pointers are written with forward slashes. Both regexes guard their left edge, so `retrievals/cache.json` and `cross-references/glossary.md` are not read as `evals/` and `references/` pointers. It is the same scan, not a new script — one failing line names the skill, the file and the pointer, and the build stops.

This is the **resolution** half of ruling 2. The **form** half — that a pointer is written as `references/<file>`, one hop — is enforced per skill by the regrade in that skill's rewrite wave, not by this scan: flagging form today would go red on every skill not yet rewritten. The scan comment and this body both say so rather than implying pointer form is closed.

The bare form resolves against every name the skill ships, and only `.md` and `.jsonl` names are candidates — those are the only extensions any shipped skill file has (measured: 254 `.md`, 11 `.jsonl`, nothing else). A bare `.json`, `.ini` or `.psc` name in these skills is a file in the modded game, not a pointer at a sibling document: OAR's `config.json`/`user.json` (58 mentions), SPID's `_DISTR.ini` (13), `SkyPatcher.ini` (6), vanilla `Form.psc`/`UI.psc`/`Input.psc` (13), `vcpkg.json` (13). Taking those extensions as pointers would hard-stop the build on 143 correct documents, so they are not candidates and the comment says why.

The Codex umbrella skill now ships as `dist/codex/skills/housecarl/SKILL.md` instead of `dist/codex/housecarl/SKILL.md`, so its skill directory is an immediate child of a `skills/` root, and the same scan covers that tree too; the installer and the setup-lock probe follow the new package path. The whole `plugin/codex` tree ships: every directory (hidden ones included) as a skill under `skills/`, and any loose file at the Codex package root, where a package-level Codex file belongs — nothing in that tree is dropped without saying so. The excluded-file scan covers the Codex package root, not just its `skills/`. The scan and the Codex copy both moved ahead of the `-PluginTreeOnly` return, which is what CI assembles with, so CI runs the check rather than only a full release build.

Both arms are proven on the real skill set. Green: 15 skills, 255 markdown files, across the two trees, leak-check clean; full build packs the zip with `houseCARL/codex/skills/housecarl/SKILL.md`. Red, six in one run on `oar-authoring/references/oar-config-reference.md`: a bare `_CORPUS_STATUS.md`, `evals/evals.json`, `references/does-not-exist.md`, `references\backslash-form.md`, a bare `gone-away.md` and a bare `gone-away.jsonl` each produce their own line and stop the build, while a bare `oar-config-reference.md` (which resolves) and the decoys `retrievals/cache.json`, `cross-references/glossary.md`, `config.json`, `Form.psc` and `_DISTR.ini` stay silent. A zero-byte `SKILL.md` is a seventh arm — it reports `oar-authoring ships an empty SKILL.md.` instead of throwing an `ArgumentNullException` out of the regex.

What the scan flagged on the current skills:

Five pointers at `_CORPUS_STATUS.md`, which the packager deletes from every shipped copy — the defect `dev/skill-validation/eval-2026-09/rewrite-inputs.md` section (b) item 1 records (the two bodies write it with the `references/` hop, the three reference files by bare filename, which is why the scan matches that name bare too):

- `dialogue-authoring/SKILL.md:68`
- `kid-authoring/SKILL.md:124`
- `dialogue-authoring/references/condition-functions.md:13`
- `dialogue-authoring/references/dialogue-branch.md:8`
- `dialogue-authoring/references/quest-objectives-tab.md:8`

Every one of those sentences already said the file is dev-side and unshipped, so this PR drops the path from each and keeps the sentence.

Four more from the bare form, each a shipped document naming another project's file by a bare name that reads as a sibling:

- `skse-plugin-authoring/references/multi-runtime.md` (18 mentions) and `references/plugin-dissection.md` (2) cite CommonLibSSE-NG's bundled `CLAUDE.md`. They now write `ng/CLAUDE.md`, the qualified form `references/hooking.md` in the same skill already used four times.
- `skse-plugin-authoring/references/hooking.md:466` cites `VERIFICATION_MIGRATION.md`; it now writes `docs/VERIFICATION_MIGRATION.md`, the form line 445 of the same file already used.
- `tool-output-awareness/SKILL.md:136` said "the modlist's own `CLAUDE.md` / project memory"; the bare name is dropped and the sentence keeps "the modlist's own project memory".

Nothing else flagged: no other pointer in any shipped markdown is broken, in either form. None of the three skills a parallel PR deletes (biped-slot-reference, papyrus-optimization, tool-output-awareness) has a broken pointer today. The rest of those bodies belongs to their own rewrite PRs; the ship list is untouched — that PR owns it.

The Codex package path is tested on both sides, not just written twice. The setup-lock probe's T1 asserts the umbrella lands at `~/.agents/skills/housecarl`, and the package fixture it installs from is the path **read out of `scripts/build-plugin.ps1`** (`$CodexRoot` / `$CodexSkills`, each a `Join-Path` of the one above it) rather than restated in the probe — so the probe pins the pair, not just the installer. Reverting the installer's path alone turns T1 red; moving the packager's `$CodexSkills` alone turns it red too, naming both sides: `FAIL Codex umbrella skill packed at codex/agents/housecarl landed at ~/.agents/skills/housecarl` (both proven). A script the probe cannot read, or an assignment that has gone away, is its own failing check with the reason — it never certifies the path pair from its own restatement.

The whole-tree excluded-file scan is back at step 10 as the backstop, and all three of its checks now walk the package root: an `appsettings.json` the step-9 setup-utility publish drops beside `houseCARL-Setup.exe` lands outside `dist/housecarl`, and is now caught rather than packed. Step 7's scan is the skill-scoped one CI runs.

No skill's `evals/eval_set.json` is renamed here; that lands per skill in its own PR. The packager never named an eval file by name, and still does not — it strips the whole `evals/` directory, and the comment now names `evals/evals.json` as the file that directory holds.

Build and tests from the worktree: `dotnet build` clean, full `build-plugin.ps1` clean (341 zip entries), 1789 tests passed, `ci-all` 127/127.
