### PR TITLE
Say which references= target each batch-rendered row hit

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -29,6 +29,15 @@ saying it sets an expectation their install may contradict. Say what is known, a
   than a plugin, and its version and runtime-compatibility checks never ran. That walk is bounded by the counts
   inside the directory, not by the header size, so a declared address is now read whatever the size says. A
   directory with no address at all is still genuine absence and still reads as no exports.
+- **A `housecarl_records` reverse lookup over several targets says which target each row hit whatever form
+  answered it.** `references=["A","B"]` records per match which of the targets it links to, and the scan render
+  has always shown that as `matches=`. The forms that read a body per row — `project.form='rows'`,
+  `'everything'`, a `fields` read under a `plugins=` scope with a named `source=`, and a `fields` projection with
+  a quantified path — render through the batch writer instead, which carried no such column, so the same
+  two-target lookup could be un-merged back into per-target answers under one form and not under another. All of
+  them now carry it, on text, on json, and in a `to_file=` artifact's rows. A single-target `references=` still
+  adds no column, for the reason it never did: there is nothing to un-merge.
+
 - **A SkyPatcher INI can be checked before it is placed in a mod.** `housecarl_records`'s overlay pole takes a
   draft file: `source={"overlay": "skypatcher", "state": "post", "ini": "<absolute path to a draft .ini>",
   "subfolder": "weapon"}` reads the record as the game would see it once that draft is placed — the live layer

--- a/src/housecarl-mcp-tests/BulkRecordsWorld.cs
+++ b/src/housecarl-mcp-tests/BulkRecordsWorld.cs
@@ -19,12 +19,18 @@ namespace HousecarlMcpTests;
 /// carry: reverse lookups with a record hitting two targets at once, a defined-vs-overridden split for
 /// aggregate counts, a scoped-body-vs-winner value pair on the same record, and a link that no plugin
 /// defines. The shared world is frozen, so this one is its own.</para>
+///
+/// <para>A switched-OFF mod carries the same two-target weapon pair OUT of the load order, so the off-order
+/// file-scan lane answers the questions the in-order scan answers.</para>
 /// </summary>
 public sealed class BulkRecordsWorld : IDisposable
 {
     public string Root { get; }
     public string MasterName { get; }
     public string ReplName { get; }
+    /// <summary>A plugin in a switched-OFF mod, so it is on disk and OUT of the active order: a source= naming
+    /// it takes the off-order file-scan lane rather than the in-order scan.</summary>
+    public string OffName { get; }
 
     public LoadOrderService Svc { get; }
     public string? Epoch { get; }
@@ -43,6 +49,11 @@ public sealed class BulkRecordsWorld : IDisposable
     public FormKey W3 { get; }
     public FormKey Armor1 { get; }
     public FormKey Armor2 { get; }
+
+    /// <summary>Defined in the off-order file, carries KwA alone.</summary>
+    public FormKey OffW1 { get; }
+    /// <summary>Defined in the off-order file, carries BOTH keywords — the file-scan lane's own two-target row.</summary>
+    public FormKey OffW2 { get; }
 
     /// <summary>A keyword link on W1 that NOTHING defines — the unresolved-annotation pole.</summary>
     public FormKey Ghost { get; }
@@ -105,14 +116,34 @@ public sealed class BulkRecordsWorld : IDisposable
 
         var a2 = repl.Armors.AddNew(); a2.EditorID = "HcBulkArmor2"; Armor2 = a2.FormKey;
 
+        // The off-order file, shaped like the active order's reverse-lookup pair: one weapon on KwA alone and one
+        // on both keywords, so a two-target references= down the FILE-scan lane has something to un-merge.
+        var offKey = ModKey.FromNameAndExtension("HcBulkOff.esp");
+        OffName = offKey.FileName.String;
+        var off = new SkyrimMod(offKey, SkyrimRelease.SkyrimSE);
+        var o1 = off.Weapons.AddNew();
+        o1.EditorID = "HcBulkOffSword1";
+        o1.BasicStats = new WeaponBasicStats { Damage = 40, Weight = 1 };
+        o1.Keywords = new Noggog.ExtendedList<IFormLinkGetter<IKeywordGetter>> { new FormLink<IKeywordGetter>(KwA) };
+        OffW1 = o1.FormKey;
+
+        var o2 = off.Weapons.AddNew();
+        o2.EditorID = "HcBulkOffSword2";
+        o2.BasicStats = new WeaponBasicStats { Damage = 50, Weight = 1 };
+        o2.Keywords = new Noggog.ExtendedList<IFormLinkGetter<IKeywordGetter>>
+            { new FormLink<IKeywordGetter>(KwA), new FormLink<IKeywordGetter>(KwB) };
+        OffW2 = o2.FormKey;
+
         var instance = Path.Combine(Root, "inst");
         var mods = Path.Combine(instance, "mods");
         Directory.CreateDirectory(Path.Combine(mods, "BulkMasterMod"));
         Directory.CreateDirectory(Path.Combine(mods, "BulkReplMod"));
+        Directory.CreateDirectory(Path.Combine(mods, "BulkOffMod"));
         var masterFile = Path.Combine(mods, "BulkMasterMod", MasterName);
         var replFile = Path.Combine(mods, "BulkReplMod", ReplName);
         master.BeginWrite.ToPath(masterFile).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
         repl.BeginWrite.ToPath(replFile).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
+        off.BeginWrite.ToPath(Path.Combine(mods, "BulkOffMod", OffName)).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
 
         var genDir = Path.Combine(Root, "corpus-gen");
         CorpusGenerator.GenerateAll(genDir, Path.Combine(Root, "corpus-ref"));
@@ -125,7 +156,8 @@ public sealed class BulkRecordsWorld : IDisposable
         Directory.CreateDirectory(prof);
         File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + MasterName + "\r\n" + ReplName + "\r\n");
         File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*" + MasterName + "\r\n*" + ReplName + "\r\n");
