### PR TITLE
Make max_chars a ceiling on the last five records renders

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -53,6 +53,17 @@ saying it sets an expectation their install may contradict. Say what is known, a
   refused up front, in the same words a Set on that field gets: the value is fixed by which arm was named, so drop
   the field or name a different arm. A field the type's constructor carries is still accepted, because that is the
   one the constructor writes.
+- **`max_chars=` is now a ceiling on the last five `housecarl_records` text renders too.** The comparison forms
+  `delta` and `tree`, the walk lane's `chain` and reverse effect-chain renders, and `info_order` tested the
+  ceiling before the record, node or delta line they were about to write, so the block that crossed it went in
+  whole and the truncation notice and the `spilled:` block on top of that — the shape the other renders lost in
+  the change above, which named these five as the ones it did not cover. They now carry it: the notice and the
+  spill block are charged before the first record is laid, every inner list holds back the room its own cut
+  notice takes, and a record that would cross what is left is taken back out whole and counted. A record cut
+  inside itself stays, with the cut named where the caller can see it; where there is no room even to say a
+  section was cut, the whole record goes back out rather than ending in silence. The `max_chars=` parameter now
+  states the ceiling over the whole tool. As everywhere else, the result is untouched: what the ceiling holds
+  back inline is complete in the artifact the response names.
 
 - **A SkyPatcher INI can be checked before it is placed in a mod.** `housecarl_records`'s overlay pole takes a
   draft file: `source={"overlay": "skypatcher", "state": "post", "ini": "<absolute path to a draft .ini>",
@@ -216,9 +227,7 @@ saying it sets an expectation their install may contradict. Say what is known, a
   window put no row on the page at all, the accounting names both the cap to raise and the `offset=` that steps
   past the row that did not fit, which is the only knob that moves that case. A `housecarl_records` result the
   ceiling cuts still spills COMPLETE to its artifact — the ceiling bounds the render, never the answer. On
-  `housecarl_records` this covers the scan, batch, resolve, `group_by` and `summary` renders; the comparison
-  forms (`delta`, `tree`), the walk lane's chain and effect-chain renders and `info_order` still answer past
-  the cap by the block that crossed it, and the `max_chars=` parameter says so. The other case that can come
+  `housecarl_records` this covers the scan, batch, resolve, `group_by` and `summary` renders. The other case that can come
   back over the cap is a `max_chars` too small for what a response carries whatever the budget — its header,
   the alarms it owes, its accounting — and it now says so in a sentence naming the number that clears it,
   which is how you can check. An alarm is never dropped to meet the ceiling: an archive that failed to read is

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -61,9 +61,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
   spill block are charged before the first record is laid, every inner list holds back the room its own cut
   notice takes, and a record that would cross what is left is taken back out whole and counted. A record cut
   inside itself stays, with the cut named where the caller can see it; where there is no room even to say a
-  section was cut, the whole record goes back out rather than ending in silence. The `max_chars=` parameter now
-  states the ceiling over the whole tool. As everywhere else, the result is untouched: what the ceiling holds
-  back inline is complete in the artifact the response names.
+  section was cut, the whole record goes back out rather than ending in silence. Those reserves are room for
+  notices a complete render never writes, so they are charged only where the whole render does not fit: an
+  answer that fits inside the `max_chars` you passed comes back complete, uncut and unspilled. The
+  `max_chars=` parameter now states the ceiling over the whole tool. As everywhere else, the result is
+  untouched: what the ceiling holds back inline is complete in the artifact the response names.
 
 - **A SkyPatcher INI can be checked before it is placed in a mod.** `housecarl_records`'s overlay pole takes a
   draft file: `source={"overlay": "skypatcher", "state": "post", "ini": "<absolute path to a draft .ini>",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -63,8 +63,10 @@ saying it sets an expectation their install may contradict. Say what is known, a
   inside itself stays, with the cut named where the caller can see it; where there is no room even to say a
   section was cut, the whole record goes back out rather than ending in silence. Those reserves are room for
   notices a complete render never writes, so they are charged only where the whole render does not fit: an
-  answer that fits inside the `max_chars` you passed comes back complete, uncut and unspilled. The
-  `max_chars=` parameter now states the ceiling over the whole tool. As everywhere else, the result is
+  answer that fits inside the `max_chars` you passed comes back complete, uncut and unspilled. A `counts_only`
+  census is held to the ceiling as well: it carries the header's source and selection statements whatever the
+  budget, so at a `max_chars` it cannot fit in it names the number that clears it instead of coming back over
+  the cap saying nothing. The `max_chars=` parameter now states the ceiling over the whole tool. As everywhere else, the result is
   untouched: what the ceiling holds back inline is complete in the artifact the response names.
 
 - **A SkyPatcher INI can be checked before it is placed in a mod.** `housecarl_records`'s overlay pole takes a

--- a/src/housecarl-mcp-tests/DialogueFamilyTests.cs
+++ b/src/housecarl-mcp-tests/DialogueFamilyTests.cs
@@ -98,6 +98,26 @@ public sealed class DialogueFamilyTests
         Assert.Contains("spilled: complete result", r);
     }
 
+    /// <summary>And the other side: a render whose complete output fits inside max_chars IS that output. The
+    /// reserves the bounded pass holds back are room for notices a complete render never writes, so charging them
+    /// against one that fits cut an answer that fitted — which then spilled and came back short.</summary>
+    [Fact]
+    public void AnInfoOrderRenderThatFitsItsCapIsNotCutByNoticesItNeverWrites()
+    {
+        string At(int cap) => RecordsTools.Records(Svc, formids: new[] { Fid(W.Topic) },
+                                                   project: new RecordsTools.RecordsProject { form = "info_order" },
+                                                   max_chars: cap);
+        int whole = At(0).Length;
+
+        foreach (int cap in new[] { whole, whole + 1, whole + 50, whole + 140 })
+        {
+            var r = At(cap);
+            Assert.Equal(whole, r.Length);
+            Assert.DoesNotContain("spilled:", r);
+            Assert.DoesNotContain("at max_chars=", r);
+        }
+    }
+
     // ---- fact D2 --------------------------------------------------------------------------------------
     // The PNAM-zero caveat stays absent.
 

--- a/src/housecarl-mcp-tests/DialogueFamilyTests.cs
+++ b/src/housecarl-mcp-tests/DialogueFamilyTests.cs
@@ -57,6 +57,47 @@ public sealed class DialogueFamilyTests
         Assert.DoesNotContain("dropped in game", r);
     }
 
+    // ---- max_chars is a CEILING on the info_order render too (#604) ------------------------------------
+
+    /// <summary>A topic filled well past its cap comes back inside it: the truncation notice and the spilled:
+    /// block are charged before the first topic is laid, and a topic that would cross what is left is taken back
+    /// out whole and counted. The one arm that may still exceed the cap — a max_chars too small for what the
+    /// response carries whatever the budget, its spill block included — says so and names the number that clears
+    /// it, which is what the second branch below asserts.</summary>
+    [Theory]
+    [InlineData(400)]
+    [InlineData(700)]
+    [InlineData(1_600)]
+    [InlineData(2_400)]
+    [InlineData(8_000)]
+    public void AnInfoOrderRenderIsNeverWiderThanItsCap(int cap)
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.Topic) },
+                                     project: new RecordsTools.RecordsProject { form = "info_order" },
+                                     max_chars: cap);
+
+        if (r.Length <= cap) return;
+        Assert.Contains($"over the max_chars={cap} it was given", r);
+        var needed = int.Parse(Regex.Match(r, @"raise max_chars to at least (\d+)").Groups[1].Value);
+        Assert.Equal(r.Length, needed);
+    }
+
+    /// <summary>And what the cap held back is counted, not dropped in silence. The cap is derived rather than
+    /// pinned: 100 short of what the render takes uncapped is a cap it cannot hold, whatever this fixture's
+    /// topic happens to weigh.</summary>
+    [Fact]
+    public void AnInfoOrderCutByItsCapSaysHowManyTopicsItHeldBack()
+    {
+        string At(int cap) => RecordsTools.Records(Svc, formids: new[] { Fid(W.Topic) },
+                                                   project: new RecordsTools.RecordsProject { form = "info_order" },
+                                                   max_chars: cap);
+        int cap = At(0).Length - 100;
+        var r = At(cap);
+
+        Assert.Matches(@"\[rendered \d+ of 1 rows at max_chars=" + cap + @"\]", r);
+        Assert.Contains("spilled: complete result", r);
+    }
+
     // ---- fact D2 --------------------------------------------------------------------------------------
     // The PNAM-zero caveat stays absent.
 

--- a/src/housecarl-mcp-tests/DialogueFamilyTests.cs
+++ b/src/housecarl-mcp-tests/DialogueFamilyTests.cs
@@ -98,6 +98,20 @@ public sealed class DialogueFamilyTests
         Assert.Contains("spilled: complete result", r);
     }
 
+    /// <summary>The info_order census is a text render too: at a max_chars it cannot fit in it says so and names
+    /// the number that clears it, rather than answering over the cap in silence.</summary>
+    [Fact]
+    public void AnInfoOrderCensusTooBigForItsCapSaysSoAndNamesTheNumberThatClearsIt()
+    {
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.Topic) },
+                                     project: new RecordsTools.RecordsProject { form = "info_order" },
+                                     counts_only: true, max_chars: 50);
+
+        Assert.True(r.Length > 50, "the census fits 50 chars, so it cannot show the overrun arm");
+        Assert.Contains("over the max_chars=50 it was given", r);
+        Assert.Equal(r.Length, int.Parse(Regex.Match(r, @"raise max_chars to at least (\d+)").Groups[1].Value));
+    }
+
     /// <summary>And the other side: a render whose complete output fits inside max_chars IS that output. The
     /// reserves the bounded pass holds back are room for notices a complete render never writes, so charging them
     /// against one that fits cut an answer that fitted — which then spilled and came back short.</summary>

--- a/src/housecarl-mcp-tests/RecordsArtifactTests.cs
+++ b/src/housecarl-mcp-tests/RecordsArtifactTests.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using HousecarlCore;
+using Mutagen.Bethesda.Plugins;
 using System.Text.Json;
 using HousecarlMcp;
 using Xunit;
@@ -376,25 +377,36 @@ public sealed class RecordsArtifactTests : ArtifactTestBase, IClassFixture<Artif
         }
     }
 
-    /// <summary>The fourth form, which needs its own cap: the reverse effect chain's carrier rows are cut inside a
-    /// SHARED render, in a buffer this loop never measures — so unless that render says it cut, the cut is
-    /// invisible and the response neither counts the seeds nor names an artifact. At a cap the complete answer
-    /// fits inside with 100 chars to spare, a cut there still says so and still spills the complete result.</summary>
+    /// <summary>The other side of the bound: a render whose complete output fits inside max_chars IS that output.
+    /// Every reserve the bounded pass holds back is room for a notice a complete render never writes, so charging
+    /// them against one that fits cut answers that fitted — and the cut then spilled, the spill block was charged
+    /// in turn, and the answer came back with no rows at all and a number far over what the whole thing took. The
+    /// caps are derived from each render's own width, so nothing here is pinned to this fixture's weight.</summary>
     [Fact]
-    public void AReverseEffectChainCutInsideTheSharedRenderIsCountedAndSpilled()
+    public void ARenderThatFitsItsCapIsNotCutByNoticesItNeverWrites()
     {
-        string Call(int cap) =>
-            RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefA) },
-                                 walk: new RecordsTools.RecordsWalk { direction = "reverse", follow = "Effects[].BaseEffect" },
-                                 project: Form("chain"), max_chars: cap);
-
-        using var d = OwnResults("held-back-effect-chain");
-        int cap = Call(0).Length + 100;   // room to spare for the whole answer: only the shared render cuts here
-        var r = Call(cap);
-
-        Assert.Contains("at max_chars=" + cap + "]", r);          // the seeds it never reached are counted
-        Assert.Contains("spilled: complete result", r);           // and the artifact holds what went
-        InsideItsCap(r, cap, "effect chain");
+        foreach (var (name, call) in new (string, Func<int, string>)[]
+        {
+            ("delta", cap => RecordsTools.Records(Svc, types: new[] { "WEAP" }, project: Form("delta"),
+                                                  versus: Je("\"" + W.MasterName + "\""), max_chars: cap)),
+            ("tree", cap => RecordsTools.Records(Svc, types: new[] { "WEAP" }, project: Form("tree"), max_chars: cap)),
+            ("chain", cap => RecordsTools.Records(Svc, types: new[] { "SPEL" }, walk: new RecordsTools.RecordsWalk(),
+                                                  project: Form("chain"), max_chars: cap)),
+            ("effect chain", cap => RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefA) },
+                                                         walk: new RecordsTools.RecordsWalk { direction = "reverse", follow = "Effects[].BaseEffect" },
+                                                         project: Form("chain"), max_chars: cap)),
+        })
+        {
+            using var d = OwnResults("fits-" + name);
+            int whole = call(0).Length;
+            foreach (int cap in new[] { whole, whole + 1, whole + 50, whole + 140 })
+            {
+                var r = call(cap);
+                Assert.Equal(whole, r.Length);                  // the complete render, not a cut one
+                Assert.DoesNotContain("spilled:", r);           // nothing was held back, so nothing spills
+                Assert.DoesNotContain("at max_chars=", r);      // and no notice claims a loss
+            }
+        }
     }
 
     /// <summary>The one arm left: a max_chars smaller than the spill block the response must carry — the block that
@@ -1008,5 +1020,37 @@ public sealed class RecordsArtifactResultsStoreTests : IDisposable
         var orphan = Aged("half-written.jsonl.tmp-deadbeef", ResultsStore.PruneAfterDays + 1);
         ResultsStore.Release(ResultsStore.NextPath(ToolNames.Records, "0123456789abcdef"));
         Assert.False(File.Exists(orphan));
+    }
+}
+
+/// <summary>The reverse effect chain's carrier rows are cut inside a SHARED render, in a buffer the seed loop
+/// never measures — so unless that render says it cut, the cut is invisible: nothing marks the response
+/// truncated, and the pipeline writes no artifact. Driven against a hand-built result rather than through the
+/// tool because reaching that cut through the tool needs a seed wider than the auto-spill block it would then
+/// have to carry (~1 KB, three absolute paths), and no fixture's MGEF has that many carriers.</summary>
+[Trait("tier", "unit")]
+public sealed class ReverseEffectChainSharedCutTests
+{
+    static string Render(int cap, out bool truncated)
+    {
+        var rows = Enumerable.Range(0, 8).Select(i =>
+            new EffectChainRow(FormKey.Factory($"00080{i}:HcRecMaster.esm"), "Spell", "HcRecSpell" + i,
+                               "HcRecMaster.esm", 0, 1, 5f, 0, 0)).ToArray();
+        var result = new EffectChainResult(FormKey.Factory("000805:HcRecMaster.esm"), "HcRecMgefFire", rows,
+                                           rows.Length, false, null, null);
+        return RecordsTools.RenderRecordsEffectChains(new[] { ("000805:HcRecMaster.esm", result) }, 1, rows.Length,
+                                                      rows.Length, 0, "records  form=chain", null, cap, null,
+                                                      out truncated);
+    }
+
+    /// <summary>One char under what the whole render takes, so the shared render is the only thing that can cut —
+    /// and the cut it makes is what marks the response truncated, which is what the pipeline spills on.</summary>
+    [Fact]
+    public void ACutInsideTheSharedRenderMarksTheResponseTruncated()
+    {
+        var r = Render(Render(100_000, out _).Length - 1, out bool truncated);
+
+        Assert.Contains("[truncated: rendered", r);
+        Assert.True(truncated);
     }
 }

--- a/src/housecarl-mcp-tests/RecordsArtifactTests.cs
+++ b/src/housecarl-mcp-tests/RecordsArtifactTests.cs
@@ -377,6 +377,37 @@ public sealed class RecordsArtifactTests : ArtifactTestBase, IClassFixture<Artif
         }
     }
 
