### PR TITLE
Say whether a no-field read is a typo or an unmodeled field

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -2553,6 +2553,14 @@ offset, paging meant slicing by `editorid_contains`. Now:
   record's, which the summary already spells with its editorid — is not annotated with itself. An element with two
   or more FormLink fields still renders as a bare `[Type]` and so shows no FormID to annotate, for the reason it
   already gives.
+- **A `project.fields` path that names no field says which kind of miss it is.** A field the record type does not
+  model and a mistyped name both read as `(no field X)`, and they need opposite next moves. The note now says
+  which, from the generated schema: a name Mutagen models on other types is told so, with how many and the first
+  few of them, and that it is just not on this type — so `VirtualMachineAdapter` on a Spell reads as a Mutagen
+  coverage limit rather than a spelling to fix. A name no modeled type carries is called mistyped and offered the
+  nearest field on the record, including the exact spelling where only the case differs. Where the corpus is not
+  built the note stays the bare `(no field X)` it was. The `where=` lane's own accounting for the same dead-end is
+  unchanged.
 
 ## 1.9.0 — 2026-07-17
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -2557,9 +2557,12 @@ offset, paging meant slicing by `editorid_contains`. Now:
   model and a mistyped name both read as `(no field X)`, and they need opposite next moves. The note now says
   which, from the generated schema: a name Mutagen models on other types is told so, with how many and the first
   few of them, and that it is just not on this type — so `VirtualMachineAdapter` on a Spell reads as a Mutagen
-  coverage limit rather than a spelling to fix. A name no modeled type carries is called mistyped and offered the
-  nearest field on the record, including the exact spelling where only the case differs. Where the corpus is not
-  built the note stays the bare `(no field X)` it was. The `where=` lane's own accounting for the same dead-end is
+  coverage limit rather than a spelling to fix. A name the record type spells differently only in case is called
+  mistyped and given that spelling, ahead of anything else the schema carries under the casing typed — `DATA` at a
+  WEAP is xEdit's spelling of the field Mutagen calls `Data`, and a real field name on `DialogResponses` besides.
+  A name no modeled type carries is called mistyped and offered the nearest field on the record. Where the corpus
+  is not built, or the path dead-ends on something the catalogue does not model at all (a `FormLink`, a string),
+  the note stays the bare `(no field X)` it was. The `where=` lane's own accounting for the same dead-end is
   unchanged.
 
 ## 1.9.0 — 2026-07-17

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -2557,7 +2557,9 @@ offset, paging meant slicing by `editorid_contains`. Now:
   model and a mistyped name both read as `(no field X)`, and they need opposite next moves. The note now says
   which, from the generated schema: a name Mutagen models on other types is told so, with how many and the first
   few of them, and that it is just not on this type — so `VirtualMachineAdapter` on a Spell reads as a Mutagen
-  coverage limit rather than a spelling to fix. A name the record type spells differently only in case is called
+  coverage limit rather than a spelling to fix. Where the record type carries a near field of its own the note
+  names that too and does not call the name right: `Effect` at a SPEL is modeled elsewhere and still the caller's
+  spelling of `Effects`. A name the record type spells differently only in case is called
   mistyped and given that spelling, ahead of anything else the schema carries under the casing typed — `DATA` at a
   WEAP is xEdit's spelling of the field Mutagen calls `Data`, and a real field name on `DialogResponses` besides.
   A name no modeled type carries is called mistyped and offered the nearest field on the record. Where the corpus