-        File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n+BulkReplMod\r\n+BulkMasterMod\r\n");
+        // BulkOffMod is switched OFF: its plugin is on disk, in no profile list, and out of the active order.
+        File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n-BulkOffMod\r\n+BulkReplMod\r\n+BulkMasterMod\r\n");
 
         Svc = LoadOrderService.WithInstance(instance, 0, new UserConfigStore(Path.Combine(Root, "user.json")));
         Epoch = Svc.Stats().epoch;

--- a/src/housecarl-mcp-tests/RecordsScanProjectionTests.cs
+++ b/src/housecarl-mcp-tests/RecordsScanProjectionTests.cs
@@ -171,6 +171,18 @@ public sealed class RecordsScanProjectionTests : BulkRecordsTestBase
         Assert.Equal($"{Fid(W.KwA)}, {Fid(W.KwB)}", w3.GetProperty("matches").GetString());
     }
 
+    /// <summary>A source= naming a plugin OUTSIDE the load order is selected by the file scan, a second body lane
+    /// that reaches the same batch render on its own — so it hands down the un-merge separately, and every test
+    /// above passes with that half reverted.</summary>
+    [Fact]
+    public void TheOffOrderFileScansRowsCarryTheMatchesColumn()
+    {
+        var doc = Doc(RecordsTools.Records(Svc, types: Weap, source: Plugin(W.OffName), references: BothKeywords,
+                                           format: "json", project: Rows("Keywords")));
+        Assert.Equal($"{Fid(W.KwA)}, {Fid(W.KwB)}", BatchRow(doc, Fid(W.OffW2)).GetProperty("matches").GetString());
+        Assert.Equal(Fid(W.KwA), BatchRow(doc, Fid(W.OffW1)).GetProperty("matches").GetString());
+    }
+
     // ---- exact-window paging ----------------------------------------------------------------------
 
     [Fact]

--- a/src/housecarl-mcp-tests/RecordsScanProjectionTests.cs
+++ b/src/housecarl-mcp-tests/RecordsScanProjectionTests.cs
@@ -87,6 +87,90 @@ public sealed class RecordsScanProjectionTests : BulkRecordsTestBase
         Assert.Contains($"{Fid(W.W2)}  matches={Fid(W.KwB)}\n", r);
     }
 