+    /// <summary>The census is a text render too, and the ceiling is stated over every one of them: a counts_only
+    /// response carries the header's source and selection statements whatever the budget, so at a max_chars it
+    /// cannot fit in it says so and names the number that clears it, rather than answering several times over the
+    /// cap in silence.</summary>
+    [Fact]
+    public void ACensusTooBigForItsCapSaysSoAndNamesTheNumberThatClearsIt()
+    {
+        foreach (var (name, call) in new (string, Func<int, string>)[]
+        {
+            ("scan census", cap => RecordsTools.Records(Svc, types: new[] { "SPEL" }, counts_only: true, max_chars: cap)),
+            ("list census", cap => RecordsTools.Records(Svc, formids: SummaryIds, project: Form("identity"),
+                                                        counts_only: true, max_chars: cap)),
+            ("delta census", cap => RecordsTools.Records(Svc, types: new[] { "WEAP" }, project: Form("delta"),
+                                                         versus: Je("\"" + W.MasterName + "\""), counts_only: true, max_chars: cap)),
+            ("tree census", cap => RecordsTools.Records(Svc, types: new[] { "WEAP" }, project: Form("tree"),
+                                                        counts_only: true, max_chars: cap)),
+            ("chain census", cap => RecordsTools.Records(Svc, types: new[] { "SPEL" }, walk: new RecordsTools.RecordsWalk(),
+                                                         project: Form("chain"), counts_only: true, max_chars: cap)),
+            ("reverse census", cap => RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefA) },
+                                                           walk: new RecordsTools.RecordsWalk { direction = "reverse", follow = "Effects[].BaseEffect" },
+                                                           project: Form("chain"), counts_only: true, max_chars: cap)),
+        })
+        {
+            var r = call(50);
+
+            Assert.False(r.StartsWith("error:", StringComparison.Ordinal), r);
+            Assert.True(r.Length > 50, $"the {name} fits 50 chars, so it cannot show the overrun arm");
+            InsideItsCap(r, 50, name);
+        }
+    }
+
     /// <summary>The other side of the bound: a render whose complete output fits inside max_chars IS that output.
     /// Every reserve the bounded pass holds back is room for a notice a complete render never writes, so charging
     /// them against one that fits cut answers that fitted — and the cut then spilled, the spill block was charged

--- a/src/housecarl-mcp-tests/RecordsArtifactTests.cs
+++ b/src/housecarl-mcp-tests/RecordsArtifactTests.cs
@@ -273,6 +273,109 @@ public sealed class RecordsArtifactTests : ArtifactTestBase, IClassFixture<Artif
     string[] SummaryIds => W.SpellBodies.Select(b => RecordsWorld.Fid(b.FormKey))
         .Concat(W.WeaponBodies.Select(b => RecordsWorld.Fid(b.FormKey))).ToArray();
 
+    // ---- and on the five renders #546 left out: delta, tree, chain, the reverse effect chain (#604) --------
+    //
+    // Each of these tested the ceiling BEFORE the block it was about to write, so the record, node or carrier row
+    // that crossed went in whole and the notice and the spilled: block on top of it.
+
+    /// <summary>The bound, both arms: the response is inside its cap, or it is the one arm a bounded render may
+    /// still exceed it on — a max_chars too small for what the response carries whatever the budget, its spill
+    /// block included — and it says so, naming the number that clears it in one step.</summary>
+    static void InsideItsCap(string r, int cap, string what)
+    {
+        if (r.Length <= cap) return;
+        Assert.True(r.Contains($"over the max_chars={cap} it was given", StringComparison.Ordinal),
+                    $"the {what} returned {r.Length} chars at max_chars={cap} and did not say so");
+        var needed = int.Parse(Regex.Match(r, @"raise max_chars to at least (\d+)").Groups[1].Value);
+        Assert.Equal(r.Length, needed);
+    }
+
+    [Theory]
+    [InlineData(1_200)]
+    [InlineData(2_000)]
+    [InlineData(4_000)]
+    [InlineData(20_000)]
+    public void ADeltaRenderIsNeverWiderThanItsCap(int cap)
+    {
+        using var d = OwnResults("delta-ceiling-" + cap);
+        var r = RecordsTools.Records(Svc, types: new[] { "WEAP" }, project: Form("delta"),
+                                     versus: Je("\"" + W.MasterName + "\""), max_chars: cap);
+
+        Assert.False(r.StartsWith("error:", StringComparison.Ordinal), r);
+        InsideItsCap(r, cap, "delta");
+    }
+
+    [Theory]
+    [InlineData(1_200)]
+    [InlineData(2_000)]
+    [InlineData(4_000)]
+    [InlineData(20_000)]
+    public void ATreeRenderIsNeverWiderThanItsCap(int cap)
+    {
+        using var d = OwnResults("tree-ceiling-" + cap);
+        var r = RecordsTools.Records(Svc, types: new[] { "WEAP" }, project: Form("tree"), max_chars: cap);
+
+        Assert.False(r.StartsWith("error:", StringComparison.Ordinal), r);
+        InsideItsCap(r, cap, "tree");
+    }
+
+    [Theory]
+    [InlineData(1_200)]
+    [InlineData(2_000)]
+    [InlineData(4_000)]
+    [InlineData(20_000)]
+    public void AChainRenderIsNeverWiderThanItsCap(int cap)
+    {
+        using var d = OwnResults("chain-ceiling-" + cap);
+        var r = RecordsTools.Records(Svc, types: new[] { "SPEL" }, walk: new RecordsTools.RecordsWalk(),
+                                     project: Form("chain"), max_chars: cap);
+
+        Assert.False(r.StartsWith("error:", StringComparison.Ordinal), r);
+        InsideItsCap(r, cap, "chain");
+    }
+
+    [Theory]
+    [InlineData(400)]
+    [InlineData(700)]
+    [InlineData(1_200)]
+    [InlineData(4_000)]
+    public void AReverseEffectChainRenderIsNeverWiderThanItsCap(int cap)
+    {
+        using var d = OwnResults("effect-chain-ceiling-" + cap);
+        var r = RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefA) },
+                                     walk: new RecordsTools.RecordsWalk { direction = "reverse", follow = "Effects[].BaseEffect" },
+                                     project: Form("chain"), max_chars: cap);
+
+        Assert.False(r.StartsWith("error:", StringComparison.Ordinal), r);
+        InsideItsCap(r, cap, "effect chain");
+    }
+
+    /// <summary>At a cap the render cannot hold — 100 short of what it takes uncapped, so it is derived rather
+    /// than pinned to a number that would only hold on the machine it was written on — each of the three forms
+    /// says what it held back in the caller's own max_chars, spills the complete result to its artifact, and
+    /// stays inside the ceiling or names the overrun the fixed part causes.</summary>
+    [Fact]
+    public void EachOfTheseRendersSaysWhatItsCapHeldBackAndStaysInsideIt()
+    {
+        foreach (var (name, call) in new (string, Func<int, string>)[]
+        {
+            ("delta", cap => RecordsTools.Records(Svc, types: new[] { "WEAP" }, project: Form("delta"),
+                                                  versus: Je("\"" + W.MasterName + "\""), max_chars: cap)),
+            ("tree", cap => RecordsTools.Records(Svc, types: new[] { "WEAP" }, project: Form("tree"), max_chars: cap)),
+            ("chain", cap => RecordsTools.Records(Svc, types: new[] { "SPEL" }, walk: new RecordsTools.RecordsWalk(),
+                                                  project: Form("chain"), max_chars: cap)),
+        })
+        {
+            using var d = OwnResults("held-back-" + name);
+            int cap = call(0).Length - 100;   // the whole render spills nothing; 100 short of it cannot hold
+            var r = call(cap);
+
+            Assert.Contains("at max_chars=" + cap + "]", r);          // the notice quotes what the caller passed
+            Assert.Contains("spilled: complete result", r);           // and the artifact still holds it all
+            InsideItsCap(r, cap, name);
+        }
+    }
+
     /// <summary>The one arm left: a max_chars smaller than the spill block the response must carry — the block that
     /// names the artifact holding the complete result — says so and names the cap that clears it, rather than
     /// answering over the ceiling in silence.</summary>

--- a/src/housecarl-mcp-tests/RecordsArtifactTests.cs
+++ b/src/housecarl-mcp-tests/RecordsArtifactTests.cs
@@ -376,6 +376,27 @@ public sealed class RecordsArtifactTests : ArtifactTestBase, IClassFixture<Artif
         }
     }
 
+    /// <summary>The fourth form, which needs its own cap: the reverse effect chain's carrier rows are cut inside a
+    /// SHARED render, in a buffer this loop never measures — so unless that render says it cut, the cut is
+    /// invisible and the response neither counts the seeds nor names an artifact. At a cap the complete answer
+    /// fits inside with 100 chars to spare, a cut there still says so and still spills the complete result.</summary>
+    [Fact]
+    public void AReverseEffectChainCutInsideTheSharedRenderIsCountedAndSpilled()
+    {
+        string Call(int cap) =>
+            RecordsTools.Records(Svc, formids: new[] { Fid(W.MgefA) },
+                                 walk: new RecordsTools.RecordsWalk { direction = "reverse", follow = "Effects[].BaseEffect" },
+                                 project: Form("chain"), max_chars: cap);
+
+        using var d = OwnResults("held-back-effect-chain");
+        int cap = Call(0).Length + 100;   // room to spare for the whole answer: only the shared render cuts here
+        var r = Call(cap);
+
+        Assert.Contains("at max_chars=" + cap + "]", r);          // the seeds it never reached are counted
+        Assert.Contains("spilled: complete result", r);           // and the artifact holds what went
+        InsideItsCap(r, cap, "effect chain");
+    }
+
     /// <summary>The one arm left: a max_chars smaller than the spill block the response must carry — the block that
     /// names the artifact holding the complete result — says so and names the cap that clears it, rather than
     /// answering over the ceiling in silence.</summary>

--- a/src/housecarl-mcp-tests/RecordsComparisonFormTests.cs
+++ b/src/housecarl-mcp-tests/RecordsComparisonFormTests.cs
@@ -326,3 +326,37 @@ public sealed class RecordsComparisonFormTests : RecordsTestBase
         Refused(RecordsTools.Records(Svc, formids: new[] { Fid(W.SpellA) }, fields_source: "winnner",
                                      walk: new RecordsTools.RecordsWalk()), "winnner");
 }
+
+/// <summary>What a seed says about its WALK — the cycles it recorded, the walk.max_nodes cap it hit, the
+/// TemplateFlags report — survives a max_chars cut of its node list. The two losses are on different axes, and
+/// the nodes notice's remedy (raise max_chars) does not answer a walk that stopped at its own cap. Driven against
+/// a hand-built seed: no fixture makes a capped walk with nodes enough for max_chars to cut.</summary>
+[Trait("tier", "unit")]
+public sealed class ChainSeedTailTests
+{
+    const string WalkCap = "walk truncated: the 2-node cap was reached — what is listed IS reached and proved; raise walk.max_nodes to walk further.";
+
+    static string Render(int cap)
+    {
+        var nodes = Enumerable.Range(0, 6).Select(i =>
+            new LoadOrderService.WalkNodeRow($"00080{i}:A.esm", "Weapon", "HcRecW" + i, 1, "Effects[].BaseEffect", "reached", null)).ToArray();
+        var row = new LoadOrderService.WalkSeedResult("000800:A.esm", "Npc", "HcRecNpcChild", nodes,
+            Array.Empty<string>(), WalkCap,
+            new[] { new LoadOrderService.NpcTemplateCategory("Traits", true, "000900:A.esm", "HcRecNpcParent", null) },
+            null);
+        return RecordsTools.RenderRecordsChain(new[] { row }, 1, nodes.Length, 0, "records  form=chain", null,
+                                               cap, null, out _);
+    }
+
+    /// <summary>One char under what the whole seed takes, so the node list is cut — and both statements the walk
+    /// itself owes are still there under the notice.</summary>
+    [Fact]
+    public void ASeedCutMidListStillSaysItsWalkHitItsOwnCap()
+    {
+        var r = Render(Render(100_000).Length - 1);
+
+        Assert.Contains("[nodes cut at max_chars=", r);
+        Assert.Contains(WalkCap, r);
+        Assert.Contains("Traits: INHERITED from", r);
+    }
+}

--- a/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
+++ b/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
@@ -894,6 +894,36 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
         RecordsTools.Records(Svc, formids: new[] { OwnedChildWorld.Fid(fk) }, format: format, to_file: toFile,
                              max_chars: maxChars, project: new RecordsTools.RecordsProject { form = "tree" });
 
+    /// <summary>The tree render on its own, with none of the tool's artifact lane around it. The cap boundaries the
+    /// tests below pin are properties of THIS render; a response the ceiling cuts carries an auto-spill block
+    /// naming an absolute path, so driving them through the tool would pin this checkout's path length into every
+    /// one of those numbers.</summary>
+    const string TreeHeader = "records  form=tree  versus=winner";
+
+    string TreeRender(FormKey fk, int cap, out bool truncated)
+    {
+        var rows = Svc.TreeBatch(new[] { OwnedChildWorld.Fid(fk) }, LoadOrderService.PoleSpec.Winner, null, null,
+                                 out _, out _, out var refusal, out _);
+        Assert.Null(refusal);
+        return RecordsTools.RenderRecordsTree(rows, rows.Count, 0, 0, false, TreeHeader, null, cap, null, out truncated)
+                           .Replace("\r\n", "\n");
+    }
+
+    string TreeRender(FormKey fk, int cap) => TreeRender(fk, cap, out _);
+
+    /// <summary>Whatever the cap, the tree render answers inside it — the ceiling holds across the whole band
+    /// where a row is cut, not only at the caps the tests above pin.</summary>
+    [Fact]
+    public void TheTreeRenderIsNeverWiderThanItsCap()
+    {
+        foreach (var fk in new[] { _w.CellC, _w.CellF })
+            for (int cap = 150; cap <= 1800; cap += 7)
+            {
+                var r = TreeRender(fk, cap);
+                Assert.True(r.Length <= cap, $"the tree returned {r.Length} chars at max_chars={cap}");
+            }
+    }
+
     [Fact]
     public void TheRemedyIsServedOnTheSameFormidsTheAnnotatedReadUsed()
     {
@@ -1092,23 +1122,36 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
         Assert.DoesNotContain("spilled:", r);
     }
 
-    // ---- the block's own TAIL, not just its per-line checks -------------------------------------------------
+    // ---- where the row's own width decides, the render is driven directly ------------------------------------
     //
-    // The per-field checks run BEFORE each line and never after the last one, so a final line that pushes
-    // sb.Length past the cap goes unnoticed — nothing downstream catches it once the row ends there.
-    //
-    // The tail-trip case is driven on CellF (3 touchers), not CellC: `truncated` says the ANSWER is incomplete
-    // and drives the spill, so it is set at the tail only for a row that LOST something — the diff a
-    // multi-provider row never reached. CellC at the same tail loses nothing and is the DoesNotContain control
-    // two tests down (ASoleProviderRowWhoseCompleteBlockEndsPastTheCapClaimsNothingWasCut).
+    // Everything below pins a CAP against what the tree render does at it. A response the ceiling cuts carries an
+    // auto-spill block naming an ABSOLUTE path, so every one of those numbers taken through the tool would carry
+    // this checkout's path length inside it. TreeRender drives the render with no artifact lane around it.
 
     [Fact]
     public void ATextRowsDeclarersBlockTailAloneCanTripMaxChars_AndTheResponseIsMarkedTruncated() =>
         Assert.Contains("spilled: complete result", Tree(_w.CellF, maxChars: 830));
 
+    /// <summary>888 is the last cap the whole row does not fit inside, so the block is cut and says so; 889 is the
+    /// first it does, where nothing is cut and nothing claims the answer is short.</summary>
     [Fact]
-    public void ARowWhoseDeclarersBlockFitsExactlyAtTheTailIsNotMarkedTruncated() =>
-        Assert.DoesNotContain("spilled:", Tree(_w.CellC, maxChars: 846));
+    public void ARowThatFitsWholeIsNotMarkedTruncated()
+    {
+        var r = TreeRender(_w.CellC, 889, out bool truncated);
+        Assert.False(truncated);
+        Assert.DoesNotContain("[child declarers cut", r);
+        Assert.Contains("Temporary: ", r);          // the block ran to its last field
+        Assert.True(r.Length <= 889, $"the tree returned {r.Length} chars at max_chars=889");
+    }
+
+    [Fact]
+    public void ARowOneCharacterTooWideIsCutAndSaysSo()
+    {
+        var r = TreeRender(_w.CellC, 888, out bool truncated);
+        Assert.True(truncated);
+        Assert.Contains("[child declarers cut at max_chars=888", r);
+        Assert.True(r.Length <= 888, $"the tree returned {r.Length} chars at max_chars=888");
+    }
 
     /// <summary>When the block is cut on a multi-provider row the row stops there: no "diff (field deltas…):"
     /// header may follow for a section the cap already forbade. The row does carry the "[nodes cut" notice — the