--- a/src/housecarl-core/ModeledFieldIndex.cs
+++ b/src/housecarl-core/ModeledFieldIndex.cs
@@ -20,8 +20,10 @@ public static class ModeledFieldIndex
 {
     /// <summary>What the schema says about a name that would not resolve on <c>OwnerType</c>.
     /// <para><see cref="OnOwner"/> true means the catalog DOES list the field on the owner type — the walk and the
-    /// schema disagree, which is a defect to name rather than a diagnosis to give.</para></summary>
-    public readonly record struct Verdict(bool OnOwner, IReadOnlyList<string> ModeledOn, string? Near);
+    /// schema disagree, which is a defect to name rather than a diagnosis to give.</para>
+    /// <para><see cref="NearIsCaseSlip"/> true means <see cref="Near"/> is the owner's own spelling of the very
+    /// name asked for, differing only in case — a certainty about the owner, not the nearest-name guess.</para></summary>
+    public readonly record struct Verdict(bool OnOwner, IReadOnlyList<string> ModeledOn, string? Near, bool NearIsCaseSlip);
 
     /// <summary>One slot, keyed by the corpus path it was built from. <c>CorpusRulebook.CorpusPath</c> is a
     /// process-global the probes and test worlds repoint at their own generated corpus, so a flat cache would
@@ -53,20 +55,22 @@ public static class ModeledFieldIndex
             var on = idx.ByField.TryGetValue(field, out var types) ? types : Array.Empty<string>();
             bool onOwner = on.Contains(owner, StringComparer.Ordinal);
             var others = onOwner ? on.Where(t => !string.Equals(t, owner, StringComparison.Ordinal)).ToArray() : on;
-            return new Verdict(onOwner, others, onOwner ? null : NearestOn(idx.ByType, owner, field));
+            var (near, caseSlip) = onOwner ? default : NearestOn(idx.ByType, owner, field);
+            return new Verdict(onOwner, others, near, caseSlip);
         });
     }
 
-    /// <summary>The owner type's own field that a miss most likely meant. A CASE-only difference is checked first
-    /// and answered exactly: field names are case-sensitive, and <see cref="PluginNameSuggest.Nearest"/> is
-    /// case-insensitive, so it declines the very match that explains the miss.</summary>
-    static string? NearestOn(Dictionary<string, string[]> byType, string ownerTypeName, string fieldName)
+    /// <summary>The owner type's own field that a miss most likely meant, and whether it is the CASE-only slip.
+    /// That case is checked first and answered exactly: field names are case-sensitive, and
+    /// <see cref="PluginNameSuggest.Nearest"/> is case-insensitive, so it declines the very match that explains
+    /// the miss.</summary>
+    static (string? Near, bool CaseSlip) NearestOn(Dictionary<string, string[]> byType, string ownerTypeName, string fieldName)
     {
-        if (!byType.TryGetValue(ownerTypeName, out var fields)) return null;
+        if (!byType.TryGetValue(ownerTypeName, out var fields)) return default;
         foreach (var f in fields)
-            if (string.Equals(f, fieldName, StringComparison.OrdinalIgnoreCase)) return f;
+            if (string.Equals(f, fieldName, StringComparison.OrdinalIgnoreCase)) return (f, true);
         var near = PluginNameSuggest.Nearest(fieldName, fields, 1);
-        return near.Count > 0 ? near[0] : null;
+        return near.Count > 0 ? (near[0], false) : default;
     }
 
     static (Dictionary<string, string[]> ByField, Dictionary<string, string[]> ByType)? Index()

--- a/src/housecarl-core/ModeledFieldIndex.cs
+++ b/src/housecarl-core/ModeledFieldIndex.cs
@@ -42,12 +42,15 @@ public static class ModeledFieldIndex
 
     /// <summary>What the schema knows about <paramref name="fieldName"/> not resolving on
     /// <paramref name="ownerTypeName"/> (a catalog name — <c>Ingestible</c>, not <c>IIngestibleGetter</c>).
