### PR TITLE
Resolve a generic type's getter interface, arity and all

### DIFF
--- a/src/housecarl-generator/ArmClassificationProbe.cs
+++ b/src/housecarl-generator/ArmClassificationProbe.cs
@@ -49,6 +49,16 @@ namespace HousecarlGenerator;
 ///       and reads what the generator reported — from the COVERAGE ANOMALIES channel, which is printed in full,
 ///       never sharing the unbounded warning stream's print cap. It pins the RECORD path only — the arm path has
 ///       no live exhibit and is stated as unpinned at the check itself, rather than left for a reader to assume.
+///   E — THE RESOLVER IS ARITY-AWARE, AND OWN-NAMED ONLY (#424). CorpusGenerator.GetterInterfaceFor built its
+///       probe name straight off Type.Name, so every generic modeled type asked for the impossible
+///       "IFoo`1Getter" and answered "no getter interface" — a hand-shaped hole in a by-construction coverage
+///       claim. E pins the arity fix: a generic type resolves, and a CLOSED one resolves the CLOSED interface
+///       rather than the open definition. The other half of #424 — whether a class that implements a getter
+///       interface named after ANOTHER type should resolve — was answered no, because that shape is exactly
+///       Mutagen's read-only projections and is what ClassifyArm reads. That boundary needs no check of its
+///       own: widening it turns B4 red (its exhibit would resolve IGenderedItemGetter&lt;bool&gt;) and D0b red
+///       (both record-path exhibits would resolve a borrowed getter interface), which is the pin working from
+///       two directions.
 ///
 /// The types in B/C are named deliberately, and a rename or a Mutagen bump that changes their shape SHOULD break
 /// this guard — that is the tripwire working. #397's whole point is that a bump is what arms this class; a guard
@@ -65,9 +75,10 @@ public static class ArmClassificationProbe
     const string AuthorableExhibit = "Mutagen.Bethesda.Skyrim.Armor";                   // getter interface + mutable twin
     const string ProjectionExhibit = "Mutagen.Bethesda.Skyrim.SkyrimMultiModOverlay";   // none resolved by name, 0 authorable
     const string ProjectionExhibit2 = "Mutagen.Bethesda.Skyrim.MergedCellBlock";        // none resolved by name, 0 authorable
-    // Resolves no I{Name}Getter BY NAME while implementing IGenderedItemGetter&lt;bool&gt;, and its data IS
-    // catalogued, as GenderedItem&lt;Boolean&gt;. That is precisely why this line reports rather than diagnoses,
-    // and why the name-resolution defect it exposes is filed as #424 instead of worked around here.
+    // Owns no getter interface while implementing IGenderedItemGetter&lt;bool&gt;, and its data IS catalogued,
+    // as GenderedItem&lt;Boolean&gt;. That is precisely why this line reports rather than diagnoses. #424 settled
+    // that borrowing another type's getter interface must NOT resolve here (see E), so this exhibit is a
+    // standing consequence of that decision, not an outstanding defect.
     const string UnextractableExhibit = "Mutagen.Bethesda.Skyrim.ArmorAddonWeightSliderContainer"; // none by name, 2/2 authorable
 
     [CiProbe("arm-classification-guard")]
@@ -235,6 +246,33 @@ public static class ArmClassificationProbe
             missing.Count == 0 ? null
                 : $"emitted report does not name: {string.Join(", ", missing.Take(10))} — the anomaly is " +
                   $"computed but never printed, which is the failure mode this arm exists for");