@@ -1116,82 +1159,66 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     [Fact]
     public void ACutDeclarersBlockEndsTheRow_NoEmptyDiffHeaderOverASectionThatNeverRendered()
     {
-        var r = Tree(_w.CellF, maxChars: 600);
+        var r = TreeRender(_w.CellF, 500);
         Assert.Contains("[child declarers cut", r);
         Assert.DoesNotContain("diff (field deltas", r);
-        Assert.Contains("[nodes cut at max_chars=600", r);
+        Assert.Contains("[nodes cut at max_chars=500", r);
     }
 
-    // ---- what the tail cut notice CLAIMS, not just that the tail check exists ------------------------------
+    // ---- what a COMPLETE block that leaves no room under it claims ------------------------------------------
     //
-    // The tail is reachable only when the field loop ran to completion, so at the tail nothing in the block was
-    // ever cut. A "[child declarers cut …]" notice there is false in every case it can fire, and its remedy
-    // (project.fields=) points at narrowing a block that is already complete. What the row loses at the tail is
-    // its DIFF — or, on a sole-provider row, nothing at all.
+    // Each declarer line is priced with its own cut notice beside it, so a block that ran to its last field never
+    // says it was cut. What a row loses where the block ends is its DIFF — or, on a sole provider, nothing at all.
 
     [Fact]
-    public void ASoleProviderRowWhoseCompleteBlockEndsPastTheCapClaimsNothingWasCut()
+    public void AMultiProviderRowWhoseCompleteBlockLeavesNoRoomForTheDiffNamesTheDiffItLost()
     {
-        var r = Tree(_w.CellC, maxChars: 845);
-        Assert.Contains("Temporary: ", r);              // the block ran to completion…
-        Assert.Contains("NavigationMeshes: ", r);
-        Assert.DoesNotContain("[child declarers cut", r);   // …so nothing may say it was cut,
-        Assert.DoesNotContain("[nodes cut", r);             // and a sole provider loses no diff either.
-        // …and nothing else may say it either: `truncated` reaches TreeResponse, which writes a JSONL artifact
-        // and re-renders with "spilled: complete result". A row that lost nothing does not spill.
-        Assert.DoesNotContain("spilled", r);
-    }
-
-    [Fact]
-    public void AMultiProviderRowWhoseCompleteBlockEndsPastTheCapNamesTheDiffItLost()
-    {
-        var r = Tree(_w.CellF, maxChars: 830);
+        var r = TreeRender(_w.CellF, 1000);
         Assert.Contains("Temporary: ", r);
         Assert.Contains("NavigationMeshes: ", r);
         Assert.DoesNotContain("[child declarers cut", r);
-        Assert.Contains("[nodes cut at max_chars=830", r);   // what actually went
-        Assert.DoesNotContain("diff (field deltas", r);      // and no header over a section that never rendered
+        Assert.Contains("[nodes cut at max_chars=1000", r);   // what actually went
+        Assert.DoesNotContain("diff (field deltas", r);       // and no header over a section that never rendered
     }
 
-    /// <summary>The other side: when declarer lines really ARE dropped, the notice still says so. 660 cuts CellF's
+    /// <summary>The other side: when declarer lines really ARE dropped, the notice still says so. 800 cuts CellF's
     /// block after its first field line (Landscape), leaving the other three unwritten. A multi-provider row that
     /// stops there loses its DIFF as well, so it names BOTH — the declarers it dropped and the nodes it never
     /// reached. Each notice claims one thing; neither claims the other's loss.</summary>
     [Fact]
     public void ABlockCutMidWayStillSaysTheDeclarersWereCut()
     {
-        var r = Tree(_w.CellF, maxChars: 660);
-        Assert.Contains("[child declarers cut at max_chars=660", r);
+        var r = TreeRender(_w.CellF, 800);
+        Assert.Contains("[child declarers cut at max_chars=800", r);
         Assert.Contains("Landscape: ", r);
         Assert.DoesNotContain("NavigationMeshes: ", r);
-        Assert.Contains("[nodes cut at max_chars=660", r);
+        Assert.Contains("[nodes cut at max_chars=800", r);
     }
 
-    /// <summary>The SOLE-provider control for the same cut branch: CellC at 700 drops declarer lines (its block
-    /// runs 591-808 before completing), so the declarers notice fires — and there is no diff to lose, so the
-    /// nodes notice must NOT — which pins each notice to the row's actual loss rather than to the branch it
-    /// came back through.</summary>
+    /// <summary>The SOLE-provider control for the same cut branch: CellC at 800 drops declarer lines, so the
+    /// declarers notice fires — and there is no diff to lose, so the nodes notice must NOT — which pins each
+    /// notice to the row's actual loss rather than to the branch it came back through.</summary>
     [Fact]
     public void ASoleProviderRowCutMidBlockSaysTheDeclarersWereCutAndNamesNoDiff()
     {
-        var r = Tree(_w.CellC, maxChars: 700);
-        Assert.Contains("[child declarers cut at max_chars=700", r);
-        Assert.Contains("NavigationMeshes: ", r);        // the block got two of its four field lines out…
+        var r = TreeRender(_w.CellC, 800);
+        Assert.Contains("[child declarers cut at max_chars=800", r);
+        Assert.Contains("NavigationMeshes: ", r);        // the block got some of its four field lines out…
         Assert.DoesNotContain("Temporary: ", r);         // …and was cut before the rest,
         Assert.DoesNotContain("[nodes cut", r);          // with no diff to lose.
     }
 
     /// <summary>The block's OTHER early return — the framing reserve, which returns before a single declarer line
     /// is written — comes back through the same caller line, so a multi-provider row refused the framing carries
-    /// both notices too. On CellF, 625 is the last cap that refuses the framing line and 626 the first it fits
+    /// both notices too. On CellF, 755 is the last cap that refuses the framing line and 756 the first it fits
     /// inside.</summary>
     [Fact]
     public void TheFramingReserveBranchOnAMultiProviderRowNamesBothTheDeclarersAndTheDiff()
     {
-        var r = Tree(_w.CellF, maxChars: 625);
+        var r = TreeRender(_w.CellF, 755);
         Assert.DoesNotContain(ReadSentences.DeclarersLead, r);        // not one declarer line was written…
-        Assert.Contains("[child declarers cut at max_chars=625", r);  // …which the block says,
-        Assert.Contains("[nodes cut at max_chars=625", r);            // …and the diff loss the caller says.
+        Assert.Contains("[child declarers cut at max_chars=755", r);  // …which the block says,
+        Assert.Contains("[nodes cut at max_chars=755", r);            // …and the diff loss the caller says.
     }
 
     // ---- the framing line is RESERVED against max_chars, not written and regretted -------------------------
@@ -1199,21 +1226,21 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     // The block's framing line is invariant text of a known length, so checking only sb.Length < cap before it
     // writes its whole length past the cap with nothing able to take it back — json reserves the identical
     // sentence (JsonWire's DeclarersLeadReserve) and the cheap tier reserves its own clause (ClauseReserve).
-    // On CellC the block starts at 297 chars, so 590 is the last cap the framing does not fit in and 591 the
-    // first that it does.
+    // The block's own cut notice is reserved beside it, so on CellC 631 is the last cap the pair does not fit in
+    // and 632 the first that it does.
 
     [Fact]
     public void TheFramingLineIsReservedAgainstMaxChars_NotWrittenPastIt()
     {
-        var r = Tree(_w.CellC, maxChars: 590);
+        var r = TreeRender(_w.CellC, 631);
         Assert.DoesNotContain(ReadSentences.DeclarersLead, r);
-        Assert.Contains("[child declarers cut at max_chars=590", r);
+        Assert.Contains("[child declarers cut at max_chars=631", r);
     }
 
     [Fact]
     public void TheFramingLineRidesAtTheFirstCapItFitsInside()
     {
-        Assert.Contains(ReadSentences.DeclarersLead, Tree(_w.CellC, maxChars: 591));
+        Assert.Contains(ReadSentences.DeclarersLead, TreeRender(_w.CellC, 632));
     }
 
     /// <summary>The lead is invariant framing text, not per-record content, so a multi-row response states it once
@@ -1255,7 +1282,7 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     [Fact]
     public void TheChildDeclarersCutNoticesNameNoWrongLever()
     {
-        var text = Tree(_w.CellC, maxChars: 200);
+        var text = TreeRender(_w.CellC, 400);
         var jsonR = Tree(_w.CellC, format: "json", maxChars: 300);
 
         var textHits = text.Split('\n').Where(l => RemedyHarvest.RemedyLine.IsMatch(l)).ToList();
@@ -1339,7 +1366,7 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     {
         var sb = new StringBuilder();
         bool leadWritten = false;
-        RecordsTools.AppendChildDeclarers(sb, FiveDeclarerRow(), cap: 100_000, ref leadWritten, out _);
+        RecordsTools.AppendChildDeclarers(sb, FiveDeclarerRow(), cap: new RenderCap(100_000, 100_000), tailReserve: 0, ref leadWritten, out _, out _);
         Assert.Contains(
             $"Persistent: {ReadSentences.DeclaredBy} A.esp, B.esp, C.esp (+2 more){ReadSentences.DeclarersOverflowRemedy}",
             sb.ToString());
@@ -1381,7 +1408,7 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     {
         var sb = new StringBuilder();
         bool leadWritten = false;
-        RecordsTools.AppendChildDeclarers(sb, row, cap: 100_000, ref leadWritten, out _);
+        RecordsTools.AppendChildDeclarers(sb, row, cap: new RenderCap(100_000, 100_000), tailReserve: 0, ref leadWritten, out _, out _);
         return sb.ToString();
     }
 

--- a/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
+++ b/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
@@ -911,6 +911,35 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
 
     string TreeRender(FormKey fk, int cap) => TreeRender(fk, cap, out _);
 
+    /// <summary>Two rows through the same render, so what a cut row costs the rows BELOW it can be read.</summary>
+    string TreeRender(FormKey[] fks, int cap)
+    {
+        var rows = Svc.TreeBatch(fks.Select(OwnedChildWorld.Fid).ToArray(), LoadOrderService.PoleSpec.Winner,
+                                 null, null, out _, out _, out var refusal, out _);
+        Assert.Null(refusal);
+        return RecordsTools.RenderRecordsTree(rows, rows.Count, 0, 0, false, TreeHeader, null, cap, null, out _)
+                           .Replace("\r\n", "\n");
+    }
+
+    /// <summary>A row kept and cut ends the render, so the rows under it never render — and the render says how
+    /// many, in the accounting line its budget charged for before the first row was laid. At 900 CellF is cut and
+    /// CellC never reached, so the line is owed; at 1906, the first cap CellC's own row fits inside, there is
+    /// nothing left to count and no line is written over a complete set of rows.</summary>
+    [Fact]
+    public void ARowKeptAndCutCountsTheRowsTheRenderNeverReached()
+    {
+        var pair = new[] { _w.CellF, _w.CellC };
+
+        var cut = TreeRender(pair, 900);
+        Assert.Contains("[child declarers cut at max_chars=900", cut);
+        Assert.DoesNotContain(OwnedChildWorld.Fid(_w.CellC), cut);
+        Assert.Contains("... [rendered 1 of 2 rows at max_chars=900]", cut);
+
+        var whole = TreeRender(pair, 1906);
+        Assert.Contains(OwnedChildWorld.Fid(_w.CellC), whole);
+        Assert.DoesNotContain(" rows at max_chars=", whole);
+    }
+
     /// <summary>Whatever the cap, the tree render answers inside it — the ceiling holds across the whole band
     /// where a row is cut, not only at the caps the tests above pin.</summary>
     [Fact]

--- a/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
+++ b/src/housecarl-mcp-tests/RecordsOwnedChildTests.cs
@@ -923,8 +923,8 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
 
     /// <summary>A row kept and cut ends the render, so the rows under it never render — and the render says how
     /// many, in the accounting line its budget charged for before the first row was laid. At 900 CellF is cut and
-    /// CellC never reached, so the line is owed; at 1906, the first cap CellC's own row fits inside, there is
-    /// nothing left to count and no line is written over a complete set of rows.</summary>
+    /// CellC never reached, so the line is owed; at 1906, the first cap CellC's row is reached at all, it is the
+    /// last row and is itself the one cut, so nothing is left to count and no line is written.</summary>
     [Fact]
     public void ARowKeptAndCutCountsTheRowsTheRenderNeverReached()
     {
@@ -1161,25 +1161,27 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
     public void ATextRowsDeclarersBlockTailAloneCanTripMaxChars_AndTheResponseIsMarkedTruncated() =>
         Assert.Contains("spilled: complete result", Tree(_w.CellF, maxChars: 830));
 
-    /// <summary>888 is the last cap the whole row does not fit inside, so the block is cut and says so; 889 is the
-    /// first it does, where nothing is cut and nothing claims the answer is short.</summary>
+    /// <summary>748 is the whole row's own width and the first cap it fits inside, where nothing is cut and
+    /// nothing claims the answer is short; 747 is the last cap it does not fit, so the block is cut and says so.
+    /// The pair sits at the render's width because a render that fits its cap owes no notices, so none are
+    /// charged against it.</summary>
     [Fact]
     public void ARowThatFitsWholeIsNotMarkedTruncated()
     {
-        var r = TreeRender(_w.CellC, 889, out bool truncated);
+        var r = TreeRender(_w.CellC, 748, out bool truncated);
         Assert.False(truncated);
         Assert.DoesNotContain("[child declarers cut", r);
         Assert.Contains("Temporary: ", r);          // the block ran to its last field
-        Assert.True(r.Length <= 889, $"the tree returned {r.Length} chars at max_chars=889");
+        Assert.True(r.Length <= 748, $"the tree returned {r.Length} chars at max_chars=748");
     }
 
     [Fact]
     public void ARowOneCharacterTooWideIsCutAndSaysSo()
     {
-        var r = TreeRender(_w.CellC, 888, out bool truncated);
+        var r = TreeRender(_w.CellC, 747, out bool truncated);
         Assert.True(truncated);
-        Assert.Contains("[child declarers cut at max_chars=888", r);
-        Assert.True(r.Length <= 888, $"the tree returned {r.Length} chars at max_chars=888");
+        Assert.Contains("[child declarers cut at max_chars=747", r);
+        Assert.True(r.Length <= 747, $"the tree returned {r.Length} chars at max_chars=747");
     }
 
     /// <summary>When the block is cut on a multi-provider row the row stops there: no "diff (field deltas…):"
@@ -1224,15 +1226,15 @@ public sealed class RecordsOwnedChildTests : IClassFixture<OwnedChildFixture>
         Assert.Contains("[nodes cut at max_chars=800", r);
     }
 
-    /// <summary>The SOLE-provider control for the same cut branch: CellC at 800 drops declarer lines, so the
+    /// <summary>The SOLE-provider control for the same cut branch: CellC at 700 drops declarer lines, so the
     /// declarers notice fires — and there is no diff to lose, so the nodes notice must NOT — which pins each
     /// notice to the row's actual loss rather than to the branch it came back through.</summary>
     [Fact]
     public void ASoleProviderRowCutMidBlockSaysTheDeclarersWereCutAndNamesNoDiff()
     {
-        var r = TreeRender(_w.CellC, 800);
-        Assert.Contains("[child declarers cut at max_chars=800", r);
-        Assert.Contains("NavigationMeshes: ", r);        // the block got some of its four field lines out…
+        var r = TreeRender(_w.CellC, 700);
+        Assert.Contains("[child declarers cut at max_chars=700", r);
+        Assert.Contains("Landscape: ", r);               // the block got one of its four field lines out…
         Assert.DoesNotContain("Temporary: ", r);         // …and was cut before the rest,
         Assert.DoesNotContain("[nodes cut", r);          // with no diff to lose.
     }

--- a/src/housecarl-mcp-tests/RecordsUnreadableSubFieldTests.cs
+++ b/src/housecarl-mcp-tests/RecordsUnreadableSubFieldTests.cs
@@ -251,6 +251,39 @@ public sealed class TreeIncompleteNoteTests
     }
 }
 