-    /// Null when the corpus is not built or will not parse: the caller then says only what it knows, never a
-    /// guessed verdict.</summary>
+    /// Null when the corpus is not built or will not parse, and null for an owner type the catalog does not carry:
+    /// the caller then says only what it knows, never a guessed verdict.</summary>
     public static Verdict? Diagnose(string ownerTypeName, string fieldName)
     {
         var path = CorpusRulebook.CorpusPath;
         if (Index() is not { } idx) return null;
+        // A read walk lands on plenty the catalog does not model — a FormLink, a string. There is no schema there
+        // to weigh the name against, so any verdict about such an owner names a schema that does not exist.
+        if (!idx.ByType.ContainsKey(ownerTypeName)) return null;
         return Verdicts.GetOrAdd((path, ownerTypeName, fieldName), key =>
         {
             Interlocked.Increment(ref VerdictComputations);

--- a/src/housecarl-core/ModeledFieldIndex.cs
+++ b/src/housecarl-core/ModeledFieldIndex.cs
@@ -1,0 +1,99 @@
+using System.Collections.Concurrent;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// Which catalog types model a field NAME — the generated schema read the other way round, by field instead of
+/// by type.
+///
+/// A path that dead-ends on a record has two causes that need opposite next moves, and the dead-end itself
+/// cannot tell them apart: the name is MISTYPED (fix the spelling), or the name is a real Mutagen field that
+/// this record type does not carry (Mutagen models <c>VirtualMachineAdapter</c> on some record types and not
+/// others, so a scripted ALCH is invisible and there is nothing to fix in the path). Only the schema can
+/// separate them, and it separates them by construction — the set of names here is the set Mutagen models,
+/// never a hand list.
+///
+/// Lookups are ORDINAL, matching <c>WriteEngine.ResolveProperty</c>'s own case-sensitive resolve, so the index
+/// and the resolver cannot disagree about what counts as a field.
+/// </summary>
+public static class ModeledFieldIndex
+{
+    /// <summary>What the schema says about a name that would not resolve on <c>OwnerType</c>.
+    /// <para><see cref="OnOwner"/> true means the catalog DOES list the field on the owner type — the walk and the
+    /// schema disagree, which is a defect to name rather than a diagnosis to give.</para></summary>
+    public readonly record struct Verdict(bool OnOwner, IReadOnlyList<string> ModeledOn, string? Near);
+
+    /// <summary>One slot, keyed by the corpus path it was built from. <c>CorpusRulebook.CorpusPath</c> is a
+    /// process-global the probes and test worlds repoint at their own generated corpus, so a flat cache would
+    /// answer from the previous world's schema; a slot per path grows without bound across a probe run. One
+    /// slot, rebuilt when the path changes, is both correct and bounded.</summary>
+    static (string Path, Dictionary<string, string[]> ByField, Dictionary<string, string[]> ByType)? _cache;
+    static readonly object Gate = new();
+
+    /// <summary>Memoised per (corpus path, owner type, field name): a scan hits the same dead-end once per scanned
+    /// record and only the first note is kept, so the nearest-name sweep must not run per record.</summary>
+    static readonly ConcurrentDictionary<(string, string, string), Verdict> Verdicts = new();
+
+    /// <summary>How many verdicts have actually been computed — the memo's own counter, so a test can say a scan
+    /// over many records diagnoses the dead-end once.</summary>
+    internal static int VerdictComputations;
+
+    /// <summary>What the schema knows about <paramref name="fieldName"/> not resolving on
+    /// <paramref name="ownerTypeName"/> (a catalog name — <c>Ingestible</c>, not <c>IIngestibleGetter</c>).
+    /// Null when the corpus is not built or will not parse: the caller then says only what it knows, never a
+    /// guessed verdict.</summary>
+    public static Verdict? Diagnose(string ownerTypeName, string fieldName)
+    {
+        var path = CorpusRulebook.CorpusPath;
+        if (Index() is not { } idx) return null;
+        return Verdicts.GetOrAdd((path, ownerTypeName, fieldName), key =>
+        {
+            Interlocked.Increment(ref VerdictComputations);
+            var (_, owner, field) = key;
+            var on = idx.ByField.TryGetValue(field, out var types) ? types : Array.Empty<string>();
+            bool onOwner = on.Contains(owner, StringComparer.Ordinal);
+            var others = onOwner ? on.Where(t => !string.Equals(t, owner, StringComparison.Ordinal)).ToArray() : on;
+            return new Verdict(onOwner, others, onOwner ? null : NearestOn(idx.ByType, owner, field));
+        });
+    }
+
+    /// <summary>The owner type's own field that a miss most likely meant. A CASE-only difference is checked first
+    /// and answered exactly: field names are case-sensitive, and <see cref="PluginNameSuggest.Nearest"/> is
+    /// case-insensitive, so it declines the very match that explains the miss.</summary>
+    static string? NearestOn(Dictionary<string, string[]> byType, string ownerTypeName, string fieldName)
+    {
+        if (!byType.TryGetValue(ownerTypeName, out var fields)) return null;
+        foreach (var f in fields)
+            if (string.Equals(f, fieldName, StringComparison.OrdinalIgnoreCase)) return f;
+        var near = PluginNameSuggest.Nearest(fieldName, fields, 1);
+        return near.Count > 0 ? near[0] : null;
+    }
+
+    static (Dictionary<string, string[]> ByField, Dictionary<string, string[]> ByType)? Index()
+    {
+        var path = CorpusRulebook.CorpusPath;
+        lock (Gate)
+        {
+            if (_cache is { } c && c.Path == path) return (c.ByField, c.ByType);
+            Corpus corpus;
+            try { corpus = CorpusRulebook.LoadCorpus(path); }
+            catch { return null; }   // corpus not built / unparseable — say nothing rather than guess
+            var byField = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+            var byType = new Dictionary<string, string[]>(StringComparer.Ordinal);
+            // corpus.Types is ordinal-sorted, so both lists come out sorted without a sort here.
+            foreach (var (typeName, schema) in corpus.Types)
+            {
+                byType[typeName] = schema.Fields.Select(f => f.Name).ToArray();
+                foreach (var f in schema.Fields)
+                {
+                    if (!byField.TryGetValue(f.Name, out var owners)) byField[f.Name] = owners = new List<string>();
+                    if (owners.Count == 0 || owners[^1] != typeName) owners.Add(typeName);
+                }
+            }
+            var built = byField.ToDictionary(kv => kv.Key, kv => kv.Value.ToArray(), StringComparer.Ordinal);
+            _cache = (path, built, byType);
+            Verdicts.Clear();
+            return (built, byType);
+        }
+    }
+}

--- a/src/housecarl-core/ModeledFieldIndex.cs
+++ b/src/housecarl-core/ModeledFieldIndex.cs
@@ -28,8 +28,11 @@ public static class ModeledFieldIndex
     /// <summary>One slot, keyed by the corpus path it was built from. <c>CorpusRulebook.CorpusPath</c> is a
     /// process-global the probes and test worlds repoint at their own generated corpus, so a flat cache would
     /// answer from the previous world's schema; a slot per path grows without bound across a probe run. One
-    /// slot, rebuilt when the path changes, is both correct and bounded.</summary>
-    static (string Path, Dictionary<string, string[]> ByField, Dictionary<string, string[]> ByType)? _cache;
+    /// slot, rebuilt when the path changes, is both correct and bounded.
+    /// <para>Published as ONE immutable reference so a reader takes the two dictionaries and the path they were
+    /// built from together, and reads them without the gate — the build is the only thing that has to serialise.</para></summary>
+    sealed record Snapshot(string Path, Dictionary<string, string[]> ByField, Dictionary<string, string[]> ByType);
+    static volatile Snapshot? _cache;
     static readonly object Gate = new();
 
     /// <summary>Memoised per (corpus path, owner type, field name): a scan hits the same dead-end once per scanned
@@ -46,19 +49,24 @@ public static class ModeledFieldIndex
     /// the caller then says only what it knows, never a guessed verdict.</summary>
     public static Verdict? Diagnose(string ownerTypeName, string fieldName)
     {
-        var path = CorpusRulebook.CorpusPath;
         if (Index() is not { } idx) return null;
         // A read walk lands on plenty the catalog does not model — a FormLink, a string. There is no schema there
         // to weigh the name against, so any verdict about such an owner names a schema that does not exist.
         if (!idx.ByType.ContainsKey(ownerTypeName)) return null;
-        return Verdicts.GetOrAdd((path, ownerTypeName, fieldName), key =>
+        // The path comes from the snapshot, never a second read of the settable global: a repoint between the two
+        // reads would file a verdict under a corpus it was not computed from.
+        var key = (idx.Path, ownerTypeName, fieldName);
+        // The memo answers before anything is allocated — a scan dead-ends on every record it crosses.
+        if (Verdicts.TryGetValue(key, out var memo)) return memo;
+        return Verdicts.GetOrAdd(key, _ =>
         {
             Interlocked.Increment(ref VerdictComputations);
-            var (_, owner, field) = key;
-            var on = idx.ByField.TryGetValue(field, out var types) ? types : Array.Empty<string>();
-            bool onOwner = on.Contains(owner, StringComparer.Ordinal);
-            var others = onOwner ? on.Where(t => !string.Equals(t, owner, StringComparison.Ordinal)).ToArray() : on;
-            var (near, caseSlip) = onOwner ? default : NearestOn(idx.ByType, owner, field);
+            var on = idx.ByField.TryGetValue(fieldName, out var types) ? types : Array.Empty<string>();
+            bool onOwner = on.Contains(ownerTypeName, StringComparer.Ordinal);
+            var others = onOwner
+                ? on.Where(t => !string.Equals(t, ownerTypeName, StringComparison.Ordinal)).ToArray()
+                : on;
+            var (near, caseSlip) = onOwner ? default : NearestOn(idx.ByType, ownerTypeName, fieldName);
             return new Verdict(onOwner, others, near, caseSlip);
         });
     }
@@ -76,12 +84,14 @@ public static class ModeledFieldIndex
         return near.Count > 0 ? (near[0], false) : default;
     }
 
-    static (Dictionary<string, string[]> ByField, Dictionary<string, string[]> ByType)? Index()
+    static Snapshot? Index()
     {
         var path = CorpusRulebook.CorpusPath;
+        // The built snapshot never changes, so the standing one answers without the gate; only a rebuild takes it.
+        if (_cache is { } cur && cur.Path == path) return cur;
         lock (Gate)
         {
-            if (_cache is { } c && c.Path == path) return (c.ByField, c.ByType);
+            if (_cache is { } c && c.Path == path) return c;
             Corpus corpus;
             try { corpus = CorpusRulebook.LoadCorpus(path); }
             catch { return null; }   // corpus not built / unparseable — say nothing rather than guess
@@ -98,9 +108,10 @@ public static class ModeledFieldIndex
                 }
             }
             var built = byField.ToDictionary(kv => kv.Key, kv => kv.Value.ToArray(), StringComparer.Ordinal);
-            _cache = (path, built, byType);
-            Verdicts.Clear();
-            return (built, byType);
+            var snap = new Snapshot(path, built, byType);
+            _cache = snap;
+            Verdicts.Clear();   // verdicts carry their corpus in the key; dropping the old one's keeps the memo bounded
+            return snap;
         }
     }
 }

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -441,7 +441,12 @@ public static class ReadEngine
     /// <summary>A "no such field" note that, when the owner is a collection, points the caller at bracket
     /// indexing — the common <c>.0</c>-vs-<c>[0]</c> confusion (the read analog of the write pre-flight's
     /// bracket hint in <c>CorpusRulebook</c>). Brackets are how you step into a list/dict element mid-path;
