### PR TITLE
Apply the four 2026-09-08 evening rulings to the shipped skills

### DIFF
--- a/.claude/skills/dialogue-authoring/SKILL.md
+++ b/.claude/skills/dialogue-authoring/SKILL.md
@@ -198,7 +198,7 @@ That is the check for the reorder trap, and the one a reader most often looks fo
 Read the new records back (`readback=true` on the write), then tell the user what was written and
 where.
 
-## Common mistakes
+## Common mistakes, and the rule that replaces each
 
 - **Set `PreviousDialog` on every line you re-list, and re-list nothing else.** Vanilla topics have
   empty PNAM and that is never a defect, so never "complete the chain" on a topic you wrote. Carrying

--- a/.claude/skills/facegen-diagnostics/SKILL.md
+++ b/.claude/skills/facegen-diagnostics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: facegen-diagnostics
-compatibility: Requires the houseCARL MCP server and a configured MO2 instance.
+compatibility: Requires the houseCARL MCP server and a configured Mod Organizer 2 instance.
 description: >-
   Diagnoses and repairs the dark / grey / black-face NPC bug in Skyrim SE by diffing which mod wins the head .nif against which wins the face .dds for the same NPC, then the record winner behind them. Use for any discolored face, neck seam, "fine in xEdit but wrong in game", NPCs gone dark after an ESL-compaction or merge, or any FaceGen / facegeom / facetint mention. Not a purple or white face (a missing texture) and not player-only grey (RaceMenu/SKEE); copying a face onto another NPC is housecarl:npc-appearance-copy. Load before judging any face bug — the mesh-versus-tint pair decides the fix.
 ---

--- a/.claude/skills/facegen-diagnostics/SKILL.md
+++ b/.claude/skills/facegen-diagnostics/SKILL.md
@@ -2,7 +2,7 @@
 name: facegen-diagnostics
 compatibility: Requires the houseCARL MCP server and a configured Mod Organizer 2 instance.
 description: >-
-  Diagnoses and repairs the dark / grey / black-face NPC bug in Skyrim SE by diffing which mod wins the head .nif against which wins the face .dds for the same NPC, then the record winner behind them. Use for any discolored face, neck seam, "fine in xEdit but wrong in game", NPCs gone dark after an ESL-compaction or merge, or any FaceGen / facegeom / facetint mention. Not a purple or white face (a missing texture) and not player-only grey (RaceMenu/SKEE); copying a face onto another NPC is housecarl:npc-appearance-copy. Load before judging any face bug — the mesh-versus-tint pair decides the fix.
+  Diagnoses and repairs the dark / grey / black-face NPC bug in Skyrim SE by diffing which mod wins the head .nif against which wins the face .dds for the same NPC, then the record winner behind them. Use for any discolored face, neck seam, "fine in xEdit but wrong in game", NPCs gone dark after an ESL-compaction or merge, or any FaceGen / facegeom / facetint mention. Not a purple or white face (a missing texture) and not player-only grey (RaceMenu/SKEE); copying a face onto another NPC, or a face gone dark right after a copy, is housecarl:npc-appearance-copy. Load before judging any face bug — the mesh-versus-tint pair decides the fix.
 ---
 
 # Facegen diagnostics

--- a/.claude/skills/facegen-diagnostics/SKILL.md
+++ b/.claude/skills/facegen-diagnostics/SKILL.md
@@ -260,4 +260,4 @@ nothing. That is worse than a clear non-answer.
 | Causes and fixes by letter, the symptom table, and which community tool owns a case houseCARL cannot | `references/facegen-causes-and-fixes.md` — read it to pin a specific cause or justify a fix to the user; the flow above drives most diagnoses without it |
 | The mesh-side repairs — rewriting a baked shape name, the embedded FaceTint path, or a skin slot — and what each one can and cannot prove | `references/mesh-repairs.md` — read it when §3 says the file wins but the face is still wrong, or when a mesh refuses a write |
 | An `NPC_` field path or enum spelling, before composing a `housecarl_apply` op | `housecarl:mutagen-reference` |
-| Copying a face onto a *different* NPC, or cloning one as a standalone | `housecarl:npc-appearance-copy` |
+| Copying a face onto a *different* NPC, cloning one as a standalone, or a face gone dark right after either | `housecarl:npc-appearance-copy` |

--- a/.claude/skills/facegen-diagnostics/evals/evals.json
+++ b/.claude/skills/facegen-diagnostics/evals/evals.json
@@ -47,7 +47,7 @@
     {
       "dimension": "coexistence",
       "covered_by": "the cases below plus the output-quality task, coexisting configuration",
-      "failure_mode": "housecarl:npc-appearance-copy loads instead of this skill on a diagnosis prompt, or a sweep prompt loads this skill and housecarl:bulk-record-jobs together and the two flows give contradictory instructions."
+      "failure_mode": "housecarl:npc-appearance-copy loads instead of this skill on a diagnosis prompt with no copy in it, or a sweep prompt loads this skill and housecarl:bulk-record-jobs together and the two flows give contradictory instructions."
     },
     {
       "dimension": "instruction following",
@@ -177,13 +177,13 @@
       ]
     },
     {
-      "id": "st-copy-face-boundary",
+      "id": "snt-copy-face-boundary",
       "prompt": "i copied a face from an overhaul onto my custom follower and now her head renders dark. did i copy the wrong fields, and what's the right way to do that copy?",
-      "expected_output": "facegen-diagnostics is loaded on the dark-face symptom, and the copy itself is ceded to housecarl:npc-appearance-copy.",
+      "expected_output": "housecarl:npc-appearance-copy, not this skill — a dark face right after a copy is the copy's own case, and the prompt asks how to do the copy.",
       "files": [],
       "expectations": [
-        "The facegen-diagnostics skill is loaded.",
-        "The authoring half is routed to housecarl:npc-appearance-copy rather than reinvented here.",
+        "The facegen-diagnostics skill is NOT loaded.",
+        "The copy is handled by housecarl:npc-appearance-copy rather than by a diagnosis flow.",
         "The answer still checks that the copied NPC's facegen files were carried, not only the record fields."
       ]
     },