+
+        // ---------------------------------------------------------------- E: the resolver is arity-aware (#424)
+        // Named generic types rather than a sweep: each is one of the issue's own measured cases, and a bump
+        // that changes their shape SHOULD break this, exactly as B/C's exhibits do.
+        var genderedOpen = CorpusGenerator.GetterInterfaceFor(typeof(Mutagen.Bethesda.Plugins.Records.GenderedItem<>));
+        Check("E1. a generic modeled type resolves its arity-matched getter interface (GenderedItem<T>)",
+            genderedOpen != null
+            && genderedOpen.IsGenericType
+            && genderedOpen.GetGenericTypeDefinition() == typeof(Mutagen.Bethesda.Plugins.Records.IGenderedItemGetter<>),
+            $"got {genderedOpen?.Name ?? "null"} — the probe name is built from Type.Name, which carries the " +
+            $"arity, so it asked for IGenderedItem`1Getter");
+
+        // The group containers are the case with teeth: IsList hard-codes ISkyrimGroupGetter`1 by full name, so
+        // the resolver disagreeing with that list is the generator contradicting itself.
+        var groupOpen = CorpusGenerator.GetterInterfaceFor(typeof(SkyrimGroup<>));
+        Check("E2. the record-group container resolves too (SkyrimGroup<T> -> ISkyrimGroupGetter<T>)",
+            groupOpen != null
+            && groupOpen.IsGenericType
+            && groupOpen.GetGenericTypeDefinition() == typeof(ISkyrimGroupGetter<>),
+            $"got {groupOpen?.Name ?? "null"}");
+
+        // A CLOSED generic must resolve the CLOSED interface. Assembly.GetType can only ever hand back the open
+        // definition, which would catalogue GenderedItem<T> where the field really carries GenderedItem<Boolean>.
+        var genderedClosed = CorpusGenerator.GetterInterfaceFor(typeof(Mutagen.Bethesda.Plugins.Records.GenderedItem<bool>));
+        Check("E3. a closed generic resolves the CLOSED interface, not the open definition",
+            genderedClosed == typeof(Mutagen.Bethesda.Plugins.Records.IGenderedItemGetter<bool>),
+            $"got {genderedClosed?.FullName ?? "null"}");
 
         Console.WriteLine();
         Console.WriteLine(failures == 0

--- a/src/housecarl-generator/ArmClassificationProbe.cs
+++ b/src/housecarl-generator/ArmClassificationProbe.cs
@@ -53,8 +53,9 @@ namespace HousecarlGenerator;
 ///       probe name straight off Type.Name, so every generic modeled type asked for the impossible
 ///       "IFoo`1Getter" and answered "no getter interface" — a hand-shaped hole in a by-construction coverage
 ///       claim. E pins the arity fix: a generic type resolves, a CLOSED one resolves the CLOSED interface
-///       rather than the open definition, and an OPEN one resolves the DEFINITION (the form that has a
-///       FullName for IsList to match). The other half of #424 — whether a class that implements a getter
+///       rather than the open definition, an OPEN one resolves the DEFINITION (the form that has a FullName
+///       for IsList to match), and the normalized fallback picks the arity match whatever order
+///       GetInterfaces() lists its candidates in. The other half of #424 — whether a class that implements a getter
 ///       interface named after ANOTHER type should resolve — was answered no, because that shape is exactly
 ///       Mutagen's read-only projections and is what ClassifyArm reads. That boundary needs no check of its
 ///       own: widening it turns B4 red (its exhibit would resolve IGenderedItemGetter&lt;bool&gt;) and D0b red
@@ -276,6 +277,26 @@ public static class ArmClassificationProbe
         Check("E3. a closed generic resolves the CLOSED interface, not the open definition",
             genderedClosed == typeof(Mutagen.Bethesda.Plugins.Records.IGenderedItemGetter<bool>),
             $"got {genderedClosed?.FullName ?? "null"}");
+
+        // The normalized fallback is the one path that can see TWO own-named candidates: FormLinkGetter`1 and
+        // AssetLinkGetter`1 implement both IFooGetter`1 and the zero-argument IFooGetter, which Normalize
+        // collapses to one key. GetInterfaces() ordering is unspecified, so the answer is asserted over the
+        // list in BOTH directions — the arity match must win either way, or a Mutagen recompile that reorders
+        // the list reads a generic class's schema off a zero-argument interface.
+        var bothWays = new[]
+        {
+            typeof(Mutagen.Bethesda.Plugins.FormLinkGetter<>),
+            typeof(Mutagen.Bethesda.Plugins.Assets.AssetLinkGetter<>),
+        };
+        var orderDependent = bothWays.Where(t =>
+        {
+            var forward = CorpusGenerator.OwnNamedGetterAmong(t, t.GetInterfaces());
+            var reversed = CorpusGenerator.OwnNamedGetterAmong(t, t.GetInterfaces().Reverse());
+            return forward != reversed || forward is not { IsGenericType: true };
+        }).Select(t => t.Name).ToArray();
+        Check("E4. the normalized fallback prefers the arity match, whatever order GetInterfaces() lists",
+            orderDependent.Length == 0,
+            $"order-dependent: {string.Join(", ", orderDependent)}");
 
         Console.WriteLine();
         Console.WriteLine(failures == 0

--- a/src/housecarl-generator/ArmClassificationProbe.cs
+++ b/src/housecarl-generator/ArmClassificationProbe.cs
@@ -291,7 +291,9 @@ public static class ArmClassificationProbe
         var orderDependent = bothWays.Where(t =>
         {
             var forward = CorpusGenerator.OwnNamedGetterAmong(t, t.GetInterfaces());
-            var reversed = CorpusGenerator.OwnNamedGetterAmong(t, t.GetInterfaces().Reverse());
+            // Enumerable.Reverse spelled out: on the Type[] this returns, `.Reverse()` binds to
+            // MemoryExtensions.Reverse<T>(Span<T>) on newer SDKs, which reverses in place and returns void.
+            var reversed = CorpusGenerator.OwnNamedGetterAmong(t, Enumerable.Reverse(t.GetInterfaces()));
             return forward != reversed || forward is not { IsGenericType: true };
         }).Select(t => t.Name).ToArray();
         Check("E4. the normalized fallback prefers the arity match, whatever order GetInterfaces() lists",

--- a/src/housecarl-generator/ArmClassificationProbe.cs
+++ b/src/housecarl-generator/ArmClassificationProbe.cs
@@ -52,8 +52,9 @@ namespace HousecarlGenerator;
 ///   E — THE RESOLVER IS ARITY-AWARE, AND OWN-NAMED ONLY (#424). CorpusGenerator.GetterInterfaceFor built its
 ///       probe name straight off Type.Name, so every generic modeled type asked for the impossible
 ///       "IFoo`1Getter" and answered "no getter interface" — a hand-shaped hole in a by-construction coverage
-///       claim. E pins the arity fix: a generic type resolves, and a CLOSED one resolves the CLOSED interface
-///       rather than the open definition. The other half of #424 — whether a class that implements a getter
+///       claim. E pins the arity fix: a generic type resolves, a CLOSED one resolves the CLOSED interface
+///       rather than the open definition, and an OPEN one resolves the DEFINITION (the form that has a
+///       FullName for IsList to match). The other half of #424 — whether a class that implements a getter
 ///       interface named after ANOTHER type should resolve — was answered no, because that shape is exactly
 ///       Mutagen's read-only projections and is what ClassifyArm reads. That boundary needs no check of its
 ///       own: widening it turns B4 red (its exhibit would resolve IGenderedItemGetter&lt;bool&gt;) and D0b red
@@ -259,13 +260,15 @@ public static class ArmClassificationProbe
             $"arity, so it asked for IGenderedItem`1Getter");
 
         // The group containers are the case with teeth: IsList hard-codes ISkyrimGroupGetter`1 by full name, so
-        // the resolver disagreeing with that list is the generator contradicting itself.
+        // the resolver disagreeing with that list is the generator contradicting itself. Asserted on the FULL
+        // NAME, which is what IsList matches on: an open class implements the CONSTRUCTED ISkyrimGroupGetter<T>
+        // over its own type parameter, and that type's FullName is null, so a resolver handing that back agrees
+        // with nothing while looking arity-correct.
         var groupOpen = CorpusGenerator.GetterInterfaceFor(typeof(SkyrimGroup<>));
-        Check("E2. the record-group container resolves too (SkyrimGroup<T> -> ISkyrimGroupGetter<T>)",
-            groupOpen != null
-            && groupOpen.IsGenericType
-            && groupOpen.GetGenericTypeDefinition() == typeof(ISkyrimGroupGetter<>),
-            $"got {groupOpen?.Name ?? "null"}");
+        Check("E2. the record-group container resolves the definition IsList names (SkyrimGroup<T>)",
+            groupOpen == typeof(ISkyrimGroupGetter<>)
+            && groupOpen.FullName == "Mutagen.Bethesda.Skyrim.ISkyrimGroupGetter`1",
+            $"got {groupOpen?.Name ?? "null"} with FullName {groupOpen?.FullName ?? "<null>"}");
 
         // A CLOSED generic must resolve the CLOSED interface. Assembly.GetType can only ever hand back the open
         // definition, which would catalogue GenderedItem<T> where the field really carries GenderedItem<Boolean>.

--- a/src/housecarl-generator/CorpusGenerator.cs
+++ b/src/housecarl-generator/CorpusGenerator.cs
@@ -558,10 +558,11 @@ public static class CorpusGenerator
         /// <summary>A read-only PROJECTION of a real writable type (Mutagen's multi-mod overlay, the
         /// merged-cell view). Nothing is lost by excluding it — it can never be composed.</summary>
         ReadOnlyProjection,
-        /// <summary>No <c>I{Name}Getter</c> resolved BY NAME, yet the class carries settable state. Reported,
-        /// not diagnosed: the name probe misses a type whose getter interface is generic or differently
-        /// named, so this verdict does NOT establish a coverage gap — only that a human should check whether
-        /// the data is reachable elsewhere in the catalogue.</summary>
+        /// <summary>No OWN-named getter interface resolved, yet the class carries settable state. Reported,
+        /// not diagnosed: <see cref="GetterInterfaceFor"/> deliberately answers only for the interface a class
+        /// owns, so a type borrowing another type's getter interface lands here, and this verdict does NOT
+        /// establish a coverage gap — only that a human should check whether the data is reachable elsewhere
+        /// in the catalogue.</summary>
         WritableButUnextractable,
     }
 
@@ -588,9 +589,8 @@ public static class CorpusGenerator
     /// <see cref="EmittedArmNames"/>.
     ///
     /// THE SPLIT. When a getter interface EXISTS, authorability is whether its mutable twin does; no twin
-    /// means a read-only projection, the correct exclusion. When NO getter interface exists, handing the
-    /// concrete class to <see cref="MutableInterfaceFor"/> always answers "excluded" — its
-    /// <c>EndsWith("Getter")</c> test a concrete class never passes — which makes "has no getter interface"
+    /// means a read-only projection, the correct exclusion. When NO getter interface exists there is nothing to
+    /// take a mutable twin of, so the type is excluded either way — which would make "has no getter interface"
     /// indistinguishable in the output from "is a read-only projection", though only the second is a correct
     /// reason to exclude. So split here on whether the class actually carries writable state.
     /// </summary>
@@ -598,12 +598,13 @@ public static class CorpusGenerator
     {
         var gi = GetterInterfaceFor(t);
 
-        // The `?? t` fallback is load-bearing, not the dead branch it looks like. A concrete class whose OWN name
-        // ends in "Getter" (FormLinkNullableGetter`1, FormLinkOrIndexGetter`1 in Mutagen.Bethesda.Core) passes
-        // MutableInterfaceFor's arity-stripped EndsWith test and resolves a mutable twin through it, so it is
-        // authorable and must stay so. Computing this from `gi` alone silently flips both types, and both are in
-        // the walk because BuildCorpus seeds IPexFileGetter from that same assembly.
-        if (MutableInterfaceFor(gi ?? t) != null) return ArmClass.Authorable;
+        // This used to read MutableInterfaceFor(gi ?? t), the `?? t` rescuing two concrete classes whose own
+        // names end in "Getter" — FormLinkNullableGetter`1 and FormLinkOrIndexGetter`1 in Mutagen.Bethesda.Core,
+        // in the walk because BuildCorpus seeds IPexFileGetter from that assembly. It was compensating for the
+        // arity bug in GetterInterfaceFor (#424): both DO own a getter interface, and now resolve it. Measured
+        // across all three assemblies the walk visits, no class reaches this line with no getter interface and a
+        // mutable twin of its own name, so the fallback is gone rather than left as a dead branch.
+        if (gi != null && MutableInterfaceFor(gi) != null) return ArmClass.Authorable;
 
         // Not authorable. Everything below only decides WHICH exclusion to report — never whether to exclude.
         if (gi != null) return ArmClass.ReadOnlyProjection;
@@ -680,11 +681,13 @@ public static class CorpusGenerator
     /// gap, and does NOT say the fix belongs upstream in Mutagen — neither is established by "no
     /// <c>I{Name}Getter</c> resolved by name", and the second is provably false for at least one type that
     /// reaches this line: ArmorAddonWeightSliderContainer implements <c>IGenderedItemGetter&lt;bool&gt;</c> and
-    /// its data ships in the reference today as <c>GenderedItem&lt;Boolean&gt;</c>, 2/2 writable. The name probe
-    /// is <c>I{Name}Getter</c> built from <c>Type.Name</c>, which carries the generic arity, so a type whose
-    /// getter interface is named differently — or is generic — resolves null here while being perfectly
-    /// extractable. That is a real defect in <see cref="GetterInterfaceFor"/>; until it is fixed this line must
-    /// not diagnose, only report, and hand the reader the one check that settles it.
+    /// its data ships in the reference today as <c>GenderedItem&lt;Boolean&gt;</c>, 2/2 writable.
+    /// <see cref="GetterInterfaceFor"/> resolves the getter interface a class OWNS and nothing else — a
+    /// deliberate boundary, not an oversight (#424): implementing someone else's getter interface is the
+    /// structural signal <see cref="ClassifyArm"/> uses to spot a read-only projection. So a type that is not a
+    /// projection yet borrows another type's getter interface resolves null here while being perfectly
+    /// extractable, and this line must not diagnose, only report, and hand the reader the one check that
+    /// settles it.
     ///
     /// Shared by the record path and the union-arm path so both name the same thing the same way.
     /// </summary>
@@ -693,9 +696,9 @@ public static class CorpusGenerator
         var (w, total) = WritableSurfaceCount(t);
         var name = t.FullName ?? t.Name;   // FullName: ~350 distinct nested types share the simple name "ErrorMask"
         if (w == 0)
-            return $"No I{t.Name}Getter resolved by name for {role} {name} — {w} of {total} properties are " +
+            return $"No {GetterProbeName(t)} resolved by name for {role} {name} — {w} of {total} properties are " +
                    $"authorable (public settable, or a mutable collection). {ReachabilityCheck}";
-        return $"UNEXTRACTABLE BY NAME: {role} {name} — no I{t.Name}Getter resolved by name, and {w} of {total} " +
+        return $"UNEXTRACTABLE BY NAME: {role} {name} — no {GetterProbeName(t)} resolved by name, and {w} of {total} " +
                $"properties are authorable (public settable, or a mutable collection). It is excluded from the " +
                $"catalog. {ReachabilityCheck}";
     }
@@ -728,15 +731,53 @@ public static class CorpusGenerator
         return gf?.GetValue(null) is RecordType g ? g.ToString() : null;
     }
 
