### PR TITLE
Build a constructor-argument arm from the compose's own fields

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -47,6 +47,13 @@ saying it sets an expectation their install may contradict. Say what is known, a
   before anything is written, naming the field to add and listing the type's constructors — as is the same value put
   in a nested `sets` entry, which runs against the already-built value and so cannot reach the constructor.
 
+- **A compose that names a field it cannot write is refused before anything is written.** A read-only field named in
+  a compose's `fields` — a condition arm's `Function`, an archetype's `AssociationKey`, and the discriminator of any
+  arm that fixes one — passed pre-flight and then threw mid-apply, reported as an internal inconsistency. It is now
+  refused up front, in the same words a Set on that field gets: the value is fixed by which arm was named, so drop
+  the field or name a different arm. A field the type's constructor carries is still accepted, because that is the
+  one the constructor writes.
+
 - **A SkyPatcher INI can be checked before it is placed in a mod.** `housecarl_records`'s overlay pole takes a
   draft file: `source={"overlay": "skypatcher", "state": "post", "ini": "<absolute path to a draft .ini>",
   "subfolder": "weapon"}` reads the record as the game would see it once that draft is placed — the live layer

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -37,6 +37,15 @@ saying it sets an expectation their install may contradict. Say what is known, a
   two-target lookup could be un-merged back into per-target answers under one form and not under another. All of
   them now carry it, on text, on json, and in a `to_file=` artifact's rows. A single-target `references=` still
   adds no column, for the reason it never did: there is nothing to un-merge.