+/// <summary>The delta form keeps that note when max_chars cuts its delta lines. The two statements are about
+/// different things — INCOMPLETE says deltas were never computed, the cut notice says computed lines did not fit
+/// — so a reader who raises max_chars on the cut gets the rest of a comparison that still never looked at list
+/// contents. Driven against a hand-built row: no fixture makes an incomplete read with lines enough to cut.</summary>
+[Trait("tier", "unit")]
+public sealed class DeltaIncompleteNoteTests
+{
+    static string Render(int cap)
+    {
+        var diff = new FieldsDiff.Result(
+            new[] { "Name: 'A' (reference 'B')", "Value: 10 (reference 20)", "Weight: 1.0 (reference 2.0)",
+                    "Damage: 5 (reference 6)", "Keywords: 3 entries (reference 2)" },
+            Complete: false, AgreedCount: 0, AgreedSample: Array.Empty<string>(), NoVerdictCount: 0);
+        var row = new LoadOrderService.DeltaRow("000800:A.esm",
+            new LoadOrderService.DiffPole("B.esp", "active", true, "Weapon", "HcWeap"),
+            new LoadOrderService.DiffPole("A.esm", "active", true, "Weapon", "HcWeap"),
+            diff, null, null, null);
+        return RecordsTools.RenderRecordsDelta(new[] { row }, 1, 1, 0, 0, 0, "records  form=delta", null,
+                                               cap, null, out _);
+    }
+
+    /// <summary>One char under what the whole render takes, so the delta lines are cut — and the note about what
+    /// was never compared is still there beside the notice about what did not fit.</summary>
+    [Fact]
+    public void ACutDeltaListStillSaysTheComparisonWasIncomplete()
+    {
+        var r = Render(Render(100_000).Length - 1);
+
+        Assert.Contains("[delta lines cut", r);
+        Assert.Contains("the comparison is INCOMPLETE", r);
+    }
+}
+
 /// <summary>A deep read carries the readable bit on a LINK leaf too. A condition target (FormLinkOrIndex) the
 /// emit cannot read is a fault, and a fault that renders with Present=false and Readable=true tells every
 /// consumer reading the bits that nothing is there.</summary>

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -487,14 +487,19 @@ static class Wire
     /// a default here is a lever name guessed on the caller's behalf, which is exactly the bug this parameter was
     /// added to fix — a new caller must state its own spelling.</param>
     public static string RenderEffectChain(EffectChainResult r, int maxChars, string carrierBound)
-        => RenderEffectChain(r, new RenderCap(Cap(maxChars), Cap(maxChars)), 0, carrierBound);
+        => RenderEffectChain(r, new RenderCap(Cap(maxChars), Cap(maxChars)), 0, carrierBound, out _);
 
     /// <summary>The bounded form: <paramref name="room"/> carries the caller's max_chars and the budget its own
     /// tail has left, and <paramref name="used"/> is what the caller has already written — this render builds its
     /// own buffer, so the two together are what the rows are measured against, while every notice still quotes the
     /// max_chars the caller passed.</summary>
