### PR TITLE
Refuse an import directory that declares an RVA but no size

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,13 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **An SKSE DLL whose import directory declares an address but no size now reads as UNKNOWN, not as a short
+  import list.** The peek walks a DLL's import and delay-import directories bounded by the size the PE header
+  declares for each. A directory with a non-zero address and a zero size read as "no such directory": its whole
+  table was skipped and the walk still reported success, so what remained rendered as the complete
+  `imports (N): …` and the debug-CRT verdict over that list returned a clean bill of health for a build the
+  loader would refuse. It is now a parse failure like every other one in that walk, and says
+  `imports: UNKNOWN`. A directory with no address at all is still genuine absence and still walks to an answer.
 - **A SkyPatcher INI can be checked before it is placed in a mod.** `housecarl_records`'s overlay pole takes a
   draft file: `source={"overlay": "skypatcher", "state": "post", "ini": "<absolute path to a draft .ini>",
   "subfolder": "weapon"}` reads the record as the game would see it once that draft is placed — the live layer

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -23,6 +23,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
   The same walk had a second silent drop: an old-style delay-load entry that gives an absolute address instead of
   a relative one was skipped, again leaving a short list that read as complete. Its address is now resolved
   against the image base like the loader does, and the read says `imports: UNKNOWN` when it cannot be.
+- **An SKSE DLL whose export directory declares an address but no size now has its exports read, instead of being
+  reported as a bundled dependency.** The same header shape on the export side failed the other way: the peek
+  answered "no exports", so a DLL that does export SKSE's entry points was named a bundled dependency DLL rather
+  than a plugin, and its version and runtime-compatibility checks never ran. That walk is bounded by the counts
+  inside the directory, not by the header size, so a declared address is now read whatever the size says. A
+  directory with no address at all is still genuine absence and still reads as no exports.
 - **A SkyPatcher INI can be checked before it is placed in a mod.** `housecarl_records`'s overlay pole takes a
   draft file: `source={"overlay": "skypatcher", "state": "post", "ini": "<absolute path to a draft .ini>",
   "subfolder": "weapon"}` reads the record as the game would see it once that draft is placed — the live layer

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -20,6 +20,9 @@ saying it sets an expectation their install may contradict. Say what is known, a
   `imports (N): …` and the debug-CRT verdict over that list returned a clean bill of health for a build the
   loader would refuse. It is now a parse failure like every other one in that walk, and says
   `imports: UNKNOWN`. A directory with no address at all is still genuine absence and still walks to an answer.
+  The same walk had a second silent drop: an old-style delay-load entry that gives an absolute address instead of
+  a relative one was skipped, again leaving a short list that read as complete. Its address is now resolved
+  against the image base like the loader does, and the read says `imports: UNKNOWN` when it cannot be.
 - **A SkyPatcher INI can be checked before it is placed in a mod.** `housecarl_records`'s overlay pole takes a
   draft file: `source={"overlay": "skypatcher", "state": "post", "ini": "<absolute path to a draft .ini>",
   "subfolder": "weapon"}` reads the record as the game would see it once that draft is placed — the live layer

--- a/src/housecarl-core/SksePluginReader.cs
+++ b/src/housecarl-core/SksePluginReader.cs
@@ -459,12 +459,16 @@ public static class SksePluginReader
     /// design: the SKSE loader itself resolves symbols by exact unmangled name string, so a name lookup is all we need.
     /// Returns an EMPTY map for a DLL with genuinely no export table (→ classify NotSkse), but <c>null</c> when the directory
     /// is present yet CORRUPT (a parse failure — the caller classifies Unreadable, never silently as a bundled