-    /// a bare dotted <c>.0</c> is parsed as a field name and dead-ends here.</summary>
+    /// a bare dotted <c>.0</c> is parsed as a field name and dead-ends here.
+    /// <para>Off a collection the note says WHICH of the two dead-end causes this is — the same pair the
+    /// <c>where=</c> lane's accounting names ("a mistyped path, or a field that doesn't exist on this record
+    /// type"), which the projection lane could only state as an either/or. The verdict comes from the generated
+    /// schema (<see cref="ModeledFieldIndex"/>), so it holds for every record type Mutagen models and for none it
+    /// does not.</para></summary>
     static string NoFieldNote(object owner, string segName, string? precedingField, string[]? trailing = null)
     {
         bool ownerIsCollection = owner is System.Collections.IDictionary
@@ -451,7 +456,23 @@ public static class ReadEngine
             var pf = precedingField ?? "<field>";
             return $"{NoFieldPrefix}'{segName}': '{pf}' is a list/dict — {ListHopRemedy(owner, segName, pf, trailing)})";
         }
-        return $"{NoFieldPrefix}{segName})";
+
+        var typeName = RecordNaming.StripGetterInterface(RecordNaming.StripOverlay(owner.GetType().Name));
+        // No corpus (not built / unparseable) ⇒ the bare note. Saying less is not saying something wrong.
+        if (ModeledFieldIndex.Diagnose(typeName, segName) is not { } v) return $"{NoFieldPrefix}{segName})";
+
+        if (v.OnOwner)
+            return $"{NoFieldPrefix}{segName}: {typeName} declares '{segName}' but the read walk cannot resolve it)";
+
+        if (v.ModeledOn.Count > 0)
+        {
+            var shown = string.Join(", ", v.ModeledOn.Take(3)) + (v.ModeledOn.Count > 3 ? ", …" : "");
+            return $"{NoFieldPrefix}{segName}: not a mistyped name — Mutagen models '{segName}' on " +
+                   $"{v.ModeledOn.Count:N0} other type(s) ({shown}), just not on {typeName})";
+        }
+
+        var near = v.Near is { } n ? $"; did you mean '{n}'?" : $"; check the name against {typeName}'s schema";
+        return $"{NoFieldPrefix}{segName}: a mistyped name — Mutagen models no field '{segName}' on any type{near})";
     }
 
     /// <summary>What to actually DO about a path that dotted THROUGH a list/dict — checked against the element

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -474,8 +474,13 @@ public static class ReadEngine
         if (v.ModeledOn.Count > 0)
         {
             var shown = string.Join(", ", v.ModeledOn.Take(3)) + (v.ModeledOn.Count > 3 ? ", …" : "");
-            return $"{NoFieldPrefix}{segName}: not a mistyped name — Mutagen models '{segName}' on " +
-                   $"{v.ModeledOn.Count:N0} other type(s) ({shown}), just not on {typeName})";
+            // A name modeled elsewhere can still be THIS record's typo — 'Effect' at a Spell that spells it
+            // 'Effects' — so the owner's own near field outranks the claim, and "not a mistyped name" is kept
+            // for the case the owner offers nothing closer.
+            var lead = v.Near is null ? "not a mistyped name — Mutagen models" : "Mutagen models";
+            var alt = v.Near is { } nm ? $"; did you mean '{nm}'?" : "";
+            return $"{NoFieldPrefix}{segName}: {lead} '{segName}' on " +
+                   $"{v.ModeledOn.Count:N0} other type(s) ({shown}), just not on {typeName}{alt})";
         }
 
         var near = v.Near is { } n ? $"; did you mean '{n}'?" : $"; check the name against {typeName}'s schema";

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -464,6 +464,13 @@ public static class ReadEngine
         if (v.OnOwner)
             return $"{NoFieldPrefix}{segName}: {typeName} declares '{segName}' but the read walk cannot resolve it)";
 