-    /// <summary>The "I{Name}Getter" interface for a concrete Mutagen class.</summary>
+    /// <summary>
+    /// The name this resolver probes for: the getter interface a class of this name would OWN.
+    /// The arity suffix stays where the runtime puts it — <c>GenderedItem`1</c>'s getter interface is
+    /// <c>IGenderedItemGetter`1</c>, never the impossible <c>IGenderedItem`1Getter</c> a probe built straight
+    /// off <see cref="Type.Name"/> asks for. One source of truth, so the anomaly line reports the name that
+    /// was actually looked up.
+    /// </summary>
+    internal static string GetterProbeName(Type concrete)
+    {
+        var tick = concrete.Name.IndexOf('`');
+        return tick >= 0
+            ? $"I{concrete.Name[..tick]}Getter{concrete.Name[tick..]}"
+            : $"I{concrete.Name}Getter";
+    }
+
+    /// <summary>
+    /// The getter interface a concrete Mutagen class OWNS — the one named after it.
+    ///
+    /// Arity-aware throughout, the same trap <see cref="MutableInterfaceFor"/> already fixes: the probe name
+    /// carries the suffix in the runtime's position (see <see cref="GetterProbeName"/>), and the last fallback
+    /// strips it before testing for the "Getter" ending, which a generic interface's own name never has
+    /// (<c>ISkyrimGroupGetter`1</c>). Missing that answered "no getter interface" for every generic modeled
+    /// type — GenderedItem&lt;T&gt;, SkyrimGroup&lt;T&gt;, FormLinkNullable&lt;T&gt; — in a walk whose whole
+    /// claim is that coverage is Mutagen's coverage by construction.
+    ///
+    /// OWN-NAMED ONLY, deliberately. A class that implements a getter interface named after some OTHER type
+    /// does NOT resolve here, and must not: implementing only the getter side of a type you are not is exactly
+    /// the shape of Mutagen's read-only projections (SkyrimMultiModOverlay implements ISkyrimModDisposableGetter,
+    /// MergedWorldspace implements IWorldspaceGetter, MergedCellBlock implements ICellBlockGetter, and the
+    /// Consolidated*/Merged* group views likewise). <see cref="ClassifyArm"/> reads "no getter interface" as
+    /// precisely that structural signal, so widening this to any implemented getter interface would hand every
+    /// one of those a mutable twin and re-admit it as an authorable arm of a union it can never be composed
+    /// into. The cost of the narrow answer is that a NON-projection implementing someone else's getter
+    /// interface — ArmorAddonWeightSliderContainer, which implements IGenderedItemGetter&lt;bool&gt; — still
+    /// resolves null; its data is catalogued anyway, as GenderedItem&lt;Boolean&gt;, which is why
+    /// <see cref="UnextractableWarning"/> reports rather than diagnoses.
+    /// </summary>
     internal static Type? GetterInterfaceFor(Type concrete)
     {
         if (concrete.IsInterface) return concrete;
-        var direct = concrete.Assembly.GetType($"{concrete.Namespace}.I{concrete.Name}Getter");
-        if (direct != null) return direct;
-        return concrete.GetInterfaces()
-            .FirstOrDefault(i => i.Name == $"I{concrete.Name}Getter")
-            ?? concrete.GetInterfaces().FirstOrDefault(i => i.Name.EndsWith("Getter") && Normalize(i.Name) == Normalize(concrete.Name));
+        var probe = GetterProbeName(concrete);
+        var ifaces = concrete.GetInterfaces();
+        // The IMPLEMENTED interface is asked first, ahead of the assembly lookup: on a CLOSED generic class it
+        // is the closed IFooGetter<Bar>, where Assembly.GetType can only ever hand back the open definition.
+        return ifaces.FirstOrDefault(i => i.Name == probe)
+            ?? concrete.Assembly.GetType($"{concrete.Namespace}.{probe}")
+            ?? ifaces.FirstOrDefault(i => i.Name.Split('`')[0].EndsWith("Getter") && Normalize(i.Name) == Normalize(concrete.Name));
     }
 
     /// <summary>The mutable twin of a getter interface (strip the "Getter" suffix).</summary>

