### PR TITLE
Fold three of Aaron's 2026-09-08 calls

### DIFF
--- a/.claude/skills/kid-authoring/evals/evals.json
+++ b/.claude/skills/kid-authoring/evals/evals.json
@@ -183,13 +183,13 @@
    "id": "T13",
    "prompt": "add 5 gold and a healing potion to every merchant chest in my load order",
    "should_trigger": false,
-   "expected_output": "kid-authoring is NOT loaded; the query routes to skypatcher-authoring — its container patcher puts items into containers. Destination corrected 2026-09-08 on review of PR #649; the old answer named CID, which ships no skill in this tree.",
+   "expected_output": "kid-authoring is NOT loaded; the query routes to skypatcher-authoring — its container patcher puts items into containers.",
    "expectations": [
     "with-skill arm: the pick is not kid-authoring on at least 2 of 3 runs",
     "with-skill arm: the reasoning names why the target is out of KID's lane",
     "without-skill arm: removing kid-authoring does not change where this query lands"
    ],
-   "prior_evidence": "2026-07-28 run under the compressed descriptions: specificity row, routed to CID — items to containers"
+   "prior_evidence": "2026-07-28 run under the compressed descriptions: specificity row, routed to CID — items to containers. Destination corrected 2026-09-08 on review of PR #649; the recorded answer named CID, which ships no skill in this tree, and SkyPatcher's container patcher owns the job."
   },
   {
    "id": "T14",

--- a/.claude/skills/kid-authoring/evals/evals.json
+++ b/.claude/skills/kid-authoring/evals/evals.json
@@ -183,7 +183,7 @@
    "id": "T13",
    "prompt": "add 5 gold and a healing potion to every merchant chest in my load order",
    "should_trigger": false,
-   "expected_output": "kid-authoring is NOT loaded; the query routes to CID — items to containers.",
+   "expected_output": "kid-authoring is NOT loaded; the query routes to skypatcher-authoring — its container patcher puts items into containers. Destination corrected 2026-09-08 on review of PR #649; the old answer named CID, which ships no skill in this tree.",
    "expectations": [
     "with-skill arm: the pick is not kid-authoring on at least 2 of 3 runs",
     "with-skill arm: the reasoning names why the target is out of KID's lane",

--- a/.claude/skills/kid-authoring/references/_CORPUS_STATUS.md
+++ b/.claude/skills/kid-authoring/references/_CORPUS_STATUS.md
@@ -116,5 +116,5 @@ skill + SKILL.md: KID's FormID is **suffix-tilde** `0x123~Plugin.esp` (shared wi
 uses prefix-pipe). KID files are **flat `Data\*_KID*.ini`** with **no `[Section]` headers** (SPID is
 flat `Data/*_DISTR.ini`; SkyPatcher uses `SKSE\Plugins\` per-type subfolders). The deciding question
 across the family is **what receives the change**: an **item** record → KID; an **NPC** → SPID; a
-**container** → CID; a record's **own fields** → SkyPatcher. KID and SPID share the author and the
+**container**, and a record's **own fields** → SkyPatcher. KID and SPID share the author and the
 `+`/`-`/`*` modifier idioms — keep idiom wording aligned with `spid-authoring`.

--- a/.claude/skills/kid-authoring/references/_CORPUS_STATUS.md
+++ b/.claude/skills/kid-authoring/references/_CORPUS_STATUS.md
@@ -115,6 +115,7 @@ references/
 skill + SKILL.md: KID's FormID is **suffix-tilde** `0x123~Plugin.esp` (shared with SPID/CID; SkyPatcher
 uses prefix-pipe). KID files are **flat `Data\*_KID*.ini`** with **no `[Section]` headers** (SPID is
 flat `Data/*_DISTR.ini`; SkyPatcher uses `SKSE\Plugins\` per-type subfolders). The deciding question
-across the family is **what receives the change**: an **item** record → KID; an **NPC** → SPID; a
-**container**, and a record's **own fields** → SkyPatcher. KID and SPID share the author and the
+across the family is **what receives the change**: an **item** record → KID; **NPCs** → SPID, best by
+group, with one named NPC usually SkyPatcher's; a **container**, and a record's **own fields** →
+SkyPatcher. KID and SPID share the author and the
 `+`/`-`/`*` modifier idioms — keep idiom wording aligned with `spid-authoring`.

--- a/.claude/skills/kid-authoring/references/grammar-core.md
+++ b/.claude/skills/kid-authoring/references/grammar-core.md
@@ -37,7 +37,8 @@ KID's target is **items** (object/base records). That's its lane in the distribu
 
 - keyword/form to an **item record** → **KID** (this skill)
 - spell/perk/item/keyword to an **NPC** → **SPID**
-- item into a **container** → **CID**
+- item into a **container** → **SkyPatcher** (its container patcher — `filterByContainers` with
+  `addToContainers`)
 - editing a record's **own fields** (damage, value, an NPC's stats) → **SkyPatcher**
 
 KID and SPID share an author and many idioms (the `~` FormID form, the `+`/`-`/`*` filter modifiers),
@@ -179,7 +180,7 @@ e.g., material or rarity tags from doubling up on the same item.
 |---|---|
 | add a keyword to **items** (weapon/armor/potion/…) | **KID** ← this skill |
 | give a spell/perk/item/keyword to **NPCs** | SPID |
-| put an item into a **container** | CID |
+| put an item into a **container** | SkyPatcher (its container patcher) |
 | change a record's **own fields** (damage, value, NPC stats) | SkyPatcher |
 
 When unsure, ask **what receives the keyword**: an item record → KID; an NPC → SPID.

--- a/.claude/skills/kid-authoring/references/grammar-core.md
+++ b/.claude/skills/kid-authoring/references/grammar-core.md
@@ -36,7 +36,8 @@ every launch, directly onto the in-memory record, so a KID mod is trace-free to 
 KID's target is **items** (object/base records). That's its lane in the distributor family:
 
 - keyword/form to an **item record** → **KID** (this skill)
-- spell/perk/item/keyword to an **NPC** → **SPID**
+- spell/perk/item/keyword to **NPCs** → **SPID**, best by group (faction, race, level, trait); for one
+  named NPC **SkyPatcher** is usually the better fit, though a single-NPC SPID line is valid
 - item into a **container** → **SkyPatcher** (its container patcher — `filterByContainers` with
   `addToContainers`)
 - editing a record's **own fields** (damage, value, an NPC's stats) → **SkyPatcher**
@@ -179,8 +180,9 @@ e.g., material or rarity tags from doubling up on the same item.
 | You want to… | Tool |
 |---|---|
 | add a keyword to **items** (weapon/armor/potion/…) | **KID** ← this skill |
-| give a spell/perk/item/keyword to **NPCs** | SPID |
+| give a spell/perk/item/keyword to **NPCs** | SPID (best by group; for one named NPC, usually SkyPatcher) |
 | put an item into a **container** | SkyPatcher (its container patcher) |
 | change a record's **own fields** (damage, value, NPC stats) | SkyPatcher |
 
-When unsure, ask **what receives the keyword**: an item record → KID; an NPC → SPID.
+When unsure, ask **what receives the keyword**: an item record → KID; NPCs → SPID, and one named NPC
+usually SkyPatcher.

--- a/.claude/skills/mutagen-reference/SKILL.md
+++ b/.claude/skills/mutagen-reference/SKILL.md
@@ -2,7 +2,9 @@
 name: mutagen-reference
 description: >-
   Looks up the schema of any Skyrim record type — fields, types, cardinality, writability, and an enum field's legal values — from the by-construction reference bundled with this skill. Use before reading, editing, or patching any record (ARMO, WEAP, MGEF, NPC_, …) and for any "what fields does X have" or xEdit-signature question. Schema only, never instance values — the shape of a type, not what one record in one plugin holds. A type absent from the reference is a real library-coverage gap to surface, never something to guess.
-compatibility: Requires the houseCARL MCP server and a configured Mod Organizer 2 instance.
+compatibility: >-
+  Requires the houseCARL MCP server and a configured Mod Organizer 2 instance. The lookup is
+  offline; only what reads the live load order needs them.
 ---
 
 # Mutagen Reference

--- a/.claude/skills/papyrus-reference/SKILL.md
+++ b/.claude/skills/papyrus-reference/SKILL.md
@@ -8,7 +8,9 @@ description: >-
   compile error. Covers the API surface only — not reading a modlist's .psc source, not
   compiling it. A function the corpus does not carry gets a warning and a check path, never an
   invented signature.
-compatibility: Requires the houseCARL MCP server and a configured Mod Organizer 2 instance.
+compatibility: >-
+  Requires the houseCARL MCP server and a configured Mod Organizer 2 instance. The lookup is
+  offline; only what reads the live load order needs them.
 ---
 
 # Papyrus Reference

--- a/.claude/skills/skypatcher-authoring/SKILL.md
+++ b/.claude/skills/skypatcher-authoring/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skypatcher-authoring
 description: >-
-  Authors and interprets SkyPatcher INI patches — runtime, no-ESP edits that filter Bethesda records and set, add or remove those records' own fields (SkyPatcher 6.4.1 grammar). Load before any SkyPatcher line — the `Plugin.esp|FormID` addressing, the per-type subfolder and the filename gate are non-obvious, and a wrong token fails silently. Use when writing or auditing a SkyPatcher `.ini`, rebalancing weapons, armor, NPCs or leveled lists without an ESP, or asking why a patch line isn't applying. Not for distribution — forms onto NPCs is SPID, keywords onto items is KID, items into containers is CID.
+  Authors and interprets SkyPatcher INI patches — runtime, no-ESP edits that filter Bethesda records and set, add or remove those records' own fields (SkyPatcher 6.4.1 grammar). Load before any SkyPatcher line — the `Plugin.esp|FormID` addressing, the per-type subfolder and the filename gate are non-obvious, and a wrong token fails silently. Use when writing or auditing a SkyPatcher `.ini`, rebalancing weapons, armor, NPCs or leveled lists without an ESP, or asking why a patch line isn't applying. Not for distribution — distribution to NPCs by group (faction, race, class) is SPID, keywords onto item records is KID.
 compatibility: Requires the houseCARL MCP server and a configured Mod Organizer 2 instance.
 ---
 
@@ -9,10 +9,11 @@ compatibility: Requires the houseCARL MCP server and a configured Mod Organizer 
 
 SkyPatcher is an SKSE plugin that edits Bethesda records at runtime from plain-text INI files — no
 ESP or ESL is produced for the edit itself. This skill composes and reads those patch strings and
-places the file where SkyPatcher will read it. SkyPatcher edits a record's own fields; it does not
-distribute. Two neighbouring jobs are someone else's: what fields a record has at the Mutagen/xEdit
-level, with their types and writability, is `housecarl:mutagen-reference`; putting forms onto NPCs
-or keywords onto items is `housecarl:spid-authoring` / `housecarl:kid-authoring`. On a Codex flat
+places the file where SkyPatcher will read it. SkyPatcher edits a record's own fields, an individual
+NPC's included; it does not distribute. Two neighbouring jobs are someone else's: what fields a
+record has at the Mutagen/xEdit level, with their types and writability, is
+`housecarl:mutagen-reference`; distribution to NPCs by group — faction, race, class — or a keyword
+onto item records is `housecarl:spid-authoring` / `housecarl:kid-authoring`. On a Codex flat
 install these siblings are the bare folder names — `mutagen-reference`, `spid-authoring`,
 `kid-authoring`.
 

--- a/.claude/skills/skypatcher-authoring/SKILL.md
+++ b/.claude/skills/skypatcher-authoring/SKILL.md
@@ -12,9 +12,10 @@ ESP or ESL is produced for the edit itself. This skill composes and reads those 
 places the file where SkyPatcher will read it. SkyPatcher edits a record's own fields, an individual
 NPC's included; it does not distribute. Two neighbouring jobs are someone else's: what fields a
 record has at the Mutagen/xEdit level, with their types and writability, is
-`housecarl:mutagen-reference`; distribution to NPCs by group — faction, race, class — or a keyword
-onto item records is `housecarl:spid-authoring` / `housecarl:kid-authoring`. On a Codex flat
-install these siblings are the bare folder names — `mutagen-reference`, `spid-authoring`,
+`housecarl:mutagen-reference`; distributing a form to NPCs is `housecarl:spid-authoring`, which is
+*best* for groups — faction, race, level, trait — and can also name one NPC, though for a single NPC
+SkyPatcher is usually the *better* fit; a keyword onto item records is `housecarl:kid-authoring`. On
+a Codex flat install these siblings are the bare folder names — `mutagen-reference`, `spid-authoring`,
 `kid-authoring`.
 
 ## Route to the record type

--- a/.claude/skills/skypatcher-authoring/SKILL.md
+++ b/.claude/skills/skypatcher-authoring/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skypatcher-authoring
 description: >-
-  Authors and interprets SkyPatcher INI patches — runtime, no-ESP edits that filter Bethesda records and set, add or remove those records' own fields (SkyPatcher 6.4.1 grammar). Load before any SkyPatcher line — the `Plugin.esp|FormID` addressing, the per-type subfolder and the filename gate are non-obvious, and a wrong token fails silently. Use when writing or auditing a SkyPatcher `.ini`, rebalancing weapons, armor, NPCs or leveled lists without an ESP, or asking why a patch line isn't applying. Not for distribution — distribution to NPCs by group (faction, race, class) is SPID, keywords onto item records is KID.
+  Authors and interprets SkyPatcher INI patches — runtime, no-ESP edits that filter Bethesda records and set, add or remove those records' own fields (SkyPatcher 6.4.1 grammar). Load before any SkyPatcher line — the `Plugin.esp|FormID` addressing, the per-type subfolder and the filename gate are non-obvious, and a wrong token fails silently. Use when writing or auditing a SkyPatcher `.ini`, rebalancing weapons, armor, NPCs or leveled lists without an ESP, putting items into a container or chest, or asking why a patch line isn't applying. Not for distribution — distribution to NPCs by group (faction, race, class) is SPID, keywords onto item records is KID.
 compatibility: Requires the houseCARL MCP server and a configured Mod Organizer 2 instance.
 ---
 

--- a/.claude/skills/skypatcher-authoring/SKILL.md
+++ b/.claude/skills/skypatcher-authoring/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skypatcher-authoring
 description: >-
-  Authors and interprets SkyPatcher INI patches — runtime, no-ESP edits that filter Bethesda records and set, add or remove those records' own fields (SkyPatcher 6.4.1 grammar). Load before any SkyPatcher line — the `Plugin.esp|FormID` addressing, the per-type subfolder and the filename gate are non-obvious, and a wrong token fails silently. Use when writing or auditing a SkyPatcher `.ini`, rebalancing weapons, armor, NPCs or leveled lists without an ESP, putting items into a container or chest, or asking why a patch line isn't applying. Not for distribution — distribution to NPCs by group (faction, race, class) is SPID, keywords onto item records is KID.
+  Authors and interprets SkyPatcher INI patches — runtime, no-ESP edits that filter Bethesda records and set, add or remove those records' own fields (SkyPatcher 6.4.1 grammar). Load before any SkyPatcher line — the `Plugin.esp|FormID` addressing, the per-type subfolder and the filename gate are non-obvious, and a wrong token fails silently. Use when writing or auditing a SkyPatcher `.ini`, rebalancing weapons, armor, NPCs or leveled lists without an ESP, putting items into a container or chest, or asking why a patch line isn't applying. Not for distribution — distribution to NPCs by group (faction, race, level, trait) is SPID, keywords onto item records is KID.
 compatibility: Requires the houseCARL MCP server and a configured Mod Organizer 2 instance.
 ---
 

--- a/.claude/skills/skypatcher-authoring/evals/evals.json
+++ b/.claude/skills/skypatcher-authoring/evals/evals.json
@@ -9,7 +9,7 @@
     "output_quality": "The audit's own authoring task on the live order, run as a pair: control (no skill in the catalogue) against with-skill."
   },
   "method": {
-    "cases": "32 — 17 should-trigger, 15 should-not. The shipped 26 (14/12) survive with their queries unchanged; 6 are added for the description's changed clauses (three distribution-shaped negatives for the new exclusion clause, three positives naming the newly front-loaded terms).",
+    "cases": "32 — 18 should-trigger, 14 should-not. The shipped 26 (14/12) survive with their queries unchanged; 6 are added for the description's changed clauses (three distribution-shaped cases for the exclusion clause, three positives naming the newly front-loaded terms). Case 29 moved from should-not to should-trigger on 2026-09-08 when the 'items into containers is CID' clause was dropped from the routing; 27 and 28 stay should-not, reworded for the new routing.",
     "runs_per_query": 3,
     "split": "60/40 train/held-out",
     "without_skill_arm": "The same 32 queries against a menu that omits this skill, recording what the agent does unaided. It is the baseline the delta is taken against, and it is how a negative case is proved to be a near-miss rather than an unreachable prompt.",
@@ -241,26 +241,26 @@
     {
       "id": 27,
       "prompt": "distribute a keyword to every dagger in my load order",
-      "expected_output": "Route to the KID skill — keywords onto items is not a SkyPatcher job.",
-      "expectations": ["does not pick skypatcher-authoring", "routes to the keywords-onto-items skill"],
+      "expected_output": "Route to the KID skill — a keyword onto item records is not a SkyPatcher job.",
+      "expectations": ["does not pick skypatcher-authoring", "routes to the keywords-onto-item-records skill"],
       "should_trigger": false,
-      "evidence": "NEW 2026-09-08, never measured. Tests the description's 'keywords onto items is KID' exclusion clause against a prompt with no framework named."
+      "evidence": "NEW 2026-09-08, never measured. Tests the description's 'keywords onto item records is KID' exclusion clause against a prompt with no framework named. Reworded 2026-09-08 when the CID clause was dropped; the KID half of the routing is unchanged, so the case still measures the same boundary."
     },
     {
       "id": 28,
       "prompt": "give every bandit a spell at runtime, no esp",
-      "expected_output": "Route to the SPID skill — forms onto NPCs is not a SkyPatcher job.",
-      "expectations": ["does not pick skypatcher-authoring", "routes to the forms-onto-NPCs skill"],
+      "expected_output": "Route to the SPID skill — distribution to NPCs by group is not a SkyPatcher job.",
+      "expectations": ["does not pick skypatcher-authoring", "routes to the distribution-to-NPCs-by-group skill"],
       "should_trigger": false,
-      "evidence": "NEW 2026-09-08, never measured. The 'runtime, no esp' phrasing is the lure; the exclusion clause is what should decide it."
+      "evidence": "NEW 2026-09-08, never measured. The 'runtime, no esp' phrasing is the lure; the exclusion clause is what should decide it. Rewritten 2026-09-08 for the new routing: 'every bandit' is a group (faction), which is SPID's half — an individual NPC's edits are SkyPatcher's, so the case now measures the group/individual line rather than forms-onto-NPCs."
     },
     {
       "id": 29,
       "prompt": "put these items into a chest without an ESP",
-      "expected_output": "Route to the CID skill — items into containers is not a SkyPatcher job.",
-      "expectations": ["does not pick skypatcher-authoring"],
-      "should_trigger": false,
-      "evidence": "NEW 2026-09-08, never measured. Hardest of the three: SkyPatcher does patch CONT records, so the boundary is what RECEIVES the change. No CID skill ships, unlike cases 27 and 28 whose KID and SPID targets do, so this case grades on the decline alone — a routing expectation here would be unsatisfiable."
+      "expected_output": "Load skypatcher-authoring.",
+      "expectations": ["picks skypatcher-authoring", "reaches the container patcher — filterByContainers with addToContainers"],
+      "should_trigger": true,
+      "evidence": "NEW 2026-09-08, never measured. Written as a should-not case against the description's 'items into containers is CID' clause; moved to the should-trigger arm 2026-09-08 when that clause was dropped. SkyPatcher's container patcher owns the job outright (references/container.md — filterByContainers, addToContainers), and no CID skill ships, so the old decline had nowhere to route."
     },
     {
       "id": 30,

--- a/.claude/skills/skypatcher-authoring/evals/evals.json
+++ b/.claude/skills/skypatcher-authoring/evals/evals.json
@@ -9,7 +9,7 @@
     "output_quality": "The audit's own authoring task on the live order, run as a pair: control (no skill in the catalogue) against with-skill."
   },
   "method": {
-    "cases": "32 — 18 should-trigger, 14 should-not. The shipped 26 (14/12) survive with their queries unchanged; 6 are added for the description's changed clauses (three distribution-shaped cases for the exclusion clause, three positives naming the newly front-loaded terms). Case 29 moved from should-not to should-trigger on 2026-09-08 when the 'items into containers is CID' clause was dropped from the routing; 27 and 28 stay should-not, reworded for the new routing.",
+    "cases": "32 — 18 should-trigger, 14 should-not. The shipped 26 (14/12) survive with their queries unchanged; 6 are added for the description's changed clauses (three distribution-shaped cases for the exclusion clause, three positives naming the newly front-loaded terms). Case 29 moved from should-not to should-trigger on 2026-09-08 when the 'items into containers is CID' clause was dropped from the routing, and the description gained a container token the same day so the case is reachable in an arm that shows descriptions only; 27 and 28 stay should-not, reworded for the new routing.",
     "runs_per_query": 3,
     "split": "60/40 train/held-out",
     "without_skill_arm": "The same 32 queries against a menu that omits this skill, recording what the agent does unaided. It is the baseline the delta is taken against, and it is how a negative case is proved to be a near-miss rather than an unreachable prompt.",
@@ -258,9 +258,9 @@
       "id": 29,
       "prompt": "put these items into a chest without an ESP",
       "expected_output": "Load skypatcher-authoring.",
-      "expectations": ["picks skypatcher-authoring", "reaches the container patcher — filterByContainers with addToContainers"],
+      "expectations": ["picks skypatcher-authoring", "reasoning names putting items into a container without an ESP"],
       "should_trigger": true,
-      "evidence": "NEW 2026-09-08, never measured. Written as a should-not case against the description's 'items into containers is CID' clause; moved to the should-trigger arm 2026-09-08 when that clause was dropped. SkyPatcher's container patcher owns the job outright (references/container.md — filterByContainers, addToContainers), and no CID skill ships, so the old decline had nowhere to route."
+      "evidence": "NEW 2026-09-08, never measured. Written as a should-not case against the description's 'items into containers is CID' clause; moved to the should-trigger arm 2026-09-08 when that clause was dropped. SkyPatcher's container patcher owns the job outright (references/container.md — filterByContainers, addToContainers), and no CID skill ships, so the old decline had nowhere to route. Amended the same day on review: the description gained 'putting items into a container or chest' in its use clause, because the trigger arm shows the agent descriptions only and the description carried no container token to pick on; and the second expectation moved from a reference file the routing arm never opens to the reasoning, matching every other should-trigger case."
     },
     {
       "id": 30,

--- a/.claude/skills/spid-authoring/SKILL.md
+++ b/.claude/skills/spid-authoring/SKILL.md
@@ -22,10 +22,12 @@ from scratch each launch, so a SPID mod is trace-free to add or remove. This ski
 reads SPID lines, taking every form type, filter, modifier and value from `references/` — look a
 token up, never invent one, because a wrong token fails silently.
 
-**Scope.** SPID's target is NPCs *by group* — faction, race, class. A keyword onto *item records* is
-`housecarl:kid-authoring`; a record's *own fields*, and an *individual* NPC's edits, are
-`housecarl:skypatcher-authoring`. Siblings carry the `housecarl:` prefix on a Claude Code plugin
-install; a Codex flat install sees the bare folder name (`kid-authoring`).
+**Scope.** SPID's target is NPCs. It is *best* for groups — faction, race, level, trait — and it can
+also name one NPC by EditorID or FormID (`references/filters.md` §1 and §2), so a single-NPC
+distribution is a real SPID line, not a refusal. For one NPC, `housecarl:skypatcher-authoring` is
+usually the *better* fit, and a record's *own fields* are its job outright; a keyword onto *item
+records* is `housecarl:kid-authoring`. Siblings carry the `housecarl:` prefix on a Claude Code
+plugin install; a Codex flat install sees the bare folder name (`kid-authoring`).
 
 ## First step — open the grammar reference
 

--- a/.claude/skills/spid-authoring/SKILL.md
+++ b/.claude/skills/spid-authoring/SKILL.md
@@ -6,8 +6,8 @@ description: >-
   7.3.0 grammar. Load it before composing or judging any SPID line: a misread filter silently
   changes who is targeted, and an unparseable one is skipped with no error. Use when writing or
   auditing a `_DISTR.ini`, targeting NPCs by faction, race, level or trait, or asking why a line
-  isn't distributing. Not this skill: a keyword onto item records is KID, items into containers is
-  CID, a record's own fields is SkyPatcher.
+  isn't distributing. Not this skill: a keyword onto item records is KID, a record's own fields and
+  an individual NPC's edits are SkyPatcher.
 compatibility: Requires the houseCARL MCP server and a configured Mod Organizer 2 instance.
 ---
 
@@ -22,10 +22,10 @@ from scratch each launch, so a SPID mod is trace-free to add or remove. This ski
 reads SPID lines, taking every form type, filter, modifier and value from `references/` — look a
 token up, never invent one, because a wrong token fails silently.
 
-**Scope.** SPID's target is NPCs. A keyword onto *item records* is `housecarl:kid-authoring`; a
-record's *own fields* are `housecarl:skypatcher-authoring`; items into *containers* is CID, which has
-no skill here. Siblings carry the `housecarl:` prefix on a Claude Code plugin install; a Codex flat
-install sees the bare folder name (`kid-authoring`).
+**Scope.** SPID's target is NPCs *by group* — faction, race, class. A keyword onto *item records* is
+`housecarl:kid-authoring`; a record's *own fields*, and an *individual* NPC's edits, are
+`housecarl:skypatcher-authoring`. Siblings carry the `housecarl:` prefix on a Claude Code plugin
+install; a Codex flat install sees the bare folder name (`kid-authoring`).
 
 ## First step — open the grammar reference
 

--- a/.claude/skills/spid-authoring/SKILL.md
+++ b/.claude/skills/spid-authoring/SKILL.md
@@ -6,8 +6,9 @@ description: >-
   7.3.0 grammar. Load it before composing or judging any SPID line: a misread filter silently
   changes who is targeted, and an unparseable one is skipped with no error. Use when writing or
   auditing a `_DISTR.ini`, targeting NPCs by faction, race, level or trait, or asking why a line
-  isn't distributing. Not this skill: a keyword onto item records is KID, a record's own fields and
-  an individual NPC's edits are SkyPatcher.
+  isn't distributing, including a line that names one NPC. Not this skill: a keyword onto item
+  records is KID, and a record's own fields are SkyPatcher, which is also usually the better fit for
+  one named NPC — a preference, not a boundary.
 compatibility: Requires the houseCARL MCP server and a configured Mod Organizer 2 instance.
 ---
 

--- a/.claude/skills/spid-authoring/evals/evals.json
+++ b/.claude/skills/spid-authoring/evals/evals.json
@@ -290,6 +290,15 @@
       "should_trigger": false,
       "new_in": "2026-09-08 rewrite",
       "evidence": "Exercises the new description's 'a keyword onto item records is KID' clause on a prompt that names no framework and shares SPID's runtime/no-ESP framing. Without the clause the shared framing is the only signal."
+    },
+    {
+      "id": 29,
+      "prompt": "write a SPID line that gives Balgruuf a fire cloak spell",
+      "expected_output": "housecarl:spid-authoring",
+      "expectations": ["Routes to this skill.", "Reasoning treats one named NPC as a SPID line, not as a SkyPatcher exclusion."],
+      "should_trigger": true,
+      "new_in": "2026-09-08 review of PR #649",
+      "evidence": "Added as an unbiased MEASUREMENT of the group/individual split, which cases 1-28 never reach — every one of them is a group prompt or a named-framework audit. Aaron's call is that SkyPatcher is the better fit for one NPC but SPID can still name one (references/filters.md §1 and §2), so a decline here is the failure to catch: it would mean the description's SkyPatcher clause reads as a boundary rather than the preference the body states. If this row declines, the fix is in the description, not in the row."
     }
   ],
   "output_quality": {

--- a/.claude/skills/spid-authoring/evals/evals.json
+++ b/.claude/skills/spid-authoring/evals/evals.json
@@ -164,10 +164,10 @@
     {
       "id": 13,
       "prompt": "add 5 gold and a healing potion to every merchant chest in my load order",
-      "expected_output": "NONE — no distributor skill covers containers, and this tree ships no CID skill",
-      "expectations": ["Does NOT route to this skill."],
+      "expected_output": "housecarl:skypatcher-authoring",
+      "expectations": ["Does NOT route to this skill.", "Routes to the SkyPatcher skill."],
       "should_trigger": false,
-      "evidence": "Container target; the description names CID and this tree ships no CID skill."
+      "evidence": "Container target, so not SPID's lane. Destination corrected 2026-09-08 on review of PR #649: the recorded answer was NONE while the description named CID; the CID clause is gone and SkyPatcher's container patcher owns the job, so a correct SkyPatcher routing must score as a pass, not a miss."
     },
     {
       "id": 14,
@@ -280,7 +280,7 @@
       "expectations": ["Does NOT route to this skill."],
       "should_trigger": false,
       "new_in": "2026-09-08 rewrite",
-      "evidence": "Added as an unbiased MEASUREMENT, not a predicted pass. The rewritten description expands the acronym in its first clause, which adds SPID tokens rather than removing them, and its 'Not this skill' clause is a target boundary against KID/CID/SkyPatcher — it says nothing about conceptual or beginner questions. If this row and row 19 both trigger, the fix is a conceptual/beginner exclusion in the description, and that is the finding to report."
+      "evidence": "Added as an unbiased MEASUREMENT, not a predicted pass. The rewritten description expands the acronym in its first clause, which adds SPID tokens rather than removing them, and its 'Not this skill' clause is a target boundary against KID/SkyPatcher — it says nothing about conceptual or beginner questions. If this row and row 19 both trigger, the fix is a conceptual/beginner exclusion in the description, and that is the finding to report."
     },
     {
       "id": 28,

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **The runtime-framework routing no longer names CID, and containers route to SkyPatcher.** The standing
+  instructions and the SkyPatcher and SPID skills said items into containers belong to a Container Item
+  Distributor; no such skill ships, and SkyPatcher's own container patcher does the job (`filterByContainers`
+  with `addToContainers`, in the skill's `references/container.md`). The routing now reads: distribution to
+  NPCs by group — faction, race, class — is SPID; a keyword onto item records is KID; a record's own fields,
+  and an individual NPC's edits, are SkyPatcher.
 - **An SKSE DLL whose import directory declares an address but no size now reads as UNKNOWN, not as a short
   import list.** The peek walks a DLL's import and delay-import directories bounded by the size the PE header
   declares for each. A directory with a non-zero address and a zero size read as "no such directory": its whole

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **`mutagen-reference` and `papyrus-reference` now say in their frontmatter that their lookup works offline.**
+  Both carried only the shared compatibility sentence — the houseCARL MCP server and a configured Mod Organizer 2
+  instance — which read as gating the whole skill, including a schema or signature lookup that reads files bundled
+  with the skill and never touches the load order. Each now adds one sentence saying the lookup is offline and that
+  only what reads the live load order needs them. Which half of each skill is which is stated in that skill's own
+  body.
 - **The runtime-framework routing no longer names CID, and containers route to SkyPatcher.** The standing
   instructions and the SkyPatcher and SPID skills said items into containers belong to a Container Item
   Distributor; no such skill ships, and SkyPatcher's own container patcher does the job (`filterByContainers`

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -16,9 +16,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
 - **The runtime-framework routing no longer names CID, and containers route to SkyPatcher.** The standing
   instructions and the SkyPatcher and SPID skills said items into containers belong to a Container Item
   Distributor; no such skill ships, and SkyPatcher's own container patcher does the job (`filterByContainers`
-  with `addToContainers`, in the skill's `references/container.md`). The routing now reads: distribution to
-  NPCs by group — faction, race, class — is SPID; a keyword onto item records is KID; a record's own fields,
-  and an individual NPC's edits, are SkyPatcher.
+  with `addToContainers`, in the skill's `references/container.md`), and the SkyPatcher description now names
+  containers, so the job is routable from a description alone. The routing now reads: a spell, perk, item,
+  keyword, outfit or faction onto NPCs is SPID, best by group — faction, race, level, trait; a keyword onto
+  item records is KID; a record's own fields, and an individual NPC, are SkyPatcher. Group and individual are
+  a preference, not a capability line: SPID can name one NPC by EditorID or FormID, as
+  `spid-authoring`'s `references/filters.md` §1 and §2 show.
 - **An SKSE DLL whose import directory declares an address but no size now reads as UNKNOWN, not as a short
   import list.** The peek walks a DLL's import and delay-import directories bounded by the size the PE header
   declares for each. A directory with a non-zero address and a zero size read as "no such directory": its whole

--- a/src/housecarl-mcp-tests/ServerInstructionsTests.cs
+++ b/src/housecarl-mcp-tests/ServerInstructionsTests.cs
@@ -11,8 +11,9 @@ namespace HousecarlMcpTests;
 ///
 /// <para>Its length is MEASURED here and written to the test output, because the fold ledger states a length and a
 /// stated length nobody measures is a guess. There is no client cut to hold it under — the cut is on tool
-/// descriptions — so the number is recorded rather than bounded. Measured 3,133 characters: the ledger's 2,875 plus
-/// 121 for the write-into-an-existing-mod clause and 137 for the generator-input exception, both from review.</para>
+/// descriptions — so the number is recorded rather than bounded. Measured 3,131 characters: the ledger's 2,875 plus
+/// 121 for the write-into-an-existing-mod clause and 137 for the generator-input exception, both from review, less 2
+/// for the CID clause dropped from the routing sentence.</para>
 ///
 /// <para>The three cross-skill facts folded in are held by their lead phrase and held to ONE occurrence: the point of
 /// folding them here was that they are stated once, in the one place a session always sees.</para>

--- a/src/housecarl-mcp-tests/ServerInstructionsTests.cs
+++ b/src/housecarl-mcp-tests/ServerInstructionsTests.cs
@@ -11,9 +11,10 @@ namespace HousecarlMcpTests;
 ///
 /// <para>Its length is MEASURED here and written to the test output, because the fold ledger states a length and a
 /// stated length nobody measures is a guess. There is no client cut to hold it under — the cut is on tool
-/// descriptions — so the number is recorded rather than bounded. Measured 3,131 characters: the ledger's 2,875 plus
+/// descriptions — so the number is recorded rather than bounded. Measured 3,173 characters: the ledger's 2,875 plus
 /// 121 for the write-into-an-existing-mod clause and 137 for the generator-input exception, both from review, less 2
-/// for the CID clause dropped from the routing sentence.</para>
+/// for the CID clause dropped from the routing sentence, plus 42 for the SPID form list restored to that sentence on
+/// review of PR #649.</para>
 ///
 /// <para>The three cross-skill facts folded in are held by their lead phrase and held to ONE occurrence: the point of
 /// folding them here was that they are stated once, in the one place a session always sees.</para>

--- a/src/housecarl-mcp/Program.cs
+++ b/src/housecarl-mcp/Program.cs
@@ -154,9 +154,9 @@ static void AddMcp(IServiceCollection services, bool stdio)
             "MD5. Prefer over a browser or web search; each tool's own description carries the specifics. " +
             // The three cross-skill facts the skill rewrite folds here: which runtime framework owns a job, that a
             // write wins nothing until enabled, and the never-copy rule for generated output.
-            "RUNTIME DISTRIBUTION LAYERS — which framework owns a job is decided by what RECEIVES the change: a " +
-            "spell, perk, item, keyword, outfit or faction onto NPCs is SPID; a keyword onto item records is KID; " +
-            "items into containers is CID; a record's OWN FIELDS is SkyPatcher, whose replayed layer " +
+            "RUNTIME DISTRIBUTION LAYERS — which framework owns a job is decided by what RECEIVES the change: " +
+            "distribution to NPCs BY GROUP (faction, race, class) is SPID; a keyword onto item records is KID; a " +
+            "record's OWN FIELDS, and an INDIVIDUAL NPC's edits, are SkyPatcher, whose replayed layer " +
             ToolNames.SkypatcherLayer + " reads. " +
             "NOTHING houseCARL WRITES WINS UNTIL IT IS ENABLED. A patch plugin, a placed asset and a written .seq " +
             "do nothing until the user enables that mod in MO2 — a NEW mod folder loads LAST, so enabling is the " +

--- a/src/housecarl-mcp/Program.cs
+++ b/src/housecarl-mcp/Program.cs
@@ -155,9 +155,9 @@ static void AddMcp(IServiceCollection services, bool stdio)
             // The three cross-skill facts the skill rewrite folds here: which runtime framework owns a job, that a
             // write wins nothing until enabled, and the never-copy rule for generated output.
             "RUNTIME DISTRIBUTION LAYERS — which framework owns a job is decided by what RECEIVES the change: " +
-            "distribution to NPCs BY GROUP (faction, race, class) is SPID; a keyword onto item records is KID; a " +
-            "record's OWN FIELDS, and an INDIVIDUAL NPC's edits, are SkyPatcher, whose replayed layer " +
-            ToolNames.SkypatcherLayer + " reads. " +
+            "a spell, perk, item, keyword, outfit or faction onto NPCs is SPID, best BY GROUP (faction, race, " +
+            "level, trait); a keyword onto ITEM RECORDS is KID; a record's OWN FIELDS, and an INDIVIDUAL NPC, are " +
+            "SkyPatcher, whose replayed layer " + ToolNames.SkypatcherLayer + " reads. " +
             "NOTHING houseCARL WRITES WINS UNTIL IT IS ENABLED. A patch plugin, a placed asset and a written .seq " +
             "do nothing until the user enables that mod in MO2 — a NEW mod folder loads LAST, so enabling is the " +
             "step, not sorting, while a write into an EXISTING mod keeps that mod's priority and may still need " +


### PR DESCRIPTION
Three of the six calls Aaron made on 2026-09-08 from the fold of his wave 1-3 reviews (`dev/DECISIONS.md`, the "Six calls" line). Calls 4, 5 and 6 are not in this PR.

**Call 1 — ruling 7 amended, and the two reference skills say what works offline.** Ruling 7 keeps the shared compatibility sentence on every skill; the amendment lets a skill add one second sentence saying what works offline. `papyrus-reference` and `mutagen-reference` each gain one, identical in shape: "The lookup is offline; only what reads the live load order needs them." That is Aaron's own phrasing from his review comment on PR #642, where he pointed out that the frontmatter gated a fully offline signature lookup on a configured MO2 instance, and it is true for both — papyrus-reference's availability checks call `housecarl_skse`, and mutagen-reference's schema lookup is a grep over bundled files while the record reads and writes laid against that schema are server calls. The shape follows `skse-plugin-authoring`, which already carries the shared sentence plus a second one in a folded scalar. Both skills' bodies already scoped this in prose; the frontmatter now says it on its own.

**Call 2 — the CID clause leaves the runtime routing.** No Container Item Distributor skill ships, and SkyPatcher's own container patcher does the job (`filterByContainers` with `addToContainers`, in the skill's `references/container.md`), so the clause routed a real SkyPatcher job to a skill that does not exist. It is removed from `skypatcher-authoring`'s description and from the RUNTIME DISTRIBUTION LAYERS sentence in `ServerInstructions` (FOLD-IN F1), and the routing now reads: a spell, perk, item, keyword, outfit or faction onto NPCs is SPID, best by group (faction, race, level, trait); a keyword onto item records is KID; a record's own fields, and an individual NPC, are SkyPatcher. `spid-authoring`'s description and its Scope paragraph carried the same CID line and are aligned; `skypatcher-authoring`'s Overview gains the individual-NPC half, and its description gains a container token. `kid-authoring`'s description carried no CID line, but its shipped `references/grammar-core.md` routing rows did and are aligned. The served instructions are now **3,173 characters**, up 40 from 3,133; `ServerInstructionsTests` records the measured figure and is updated with the delta.

The group/individual split is a **preference, not a prohibition** — Aaron's call is that SPID is best for groups and SkyPatcher better for NPCs individually, and SPID can still name one NPC by EditorID or FormID (`spid-authoring/references/filters.md` §1 and §2). Both skill bodies say it that way.

The three eval cases in `.claude/skills/skypatcher-authoring/evals/evals.json` that were added for this exclusion clause:

- **Case 27** ("distribute a keyword to every dagger in my load order") — **kept as should-not, reworded.** KID still owns a keyword onto item records, so the boundary it measures is unchanged; the expected output and evidence now say "item records" to match the routing's wording.
- **Case 28** ("give every bandit a spell at runtime, no esp") — **kept as should-not, rewritten to measure the new routing.** It used to grade against "forms onto NPCs is not a SkyPatcher job", which the new routing makes false — an individual NPC's edits are SkyPatcher's. It now grades on the group/individual line: "every bandit" is a group, which is SPID's half.
- **Case 29** ("put these items into a chest without an ESP") — **moved to the should-trigger arm.** With the CID clause gone this is SkyPatcher's job outright, and its own evidence already noted the problem: no CID skill ships, so the case graded on the decline alone because a routing expectation would have been unsatisfiable. On review, the description gained "putting items into a container or chest" in its use clause, because the trigger arm shows an agent descriptions only and the description carried no container token to pick on; and its second expectation moved from a reference file that arm never opens to the reasoning, matching the other should-trigger cases.

The arm counts in the suite's `cases` line move from 17/15 to 18/14; the 32 prompts are unchanged.

The same prompt appears in two sibling suites and both recorded a destination the routing no longer has: `spid-authoring` case 13 said NONE and `kid-authoring` T13 said CID. Both now say `skypatcher-authoring`, so the three suites agree.

**Call 3 — the npc-appearance-copy rewrite document matches what shipped.** `dev/skill-validation/eval-2026-09/npc-appearance-copy/REWRITE.md` §3 printed the description as three separate calls at 483 characters; the shipped skill says four, because the tint path baked inside the placed mesh is its own call. §3 now prints the description as it stands on the tip, measured at 525 characters (listing entry 544 against Claude Code's 1,536 cap, 35% of it), the D2.26a bullet quotes the four-part decomposition, and the section carries a one-line note saying it was amended 2026-09-08 on Aaron's review of PR #646. `dev/` is gitignored, so this change is not in the diff.

Package rebuilt with `scripts/build-plugin.ps1` — leak-check clean on both trees, 12 skills, 223 markdown files. `dotnet test --filter "tier!=bridge"`: 1890 passed, 0 failed. Generator `ci-all`: 128/128, `description-vocab-guard` green.