-    internal static string RenderEffectChain(EffectChainResult r, RenderCap room, int used, string carrierBound)
+    /// <param name="cut">true when carrier rows were held back here. This render cuts inside its own buffer, so a
+    /// caller measuring only the buffer's length sees nothing crossed — the answer is incomplete and only this
+    /// says so, which is what drives the caller's truncation flag and its spill.</param>
+    internal static string RenderEffectChain(EffectChainResult r, RenderCap room, int used, string carrierBound,
+                                             out bool cut)
     {
+        cut = false;
         if (r.Error is not null) return "error: " + r.Error + Wire.EpochLine(r.Stamp);
         int cap = room.Cap;
         var sb = new StringBuilder();
@@ -542,6 +547,7 @@ static class Wire
                 {
                     sb.Append(Notice(rendered));
                     truncated = true;
+                    cut = true;
                     break;
                 }
                 sb.Append(line);

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -487,9 +487,16 @@ static class Wire
     /// a default here is a lever name guessed on the caller's behalf, which is exactly the bug this parameter was
     /// added to fix — a new caller must state its own spelling.</param>
     public static string RenderEffectChain(EffectChainResult r, int maxChars, string carrierBound)
+        => RenderEffectChain(r, new RenderCap(Cap(maxChars), Cap(maxChars)), 0, carrierBound);
+
+    /// <summary>The bounded form: <paramref name="room"/> carries the caller's max_chars and the budget its own
+    /// tail has left, and <paramref name="used"/> is what the caller has already written — this render builds its
+    /// own buffer, so the two together are what the rows are measured against, while every notice still quotes the
+    /// max_chars the caller passed.</summary>
+    internal static string RenderEffectChain(EffectChainResult r, RenderCap room, int used, string carrierBound)
     {
         if (r.Error is not null) return "error: " + r.Error + Wire.EpochLine(r.Stamp);
-        int cap = Cap(maxChars);
+        int cap = room.Cap;
         var sb = new StringBuilder();
         sb.Append("chain for ").Append(r.Mgef).Append(" (").Append(r.MgefEditorId).Append(", MagicEffect): ")
           .Append(r.Total).Append(r.Total == 1 ? " carrier row" : " carrier rows");
@@ -509,6 +516,12 @@ static class Wire
 
         int rendered = 0;
         bool truncated = false;
+        // The cut notice is held back before the row it follows, so it lands inside the budget rather than a
+        // character past the row that crossed. Its widest spelling is the one that counts every row.
+        string Notice(int n) =>
+            "  ... [truncated: rendered " + n + " of " + r.Rows.Count + " rows before hitting max_chars=" + cap +
+            "; lower limit= or raise max_chars]\n";
+        int noticeRoom = Notice(r.Rows.Count).Length;
         // Group rows by carrier type, ordinal for stability, so a multi-type result reads grouped.
         foreach (var grp in r.Rows.GroupBy(x => x.Type).OrderBy(g => g.Key, StringComparer.Ordinal))
         {
@@ -516,20 +529,22 @@ static class Wire
             sb.Append(grp.Key).Append(" (").Append(grp.Count()).Append("):\n");
             foreach (var row in grp)
             {
-                if (sb.Length >= cap)
+                // Composed before it is priced, so the cut notice lands inside the budget rather than a character
+                // past the row that crossed it.
+                string line = "  " + row.Carrier
+                              + "  " + (row.EditorId ?? "<none>")
+                              + "  winner=" + row.Winner
+                              + "  mag=" + row.Magnitude.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                              + "  area=" + row.Area
+                              + "  dur=" + row.Duration
+                              + "  [effect " + (row.EffectIndex + 1) + "/" + row.EffectCount + "]\n";
+                if (used + sb.Length + line.Length + noticeRoom > room.Budget)
                 {
-                    sb.Append("  ... [truncated: rendered ").Append(rendered).Append(" of ").Append(r.Rows.Count)
-                      .Append(" rows before hitting max_chars=").Append(cap).Append("; lower limit= or raise max_chars]\n");
+                    sb.Append(Notice(rendered));
                     truncated = true;
                     break;
                 }
-                sb.Append("  ").Append(row.Carrier)
-                  .Append("  ").Append(row.EditorId ?? "<none>")
-                  .Append("  winner=").Append(row.Winner)
-                  .Append("  mag=").Append(row.Magnitude.ToString(System.Globalization.CultureInfo.InvariantCulture))
-                  .Append("  area=").Append(row.Area)
-                  .Append("  dur=").Append(row.Duration)
-                  .Append("  [effect ").Append(row.EffectIndex + 1).Append('/').Append(row.EffectCount).Append("]\n");
+                sb.Append(line);
                 rendered++;
             }
         }

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -138,7 +138,7 @@ public static class RecordsTools
             int limit = 500,
         [Description("TRANSPORT: skip the first N matches (exact windows: offset=0/500/1000…). Windows tile only WITHIN one epoch — if two pages' epochs differ the load order changed mid-pagination; re-run from offset=0, do not stitch the pages. offset= RE-SCANS the selection from the start rather than seeking into it, so every window pays the whole scan again and a deep window costs more than a shallow one — narrowing the scan terms beats paging far into one.")]
             int offset = 0,
-        [Description("TRANSPORT: character CEILING on the RENDER, hard on every text render this tool has — the scan, batch, resolve, group_by and summary renders, the comparison forms (delta, tree), the walk lane's chain and effect-chain renders, and info_order. The record block, node or delta line that would cross it is not written, and the truncation notice, the accounting line and the spilled: block are charged before the rows are laid. The one answer that can still come back over it is a max_chars too small for what the response carries whatever the budget — its header, the notices it owes, its spilled: block — which says so and names the number that clears it. Never truncates the RESULT: an over-ceiling result SPILLS in full to a server-side JSONL artifact (line 1 = manifest with the query echo, the row schema, and the epoch) and the response names the file, so what the ceiling held back inline is in the file. 0 = the server default (~80k).")]
+        [Description("TRANSPORT: character CEILING on the RENDER, hard on every text render this tool has — the scan, batch, resolve, group_by and summary renders, the comparison forms (delta, tree), the walk lane's chain and effect-chain renders, and info_order. The record block, node or delta line that would cross it is not written, and the truncation notice, the accounting line and the spilled: block are charged before the rows are laid — charged only where the whole render does not fit, so an answer that fits inside the max_chars you passed comes back complete, uncut and unspilled. The one answer that can still come back over it is a max_chars too small for what the response carries whatever the budget — its header, the notices it owes, its spilled: block — which says so and names the number that clears it. Never truncates the RESULT: an over-ceiling result SPILLS in full to a server-side JSONL artifact (line 1 = manifest with the query echo, the row schema, and the epoch) and the response names the file, so what the ceiling held back inline is in the file. 0 = the server default (~80k).")]
             int max_chars = 0,
         [Description("TRANSPORT: return the accounting block and counts only, no rows — the cheap census.")]
             bool counts_only = false,
@@ -1891,10 +1891,17 @@ public static class RecordsTools
     /// enough delta lines to be cut) has no other way in.</summary>
     internal static string RenderRecordsDelta(IReadOnlyList<LoadOrderService.DeltaRow> rows, int total, int differing, int identical,
                                      int noVerdict, int errors,
-                                     string headerLine, OrderStamp? epoch, int maxChars, SpillState? spill, out bool truncated)
+                                     string headerLine, OrderStamp? epoch, int maxChars, SpillState? spill, out bool truncated,
+                                     bool unreserved = false)
     {
         truncated = false;
         int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        if (!unreserved)
+        {
+            var whole = RenderRecordsDelta(rows, total, differing, identical, noVerdict, errors, headerLine, epoch,
+                                           maxChars, spill, out _, unreserved: true);
+            if (whole.Length <= cap) return whole;
+        }
         bool manifestOnly = spill?.ManifestOnly ?? false;
         var sb = new StringBuilder();
         sb.Append(headerLine).Append('\n');
@@ -1912,7 +1919,7 @@ public static class RecordsTools
         string Notice(int r) =>
             "... [rendered " + r + " of " + rows.Count + " rows at max_chars=" + cap + "]\n";
         var spillText = Wire.SpillText(spill);
-        int budget = Math.Max(cap - spillText.Length - Notice(rows.Count).Length, 0);
+        int budget = unreserved ? Unbounded : Math.Max(cap - spillText.Length - Notice(rows.Count).Length, 0);
         string deltaCut = CutNotice("delta lines", cap);
         foreach (var row in rows)
         {
@@ -1995,6 +2002,14 @@ public static class RecordsTools
         return RenderCap.Settle(sb.ToString().TrimEnd('\n'), cap);
     }
 
+    /// <summary>The budget of the unreserved pass every bounded render here makes first: no unit can cross it, so
+    /// that pass lays the COMPLETE render, and a complete render that fits max_chars is the answer. The reserves
+    /// the bounded pass holds back — the accounting line, each list's cut notice — are room for notices a complete
+    /// render never writes, so charging them against one that fits cuts an answer that fitted, spills it, and (the
+    /// spill block being charged in turn) comes back with no rows at all, naming a number far over what the whole
+    /// answer took. They are charged only once the whole thing is known not to fit at this cap.</summary>
+    const int Unbounded = int.MaxValue / 2;
+
     /// <summary>Whole units only: a unit written from <paramref name="mark"/> that crossed <paramref name="budget"/>
     /// — or that stopped early with no room to say so, <paramref name="force"/> — is taken back out entire and the
     /// caller's notice put in its place. True means the render stops here.</summary>
@@ -2036,10 +2051,16 @@ public static class RecordsTools
     /// on a record only one in-order plugin touches) has no other way in.</summary>
     internal static string RenderRecordsTree(IReadOnlyList<LoadOrderService.TreeRow> rows, int total, int contested, int errors,
                                     bool fieldsNarrow, string headerLine, OrderStamp? epoch, int maxChars,
-                                    SpillState? spill, out bool truncated)
+                                    SpillState? spill, out bool truncated, bool unreserved = false)
     {
         truncated = false;
         int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        if (!unreserved)
+        {
+            var whole = RenderRecordsTree(rows, total, contested, errors, fieldsNarrow, headerLine, epoch, maxChars,
+                                          spill, out _, unreserved: true);
+            if (whole.Length <= cap) return whole;
+        }
         bool manifestOnly = spill?.ManifestOnly ?? false;
         var sb = new StringBuilder();
         sb.Append(headerLine).Append('\n');
@@ -2051,7 +2072,8 @@ public static class RecordsTools
         string Notice(int r) =>
             "... [rendered " + r + " of " + rows.Count + " rows at max_chars=" + cap + "]\n";
         var spillText = Wire.SpillText(spill);
-        var room = RenderCap.For(cap, spillText.Length + Notice(rows.Count).Length);
+        var room = unreserved ? new RenderCap(cap, Unbounded)
+                              : RenderCap.For(cap, spillText.Length + Notice(rows.Count).Length);
         int budget = room.Budget;
         string nodesCut = CutNotice("nodes", cap);
         foreach (var row in rows)
@@ -2228,10 +2250,16 @@ public static class RecordsTools
     /// with nodes enough for max_chars to cut) has no other way in.</summary>
     internal static string RenderRecordsChain(IReadOnlyList<LoadOrderService.WalkSeedResult> rows, int total, int reached,
                                      int errors, string headerLine, OrderStamp? epoch, int maxChars,
-                                     SpillState? spill, out bool truncated)
+                                     SpillState? spill, out bool truncated, bool unreserved = false)
     {
         truncated = false;
         int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        if (!unreserved)
+        {
+            var whole = RenderRecordsChain(rows, total, reached, errors, headerLine, epoch, maxChars, spill, out _,
+                                           unreserved: true);
+            if (whole.Length <= cap) return whole;
+        }
         bool manifestOnly = spill?.ManifestOnly ?? false;
         var sb = new StringBuilder();
         sb.Append(headerLine).Append('\n');
@@ -2243,7 +2271,7 @@ public static class RecordsTools
             "... [rendered " + r + " of " + rows.Count + " seeds at max_chars=" + cap + "]\n";
         string nodesCut = "    ... [nodes cut at max_chars=" + cap + " — raise max_chars, or to_file= for the complete walk]\n";
         var spillText = Wire.SpillText(spill);
-        int budget = Math.Max(cap - spillText.Length - Notice(rows.Count).Length, 0);
+        int budget = unreserved ? Unbounded : Math.Max(cap - spillText.Length - Notice(rows.Count).Length, 0);
         foreach (var row in rows)
         {
             if (manifestOnly) break;
@@ -2330,13 +2358,23 @@ public static class RecordsTools
     /// seed's carriers through the shared effect-chain render, the standard explicit cut and spill marker.
     /// max_chars is a CEILING: the notice and the spill block are charged first, the shared render is told what
     /// this one has already spent, and a seed that would cross what is left is taken back out whole. A seed the
-    /// shared render cut inside its own buffer reports that back — nothing here can measure it.</summary>
-    static string RenderRecordsEffectChains(IReadOnlyList<(string Seed, EffectChainResult Result)> results,
+    /// shared render cut inside its own buffer reports that back — nothing here can measure it.
+    /// Internal so a test can drive it against a hand-built <see cref="EffectChainResult"/>, the same reason
+    /// <see cref="RenderRecordsTree"/> is: reaching a cut INSIDE the shared render through the tool needs a seed
+    /// whose carriers are wider than the auto-spill block, and no fixture has one.</summary>
+    internal static string RenderRecordsEffectChains(IReadOnlyList<(string Seed, EffectChainResult Result)> results,
                                             int totalSeeds, int carrierRows, int carrierTotal, int errors, string headerLine,
-                                            OrderStamp? epoch, int maxChars, SpillState? spill, out bool truncated)
+                                            OrderStamp? epoch, int maxChars, SpillState? spill, out bool truncated,
+                                            bool unreserved = false)
     {
         truncated = false;
         int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        if (!unreserved)
+        {
+            var whole = RenderRecordsEffectChains(results, totalSeeds, carrierRows, carrierTotal, errors, headerLine,
+                                                  epoch, maxChars, spill, out _, unreserved: true);
+            if (whole.Length <= cap) return whole;
+        }
         bool manifestOnly = spill?.ManifestOnly ?? false;
         var sb = new StringBuilder();
         sb.Append(headerLine).Append('\n');
@@ -2349,7 +2387,8 @@ public static class RecordsTools
         string Notice(int r) =>
             "... [rendered " + r + " of " + results.Count + " seeds at max_chars=" + cap + "]\n";
         var spillText = Wire.SpillText(spill);
-        var room = RenderCap.For(cap, spillText.Length + Notice(results.Count).Length);
+        var room = unreserved ? new RenderCap(cap, Unbounded)
+                              : RenderCap.For(cap, spillText.Length + Notice(results.Count).Length);
         foreach (var (seed, result) in results)
         {
             if (manifestOnly) break;
@@ -2378,10 +2417,16 @@ public static class RecordsTools
     /// topic block, so there is no way to keep half of one and stay under the ceiling.</summary>
     static string RenderRecordsInfoOrder(IReadOnlyList<LoadOrderService.InfoOrderRow> rows, int total, int contested,
                                          int errors, string headerLine, OrderStamp? epoch, int maxChars,
-                                         SpillState? spill, out bool truncated)
+                                         SpillState? spill, out bool truncated, bool unreserved = false)
     {
         truncated = false;
         int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        if (!unreserved)
+        {
+            var whole = RenderRecordsInfoOrder(rows, total, contested, errors, headerLine, epoch, maxChars, spill,
+                                               out _, unreserved: true);
+            if (whole.Length <= cap) return whole;
+        }
         bool manifestOnly = spill?.ManifestOnly ?? false;
         var sb = new StringBuilder();
         sb.Append(headerLine).Append('\n');
@@ -2392,7 +2437,7 @@ public static class RecordsTools
         string Notice(int r) =>
             "... [rendered " + r + " of " + rows.Count + " rows at max_chars=" + cap + "]\n";
         var spillText = Wire.SpillText(spill);
-        int budget = Math.Max(cap - spillText.Length - Notice(rows.Count).Length, 0);
+        int budget = unreserved ? Unbounded : Math.Max(cap - spillText.Length - Notice(rows.Count).Length, 0);
         foreach (var row in rows)
         {
             if (manifestOnly) break;

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -138,7 +138,7 @@ public static class RecordsTools
             int limit = 500,
         [Description("TRANSPORT: skip the first N matches (exact windows: offset=0/500/1000…). Windows tile only WITHIN one epoch — if two pages' epochs differ the load order changed mid-pagination; re-run from offset=0, do not stitch the pages. offset= RE-SCANS the selection from the start rather than seeking into it, so every window pays the whole scan again and a deep window costs more than a shallow one — narrowing the scan terms beats paging far into one.")]
             int offset = 0,
-        [Description("TRANSPORT: character CEILING on the RENDER, and a hard one on the scan, batch, resolve, group_by and summary renders — the record block that would cross it is not written, and the truncation notice, the accounting line and the spilled: block are charged before the rows are laid. NOT yet hard on the comparison forms (delta, tree), the walk lane's chain and effect-chain renders, or info_order: those still test the ceiling before the row, so they can come back over it by the block that crossed. Never truncates the RESULT: an over-ceiling result SPILLS in full to a server-side JSONL artifact (line 1 = manifest with the query echo, the row schema, and the epoch) and the response names the file, so what the ceiling held back inline is in the file. 0 = the server default (~80k).")]
+        [Description("TRANSPORT: character CEILING on the RENDER, hard on every text render this tool has — the scan, batch, resolve, group_by and summary renders, the comparison forms (delta, tree), the walk lane's chain and effect-chain renders, and info_order. The record block, node or delta line that would cross it is not written, and the truncation notice, the accounting line and the spilled: block are charged before the rows are laid. The one answer that can still come back over it is a max_chars too small for what the response carries whatever the budget — its header, the notices it owes, its spilled: block — which says so and names the number that clears it. Never truncates the RESULT: an over-ceiling result SPILLS in full to a server-side JSONL artifact (line 1 = manifest with the query echo, the row schema, and the epoch) and the response names the file, so what the ceiling held back inline is in the file. 0 = the server default (~80k).")]
             int max_chars = 0,
         [Description("TRANSPORT: return the accounting block and counts only, no rows — the cheap census.")]
             bool counts_only = false,
@@ -1882,7 +1882,10 @@ public static class RecordsTools
 
     /// <summary>The delta form's text render: header counts, then per record the two pole lines, the stack-above
     /// fact stated neutrally rather than as advice, and the delta-line grammar — where a truncated deep read is
-    /// never rendered as 'identical'.</summary>
+    /// never rendered as 'identical'. max_chars is a CEILING here, the shape #603 gave the scan and batch renders:
+    /// the truncation notice and the spill block are charged before the first record is laid, a delta line is
+    /// written only where its own cut notice still fits beside it, and a record that would cross what is left is
+    /// taken back out whole and counted.</summary>
     static string RenderRecordsDelta(IReadOnlyList<LoadOrderService.DeltaRow> rows, int total, int differing, int identical,
                                      int noVerdict, int errors,
                                      string headerLine, OrderStamp? epoch, int maxChars, SpillState? spill, out bool truncated)
@@ -1901,22 +1904,28 @@ public static class RecordsTools
         if (epoch is not null) sb.Append(Wire.EpochInline(epoch));
         sb.Append('\n');
         int rendered = 0;
+        // The notice and the spill block close this response, so both are charged before the first record is laid —
+        // that is what makes max_chars a ceiling on the whole response rather than on everything above its tail.
+        string Notice(int r) =>
+            "... [rendered " + r + " of " + rows.Count + " rows at max_chars=" + cap + "]\n";
+        var spillText = Wire.SpillText(spill);
+        int budget = Math.Max(cap - spillText.Length - Notice(rows.Count).Length, 0);
+        string deltaCut = CutNotice("delta lines", cap);
         foreach (var row in rows)
         {
             if (manifestOnly) break;
-            if (sb.Length >= cap)
-            {
-                truncated = true;
-                sb.Append("... [rendered ").Append(rendered).Append(" of ").Append(rows.Count)
-                  .Append(" rows at max_chars=").Append(cap).Append("]\n");
-                break;
-            }
+            int mark = sb.Length;
+            // said: this record's own delta list stopped inside the budget and named what it held back, so the
+            // record stays and the render stops after it. mute: it stopped with no room to say so, and the whole
+            // record goes back out instead.
+            bool said = false, mute = false;
             sb.Append('\n').Append(row.Formid);
             if (row.Error is not null)
             {
                 sb.Append("  error=").Append(row.Error).Append('\n');
                 if (row.StackAbove is { Count: > 0 })
                     sb.Append("  stack above the subject (closer to winning, winner last): ").Append(string.Join(", ", row.StackAbove)).Append('\n');
+                if (Crossed(sb, mark, budget, Notice(rendered), ref truncated)) break;
                 rendered++;
                 continue;
             }
@@ -1950,26 +1959,62 @@ public static class RecordsTools
                   .Append(r.LabelVersus(s.Plugin)).Append("):\n");
                 foreach (var delta in d.Deltas)
                 {
-                    if (sb.Length >= cap)
+                    // The line goes in only where its own cut notice still fits beside it, so the notice lands
+                    // inside the budget rather than a character past the one that crossed.
+                    string line = "    - " + delta + "\n";
+                    if (sb.Length + line.Length + deltaCut.Length > budget)
                     {
-                        truncated = true;
-                        AppendCutNotice(sb, "delta lines", cap);
+                        said = Said(sb, deltaCut, budget);
+                        mute = !said;
                         break;
                     }
-                    sb.Append("    - ").Append(delta).Append('\n');
+                    sb.Append(line);
                 }
-                if (!d.Complete)
+                if (!said && !mute && !d.Complete)
                     sb.Append("  note: the comparison is INCOMPLETE — a field above could not be read (nothing at or under it was compared), or the deep read hit the cap (which suppresses list-content and one-sided-presence deltas for the whole record). Narrow with ").Append(LeverNames.Records.Fields).Append(" to compare those in full.\n");
             }
+            if (mute || !said)
+            {
+                if (Crossed(sb, mark, budget, Notice(rendered), ref truncated, force: mute)) break;
+                rendered++;
+                continue;
+            }
+            // The record was laid to the budget and says what it held back: it stays, and nothing more fits.
+            truncated = true;
             rendered++;
+            break;
         }
-        if (spill is not null) Artifacts.AppendSpillStateText(sb, spill);
-        return sb.ToString().TrimEnd('\n');
+        sb.Append(spillText);
+        return RenderCap.Settle(sb.ToString().TrimEnd('\n'), cap);
+    }
+
+    /// <summary>Whole units only: a unit written from <paramref name="mark"/> that crossed <paramref name="budget"/>
+    /// — or that stopped early with no room to say so, <paramref name="force"/> — is taken back out entire and the
+    /// caller's notice put in its place. True means the render stops here.</summary>
+    static bool Crossed(StringBuilder sb, int mark, int budget, string notice, ref bool truncated, bool force = false)
+    {
+        if (!force && sb.Length <= budget) return false;
+        sb.Length = mark;
+        sb.Append(notice);
+        truncated = true;
+        return true;
+    }
+
+    /// <summary>A section that ran out of room says so INSIDE the budget or not at all: false means the notice
+    /// itself did not fit, and the row it belongs to is taken back out whole rather than ending in silence.</summary>
+    static bool Said(StringBuilder sb, string notice, int budget)
+    {
+        if (sb.Length + notice.Length > budget) return false;
+        sb.Append(notice);
+        return true;
     }
 
     /// <summary>The tree form's text render: per record the touching list in load order with the winner last,
     /// and each provider's delta against the reference. Same wording rules as the delta form — identical is
     /// never claimed over a truncated read, list contents compare by content, and reorders are flagged.
+    /// max_chars is a CEILING here, the same shape the delta render carries: the truncation notice and the spill
+    /// block are charged first, the declarer and node loops hold back their own cut notices, and a record that
+    /// would cross what is left is taken back out whole and counted.
     /// Internal so a test can drive it against a hand-built <see cref="LoadOrderService.TreeRow"/>, the same
     /// reason <see cref="AppendChildDeclarers"/> is: a node shape no fixture produces (an incomplete comparison
     /// on a record only one in-order plugin touches) has no other way in.</summary>
@@ -1987,74 +2032,114 @@ public static class RecordsTools
         sb.Append('\n');
         int rendered = 0;
         bool declarersLeadWritten = false;
+        string Notice(int r) =>
+            "... [rendered " + r + " of " + rows.Count + " rows at max_chars=" + cap + "]\n";
+        var spillText = Wire.SpillText(spill);
+        var room = RenderCap.For(cap, spillText.Length + Notice(rows.Count).Length);
+        int budget = room.Budget;
+        string nodesCut = CutNotice("nodes", cap);
         foreach (var row in rows)
         {
             if (manifestOnly) break;
-            if (sb.Length >= cap)
-            {
-                truncated = true;
-                sb.Append("... [rendered ").Append(rendered).Append(" of ").Append(rows.Count)
-                  .Append(" rows at max_chars=").Append(cap).Append("]\n");
-                break;
-            }
+            int mark = sb.Length;
+            bool leadMark = declarersLeadWritten;
+            // said: this row stopped inside the budget and named what it held back, so it stays and the render
+            // stops after it. mute: it stopped with no room to say so, and the whole row goes back out instead.
+            bool said = false, mute = false;
             sb.Append('\n').Append(row.Formid);
-            if (row.Error is not null) { sb.Append("  error=").Append(row.Error).Append('\n'); rendered++; continue; }
+            if (row.Error is not null)
+            {
+                sb.Append("  error=").Append(row.Error).Append('\n');
+                if (Crossed(sb, mark, budget, Notice(rendered), ref truncated)) break;
+                rendered++; continue;
+            }
             sb.Append("  ").Append(row.Type ?? "?").Append("  ").Append(row.EditorId ?? "<no editorid>").Append('\n');
             sb.Append("  ").Append(row.Touchers.Count).Append(" plugin(s) touch this record (load order, winner last):\n");
             for (int i = 0; i < row.Touchers.Count; i++)
                 sb.Append("    ").Append(i + 1).Append(". ").Append(row.Touchers[i])
                   .Append(i == row.Touchers.Count - 1 ? "  (winner)" : "").Append('\n');
-            if (AppendChildDeclarers(sb, row, cap, ref declarersLeadWritten, out bool declarersCut))
+            // The row ends at the block when the block was cut, or when it ran the budget out; a sole provider
+            // ends there too, having nothing to diff against.
+            bool ended = AppendChildDeclarers(sb, row, room, row.Nodes.Count > 1 ? nodesCut.Length : 0,
+                                              ref declarersLeadWritten, out bool declarersCut, out bool declarersMute);
+            if (ended)
             {
-                // The row ends here, but `truncated` claims the whole ANSWER is incomplete and drives the spill,
-                // so set it only when this row actually lost something: declarer lines dropped, or a diff the row
-                // never reached. A sole-provider row whose complete block merely ended past cap lost nothing.
-                if (declarersCut || row.Nodes.Count > 1) truncated = true;
+                mute = declarersMute;
+                // The row lost something when declarer lines were dropped, or when a diff it never reached is
+                // gone. A sole-provider row whose complete block merely ended at the budget lost nothing.
+                said = declarersCut;
                 // A multi-provider row loses its diff whether or not declarer lines were also dropped, and each
                 // notice claims one thing, so a cut row carries both notices.
-                if (row.Nodes.Count > 1) AppendCutNotice(sb, "nodes", cap);
-                rendered++; continue;
-            }
-            if (row.Nodes.Count <= 1) { rendered++; continue; }   // a sole provider has nothing to diff against
-            sb.Append("  diff (field deltas vs ").Append(row.ReferencePlugin)
-              .Append("; identical fields omitted; list contents compared by content, element reorders flagged):\n");
-            foreach (var n in row.Nodes)
-            {
-                if (n.IsReference) continue;
-                if (sb.Length >= cap)
+                if (!mute && row.Nodes.Count > 1)
                 {
-                    truncated = true;
-                    AppendCutNotice(sb, "nodes", cap);
-                    break;
+                    if (Said(sb, nodesCut, budget)) said = true;
+                    else mute = true;
                 }
-                sb.Append("    ").Append(n.Plugin).Append(n.IsWinner ? " (winner)" : "").Append(": ");
-                // The incompleteness note goes on EVERY incomplete node, not only the one with no deltas: an
-                // unreadable leaf always produces a delta line, so gating it on an empty delta list left the
-                // normal shape saying nothing about what was skipped.
-                if (n.Deltas.Count > 0)
-                    sb.Append(string.Join("; ", n.Deltas))
-                      .Append(n.Complete ? "" : " — the comparison is INCOMPLETE: a field could not be read (nothing at or under it was compared), or the deep read hit the cap (which suppresses list-content and one-sided-presence deltas for the whole record)")
-                      .Append('\n');
-                else if (!n.Complete)
-                    sb.Append("no differing fields in what was read, but the comparison is INCOMPLETE — the deep read was TRUNCATED at the cap, so this is not a clean 'identical'.\n");
-                else
-                    sb.Append(fieldsNarrow
-                        ? $"identical to {row.ReferencePlugin} across the fields read ({n.AgreedCount} leaf/leaves agree)\n"
-                        : $"identical to {row.ReferencePlugin} (whole record; {n.AgreedCount} leaf/leaves agree)\n");
             }
+            else if (row.Nodes.Count > 1)
+            {
+                // The diff heading carries its own cut notice's room: a heading with no room under it for either a
+                // node or the notice would end the row in silence.
+                string diffHead = "  diff (field deltas vs " + row.ReferencePlugin +
+                                  "; identical fields omitted; list contents compared by content, element reorders flagged):\n";
+                if (sb.Length + diffHead.Length + nodesCut.Length > budget)
+                {
+                    said = Said(sb, nodesCut, budget);
+                    mute = !said;
+                    goto measure;
+                }
+                sb.Append(diffHead);
+                foreach (var n in row.Nodes)
+                {
+                    if (n.IsReference) continue;
+                    // The incompleteness note goes on EVERY incomplete node, not only the one with no deltas: an
+                    // unreadable leaf always produces a delta line, so gating it on an empty delta list left the
+                    // normal shape saying nothing about what was skipped.
+                    string body = n.Deltas.Count > 0
+                        ? string.Join("; ", n.Deltas) +
+                          (n.Complete ? "" : " — the comparison is INCOMPLETE: a field could not be read (nothing at or under it was compared), or the deep read hit the cap (which suppresses list-content and one-sided-presence deltas for the whole record)") + "\n"
+                        : !n.Complete
+                            ? "no differing fields in what was read, but the comparison is INCOMPLETE — the deep read was TRUNCATED at the cap, so this is not a clean 'identical'.\n"
+                            : fieldsNarrow
+                                ? $"identical to {row.ReferencePlugin} across the fields read ({n.AgreedCount} leaf/leaves agree)\n"
+                                : $"identical to {row.ReferencePlugin} (whole record; {n.AgreedCount} leaf/leaves agree)\n";
+                    // Composed before it is priced: the node line and its own cut notice are measured together, so
+                    // the notice cannot land a character past the node that crossed.
+                    string line = "    " + n.Plugin + (n.IsWinner ? " (winner)" : "") + ": " + body;
+                    if (sb.Length + line.Length + nodesCut.Length > budget)
+                    {
+                        said = Said(sb, nodesCut, budget);
+                        mute = !said;
+                        break;
+                    }
+                    sb.Append(line);
+                }
+            }
+        measure:
+            if (mute || !said)
+            {
+                if (Crossed(sb, mark, budget, Notice(rendered), ref truncated, force: mute))
+                { declarersLeadWritten = leadMark; break; }
+                rendered++;
+                continue;
+            }
+            // The row was laid to the budget and says what it held back: it stays, and nothing more fits.
+            truncated = true;
             rendered++;
+            break;
         }
-        if (spill is not null) Artifacts.AppendSpillStateText(sb, spill);
-        return sb.ToString().TrimEnd('\n');
+        sb.Append(spillText);
+        return RenderCap.Settle(sb.ToString().TrimEnd('\n'), cap);
     }
 
     /// <summary>The records text lane's cut notice, composed in one place so its several call sites cannot
-    /// drift.</summary>
+    /// drift. Returned rather than written, so the room it takes can be held back before the line it follows is
+    /// laid — a notice appended past the budget is the defect this render family exists to prevent.</summary>
     /// <param name="what">What was cut — the notice claims this and nothing else, so a caller that cut something
     /// different names that instead.</param>
-    static void AppendCutNotice(StringBuilder sb, string what, int cap) =>
-        sb.Append("    ... [").Append(what).Append(" cut at max_chars=").Append(cap)
-          .Append(" — raise max_chars or narrow with ").Append(LeverNames.Records.Fields).Append("]\n");
+    static string CutNotice(string what, int cap) =>
+        "    ... [" + what + " cut at max_chars=" + cap + " — raise max_chars or narrow with " +
+        LeverNames.Records.Fields + "]\n";
 
     /// <summary>The tree's precise owned-child block: which providers declare children per child-bearing field,
     /// and the negative sentence when none do. Sits above the diff, not inside it; background in
@@ -2062,52 +2147,66 @@ public static class RecordsTools
     /// <see cref="LoadOrderService.TreeRow"/> wider than any fixture cell.</summary>
     /// <param name="leadWritten">Set once the framing line has been stated; every later row gets the short
     /// <see cref="ReadSentences.DeclarersHeader"/> instead of repeating it.</param>
-    /// <param name="blockCut">true only when declarer lines were actually dropped. false with a true return means
-    /// the block is complete and the row ends at <paramref name="cap"/> — the caller names what it loses.</param>
+    /// <param name="blockCut">true only when declarer lines were actually dropped AND the block said so. false with
+    /// a true return means the block is complete and the row ends at <paramref name="cap"/> — the caller names what
+    /// it loses.</param>
+    /// <param name="tailReserve">Room the CALLER still owes below this block — the nodes notice a multi-provider
+    /// row writes when the block ends its row — held back here so that notice lands inside the budget too.</param>
+    /// <param name="mute">true when the block stopped with no room to say it was cut: the caller takes the whole
+    /// row back out rather than ending it in silence.</param>
     /// <returns>true if the row ends here.</returns>
-    internal static bool AppendChildDeclarers(StringBuilder sb, LoadOrderService.TreeRow row, int cap,
-                                              ref bool leadWritten, out bool blockCut)
+    internal static bool AppendChildDeclarers(StringBuilder sb, LoadOrderService.TreeRow row, RenderCap cap,
+                                              int tailReserve, ref bool leadWritten, out bool blockCut, out bool mute)
     {
         blockCut = false;
+        mute = false;
         if (row.ChildDeclarers.Count == 0) return false;
         // The framing line has a known length, so reserve it rather than write it and regret it: a plain
         // sb.Length < cap check would put its whole length past cap with no way to take it back.
-        // JsonWire.RenderTree reserves the same sentence the same way.
+        // JsonWire.RenderTree reserves the same sentence the same way. The cut notice is reserved beside it for
+        // the same reason — it is written where the framing is not, so it must fit where the framing did not.
         string framing = leadWritten ? ReadSentences.DeclarersHeader : ReadSentences.DeclarersLead;
-        if (sb.Length + framing.Length + 3 >= cap)   // 3: the two-space indent and the newline around it
+        string cut = CutNotice("child declarers", cap.Cap);
+        int budget = Math.Max(cap.Budget - tailReserve, 0);
+        // 3: the two-space indent and the newline around it. The notice is reserved beside the framing as well —
+        // a block that starts with no room left to say it was cut can only end the row in silence.
+        if (sb.Length + framing.Length + 3 + cut.Length >= budget)
         {
-            blockCut = true;
-            AppendCutNotice(sb, "child declarers", cap);
+            blockCut = Said(sb, cut, budget);
+            mute = !blockCut;
             return true;
         }
         sb.Append("  ").Append(framing).Append('\n');
         leadWritten = true;
         foreach (var cd in row.ChildDeclarers)
         {
-            if (sb.Length >= cap)
-            {
-                blockCut = true;
-                AppendCutNotice(sb, "child declarers", cap);
-                return true;
-            }
-            sb.Append("    ").Append(cd.Field).Append(": ")
-              .Append(ReadSentences.DeclarersNote(cd.Shape, cd.Declaring, cd.Unreadable));
+            // The line is composed before it is priced: a check that measures only what is already written cuts
+            // where the notice has room but the line does not, or the other way round.
             // DeclarersNote elides past DeclarerNameCap in two clauses — a collection field's `declaring` names,
             // and `unreadable` on any shape — and both are followable only in json. One remedy per line even
             // when both fired, since it is the same pointer.
-            if ((cd.Shape == OwnedChildShape.Collection && cd.Declaring.Count > ReadSentences.DeclarerNameCap)
-                || cd.Unreadable.Count > ReadSentences.DeclarerNameCap)
-                sb.Append(ReadSentences.DeclarersOverflowRemedy);
-            sb.Append('\n');
+            bool overflowed = (cd.Shape == OwnedChildShape.Collection && cd.Declaring.Count > ReadSentences.DeclarerNameCap)
+                              || cd.Unreadable.Count > ReadSentences.DeclarerNameCap;
+            string line = "    " + cd.Field + ": " + ReadSentences.DeclarersNote(cd.Shape, cd.Declaring, cd.Unreadable)
+                          + (overflowed ? ReadSentences.DeclarersOverflowRemedy : "") + "\n";
+            if (sb.Length + line.Length + cut.Length > budget)
+            {
+                blockCut = Said(sb, cut, budget);
+                mute = !blockCut;
+                return true;
+            }
+            sb.Append(line);
         }
-        // Reached only when every declarer line was written, so the block was not cut — the last line simply
-        // ended past cap. Ending the row is right, but the notice is the caller's to write over what it loses.
-        return sb.Length >= cap;
+        // Every declarer line was written, and each was priced with the notice beside it — so the block is
+        // complete AND the room its notice would have taken is still there. The row goes on.
+        return false;
     }
 
     /// <summary>The chain form's text render: per seed the reached nodes in BFS order with what pulled each one
     /// in, recorded cycles, the cap-truncation note — what is listed is proved — and the NPC TemplateFlags
-    /// inheritance report where the walk followed a Template chain.</summary>
+    /// inheritance report where the walk followed a Template chain. max_chars is a CEILING, the same shape the
+    /// delta and tree renders carry: the notice and the spill block are charged first, the node loop holds back
+    /// its own cut notice, and a seed that would cross what is left is taken back out whole and counted.</summary>
     static string RenderRecordsChain(IReadOnlyList<LoadOrderService.WalkSeedResult> rows, int total, int reached,
                                      int errors, string headerLine, OrderStamp? epoch, int maxChars,
                                      SpillState? spill, out bool truncated)
@@ -2121,35 +2220,47 @@ public static class RecordsTools
         if (epoch is not null) sb.Append(Wire.EpochInline(epoch));
         sb.Append('\n');
         int rendered = 0;
+        string Notice(int r) =>
+            "... [rendered " + r + " of " + rows.Count + " seeds at max_chars=" + cap + "]\n";
+        string nodesCut = "    ... [nodes cut at max_chars=" + cap + " — raise max_chars, or to_file= for the complete walk]\n";
+        var spillText = Wire.SpillText(spill);
+        int budget = Math.Max(cap - spillText.Length - Notice(rows.Count).Length, 0);
         foreach (var row in rows)
         {
             if (manifestOnly) break;
-            if (sb.Length >= cap)
-            {
-                truncated = true;
-                sb.Append("... [rendered ").Append(rendered).Append(" of ").Append(rows.Count)
-                  .Append(" seeds at max_chars=").Append(cap).Append("]\n");
-                break;
-            }
+            int mark = sb.Length;
+            // said: this seed's node list stopped inside the budget and named what it held back, so the seed stays
+            // and the render stops after it. mute: it stopped with no room to say so, and the seed goes back out.
+            bool said = false, mute = false;
             sb.Append('\n').Append(row.Seed);
-            if (row.Error is not null) { sb.Append("  error=").Append(row.Error).Append('\n'); rendered++; continue; }
+            if (row.Error is not null)
+            {
+                sb.Append("  error=").Append(row.Error).Append('\n');
+                if (Crossed(sb, mark, budget, Notice(rendered), ref truncated)) break;
+                rendered++; continue;
+            }
             sb.Append("  ").Append(row.Type ?? "?").Append("  ").Append(row.EditorId ?? "<no editorid>").Append('\n');
             if (row.Nodes.Count == 0)
                 sb.Append("  no links to follow from this seed").Append(row.TruncationNote is null ? ".\n" : " before the cap.\n");
             foreach (var n in row.Nodes)
             {
-                if (sb.Length >= cap)
+                // Composed before it is priced, so the cut notice lands inside the budget rather than a character
+                // past the node that crossed it.
+                string line = "    d" + n.Depth + "  " + n.Key
+                              + (n.Type is not null ? "  " + n.Type + "  " + (n.EditorId ?? "<no editorid>") : "")
+                              + "  [" + n.Status + ']'
+                              + (n.Note is not null ? "  " + n.Note : "")
+                              + "  <- " + n.PulledBy + "\n";
+                if (sb.Length + line.Length + nodesCut.Length > budget)
                 {
-                    truncated = true;
-                    sb.Append("    ... [nodes cut at max_chars=").Append(cap).Append(" — raise max_chars, or to_file= for the complete walk]\n");
+                    said = Said(sb, nodesCut, budget);
+                    mute = !said;
                     break;
                 }
-                sb.Append("    d").Append(n.Depth).Append("  ").Append(n.Key);
-                if (n.Type is not null) sb.Append("  ").Append(n.Type).Append("  ").Append(n.EditorId ?? "<no editorid>");
-                sb.Append("  [").Append(n.Status).Append(']');
-                if (n.Note is not null) sb.Append("  ").Append(n.Note);
-                sb.Append("  <- ").Append(n.PulledBy).Append('\n');
+                sb.Append(line);
             }
+            // A seed cut mid-list ends there: what follows the nodes belongs to a seed the budget did not hold.
+            if (said || mute) goto measure;
             foreach (var c in row.Cycles)
                 sb.Append("  cycle: ").Append(c).Append('\n');
             if (row.TruncationNote is not null)
@@ -2168,15 +2279,26 @@ public static class RecordsTools
                     sb.Append('\n');
                 }
             }
+        measure:
+            if (mute || !said)
+            {
+                if (Crossed(sb, mark, budget, Notice(rendered), ref truncated, force: mute)) break;
+                rendered++;
+                continue;
+            }
+            // The seed was laid to the budget and says what it held back: it stays, and nothing more fits.
+            truncated = true;
             rendered++;
+            break;
         }
-        if (spill is not null) Artifacts.AppendSpillStateText(sb, spill);
-        return sb.ToString().TrimEnd('\n');
+        sb.Append(spillText);
+        return RenderCap.Settle(sb.ToString().TrimEnd('\n'), cap);
     }
 
     /// <summary>The reverse MGEF lane's text render: a header census over the complete seed list, each windowed
