### PR TITLE
Read a short-circuit whose value is a mid-list call argument

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -91,6 +91,14 @@ saying it sets an expectation their install may contradict. Say what is known, a
   skill directory that is an immediate child of `skills/`. The installer places it in the same place it always
   did (`~/.agents/skills/housecarl`), so an install run from `houseCARL-Setup.exe` is unchanged; a copy taken by
   hand out of the zip comes from the new path.
+- **`housecarl_decompile_script` now reconstructs a short-circuit (`&&` / `||`) whose value is a call argument
+  followed by another argument.** The arguments after it evaluate before the call, so the false-path jump lands on
+  the next argument's first instruction rather than on the call itself; the reader took only the jump-lands-on-the-
+  consumer form, read the rest as a plain `if`, and promoted the condition temp to a named local — which then made
+  a later arm of the same expression emit statements and fail the whole function to a raw-bytecode comment block.
+  The expression now comes back whole, and because the CK compiler itself emits this form, the optimizer-compiled
+  ("Caprica class") note it used to trigger no longer fires on it. An arm that genuinely evaluates a statement
+  still fails loud, and the failure now names the statement.
 
 - **A `housecarl_records` `formids=` read is now held to the render bound on every form that reads a body, and
   says what those bodies cost.** `summary` and `aggregate` read a body per id on this lane exactly as `fields`,

--- a/src/housecarl-core/PapyrusDecompiler.cs
+++ b/src/housecarl-core/PapyrusDecompiler.cs
@@ -10,7 +10,8 @@ namespace HousecarlCore;
 ///   - jump offsets relative to the jump instruction itself
 ///   - while  = cond; JMPF -> E; body; JMP (backward); E:
 ///   - if     = cond; JMPF -> L; then; JMP -> M; L: else; M:   (JMP -> L means no else)
-///   - and/or = short-circuit JMPF/JMPT landing ON the final consuming conditional jump, same temp
+///   - and/or = short-circuit JMPF/JMPT whose arm rewrites the same temp, read again at the join —
+///     usually landing ON the consumer, further on when later call arguments evaluate in between
 ///   - auto-prop backing var ::Name_var; AutoReadOnly = GET returning a literal
 ///   - compiler-generated GotoState/GetState in the '' state (skipped on emit)
 ///   - FunctionFlags raw bits: bit0 = Global, bit1 = Native (Mutagen's enum names sit one off)
@@ -559,12 +560,18 @@ public sealed class PapyrusDecompiler
                             target = hi;
                         }
 
-                        // Short-circuit: the jump lands ON the instruction that consumes the temp as a
-                        // source — another conditional jump (plain &&/||), a CAST hop into a different
-                        // temp (nested mixed-temp conditions), an ASSIGN/RETURN/call-arg (`x = a || b`).
-                        // Temps only: a real-var condition is always a plain if.
+                        // Short-circuit: the arm leaves the right operand in the SAME temp and the
+                        // join side still reads it. The jump usually lands ON that consumer — another
+                        // conditional jump (plain &&/||), a CAST hop into a different temp (nested
+                        // mixed-temp conditions), an ASSIGN/RETURN/call-arg (`x = a || b`). When the
+                        // value is a call argument that is NOT the last one, the arguments after it
+                        // evaluate first and the consuming call sits further on, so also accept an
+                        // arm that writes the temp whose value is read before being rewritten at or
+                        // after the join. Temps only: a real-var condition is always a plain if.
                         if (condName is not null && IsTemp(condName) && target < hi
-                            && ConsumesAsSource(_ins[target], condName))
+                            && (ConsumesAsSource(_ins[target], condName)
+                                || (WritesDestIn(i + 1, target, condName)
+                                    && ReadsBeforeWrite(target, hi, condName))))
                         {
                             var (left, leftStart) = Consume(condName, i);
                             // Pre-if discarded-result calls may still pend here (their temps can be
@@ -573,7 +580,12 @@ public sealed class PapyrusDecompiler
                             FlushPendingCalls(stmts);
                             // Evaluate the right side (cur+1 .. target) — must produce only pending values.
                             var sub = Structure(i + 1, target, flushAtEnd: false, exits: new HashSet<int>(), cont: target);
-                            if (sub.Count > 0) throw new StructureException($"short-circuit arm @{i + 1}..{target} produced statements");
+                            // The arm is lazily evaluated, so a statement in it cannot be hoisted out
+                            // without changing semantics. Name the first one: it is what pins the
+                            // sub-shape when the pex itself is not to hand.
+                            if (sub.Count > 0)
+                                throw new StructureException(
+                                    $"short-circuit arm @{i + 1}..{target} evaluates a statement, not just a value (first: {sub[0].Trim()})");
                             var (right, _) = Consume(condName, target);
                             var combined = new EBin(op == InstructionOpcode.JMPF ? "&&" : "||", left, right);
                             SetPending(condName, combined, stmts, leftStart);
@@ -1041,6 +1053,16 @@ public sealed class PapyrusDecompiler
                 if (ConsumesAsSource(_ins[k], name)) return true;
                 if (WritesDest(_ins[k], name)) return false;
             }