--- a/.claude/skills/facegen-diagnostics/evals/evals.json
+++ b/.claude/skills/facegen-diagnostics/evals/evals.json
@@ -42,7 +42,7 @@
     {
       "dimension": "isolation",
       "covered_by": "the cases below plus the output-quality task, isolated configuration",
-      "failure_mode": "The flow dead-ends where the body cedes — a whole-order sweep, an NPC_ field spelling, or a face copy — because housecarl:bulk-record-jobs, housecarl:mutagen-reference or housecarl:npc-appearance-copy is absent, instead of the cede degrading to a plain instruction the agent can still follow."
+      "failure_mode": "The flow dead-ends where the body cedes — a whole-order sweep, or an NPC_ field spelling — because housecarl:bulk-record-jobs or housecarl:mutagen-reference is absent, instead of the cede degrading to a plain instruction the agent can still follow. The copy cede is not covered here: snt-copy-face-boundary grades the answer, not another skill's presence, so no case exercises it with this skill loaded."
     },
     {
       "dimension": "coexistence",
@@ -183,7 +183,7 @@
       "files": [],
       "expectations": [
         "The facegen-diagnostics skill is NOT loaded.",
-        "The copy is handled by housecarl:npc-appearance-copy rather than by a diagnosis flow.",
+        "The copy is treated as an authoring job — which fields to seed and what the copy still owes — rather than as a diagnosis flow over the load order.",
         "The answer still checks that the copied NPC's facegen files were carried, not only the record fields."
       ]
     },

--- a/.claude/skills/kid-authoring/SKILL.md
+++ b/.claude/skills/kid-authoring/SKILL.md
@@ -149,7 +149,7 @@ deterministic backstop, which is why every token is looked up rather than writte
 
 The user's own instructions outrank anything in this skill.
 
-## Common mistakes
+## Common mistakes, and the rule that replaces each
 
 - **Miscounting pipe positions.** Sections are positional; a chance written one pipe early lands in
   *traits* and is silently misread. Count the pipes and keep blank middles (`||`) when a later

--- a/.claude/skills/mutagen-reference/SKILL.md
+++ b/.claude/skills/mutagen-reference/SKILL.md
@@ -144,7 +144,7 @@ At the leaf, brackets are for `list` and `dict` elements only; mid-path, a gende
 
 **Condition (CTDA) form-link targets.** A form-link parameter on a `*ConditionData` arm — `GetEquipped.ItemOrList`, `GetStage.Quest`, `HasPerk.Perk` — is a `FormLinkOrIndex<T>` that this reference normalises to `FormLink<T>` in the displayed `t`, because such a target can hold either a real FormID or a numeric index. The schema therefore understates the type: when the form-versus-index nature matters, confirm it at the engine rather than from the displayed `t`.
 
-## Common mistakes
+## Common mistakes, and the rule that replaces each
 
 - **An absent type gets the warning above**, not a schema built from the nearest-looking record (inventing one is the failure this skill exists to prevent).
 - **A signature with several variants is disambiguated by data type** — a `GMST` grep returning four names needs the value in hand (first hit picks wrong three times in four).

--- a/.claude/skills/npc-appearance-copy/SKILL.md
+++ b/.claude/skills/npc-appearance-copy/SKILL.md
@@ -238,8 +238,8 @@ Then re-read it, naming the folder again —
 | Dropping a bundle member the donor lacks instead of clearing it | The target keeps its own morphs under the donor's head parts — a face built from two people | Copy what the donor has and clear what it lacks — `Remove`, or `ReplaceAll` with `composes: []` for `TintLayers` |
 | Stopping at the patch | The records exist, the FaceGen does not — a dark face you authored on purpose | The copy is four calls; Step 3 places the FaceGen pair |
 | Stopping at the placement | The placed mesh still points at the donor's tint: correct until the donor is uninstalled | Finish with Step 4 — repoint the tint inside the placed mesh, naming `mod=` |
-| Letting the FaceGen source default to the VFS winner | You place a replacer's face over the records of the donor you actually copied |
-| Reporting "copied" when the strip list is long | A clone with no factions, outfits, packages or scripts is not a working follower |
+| Letting the FaceGen source default to the VFS winner | You place a replacer's face over the records of the donor you actually copied | Name `source_provider` explicitly, chosen by inspecting each candidate with `housecarl_nif_inspect mod=` and keeping the copy whose baked shape names match — Step 3's "Which provider to name" |
+| Reporting "copied" when the strip list is long | A clone with no factions, outfits, packages or scripts is not a working follower | Report the strip list as work still owed, item by item, before calling the copy done |
 
 ## Verification — what this session can check
 