+        // The owner's own spelling of the very name asked for settles it, whatever else the corpus carries under
+        // that casing: DATA is a real field name (on DialogResponses) and still a typo at a Weapon, which spells
+        // it Data. The owner's schema is the one to fix the path against.
+        if (v.NearIsCaseSlip)
+            return $"{NoFieldPrefix}{segName}: a mistyped name — field names are case-sensitive; " +
+                   $"did you mean '{v.Near}'?)";
+
         if (v.ModeledOn.Count > 0)
         {
             var shown = string.Join(", ", v.ModeledOn.Take(3)) + (v.ModeledOn.Count > 3 ? ", …" : "");

--- a/src/housecarl-mcp-tests/RecordsNoFieldNoteTests.cs
+++ b/src/housecarl-mcp-tests/RecordsNoFieldNoteTests.cs
@@ -53,6 +53,17 @@ public sealed class RecordsNoFieldNoteTests : RecordsTestBase
         Assert.DoesNotContain("not a mistyped name", r);
     }
 
+    /// <summary>A name the corpus models on other types can still be this record's typo. A Spell spells it
+    /// 'Effects' and the corpus carries the exact name 'Effect' on one other type, so the owner's own near field
+    /// is what the caller needs — not "not a mistyped name" over a one-character fix.</summary>
+    [Fact]
+    public void AnOwnerNearFieldBeatsTheModeledElsewhereClaim()
+    {
+        var r = Spell("Effect");
+        Served(r, "did you mean 'Effects'?");
+        Assert.DoesNotContain("not a mistyped name", r);
+    }
+
     /// <summary>The walk lands on values the catalog does not model at all — a FormLink is one — and the index can
     /// only speak about types it carries. Off one of those the note stays bare: a verdict there would name a
     /// schema that does not exist and tell the caller the name is right when the whole path is wrong.</summary>