--- a/src/housecarl-generator/CorpusGenerator.cs
+++ b/src/housecarl-generator/CorpusGenerator.cs
@@ -754,7 +754,9 @@ public static class CorpusGenerator
     /// strips it before testing for the "Getter" ending, which a generic interface's own name never has
     /// (<c>ISkyrimGroupGetter`1</c>). Missing that answered "no getter interface" for every generic modeled
     /// type — GenderedItem&lt;T&gt;, SkyrimGroup&lt;T&gt;, FormLinkNullable&lt;T&gt; — in a walk whose whole
-    /// claim is that coverage is Mutagen's coverage by construction.
+    /// claim is that coverage is Mutagen's coverage by construction. A CLOSED generic answers with the closed
+    /// interface; an OPEN one answers with the generic type DEFINITION, which is the form that carries a
+    /// FullName the rest of the generator can key on.
     ///
     /// OWN-NAMED ONLY, deliberately. A class that implements a getter interface named after some OTHER type
     /// does NOT resolve here, and must not: implementing only the getter side of a type you are not is exactly
@@ -775,9 +777,18 @@ public static class CorpusGenerator
         var ifaces = concrete.GetInterfaces();
         // The IMPLEMENTED interface is asked first, ahead of the assembly lookup: on a CLOSED generic class it
         // is the closed IFooGetter<Bar>, where Assembly.GetType can only ever hand back the open definition.