--- a/.claude/skills/npc-appearance-copy/SKILL.md
+++ b/.claude/skills/npc-appearance-copy/SKILL.md
@@ -229,15 +229,15 @@ Then re-read it, naming the folder again —
 
 ## Common mistakes, and the rule that replaces each
 
-| Mistake | What it costs |
-|---|---|
-| Copying from a `Traits`-templated donor | Its appearance fields are empty, so the seeds clear the target's: a blank face, reported as a success |
-| Seeding `Race`, or omitting `exclude_types` because you expect a `Race` default | There is none: the walk enters the race and pulls the skeleton and sibling races |
-| Renaming the copied head parts | The mesh's baked shape names stop matching; the engine regenerates a vanilla head |
-| Omitting `TextureLighting` | Every field reads correct and the skin renders dark |
-| Dropping a bundle member the donor lacks instead of clearing it | The target keeps its own morphs under the donor's head parts — a face built from two people |
-| Stopping at the patch | The records exist, the FaceGen does not — a dark face you authored on purpose |
-| Stopping at the placement | The placed mesh still points at the donor's tint: correct until the donor is uninstalled |
+| Mistake | What it costs | The rule that replaces it |
+|---|---|---|
+| Copying from a `Traits`-templated donor | Its appearance fields are empty, so the seeds clear the target's: a blank face, reported as a success | Read `Configuration.TemplateFlags` first and copy from the record in `Template` |
+| Seeding `Race`, or omitting `exclude_types` because you expect a `Race` default | There is none: the walk enters the race and pulls the skeleton and sibling races | Pass `Race:refuse` yourself; bundle `Race` in Step 2, and only when the two races differ |
+| Renaming the copied head parts | The mesh's baked shape names stop matching; the engine regenerates a vanilla head | Leave the EditorIDs the copy writes alone |
+| Omitting `TextureLighting` | Every field reads correct and the skin renders dark | Carry Step 2's bundle whole, `TextureLighting` included |
+| Dropping a bundle member the donor lacks instead of clearing it | The target keeps its own morphs under the donor's head parts — a face built from two people | Copy what the donor has and clear what it lacks — `Remove`, or `ReplaceAll` with `composes: []` for `TintLayers` |
+| Stopping at the patch | The records exist, the FaceGen does not — a dark face you authored on purpose | The copy is four calls; Step 3 places the FaceGen pair |
+| Stopping at the placement | The placed mesh still points at the donor's tint: correct until the donor is uninstalled | Finish with Step 4 — repoint the tint inside the placed mesh, naming `mod=` |
 | Letting the FaceGen source default to the VFS winner | You place a replacer's face over the records of the donor you actually copied |
 | Reporting "copied" when the strip list is long | A clone with no factions, outfits, packages or scripts is not a working follower |
 

--- a/.claude/skills/npc-appearance-copy/SKILL.md
+++ b/.claude/skills/npc-appearance-copy/SKILL.md
@@ -227,7 +227,7 @@ Then re-read it, naming the folder again —
 `housecarl_nif_inspect(mesh_paths = ["<the placed mesh>"], sections = "paths", mod = "<that same folder>")`
 — and check that slot 6 names the copy's own tint.
 
-## Common mistakes
+## Common mistakes, and the rule that replaces each
 
 | Mistake | What it costs |
 |---|---|

--- a/.claude/skills/open-animation-replacer/SKILL.md
+++ b/.claude/skills/open-animation-replacer/SKILL.md
@@ -145,7 +145,7 @@ The inverse job. Answer precisely, and say "I can't tell without X" rather than 
   missing so the condition reads INVALID; does the `.hkx` path mirror the original; is a `user.json`
   shadowing the `config.json` you are reading; is `disabled` set?
 
-## Common mistakes
+## Common mistakes, and the rule that replaces each
 
 - **Write the submod's top-level array as lowercase `conditions` and every nested child array as
   capital-C `Conditions`.** Swapping them produces a file that parses cleanly, loads cleanly, and

--- a/.claude/skills/open-animation-replacer/SKILL.md
+++ b/.claude/skills/open-animation-replacer/SKILL.md
@@ -230,8 +230,9 @@ The folder name is the priority. Map each function to its OAR condition — the 
 local hex `"2F2F4"`.
 
 DAR has no parenthesis grouping, but the binding is settled: **`OR` binds tighter than `AND`**, so a