+- **A polymorphic arm whose value is built by its constructor can now be composed from scratch.** Mutagen models a
+  MagicEffect's plain `MagicEffectArchetype` with one constructor, `MagicEffectArchetype(TypeEnum)`, and no
+  parameterless one, so `compose={"type": "MagicEffectArchetype", "fields": {"Type": "Script"}}` was accepted by
+  pre-flight and then threw at apply — a Script-archetype effect could be had only by forwarding one that already
+  existed. A compose now builds such a type from its own `fields`: a field naming a constructor parameter (matched
+  without regard to case, so `Type` supplies the `type` parameter) is passed to the constructor and not set again
+  afterwards. `ctor_args` still supplies the same values positionally. A compose that names none of them is refused
+  before anything is written, naming the field to add and listing the type's constructors — as is the same value put
+  in a nested `sets` entry, which runs against the already-built value and so cannot reach the constructor.
 
 - **A SkyPatcher INI can be checked before it is placed in a mod.** `housecarl_records`'s overlay pole takes a
   draft file: `source={"overlay": "skypatcher", "state": "post", "ini": "<absolute path to a draft .ini>",

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -1039,6 +1039,12 @@ public sealed class CorpusRulebook
             if (CheckValue(af.Type, f.Value, $"'{f.Key}' on '{spec.Type}'",
                     af.MutableTypeAssemblyQualified ?? af.GetterTypeAssemblyQualified) is { } e) return e;
         }
+        // With no ctor_args the type still has to be BUILDABLE: either it has a parameterless constructor, or the
+        // fields just checked satisfy one of its constructors (a discriminator arm). WriteEngine.TryRecognizeInstantiable
+        // calls the very method BuildStruct instantiates through, so gate and apply cannot drift. Runs AFTER the field
+        // loop so a field that is misspelled or won't coerce is reported as itself, not as a missing constructor arg.
+        if (spec.CtorArgs is null && WriteEngine.TryRecognizeInstantiable(spec.Type, spec.Fields) is { } buildErr)
+            return buildErr;
         foreach (var s in spec.Sets ?? new())
             // siblingEditorIds threads through — a same-call @editorid ref inside a COMPOSED struct's nested Sets
             // (e.g. a VMAD quest-fragment's Property.Object=@<own quest>) validates by the SAME gates as a top-level

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -1012,10 +1012,19 @@ public sealed class CorpusRulebook
         // before the per-field checks. Skipped when CtorArgs is null (the parameterless/fields-only compose path).
         if (spec.CtorArgs is { } ctorArgs && WriteEngine.TryRecognizeCtorArgs(spec.Type, ctorArgs) is { } ctorErr)
             return ctorErr;
+        // The fields BuildStruct hands to the constructor instead of setting — legal to name even when the property
+        // has no setter, and only on the no-ctor_args lane, which is exactly when BuildStruct skips them.
+        var ctorCarried = spec.CtorArgs is null
+            ? WriteEngine.CtorConsumedFields(spec.Type, spec.Fields)
+            : (IReadOnlySet<string>)new HashSet<string>();
         foreach (var f in spec.Fields ?? new())
         {
             var af = structSchema.Fields.FirstOrDefault(x => x.Name == f.Key);
             if (af is null) return FieldNotFound(structSchema, f.Key);
+            // A field the apply cannot set is refused HERE, not thrown mid-apply: BuildStruct's field pass rejects a
+            // read-only property, and a discriminator on an arm (Condition data's Function, an arm's AssociationKey)
+            // is the natural thing to copy out of a read and back into a compose.
+            if (!af.Writable && !ctorCarried.Contains(f.Key)) return WritabilityRejection(structSchema, af);
             // A '@editorid' same-call reference in a compose FIELD (the VMAD alias-fragment
             // Property.Object=@<the quest itself> shape) — legal on a singular FORMLINK field in CREATE context only,
             // mirroring the top-level singular-value gate exactly (formlink-only + declared-earlier-or-self); the

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -2320,7 +2320,9 @@ public static class WriteEngine
         // ctor_args were given — the caller names the discriminator as a field, which is the natural spelling and the
         // one the discriminator refusal already sends them to.
         var fromFields = spec.CtorArgs is null ? CtorArgsFromFields(type, spec.Fields) : null;
-        var instance = Instantiate(type, spec.CtorArgs ?? fromFields?.Args);
+        // The constructor CtorArgsFromFields chose is the one invoked — not one re-derived from the arg count, which
+        // would pick a different overload of the same arity than the gate validated.
+        var instance = fromFields is { } ff ? Instantiate(ff.Ctor, ff.Args) : Instantiate(type, spec.CtorArgs);
         foreach (var (name, val) in spec.Fields ?? new())
         {
             // A field the constructor already carried is not re-set: it is written, and on an arm whose discriminator
@@ -2451,13 +2453,24 @@ public static class WriteEngine
             var ctor = t.GetConstructors().FirstOrDefault(c => c.GetParameters().Length == ctorArgs.Length)
                 ?? throw new InvalidOperationException(
                     $"{t.Name}: no constructor taking {ctorArgs.Length} arg(s). Ctors: {CtorList(t)}");
-            var ps = ctor.GetParameters();
-            return ctor.Invoke(ps.Select((p, i) => Coerce(ctorArgs[i], p.ParameterType)).ToArray());
+            return Instantiate(ctor, ctorArgs);
         }
         var paramless = t.GetConstructor(Type.EmptyTypes);
         if (paramless is not null) return paramless.Invoke(null);
         return InstantiateComposition(t);
     }
+
+    /// <summary>Invoke ONE already-chosen constructor with positional string args, each coerced to its parameter
+    /// type. Taking the <see cref="ConstructorInfo"/> rather than re-selecting it by arity is what makes the
+    /// fields-lane gate and apply the same choice: two overloads of the same arity are two different builds, and
+    /// arity alone cannot tell them apart.</summary>
+    static object Instantiate(ConstructorInfo ctor, string[] args) =>
+        ctor.Invoke(ctor.GetParameters().Select((p, i) => Coerce(args[i], p.ParameterType)).ToArray());
+
+    /// <summary>Build a type from the constructor its own compose fields satisfy, or null when none does — the seam
+    /// <see cref="BuildStruct"/>'s no-<c>ctor_args</c> lane is made of (choose a constructor, invoke THAT one).</summary>
+    internal static object? BuildFromFieldConstructor(Type t, IReadOnlyDictionary<string, string>? fields) =>
+        CtorArgsFromFields(t, fields) is { } ff ? Instantiate(ff.Ctor, ff.Args) : null;
 
     /// <summary>Recognition-only mirror of <see cref="Instantiate"/>'s ctor-args path — the write pre-flight gate's twin
     /// of the apply-time ctor build. Does this struct type have a constructor of the supplied arity, and does each
@@ -2491,10 +2504,12 @@ public static class WriteEngine
     /// (<c>MagicEffectArchetype(TypeEnum)</c>). Recognised by the missing parameterless ctor, never by type name.
     /// Picks the SMALLEST public constructor whose every parameter is named by a supplied field (matched
     /// case-insensitively, so the parameter <c>type</c> is satisfied by the field <c>Type</c>) and whose value
-    /// coerces; returns those args in positional order together with the field names it consumed, or null when no
-    /// constructor is satisfied. Reads nothing and builds nothing, so the pre-flight gate calls the same method the
-    /// apply does and the two cannot drift.</summary>
-    static (string[] Args, HashSet<string> Consumed)? CtorArgsFromFields(Type t, IReadOnlyDictionary<string, string>? fields)
+    /// coerces; returns THAT constructor with its args in positional order and the field names it consumed, or null
+    /// when no constructor is satisfied. The chosen <see cref="ConstructorInfo"/> travels with the args because the
+    /// args alone do not identify it — two overloads of the same arity would let the apply invoke one the gate never
+    /// validated. Reads nothing and builds nothing, so the pre-flight gate calls the same method the apply does and
+    /// the two cannot drift.</summary>
+    static (ConstructorInfo Ctor, string[] Args, HashSet<string> Consumed)? CtorArgsFromFields(Type t, IReadOnlyDictionary<string, string>? fields)
     {
         if (t.GetConstructor(Type.EmptyTypes) is not null || fields is not { Count: > 0 }) return null;
         foreach (var ctor in t.GetConstructors().Where(c => c.GetParameters().Length > 0)
@@ -2511,7 +2526,7 @@ public static class WriteEngine
                 args[i] = fields[named];
                 consumed.Add(named);
             }
-            if (ok) return (args, consumed);
+            if (ok) return (ctor, args, consumed);
         }
         return null;
     }

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -2472,6 +2472,22 @@ public static class WriteEngine
     internal static object? BuildFromFieldConstructor(Type t, IReadOnlyDictionary<string, string>? fields) =>
         CtorArgsFromFields(t, fields) is { } ff ? Instantiate(ff.Ctor, ff.Args) : null;
 
+    /// <summary>The compose FIELDS a constructor carries, for a compose with no <c>ctor_args</c> — the names
+    /// <see cref="BuildStruct"/> passes to the constructor and then skips in its field pass. The pre-flight gate asks
+    /// this so it skips the same ones: a constructor-carried field is written by the constructor, so it is legal even
+    /// where the property itself has no setter. Empty for every other compose, which is exactly when BuildStruct
+    /// skips nothing.</summary>
+    internal static IReadOnlySet<string> CtorConsumedFields(string structTypeName, IReadOnlyDictionary<string, string>? fields)
+    {
+        try
+        {
+            return CtorArgsFromFields(ResolveStructType(structTypeName), fields)?.Consumed ?? NoConsumedFields;
+        }
+        catch { return NoConsumedFields; }                        // unknown type — ResolveStructType says so at apply
+    }
+
+    static readonly HashSet<string> NoConsumedFields = new(StringComparer.Ordinal);
+
     /// <summary>Recognition-only mirror of <see cref="Instantiate"/>'s ctor-args path — the write pre-flight gate's twin
     /// of the apply-time ctor build. Does this struct type have a constructor of the supplied arity, and does each
     /// supplied arg COERCE to its parameter type? Resolves the type the SAME way <see cref="BuildStruct"/> feeds

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -2316,9 +2316,16 @@ public static class WriteEngine
     static object BuildStruct(StructSpec spec)
     {
         var type = ResolveStructType(spec.Type);
-        var instance = Instantiate(type, spec.CtorArgs);
+        // A type whose every constructor takes arguments is built FROM the compose's own fields when no explicit
+        // ctor_args were given — the caller names the discriminator as a field, which is the natural spelling and the
+        // one the discriminator refusal already sends them to.
+        var fromFields = spec.CtorArgs is null ? CtorArgsFromFields(type, spec.Fields) : null;
+        var instance = Instantiate(type, spec.CtorArgs ?? fromFields?.Args);
         foreach (var (name, val) in spec.Fields ?? new())
         {
+            // A field the constructor already carried is not re-set: it is written, and on an arm whose discriminator
+            // is read-only re-setting it would throw.
+            if (fromFields?.Consumed.Contains(name) == true) continue;
             var p = ResolveProperty(type, name)
                 ?? throw new InvalidOperationException($"No field '{name}' on '{spec.Type}'");
             if (!p.CanWrite) throw new InvalidOperationException($"Field '{name}' on '{spec.Type}' is not writable");
@@ -2422,8 +2429,9 @@ public static class WriteEngine
     /// EXCLUDES the composition-residuals <c>GenderedItem&lt;T&gt;</c> / <c>Array2d&lt;T&gt;</c> (no parameterless ctor,
     /// so Instantiate routes to <see cref="InstantiateComposition"/>, which builds only gendered halves and throws for the
     /// rest) and any name ResolveStructType can't resolve. Used by the substruct-leaf compose gate so it accepts EXACTLY
-    /// what apply can build (gate==apply, by construction; no per-type list). A ctor-arg-only type is (correctly) excluded:
-    /// a substruct leaf whose whole value needs positional ctor args is not a plain compose target.</summary>
+    /// what apply can build (gate==apply, by construction; no per-type list). A ctor-arg-only type is excluded here
+    /// because this question is asked of the SCHEMA alone, with no spec in hand; whether a given compose satisfies
+    /// such a type's constructor is <see cref="TryRecognizeInstantiable"/>'s question, asked per call.</summary>
     internal static bool IsPlainComposableStruct(string? typeName)
     {
         if (typeName is null) return false;
@@ -2477,6 +2485,73 @@ public static class WriteEngine
                        $"{Pretty(ps[i].ParameterType)} (parameter '{ps[i].Name}').";
         return null;
     }
+
+    /// <summary>Positional constructor args drawn from a compose's OWN fields, for a type whose every constructor
+    /// takes arguments — a polymorphic arm carrying its discriminator in the constructor
+    /// (<c>MagicEffectArchetype(TypeEnum)</c>). Recognised by the missing parameterless ctor, never by type name.
+    /// Picks the SMALLEST public constructor whose every parameter is named by a supplied field (matched
+    /// case-insensitively, so the parameter <c>type</c> is satisfied by the field <c>Type</c>) and whose value
+    /// coerces; returns those args in positional order together with the field names it consumed, or null when no
+    /// constructor is satisfied. Reads nothing and builds nothing, so the pre-flight gate calls the same method the
+    /// apply does and the two cannot drift.</summary>
+    static (string[] Args, HashSet<string> Consumed)? CtorArgsFromFields(Type t, IReadOnlyDictionary<string, string>? fields)
+    {
+        if (t.GetConstructor(Type.EmptyTypes) is not null || fields is not { Count: > 0 }) return null;
+        foreach (var ctor in t.GetConstructors().Where(c => c.GetParameters().Length > 0)
+                              .OrderBy(c => c.GetParameters().Length))
+        {
+            var ps = ctor.GetParameters();
+            var args = new string[ps.Length];
+            var consumed = new HashSet<string>(StringComparer.Ordinal);
+            bool ok = true;
+            for (int i = 0; i < ps.Length && ok; i++)
+            {
+                var named = fields.Keys.FirstOrDefault(k => string.Equals(k, ps[i].Name, StringComparison.OrdinalIgnoreCase));
+                if (named is null || !TryCoerce(fields[named], ps[i].ParameterType, out _)) { ok = false; break; }
+                args[i] = fields[named];
+                consumed.Add(named);
+            }
+            if (ok) return (args, consumed);
+        }
+        return null;
+    }
+
+    /// <summary>The pre-flight twin of <see cref="BuildStruct"/>'s no-ctor_args instantiate: can this compose type be
+    /// built at all from the fields supplied? Null = yes (it has a parameterless ctor, or its constructor is
+    /// satisfied by the fields — the <see cref="CtorArgsFromFields"/> path, called here so gate and apply agree by
+    /// construction); else the loud message naming the constructor parameter the compose is missing. Without it a
+    /// compose of a constructor-argument arm is ACCEPTED and then throws mid-apply (#563). A type with no
+    /// argument-taking constructor at all is left alone: that is Mutagen's composition family
+    /// (<c>GenderedItem&lt;T&gt;</c>, <c>Array2d&lt;T&gt;</c>), whose gap
+    /// <see cref="InstantiateComposition"/> names in its own words. Called only when <c>spec.CtorArgs</c> is null;
+    /// supplied ctor_args are checked by <see cref="TryRecognizeCtorArgs"/> instead.</summary>
+    internal static string? TryRecognizeInstantiable(string structTypeName, IReadOnlyDictionary<string, string>? fields)
+    {
+        Type t;
+        try { t = ResolveStructType(structTypeName); }
+        catch { return null; }                                   // unknown type — ResolveStructType says so loudly at apply
+        if (t.GetConstructor(Type.EmptyTypes) is not null) return null;
+        if (CtorArgsFromFields(t, fields) is not null) return null;
+        var ctor = t.GetConstructors().Where(c => c.GetParameters().Length > 0)
+                    .OrderBy(c => c.GetParameters().Length).FirstOrDefault();
+        if (ctor is null) return null;
+        var ps = ctor.GetParameters();
+        var named = ps.Select(p => FieldNameFor(t, p)).ToList();
+        return $"compose type '{structTypeName}' has no parameterless constructor — it is built from " +
+               string.Join(" and ", ps.Select((p, i) => $"'{named[i]}' ({Pretty(p.ParameterType)})")) +
+               $", so a compose that leaves {(ps.Length == 1 ? "it" : "one")} out has nothing to build. Name " +
+               $"{string.Join(" and ", named.Select(n => $"'{n}'"))} in fields= (e.g. " +
+               $"fields={{\"{named[0]}\":\"<value>\"}}), or pass the same value(s) positionally in ctor_args. " +
+               $"Constructors on {structTypeName}: {CtorList(t)}.";
+    }
+
+    /// <summary>The FIELD name a constructor parameter is named by — the type's own property matching the parameter
+    /// case-insensitively (Mutagen's <c>type</c> parameter is the <c>Type</c> property), so the advice names what a
+    /// caller can actually pass rather than a capitalisation guess. Falls back to the parameter's own name.</summary>
+    static string FieldNameFor(Type t, ParameterInfo p) =>
+        t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(x => string.Equals(x.Name, p.Name, StringComparison.OrdinalIgnoreCase))?.Name
+        ?? p.Name ?? "arg";
 
     /// <summary>A composition type has NO parameterless ctor — it is built only from its parts. Recognised by its
     /// generic definition (the engine's normal type-recognition, like IList&lt;&gt;/FormLink&lt;&gt; — NOT a hand-listed

--- a/src/housecarl-mcp-tests/ComposeFieldWritabilityTests.cs
+++ b/src/housecarl-mcp-tests/ComposeFieldWritabilityTests.cs
@@ -1,0 +1,40 @@
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// A compose FIELD the apply cannot set. <c>BuildStruct</c>'s field pass throws on a property with no setter, and a
+/// read-only field is the natural thing to copy out of a read and back into a compose — a condition arm's
+/// <c>Function</c> is the discriminator the read shows first. Pre-flight used to check only that the field existed
+/// and that its value coerced, so the call was accepted and then threw mid-apply: the same accept-then-throw as the
+/// constructor-argument arm this PR closes, one field pass along.
+///
+/// <para>Dry runs: the shared world must stay unwritten.</para>
+/// </summary>
+[Collection("records")]
+[Trait("tier", "integration")]
+public sealed class ComposeFieldWritabilityTests : RecordsTestBase
+{
+    string ComposeConditionData(string fields) => ApplyTools.Apply(Svc,
+        ops: Je($@"[{{""formid"":""{Fid(W.MgefB)}"",""field_path"":""Conditions[0].Data"",""op"":""Set"",""compose"":{{""type"":""GetActorValueConditionData"",""fields"":{fields}}}}}]"),
+        dry_run: true);
+
+    public ComposeFieldWritabilityTests(RecordsFixture f) : base(f) { }
+
+    /// <summary>The read-only discriminator named alongside a settable field is refused at pre-flight, in the
+    /// rulebook's own words for a discriminator — not accepted and thrown at apply.</summary>
+    [Fact]
+    public void AReadOnlyComposeFieldIsRefusedBeforeAnythingIsWritten()
+    {
+        var r = ComposeConditionData(@"{""Function"":""GetActorValue"",""ActorValue"":""Destruction""}");
+
+        Refused(r, "'Function'", "discriminator");
+        Assert.DoesNotContain("the apply threw", r);
+    }
+
+    /// <summary>The same compose without it still composes — the refusal is about the one field, not the arm.</summary>
+    [Fact]
+    public void TheSameComposeWithoutThatFieldStillComposes()
+        => Served(ComposeConditionData(@"{""ActorValue"":""Destruction""}"), "Set Conditions[0].Data");
+}

--- a/src/housecarl-mcp-tests/ConstructorArgComposeTests.cs
+++ b/src/housecarl-mcp-tests/ConstructorArgComposeTests.cs
@@ -155,3 +155,41 @@ public sealed class ConstructorArgComposeWriteTests
         finally { Directory.Delete(dir, recursive: true); }
     }
 }
+
+/// <summary>
+/// WHICH constructor the fields lane picks, and whether the apply invokes that one. The chooser matches parameters
+/// by name; an apply that re-derived the constructor from the argument COUNT would agree with it only while no
+/// candidate type has two constructors of the same arity — and then build a different overload than the gate
+/// validated. Synthetic types, because the shape is about constructor overloads and not about any record.
+/// </summary>
+[Trait("tier", "unit")]
+public sealed class ConstructorSelectionTests
+{
+    // Two one-argument constructors, declared in both orders across the two types, so the test does not depend on
+    // the order reflection happens to report constructors in: whichever order that is, one of these picks wrong
+    // under arity-alone selection.
+    public sealed class IntFirst
+    {
+        public string Chosen { get; }
+        public IntFirst(int alpha) => Chosen = "alpha";
+        public IntFirst(string beta) => Chosen = "beta";
+    }
+
+    public sealed class StringFirst
+    {
+        public string Chosen { get; }
+        public StringFirst(string beta) => Chosen = "beta";
+        public StringFirst(int alpha) => Chosen = "alpha";
+    }
+
+    /// <summary>The constructor a field NAMES is the one invoked, not another of the same arity.</summary>
+    [Theory]
+    [InlineData(typeof(IntFirst))]
+    [InlineData(typeof(StringFirst))]
+    public void TheConstructorTheFieldsNameIsTheOneInvoked(Type type)
+    {
+        var built = WriteEngine.BuildFromFieldConstructor(type, new Dictionary<string, string> { ["Beta"] = "hello" });
+
+        Assert.Equal("beta", type.GetProperty("Chosen")!.GetValue(built));
+    }
+}

--- a/src/housecarl-mcp-tests/ConstructorArgComposeTests.cs
+++ b/src/housecarl-mcp-tests/ConstructorArgComposeTests.cs
@@ -1,0 +1,157 @@
+using HousecarlCore;
+using HousecarlMcp;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// Composing an arm whose type has NO parameterless constructor — a MagicEffect's plain
+/// <c>MagicEffectArchetype</c>, which Mutagen builds as <c>MagicEffectArchetype(TypeEnum)</c> and which is the only
+/// way to author a Script-archetype effect from scratch (#563). The compose used to be accepted by pre-flight and
+/// then throw at apply, leaving forking an existing effect as the only route.
+///
+/// <para>Every call here is a dry run: the shared world must stay unwritten. The round trip that proves the arm
+/// actually lands lives in <see cref="ConstructorArgComposeWriteTests"/>, which builds its own instance.</para>
+/// </summary>
+[Collection("records")]
+[Trait("tier", "integration")]
+public sealed class ConstructorArgComposeTests : RecordsTestBase
+{
+    public ConstructorArgComposeTests(RecordsFixture f) : base(f) { }
+
+    string Compose(string body) => ApplyTools.Apply(Svc,
+        ops: Je($@"[{{""formid"":""{Fid(W.MgefA)}"",""field_path"":""Archetype"",""op"":""Set"",""compose"":{{{body}}}}}]"),
+        dry_run: true);
+
+    /// <summary>The call the report made: the arm named, its constructor argument named as an ordinary field.</summary>
+    [Fact]
+    public void AnArmBuiltFromItsConstructorIsComposedByNamingThatArgumentAsAField()
+        => Served(Compose(@"""type"":""MagicEffectArchetype"",""fields"":{""Type"":""Script""}"),
+                  "Set Archetype", "MagicEffectArchetype");
+
+    /// <summary>…and it is the COMPOSE that builds it, not an accept followed by a throw. The engine labels a
+    /// gate/apply disagreement in its own words; none may appear here.</summary>
+    [Fact]
+    public void TheComposeDoesNotReachTheApplyAsAnInconsistency()
+    {
+        var r = Compose(@"""type"":""MagicEffectArchetype"",""fields"":{""Type"":""Script""}");
+        Assert.DoesNotContain("pre-flight ACCEPTED it but the apply threw", r);
+        Assert.DoesNotContain("no parameterless constructor", r);
+    }
+
+    /// <summary>Another field alongside the constructor argument is still set on the built arm.</summary>
+    [Fact]
+    public void AFieldBesideTheConstructorArgumentIsStillPartOfTheCompose()
+        => Served(Compose(@"""type"":""MagicEffectArchetype"",""fields"":{""Type"":""Script"",""ActorValue"":""Health""}"),
+                  "Set Archetype");
+
+    /// <summary>The positional lane that already worked keeps working — it is what the fields lane falls back to.</summary>
+    [Fact]
+    public void PositionalConstructorArgsStillBuildTheSameArm()
+        => Served(Compose(@"""type"":""MagicEffectArchetype"",""ctor_args"":[""Script""]"), "Set Archetype");
+
+    /// <summary>A compose that never names the constructor argument cannot be built, and is refused BEFORE anything
+    /// is written — naming the field to add.</summary>
+    [Fact]
+    public void AComposeMissingTheConstructorArgumentIsRefusedAtPreFlight()
+    {
+        var r = Compose(@"""type"":""MagicEffectArchetype"",""fields"":{""ActorValue"":""Health""}");
+        Refused(r, "no parameterless constructor", "'Type'", "fields=", "ctor_args");
+        Assert.Contains("NO patch written", r);
+    }
+
+    /// <summary>The constructor argument has to be a FIELD: nested sets run against the already-built instance, so
+    /// one there cannot supply what the constructor needs. The refusal says which slot to move it to.</summary>
+    [Fact]
+    public void TheConstructorArgumentInNestedSetsIsRefusedAndSentToFields()
+        => Refused(Compose(@"""type"":""MagicEffectArchetype"",""sets"":[{""path"":""Type"",""value"":""Script""}]"),
+                   "no parameterless constructor", "fields=");
+
+    /// <summary>An arm that HAS a parameterless constructor is untouched by any of this.</summary>
+    [Fact]
+    public void AnArmWithAParameterlessConstructorComposesAsBefore()
+        => Served(Compose(@"""type"":""MagicEffectCloakArchetype"",""fields"":{""ActorValue"":""Health""}"),
+                  "MagicEffectCloakArchetype");
+}
+
+/// <summary>
+/// What the composed arm actually IS, and what a plugin carrying it says on disk — the half the dry runs above
+/// cannot see. World-free: the write engine takes a record, and Mutagen serializes a mod to a file, so a synthetic
+/// mod is the whole world these need.
+/// </summary>
+[Trait("tier", "unit")]
+public sealed class ConstructorArgComposeWriteTests
+{
+    static MagicEffect Effect(out SkyrimMod mod)
+    {
+        mod = new SkyrimMod(new ModKey("HcCtorCompose", ModType.Plugin), SkyrimRelease.SkyrimSE);
+        var mgef = mod.MagicEffects.AddNew();
+        mgef.EditorID = "HcCtorComposeEffect";
+        return mgef;
+    }
+
+    /// <summary>The archetype's discriminator: declared on the getter interface, so the mutable class is read
+    /// through it rather than by casting to one particular arm.</summary>
+    static MagicEffectArchetype.TypeEnum ArchetypeType(IAMagicEffectArchetypeGetter archetype) => archetype.Type;
+
+    static WriteRequest SetArchetype(StructSpec arm) => new()
+    {
+        RecordType = "MagicEffect", Path = new[] { "Archetype" }, Verb = "Set", Struct = arm,
+    };
+
+    /// <summary>The constructor argument named as a field IS the discriminator on the built arm.</summary>
+    [Fact]
+    public void TheFieldNamingTheConstructorArgumentBecomesTheArmsDiscriminator()
+    {
+        var mgef = Effect(out _);
+        WriteEngine.ApplyVerb(mgef, SetArchetype(new StructSpec
+        {
+            Type = "MagicEffectArchetype", Fields = new() { ["Type"] = "Script" },
+        }));
+
+        Assert.Equal(MagicEffectArchetype.TypeEnum.Script, ArchetypeType(mgef.Archetype));
+    }
+
+    /// <summary>A field beside the constructor argument lands too — the constructor consumes its own and leaves the
+    /// rest to the ordinary field pass.</summary>
+    [Fact]
+    public void TheOtherFieldsOfSuchAComposeStillLand()
+    {
+        var mgef = Effect(out _);
+        WriteEngine.ApplyVerb(mgef, SetArchetype(new StructSpec
+        {
+            Type = "MagicEffectArchetype", Fields = new() { ["Type"] = "Script", ["ActorValue"] = "Health" },
+        }));
+
+        Assert.Equal(MagicEffectArchetype.TypeEnum.Script, ArchetypeType(mgef.Archetype));
+        Assert.Equal(ActorValue.Health, mgef.Archetype.ActorValue);
+    }
+
+    /// <summary>…and the effect written to a plugin reads back as a Script effect, which is the thing #563 could not
+    /// produce without forking one that already existed.</summary>
+    [Fact]
+    public void TheEffectSerializesAndReadsBackAsScriptArchetype()
+    {
+        var mgef = Effect(out var mod);
+        WriteEngine.ApplyVerb(mgef, SetArchetype(new StructSpec
+        {
+            Type = "MagicEffectArchetype", Fields = new() { ["Type"] = "Script" },
+        }));
+
+        var dir = Path.Combine(Path.GetTempPath(), "hc-ctor-compose-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var path = Path.Combine(dir, "HcCtorCompose.esp");
+            mod.BeginWrite.ToPath(path).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            using var back = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+            var read = Assert.Single(back.MagicEffects);
+            Assert.Equal(MagicEffectArchetype.TypeEnum.Script, read.Archetype.Type);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+}


### PR DESCRIPTION
A compose of a polymorphic arm whose type has no parameterless constructor was accepted by pre-flight and then threw at apply. Mutagen models a MagicEffect's plain `MagicEffectArchetype` with a single constructor, `MagicEffectArchetype(TypeEnum)`, so `compose={"type": "MagicEffectArchetype", "fields": {"Type": "Script"}}` reached `BuildStruct`, fell through `Instantiate` into `InstantiateComposition`, and came back as a `CompositionRequiredException` claiming the type was a `GenderedItem`/`Array2d` composition buildable only from its parts — which it is not. With no way to construct one, a Script-archetype effect could only be had by forwarding an effect that already carried one.

The fix is general and stays on the constructor, not the record type. `BuildStruct` now draws positional constructor args from the compose's OWN fields when no `ctor_args` were given: it picks the smallest public constructor every parameter of which a supplied field names (matched without regard to case, so the field `Type` supplies the parameter `type`) and whose value coerces, passes those to the constructor, and does not set them again in the field pass. Recognition is by the missing parameterless constructor, never by type name, so any arm Mutagen models this way is covered. `ctor_args` still supplies the same values positionally and is unchanged.

The gate now predicts the same thing rather than accepting and throwing: `StructSpecContents` asks `WriteEngine.TryRecognizeInstantiable`, which calls the very method the apply instantiates through, so the two cannot drift. A compose that names none of the constructor's arguments is refused before anything is written, naming the field to add and listing the type's constructors. The same value put in a nested `sets` entry is refused too — nested sets run against the already-built value, so they cannot reach the constructor.

Two things I did not change, both notes rather than diff:

- The discriminator refusal on a dotted `Archetype.Type` Set (P-DISC) is keyed on the polymorphic BASE, `AMagicEffectArchetype`, where `Type` is read-only; the live value may be a `MagicEffectArchetype`, where it is writable. That refusal is now correct advice rather than a dead end — it sends the caller to the arm Set, which works — so I left it alone.
- `CompositionRequiredException`'s message still says every no-parameterless-constructor type is a `GenderedItem`/`Array2d` composition. After this change the only path that can reach it with a constructor-argument type is `MaterializeSubstruct` on a substruct-typed leaf, and no such leaf exists in the Skyrim model, so the wording is unreachable rather than wrong in practice.

Tests: seven through the tool surface (dry runs against the shared world, so nothing is written) covering the reported call, the positional lane, the parameterless arm, and both refusals; three world-free engine tests for what the built arm IS, including a plugin written and re-read as a Script-archetype effect. Eight of the ten fail without the fix; the two that do not are the regression guards.

Run locally: `dotnet build` clean, `dotnet test --filter "tier!=bridge"` 1799/1799, `ci-all` 127/127.

Closes #563