--- a/src/housecarl-mcp-tests/RecordsNoFieldNoteTests.cs
+++ b/src/housecarl-mcp-tests/RecordsNoFieldNoteTests.cs
@@ -1,0 +1,64 @@
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// The projection lane's no-such-field note says WHICH of the two dead-end causes it is. A field the record type
+/// does not model (Mutagen models VirtualMachineAdapter on some record types and not others, so a scripted ALCH
+/// is invisible) and a mistyped name both used to read as a bare "(no field X)", and they need opposite next
+/// moves: nothing to fix in the path, versus fix the spelling.
+/// </summary>
+[Collection("records")]
+[Trait("tier", "integration")]
+public sealed class RecordsNoFieldNoteTests : RecordsTestBase
+{
+    public RecordsNoFieldNoteTests(RecordsFixture f) : base(f) { }
+
+    string Spell(params string[] paths) =>
+        RecordsTools.Records(Svc, formids: new[] { Fid(W.SpellA) }, project: Fields(paths));
+
+    /// <summary>Issue #528's own case, on the record type the fixture has: Mutagen models VirtualMachineAdapter on
+    /// many types and not on Spell, so the name is right and the path is not the thing to fix.</summary>
+    [Fact]
+    public void AFieldTheTypeDoesNotModelIsToldTheNameIsNotMistyped()
+    {
+        var r = Spell("VirtualMachineAdapter");
+        Served(r, "not a mistyped name", "just not on Spell");
+    }
+
+    /// <summary>A name no modeled type carries is the other cause, and is named as such.</summary>
+    [Fact]
+    public void AMistypedFieldIsToldItIsMistyped()
+    {
+        var r = Spell("Effcts");
+        Served(r, "a mistyped name", "did you mean 'Effects'?");
+        Assert.DoesNotContain("not a mistyped name", r);
+    }
+
+    /// <summary>Field names are case-sensitive, so a case-only slip is a miss — and the exact spelling is the one
+    /// thing to say about it.</summary>
+    [Fact]
+    public void ACaseOnlySlipIsOfferedTheExactSpelling() =>
+        Served(Spell("editorid"), "did you mean 'EditorID'?");
+
+    /// <summary>The types the field IS modeled on are named, not just counted, so a caller can see the name is
+    /// real. ArmorRating lives on exactly one type, which is the tightest form of that claim.</summary>
+    [Fact]
+    public void TheTypesThatDoModelTheFieldAreNamed() =>
+        Served(RecordsTools.Records(Svc, formids: new[] { Fid(W.Weapons[0]) }, project: Fields("ArmorRating")),
+               "1 other type(s) (Armor)", "just not on Weapon");
+
+    /// <summary>The verdict costs a schema lookup and a nearest-name sweep over the owner type's whole field list,
+    /// and every record in a scan dead-ends the same way — so it is computed once per (corpus, owner type, name),
+    /// not once per scanned record. The name is unique to this test so the memo is cold when it runs.</summary>
+    [Fact]
+    public void AScanComputesOneVerdictForTheWholeScan()
+    {
+        var before = HousecarlCore.ModeledFieldIndex.VerdictComputations;
+        var r = RecordsTools.Records(Svc, types: new[] { "SPEL" }, project: Fields("NoFieldMemoProbe"));
+        Served(r, "a mistyped name");
+        Assert.True(W.SpellBodies.Count > 1, "the scan must cross more than one record for this to say anything");
+        Assert.Equal(1, HousecarlCore.ModeledFieldIndex.VerdictComputations - before);
+    }
+}