+    // The body-lane forms answer the same selection through the shared BATCH render rather than the scan's own,
+    // so each of them has to carry the un-merge too — one lookup that cannot be un-merged under one form and can
+    // under another is the same query answered two different ways (#576).
+
+    static RecordsTools.RecordsProject Rows(params string[] paths) =>
+        new() { form = "rows", fields = paths };
+
+    /// <summary>A record object from a batch render's "records" array, by FormID.</summary>
+    static JsonElement BatchRow(JsonElement root, string formid) =>
+        root.GetProperty("records").EnumerateArray().Single(m => m.GetProperty("formid").GetString() == formid);
+
+    string[] BothKeywords => new[] { Fid(W.KwA), Fid(W.KwB) };
+
+    [Fact]
+    public void TheRowsFormSaysWhichTargetsEachRowHit()
+    {
+        var r = RecordsTools.Records(Svc, types: Weap, references: BothKeywords, project: Rows("Keywords"));
+        Served(r, $"matches={Fid(W.KwA)}, {Fid(W.KwB)}");   // W3, both targets
+        Assert.Contains($"{Fid(W.W2)}  matches={Fid(W.KwB)}\n", r);
+    }
+
+    [Fact]
+    public void TheRowsFormsJsonRecordsCarryTheMatchesColumn()
+    {
+        var doc = Doc(RecordsTools.Records(Svc, types: Weap, references: BothKeywords,
+                                           format: "json", project: Rows("Keywords")));
+        Assert.Equal($"{Fid(W.KwA)}, {Fid(W.KwB)}", BatchRow(doc, Fid(W.W3)).GetProperty("matches").GetString());
+        Assert.Equal(Fid(W.KwB), BatchRow(doc, Fid(W.W2)).GetProperty("matches").GetString());
+    }
+
+    /// <summary>A quantified fields= path folds through the body lane, so it reads the batch render too.</summary>
+    [Fact]
+    public void AQuantifiedFieldsProjectionCarriesTheMatchesColumn()
+    {
+        var doc = Doc(RecordsTools.Records(Svc, types: Weap, references: BothKeywords, format: "json",
+                                           project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "Keywords[*]" } }));
+        Assert.Equal($"{Fid(W.KwA)}, {Fid(W.KwB)}", BatchRow(doc, Fid(W.W3)).GetProperty("matches").GetString());
+    }
+
+    /// <summary>A plugins= scope with a named source= reads the POLE's bodies through the batch render, and the
+    /// two scoped matches hit different targets — the column is the only thing that says which.</summary>
+    [Fact]
+    public void AScopedFieldsReadCarriesTheMatchesColumn()
+    {
+        var doc = Doc(RecordsTools.Records(Svc, types: Weap, plugins: MasterScope, source: Plugin(W.MasterName),
+                                           references: BothKeywords, format: "json", project: Fields(DamagePath)));
+        Assert.Equal(Fid(W.KwA), BatchRow(doc, Fid(W.W1)).GetProperty("matches").GetString());
+        Assert.Equal(Fid(W.KwB), BatchRow(doc, Fid(W.W2)).GetProperty("matches").GetString());
+    }
+
+    /// <summary>The whole-body form takes the same lane and states the same thing.</summary>
+    [Fact]
+    public void TheEverythingFormCarriesTheMatchesColumn()
+    {
+        var doc = Doc(RecordsTools.Records(Svc, types: Weap, references: BothKeywords,
+                                           format: "json", project: Form("everything")));
+        Assert.Equal(Fid(W.KwB), BatchRow(doc, Fid(W.W2)).GetProperty("matches").GetString());
+    }
+
+    /// <summary>One target is nothing to un-merge, so the column would be the same value on every row — the
+    /// batch render stays as quiet about it as the scan render does.</summary>
+    [Fact]
+    public void ASingleTargetReverseLookupAddsNoMatchesColumnToTheBodyLane()
+    {
+        var doc = Doc(RecordsTools.Records(Svc, types: Weap, references: new[] { Fid(W.KwB) },
+                                           format: "json", project: Rows("Keywords")));
+        Assert.False(BatchRow(doc, Fid(W.W2)).TryGetProperty("matches", out _));
+    }
+
+    /// <summary>Under to_file= the rows ARE the answer, so the un-merge has to reach the file — an artifact
+    /// re-entered later has no response beside it to read the targets off.</summary>
+    [Fact]
+    public void ASpilledBodyLaneArtifactCarriesTheMatchesColumn()
+    {
+        var art = W.Scratch("rows-matches.jsonl");
+        RecordsTools.Records(Svc, types: Weap, references: BothKeywords, format: "json",
+                             project: Rows("Keywords"), to_file: art);
+        var lines = File.ReadAllLines(art);
+        Assert.Contains(Doc(lines[0]).GetProperty("row_schema").EnumerateArray().Select(e => e.GetString()),
+                        s => s == "matches?");
+        var w3 = lines.Skip(1).Select(Doc).Single(d => d.GetProperty("formid").GetString() == Fid(W.W3));
+        Assert.Equal($"{Fid(W.KwA)}, {Fid(W.KwB)}", w3.GetProperty("matches").GetString());
+    }
+
     // ---- exact-window paging ----------------------------------------------------------------------
 
     [Fact]

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -246,25 +246,34 @@ internal static class Artifacts
     /// <summary>Build and save the artifact for a batch read — one row per input, in input order, exactly the rows
     /// the json render emits. Per-item errors are included: dropping them would make the file claim a cleaner
     /// batch than the call returned. <paramref name="levers"/> and <paramref name="rowCap"/> carry the same