-    /// dependency). Never throws.</summary>
+    /// dependency). ABSENCE is a zero RVA and nothing else: a declared RVA is read whatever the header's Size says,
+    /// since this walk is driven by the directory's own counts (capped by <c>MaxExports</c>) and never by that Size.
+    /// Never throws.</summary>
     static Dictionary<string, int>? ReadExportRvas(PEReader pe)
     {
         var byName = new Dictionary<string, int>(StringComparer.Ordinal);
         var dir = pe.PEHeaders.PEHeader!.ExportTableDirectory;
-        if (dir.Size == 0 || dir.RelativeVirtualAddress == 0) return byName;   // no export table → empty (genuinely no exports)
+        // A zero Size beside a declared RVA is NOT "no exports": the table is there, and reading it as empty would
+        // classify a real plugin NotSkse — "a bundled dependency DLL, not a plugin" — and skip its version checks.
+        if (dir.RelativeVirtualAddress == 0) return byName;                    // no export table → empty (genuinely no exports)
         try
         {
             var ed = pe.GetSectionData(dir.RelativeVirtualAddress).GetReader();

--- a/src/housecarl-core/SksePluginReader.cs
+++ b/src/housecarl-core/SksePluginReader.cs
@@ -388,7 +388,12 @@ public static class SksePluginReader
 
         bool Walk(int dirRva, int dirSize, int stride, int nameOff, bool delay)
         {
-            if (dirSize == 0 || dirRva == 0) return true;              // directory genuinely absent → nothing to add
+            if (dirRva == 0) return true;                              // directory genuinely absent → nothing to add
+            // A declared RVA with a zero Size is NOT absence: there is a table there, and this walk's only bound on it
+            // is that Size (see the limit below). Returning true would walk nothing and still report success — a whole
+            // directory of imports dropped behind a complete-looking "imports (N): …", the same silent partial the
+            // unresolvable-name case below refuses. Answer UNKNOWN instead, like every other failure here.
+            if (dirSize == 0) return false;
             try
             {
                 var block = pe.GetSectionData(dirRva);

--- a/src/housecarl-core/SksePluginReader.cs
+++ b/src/housecarl-core/SksePluginReader.cs
@@ -372,7 +372,8 @@ public static class SksePluginReader
     ///
     /// Both directories are arrays of fixed-size descriptors terminated by an all-zero entry, each carrying an RVA to the
     /// imported DLL's ASCII name. Delay-load descriptors predate the RVA convention: bit0 of their Attributes is
-    /// <c>RvaBased</c>, and a (long-obsolete) VA-based table is SKIPPED rather than misread as an RVA.</summary>
+    /// <c>RvaBased</c>, and a (long-obsolete) VA-based table carries absolute addresses, resolved here the way the
+    /// loader does — VA minus the image base — and refused when that lands outside the image.</summary>
     static List<string>? ReadImportNames(PEReader pe)
     {
         var names = new List<string>();
@@ -409,10 +410,19 @@ public static class SksePluginReader
                     uint attributes = delay ? rd.ReadUInt32() : 0;     // delay-load: Attributes precedes the name RVA
                     rd.Offset = i * stride + nameOff;
                     int nameRva = rd.ReadInt32();
-                    // The all-zero descriptor terminates the array. A delay-load table whose bit0 (RvaBased) is clear is
-                    // VA-based (pre-VS2015); its "RVA" is an absolute address we must NOT resolve — skip, don't guess.
+                    // The all-zero descriptor terminates the array.
                     if (nameRva == 0) return true;
-                    if (delay && (attributes & 1) == 0) continue;
+                    // A delay-load table whose bit0 (RvaBased) is clear is VA-based (pre-VS2015): the field is an
+                    // absolute address, so subtract the image base to get the RVA, which is what the loader does.
+                    // Skipping it instead would drop the name behind a complete-looking list — the same silent partial
+                    // the zero Size above refuses. A VA outside the image is unresolvable, so it fails the walk; a
+                    // 32-bit field cannot express a 64-bit image's addresses, which is why such a table is x86-only.
+                    if (delay && (attributes & 1) == 0)
+                    {
+                        long fromBase = (uint)nameRva - (long)hdr.ImageBase;
+                        if (fromBase is <= 0 or > int.MaxValue) return false;
+                        nameRva = (int)fromBase;
+                    }
                     // An unresolvable name is CORRUPTION, and skipping it would hand back a short list that renders as a
                     // complete "imports (N): …" — a silent partial answer, which is worse here than no answer: if the
                     // entry we dropped were vcruntime140d.dll, the Debug-CRT check would report a clean bill of health.

--- a/src/housecarl-core/SksePluginReader.cs
+++ b/src/housecarl-core/SksePluginReader.cs
@@ -365,10 +365,12 @@ public static class SksePluginReader
     }
 
     /// <summary>Walk the PE IMPORT + DELAY-LOAD directories and return the imported DLL names, lower-cased and
-    /// deduplicated, in image order. Same rule as <see cref="ReadExportRvas"/>: an ABSENT directory yields an empty
-    /// list (a real, if odd, "imports nothing"), while a PRESENT-but-CORRUPT one yields <c>null</c> — a parse failure
-    /// the caller renders as UNKNOWN, since a corrupt import table must not read as a clean bill of health.
-    /// Never throws.
+    /// deduplicated, in image order. Absence is a zero RVA and nothing else, as in <see cref="ReadExportRvas"/>: an
+    /// ABSENT directory yields an empty list (a real, if odd, "imports nothing"), while a PRESENT-but-CORRUPT one
+    /// yields <c>null</c> — a parse failure the caller renders as UNKNOWN, since a corrupt import table must not read
+    /// as a clean bill of health. The two walks agree on what is present and part company only on what a DECLARED
+    /// directory with a zero Size can be made to yield: that Size is this walk's ONLY bound, so it fails here, while
+    /// the export walk is bounded by the directory's own counts and reads it. Never throws.
     ///
     /// Both directories are arrays of fixed-size descriptors terminated by an all-zero entry, each carrying an RVA to the
     /// imported DLL's ASCII name. Delay-load descriptors predate the RVA convention: bit0 of their Attributes is

--- a/src/housecarl-mcp-tests/SkseDirectoryReadTests.cs
+++ b/src/housecarl-mcp-tests/SkseDirectoryReadTests.cs
@@ -5,16 +5,17 @@ using Xunit;
 
 namespace HousecarlMcpTests;
 
-/// <summary>The import walk's bound on a declared directory. A data directory whose Size is zero but whose RVA is not
-/// is a table that IS there and cannot be bounded; the walk used to read that as "genuinely absent", so a DLL's whole
-/// delay-import set was dropped and the read still reported success — a complete-looking "imports (N): …" missing the
-/// very names the Debug-CRT verdict is built on (#416). Synthetic PEs, because the shape is a header field: the image
-/// below is the minimum <see cref="System.Reflection.PortableExecutable.PEReader"/> will open, with one .rdata section
-/// carrying a real import descriptor table, a real delay-load descriptor table, and the two name strings. The same
-/// image serves the sibling drop at the bottom: a VA-based delay descriptor, which used to be skipped the same
-/// way.</summary>
+/// <summary>What the reader makes of a PE data directory the header declares oddly. A directory whose Size is zero but
+/// whose RVA is not is a table that IS there, and both walks used to read that as "genuinely absent": the import walk
+/// dropped a DLL's whole delay-import set and still reported success — a complete-looking "imports (N): …" missing the
+/// very names the Debug-CRT verdict is built on (#416) — and the export walk answered an empty map, which classifies a
+/// real plugin as a bundled dependency. Synthetic PEs, because the shape is a header field: the image below is the
+/// minimum <see cref="System.Reflection.PortableExecutable.PEReader"/> will open, with one .rdata section carrying a
+/// real import descriptor table, a real delay-load descriptor table, a real export directory, and their name strings.
+/// The same image serves the sibling drop in the middle: a VA-based delay descriptor, which used to be skipped the
+/// same way.</summary>
 [Trait("tier", "unit")]
-public sealed class SkseImportDirectoryBoundTests
+public sealed class SkseDirectoryReadTests
 {
     /// <summary>A well-formed delay directory is walked, and what it carries is a debug-CRT import — the thing the
     /// Size==0 read dropped, and the reason dropping it is not cosmetic: absent from the list, the DLL reads as a clean
@@ -92,6 +93,38 @@ public sealed class SkseImportDirectoryBoundTests
         Assert.Null(info.Imports);
     }
 
+    /// <summary>The same declared-but-unsized shape on the export directory, where the header Size bounds nothing at
+    /// all — the walk is driven by the directory's own counts. A zero Size there answered an empty map, so a DLL that
+    /// does export SKSE's entry points was reported to the modder as "a bundled dependency DLL, not a plugin" and its
+    /// version and runtime checks never ran.</summary>
+    [Fact]
+    public void ExportDirectoryWithZeroSizeIsStillRead()
+    {
+        var info = SksePluginReader.ReadBytes("exports.dll", Image(0, 0, 0, 0, exportRva: ExportRva, exportSize: 0));
+
+        Assert.Equal(SksePluginReader.SksePluginKind.LegacyQuery, info.Kind);
+    }
+
+    /// <summary>The control for the case above: the same export directory with its Size declared, so what changes
+    /// between the two is the header field and nothing else.</summary>
+    [Fact]
+    public void ExportDirectoryWithItsSizeDeclaredIsRead()
+    {
+        var info = SksePluginReader.ReadBytes("exports.dll", Image(0, 0, 0, 0, exportRva: ExportRva, exportSize: ExportSize));
+
+        Assert.Equal(SksePluginReader.SksePluginKind.LegacyQuery, info.Kind);
+    }
+
+    /// <summary>The other half of that fork: no export RVA is a genuinely absent export table, and still classifies
+    /// NotSkse. Reading a declared directory must not stop a real bundled dependency from being named as one.</summary>
+    [Fact]
+    public void AbsentExportDirectoryIsNotSkse()
+    {
+        var info = SksePluginReader.ReadBytes("dep.dll", Image(ImportRva, ImportSize, 0, 0));
+
+        Assert.Equal(SksePluginReader.SksePluginKind.NotSkse, info.Kind);
+    }
+
     // ── the synthetic image ──────────────────────────────────────────────────────────────────────────────────────
 
     const int HeaderBytes = 0x200;      // SizeOfHeaders, one file-alignment unit
@@ -104,12 +137,20 @@ public sealed class SkseImportDirectoryBoundTests
     const int DelaySize = 64;                    // 2 * 32
     const int Kernel32Rva = SectionRva + 0x0C0;
     const int DebugCrtRva = SectionRva + 0x100;
+    const int ExportRva = SectionRva + 0x120;    // IMAGE_EXPORT_DIRECTORY, exporting SKSEPlugin_Query
+    const int ExportSize = 40;
+    const int EatRva = SectionRva + 0x150;       // AddressOfFunctions[1]
+    const int NameTableRva = SectionRva + 0x158; // AddressOfNames[1]
+    const int OrdinalTableRva = SectionRva + 0x160;
+    const int QueryNameRva = SectionRva + 0x168;
 
-    /// <summary>A minimal x64 PE image declaring the two import directories at the given RVA/Size. The tables and their
-    /// name strings are always written; only what the header declares about them varies, which is exactly the axis
-    /// under test. <paramref name="delayAttributes"/> and <paramref name="imageBase"/> pick how the delay table
-    /// addresses its name: bit0 set is an RVA, clear is the absolute address a VA-based table would carry.</summary>
-    static byte[] Image(int importRva, int importSize, int delayRva, int delaySize, uint delayAttributes = 1, ulong imageBase = 0x180000000)
+    /// <summary>A minimal x64 PE image declaring the two import directories and the export directory at the given
+    /// RVA/Size. The tables and their name strings are always written; only what the header declares about them varies,
+    /// which is exactly the axis under test. <paramref name="delayAttributes"/> and <paramref name="imageBase"/> pick
+    /// how the delay table addresses its name: bit0 set is an RVA, clear is the absolute address a VA-based table would
+    /// carry.</summary>
+    static byte[] Image(int importRva, int importSize, int delayRva, int delaySize, uint delayAttributes = 1, ulong imageBase = 0x180000000,
+                        int exportRva = 0, int exportSize = 0)
     {
         var img = new byte[HeaderBytes + SectionBytes];
 
@@ -136,6 +177,8 @@ public sealed class SkseImportDirectoryBoundTests
         U32(img, opt + 0x6C, 16);                    // NumberOfRvaAndSizes
 
         int dirs = opt + 0x70;
+        U32(img, dirs + 0 * 8, (uint)exportRva);     // IMAGE_DIRECTORY_ENTRY_EXPORT
+        U32(img, dirs + 0 * 8 + 4, (uint)exportSize);
         U32(img, dirs + 1 * 8, (uint)importRva);     // IMAGE_DIRECTORY_ENTRY_IMPORT
         U32(img, dirs + 1 * 8 + 4, (uint)importSize);
         U32(img, dirs + 13 * 8, (uint)delayRva);     // IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT
@@ -155,6 +198,16 @@ public sealed class SkseImportDirectoryBoundTests
         U32(img, At(DelayRva) + 0x04, delayName);        // ImgDelayDescr.DllName
         Ascii(img, At(Kernel32Rva), "kernel32.dll");
         Ascii(img, At(DebugCrtRva), "vcruntime140d.dll");
+
+        U32(img, At(ExportRva) + 0x14, 1);                       // NumberOfFunctions
+        U32(img, At(ExportRva) + 0x18, 1);                       // NumberOfNames
+        U32(img, At(ExportRva) + 0x1C, (uint)EatRva);            // AddressOfFunctions
+        U32(img, At(ExportRva) + 0x20, (uint)NameTableRva);      // AddressOfNames
+        U32(img, At(ExportRva) + 0x24, (uint)OrdinalTableRva);   // AddressOfNameOrdinals
+        U32(img, At(EatRva), (uint)SectionRva);                     // the export's own RVA; unread for a Query export, which classifies on the name
+        U32(img, At(NameTableRva), (uint)QueryNameRva);
+        U16(img, At(OrdinalTableRva), 0);
+        Ascii(img, At(QueryNameRva), "SKSEPlugin_Query");
         return img;
     }
 

--- a/src/housecarl-mcp-tests/SkseImportDirectoryBoundTests.cs
+++ b/src/housecarl-mcp-tests/SkseImportDirectoryBoundTests.cs
@@ -1,0 +1,140 @@
+using System.Buffers.Binary;
+using System.Text;
+using HousecarlCore;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>The import walk's bound on a declared directory. A data directory whose Size is zero but whose RVA is not
+/// is a table that IS there and cannot be bounded; the walk used to read that as "genuinely absent", so a DLL's whole
+/// delay-import set was dropped and the read still reported success — a complete-looking "imports (N): …" missing the
+/// very names the Debug-CRT verdict is built on (#416). Synthetic PEs, because the shape is a header field: the image
+/// below is the minimum <see cref="System.Reflection.PortableExecutable.PEReader"/> will open, with one .rdata section
+/// carrying a real import descriptor table, a real delay-load descriptor table, and the two name strings.</summary>
+[Trait("tier", "unit")]
+public sealed class SkseImportDirectoryBoundTests
+{
+    /// <summary>A well-formed delay directory is walked, and what it carries is a debug-CRT import — the thing the
+    /// Size==0 read dropped, and the reason dropping it is not cosmetic: absent from the list, the DLL reads as a clean
+    /// build that will load, while the loader would refuse it with error 126.</summary>
+    [Fact]
+    public void DelayDirectoryWithItsSizeDeclaredIsWalked()
+    {
+        var info = SksePluginReader.ReadBytes("delay.dll", Image(ImportRva, ImportSize, DelayRva, DelaySize));
+
+        Assert.NotNull(info.Imports);
+        Assert.Equal(new[] { "kernel32.dll", "vcruntime140d.dll" }, info.Imports);
+        Assert.Equal(new[] { "vcruntime140d.dll" }, SksePluginReader.DebugCrtImportsOf(info));
+    }
+
+    /// <summary>The bug: same image, same delay table, Size zeroed. The walk must answer UNKNOWN (null Imports), not a
+    /// short list that renders as the whole truth.</summary>
+    [Fact]
+    public void DelayDirectoryWithZeroSizeAnswersUnknown()
+    {
+        var info = SksePluginReader.ReadBytes("delay.dll", Image(ImportRva, ImportSize, DelayRva, 0));
+
+        Assert.Null(info.Imports);
+    }
+
+    /// <summary>The same bound guards the ordinary import directory — one walk serves both, so the zero Size refuses
+    /// there too.</summary>
+    [Fact]
+    public void ImportDirectoryWithZeroSizeAnswersUnknown()
+    {
+        var info = SksePluginReader.ReadBytes("imports.dll", Image(ImportRva, 0, DelayRva, DelaySize));
+
+        Assert.Null(info.Imports);
+    }
+
+    /// <summary>The other half of the fork: a directory with NO RVA is genuinely absent, and stays a walked, honest
+    /// answer. Refusing on either zero would turn every DLL that delay-imports nothing — nearly all of them — into an
+    /// UNKNOWN.</summary>
+    [Fact]
+    public void AbsentDelayDirectoryStaysAWalkedAnswer()
+    {
+        var info = SksePluginReader.ReadBytes("plain.dll", Image(ImportRva, ImportSize, 0, 0));
+
+        Assert.Equal(new[] { "kernel32.dll" }, info.Imports);
+    }
+
+    /// <summary>A DLL importing nothing at all: both directories absent, so the walk succeeds and says empty. Pins that
+    /// "walked, genuinely empty" survives the refusal, since it is the answer the refusal must not swallow.</summary>
+    [Fact]
+    public void ImageWithNoDirectoriesImportsNothing()
+    {
+        var info = SksePluginReader.ReadBytes("bare.dll", Image(0, 0, 0, 0));
+
+        Assert.Empty(info.Imports!);
+    }
+
+    // ── the synthetic image ──────────────────────────────────────────────────────────────────────────────────────
+
+    const int HeaderBytes = 0x200;      // SizeOfHeaders, one file-alignment unit
+    const int SectionRva = 0x1000;      // the one section, .rdata
+    const int SectionBytes = 0x200;
+
+    const int ImportRva = SectionRva + 0x000;    // IMAGE_IMPORT_DESCRIPTOR[2]: one entry + the all-zero terminator
+    const int ImportSize = 40;                   // 2 * 20
+    const int DelayRva = SectionRva + 0x040;     // ImgDelayDescr[2]: one entry + terminator
+    const int DelaySize = 64;                    // 2 * 32
+    const int Kernel32Rva = SectionRva + 0x0C0;
+    const int DebugCrtRva = SectionRva + 0x100;
+
+    /// <summary>A minimal x64 PE image declaring the two import directories at the given RVA/Size. The tables and their
+    /// name strings are always written; only what the header declares about them varies, which is exactly the axis
+    /// under test.</summary>
+    static byte[] Image(int importRva, int importSize, int delayRva, int delaySize)
+    {
+        var img = new byte[HeaderBytes + SectionBytes];
+
+        img[0] = (byte)'M'; img[1] = (byte)'Z';
+        const int PeSig = 0x80;
+        U32(img, 0x3C, PeSig);                       // e_lfanew
+        img[PeSig] = (byte)'P'; img[PeSig + 1] = (byte)'E';
+
+        int coff = PeSig + 4;
+        U16(img, coff + 0x00, 0x8664);               // Machine = AMD64
+        U16(img, coff + 0x02, 1);                    // NumberOfSections
+        U16(img, coff + 0x10, 0xF0);                 // SizeOfOptionalHeader (PE32+ with 16 directories)
+        U16(img, coff + 0x12, 0x2022);               // EXECUTABLE_IMAGE | LARGE_ADDRESS_AWARE | DLL
+
+        int opt = coff + 20;
+        U16(img, opt + 0x00, 0x20B);                 // PE32+
+        U32(img, opt + 0x20, 0x1000);                // SectionAlignment
+        U32(img, opt + 0x24, 0x200);                 // FileAlignment
+        U16(img, opt + 0x30, 6);                     // MajorSubsystemVersion
+        U32(img, opt + 0x38, 0x2000);                // SizeOfImage
+        U32(img, opt + 0x3C, HeaderBytes);           // SizeOfHeaders
+        U16(img, opt + 0x44, 3);                     // Subsystem = CONSOLE
+        U32(img, opt + 0x6C, 16);                    // NumberOfRvaAndSizes
+
+        int dirs = opt + 0x70;
+        U32(img, dirs + 1 * 8, (uint)importRva);     // IMAGE_DIRECTORY_ENTRY_IMPORT
+        U32(img, dirs + 1 * 8 + 4, (uint)importSize);
+        U32(img, dirs + 13 * 8, (uint)delayRva);     // IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT
+        U32(img, dirs + 13 * 8 + 4, (uint)delaySize);
+
+        int sec = opt + 0xF0;
+        Ascii(img, sec, ".rdata");
+        U32(img, sec + 0x08, SectionBytes);          // VirtualSize
+        U32(img, sec + 0x0C, SectionRva);            // VirtualAddress
+        U32(img, sec + 0x10, SectionBytes);          // SizeOfRawData
+        U32(img, sec + 0x14, HeaderBytes);           // PointerToRawData
+        U32(img, sec + 0x24, 0x40000040);            // CNT_INITIALIZED_DATA | MEM_READ
+
+        U32(img, At(ImportRva) + 0x0C, Kernel32Rva); // IMAGE_IMPORT_DESCRIPTOR.Name
+        U32(img, At(DelayRva) + 0x00, 1);            // ImgDelayDescr.Attributes, bit0 = RvaBased
+        U32(img, At(DelayRva) + 0x04, DebugCrtRva);  // ImgDelayDescr.DllName
+        Ascii(img, At(Kernel32Rva), "kernel32.dll");
+        Ascii(img, At(DebugCrtRva), "vcruntime140d.dll");
+        return img;
+    }
+
+    /// <summary>File offset of an RVA inside the one section.</summary>
+    static int At(int rva) => HeaderBytes + rva - SectionRva;
+
+    static void U16(byte[] b, int off, ushort v) => BinaryPrimitives.WriteUInt16LittleEndian(b.AsSpan(off), v);
+    static void U32(byte[] b, int off, uint v) => BinaryPrimitives.WriteUInt32LittleEndian(b.AsSpan(off), v);
+    static void Ascii(byte[] b, int off, string s) => Encoding.ASCII.GetBytes(s).CopyTo(b.AsSpan(off));
+}

--- a/src/housecarl-mcp-tests/SkseImportDirectoryBoundTests.cs
+++ b/src/housecarl-mcp-tests/SkseImportDirectoryBoundTests.cs
@@ -10,7 +10,9 @@ namespace HousecarlMcpTests;
 /// delay-import set was dropped and the read still reported success — a complete-looking "imports (N): …" missing the
 /// very names the Debug-CRT verdict is built on (#416). Synthetic PEs, because the shape is a header field: the image
 /// below is the minimum <see cref="System.Reflection.PortableExecutable.PEReader"/> will open, with one .rdata section
-/// carrying a real import descriptor table, a real delay-load descriptor table, and the two name strings.</summary>
+/// carrying a real import descriptor table, a real delay-load descriptor table, and the two name strings. The same
+/// image serves the sibling drop at the bottom: a VA-based delay descriptor, which used to be skipped the same
+/// way.</summary>
 [Trait("tier", "unit")]
 public sealed class SkseImportDirectoryBoundTests
 {
@@ -68,6 +70,28 @@ public sealed class SkseImportDirectoryBoundTests
         Assert.Empty(info.Imports!);
     }
 
+    /// <summary>The sibling drop, in the same walk: a delay descriptor with Attributes bit0 clear is VA-based, and its
+    /// name field is an absolute address. That is resolvable — VA minus the image base is what the loader does — so it
+    /// must be read, not skipped past into a list that renders as the whole truth.</summary>
+    [Fact]
+    public void VaBasedDelayDescriptorIsResolvedAgainstTheImageBase()
+    {
+        var info = SksePluginReader.ReadBytes("va.dll", Image(ImportRva, ImportSize, DelayRva, DelaySize, delayAttributes: 0, imageBase: 0x400000));
+
+        Assert.Equal(new[] { "kernel32.dll", "vcruntime140d.dll" }, info.Imports);
+        Assert.Equal(new[] { "vcruntime140d.dll" }, SksePluginReader.DebugCrtImportsOf(info));
+    }
+
+    /// <summary>The same VA-based table under a 64-bit image base, which a 32-bit name field cannot express, so the
+    /// address lands outside the image. Unresolvable is UNKNOWN here, never a silently short list.</summary>
+    [Fact]
+    public void VaBasedDelayDescriptorOutsideTheImageAnswersUnknown()
+    {
+        var info = SksePluginReader.ReadBytes("va.dll", Image(ImportRva, ImportSize, DelayRva, DelaySize, delayAttributes: 0));
+
+        Assert.Null(info.Imports);
+    }
+
     // ── the synthetic image ──────────────────────────────────────────────────────────────────────────────────────
 
     const int HeaderBytes = 0x200;      // SizeOfHeaders, one file-alignment unit
@@ -83,8 +107,9 @@ public sealed class SkseImportDirectoryBoundTests
 
     /// <summary>A minimal x64 PE image declaring the two import directories at the given RVA/Size. The tables and their
     /// name strings are always written; only what the header declares about them varies, which is exactly the axis
-    /// under test.</summary>
-    static byte[] Image(int importRva, int importSize, int delayRva, int delaySize)
+    /// under test. <paramref name="delayAttributes"/> and <paramref name="imageBase"/> pick how the delay table
+    /// addresses its name: bit0 set is an RVA, clear is the absolute address a VA-based table would carry.</summary>
+    static byte[] Image(int importRva, int importSize, int delayRva, int delaySize, uint delayAttributes = 1, ulong imageBase = 0x180000000)
     {
         var img = new byte[HeaderBytes + SectionBytes];
 
@@ -101,6 +126,7 @@ public sealed class SkseImportDirectoryBoundTests
 
         int opt = coff + 20;
         U16(img, opt + 0x00, 0x20B);                 // PE32+
+        U64(img, opt + 0x18, imageBase);             // ImageBase, what a VA-based delay name is measured from
         U32(img, opt + 0x20, 0x1000);                // SectionAlignment
         U32(img, opt + 0x24, 0x200);                 // FileAlignment
         U16(img, opt + 0x30, 6);                     // MajorSubsystemVersion
@@ -124,8 +150,9 @@ public sealed class SkseImportDirectoryBoundTests
         U32(img, sec + 0x24, 0x40000040);            // CNT_INITIALIZED_DATA | MEM_READ
 
         U32(img, At(ImportRva) + 0x0C, Kernel32Rva); // IMAGE_IMPORT_DESCRIPTOR.Name
-        U32(img, At(DelayRva) + 0x00, 1);            // ImgDelayDescr.Attributes, bit0 = RvaBased
-        U32(img, At(DelayRva) + 0x04, DebugCrtRva);  // ImgDelayDescr.DllName
+        uint delayName = (delayAttributes & 1) != 0 ? (uint)DebugCrtRva : (uint)(imageBase + (ulong)DebugCrtRva);
+        U32(img, At(DelayRva) + 0x00, delayAttributes);  // ImgDelayDescr.Attributes, bit0 = RvaBased
+        U32(img, At(DelayRva) + 0x04, delayName);        // ImgDelayDescr.DllName
         Ascii(img, At(Kernel32Rva), "kernel32.dll");
         Ascii(img, At(DebugCrtRva), "vcruntime140d.dll");
         return img;
@@ -136,5 +163,6 @@ public sealed class SkseImportDirectoryBoundTests
 
     static void U16(byte[] b, int off, ushort v) => BinaryPrimitives.WriteUInt16LittleEndian(b.AsSpan(off), v);
     static void U32(byte[] b, int off, uint v) => BinaryPrimitives.WriteUInt32LittleEndian(b.AsSpan(off), v);
+    static void U64(byte[] b, int off, ulong v) => BinaryPrimitives.WriteUInt64LittleEndian(b.AsSpan(off), v);
     static void Ascii(byte[] b, int off, string s) => Encoding.ASCII.GetBytes(s).CopyTo(b.AsSpan(off));
 }


### PR DESCRIPTION
`ReadImportNames` walks the PE import and delay-import directories bounded by the Size the header declares for each — that bound is the only thing stopping an unterminated table from reading on into adjacent `.rdata` and inventing descriptors. It treated `Size == 0` as "directory absent" and returned success, so a directory with a non-zero RVA and a zero Size had its whole table skipped while the walk still reported a clean result. The remaining names rendered as a complete `imports (N): …`, and `DebugCrtBlocker` over that list returned a clean bill of health for a DLL whose dropped delay imports could have been the debug CRT — the one silent partial in a method that answers UNKNOWN everywhere else. Now a declared RVA with no Size fails the walk like every other parse failure there, so the DLL reads `imports: UNKNOWN`. `RVA == 0` is unchanged: that is genuine absence, and refusing it would turn every DLL that delay-imports nothing into an UNKNOWN.

Closes #416.

## The specimen the issue was waiting on

The issue deferred the fix because refusing on `rva != 0 && size == 0` "might reject legal images" — the loader walks to the null terminator and treats Size as informational — and said the `297/297 walked · 0 UNKNOWN` evidence counted walk success, not whether delay imports were seen. That is measurable rather than undecidable, so I measured it on this machine: 3,598 PE images in `System32` and the 323 SKSE plugin DLLs in the ARR 2.0 modlist, 1,748 of which declare a delay-import directory at all (1,745 + 3). **Zero** carry the `rva != 0 && size == 0` shape, in either directory. No legal image in the population houseCARL reads is rejected by this. (Incidentally: only 3 of the 323 SKSE plugins declare a delay-import directory, which is why the old walk-success evidence could not have caught this.)

Because no real image has the shape, the tests build the PE bytes instead: a minimal x64 image with one `.rdata` section carrying a real import descriptor table, a real delay-load descriptor table, and their two name strings, so only what the header declares about them varies. Five cases — the well-formed delay directory (which imports `vcruntime140d.dll`, i.e. exactly what the silent drop was hiding from the debug-CRT check), the same directory with Size zeroed, the same shape on the ordinary import directory, an absent delay directory, and an image importing nothing. The two zero-Size cases fail on `main` with `["kernel32.dll"]` instead of null; the other three pass either way and are there to pin the refusal's edge — they fail against the naive `dirSize == 0 || dirRva == 0 → false`.

## Not done here

There is a third option the issue did not name: on `Size == 0`, walk the table to its null terminator bounded by the section remainder instead of refusing. That would answer instead of degrade, and the existing terminator and `MaxDescriptors` checks would still make a genuinely unterminated table loud. I did not take it — it drops the header bound this method deliberately keeps, and with zero specimens in ~3,900 images there is nothing to justify the extra surface. Worth an issue if a specimen ever does turn up.

## Run

`dotnet build housecarl.sln -c Release` clean; `dotnet test src/housecarl-mcp-tests -c Release --no-build --filter "tier!=bridge"` 1794/1794; `ci-all` 127/127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