-        return ifaces.FirstOrDefault(i => i.Name == probe)
+        var gi = ifaces.FirstOrDefault(i => i.Name == probe)
             ?? concrete.Assembly.GetType($"{concrete.Namespace}.{probe}")
             ?? ifaces.FirstOrDefault(i => i.Name.Split('`')[0].EndsWith("Getter") && Normalize(i.Name) == Normalize(concrete.Name));
+        // An OPEN generic class implements the CONSTRUCTED IFooGetter<T> over its own type parameter, and that
+        // type's FullName and AssemblyQualifiedName are both null. Every consumer keyed on the full name would
+        // degrade silently rather than fail: ExtractType would write GetterInterface as the bare
+        // "ISkyrimGroupGetter`1" with no namespace, and IsList's hard-coded
+        // "Mutagen.Bethesda.Skyrim.ISkyrimGroupGetter`1" could never match. An open class's own name denotes the
+        // DEFINITION, so answer with the definition and keep the closed-generic win of asking ifaces first.
+        return concrete.IsGenericTypeDefinition && gi is { IsGenericType: true, IsGenericTypeDefinition: false }
+            ? gi.GetGenericTypeDefinition()
+            : gi;
     }
 
     /// <summary>The mutable twin of a getter interface (strip the "Getter" suffix).</summary>