-    /// contract as on <see cref="WriteCrossQuery"/>.</summary>
+    /// contract as on <see cref="WriteCrossQuery"/>. <paramref name="matches"/> is parallel to
+    /// <paramref name="outcomes"/> and carries the multi-target references= un-merge, so a spilled body-lane row says
+    /// which target it hit exactly as the inline render does (#576).</summary>
     public static (SpillInfo? Spill, string? Error) WriteBatch(
         IReadOnlyList<ReadOutcome> outcomes, string path, string reason, IReadOnlyList<KeyValuePair<string, string>> query,
-        LeverNames? levers = null, int rowCap = int.MaxValue)
+        LeverNames? levers = null, int rowCap = int.MaxValue, IReadOnlyList<string?>? matches = null)
     {
         using var writer = new ResultArtifact.Writer();
-        foreach (var o in outcomes)
+        for (int i = 0; i < outcomes.Count; i++)
         {
+            var o = outcomes[i];
+            string? hit = matches is { } mt && i < mt.Count ? mt[i] : null;
             if (o.Error is not null)
-                writer.WriteRow((w, _) => { w.WriteStartObject(); w.WriteString("formid", o.FormKey.ToString()); w.WriteString("error", o.Error); w.WriteEndObject(); });
+                writer.WriteRow((w, _) =>
+                {
+                    w.WriteStartObject(); w.WriteString("formid", o.FormKey.ToString()); w.WriteString("error", o.Error);
+                    if (hit is not null) w.WriteString("matches", hit);
+                    w.WriteEndObject();
+                });
             else
-                writer.WriteRow((w, ms) => JsonWire.WriteReadRecord(w, o, ms, rowCap, levers: levers), o.Record!.Type);
+                writer.WriteRow((w, ms) => JsonWire.WriteReadRecord(w, o, ms, rowCap, hit, levers: levers), o.Record!.Type);
         }
         // The batch's one build, from the first row that consulted one. A batch of pure parse failures carries "",
         // and such an artifact refuses epoch-checked re-entry against any build.
         var epoch = outcomes.FirstOrDefault(o => o.Epoch is not null)?.Epoch ?? "";
         // The manifest's tool stamp; see WriteResolve.
         var (manifest, err) = writer.Save(path, ToolNames.Records, query, "formid",
-                                          new[] { "formid", "runtime_formid", "type", "editorid", "winner", "override_depth", "source", "fields" },
+                                          new[] { "formid", "runtime_formid", "type", "editorid", "winner", "override_depth", "source", "matches?", "fields" },
                                           "input order", outcomes.Count, epoch, OwnedChildNotes(AnnotatedFields(outcomes), outcomes.Any(o => o.OwnedChildUnioned)));
         return err is not null ? (null, err) : (new SpillInfo(path, manifest!, reason), null);
     }

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -472,9 +472,13 @@ static class JsonWire
     /// WITH the milliseconds rather than being taken off this list: the formids= lane hands this renderer a
     /// limit=/offset= window, and the count beside the cost is the BODIES READ, which a pole that has no version of
     /// an id or a malformed token leaves short of the list (#607).</param>