--- a/src/housecarl-mcp-tests/RecordsNoFieldNoteTests.cs
+++ b/src/housecarl-mcp-tests/RecordsNoFieldNoteTests.cs
@@ -42,6 +42,17 @@ public sealed class RecordsNoFieldNoteTests : RecordsTestBase
     public void ACaseOnlySlipIsOfferedTheExactSpelling() =>
         Served(Spell("editorid"), "did you mean 'EditorID'?");
 
+    /// <summary>A case-only slip whose OTHER casing is a real field somewhere else is still a case-only slip. The
+    /// corpus models 'DATA' on DialogResponses and nowhere else, and a Weapon spells the same subrecord 'Data' —
+    /// so a caller who typed xEdit's own spelling at a WEAP must be given 'Data', not told the name is fine.</summary>
+    [Fact]
+    public void ACaseOnlySlipBeatsTheSameCasingModeledElsewhere()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.Weapons[0]) }, project: Fields("DATA"));
+        Served(r, "did you mean 'Data'?");
+        Assert.DoesNotContain("not a mistyped name", r);
+    }
+
     /// <summary>The types the field IS modeled on are named, not just counted, so a caller can see the name is
     /// real. ArmorRating lives on exactly one type, which is the tightest form of that claim.</summary>
     [Fact]

