### PR TITLE
Annotate the FormID an element summary renders

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -2514,7 +2514,9 @@ offset, paging meant slicing by `editorid_contains`. Now:
   shows a FormID — `Effects[0] = [Effect] BaseEffect=033975:Skyrim.esm`. `resolve_names=true` annotated only a
   field's round-trip value, so the FormID on that line was left bare and the editorid was reachable only by
   re-reading at `depth=3`. It is now annotated wherever the read shows it, in the same parenthetical and the same
-  `link` sibling in json, and the summary text itself is unchanged. The element's OWN FormID — an owned child
+  `link` sibling in json, and the summary text itself is unchanged. The json summary line also carries the FormID
+  it rendered as a `note_ref` sibling of its `note`, so a consumer reads it back through `formids=` without
+  parsing the prose. The element's OWN FormID — an owned child
   record's, which the summary already spells with its editorid — is not annotated with itself. An element with two
   or more FormLink fields still renders as a bare `[Type]` and so shows no FormID to annotate, for the reason it
   already gives.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -2516,7 +2516,11 @@ offset, paging meant slicing by `editorid_contains`. Now:
   re-reading at `depth=3`. It is now annotated wherever the read shows it, in the same parenthetical and the same
   `link` sibling in json, and the summary text itself is unchanged. The json summary line also carries the FormID
   it rendered as a `note_ref` sibling of its `note`, so a consumer reads it back through `formids=` without
-  parsing the prose. The element's OWN FormID — an owned child
+  parsing the prose. At `depth=3` the element's own leaf is printed under the summary and both lines show the same
+  FormID, so both carry the name: the annotation repeats exactly where the read repeats the FormID. The `rows` form
+  is where it does not — a row that carries the element's sub-fields trims the element cell back to its bare
+  `[Type]`, and the name goes out with the FormID the trim took, leaving it on the sub-field cell that still shows
+  it. The element's OWN FormID — an owned child
   record's, which the summary already spells with its editorid — is not annotated with itself. An element with two
   or more FormLink fields still renders as a bare `[Type]` and so shows no FormID to annotate, for the reason it
   already gives.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -2509,6 +2509,16 @@ offset, paging meant slicing by `editorid_contains`. Now:
   name the chain form and `housecarl_records references=[…]` (bounded with `types=` or `plugins=`) now. The
   unscannable-record note that said "Inspect one with read_record" names `housecarl_records formids=[…]`.
 
+- **`resolve_names` now names the target a container element's summary line shows.** At `project.depth=2` a list
+  element renders as a one-line summary carrying its identity field, and where that field is a FormLink the line
+  shows a FormID — `Effects[0] = [Effect] BaseEffect=033975:Skyrim.esm`. `resolve_names=true` annotated only a
+  field's round-trip value, so the FormID on that line was left bare and the editorid was reachable only by
+  re-reading at `depth=3`. It is now annotated wherever the read shows it, in the same parenthetical and the same
+  `link` sibling in json, and the summary text itself is unchanged. The element's OWN FormID — an owned child
+  record's, which the summary already spells with its editorid — is not annotated with itself. An element with two
+  or more FormLink fields still renders as a bare `[Type]` and so shows no FormID to annotate, for the reason it
+  already gives.
+
 ## 1.9.0 — 2026-07-17
 
 houseCARL's view of the **SKSE-plugin layer** grows from *inventory* into *diagnosis*: two new audit tools

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -18,12 +18,13 @@ namespace HousecarlCore;
 /// read-proof, and diff. Used to decode a value that is correct but opaque — a biped-slot bitmask into its slot
 /// numbers — without disturbing the token that must round-trip. Null on every leaf that needs no annotation.</para>
 ///