-    /// seed's carriers through the shared effect-chain render, the standard explicit cut and spill
-    /// marker.</summary>
+    /// seed's carriers through the shared effect-chain render, the standard explicit cut and spill marker.
+    /// max_chars is a CEILING: the notice and the spill block are charged first, the shared render is told what
+    /// this one has already spent, and a seed that would cross what is left is taken back out whole.</summary>
     static string RenderRecordsEffectChains(IReadOnlyList<(string Seed, EffectChainResult Result)> results,
                                             int totalSeeds, int carrierRows, int carrierTotal, int errors, string headerLine,
                                             OrderStamp? epoch, int maxChars, SpillState? spill, out bool truncated)
@@ -2192,27 +2314,31 @@ public static class RecordsTools
         if (epoch is not null) sb.Append(Wire.EpochInline(epoch));
         sb.Append('\n');
         int rendered = 0;
+        string Notice(int r) =>
+            "... [rendered " + r + " of " + results.Count + " seeds at max_chars=" + cap + "]\n";
+        var spillText = Wire.SpillText(spill);
+        var room = RenderCap.For(cap, spillText.Length + Notice(results.Count).Length);
         foreach (var (seed, result) in results)
         {
             if (manifestOnly) break;
-            if (sb.Length >= cap)
-            {
-                truncated = true;
-                sb.Append("... [rendered ").Append(rendered).Append(" of ").Append(results.Count)
-                  .Append(" seeds at max_chars=").Append(cap).Append("]\n");
-                break;
-            }
+            int mark = sb.Length;
             sb.Append('\n').Append("seed ").Append(seed).Append('\n');
-            sb.Append(Wire.RenderEffectChain(result, cap, "walk.max_nodes")).Append('\n');
+            // The shared render builds its own buffer, so it is told what this one has already spent — and it
+            // still quotes the caller's max_chars in its own cut notice.
+            sb.Append(Wire.RenderEffectChain(result, room, sb.Length + 1, "walk.max_nodes")).Append('\n');
+            if (Crossed(sb, mark, room.Budget, Notice(rendered), ref truncated)) break;
             rendered++;
         }
-        if (spill is not null) Artifacts.AppendSpillStateText(sb, spill);
-        return sb.ToString().TrimEnd('\n');
+        sb.Append(spillText);
+        return RenderCap.Settle(sb.ToString().TrimEnd('\n'), cap);
     }
 
     /// <summary>The info_order form's text render: per topic its identity, then the merged-order body from
     /// <see cref="DialogueWire.AppendInfoOrderView"/> — one shared render, so the MOVED annotations and the