--- a/src/housecarl-mcp-tests/RecordsNoFieldNoteTests.cs
+++ b/src/housecarl-mcp-tests/RecordsNoFieldNoteTests.cs
@@ -53,6 +53,17 @@ public sealed class RecordsNoFieldNoteTests : RecordsTestBase
         Assert.DoesNotContain("not a mistyped name", r);
     }
 
+    /// <summary>The walk lands on values the catalog does not model at all — a FormLink is one — and the index can
+    /// only speak about types it carries. Off one of those the note stays bare: a verdict there would name a
+    /// schema that does not exist and tell the caller the name is right when the whole path is wrong.</summary>
+    [Fact]
+    public void AnOwnerTheCatalogDoesNotModelGetsTheBareNote()
+    {
+        var r = Spell("HalfCostPerk.Name");
+        Served(r, "(no field Name)");
+        Assert.DoesNotContain("mistyped name", r);
+    }
+
     /// <summary>The types the field IS modeled on are named, not just counted, so a caller can see the name is
     /// real. ArmorRating lives on exactly one type, which is the tightest form of that claim.</summary>
     [Fact]


### PR DESCRIPTION
On the projection lane, a `project.fields` path that named no field came back as `(no field X)` whether the
name was misspelled or was a real Mutagen field the record type does not carry. Those need opposite next moves —
fix the spelling, versus nothing in the path is wrong and the data is out of reach — so the note now says which.
The verdict comes from the generated schema, read by field name instead of by type: a name the corpus carries on
other types is not mistyped, and a name it carries nowhere is. `VirtualMachineAdapter` on a Spell now reads
"not a mistyped name — Mutagen models 'VirtualMachineAdapter' on 34 other type(s) (Activator,
AlchemicalApparatus, Armor, …), just not on Spell"; `Effcts` reads "a mistyped name … did you mean 'Effects'?".
A case-only slip (`editorid`) gets the exact spelling, which `PluginNameSuggest.Nearest` declines on its own
because it is case-insensitive and treats the match as exact.

The by-field index is its own file (`src/housecarl-core/ModeledFieldIndex.cs`) rather than more lines in
`ReadEngine.cs`. It caches one slot keyed by `CorpusRulebook.CorpusPath` — a process-global the probes and test
worlds repoint — and memoises the verdict per (corpus, owner type, name), because a scan dead-ends the same way
on every record it crosses and the nearest-name sweep walks the owner's whole field list. Where the corpus is not
built the note stays the bare `(no field X)`; saying less is not saying something wrong. The list/dict arm of
`NoFieldNote` is untouched, as is `ReadEngine.IsNoSuchFieldNote` and the `where=` lane's parsing of the note.

This is the second half of the issue only. The first half is the Mutagen gap itself — `Ingestible` models no
`VirtualMachineAdapter` — which is not code work here.

Two things noticed and left alone. `FieldPredicate.AccountingNote`'s all-records-missed sentence still states the
same either/or the projection lane no longer has to ("a mistyped path, or a field that doesn't exist on this record
type"); it could route through the same verdict, but that is the `where=` lane and the issue calls it already
handled. And nothing surfaces the Mutagen-versus-xEdit gap directly — the note can say Mutagen models a field
elsewhere, never that the game has it here.

Closes #528