+    /// <param name="matches">Parallel to <paramref name="outcomes"/>: which multi-target references= target(s) each
+    /// row hit, written on the row under the same key the scan lane uses, so a body-lane form un-merges a reverse
+    /// lookup the same way the scan lane does. Null when the selection was not a multi-target reverse lookup (#576).</param>
     public static string RenderBatch(IReadOnlyList<ReadOutcome> outcomes, int maxChars, SpillState? spill, out bool truncated,
                                      IReadOnlyList<KeyValuePair<string, string>>? envelope = null, LeverNames? levers = null,
-                                     (int RowsRead, long Millis)? bodyCost = null)
+                                     (int RowsRead, long Millis)? bodyCost = null,
+                                     IReadOnlyList<string?>? matches = null)
     {
         truncated = false;
         int cap = Cap(maxChars);
@@ -491,13 +495,15 @@ static class JsonWire
             w.WriteStartArray("records");
             int rendered = 0; bool rowsTruncated = false;
             var childFields = new SortedSet<string>(StringComparer.Ordinal);   // the annotated fields the rows RENDERED carried
-            foreach (var o in outcomes)
+            for (int i = 0; i < outcomes.Count; i++)
             {
                 if (manifestOnly) break;   // to_file: the rows are the FILE
                 w.Flush();
                 if (ms.Length >= cap) { rowsTruncated = true; break; }
-                if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", o.FormKey.ToString()); w.WriteString("error", o.Error); w.WriteEndObject(); }
-                else WriteReadRecord(w, o, ms, cap, childFields: childFields, levers: levers);
+                var o = outcomes[i];
+                string? hit = matches is { } mt && i < mt.Count ? mt[i] : null;   // multi-target references= un-merge
+                if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", o.FormKey.ToString()); w.WriteString("error", o.Error); if (hit is not null) w.WriteString("matches", hit); w.WriteEndObject(); }
+                else WriteReadRecord(w, o, ms, cap, hit, childFields: childFields, levers: levers);
                 rendered++;
             }
             w.WriteEndArray();

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -233,9 +233,13 @@ static class Wire
     /// limit=/offset= window, and the count beside the cost is the BODIES READ, which a pole that has no version of
     /// an id or a malformed token leaves short of the list (#607).</param>
     /// <param name="header">The caller's own header line, written INSIDE the budget for the same reason.</param>
+    /// <param name="matches">Parallel to <paramref name="outcomes"/>: which multi-target references= target(s) each
+    /// row hit, in the scan render's own spelling, so a body-lane form un-merges a reverse lookup the same way the
+    /// scan lane does. Null when the selection was not a multi-target reverse lookup (#576).</param>
     public static string RenderBatch(IReadOnlyList<ReadOutcome> outcomes, int maxChars,
                                      SpillState? spill, out bool truncated, LeverNames? levers = null,
-                                     (int RowsRead, long Millis)? bodyCost = null, string? header = null)
+                                     (int RowsRead, long Millis)? bodyCost = null, string? header = null,
+                                     IReadOnlyList<string?>? matches = null)
     {
         truncated = false;
         var lv = levers ?? LeverNames.Legacy;
@@ -259,12 +263,16 @@ static class Wire
             " or raise max_chars]\n";
         var spillText = SpillText(spill);
         int budget = cap - costReserve - spillText.Length - Notice(outcomes.Count).Length;
-        foreach (var o in outcomes)
+        for (int i = 0; i < outcomes.Count; i++)
         {
             if (spill?.ManifestOnly ?? false) break;   // to_file: only the manifest renders — the rows are the FILE
+            var o = outcomes[i];
             int mark = sb.Length;
             var noteMark = notes.Mark();
             sb.Append('\n');
+            // The scan render's exact line, so a reverse lookup un-merges the same way whichever form answered it.
+            if (matches is { } mt && i < mt.Count && mt[i] is { } hit)
+                sb.Append("  ").Append(o.FormKey).Append("  matches=").Append(hit).Append('\n');
             if (o.Error is not null) sb.Append("error: ").Append(o.Error).Append('\n');
             else AppendRecordBlock(sb, o, new RenderCap(cap, budget), notes, lv);
             // Whole records only, and the clause this record earned goes back with it: the clauses already earned are

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -1518,13 +1518,16 @@ public static class RecordsTools
                 // These bodies were selected by a scan, not a formids list, so the batch notice's selection
                 // clause must name limit= — the knob that actually windows this response.
                 var evLevers = formLevers.OnScanSelection();
+                // These rows were selected by the scan, so they carry its multi-target references= un-merge too —
+                // one row per key, in key order, which is what makes the list parallel to the bodies.
+                var evMatches = outcome.MatchedTargets;
                 string RenderEv(SpillState? sp, out bool trunc) => json
-                    ? JsonWire.RenderBatch(bodies, max_chars, sp, out trunc, envelope, evLevers, (bodies.Count, bodyClock.ElapsedMilliseconds))
-                    : Wire.RenderBatch(bodies, max_chars, sp, out trunc, evLevers, (bodies.Count, bodyClock.ElapsedMilliseconds), headerLine);
+                    ? JsonWire.RenderBatch(bodies, max_chars, sp, out trunc, envelope, evLevers, (bodies.Count, bodyClock.ElapsedMilliseconds), evMatches)
+                    : Wire.RenderBatch(bodies, max_chars, sp, out trunc, evLevers, (bodies.Count, bodyClock.ElapsedMilliseconds), headerLine, evMatches);
                 SpillState? evSpill = null;
                 if (wantFile)
                 {
-                    var (s, aerr) = Artifacts.WriteBatch(bodies, toFile!, "to_file", Echo(), evLevers);
+                    var (s, aerr) = Artifacts.WriteBatch(bodies, toFile!, "to_file", Echo(), evLevers, matches: evMatches);
                     if (aerr is not null) return json ? JsonWire.RenderError(aerr, bodyEpoch) : "error: " + aerr;
                     evSpill = SpillState.Spilled(s!, manifestOnly: true);
                 }
@@ -1532,7 +1535,7 @@ public static class RecordsTools
                 if (evSpill is null && evTrunc)
                 {
                     var path = ResultsStore.NextPath(ToolNames.Records, bodyEpoch?.Epoch ?? "none");
-                    var (s, aerr) = Artifacts.WriteBatch(bodies, path, "ceiling", Echo(), evLevers);
+                    var (s, aerr) = Artifacts.WriteBatch(bodies, path, "ceiling", Echo(), evLevers, matches: evMatches);
                     if (aerr is not null) ResultsStore.Release(path);
                     evRendered = RenderEv(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
                 }
@@ -1738,14 +1741,16 @@ public static class RecordsTools
                 headerLine += $"\n{outcome.Total} match(es); bodies for the {keys.Count}-row window below";
                 // Selected by the off-order file scan, so the remedy vocabulary matches the body lane above.
                 var offLevers = formLevers.OnScanSelection();
+                // Same rule as the in-order body lane: the file scan's rows carry its references= un-merge too.
+                var offMatches = outcome.MatchedTargets;
                 string RenderOff(SpillState? sp, out bool trunc) => json
-                    ? JsonWire.RenderBatch(bodies, max_chars, sp, out trunc, envelope, offLevers, (bodies.Count, offClock.ElapsedMilliseconds))
-                    : Wire.RenderBatch(bodies, max_chars, sp, out trunc, offLevers, (bodies.Count, offClock.ElapsedMilliseconds), headerLine);
+                    ? JsonWire.RenderBatch(bodies, max_chars, sp, out trunc, envelope, offLevers, (bodies.Count, offClock.ElapsedMilliseconds), offMatches)
+                    : Wire.RenderBatch(bodies, max_chars, sp, out trunc, offLevers, (bodies.Count, offClock.ElapsedMilliseconds), headerLine, offMatches);
                 SpillState? offSpill = null;
                 var offEpoch = bodies.FirstOrDefault(o => o.Stamp is not null)?.Stamp ?? outcome.Stamp;
                 if (wantFile)
                 {
-                    var (sp, aerr) = Artifacts.WriteBatch(bodies, toFile!, "to_file", Echo(), offLevers);
+                    var (sp, aerr) = Artifacts.WriteBatch(bodies, toFile!, "to_file", Echo(), offLevers, matches: offMatches);
                     if (aerr is not null) return json ? JsonWire.RenderError(aerr, offEpoch) : "error: " + aerr;
                     offSpill = SpillState.Spilled(sp!, manifestOnly: true);
                 }
@@ -1753,7 +1758,7 @@ public static class RecordsTools
                 if (offSpill is null && offTrunc)
                 {
                     var path = ResultsStore.NextPath(ToolNames.Records, offEpoch?.Epoch ?? "none");
-                    var (sp, aerr) = Artifacts.WriteBatch(bodies, path, "ceiling", Echo(), offLevers);
+                    var (sp, aerr) = Artifacts.WriteBatch(bodies, path, "ceiling", Echo(), offLevers, matches: offMatches);
                     if (aerr is not null) ResultsStore.Release(path);
                     offRendered = RenderOff(aerr is null ? SpillState.Spilled(sp!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
                 }


### PR DESCRIPTION
A `references=["A","B"]` scan records which of the targets each match hit, and the scan render shows it as a per-row `matches` column. The forms that read a body per row — `project.form='rows'`, `'everything'`, a `fields` read under a `plugins=` scope with a named `source=`, and a `fields` projection with a quantified path — do not render through the scan render at all; they hand their bodies to the shared batch render, which had no such column. So the same two-target lookup could be un-merged back into per-target answers under one form and stayed silent under another, with nothing in the response saying the column had been dropped. The fix is one per-row `matches` on the shared batch render rather than a patch per form: `Wire.RenderBatch` and `JsonWire.RenderBatch` take the list parallel to their outcomes, and both body lanes in `RecordsTools.cs` (the in-order scan and the off-order file scan) pass the scan outcome's `MatchedTargets` down. The text line and the json key are the scan render's own, so the two transports cannot drift. A single-target `references=` still passes null and adds no column.

One thing beyond the issue's stated scope: the issue says the artifact lane already carries `matches?`, which is true of `Artifacts.WriteCrossQuery` but not of `Artifacts.WriteBatch` — the artifact the body lane spills to. Under `to_file=` the rows *are* the answer, so leaving that one out would have moved the gap rather than closed it; `WriteBatch` now takes the same list and names `matches?` in its row schema.

Tests are eight in `RecordsScanProjectionTests`, beside the existing multi-target reverse-lookup test: the rows form on text and on json, the quantified `fields` projection, the scoped `fields` read, `everything`, a spilled artifact's row plus its schema, the off-order file scan's rows, and the single-target negative. Seven of them fail at the branch point and pass after; the single-target one is an absence guard — it passes at the branch point too, and holds the column quiet once the other seven make it appear. The off-order one drives the second body lane, which the other seven never reach: `BulkRecordsWorld` gained a switched-off mod carrying the same two-target weapon pair out of the load order, so a `source=` naming that plugin takes the file-scan lane, and reverting `offMatches` in `RecordsTools.cs` fails that test alone.

Closes #576