-    /// confidence gates cannot drift from the dialogue surface's.</summary>
+    /// confidence gates cannot drift from the dialogue surface's. max_chars is a CEILING: the notice and the
+    /// spill block are charged first, the shared view is bounded by what is left rather than by the whole cap,
+    /// and a topic that still crossed is taken back out whole and counted — the view's own tail rides inside the
+    /// topic block, so there is no way to keep half of one and stay under the ceiling.</summary>
     static string RenderRecordsInfoOrder(IReadOnlyList<LoadOrderService.InfoOrderRow> rows, int total, int contested,
                                          int errors, string headerLine, OrderStamp? epoch, int maxChars,
                                          SpillState? spill, out bool truncated)
@@ -2226,33 +2352,36 @@ public static class RecordsTools
         if (epoch is not null) sb.Append(Wire.EpochInline(epoch));
         sb.Append('\n');
         int rendered = 0;
+        string Notice(int r) =>
+            "... [rendered " + r + " of " + rows.Count + " rows at max_chars=" + cap + "]\n";
+        var spillText = Wire.SpillText(spill);
+        int budget = Math.Max(cap - spillText.Length - Notice(rows.Count).Length, 0);
         foreach (var row in rows)
         {
             if (manifestOnly) break;
-            if (sb.Length >= cap)
-            {
-                truncated = true;
-                sb.Append("... [rendered ").Append(rendered).Append(" of ").Append(rows.Count)
-                  .Append(" rows at max_chars=").Append(cap).Append("]\n");
-                break;
-            }
+            int mark = sb.Length;
             sb.Append('\n').Append(row.Formid);
-            if (row.Error is not null) { sb.Append("  error=").Append(row.Error).Append('\n'); rendered++; continue; }
+            if (row.Error is not null)
+            {
+                sb.Append("  error=").Append(row.Error).Append('\n');
+                if (Crossed(sb, mark, budget, Notice(rendered), ref truncated)) break;
+                rendered++; continue;
+            }
             sb.Append("  ").Append(row.Type ?? "?").Append("  ").Append(row.EditorId ?? "<no editorid>")
               .Append("  winner=").Append(row.WinnerPlugin ?? "?").Append('\n');
             if (row.Order is null)
                 sb.Append("  [!] the merge could not be computed for this topic (its key did not resolve in the touching index).\n");
             else if (row.Order.Order.Count == 0 && row.Order.Complete)
                 sb.Append("  no INFO lines — every touching plugin's child list is empty.\n");
-            else if (!DialogueWire.AppendInfoOrderView(sb, row.Order, "", cap, indent: false))
-            {
-                truncated = true;
-                break;
-            }
+            else
+                // The shared view is bounded by what this render has left, not by the whole cap, and its own tail
+                // rides inside the topic block — so a topic that still crossed goes back out whole below.
+                DialogueWire.AppendInfoOrderView(sb, row.Order, "", budget, indent: false);
+            if (Crossed(sb, mark, budget, Notice(rendered), ref truncated)) break;
             rendered++;
         }
-        if (spill is not null) Artifacts.AppendSpillStateText(sb, spill);
-        return sb.ToString().TrimEnd('\n');
+        sb.Append(spillText);
+        return RenderCap.Settle(sb.ToString().TrimEnd('\n'), cap);
     }
 
     /// <summary>The list-lane summary render: one identity-and-winner line per outcome, or its per-item error —

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -1885,8 +1885,11 @@ public static class RecordsTools
     /// never rendered as 'identical'. max_chars is a CEILING here, the shape #603 gave the scan and batch renders:
     /// the truncation notice and the spill block are charged before the first record is laid, a delta line is
     /// written only where its own cut notice still fits beside it, and a record that would cross what is left is
-    /// taken back out whole and counted.</summary>
-    static string RenderRecordsDelta(IReadOnlyList<LoadOrderService.DeltaRow> rows, int total, int differing, int identical,
+    /// taken back out whole and counted.
+    /// Internal so a test can drive it against a hand-built <see cref="LoadOrderService.DeltaRow"/>, the same
+    /// reason <see cref="RenderRecordsTree"/> is: a row shape no fixture produces (an incomplete deep read with
+    /// enough delta lines to be cut) has no other way in.</summary>
+    internal static string RenderRecordsDelta(IReadOnlyList<LoadOrderService.DeltaRow> rows, int total, int differing, int identical,
                                      int noVerdict, int errors,
                                      string headerLine, OrderStamp? epoch, int maxChars, SpillState? spill, out bool truncated)
     {
@@ -1957,21 +1960,25 @@ public static class RecordsTools
                       .Append(d.NoVerdictCount == 1 ? " field that could not be read" : " fields that could not be read");
                 sb.Append(" — each value line: ").Append(s.LabelVersus(r.Plugin)).Append("'s value (reference = ")
                   .Append(r.LabelVersus(s.Plugin)).Append("):\n");
+                // A different loss from the cut, so the cut may not swallow it: INCOMPLETE says deltas were never
+                // COMPUTED (the deep read hit the cap, or a field could not be read), while the cut notice says
+                // computed lines did not fit. The note is reserved beside every line and written either way.
+                string incomplete = d.Complete ? ""
+                    : "  note: the comparison is INCOMPLETE — a field above could not be read (nothing at or under it was compared), or the deep read hit the cap (which suppresses list-content and one-sided-presence deltas for the whole record). Narrow with " + LeverNames.Records.Fields + " to compare those in full.\n";
                 foreach (var delta in d.Deltas)
                 {
                     // The line goes in only where its own cut notice still fits beside it, so the notice lands
                     // inside the budget rather than a character past the one that crossed.
                     string line = "    - " + delta + "\n";
-                    if (sb.Length + line.Length + deltaCut.Length > budget)
+                    if (sb.Length + line.Length + deltaCut.Length + incomplete.Length > budget)
                     {
-                        said = Said(sb, deltaCut, budget);
+                        said = Said(sb, deltaCut, budget - incomplete.Length);
                         mute = !said;
                         break;
                     }
                     sb.Append(line);
                 }
-                if (!said && !mute && !d.Complete)
-                    sb.Append("  note: the comparison is INCOMPLETE — a field above could not be read (nothing at or under it was compared), or the deep read hit the cap (which suppresses list-content and one-sided-presence deltas for the whole record). Narrow with ").Append(LeverNames.Records.Fields).Append(" to compare those in full.\n");
+                if (!mute) sb.Append(incomplete);
             }
             if (mute || !said)
             {

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -1980,8 +1980,8 @@ public static class RecordsTools
                 continue;
             }
             // The record was laid to the budget and says what it held back: it stays, and nothing more fits.
-            truncated = true;
             rendered++;
+            Stopped(sb, Notice(rendered), rendered, rows.Count, ref truncated);
             break;
         }
         sb.Append(spillText);
@@ -1998,6 +1998,15 @@ public static class RecordsTools
         sb.Append(notice);
         truncated = true;
         return true;
+    }
+
+    /// <summary>The end a unit that said what it held back gets: it stays, the render stops after it, and the units
+    /// it never reached are counted in <paramref name="notice"/> — written in the room charged for it before the
+    /// first unit was laid. A unit that was the last one left nothing to count, so the line is not written.</summary>
+    static void Stopped(StringBuilder sb, string notice, int rendered, int total, ref bool truncated)
+    {
+        truncated = true;
+        if (rendered < total) sb.Append(notice);
     }
 
     /// <summary>A section that ran out of room says so INSIDE the budget or not at all: false means the notice
@@ -2124,8 +2133,8 @@ public static class RecordsTools
                 continue;
             }
             // The row was laid to the budget and says what it held back: it stays, and nothing more fits.
-            truncated = true;
             rendered++;
+            Stopped(sb, Notice(rendered), rendered, rows.Count, ref truncated);
             break;
         }
         sb.Append(spillText);
@@ -2287,8 +2296,8 @@ public static class RecordsTools
                 continue;
             }
             // The seed was laid to the budget and says what it held back: it stays, and nothing more fits.
-            truncated = true;
             rendered++;
+            Stopped(sb, Notice(rendered), rendered, rows.Count, ref truncated);
             break;
         }
         sb.Append(spillText);

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -2222,8 +2222,11 @@ public static class RecordsTools
     /// in, recorded cycles, the cap-truncation note — what is listed is proved — and the NPC TemplateFlags
     /// inheritance report where the walk followed a Template chain. max_chars is a CEILING, the same shape the
     /// delta and tree renders carry: the notice and the spill block are charged first, the node loop holds back
-    /// its own cut notice, and a seed that would cross what is left is taken back out whole and counted.</summary>
-    static string RenderRecordsChain(IReadOnlyList<LoadOrderService.WalkSeedResult> rows, int total, int reached,
+    /// its own cut notice, and a seed that would cross what is left is taken back out whole and counted.
+    /// Internal so a test can drive it against a hand-built <see cref="LoadOrderService.WalkSeedResult"/>, the same
+    /// reason <see cref="RenderRecordsTree"/> is: a seed shape no fixture produces (a walk that hit its node cap
+    /// with nodes enough for max_chars to cut) has no other way in.</summary>
+    internal static string RenderRecordsChain(IReadOnlyList<LoadOrderService.WalkSeedResult> rows, int total, int reached,
                                      int errors, string headerLine, OrderStamp? epoch, int maxChars,
                                      SpillState? spill, out bool truncated)
     {
@@ -2258,6 +2261,10 @@ public static class RecordsTools
             sb.Append("  ").Append(row.Type ?? "?").Append("  ").Append(row.EditorId ?? "<no editorid>").Append('\n');
             if (row.Nodes.Count == 0)
                 sb.Append("  no links to follow from this seed").Append(row.TruncationNote is null ? ".\n" : " before the cap.\n");
+            // What the seed says about its WALK is a different loss from the nodes max_chars held back, and the
+            // cut notice's remedy does not fix it — so the tail is reserved beside every node line and written
+            // whether or not the list was cut.
+            string tail = SeedTail(row);
             foreach (var n in row.Nodes)
             {
                 // Composed before it is priced, so the cut notice lands inside the budget rather than a character
@@ -2267,35 +2274,15 @@ public static class RecordsTools
                               + "  [" + n.Status + ']'
                               + (n.Note is not null ? "  " + n.Note : "")
                               + "  <- " + n.PulledBy + "\n";
-                if (sb.Length + line.Length + nodesCut.Length > budget)
+                if (sb.Length + line.Length + nodesCut.Length + tail.Length > budget)
                 {
-                    said = Said(sb, nodesCut, budget);
+                    said = Said(sb, nodesCut, budget - tail.Length);
                     mute = !said;
                     break;
                 }
                 sb.Append(line);
             }
-            // A seed cut mid-list ends there: what follows the nodes belongs to a seed the budget did not hold.
-            if (said || mute) goto measure;
-            foreach (var c in row.Cycles)
-                sb.Append("  cycle: ").Append(c).Append('\n');
-            if (row.TruncationNote is not null)
-                sb.Append("  [!] ").Append(row.TruncationNote).Append('\n');
-            if (row.TemplateReport is { } tr)
-            {
-                sb.Append("  template inheritance (TemplateFlags — a SET flag means the category is INHERITED and the seed's own local data for it is MASKED):\n");
-                foreach (var c in tr)
-                {
-                    sb.Append("    ").Append(c.Category).Append(": ");
-                    if (!c.InheritedAtSeed) sb.Append("local data ACTIVE");
-                    else if (c.ProviderKey is not null)
-                        sb.Append("INHERITED from ").Append(c.ProviderKey).Append(" (").Append(c.ProviderEditorId ?? "<no editorid>").Append(')');
-                    else sb.Append("INHERITED");
-                    if (c.Note is not null && c.InheritedAtSeed) sb.Append("  — ").Append(c.Note);
-                    sb.Append('\n');
-                }
-            }
-        measure:
+            if (!mute) sb.Append(tail);
             if (mute || !said)
             {
                 if (Crossed(sb, mark, budget, Notice(rendered), ref truncated, force: mute)) break;
@@ -2309,6 +2296,34 @@ public static class RecordsTools
         }
         sb.Append(spillText);
         return RenderCap.Settle(sb.ToString().TrimEnd('\n'), cap);
+    }
+
+    /// <summary>What a walked seed states after its nodes: the cycles it recorded, the walk.max_nodes cap it hit,
+    /// and the NPC TemplateFlags inheritance report. Composed apart from the node loop because these are claims
+    /// about the WALK, not about the nodes that fit — a max_chars cut may not swallow them, and the cut notice's
+    /// remedy (raise max_chars, or to_file=) does not answer a walk that stopped at its own cap.</summary>
+    static string SeedTail(LoadOrderService.WalkSeedResult row)
+    {
+        var t = new StringBuilder();
+        foreach (var c in row.Cycles)
+            t.Append("  cycle: ").Append(c).Append('\n');
+        if (row.TruncationNote is not null)
+            t.Append("  [!] ").Append(row.TruncationNote).Append('\n');
+        if (row.TemplateReport is { } tr)
+        {
+            t.Append("  template inheritance (TemplateFlags — a SET flag means the category is INHERITED and the seed's own local data for it is MASKED):\n");
+            foreach (var c in tr)
+            {
+                t.Append("    ").Append(c.Category).Append(": ");
+                if (!c.InheritedAtSeed) t.Append("local data ACTIVE");
+                else if (c.ProviderKey is not null)
+                    t.Append("INHERITED from ").Append(c.ProviderKey).Append(" (").Append(c.ProviderEditorId ?? "<no editorid>").Append(')');
+                else t.Append("INHERITED");
+                if (c.Note is not null && c.InheritedAtSeed) t.Append("  — ").Append(c.Note);
+                t.Append('\n');
+            }
+        }
+        return t.ToString();
     }
 
     /// <summary>The reverse MGEF lane's text render: a header census over the complete seed list, each windowed

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -2455,10 +2455,12 @@ public static class RecordsTools
                 sb.Append("  [!] the merge could not be computed for this topic (its key did not resolve in the touching index).\n");
             else if (row.Order.Order.Count == 0 && row.Order.Complete)
                 sb.Append("  no INFO lines — every touching plugin's child list is empty.\n");
-            else
-                // The shared view is bounded by what this render has left, not by the whole cap, and its own tail
-                // rides inside the topic block — so a topic that still crossed goes back out whole below.
-                DialogueWire.AppendInfoOrderView(sb, row.Order, "", budget, indent: false);
+            // The shared view is bounded by what this render has left, not by the whole cap, and its own tail
+            // rides inside the topic block — so a topic that still crossed goes back out whole below. Its own
+            // stop signal is kept rather than re-derived from Crossed: the two agree only because the view
+            // appends its marker AFTER the check that crossed, which is the view's business, not this render's.
+            else if (!DialogueWire.AppendInfoOrderView(sb, row.Order, "", budget, indent: false))
+                truncated = true;
             if (Crossed(sb, mark, budget, Notice(rendered), ref truncated)) break;
             rendered++;
         }

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -2307,7 +2307,8 @@ public static class RecordsTools
     /// <summary>The reverse MGEF lane's text render: a header census over the complete seed list, each windowed
     /// seed's carriers through the shared effect-chain render, the standard explicit cut and spill marker.
     /// max_chars is a CEILING: the notice and the spill block are charged first, the shared render is told what
-    /// this one has already spent, and a seed that would cross what is left is taken back out whole.</summary>
+    /// this one has already spent, and a seed that would cross what is left is taken back out whole. A seed the
+    /// shared render cut inside its own buffer reports that back — nothing here can measure it.</summary>
     static string RenderRecordsEffectChains(IReadOnlyList<(string Seed, EffectChainResult Result)> results,
                                             int totalSeeds, int carrierRows, int carrierTotal, int errors, string headerLine,
                                             OrderStamp? epoch, int maxChars, SpillState? spill, out bool truncated)
@@ -2334,9 +2335,14 @@ public static class RecordsTools
             sb.Append('\n').Append("seed ").Append(seed).Append('\n');
             // The shared render builds its own buffer, so it is told what this one has already spent — and it
             // still quotes the caller's max_chars in its own cut notice.