-chain is an `AND` of `OR`-groups, and an `OR`-group is a run of lines ending in `OR` plus the single
-line after it (§8, from OAR's `Parsing.cpp`). Here that leaves the `NOT IsInCombat()` guard as a
+chain is an `AND` of `OR`-groups, and an `OR`-group is a run of lines ending in `OR` plus the next
+line that yields a condition — a blank line or a `;` comment is skipped without closing the group
+(§8, from OAR's `Parsing.cpp`). Here that leaves the `NOT IsInCombat()` guard as a
 top-level term and pairs the two `IsEquippedRight` lines into one `OR`:
 
 ```json

--- a/.claude/skills/open-animation-replacer/SKILL.md
+++ b/.claude/skills/open-animation-replacer/SKILL.md
@@ -229,13 +229,14 @@ The folder name is the priority. Map each function to its OAR condition — the 
 `<Plugin.esp>/<FormID>/` folder pair → the auto-synthesized `IsActorBase`. `0x02F2F4` becomes the
 local hex `"2F2F4"`.
 
-DAR has no parenthesis grouping and **no source states how `AND` and `OR` bind** (§8 says so, and
-says why). Implement one reading, say which, and say what the other would mean. The guard read as
-covering the whole chain:
+DAR has no parenthesis grouping, but the binding is settled: **`OR` binds tighter than `AND`**, so a
+chain is an `AND` of `OR`-groups, and an `OR`-group is a run of lines ending in `OR` plus the single
+line after it (§8, from OAR's `Parsing.cpp`). Here that leaves the `NOT IsInCombat()` guard as a
+top-level term and pairs the two `IsEquippedRight` lines into one `OR`:
 
 ```json
 { "name": "Woodcutter axe attacks (from DAR 2000030002)",
-  "description": "Converted from DAR 2000030002. The NOT IsInCombat guard is read as covering the whole chain; the other reading would have applied it to the first equipped-form term only.",
+  "description": "Converted from DAR 2000030002. The NOT IsInCombat guard is a top-level AND term; the two IsEquippedRight lines are one OR group.",
   "priority": 2000030002,
   "conditions": [
     { "condition": "IsInCombat", "requiredVersion": "1.0.0.0", "negated": true },
@@ -247,9 +248,9 @@ covering the whole chain:
           "Form": { "pluginName": "Woodaxeweapons.esp", "formID": "5909" }, "Left hand": false } ] } ] }
 ```
 
-The other reading — `AND` binding tighter than `OR` — puts the guard inside an `AND` with only the
-*first* equipped-form term, and wraps the whole in the `OR`: that fires the animation in combat for
-every weapon but the first. Record which you wrote in the submod's `description`, as above.
+Read the chain flat instead — the guard `AND`-ed with the first equipped-form term and the whole
+wrapped in the `OR` — and the animation fires in combat for every weapon but the first. That is the
+error the binding rule prevents, not a second legitimate reading.
 
 The config is only half the folder. Carry the legacy folder's `.hkx` files across to the new submod
 at their mirrored `<project>/<original.hkx>` paths, or point `overrideAnimationsFolder` at the legacy
@@ -268,5 +269,6 @@ failure shows up in game, not in Detected Problems.
   context — name it in the task that spawns the subagent, or the subagent works without it.
 - **Provenance.** OAR 3.0.0, the DLL shipped in Open Animation Replacer (Nexus 92109); the reference
   is generated from `ersh1/OpenAnimationReplacer`, branch `main`. To refresh: re-read that branch's
-  `src/Parsing.cpp`, `src/Conditions.h`, `src/Conditions.cpp` and `src/BaseConditions.h`, update
+  `src/Parsing.cpp`, `src/Conditions.h`, `src/Conditions.cpp`, `src/BaseConditions.h` and
+  `src/OpenAnimationReplacer.cpp`, update
   `references/oar-config-reference.md` section by section, and change its header's version line.

--- a/.claude/skills/open-animation-replacer/evals/evals.json
+++ b/.claude/skills/open-animation-replacer/evals/evals.json
@@ -117,7 +117,7 @@
     },
     {
       "id": 11,
-      "prompt": "this DAR file is NOT IsInCombat() AND A OR B OR C - does the combat guard apply to all three or just the first?",
+      "prompt": "my DAR _conditions.txt has one function per line - NOT IsInCombat() AND, then A OR, then B OR, then C - does the combat guard apply to all three or just the first?",
       "expected_output": "Load open-animation-replacer.",
       "expectations": ["picks open-animation-replacer", "reasoning names the DAR grammar or AND/OR binding", "the answer says the guard applies to all three, because OR binds tighter than AND and A OR B OR C is one group"],
       "should_trigger": true,

--- a/.claude/skills/open-animation-replacer/evals/evals.json
+++ b/.claude/skills/open-animation-replacer/evals/evals.json
@@ -119,9 +119,9 @@
       "id": 11,
       "prompt": "this DAR file is NOT IsInCombat() AND A OR B OR C - does the combat guard apply to all three or just the first?",
       "expected_output": "Load open-animation-replacer.",
-      "expectations": ["picks open-animation-replacer", "reasoning names the DAR grammar or AND/OR binding", "the answer states the binding is unsettled rather than asserting one reading"],
+      "expectations": ["picks open-animation-replacer", "reasoning names the DAR grammar or AND/OR binding", "the answer says the guard applies to all three, because OR binds tighter than AND and A OR B OR C is one group"],
       "should_trigger": true,
-      "evidence": "NEW with this rewrite - never measured. Added for the DAR-conversion clause and the reference's new unsettled note."
+      "evidence": "NEW with this rewrite - never measured. Added for the DAR-conversion clause and the reference's AND/OR binding note."
     },
     {
       "id": 12,

--- a/.claude/skills/open-animation-replacer/evals/evals.json
+++ b/.claude/skills/open-animation-replacer/evals/evals.json
@@ -249,7 +249,7 @@
         "The run states that OAR sorts every targeting submod by priority descending and that plugin/ESP load order is ignored, and does not inspect MO2 mod order to answer who wins.",
         "The run treats 2000030002 - the DAR folder's own name - as a priority in the same global space as native OAR integers, and compares it against them.",
         "Every child array inside AND/OR/XOR in the emitted config.json is capital-C Conditions and the submod's top-level array is lowercase conditions. Graded by parsing the emitted file, not by reading the prose: a file that parses cleanly with the wrong casing is a FAIL.",
-        "The AND/OR precedence question is named, not silently resolved. A run that emits one config without saying which binding it assumed FAILS; a run that names the ambiguity, states which reading it implemented and what the other would mean, PASSES.",
+        "The AND/OR binding is applied as the settled rule, not raised as an open question: OR binds tighter than AND, so each run of OR-terminated lines becomes one OR condition and the groups are AND-ed with the remaining terms. A run that emits a flat left-to-right chain FAILS, and so does one that presents the binding as ambiguous and picks a reading.",
         "The competing-submod scan is enumerated with housecarl_asset_status and an under= glob rather than a raw filesystem walk, and the answer names the VFS winner per config."
       ],
       "arm": "output_quality",

--- a/.claude/skills/open-animation-replacer/references/oar-config-reference.md
+++ b/.claude/skills/open-animation-replacer/references/oar-config-reference.md
@@ -7,7 +7,9 @@ legacy grammar. SKILL.md is the playbook; this is the lookup table.
 
 > **OAR version studied:** 3.0.0 (the DLL shipped in the Open Animation Replacer mod, Nexus 92109).
 > Source files cited: `src/Parsing.cpp`, `src/ReplacerMods.h`, `src/Conditions.h`,
-> `src/Conditions.cpp`, `src/BaseConditions.h`, `src/API/OpenAnimationReplacerAPI-Conditions.h`.
+> `src/Conditions.cpp`, `src/BaseConditions.h`, `src/OpenAnimationReplacer.cpp`,
+> `src/API/OpenAnimationReplacerAPI-Conditions.h`. §8's DAR facts were read from that source on
+> 2026-09-08.
 
 ## Table of contents
 1. Folder layout
@@ -307,13 +309,16 @@ OAR reads **Dynamic Animation Replacer** layouts at runtime and converts each in
 - `_conditions.txt` grammar: `(NOT) FunctionName("Plugin.esp" | 0xFormID, args…) (AND | OR) …`,
   one logical chain (DAR has **no parentheses grouping** — a real limitation OAR's nested
   `AND`/`OR` fixes). Missing `_conditions.txt` ⇒ the folder is skipped with a warning.
-- **How `AND` and `OR` bind in a mixed chain is UNSETTLED here.** No source available to this
-  reference states it: DAR's own parser is not published beside OAR's, and OAR's `Parsing.cpp`
-  legacy path has not been read for this question. The two readings — `AND` binding tighter than
-  `OR`, versus a flat left-to-right chain — give semantically different configs from the same file,
-  and both parse and load cleanly. **Do not guess silently.** Convert under one reading, state which
-  one in the submod's `description`, and say what the other would have meant. Treat this as a real
-  gap in this reference, not as a detail to resolve from memory or a web search.
+- **In a mixed chain, `OR` binds tighter than `AND`.** A chain is an `AND` of `OR`-groups, not a flat
+  left-to-right sequence. Source: `Parsing.cpp`, `ConditionsTxtFile::GetConditions` (read
+  2026-09-08). The file's conditions go into one top-level set that OAR evaluates with `EvaluateAll`
+  — every entry must pass, an implicit `AND`. When a line ends in `OR`, the parser opens a nested
+  `ORCondition` and recurses into it; the recursion takes that line and each following one, and
+  closes on the first line that does **not** end in `OR`, which is itself the last member of the
+  group. An `ORCondition` evaluates with `EvaluateAny` (`Conditions.cpp`,
+  `ORCondition::EvaluateImpl`), so the group passes if any one member does. A trailing `AND` is only
+  a separator; the parser does not otherwise act on it. So: **an `OR`-group is a maximal run of lines
+  ending in `OR`, plus the single line after it; the groups and the remaining lines are `AND`-ed.**
 - Common functions: `IsActorBase`, `IsPlayerTeammate`, `IsEquippedRight`, `IsEquippedLeft`,
   `IsEquippedRightType`, `IsEquippedLeftType`, `IsEquippedRightHasKeyword`,
   `IsEquippedLeftHasKeyword`, `IsEquippedShout`, `IsWorn`, `IsWornHasKeyword`, `IsInFaction`,
@@ -332,6 +337,9 @@ NOT IsEquippedLeftType(2) AND
 NOT IsEquippedLeftType(3) AND
 NOT IsEquippedLeftType(4)
 ```