--- a/src/housecarl-generator/CorpusGenerator.cs
+++ b/src/housecarl-generator/CorpusGenerator.cs
@@ -779,7 +779,7 @@ public static class CorpusGenerator
         // is the closed IFooGetter<Bar>, where Assembly.GetType can only ever hand back the open definition.
         var gi = ifaces.FirstOrDefault(i => i.Name == probe)
             ?? concrete.Assembly.GetType($"{concrete.Namespace}.{probe}")
-            ?? ifaces.FirstOrDefault(i => i.Name.Split('`')[0].EndsWith("Getter") && Normalize(i.Name) == Normalize(concrete.Name));
+            ?? OwnNamedGetterAmong(concrete, ifaces);
         // An OPEN generic class implements the CONSTRUCTED IFooGetter<T> over its own type parameter, and that
         // type's FullName and AssemblyQualifiedName are both null. Every consumer keyed on the full name would
         // degrade silently rather than fail: ExtractType would write GetterInterface as the bare
@@ -789,6 +789,26 @@ public static class CorpusGenerator
         return concrete.IsGenericTypeDefinition && gi is { IsGenericType: true, IsGenericTypeDefinition: false }
             ? gi.GetGenericTypeDefinition()
             : gi;
+    }
+
+    /// <summary>
+    /// The own-named getter interface among <paramref name="ifaces"/>, matched on the NORMALIZED name. Last
+    /// resort, for a class whose own name already ends in "Getter" (FormLinkGetter`1), whose probe name is
+    /// therefore the impossible IFormLinkGetterGetter`1.
+    ///
+    /// The ARITY MATCH is preferred over a plain first-match because <see cref="Type.GetInterfaces"/> ordering
+    /// is unspecified. FormLinkGetter`1 and AssetLinkGetter`1 each implement BOTH IFooGetter`1 and the
+    /// zero-argument IFooGetter, and <see cref="Normalize"/> collapses the two to one key; taking whichever the
+    /// runtime happens to list first would read a generic class's schema off a zero-argument interface as soon
+    /// as a recompile reorders that list.
+    /// </summary>
+    internal static Type? OwnNamedGetterAmong(Type concrete, IEnumerable<Type> ifaces)
+    {
+        static int Arity(Type t) => t.IsGenericType ? t.GetGenericArguments().Length : 0;
+        var matches = ifaces
+            .Where(i => i.Name.Split('`')[0].EndsWith("Getter") && Normalize(i.Name) == Normalize(concrete.Name))
+            .ToArray();
+        return matches.FirstOrDefault(i => Arity(i) == Arity(concrete)) ?? matches.FirstOrDefault();
     }
 
     /// <summary>The mutable twin of a getter interface (strip the "Getter" suffix).</summary>