-/// <para><see cref="Link"/> is the resolve_names annotation: when a leaf's <see cref="Token"/> is a
-/// form reference (a token that round-trips to a FormKey), the SERVICE layer resolves its target's identity
-/// (editorid/name) against the load order and hangs it here. Like <see cref="Display"/> it is DISPLAY-ONLY — never
-/// part of the round-trip <see cref="Token"/>, so it is invisible to write, read-proof, and diff. Populated by the
-/// service (which holds the resolver), never by the core read (which reads one record's bytes and cannot resolve a
-/// target). Null unless resolve_names was requested and the leaf carries a resolvable FormKey.</para></summary>
+/// <para><see cref="Link"/> is the resolve_names annotation: when a line RENDERS a form reference — its
+/// <see cref="Token"/>, or the <see cref="NoteRef"/> its summary note shows — the SERVICE layer resolves that
+/// target's identity (editorid/name) against the load order and hangs it here. Like <see cref="Display"/> it is
+/// DISPLAY-ONLY — never part of the round-trip <see cref="Token"/>, so it is invisible to write, read-proof, and
+/// diff. Populated by the service (which holds the resolver), never by the core read (which reads one record's
+/// bytes and cannot resolve a target). Null unless resolve_names was requested and the line renders a
+/// FormKey.</para></summary>
 /// <param name="Present">Is anything THERE? True for a value and for a present container/substruct (whose own
 /// <paramref name="Count"/> says how much); false only when the leaf holds nothing — absent, no such field,
 /// unreadable. Carried structurally because the two render alike (both are parenthesised notes), so a consumer
@@ -37,9 +38,14 @@ namespace HousecarlCore;
 /// carried structurally for the same reason <paramref name="Present"/> is: the folded line's TEXT is prose, and a
 /// consumer must be able to read the values, the resolve_names links and the counts out of the row without
 /// parsing it.</param>
+/// <param name="NoteRef">The form reference this line's <paramref name="Note"/> RENDERS, when the line carries no
+/// round-trip <paramref name="Token"/> — a container element's summary identity (<c>[Effect]
+/// BaseEffect=033975:Skyrim.esm</c>). Carried structurally for the same reason <paramref name="Present"/> is: the
+/// note is prose, and resolve_names must reach the FormID a line shows without parsing it. Null on every line
+/// whose note renders no form reference.</param>
 public sealed record FieldValue(string Path, bool HasValue, string? Token, string? Note, string? Display = null, ResolvedRef? Link = null,
                                 bool Present = true, int? Count = null, bool Readable = true,
-                                IReadOnlyList<FieldValue>? Cells = null);
+                                IReadOnlyList<FieldValue>? Cells = null, string? NoteRef = null);
 
 /// <summary>The resolved identity of a form reference — the shared contract behind housecarl_resolve (a full row)
 /// and the resolve_names field annotation. <see cref="Resolved"/> false ⇒ the FormKey is valid but not present in
@@ -620,8 +626,11 @@ public static class ReadEngine
         // a container or substruct — summarise (with an element identity where we can), then maybe open it.
         // Present/Count are set on the DEEP path too: they exist so a consumer never parses a note to decide
         // presence, and left at their defaults a depth-2 read of an EMPTY list claims content.
+        // NoteRef carries the FormID the summary spelled, so resolve_names annotates the reference this line SHOWS
+        // by the one rule it applies to a token — no second, note-shaped special case.
         int? deepCount = val is System.Collections.IEnumerable de and not string ? de.Cast<object?>().Count() : null;
-        if (!Emit(sink, ref budget, new FieldValue(path, false, null, ElementSummary(val, isDict), Present: true, Count: deepCount))) return;
+        var summary = ElementSummary(val, isDict, out var summaryRef);
+        if (!Emit(sink, ref budget, new FieldValue(path, false, null, summary, Present: true, Count: deepCount, NoteRef: summaryRef))) return;
 
         // Two POLYMORPHIC-ARM families normally stop here at their identity summary, hiding their VALUE, and both
         // surface it ONE bounded level deeper even at the depth floor so a read reaches parity with the write
@@ -836,8 +845,17 @@ public static class ReadEngine
     /// (<see cref="SummariseContainer"/>); for a struct, <c>[TypeName]</c> plus a representative identity
     /// field (Name/EditorID/Title) where present — so a list line like
     /// <c>Properties[5] = [ScriptObjectProperty] Name=DAK_HorseBuyPerk</c> reveals which element is which.</summary>