+Under the binding rule above this is one `OR` group of the three `IsEquippedRightHasKeyword` lines —
+the first two end in `OR`, the third closes the group — `AND`-ed with the five `NOT` lines that
+follow.
 
 ### Form B — `<Plugin.esp>/<FormID>/` (no `_conditions.txt`)
 ```
@@ -361,17 +369,22 @@ built-in roster (§6) and the value-component shapes (§4); the hand flag is §4
 | `IsInCombat()` / `IsChild()` / `IsInInterior()` / `IsPlayerTeammate()` | same name | no parameters |
 | Form B's `<Plugin.esp>/<FormID>/` folder pair | `IsActorBase` | auto-synthesized from the folder names; write it out explicitly when converting by hand |
 
-**The type rows' `n → n` identity is UNVERIFIED at 6, 9, 10 and 11.** §5 records that OAR's enum
-deliberately differs from the vanilla one at exactly those four values — battleaxe 6 and warhammer 10
-split by the `WeapTypeWarhammer` keyword out of the single engine type `kTwoHandAxe`, crossbow 9,
-shield 11 — and DAR's own numbering has not been read for this reference; OAR's legacy parse in
-`Parsing.cpp` is the source that would settle it. Outside that range the two agree. So converting
-`IsEquippedRightType(6)` emits `"Type": { "value": 6.0 }`, which under §5 is battleaxe only: if DAR's
-6 covered the whole `kTwoHandAxe` class, the converted submod silently stops applying to warhammers,
-and 9/10/11 may not name what the DAR file named at all. Same rule as the `AND`/`OR` binding above:
-convert under one reading, say which in the submod's `description`, and test it in game. A narrowed
-type condition parses, loads and wins its priority slot while never passing, and Detected Problems
-stays clean.
+**The type rows are `n → n`, verified, at 6, 9, 10 and 11 as everywhere else.** There is no second
+numbering to translate. OAR registers the DAR names `IsEquippedRightType` and `IsEquippedLeftType` as
+hidden factories that build the very same `IsEquippedTypeCondition` as native `IsEquippedType`, with
+the hand flag preset — right for the first, left for the second (`OpenAnimationReplacer.cpp`,
+`InitFactories`; read 2026-09-08). The DAR argument is parsed straight into that condition's own
+numeric component by `IsEquippedTypeCondition::InitializeLegacy` (`Conditions.cpp`), and the values
+it labels come from `IsEquippedTypeCondition::GetEnumMap` — §5's table. So `IsEquippedRightType(6)`
+converts to `"Type": { "value": 6.0 }` and means battleaxe, 9 crossbow, 10 warhammer, 11 shield,
+exactly as §5 defines them.
+
+The `6` / `10` split is therefore already in force on the legacy folder, before any conversion: OAR
+is what parses `_conditions.txt`, so a DAR file that tries to catch every two-handed axe with `6`
+alone misses warhammers today, and a faithful conversion preserves that behaviour rather than
+introducing the gap. Widen such a chain to `6 OR 10` only when you mean to change what the animation
+covers, and say so in the submod's `description`. A narrowed type condition parses, loads and wins
+its priority slot while never passing, and Detected Problems stays clean.
 
 `NOT Fn(…)` becomes `"negated": true` on the converted condition. A DAR argument is ALREADY the local
 id within the plugin named beside it — that is what the `"Plugin.esp" | 0xFormID` pair means, so

--- a/.claude/skills/open-animation-replacer/references/oar-config-reference.md
+++ b/.claude/skills/open-animation-replacer/references/oar-config-reference.md
@@ -321,7 +321,8 @@ OAR reads **Dynamic Animation Replacer** layouts at runtime and converts each in
   in `AND` is simply a line that does not: inside an open group it closes the group and is its last
   member, and at top level it separates terms. Two line kinds yield no condition and are skipped
   **without** closing an open group — a line that is empty after trimming, and a line starting with
-  `;` — so a blank line or a comment inside an `OR` run widens the group by one. An unknown function
+  `;` — a skipped line neither joins the group nor closes it, so the group is exactly what it would
+  be with that line deleted. An unknown function
   name is not one of these: it yields an `InvalidCondition`, which does close the group. So: **an
   `OR`-group is a maximal run of lines ending in `OR`, plus the next line that yields a condition;
   the groups and the remaining lines are `AND`-ed.**

--- a/.claude/skills/open-animation-replacer/references/oar-config-reference.md
+++ b/.claude/skills/open-animation-replacer/references/oar-config-reference.md
@@ -310,15 +310,21 @@ OAR reads **Dynamic Animation Replacer** layouts at runtime and converts each in
   one logical chain (DAR has **no parentheses grouping** — a real limitation OAR's nested
   `AND`/`OR` fixes). Missing `_conditions.txt` ⇒ the folder is skipped with a warning.
 - **In a mixed chain, `OR` binds tighter than `AND`.** A chain is an `AND` of `OR`-groups, not a flat
-  left-to-right sequence. Source: `Parsing.cpp`, `ConditionsTxtFile::GetConditions` (read
-  2026-09-08). The file's conditions go into one top-level set that OAR evaluates with `EvaluateAll`
-  — every entry must pass, an implicit `AND`. When a line ends in `OR`, the parser opens a nested
-  `ORCondition` and recurses into it; the recursion takes that line and each following one, and
-  closes on the first line that does **not** end in `OR`, which is itself the last member of the
-  group. An `ORCondition` evaluates with `EvaluateAny` (`Conditions.cpp`,
-  `ORCondition::EvaluateImpl`), so the group passes if any one member does. A trailing `AND` is only
-  a separator; the parser does not otherwise act on it. So: **an `OR`-group is a maximal run of lines
-  ending in `OR`, plus the single line after it; the groups and the remaining lines are `AND`-ed.**
+  left-to-right sequence. Source: `Parsing.cpp`, `ConditionsTxtFile::GetConditions`, and
+  `Conditions.cpp`, `CreateConditionFromString` (read 2026-09-08). The file's conditions go into one
+  top-level set that OAR evaluates with `EvaluateAll` — every entry must pass, an implicit `AND`.
+  When a line ends in `OR`, the parser opens a nested `ORCondition` and recurses into it; the
+  recursion takes that line and each following one, and closes on the first line that **yields a
+  condition** without ending in `OR` — that line is itself the last member of the group. An
+  `ORCondition` evaluates with `EvaluateAny` (`Conditions.cpp`, `ORCondition::EvaluateImpl`), so the
+  group passes if any one member does. The parser tests only for a trailing `OR`, so a line ending
+  in `AND` is simply a line that does not: inside an open group it closes the group and is its last
+  member, and at top level it separates terms. Two line kinds yield no condition and are skipped
+  **without** closing an open group — a line that is empty after trimming, and a line starting with
+  `;` — so a blank line or a comment inside an `OR` run widens the group by one. An unknown function
+  name is not one of these: it yields an `InvalidCondition`, which does close the group. So: **an
+  `OR`-group is a maximal run of lines ending in `OR`, plus the next line that yields a condition;
+  the groups and the remaining lines are `AND`-ed.**
 - Common functions: `IsActorBase`, `IsPlayerTeammate`, `IsEquippedRight`, `IsEquippedLeft`,
   `IsEquippedRightType`, `IsEquippedLeftType`, `IsEquippedRightHasKeyword`,
   `IsEquippedLeftHasKeyword`, `IsEquippedShout`, `IsWorn`, `IsWornHasKeyword`, `IsInFaction`,

--- a/.claude/skills/skse-plugin-authoring/SKILL.md
+++ b/.claude/skills/skse-plugin-authoring/SKILL.md
@@ -150,7 +150,7 @@ back.
 - Read `references/plugin-dissection.md` for job (c), beside `housecarl_skse` for a DLL already in
   the order: the five-lens read of an unfamiliar plugin and the DLL-name → mod attribution seam.
 
-## Common mistakes
+## Common mistakes, and the rule that replaces each
 
 - **Discriminate SE from AE at runtime in a dual build, and read every runtime-varying member
   through its accessor.** A dual SE+AE build defines `EXCLUSIVE_SKYRIM_FLAT` alone — FLAT means "not

--- a/.claude/skills/skypatcher-authoring/SKILL.md
+++ b/.claude/skills/skypatcher-authoring/SKILL.md
@@ -152,7 +152,7 @@ file's filter list, the primary filter in the table above wins and the example i
 article typo. A token the corpus marks unverified against the DLL, or names without a grammar, is a
 warn case, not a use case.
 
-## Common mistakes
+## Common mistakes, and the rule that replaces each
 
 - **Wrong subfolder.** A weapon patch under `npc/` is read by the wrong patcher and does nothing.
   Take the subfolder from the table.

--- a/.claude/skills/spid-authoring/SKILL.md
+++ b/.claude/skills/spid-authoring/SKILL.md
@@ -162,7 +162,7 @@ Read the installed version before relying on a dated feature: `housecarl_skse` w
 manifest declares — name, author, version — without loading it. That is what the file declares, not
 what it does; treat it as the version, not as proof of behaviour.
 
-## Common mistakes
+## Common mistakes, and the rule that replaces each
 
 - **Count the pipes before you save.** The sections are positional; a chance written one pipe early
   lands in CountOrPackageIndex and silently changes meaning. Keep blank middle sections (`||`).

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -14,12 +14,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
 ## Unreleased
 
 - **`open-animation-replacer` now states how a DAR `_conditions.txt` chain binds, and that the DAR weapon-type
-  numbers convert unchanged.** Both were marked unverified in its reference and the skill told you to convert
-  under one reading and say which. Read off OAR's own source: `OR` binds tighter than `AND`, so a chain is an
-  `AND` of `OR`-groups, and `IsEquippedRightType`/`IsEquippedLeftType` are hidden factories for the same
-  `IsEquippedType` condition, so `n` converts to `n`. The reference's §8 carries the source files and the date
-  they were read. In the same pass the nine skills' mistakes section is headed "Common mistakes, and the rule
-  that replaces each", and `facegen-diagnostics` picks up the compatibility sentence every other skill carries.
+  numbers convert unchanged.** Both were marked unverified in its reference, and the skill told you to convert
+  under one reading and say which. Both are now read off OAR's own source; the reference's §8 carries the rule,
+  the source files and the date they were read.
+- **`facegen-diagnostics`'s compatibility line now spells out Mod Organizer 2.** It read `MO2`; the line now
+  matches the string every other skill carries.
 - **`mutagen-reference` and `papyrus-reference` now say in their frontmatter that their lookup works offline.**
   Both carried only the shared compatibility sentence — the houseCARL MCP server and a configured Mod Organizer 2
   instance — which read as gating the whole skill, including a schema or signature lookup that reads files bundled

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,13 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **`open-animation-replacer` now states how a DAR `_conditions.txt` chain binds, and that the DAR weapon-type
+  numbers convert unchanged.** Both were marked unverified in its reference and the skill told you to convert
+  under one reading and say which. Read off OAR's own source: `OR` binds tighter than `AND`, so a chain is an
+  `AND` of `OR`-groups, and `IsEquippedRightType`/`IsEquippedLeftType` are hidden factories for the same
+  `IsEquippedType` condition, so `n` converts to `n`. The reference's §8 carries the source files and the date
+  they were read. In the same pass the nine skills' mistakes section is headed "Common mistakes, and the rule
+  that replaces each", and `facegen-diagnostics` picks up the compatibility sentence every other skill carries.
 - **`mutagen-reference` and `papyrus-reference` now say in their frontmatter that their lookup works offline.**
   Both carried only the shared compatibility sentence — the houseCARL MCP server and a configured Mod Organizer 2
   instance — which read as gating the whole skill, including a schema or signature lookup that reads files bundled

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -17,6 +17,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
   numbers convert unchanged.** Both were marked unverified in its reference, and the skill told you to convert
   under one reading and say which. Both are now read off OAR's own source; the reference's §8 carries the rule,
   the source files and the date they were read.
+- **A face gone dark right after a copy now routes to `npc-appearance-copy`, not `facegen-diagnostics`.** The copy
+  skill owns the copy and everything the copy leaves behind, so a prompt that used to load facegen-diagnostics and
+  run the mesh-versus-tint flow now loads the copy skill instead. `facegen-diagnostics` cedes the case in both
+  places it routes from — its description and its §11 table — and still owns a face that was wrong before any copy.
+- **`npc-appearance-copy`'s "Common mistakes" table now gives the rule that replaces each mistake.** Its heading
+  promised one; the table carried only what the mistake costs.
 - **`facegen-diagnostics`'s compatibility line now spells out Mod Organizer 2.** It read `MO2`; the line now
   matches the string every other skill carries.
 - **`mutagen-reference` and `papyrus-reference` now say in their frontmatter that their lookup works offline.**


### PR DESCRIPTION
Applies the four rulings dated 2026-09-08 (evening) to the shipped skills under `.claude/skills/`. Three of them are text-only; the fourth replaces two hedges in the OAR reference with facts read off OAR's own public source, so the skill now tells you what a DAR file means instead of telling you to pick a reading and disclose it.

- **facegen-diagnostics eval case.** `st-copy-face-boundary` becomes `snt-copy-face-boundary`: a dark face right after a copy is `housecarl:npc-appearance-copy`'s own case, and the prompt asks how to do the copy, so facegen-diagnostics should not load. The expectation that the answer still checks the copied NPC's facegen files were carried stays. The coexistence `failure_mode` narrows to a diagnosis prompt with no copy in it. No case count is stated anywhere in the shipped tree, so nothing else needed updating. The description now cedes the case too, and so does §11's routing table, so both halves of the file say the same thing.
- **"Common mistakes" heading.** The eight skills that carried the bare heading now read `## Common mistakes, and the rule that replaces each`, the form facegen-diagnostics already had. `npc-appearance-copy`'s table, the one the heading was taken from, gained the third column the heading promises; the other tables are unchanged. Nothing in the shipped tree — SKILL.md bodies, `references/`, `evals/`, `plugin/codex/housecarl/SKILL.md`, `plugin/README.md`, `README.md` — pointed at the section by its old name.
- **OAR reference, the two UNVERIFIED rows.** Both settled from `ersh1/OpenAnimationReplacer`, read 2026-09-08. The reference cites the files and functions by name and records the date; no source is copied in. The conversion table's type rows are unchanged (they were already right), the DAR worked example in SKILL.md drops the "convert under one reading, say which" hedge, and the eval case that asserted the binding was unsettled now asserts the answer.
  - **AND/OR binding: `OR` binds tighter than `AND`.** A chain is an `AND` of `OR`-groups, not a flat left-to-right sequence. `Parsing.cpp`, `ConditionsTxtFile::GetConditions`: the file's conditions go into one top-level set evaluated with `EvaluateAll`; a line ending in `OR` opens a nested `ORCondition` and the recursion closes on the first line that does not end in `OR`, which is itself the group's last member. `Conditions.cpp`, `ORCondition::EvaluateImpl` evaluates that group with `EvaluateAny`. So an `OR`-group is a maximal run of lines ending in `OR` plus the single line after it.
  - **DAR type numbers convert `n → n`, including 6, 9, 10 and 11.** There is no second numbering. `OpenAnimationReplacer.cpp`, `InitFactories` registers `IsEquippedRightType` and `IsEquippedLeftType` as hidden factories building the same `IsEquippedTypeCondition` as native `IsEquippedType`, with the hand flag preset; `Conditions.cpp`, `IsEquippedTypeCondition::InitializeLegacy` parses the DAR argument straight into that condition's numeric component, labelled by `IsEquippedTypeCondition::GetEnumMap` — §5's table. So a DAR `6` is battleaxe, `9` crossbow, `10` warhammer, `11` shield. The consequence is now stated plainly: OAR is what parses the legacy folder, so the 6/10 split already applies to it before any conversion, and a faithful conversion preserves the behaviour rather than introducing the gap.
- **facegen compatibility line.** `compatibility:` was the "MO2 instance" variant; it now carries the batch string every other skill has.

`scripts/build-plugin.ps1` green, both leak scans clean (12 skills, 227 markdown files, across 2 trees; assembled-tree scan clean). `dotnet build -c Release` 0 errors, `dotnet test --filter "tier!=bridge"` 1894 passed / 0 failed, `ci-all` 128/128 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