+            return false;
+        }
+
+        /// <summary>Is <paramref name="name"/> written as a destination anywhere in [lo, hi)?
+        /// A short-circuit arm always writes its own temp; a plain if's condition temp is dead in
+        /// the block it guards.</summary>
+        bool WritesDestIn(int lo, int hi, string name)
+        {
+            for (int k = lo; k < hi && k < _ins.Count; k++)
+                if (WritesDest(_ins[k], name)) return true;
             return false;
         }
 

--- a/src/housecarl-core/PapyrusDecompiler.cs
+++ b/src/housecarl-core/PapyrusDecompiler.cs
@@ -1060,8 +1060,8 @@ public sealed class PapyrusDecompiler
         }
 
         /// <summary>Is <paramref name="name"/> written as a destination anywhere in [lo, hi)?
-        /// A short-circuit arm always writes its own temp; a plain if's condition temp is dead in
-        /// the block it guards.</summary>
+        /// A short-circuit arm always writes its own temp, so a guarded block that never touches
+        /// the condition temp is not an arm and must not be reported as one.</summary>
         bool WritesDestIn(int lo, int hi, string name)
         {
             for (int k = lo; k < hi && k < _ins.Count; k++)

--- a/src/housecarl-core/PapyrusDecompiler.cs
+++ b/src/housecarl-core/PapyrusDecompiler.cs
@@ -567,10 +567,13 @@ public sealed class PapyrusDecompiler
                         // value is a call argument that is NOT the last one, the arguments after it
                         // evaluate first and the consuming call sits further on, so also accept an
                         // arm that writes the temp whose value is read before being rewritten at or
-                        // after the join. Temps only: a real-var condition is always a plain if.
+                        // after the join. An arm that READS the temp first is not an arm at all: it
+                        // is a guarded block over a reused condition temp, which the promotion path
+                        // below owns. Temps only: a real-var condition is always a plain if.
                         if (condName is not null && IsTemp(condName) && target < hi
                             && (ConsumesAsSource(_ins[target], condName)
                                 || (WritesDestIn(i + 1, target, condName)
+                                    && !ReadsBeforeWrite(i + 1, target, condName)
                                     && ReadsBeforeWrite(target, hi, condName))))
                         {
                             var (left, leftStart) = Consume(condName, i);

--- a/src/housecarl-core/PapyrusDecompiler.cs
+++ b/src/housecarl-core/PapyrusDecompiler.cs
@@ -569,10 +569,13 @@ public sealed class PapyrusDecompiler
                         // arm that writes the temp whose value is read before being rewritten at or
                         // after the join. An arm that READS the temp first is not an arm at all: it
                         // is a guarded block over a reused condition temp, which the promotion path
-                        // below owns. Temps only: a real-var condition is always a plain if.
+                        // below owns. A real arm is straight-line, so a trailing JMP in the region
+                        // means an if/else or a while, not an arm. Temps only: a real-var condition
+                        // is always a plain if.
                         if (condName is not null && IsTemp(condName) && target < hi
                             && (ConsumesAsSource(_ins[target], condName)
                                 || (WritesDestIn(i + 1, target, condName)
+                                    && (target - 1 <= i || _ins[target - 1].OpCode != InstructionOpcode.JMP)
                                     && !ReadsBeforeWrite(i + 1, target, condName)
                                     && ReadsBeforeWrite(target, hi, condName))))
                         {

--- a/src/housecarl-core/PapyrusDecompiler.cs
+++ b/src/housecarl-core/PapyrusDecompiler.cs
@@ -571,8 +571,9 @@ public sealed class PapyrusDecompiler
                         // is a guarded block over a reused condition temp, which the promotion path
                         // below owns. A real arm is straight-line, so a trailing JMP in the region
                         // means an if/else or a while, not an arm. Temps only: a real-var condition
-                        // is always a plain if.
-                        if (condName is not null && IsTemp(condName) && target < hi
+                        // is always a plain if, and a temp the promotion path already took is a named
+                        // local — writes to it are statements, which an arm can never carry.
+                        if (condName is not null && IsTemp(condName) && !Materialized.Contains(condName) && target < hi
                             && (ConsumesAsSource(_ins[target], condName)
                                 || (WritesDestIn(i + 1, target, condName)
                                     && (target - 1 <= i || _ins[target - 1].OpCode != InstructionOpcode.JMP)

--- a/src/housecarl-mcp-tests/DecompileShortCircuitTests.cs
+++ b/src/housecarl-mcp-tests/DecompileShortCircuitTests.cs
@@ -1,0 +1,119 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Pex;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// A short-circuit whose value is a call argument that is NOT the last one: the arguments after it
+/// evaluate between the arm and the call, so the false-path jump lands on the next argument's first
+/// instruction instead of on the consumer.
+///
+/// The Feed stream below is what the CK's own PapyrusCompiler emits for the source above it — checked
+/// by compiling that source, and by recompiling the decompiled output back to a byte-identical .pex.
+/// CI has no CK compiler, so the stream is pinned here by hand.
+/// </summary>
+[Trait("tier", "unit")]
+public class DecompileShortCircuitTests
+{
+    // Function Feed(bool isActive, int tier, string label)
+    //     Sink(isActive && tier >= Self.Threshold, "T " + label)
+    // EndFunction
+    static PexObjectFunction Feed()
+    {
+        var f = Fn(("Bool", "isActive"), ("Int", "tier"), ("String", "label"));
+        Local(f, "Int", "::temp0");
+        Local(f, "Bool", "::temp1");
+        Local(f, "String", "::temp2");
+        Local(f, "None", "::NoneVar");
+        Ins(f, InstructionOpcode.CAST, Id("::temp1"), Id("isActive"));
+        Ins(f, InstructionOpcode.JMPF, Id("::temp1"), Int(4));                       // -> 5, the STRCAT
+        Ins(f, InstructionOpcode.PROPGET, Id("Threshold"), Id("self"), Id("::temp0"));
+        Ins(f, InstructionOpcode.CMP_GTE, Id("::temp1"), Id("tier"), Id("::temp0"));
+        Ins(f, InstructionOpcode.CAST, Id("::temp1"), Id("::temp1"));
+        Ins(f, InstructionOpcode.STRCAT, Id("::temp2"), Str("T "), Id("label"));     // the next argument
+        Ins(f, InstructionOpcode.CALLMETHOD, Id("Sink"), Id("self"), Id("::NoneVar"),
+                                             Int(2), Id("::temp1"), Id("::temp2"));  // the real consumer
+        return f;
+    }
+
+    [Fact]
+    public void AShortCircuitArgumentFollowedByAnotherArgumentReadsAsOneExpression()
+    {
+        var res = PapyrusDecompiler.DecompileFile(File("HC_ScArgProbe", ("Feed", Feed())));
+
+        Assert.Equal(0, res.FunctionsFailed);
+        Assert.Contains("Sink(isActive && tier >= Self.Threshold, \"T \" + label)", res.Source);
+    }
+
+    [Fact]
+    public void ThatShapeIsNotCountedAsOptimizerOutput()
+    {
+        // The CK compiler emits it, so the Caprica marker must stay silent: the note it drives tells
+        // the reader a recompile will not reproduce the original bytes, and here it will.
+        var res = PapyrusDecompiler.DecompileFile(File("HC_ScArgProbe", ("Feed", Feed())));
+
+        Assert.Equal(0, res.OptimizerHints);
+    }
+
+    [Fact]
+    public void AnArmThatEvaluatesAStatementStillFailsLoudAndNamesTheStatement()
+    {
+        // No source compiles to this — an arm is lazily evaluated, so a statement in it cannot be
+        // hoisted out. Reconstructing it would read plausibly and mean something else, so the
+        // function fails and the offending statement is named for whoever reports the shape.
+        var f = Fn(("Bool", "flag"));
+        Local(f, "Bool", "::temp0");
+        Local(f, "None", "::NoneVar");
+        Ins(f, InstructionOpcode.CAST, Id("::temp0"), Id("flag"));
+        Ins(f, InstructionOpcode.JMPF, Id("::temp0"), Int(3));
+        Ins(f, InstructionOpcode.CALLMETHOD, Id("Nudge"), Id("self"), Id("::NoneVar"), Int(0));
+        Ins(f, InstructionOpcode.CALLMETHOD, Id("Ask"), Id("self"), Id("::temp0"), Int(0));
+        Ins(f, InstructionOpcode.CALLMETHOD, Id("Sink"), Id("self"), Id("::NoneVar"), Int(1), Id("::temp0"));
+
+        var res = PapyrusDecompiler.DecompileFile(File("HC_ArmProbe", ("Twisted", f)));
+
+        Assert.Equal(1, res.FunctionsFailed);
+        Assert.Contains("Nudge()", Assert.Single(res.Failures));
+    }
+
+    // ---------------------------------------------------------------- in-memory pex builders
+    static PexFile File(string objectName, params (string Name, PexObjectFunction Fn)[] fns)
+    {
+        var state = new PexObjectState { Name = "" };
+        foreach (var (name, fn) in fns)
+            state.Functions.Add(new PexObjectNamedFunction { FunctionName = name, Function = fn });
+        var obj = new PexObject { Name = objectName, ParentClassName = "", DocString = "", AutoStateName = "" };
+        obj.States.Add(state);
+        var pex = new PexFile(GameCategory.Skyrim) { MajorVersion = 3, MinorVersion = 2, GameId = 1 };
+        pex.Objects.Add(obj);
+        return pex;
+    }
+
+    static PexObjectFunction Fn(params (string Type, string Name)[] parameters)
+    {
+        var f = new PexObjectFunction { ReturnTypeName = "None", DocString = "" };
+        foreach (var (type, name) in parameters)
+            f.Parameters.Add(new PexObjectFunctionVariable { TypeName = type, Name = name });
+        return f;
+    }
+
+    static void Local(PexObjectFunction f, string type, string name)
+        => f.Locals.Add(new PexObjectFunctionVariable { TypeName = type, Name = name });
+
+    static void Ins(PexObjectFunction f, InstructionOpcode op, params PexObjectVariableData[] args)
+    {
+        var ins = new PexObjectFunctionInstruction { OpCode = op };
+        foreach (var a in args) ins.Arguments.Add(a);
+        f.Instructions.Add(ins);
+    }
+
+    static PexObjectVariableData Id(string name)
+        => new() { VariableType = VariableType.Identifier, StringValue = name };
+
+    static PexObjectVariableData Str(string value)
+        => new() { VariableType = VariableType.String, StringValue = value };
+
+    static PexObjectVariableData Int(int value)
+        => new() { VariableType = VariableType.Integer, IntValue = value };
+}

--- a/src/housecarl-mcp-tests/DecompileShortCircuitTests.cs
+++ b/src/housecarl-mcp-tests/DecompileShortCircuitTests.cs
@@ -127,6 +127,32 @@ public class DecompileShortCircuitTests
         Assert.DoesNotContain("short-circuit", Assert.Single(res.Failures));
     }
 
+    [Fact]
+    public void AnIfElseWhoseThenBlockWritesTheConditionTempStaysAnIfElse()
+    {
+        // if a / b = X() / else / DoSomething() / endif / Sink(b) with b sharing the condition's temp
+        // slot: the then-block writes the temp without reading it and the temp is read after the join,
+        // but the block ends with the then-block's JMP to the join. A short-circuit arm is
+        // straight-line, so this is an if/else and must read as one.
+        var f = Fn(("Bool", "a"));
+        Local(f, "Bool", "::temp0");
+        Local(f, "None", "::NoneVar");
+        Ins(f, InstructionOpcode.CAST, Id("::temp0"), Id("a"));
+        Ins(f, InstructionOpcode.JMPF, Id("::temp0"), Int(3));                        // -> 4, the else
+        Ins(f, InstructionOpcode.CALLMETHOD, Id("X"), Id("self"), Id("::temp0"), Int(0));
+        Ins(f, InstructionOpcode.JMP, Int(3));                                         // -> 6, the join
+        Ins(f, InstructionOpcode.CALLMETHOD, Id("DoSomething"), Id("self"), Id("::NoneVar"), Int(0));
+        Ins(f, InstructionOpcode.NOP);
+        Ins(f, InstructionOpcode.CALLMETHOD, Id("Sink"), Id("self"), Id("::NoneVar"), Int(1), Id("::temp0"));
+
+        var res = PapyrusDecompiler.DecompileFile(File("HC_IfElseProbe", ("Branch", f)));
+
+        Assert.Equal(0, res.FunctionsFailed);
+        Assert.Contains("if a", res.Source);
+        Assert.Contains("else", res.Source);
+        Assert.Contains("Sink(temp0)", res.Source);
+    }
+
     // ---------------------------------------------------------------- in-memory pex builders
     static PexFile File(string objectName, params (string Name, PexObjectFunction Fn)[] fns)
     {

--- a/src/housecarl-mcp-tests/DecompileShortCircuitTests.cs
+++ b/src/housecarl-mcp-tests/DecompileShortCircuitTests.cs
@@ -104,6 +104,29 @@ public class DecompileShortCircuitTests
         Assert.Contains("Sink(temp0, \"T \" + label)", res.Source);
     }
 
+    [Fact]
+    public void AGuardedBlockThatNeverTouchesItsConditionTempIsNotReportedAsAnArm()
+    {
+        // Same shape with the block's read taken away: it neither reads nor writes the temp, so it
+        // is not an arm, and the later read of a temp the condition already spent is an unsupported
+        // shape either way. The failure must say which temp, not blame a short-circuit arm.
+        var f = Fn(("Bool", "flag"), ("String", "label"));
+        Local(f, "Bool", "::temp0");
+        Local(f, "String", "::temp2");
+        Local(f, "None", "::NoneVar");
+        Ins(f, InstructionOpcode.CAST, Id("::temp0"), Id("flag"));
+        Ins(f, InstructionOpcode.JMPF, Id("::temp0"), Int(2));                        // -> 3, the STRCAT
+        Ins(f, InstructionOpcode.CALLMETHOD, Id("Nudge"), Id("self"), Id("::NoneVar"), Int(0));
+        Ins(f, InstructionOpcode.STRCAT, Id("::temp2"), Str("T "), Id("label"));
+        Ins(f, InstructionOpcode.CALLMETHOD, Id("Sink"), Id("self"), Id("::NoneVar"),
+                                             Int(2), Id("::temp0"), Id("::temp2"));
+
+        var res = PapyrusDecompiler.DecompileFile(File("HC_UntouchedProbe", ("Untouched", f)));
+
+        Assert.Contains("::temp0", Assert.Single(res.Failures));
+        Assert.DoesNotContain("short-circuit", Assert.Single(res.Failures));
+    }
+
     // ---------------------------------------------------------------- in-memory pex builders
     static PexFile File(string objectName, params (string Name, PexObjectFunction Fn)[] fns)
     {

--- a/src/housecarl-mcp-tests/DecompileShortCircuitTests.cs
+++ b/src/housecarl-mcp-tests/DecompileShortCircuitTests.cs
@@ -77,6 +77,33 @@ public class DecompileShortCircuitTests
         Assert.Contains("Nudge()", Assert.Single(res.Failures));
     }
 
+    [Fact]
+    public void AGuardedBlockThatRewritesItsConditionTempStaysAPlainIf()
+    {
+        // bool b = flag / if b / Nudge(b) / b = Ping() / endif / Sink(b, "T " + label) under a
+        // compiler that keeps b in a temp slot: the block writes the temp and the temp is read after
+        // the join, but it is also READ in the block, which is what the promotion path is for. The
+        // short-circuit match must leave this one alone.
+        var f = Fn(("Bool", "flag"), ("String", "label"));
+        Local(f, "Bool", "::temp0");
+        Local(f, "String", "::temp2");
+        Local(f, "None", "::NoneVar");
+        Ins(f, InstructionOpcode.CAST, Id("::temp0"), Id("flag"));
+        Ins(f, InstructionOpcode.JMPF, Id("::temp0"), Int(3));                        // -> 4, the STRCAT
+        Ins(f, InstructionOpcode.CALLMETHOD, Id("Nudge"), Id("self"), Id("::NoneVar"),
+                                             Int(1), Id("::temp0"));                  // reads the temp
+        Ins(f, InstructionOpcode.CALLMETHOD, Id("Ping"), Id("self"), Id("::temp0"), Int(0));
+        Ins(f, InstructionOpcode.STRCAT, Id("::temp2"), Str("T "), Id("label"));
+        Ins(f, InstructionOpcode.CALLMETHOD, Id("Sink"), Id("self"), Id("::NoneVar"),
+                                             Int(2), Id("::temp0"), Id("::temp2"));
+
+        var res = PapyrusDecompiler.DecompileFile(File("HC_ReuseProbe", ("Reuse", f)));
+
+        Assert.Equal(0, res.FunctionsFailed);
+        Assert.Contains("if temp0", res.Source);
+        Assert.Contains("Sink(temp0, \"T \" + label)", res.Source);
+    }
+
     // ---------------------------------------------------------------- in-memory pex builders
     static PexFile File(string objectName, params (string Name, PexObjectFunction Fn)[] fns)
     {

--- a/src/housecarl-mcp-tests/DecompileShortCircuitTests.cs
+++ b/src/housecarl-mcp-tests/DecompileShortCircuitTests.cs
@@ -153,6 +153,31 @@ public class DecompileShortCircuitTests
         Assert.Contains("Sink(temp0)", res.Source);
     }
 
+    [Fact]
+    public void AConditionTempAlreadyPromotedToALocalIsNotAnArm()
+    {
+        // bool b = X() / DoThing() / if b / b = Y() / endif / Sink(b): the bare call at 1 flushes the
+        // pending temp into a named local, so from there on writes to it are real assignments — an arm
+        // over it could only ever produce a statement. It is a plain if and must read as one.
+        var f = Fn();
+        Local(f, "Bool", "::temp0");
+        Local(f, "None", "::NoneVar");
+        Ins(f, InstructionOpcode.CALLMETHOD, Id("X"), Id("self"), Id("::temp0"), Int(0));
+        Ins(f, InstructionOpcode.CALLMETHOD, Id("DoThing"), Id("self"), Id("::NoneVar"), Int(0));
+        Ins(f, InstructionOpcode.JMPF, Id("::temp0"), Int(3));                        // -> 5, the join
+        Ins(f, InstructionOpcode.CALLMETHOD, Id("Y"), Id("self"), Id("::temp0"), Int(0));
+        Ins(f, InstructionOpcode.NOP);
+        Ins(f, InstructionOpcode.NOP);
+        Ins(f, InstructionOpcode.CALLMETHOD, Id("Sink"), Id("self"), Id("::NoneVar"), Int(1), Id("::temp0"));
+
+        var res = PapyrusDecompiler.DecompileFile(File("HC_PromotedProbe", ("Promoted", f)));
+
+        Assert.Equal(0, res.FunctionsFailed);
+        Assert.Contains("if temp0", res.Source);
+        Assert.Contains("temp0 = Y()", res.Source);
+        Assert.Contains("Sink(temp0)", res.Source);
+    }
+
     // ---------------------------------------------------------------- in-memory pex builders
     static PexFile File(string objectName, params (string Name, PexObjectFunction Fn)[] fns)
     {


### PR DESCRIPTION
﻿The decompiler took a short-circuit only when the false-path jump landed *on* the instruction that consumes the temp. When the short-circuit's value is a call argument that is not the last one, the arguments after it evaluate before the call, so the jump lands on the next argument's first instruction and the consuming call sits further on. The reader took that for a plain `if`, found the condition temp read again at the call, and promoted it to a named local. That promotion is what broke the reported function: a later arm of the same expression then wrote a materialized local, which is a statement, and a statement inside a lazily-evaluated arm cannot be hoisted out — so the function failed to a raw-bytecode comment block. The fix broadens the match to the shape's actual definition: the arm rewrites the same temp without reading it first, and the join side reads it before rewriting it. The old jump-lands-on-the-consumer form stays accepted as-is. The "without reading it first" half keeps the broadened match off a guarded block that reads *and* rewrites its condition temp — that is a reused condition temp, which the promotion path owns and reads cleanly today — so nothing that worked before changes.

Two things follow. Because the CK's own compiler emits this form, the old reading also fired the optimizer-compiled ("Caprica class") marker on canonical CK output — the note in the issue's own transcript is that false positive, and it stops firing. And an arm that genuinely evaluates a statement still fails loud; its message now names the first statement, so the next report pins the sub-shape without the `.pex`.

Closes #393.

## Repro

The reporter's `ST_Config.pex` was not obtainable (mod updated the day after the report). A second instance was found instead, in Aaron's own ARR 2.0 modlist: `Devotion/Scripts/PDV__ManagerQuest.pex`, `SyncKhajiitEmphasisFamily`, failing at `short-circuit arm @34..37`. Tracing it gave the mechanism above, and it is the promotion — not an irreducible arm — that is the cause, so resolution (1) in the issue applies, not (2). The function now decompiles to

```papyrus
SyncRaceRewardSpell(playerRef, t1, isActive && activeTier == Self.TIER_SEEKER, "Khajiit " + label + " T1")
```

and the whole 1,287-function script comes back with zero failures and zero optimizer hints.

## What was run

- `dotnet build -c Release`, `dotnet test --filter "tier!=bridge"` — 1774 passed. `ci-all` — 127/127, decompile-guard's golden unchanged.
- **Round trip through the real compiler** (local; CI has no CK compiler). Authored `HC_ScArgProbe.psc` with the shape, compiled it with the CK's `PapyrusCompiler.exe`, decompiled the `.pex` with this branch, recompiled the decompiled source: **instruction streams byte-identical**. That stream is what `DecompileShortCircuitTests` pins by hand.
- **Corpus sweep**, 18,562 `.pex` files across both local Skyrim modding trees (47,580 functions after de-duplication), before and after:

  | | failed functions | optimizer hints | files flagged optimizer-compiled |
  |---|---|---|---|
  | before | 6 | 17 | 4 |
  | after | 5 | 9 | 3 |

  Re-swept over the larger of the two trees (14,424 unique `.pex`) after the review added the
  `!ReadsBeforeWrite(i + 1, …)` conjunct: totals and every per-script source hash are identical with
  and without it, so the narrowing costs the corpus nothing.

  The second review found two more shapes the broadened match stole from the plain-`if` path: an
  if/else whose then-block writes the condition temp (the arm swallowed the then-block's trailing
  `JMP`), and a temp the promotion path had already turned into a named local (writes to it are
  statements, so the arm could only ever fail). Both are declined now — a trailing `JMP` in the
  region, and `Materialized`. Both trees were swept again for each fix (18,408 unique `.pex`,
  57,561 functions): totals and every per-script source hash identical each time.

  The short-circuit class is gone; the two remaining classes are the known `nl_mcm_module.Get` irreducible and a `::NoneVar` case in `Condiexp_RandomFrostbite.Random` that this change does not touch. No new failure class, and the decompiled source of every other script in the corpus is byte-identical (SHA-256 per script, before vs after).

## Notes

- The `WritesDestIn(...)` half of the new match — the arm must write the temp — makes no difference anywhere in that corpus; the whole sweep's output is identical with and without it. It is kept because it is half of what a short-circuit arm *is* (the arm produces the right operand), and it does change what a block that never touches its condition temp is told: without it, that shape's loud failure blames a short-circuit arm instead of naming the temp. `DecompileShortCircuitTests` pins that. Plain-`if` reading stays covered by decompile-guard's exact golden.
- The `::NoneVar` failure class above (4 functions in one script) is a separate shape and is not filed as an issue yet.