-    static string ElementSummary(object val, bool isDict = false)
+    static string ElementSummary(object val, bool isDict = false) => ElementSummary(val, isDict, out _);
+
+    /// <summary>Overload that also yields the form reference the summary RENDERED, so a caller building the line's
+    /// <see cref="FieldValue"/> can carry it on <see cref="FieldValue.NoteRef"/> and resolve_names annotates the
+    /// FormID a reader can see. It is the identity FIELD's target (an <c>Effect</c>'s BaseEffect, a
+    /// <c>PerkPlacement</c>'s Perk) — a reference OUT of this element, exactly what a leaf Token is. An owned child
+    /// RECORD's own FormKey is not one: it is this element's own identity, already spelled with its editorid, and
+    /// resolving it would annotate a line with itself.</summary>
+    static string ElementSummary(object val, bool isDict, out string? refToken)
     {
+        refToken = null;
         if (val is System.Collections.IEnumerable && val is not string) return SummariseContainer(val, isDict);
         var t = val.GetType();
         var typeName = RecordNaming.StripGetterInterface(RecordNaming.StripOverlay(t.Name));
@@ -855,14 +873,16 @@ public static class ReadEngine
             if (p is null || p.GetIndexParameters().Length != 0) continue;
             object? iv; try { iv = p.GetValue(val); } catch { continue; }
             var s = iv switch { null => null, string str => str, IFormLinkGetter fl => fl.FormKey.ToString(), _ => iv.ToString() };
-            if (!string.IsNullOrEmpty(s)) return $"[{typeName}] {idName}={s}";
+            if (string.IsNullOrEmpty(s)) continue;
+            if (iv is IFormLinkGetter) refToken = s;
+            return $"[{typeName}] {idName}={s}";
         }
         // No Name/EditorID/Title identity. If the struct carries EXACTLY ONE FormLink field, that link IS its
         // identity (PerkPlacement.Perk, and any other single-link struct) — surface it so a depth=2 element line
         // reveals which record it points at, the way a Name= identity does, instead of a bare [Type] that reads as
         // "the FormID isn't surfaced". Exactly one link only — 2+ are ambiguous and we don't guess which is the
         // identity.
-        if (LoneFormLinkIdentity(val, t) is { } linkId) return $"[{typeName}] {linkId}";
+        if (LoneFormLinkIdentity(val, t, out refToken) is { } linkId) return $"[{typeName}] {linkId}";
         return $"[{typeName}]";
     }
 
@@ -871,8 +891,11 @@ public static class ReadEngine
     /// FormLink or MORE THAN ONE (ambiguous — don't guess which is the identity). A present-but-null link still
     /// counts: it names the field and shows the null FormKey, the exact signal a reader chasing a dangling ref wants.
     /// Display-only, best-effort — any reflection fault yields null (falls back to the bare <c>[Type]</c>).</summary>
-    static string? LoneFormLinkIdentity(object val, Type t)
+    /// <param name="refToken">The FormKey the identity renders, for <see cref="FieldValue.NoteRef"/>; null
+    /// whenever this returns null.</param>
+    static string? LoneFormLinkIdentity(object val, Type t, out string? refToken)
     {
+        refToken = null;
         PropertyInfo? only = null;
         foreach (var p in t.GetProperties(BindingFlags.Public | BindingFlags.Instance))
         {
@@ -882,7 +905,12 @@ public static class ReadEngine
             only = p;
         }
         if (only is null) return null;
-        try { return only.GetValue(val) is IFormLinkGetter fl ? $"{only.Name}={fl.FormKey}" : null; }
+        try
+        {
+            if (only.GetValue(val) is not IFormLinkGetter fl) return null;
+            refToken = fl.FormKey.ToString();
+            return $"{only.Name}={refToken}";
+        }
         catch { return null; }
     }
 

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -41,8 +41,9 @@ namespace HousecarlCore;
 /// <param name="NoteRef">The form reference this line's <paramref name="Note"/> RENDERS, when the line carries no
 /// round-trip <paramref name="Token"/> — a container element's summary identity (<c>[Effect]
 /// BaseEffect=033975:Skyrim.esm</c>). Carried structurally for the same reason <paramref name="Present"/> is: the
-/// note is prose, and resolve_names must reach the FormID a line shows without parsing it. Null on every line
-/// whose note renders no form reference.</param>
+/// note is prose, and neither resolve_names nor a consumer may parse it to reach the FormID the line shows — the
+/// json lane emits it as a <c>note_ref</c> sibling of the note. Null on every line whose note renders no form
+/// reference.</param>
 public sealed record FieldValue(string Path, bool HasValue, string? Token, string? Note, string? Display = null, ResolvedRef? Link = null,
                                 bool Present = true, int? Count = null, bool Readable = true,
                                 IReadOnlyList<FieldValue>? Cells = null, string? NoteRef = null);

--- a/src/housecarl-mcp-tests/RecordsRowsFormTests.cs
+++ b/src/housecarl-mcp-tests/RecordsRowsFormTests.cs
@@ -262,6 +262,19 @@ public sealed class RecordsRowsFormTests : RecordsTestBase
     }
 
     [Fact]