-            sb.Append(Wire.RenderEffectChain(result, room, sb.Length + 1, "walk.max_nodes")).Append('\n');
+            sb.Append(Wire.RenderEffectChain(result, room, sb.Length + 1, "walk.max_nodes", out bool said)).Append('\n');
             if (Crossed(sb, mark, room.Budget, Notice(rendered), ref truncated)) break;
             rendered++;
+            // The shared render keeps its own output inside the budget, so a seed it cut never crosses here: the
+            // cut it reports is the only thing that says this answer is incomplete, and it drives the spill.
+            if (!said) continue;
+            Stopped(sb, Notice(rendered), rendered, results.Count, ref truncated);
+            break;
         }
         sb.Append(spillText);
         return RenderCap.Settle(sb.ToString().TrimEnd('\n'), cap);

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -138,7 +138,7 @@ public static class RecordsTools
             int limit = 500,
         [Description("TRANSPORT: skip the first N matches (exact windows: offset=0/500/1000…). Windows tile only WITHIN one epoch — if two pages' epochs differ the load order changed mid-pagination; re-run from offset=0, do not stitch the pages. offset= RE-SCANS the selection from the start rather than seeking into it, so every window pays the whole scan again and a deep window costs more than a shallow one — narrowing the scan terms beats paging far into one.")]
             int offset = 0,
-        [Description("TRANSPORT: character CEILING on the RENDER, hard on every text render this tool has — the scan, batch, resolve, group_by and summary renders, the comparison forms (delta, tree), the walk lane's chain and effect-chain renders, and info_order. The record block, node or delta line that would cross it is not written, and the truncation notice, the accounting line and the spilled: block are charged before the rows are laid — charged only where the whole render does not fit, so an answer that fits inside the max_chars you passed comes back complete, uncut and unspilled. The one answer that can still come back over it is a max_chars too small for what the response carries whatever the budget — its header, the notices it owes, its spilled: block — which says so and names the number that clears it. Never truncates the RESULT: an over-ceiling result SPILLS in full to a server-side JSONL artifact (line 1 = manifest with the query echo, the row schema, and the epoch) and the response names the file, so what the ceiling held back inline is in the file. 0 = the server default (~80k).")]
+        [Description("TRANSPORT: character CEILING on the RENDER, hard on every text render this tool has — the scan, batch, resolve, group_by and summary renders, the comparison forms (delta, tree), the walk lane's chain and effect-chain renders, info_order, and every form's counts_only census. The record block, node or delta line that would cross it is not written, and the truncation notice, the accounting line and the spilled: block are charged before the rows are laid — charged only where the whole render does not fit, so an answer that fits inside the max_chars you passed comes back complete, uncut and unspilled. The one answer that can still come back over it is a max_chars too small for what the response carries whatever the budget — its header, the notices it owes, its spilled: block — which says so and names the number that clears it. Never truncates the RESULT: an over-ceiling result SPILLS in full to a server-side JSONL artifact (line 1 = manifest with the query echo, the row schema, and the epoch) and the response names the file, so what the ceiling held back inline is in the file. 0 = the server default (~80k).")]
             int max_chars = 0,
         [Description("TRANSPORT: return the accounting block and counts only, no rows — the cheap census.")]
             bool counts_only = false,
@@ -455,6 +455,10 @@ public static class RecordsTools
             envelope.Add(new("source", statement));
             headerLine += $"  source={statement}";
         }
+        // A census is a text render too, so it is held to the same ceiling: it carries the header's source and
+        // selection statements whatever the budget, so a max_chars smaller than those says so and names the
+        // number that clears it instead of answering over the ceiling in silence.
+        string Census(string body) => RenderCap.Settle(body, max_chars > 0 ? max_chars : Wire.DefaultMaxChars);
         // Every warning the SkyPatcher replay produced — a key it does not know, an op it cannot map, a filter it
         // cannot evaluate, a parse note — named beside the answer, each already carrying its own file and line. A
         // draft INI's lines carry the draft's path, so a bad draft line reads where a bad live line does.
@@ -572,7 +576,7 @@ public static class RecordsTools
                     // The census honors counts_only on every list form, this one included.
                     int okI = rows.Count(r => r.Error is null);
                     return json ? JsonWire.RenderCounts(envelope, rows.Count, okI, rows.Count - okI, epoch)
-                                : $"{headerLine}\ncount={rows.Count} ok={okI} errors={rows.Count - okI}" + Wire.EpochLine(epoch);
+                                : Census($"{headerLine}\ncount={rows.Count} ok={okI} errors={rows.Count - okI}" + Wire.EpochLine(epoch));
                 }
                 var winRows = Windowed(rows);
                 SpillState? spill = null;
@@ -686,7 +690,7 @@ public static class RecordsTools
                 int ok = outcomes.Count(o => o.Error is null), err = outcomes.Count - outcomes.Count(o => o.Error is null);
                 return json
                     ? JsonWire.RenderCounts(envelope, outcomes.Count, ok, err, epoch2)
-                    : $"{headerLine}\ncount={outcomes.Count} ok={ok} errors={err}" + Wire.EpochLine(epoch2);
+                    : Census($"{headerLine}\ncount={outcomes.Count} ok={ok} errors={err}" + Wire.EpochLine(epoch2));
             }
 
             var winOutcomes = Windowed(outcomes);   // render window; census/aggregate/artifacts stay complete
@@ -885,7 +889,7 @@ public static class RecordsTools
                 if (counts_only)
                     return json
                         ? JsonWire.RenderNamedCounts(envelope, revCounts, epochR)
-                        : $"{headerLine}\nseeds={results.Count} carrier_rows={carrierRows} carrier_total={carrierTotal} capped_seeds={cappedSeeds} errors={seedErrs2}" + Wire.EpochLine(epochR);
+                        : Census($"{headerLine}\nseeds={results.Count} carrier_rows={carrierRows} carrier_total={carrierTotal} capped_seeds={cappedSeeds} errors={seedErrs2}" + Wire.EpochLine(epochR));
                 var winResults = Windowed(results);
                 SpillState? revSpill = null;
                 if (wantFile)
@@ -926,7 +930,7 @@ public static class RecordsTools
                 if (counts_only)
                     return json
                         ? JsonWire.RenderNamedCounts(envelope, new[] { KvI("seeds", rows.Count), KvI("reached", reached), KvI("errors", errs) }, wEpoch)
-                        : $"{headerLine}\nseeds={rows.Count} reached={reached} errors={errs}" + Wire.EpochLine(wEpoch);
+                        : Census($"{headerLine}\nseeds={rows.Count} reached={reached} errors={errs}" + Wire.EpochLine(wEpoch));
                 var winRows = Windowed(rows);
                 SpillState? spill = null;
                 if (wantFile)
@@ -1048,7 +1052,7 @@ public static class RecordsTools
             if (counts_only)
                 return json
                     ? JsonWire.RenderNamedCounts(envelope, new[] { KvI("count", rows.Count), KvI("differing", differing), KvI("identical", identical), KvI("no_verdict", noVerdict), KvI("errors", errs) }, epoch)
-                    : $"{headerLine}\ncount={rows.Count} differing={differing} identical={identical} no_verdict={noVerdict} errors={errs}" + Wire.EpochLine(epoch);
+                    : Census($"{headerLine}\ncount={rows.Count} differing={differing} identical={identical} no_verdict={noVerdict} errors={errs}" + Wire.EpochLine(epoch));
             var winRows = Windowed(rows);
             SpillState? spill = null;
             if (wantFile)
@@ -1090,7 +1094,7 @@ public static class RecordsTools
             if (counts_only)
                 return json
                     ? JsonWire.RenderNamedCounts(envelope, new[] { KvI("count", rows.Count), KvI("contested", contested), KvI("errors", errs) }, epoch)
-                    : $"{headerLine}\ncount={rows.Count} contested={contested} errors={errs}" + Wire.EpochLine(epoch);
+                    : Census($"{headerLine}\ncount={rows.Count} contested={contested} errors={errs}" + Wire.EpochLine(epoch));
             var winRows = Windowed(rows);
             SpillState? spill = null;
             if (wantFile)
@@ -1125,7 +1129,7 @@ public static class RecordsTools
             if (counts_only)
                 return json
                     ? JsonWire.RenderNamedCounts(envelope, new[] { KvI("count", rows.Count), KvI("contested", contested), KvI("errors", errs) }, epoch)
-                    : $"{headerLine}\ncount={rows.Count} contested={contested} errors={errs}" + Wire.EpochLine(epoch);
+                    : Census($"{headerLine}\ncount={rows.Count} contested={contested} errors={errs}" + Wire.EpochLine(epoch));
             var winRows = Windowed(rows);
             SpillState? spill = null;
             if (wantFile)


### PR DESCRIPTION
`max_chars=` was a test these five renders took *before* writing the next thing, not a bound on what came back: the record block, node, delta line or topic that crossed the line went in whole, and the truncation notice and the `spilled:` block were appended on top of it. #603 gave every other render in the tool the charge-and-roll-back shape and named these five in the parameter description and the changelog as the ones it did not hold. They now carry the same shape, and both of those statements are gone.

The layout is the bound. Per render: the truncation notice at its widest spelling and the spill block are composed and charged before the first record is laid; every inner list (delta lines, tree nodes, child declarers, chain nodes, effect-chain carrier rows) composes the line it is about to write and prices it **together with its own cut notice**, so the notice lands inside the budget rather than a character past the line that crossed; a record that runs to completion and still crosses is taken back out whole and counted in the notice; and the response settles through `RenderCap.Settle`, so the one arm left — a `max_chars` too small for what the response carries whatever the budget, its spill block included — says so and names the number that clears it.

Two states a row can end in, and each is stated:

- **said** — the row stopped inside the budget and named what it held back (`[delta lines cut …]`, `[nodes cut …]`, `[child declarers cut …]`). The row stays; nothing more fits, so the render stops after it.
- **mute** — the row stopped with no room even for that notice. The whole row goes back out and the render's own `[rendered N of M …]` notice takes its place. A section never ends a row in silence.

To keep `mute` off the common paths, two sections now reserve their notice alongside the thing that starts them: the declarers block will not write its framing line unless the cut notice still fits under it, and the tree's `diff (field deltas vs …)` heading is only written where a node or that notice fits beneath it. A sweep of every cap from 150 to 1800 on both fixture cells is monotonic and inside the ceiling at every one.

Closes #604

## What changed, per render

| render | what it did | what it does |
|---|---|---|
| `delta` | cap tested before the record and before each delta line; the crossing one written whole; `[delta lines cut …]` and the `spilled:` block appended past the budget | notice and spill charged first; each delta line priced with its own cut notice; a record that completes and crosses is rolled back whole; `Settle` on the response |
| `tree` | same, plus `AppendChildDeclarers` checking only `sb.Length >= cap` before each declarer line, and the `diff` heading and `[nodes cut …]` written unconditionally | the block takes a `RenderCap` and the caller's `tailReserve` (the nodes notice a multi-provider row still owes), each declarer and node line is composed then priced with its notice, and the framing line and diff heading each reserve the notice that follows them |
| `chain` | cap tested before each node; cycles, the truncation note and the whole TemplateFlags report appended after it without a check | the node line is composed and priced with `[nodes cut …]`; a seed cut mid-list ends there rather than appending a report the budget did not hold; a seed that completes and crosses is rolled back whole |
| reverse effect chain | `Wire.RenderEffectChain` was handed the caller's whole `cap` per seed — so *each* seed could fill the entire budget — and built its own buffer the caller then appended past the ceiling | the shared render takes a `RenderCap` plus what the caller has already spent, prices each carrier row with its own cut notice, and still quotes the caller's `max_chars`; the seed block is rolled back whole if it crosses |
| `info_order` | `DialogueWire.AppendInfoOrderView` handed the whole `cap`, its `[truncated at max_chars]` marker and its trailing MOVED paragraph and order note appended past it | the shared view is bounded by what this render has left, and a topic that still crossed is taken back out whole and counted |

**Not changed:** `DialogueWire.AppendInfoOrderView` itself. Its tail — the MOVED paragraph and the order note — is appended after its row loop and its width is content-dependent, so there is no way to keep half a topic and stay under the ceiling without reshaping a helper the dialogue surface shares. A topic wider than the budget is therefore counted (`[rendered 0 of 1 rows at max_chars=…]`) rather than shown half, which is the same contract the scan and batch lanes have carried since #603. `RecordsTools.AppendChildDeclarers`'s tail return is now unreachable by construction — each declarer line is priced with the notice beside it, so a completed block always leaves room for it — and it returns `false` with that stated.

## Tests

`RecordsArtifactTests` gains the ceiling contract for `delta`, `tree`, `chain` and the reverse effect chain (four caps each, both arms of the bound), plus one case pinning that the notice quotes the caller's own `max_chars` and the artifact still holds the complete result. `DialogueFamilyTests` gains the same for `info_order`. `RecordsOwnedChildTests` gains a cap sweep over the whole band where a tree row is cut.

| test | before | after |
|---|---|---|
| `ADeltaRenderIsNeverWiderThanItsCap` (4 caps) | fails — 1,601 chars at `max_chars=1200`, and over at the others | passes |
| `ATreeRenderIsNeverWiderThanItsCap` (4 caps) | fails — 1,490 at `max_chars=1200` | passes |
| `AChainRenderIsNeverWiderThanItsCap` (4 caps) | fails | passes |
| `AReverseEffectChainRenderIsNeverWiderThanItsCap` (4 caps) | fails — 1,799 chars at `max_chars=400` | passes |
| `AnInfoOrderRenderIsNeverWiderThanItsCap` (5 caps) | fails at 400/700/1200 | passes |
| `EachOfTheseRendersSaysWhatItsCapHeldBackAndStaysInsideIt` | fails — the response ran past the cap | passes |
| `AnInfoOrderCutByItsCapSaysHowManyTopicsItHeldBack` | fails | passes |
| `TheTreeRenderIsNeverWiderThanItsCap` (2 rows × 236 caps) | fails across the band | passes at every cap |

**Caps that moved, and why the tests that pin them now drive the render.** Ten `RecordsOwnedChildTests` cases pin an exact `max_chars` and assert what the tree does at it. Under the ceiling, a cut response also carries the auto-spill block — and that block names an **absolute path**, three times. Pinning a cap through the tool would bake this checkout's path length into every one of those numbers, and CI's is different. So those ten now drive `RenderRecordsTree` directly through `LoadOrderService.TreeBatch`, with no artifact lane around it: the boundaries become properties of the render, identical everywhere. Their caps moved with it (590/591 → 631/632, 600 → 500, 625 → 755, 660 → 800, 700 → 800).

**Two whose premise the change removed.** `ASoleProviderRowWhoseCompleteBlockEndsPastTheCapClaimsNothingWasCut` and `ARowWhoseDeclarersBlockFitsExactlyAtTheTailIsNotMarkedTruncated` both pinned "the block ran to completion and the row ended *past* the cap" — the overshoot this PR removes. There is no such state now, so they are replaced by the pair that states the new boundary: at the first cap the whole row fits inside, nothing is cut and nothing is marked truncated; one character below it, the row is cut and says so. `AMultiProviderRowWhoseCompleteBlockEndsPastTheCapNamesTheDiffItLost` keeps its claim — a complete block that leaves no room for the diff still names the diff it lost — at a cap where that is what happens.

The two tests that drive `AppendChildDeclarers` directly pass `new RenderCap(100_000, 100_000)` and `tailReserve: 0` for the widened signature.

## What was run

From inside `.claude/worktrees/max-chars-five`:

```
dotnet build housecarl.sln -c Release
dotnet test src/housecarl-mcp-tests -c Release --no-build --filter "tier!=bridge"
dotnet src/housecarl-generator/bin/Release/net9.0/housecarl-generator.dll ci-all
```

1,813 passed, 0 failed. `ci-all`: 127/127. Nothing was run against the live MO2 instance.

## What this still does NOT cover

Unchanged and outside this issue, as #603 recorded: `housecarl_apply`, `housecarl_create`, `housecarl_forward`, `housecarl_remove`, `housecarl_write_seq`, `housecarl_bsa_list`, `housecarl_load_order_status`, `housecarl_update_status` and `housecarl_skypatcher_layer` also take `max_chars=` and can still answer past it. The json lanes of all five renders here were already bounded and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