### PR DESCRIPTION
`CorpusGenerator.GetterInterfaceFor` built its probe name straight off `Type.Name`, which carries the generic arity, so for a generic class it asked for the impossible ``IFoo`1Getter``, and both `GetInterfaces` fallbacks failed for the same reason — a generic getter interface is named ``IFooGetter`1``, whose name does not end in "Getter". Every generic modeled type therefore answered "no getter interface" in a walk whose whole claim is that coverage is Mutagen's coverage by construction. `MutableInterfaceFor` already carries this exact fix, with a comment naming `IGenderedItem<T>`; this is the same fix on its twin. The probe name now lives in one helper (`GetterProbeName`) that both the resolver and the anomaly line read, so the line reports the name that was actually looked up. The implemented interface is also asked before the assembly lookup, so a closed generic resolves the closed `IFooGetter<Bar>` rather than the open definition `Assembly.GetType` can only ever hand back.

The issue's second half — whether a class implementing a getter interface named after *another* type should resolve — is answered **no**, deliberately, and the code says why. That shape is exactly Mutagen's read-only projections (`SkyrimMultiModOverlay` implements `ISkyrimModDisposableGetter`, `MergedWorldspace` implements `IWorldspaceGetter`, `MergedCellBlock` implements `ICellBlockGetter`, and the `Consolidated*` / `Merged*` / `*Wrapper` group views likewise), and "owns no getter interface" is the structural signal `ClassifyArm` reads to spot one. Measured: widening the resolver to accept any implemented getter interface resolves one for 32 further types, 31 of which are borrowed-name shapes dominated by those read-only views. `SkyrimMultiModOverlay` and `MergedCellBlock` — the two exhibits this guard already pins as `ReadOnlyProjection` — flip to `Authorable` under that widening, i.e. re-enter as arms of unions they can never be composed into. That is a straight regression of #397's split, so the resolver stays own-named.

The cost of the narrow answer is the 32nd type: `ArmorAddonWeightSliderContainer` is not a projection, implements `IGenderedItemGetter<bool>`, and still resolves null. Its data is catalogued anyway, as `GenderedItem<Boolean>`, which is exactly why `UnextractableWarning` reports rather than diagnoses. The comments that called this an outstanding defect in `GetterInterfaceFor` now call it a settled boundary.

The fix also makes `ClassifyArm`'s `?? t` fallback unreachable. It was rescuing ``FormLinkNullableGetter`1`` and ``FormLinkOrIndexGetter`1``, whose own names end in "Getter" — both were failing to resolve their real getter interfaces for the arity reason, so that fallback was compensating for this bug. Measured across all three assemblies the walk visits: no class now reaches that line with no getter interface and a mutable twin of its own name. Removed rather than left as a dead branch under a comment saying it is load-bearing.

## The corpus diff, read

**There is none.** A full emit before and after the fix is byte-identical: `corpus.json`, `corpus.summary.md`, and all six committed `mutagen-reference` shards (`index`, `records`, `structs`, `arms`, `polymorphic`, `enums`). The generator's printed report is identical too, coverage-anomaly section included — still the same two lines, `MergedWorldspace` and `MergedWorldspaceCell`. Nothing was regenerated because nothing changed, and `emit-match-guard` is green against the committed shards untouched.