+    public void ATrimmedElementCellKeepsNeitherTheFormIdNorItsName()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.SpellA) },
+            project: new RecordsTools.RecordsProject { form = "rows", fields = new[] { "Effects" }, resolve_names = true });
+        var row = RowLine(r, "Effects[0]");
+        // The element cell is trimmed to its bare type because BaseEffect is a cell of its own on the same row.
+        // The name the trim's FormID resolved to goes with it: it names a FormID this cell no longer shows, and
+        // the cell that still shows it carries the same name one cell along.
+        Assert.Contains("[Effect] | BaseEffect=", row);
+        Assert.Equal(1, row.Split("HcRecMgefFire").Length - 1);
+    }
+
+    [Fact]
     public void ADepthOfTwoLeavesTheRowAtItsElementType()
     {
         // depth= means the same thing here as on the fields form: how far into each element the line reaches.

--- a/src/housecarl-mcp-tests/RecordsRowsFormTests.cs
+++ b/src/housecarl-mcp-tests/RecordsRowsFormTests.cs
@@ -271,7 +271,7 @@ public sealed class RecordsRowsFormTests : RecordsTestBase
         // The name the trim's FormID resolved to goes with it: it names a FormID this cell no longer shows, and
         // the cell that still shows it carries the same name one cell along.
         Assert.Contains("[Effect] | BaseEffect=", row);
-        Assert.Equal(1, row.Split("HcRecMgefFire").Length - 1);
+        Assert.Equal(1, CountOf(row, "HcRecMgefFire"));
     }
 
     [Fact]

--- a/src/housecarl-mcp-tests/RecordsSummaryLinkTests.cs
+++ b/src/housecarl-mcp-tests/RecordsSummaryLinkTests.cs
@@ -30,6 +30,17 @@ public sealed class RecordsSummaryLinkTests : RecordsTestBase
     }
 
     [Fact]
+    public void ADeeperReadNamesTheSummaryAndItsLeafBecauseBothShowTheFormId()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.SpellA) },
+            project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "Effects" }, depth = 3, resolve_names = true });
+        // depth=3 prints the element's own leaf under its summary, and the fields lane spells the FormID on both.
+        // The name follows the FormID, so it is on both too — the repetition is the read's, not the annotation's.
+        Assert.Contains($"Effects[0] = [Effect] BaseEffect={Fid(W.MgefA)}   (→ HcRecMgefFire)", r);
+        Assert.Contains($"Effects[0].BaseEffect = {Fid(W.MgefA)}   (→ HcRecMgefFire)", r);
+    }
+
+    [Fact]
     public void WithoutResolveNamesTheSummaryStandsAlone()
     {
         var r = Spell(names: false);

--- a/src/housecarl-mcp-tests/RecordsSummaryLinkTests.cs
+++ b/src/housecarl-mcp-tests/RecordsSummaryLinkTests.cs
@@ -37,15 +37,28 @@ public sealed class RecordsSummaryLinkTests : RecordsTestBase
         Assert.DoesNotContain("HcRecMgefFire", r);
     }
 
+    JsonElement JsonEffectZero(bool names = true) =>
+        Je(Spell(names, format: "json")).GetProperty("records")[0].GetProperty("fields")
+          .EnumerateArray().Single(f => f.GetProperty("path").GetString() == "Effects[0]");
+
     [Fact]
     public void TheJsonSummaryLineCarriesTheIdentityAsALinkSiblingOfItsNote()
     {
-        var field = Je(Spell(names: true, format: "json")).GetProperty("records")[0].GetProperty("fields")
-                     .EnumerateArray().Single(f => f.GetProperty("path").GetString() == "Effects[0]");
+        var field = JsonEffectZero();
         // The note is prose and stays prose; the identity is structure beside it.
         Assert.Equal($"[Effect] BaseEffect={Fid(W.MgefA)}", field.GetProperty("note").GetString());
         var link = field.GetProperty("link");
         Assert.True(link.GetProperty("resolved").GetBoolean());
         Assert.Equal("HcRecMgefFire", link.GetProperty("editorid").GetString());
+    }
+
+    [Fact]
+    public void TheJsonSummaryLineCarriesTheFormIdItRenderedBesideTheProse()
+    {
+        // The FormID inside the note is the answer to "which record is this element", and a consumer reads it
+        // back through the same formids= door — so it rides as structure, not only inside the prose. It is the
+        // line's own shape, not the annotation's: it is there whether or not resolve_names was asked for.
+        Assert.Equal(Fid(W.MgefA), JsonEffectZero().GetProperty("note_ref").GetString());
+        Assert.Equal(Fid(W.MgefA), JsonEffectZero(names: false).GetProperty("note_ref").GetString());
     }
 }