Read record type by record type, the answer is that **no record type's schema moved**, and here is why, from the measurement rather than from reasoning. Sixteen types resolve differently after the fix, and every one of them is an **open generic type definition**:

| type | before | after |
|---|---|---|
| ``SkyrimGroup`1`` | null | ``ISkyrimGroupGetter`1`` |
| ``SkyrimListGroup`1`` | null | ``ISkyrimListGroupGetter`1`` |
| ``GenderedItem`1`` | null | ``IGenderedItemGetter`1`` |
| ``FormLinkNullable`1`` | null | ``IFormLinkNullableGetter`1`` |
| ``FormLinkNullableGetter`1`` | null | ``IFormLinkNullableGetter`1`` |
| ``FormLinkOrIndex`1`` | null | ``IFormLinkOrIndexGetter`1`` |
| ``FormLinkOrIndexGetter`1`` | null | ``IFormLinkOrIndexGetter`1`` |
| ``SortingListDictionary`2`` | null | ``ISortingListDictionaryGetter`2`` |
| ``FormLink`1`` | `IFormLinkGetter` | ``IFormLinkGetter`1`` |
| ``FormLinkGetter`1`` | `IFormLinkGetter` | ``IFormLinkGetter`1`` |
| ``EDIDLink`1`` | `IEDIDLinkGetter` | ``IEDIDLinkGetter`1`` |
| ``AssetLink`1`` | `IAssetLinkGetter` | ``IAssetLinkGetter`1`` |
| ``AssetLinkGetter`1`` | `IAssetLinkGetter` | ``IAssetLinkGetter`1`` |
| ``MajorRecordIdentifier`1`` | `IMajorRecordIdentifierGetter` | ``IMajorRecordIdentifierGetter`1`` |
| ``LoadOrder`1`` | `ILoadOrderGetter` | ``ILoadOrderGetter`1`` |
| ``ModListing`1`` | `IModListingGetter` | ``IModListingGetter`1`` |

The five in the issue's table are all here, plus eleven the issue did not measure. That second group is types that *did* resolve before, through the normalized fallback, but resolved the non-generic same-named interface instead of the arity-matched one — `FormLink<T>` implements both `IFormLinkGetter<T>` and `IFormLinkGetter`, and the old code picked the latter. The arity-matched answer is the correct one, and it also does not move the corpus.

None of the sixteen reaches emission, for the reason the issue gives: `FindUnionArms` filters candidates with `getterIfc.IsAssignableFrom(t)`, and `Assembly.GetTypes()` yields open definitions, for which that is always false. Closed generics never appear in `GetTypes()`, and a closed generic sitting in a field position reaches the walk as its *getter interface* (`IGenderedItemGetter<bool>`), which `GetterInterfaceFor` returns unchanged on its first line. So the fix is exactly as latent as the issue said, and it lands with the corpus provably still.

That is also the point of landing it now. The next Mutagen release that adds a generic or differently-named modelled type is the run where this stops being latent, and it should walk into a resolver that answers correctly rather than into a name match.

## Tests

Three new arms on `arm-classification-guard`, the existing guard over this classifier: a generic type resolves its arity-matched getter interface (E1); the record-group container does too (E2), which matters because `IsList` hard-codes ``ISkyrimGroupGetter`1`` by full name and a resolver disagreeing with that list is the generator contradicting itself; and a closed generic resolves the closed interface rather than the open definition (E3). All three are red before the fix and green after — measured by reverting `CorpusGenerator.cs` and rerunning the guard.

The own-named boundary deliberately gets no arm of its own. Widening the resolver turns B4 red (its exhibit would resolve `IGenderedItemGetter<bool>`) and D0b red (both record-path exhibits would resolve a borrowed getter interface), so it is already pinned from two directions and a third check could not fail today. The guard header says that rather than leaving a reader to work it out.

This is generator-internal reflection with no server-side surface, so it is pinned where the rest of this classifier is pinned rather than in `housecarl-mcp-tests`, which the generator does not expose internals to.

Ran: `dotnet build housecarl.sln -c Release`; `dotnet test src/housecarl-mcp-tests -c Release --no-build --filter "tier!=bridge"` (1767 passed); `ci-all` (127/127).

No `plugin/CHANGELOG.md` line: the emitted corpus and the shipped reference shards are byte-identical, so there is nothing a user would notice.

## Not done

The issue's "also in scope" item — collapsing `WritableSurfaceCount`'s local property walk back into `CollectAllProperties` — is conditional on that shared helper being tightened, which this change does not do. Left alone.

Closes #424