--- a/src/housecarl-mcp-tests/RecordsSummaryLinkTests.cs
+++ b/src/housecarl-mcp-tests/RecordsSummaryLinkTests.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// resolve_names on a line whose FormID is rendered by a container element's SUMMARY rather than by a round-trip
+/// token — "Effects[0] = [Effect] BaseEffect=033975:Skyrim.esm" at depth 2. The annotation follows the FormID the
+/// read shows, not the carrier it happens to sit on.
+/// </summary>
+[Collection("records")]
+[Trait("tier", "integration")]
+public sealed class RecordsSummaryLinkTests : RecordsTestBase
+{
+    public RecordsSummaryLinkTests(RecordsFixture f) : base(f) { }
+
+    static RecordsTools.RecordsProject Effects(bool names) =>
+        new() { form = "fields", fields = new[] { "Effects" }, depth = 2, resolve_names = names };
+
+    string Spell(bool names, string? format = null) =>
+        RecordsTools.Records(Svc, formids: new[] { Fid(W.SpellA) }, project: Effects(names), format: format);
+
+    [Fact]
+    public void AFormIdRenderedInAnElementSummaryIsAnnotatedLikeALeafToken()
+    {
+        var r = Spell(names: true);
+        Served(r, $"Effects[0] = [Effect] BaseEffect={Fid(W.MgefA)}");   // the summary itself, unchanged
+        Assert.Contains($"BaseEffect={Fid(W.MgefA)}   (→ HcRecMgefFire)", r);
+    }
+
+    [Fact]
+    public void WithoutResolveNamesTheSummaryStandsAlone()
+    {
+        var r = Spell(names: false);
+        Served(r, $"Effects[0] = [Effect] BaseEffect={Fid(W.MgefA)}");
+        Assert.DoesNotContain("HcRecMgefFire", r);
+    }
+
+    [Fact]
+    public void TheJsonSummaryLineCarriesTheIdentityAsALinkSiblingOfItsNote()
+    {
+        var field = Je(Spell(names: true, format: "json")).GetProperty("records")[0].GetProperty("fields")
+                     .EnumerateArray().Single(f => f.GetProperty("path").GetString() == "Effects[0]");
+        // The note is prose and stays prose; the identity is structure beside it.
+        Assert.Equal($"[Effect] BaseEffect={Fid(W.MgefA)}", field.GetProperty("note").GetString());
+        var link = field.GetProperty("link");
+        Assert.True(link.GetProperty("resolved").GetBoolean());
+        Assert.Equal("HcRecMgefFire", link.GetProperty("editorid").GetString());
+    }
+}

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -343,6 +343,10 @@ static class JsonWire
         w.WriteString("path", f.Path);
         if (f.HasValue) w.WriteString("value", f.Token);   // round-trip parity: identical token to the text render
         else if (f.Cells is null) WriteNullable(w, "note", f.Note);
+        // The FormID a no-value summary note SPELLED, beside the prose that spells it: the note is prose, so a
+        // consumer reading an element line at depth 2 reaches the reference the same way it reaches a leaf's
+        // 'value' — and feeds it straight back through formids= — instead of regexing the note.
+        if (f.NoteRef is { } noteRef && f.Cells is null) w.WriteString("note_ref", noteRef);
         if (f.Display is not null) w.WriteString("display", f.Display);
         if (f.Link is { } link)
         {

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2437,9 +2437,12 @@ public sealed class LoadOrderService : IDisposable
                { OwnedChildFields = childFields }.WithRuntime(view.RuntimeAddressOf(fk));
     }
 
-    /// <summary>resolve_names (P7): annotate every field whose <see cref="FieldValue.Token"/> is a form reference (a
-    /// token that round-trips to a FormKey) with its target's load-order identity, hung on <see cref="FieldValue.Link"/>
-    /// — DISPLAY-ONLY, never touching the round-trip Token. Type-agnostic: a token that parses as a FormKey IS a form
+    /// <summary>resolve_names (P7): annotate every field that RENDERS a form reference with its target's load-order
+    /// identity, hung on <see cref="FieldValue.Link"/> — DISPLAY-ONLY, never touching the round-trip Token. The
+    /// reference is the leaf's <see cref="FieldValue.Token"/>, or, on a line that has no token, the
+    /// <see cref="FieldValue.NoteRef"/> a container element's summary spelled ("[Effect]
+    /// BaseEffect=033975:Skyrim.esm") — so the annotation reaches the FormID wherever the read shows one.
+    /// Type-agnostic: a token that parses as a FormKey IS a form
     /// reference (FormLinks and condition-target FLOIs both emit a bare FormKey token; scalars never do), so this
     /// inherits coverage from the read surface with no per-type wiring. Resolution rides the SAME captured view +
     /// open session the read used, memoised so a keyword that recurs across a whole record (or batch) resolves once.
@@ -2455,7 +2458,10 @@ public sealed class LoadOrderService : IDisposable
         for (int i = 0; i < rf.Fields.Count; i++)
         {
             var f = rf.Fields[i];
-            if (f.HasValue && f.Token is { } tok && FormKey.TryFactory(tok, out var fk) && !fk.IsNull)
+            // Whichever carrier the line RENDERED its reference on: the round-trip token, or the FormID a
+            // container element's summary note spelled (FieldValue.NoteRef). One rule, one shape of value.
+            var rendered = f.HasValue ? f.Token : f.NoteRef;
+            if (rendered is { } tok && FormKey.TryFactory(tok, out var fk) && !fk.IsNull)
             {
                 rebuilt ??= new List<FieldValue>(rf.Fields);
                 rebuilt[i] = f with { Link = ResolveRefOne(view, session, fk, memo) };

--- a/src/housecarl-mcp/RowProjection.cs
+++ b/src/housecarl-mcp/RowProjection.cs
@@ -162,11 +162,15 @@ static class RowProjection
     static string Cell(FieldValue f, string rowKey, bool trimToType)
     {
         var val = f.HasValue ? f.Token : f.Note;
+        bool trimmed = false;
         if (trimToType && !f.HasValue && val is { Length: > 0 } n && n[0] == '['
             && n.IndexOf(']') is var close && close > 0 && close < n.Length - 1)
-            val = n[..(close + 1)];
+            { val = n[..(close + 1)]; trimmed = true; }
         if (f.Display is not null) val += $" ({f.Display})";
-        if (f.Link is not null) val += $" ({Wire.LinkText(f.Link)})";
+        // The trim took away the FormID the summary named, so its resolve_names identity goes with it: it would
+        // name a reference this cell no longer shows, and the sub-field cell that still shows it carries the
+        // same identity a cell along. json is untrimmed and keeps both.
+        if (f.Link is not null && !trimmed) val += $" ({Wire.LinkText(f.Link)})";
         if (f.Path.Length == rowKey.Length) return val ?? "";
         return $"{f.Path[rowKey.Length..].TrimStart('.')}={val}";
     }


### PR DESCRIPTION
At `project.depth=2` a container element renders as a one-line summary that carries its identity field, and where that field is a FormLink the line shows a FormID — `Effects[0] = [Effect] BaseEffect=033975:Skyrim.esm`. `AnnotateLinks` read the reference off `FieldValue.Token`, which that line does not have (it is a no-value line with the FormID inside its prose `Note`), so `resolve_names=true` left it bare and the editorid was reachable only by re-reading at `depth=3`. Rather than teach the annotator to parse the note, the read now carries the FormID it rendered on a new structural member, `FieldValue.NoteRef`, and `AnnotateLinks` resolves whichever carrier the line rendered its reference on — the token, or that. One rule, one shape of value, and every render site already appended `Link` regardless of `HasValue`, so the text, json, dense and rows lanes all show it with no per-lane change.

Two bounds, both in the code and the changelog entry: an owned child record's own FormKey (`[DialogResponses 4D9A74:Plugin.esp editorid=…]`) is the element's own identity, already spelled with its editorid, so it is not annotated with itself; and an element with two or more FormLink fields still renders as a bare `[Type]` and shows no FormID to annotate, for the reason `LoneFormLinkIdentity` already gives.

Three tests in `RecordsSummaryLinkTests` over the shared records world's two-effect spell: the text annotation beside the unchanged summary, the json `link` sibling of the `note`, and the un-annotated line when `resolve_names` is off. Two of the three fail before the fix.

Ran on this branch: `dotnet build -c Release` clean, `dotnet test --filter "tier!=bridge"` 1792/1792, `ci-all` 127/127.

Closes #530
