### PR TITLE
Rebuild the Codex umbrella skill as a router

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -25,6 +25,16 @@ saying it sets an expectation their install may contradict. Say what is known, a
   promised one; the table carried only what the mistake costs.
 - **`facegen-diagnostics`'s compatibility line now spells out Mod Organizer 2.** It read `MO2`; the line now
   matches the string every other skill carries.
+- **The Codex umbrella skill is rebuilt as a router, and no longer teaches seventeen tools that do not exist.**
+  Its body carried a ~39-line catalogue of the whole tool surface, half of it 1.x names the 2.0 build retired,
+  under a sentence promising they "keep working" — a Codex session following it composed calls the server refuses
+  by name. The catalogue is gone: what a tool takes is in that tool's own description, which the server injects.
+  What is left is what only a router can do — a row per bundled skill saying which job it owns and when to load
+  it, the read-before-you-write order with one worked call, the FormID form, and the three write lanes (the
+  in-place one is gated by `acknowledge=` at the server, not by prose here). The description is 611 characters
+  against the 1,024 ceiling it used to breach, and opens on its trigger. The CI guard that watched this file
+  changed direction to match: it used to require every tool name to appear here, which is why it stayed green
+  through all seventeen dead names, and now requires every `housecarl_*` name written here to be a live tool.
 - **`mutagen-reference` and `papyrus-reference` now say in their frontmatter that their lookup works offline.**
   Both carried only the shared compatibility sentence — the houseCARL MCP server and a configured Mod Organizer 2
   instance — which read as gating the whole skill, including a schema or signature lookup that reads files bundled

--- a/plugin/codex/housecarl/SKILL.md
+++ b/plugin/codex/housecarl/SKILL.md
@@ -55,15 +55,17 @@ Claude Code invocation — on Codex it is the bare folder name (`facegen-diagnos
 4. **Read the written record back**, and say what happened when it did not take.
 
 ```
-housecarl_apply(ops=[{"formid": "013BA3:Skyrim.esm", "field_path": "BasicStats.Damage", "value": 12}], patch="SwordFix", readback=true)
+housecarl_apply(ops=[{"formid": "012EB7:Skyrim.esm", "field_path": "BasicStats.Damage", "value": 12}], patch="SwordFix", readback=true)
 ```
 ```
-wrote SwordFix.esp   1 record, 1 op   epoch=7f3a1c
-  013BA3:Skyrim.esm  IronSword  BasicStats.Damage  10 -> 12
+wrote SwordFix.esp (new patch; 1284 bytes)
+full read-back — the ENTIRE record(s) as written, re-read from the patch file (NOT load-order truth):
+  Weapon 012EB7:Skyrim.esm  editorid=IronSword
+    BasicStats.Damage = 12
+    ...
 ```
 
-The read-back is the written FILE, not load-order truth. Report the patch name back — it is auto-suffixed
-when taken — and tell the user to enable it. A refused call wrote nothing: fix the path and send it again.
+Report the patch name back — it is auto-suffixed when taken. A refused call wrote nothing.
 
 ## Lanes and FormIDs
 

--- a/plugin/codex/housecarl/SKILL.md
+++ b/plugin/codex/housecarl/SKILL.md
@@ -17,9 +17,8 @@ compatibility: Requires the houseCARL MCP server and a configured Mod Organizer 
 
 **In:** a live Mod Organizer 2 instance, read through the houseCARL MCP server. **The work:** read the
 record at its true load-order winner, check the schema, then write. **Out:** a patch plugin the user
-reviews and enables in MO2. This file does two things and defers the rest — it routes a job to the skill
-that owns its grammar, and it gives the read order every write depends on. What a tool takes is in that
-tool's own description.
+reviews and enables in MO2. This file routes a job to the skill that owns its grammar, and gives the read
+order every write depends on. What a tool takes is in that tool's own description.
 
 The user's instructions take precedence over guidelines provided in a skill.
 
@@ -40,38 +39,40 @@ The user's instructions take precedence over guidelines provided in a skill.
 | A catalogue, audit, conflict survey or link graph over many records | `housecarl:bulk-record-jobs` | before the first call |
 
 MCP tools are written bare on both hosts (`housecarl_records`); a sibling is written `housecarl:<skill>`, the
-Claude Code invocation — on Codex it is the bare folder name (`facegen-diagnostics`), installed beside this one.
+Claude Code form — on Codex it is the bare folder name (`facegen-diagnostics`) installed beside this one.
 
 ## Read before you write
 
 1. **Confirm context when it matters.** `housecarl_load_order_status` says what is active;
-   `housecarl_set_mo2_instance` when the user names a different MO2 instance folder.
+   `housecarl_set_mo2_instance` when the user names another MO2 instance folder.
 2. **Read the winner and the schema.** `housecarl:mutagen-reference` for the field path and its legal
-   values — if it has no entry for a type, say so rather than guessing; `housecarl_records` for the record
-   as the order resolves it, `project={"form":"tree"}` for every provider when the winner is contested.
+   values — no entry for a type means say so, never guess; `housecarl_records` for the record
+   as the order resolves it, `project={"form":"tree"}` for every provider when contested.
 3. **Write with one verb.** `housecarl_apply` edits fields (`ops=`), `housecarl_create` mints records
    (`records=`), `housecarl_remove` drops them (`formids=`), `housecarl_forward` carries another plugin's
-   record as an override. Every list is set-valued — one op is a set of one — there is no single/bulk pair.
-4. **Read the written record back**, and say what happened when it did not take.
+   record as an override. Every list is set-valued — one op is a set of one; no single/bulk pair.
+4. **Read the written record back**, and say what happened if it did not take.
 
 ```
 housecarl_apply(ops=[{"formid": "012EB7:Skyrim.esm", "field_path": "BasicStats.Damage", "value": 12}], patch="SwordFix", readback=true)
 ```
 ```
 wrote SwordFix.esp (new patch; 1284 bytes)
-full read-back — the ENTIRE record(s) as written, re-read from the patch file (NOT load-order truth):
+mod folder: SwordFix  — enable + sort it in MO2 to use the patch
+full read-back — … NOT load-order truth; the patch wins nothing until enabled + sorted in MO2:
   Weapon 012EB7:Skyrim.esm  editorid=IronSword
     BasicStats.Damage = 12
     ...
 ```
 
-Report the patch name back — it is auto-suffixed when taken. A refused call wrote nothing.
+Report the patch name and mod folder back — the name is auto-suffixed when taken. A refused call wrote
+nothing — except in place, where the file may already have changed.
 
 ## Lanes and FormIDs
 
 A FormID is `XXXXXX:Plugin.esp` — six hex digits, then the defining master's filename. The runtime form a log
 or the console prints is read-only: `housecarl_records` takes it, every write refuses it and names the
-`XXXXXX:Plugin.esp` form to use. SkyPatcher, SPID and KID write their own syntax.
+`XXXXXX:Plugin.esp` form. SkyPatcher, SPID and KID write their own syntax.
 
 `housecarl_apply`, `housecarl_create` and `housecarl_forward` take three lanes: `patch=` a new plugin, `into=`
 an existing houseCARL patch, `in_place=` the file it names. `housecarl_remove` edits only what exists: `into=`
@@ -79,13 +80,13 @@ or `in_place=`, no `patch=`. In place is consent-gated per plugin by `acknowledg
 
 ## Where this does not apply
 
-Another game; installing or configuring MO2; gameplay advice with no record, file or INI in it. Two reaches the
-surface does not have today, both filed: `housecarl_check` with `findings=["dialogue"]` resolves against the
-active order, so a plugin not yet enabled cannot be dialogue-checked (#615); and a hand-composed raw mods-folder
-path is not refused in one sentence by `housecarl_place` or `housecarl_nif_inspect` (#617) — pass the mod
-folder a read-back named instead.
+Another game; installing or configuring MO2; gameplay advice with no record, file or INI. Two reaches the
+surface lacks today, both filed: `housecarl_check` with `findings=["dialogue"]` resolves against the active
+order, so a plugin not yet enabled cannot be dialogue-checked (#615); and a hand-composed raw mods-folder path
+is not refused in one sentence by `housecarl_place` or `housecarl_nif_inspect` (#617) — pass the mod folder a
+read-back named.
 
 ## The sidecar
 
-Codex reads `agents/openai.yaml` beside this file for the display name and invocation policy; nothing in
-this body depends on it.
+Codex reads `agents/openai.yaml` beside this file for the display name and invocation policy; nothing here
+depends on it.

--- a/plugin/codex/housecarl/SKILL.md
+++ b/plugin/codex/housecarl/SKILL.md
@@ -54,7 +54,7 @@ Claude Code form — on Codex it is the bare folder name (`facegen-diagnostics`)
 4. **Read the written record back**, and say what happened if it did not take.
 
 ```
-housecarl_apply(ops=[{"formid": "012EB7:Skyrim.esm", "field_path": "BasicStats.Damage", "value": 12}], patch="SwordFix", readback=true)
+housecarl_apply(ops=[{"formid": "012EB7:Skyrim.esm", "field_path": "BasicStats.Damage", "value": "12"}], patch="SwordFix", readback=true)
 ```
 ```
 wrote SwordFix.esp (new patch; 1284 bytes)

--- a/plugin/codex/housecarl/SKILL.md
+++ b/plugin/codex/housecarl/SKILL.md
@@ -67,13 +67,13 @@ when taken — and tell the user to enable it. A refused call wrote nothing: fix
 
 ## Lanes and FormIDs
 
-A FormID is `XXXXXX:Plugin.esp` — six hex digits, then the filename of the master that defines the record.
-The runtime form a log or the console prints is taken too, wherever a parameter holds nothing but FormIDs.
-SkyPatcher, SPID and KID each write their own syntax; their skills say so.
+A FormID is `XXXXXX:Plugin.esp` — six hex digits, then the defining master's filename. The runtime form a log
+or the console prints is read-only: `housecarl_records` takes it, every write refuses it and names the
+`XXXXXX:Plugin.esp` form to use. SkyPatcher, SPID and KID write their own syntax.
 
-Every write tool has the same three lanes: `patch=` writes a new plugin, `into=` extends an existing houseCARL
-patch, `in_place=` overwrites the file it names. In place is consent-gated at the server, per plugin, by
-`acknowledge=` — it refuses rather than asking this skill to police it.
+`housecarl_apply`, `housecarl_create` and `housecarl_forward` take three lanes: `patch=` a new plugin, `into=`
+an existing houseCARL patch, `in_place=` the file it names. `housecarl_remove` edits only what exists: `into=`
+or `in_place=`, no `patch=`. In place is consent-gated per plugin by `acknowledge=`.
 
 ## Where this does not apply
 

--- a/plugin/codex/housecarl/SKILL.md
+++ b/plugin/codex/housecarl/SKILL.md
@@ -66,7 +66,7 @@ full read-back — … NOT load-order truth; the patch wins nothing until enable
 ```
 
 Report the patch name and mod folder back — the name is auto-suffixed when taken. A refused call wrote
-nothing — except in place, where the file may already have changed.
+nothing; a failed in-place write says so in its message.
 
 ## Lanes and FormIDs
 

--- a/plugin/codex/housecarl/SKILL.md
+++ b/plugin/codex/housecarl/SKILL.md
@@ -1,85 +1,89 @@
 ---
 name: housecarl
-description: Work with Skyrim Special Edition load-order records and assets through the houseCARL MCP server — set or switch the MO2 instance, inspect active or disabled plugins and conflict trees, read records, query across plugins, author reviewable patch ESPs, create or remove records, edit leveled lists and composed structs, diff and resolve, edit NIF meshes and facegen, author dialogue, audit the SkyPatcher and SKSE runtime layers, compact or merge plugins, drive Papyrus compile/decompile and BSA archives, and look mods up on Nexus. Also the router for the bundled Skyrim helper skills (mutagen-reference, papyrus-reference, skypatcher-authoring, spid-authoring, kid-authoring, dialogue-authoring, facegen-diagnostics, open-animation-replacer, skse-plugin-authoring, bulk-record-jobs, npc-appearance-copy). Use whenever the user mentions houseCARL, an MO2 modlist, plugins, load order, conflicts, ESP patches, overrides, a record type (ARMO/WEAP/NPC_/LVLI/MGEF/…), leveled lists, keywords, facegen or dark faces, dialogue, SKSE plugins, Papyrus, BSA archives, Nexus, or a no-ESP runtime distribution — even when the task looks like a single edit, load this first to pick the right tool and read before you write.
+description: >-
+  Use whenever a task touches a Mod Organizer 2 modlist, load order, plugins,
+  conflicts, ESP patches or overrides, a record type (ARMO, WEAP, NPC_, LVLI,
+  MGEF), leveled lists, dark faces or facegen, dialogue, NIF meshes, SkyPatcher,
+  SPID or KID lines, SKSE plugins, Papyrus, or BSA archives. Routes Skyrim
+  Special Edition data-layer work through the houseCARL MCP server — a live MO2
+  instance read at the true load-order winner, written into reviewable patch
+  plugins — and names the specialist skill that owns each grammar. Not for
+  another game, for installing MO2, or for gameplay advice with no data-layer
+  step.
+compatibility: Requires the houseCARL MCP server and a configured Mod Organizer 2 instance.
 ---
 
 # houseCARL
 
-Use this skill for data-layer Skyrim Special Edition modding through the configured houseCARL MCP server. houseCARL reads a Mod Organizer 2 instance, resolves the true load-order winner, and writes changes into reviewable patch plugins; original source mods are never edited. Beyond the record read/write core it reaches the whole data layer — assets and NIF meshes, the SkyPatcher and SKSE runtime layers, dialogue, plugin operations, Papyrus compile/decompile, BSA archives, and keyless Nexus lookups — plus the 11 focused helper skills below for the specialist grammars and workflows.
+**In:** a live Mod Organizer 2 instance, read through the houseCARL MCP server. **The work:** read the
+record at its true load-order winner, check the schema, then write. **Out:** a patch plugin the user
+reviews and enables in MO2. This file does two things and defers the rest — it routes a job to the skill
+that owns its grammar, and it gives the read order every write depends on. What a tool takes is in that
+tool's own description.
 
-## Core workflow (read before you write)
+The user's instructions take precedence over guidelines provided in a skill.
 
-1. Confirm context when it matters:
-   - `housecarl_load_order_status` for profile/plugin status, or to check whether a mod or plugin is active.
-   - `housecarl_set_mo2_instance` when the user gives a new MO2 instance folder.
-2. Read before any record write:
-   - `mutagen-reference` to verify field names, writability, enum values, and composed-struct shapes.
-   - `housecarl_read_record` or `housecarl_batch_record_detail` to inspect the current winner. Add `conflict_tree=true` for contested records or when winner provenance matters.
-   - `housecarl_cross_plugin_query` to locate records or references across the load order (page big results with `offset=`).
-3. Pick the narrowest write tool:
-   - `housecarl_set_field` for a single scalar or simple-collection edit.
-   - `housecarl_bulk_apply` for several edits in one patch, dict merges, leveled-list entries, effects, or other composed structs.
-   - `housecarl_create_record` (or `housecarl_bulk_create` for many at once) for a new top-level record — it needs an EditorID.
-   - `housecarl_remove_record` only to drop a record or override from a houseCARL-owned patch — never from a source mod.
-4. Name the patch on the **first** write that creates one with `patch=<name>` (not `housecarl_remove_record`, whose `patch=` names one that already exists) — omit it and houseCARL names it `Patch`. Either way the name is auto-suffixed if it is already taken, so read the patch name back off the response. After that, accumulate related edits into it with `into=<patch filename>`.
-5. Prefer runtime, no-ESP INI systems when they fit the user's intent — `skypatcher-authoring`, `spid-authoring`, `kid-authoring` (see the helper skills below).
+## Which skill owns the job
 
-## The full tool surface
+| The user is asking about | Load | When |
+|---|---|---|
+| A dark, grey or black NPC face; a face wrong after compacting or merging | `housecarl:facegen-diagnostics` | before judging the fix |
+| Copying one NPC's face onto another, or cloning a standalone follower | `housecarl:npc-appearance-copy` | before the copy |
+| What fields a record type has, or a legal enum value | `housecarl:mutagen-reference` | before the write |
+| A no-ESP edit to a record's own fields, or to one NPC | `housecarl:skypatcher-authoring` | before the INI line |
+| Spells, perks, items, outfits or factions onto NPCs by group | `housecarl:spid-authoring` | before the `_DISTR.ini` line |
+| Keywords onto item records | `housecarl:kid-authoring` | before the `_KID.ini` line |
+| Adding, wiring or auditing dialogue topics and lines | `housecarl:dialogue-authoring` | before the DIAL/INFO write |
+| Gating animations by weapon, keyword, perk or race | `housecarl:open-animation-replacer` | before the condition |
+| A Papyrus or SKSE function signature, or a `.psc` edit | `housecarl:papyrus-reference` | before the script edit |
+| Writing or building a native SKSE plugin DLL in C++ | `housecarl:skse-plugin-authoring` | before the first C++ |
+| A catalogue, audit, conflict survey or link graph over many records | `housecarl:bulk-record-jobs` | before the first call |
 
-Beyond the core workflow, reach for the right group. Depth for the specialist areas lives in the helper skills (next section) — load the skill before composing in that area.
+MCP tools are written bare on both hosts (`housecarl_records`); a sibling is written `housecarl:<skill>`, the
+Claude Code invocation — on Codex it is the bare folder name (`facegen-diagnostics`), installed beside this one.
 
-**Read / query / resolve**
-- `housecarl_records` — the consolidated 2.0 read surface (SELECT × SOURCE × PROJECT in one call): record lists or scans, any plugin's version wherever it lives (active or on disk), form-scoped `project=` shapes. The 1.x read tools below keep working through the 2.0 build.
-- `housecarl_read_record`, `housecarl_batch_record_detail` — read one or many records at the true winner (`conflict_tree=true` for provenance).
-- `housecarl_read_plugin_file` — read a plugin directly, even one that is disabled or not active.
-- `housecarl_cross_plugin_query` — query and filter records or references across the whole order; page with `offset=`, count with `group_by=`.
-- `housecarl_resolve` — resolve a list of FormIDs to identity; `housecarl_diff_record` — diff two plugins' versions of a record.
-- `housecarl_effect_chain` — trace a magic effect to every spell / enchantment / potion / scroll / ingredient that carries it.
-- `housecarl_load_order_status` — enabled/disabled mods & plugins; `housecarl_check_errors` — dangling refs, missing masters, broken links.
-- `housecarl_check` — the merged derived-findings sweep: `findings=` picks the family (`errors` — dangling refs, missing masters, parse failures, the default; `scripts` — unbound VMAD script properties; `dialogue` — the dialogue graph over the topics and quests `seeds=` names) or a class inside one, in one call.
+## Read before you write
 
-**Runtime layers (what xEdit can't see)**
-- `housecarl_skypatcher_read` — a record's true state after the SkyPatcher INI layer replays; `housecarl_skypatcher_layer` — the INIs, apply order, conflicts.
-- `housecarl_skse` — the SKSE layer, one family per call via `findings=`: `inventory` (SKSE-plugin DLLs, configs, provider/metadata — the default), `pairing` (native Papyrus declarations vs the DLLs implementing them), `config` (config references vs the load order).
+1. **Confirm context when it matters.** `housecarl_load_order_status` says what is active;
+   `housecarl_set_mo2_instance` when the user names a different MO2 instance folder.
+2. **Read the winner and the schema.** `housecarl:mutagen-reference` for the field path and its legal
+   values — if it has no entry for a type, say so rather than guessing; `housecarl_records` for the record
+   as the order resolves it, `project={"form":"tree"}` for every provider when the winner is contested.
+3. **Write with one verb.** `housecarl_apply` edits fields (`ops=`), `housecarl_create` mints records
+   (`records=`), `housecarl_remove` drops them (`formids=`), `housecarl_forward` carries another plugin's
+   record as an override. Every list is set-valued — one op is a set of one — there is no single/bulk pair.
+4. **Read the written record back**, and say what happened when it did not take.
 
-**Write / author**
-- `housecarl_apply` — the consolidated 2.0 field-write surface (one or many edits × the lane × the read-back in one call): `ops=` for field edits, `bundle=`+`assignments=` to copy a field bundle from one record onto another, and one lane spelling — a new patch, `into=` an existing one, or `in_place="X.esp"` naming the file you intend to overwrite. The 1.x write tools below keep working through the 2.0 build.
-- `housecarl_create` — the consolidated 2.0 authoring surface: `records=[{record_type, editorid, ops}]`, one record being a set of one, and a nested unit (a topic AND its lines, a cell AND its refs) authored in one call by parenting a spec on an earlier sibling's editorid. Same lane spelling as `apply`.
-- `housecarl_remove` — drop whole records; `formids=` is set-valued, so many drop in one re-serialize. The lane is `into=` a houseCARL patch or `in_place="X.esp"` (a removal edits an artifact that already exists, so there is no `patch=`).
-- `housecarl_copy` — copy a record together with the records it depends on (its link closure) into a patch under new FormIDs, so the result no longer masters the plugin you copied from: `seed_paths=` names the link-bearing fields the walk starts from, `from_source=` is an ordered list of sources tried first-hit-wins (`winner`, or plugin filenames — active or disabled), and the destination is either `target=` (an existing record) or `new_editorid=` (a clone, with every remaining link into the source stripped and named). For a source that resolved into an MO2 mod folder the readback names that folder — the name to pass `housecarl_place` as `source_provider=` when you carry that record's files; a source with no such folder (the `winner` pole, overwrite, the game's `Data` folder, a file outside all of them) says so instead.
-- `housecarl_forward` — copy a specific plugin's whole record as an override: `source=` names whose version (any plugin — active, or one that is only on disk in a DISABLED mod; a master reverts to vanilla), and the response names the winner it will out-rank plus, for an off-order source, which copy on disk it read.
-- `housecarl_set_field`, `housecarl_bulk_apply`, `housecarl_create_record`, `housecarl_bulk_create`, `housecarl_create_plugin` (header-only trigger plugin), `housecarl_remove_record`, `housecarl_forward_record` (copy-as-override, or revert to another plugin's version), `housecarl_validate_scripts` (unbound script properties).
+```
+housecarl_apply(ops=[{"formid": "013BA3:Skyrim.esm", "field_path": "BasicStats.Damage", "value": 12}], patch="SwordFix", readback=true)
+```
+```
+wrote SwordFix.esp   1 record, 1 op   epoch=7f3a1c
+  013BA3:Skyrim.esm  IronSword  BasicStats.Damage  10 -> 12
+```
 
-**Dialogue** — `housecarl_validate_dialogue`, `housecarl_write_seq` (the start-game-enabled quest `.seq`; `source=` takes the plugin's filename or an absolute path; `output_dir=` lands it in the mod's own `SEQ\` after an in-place edit). Depth: `dialogue-authoring`.
+The read-back is the written FILE, not load-order truth. Report the patch name back — it is auto-suffixed
+when taken — and tell the user to enable it. A refused call wrote nothing: fix the path and send it again.
 
-**Assets / NIF / facegen** — `housecarl_asset_status` (which mod/BSA wins a Data-relative path), `housecarl_place` (make a chosen copy win MO2's VFS), `housecarl_nif_inspect` / `housecarl_nif_set` (read/write mesh data values). Depth: `facegen-diagnostics`.
+## Lanes and FormIDs
 
-**Plugin operations** — `housecarl_compact_plugin` (ESL-renumber, carries FormID-keyed facegen/voice along), `housecarl_merge_plugins`. A standalone NPC appearance is two calls — `housecarl_copy` for the records, `housecarl_place` for the FaceGen, with the mod folder the copy names as `source_provider=`; depth: `npc-appearance-copy`.
+A FormID is `XXXXXX:Plugin.esp` — six hex digits, then the filename of the master that defines the record.
+The runtime form a log or the console prints is taken too, wherever a parameter holds nothing but FormIDs.
+SkyPatcher, SPID and KID each write their own syntax; their skills say so.
 
-**Papyrus / SKSE code** — `housecarl_compile_script` (`.psc` → `.pex`), `housecarl_decompile_script` (`.pex` → `.psc`). Depth: `papyrus-reference`, `skse-plugin-authoring`.
+Every write tool has the same three lanes: `patch=` writes a new plugin, `into=` extends an existing houseCARL
+patch, `in_place=` overwrites the file it names. In place is consent-gated at the server, per plugin, by
+`acknowledge=` — it refuses rather than asking this skill to police it.
 
-**BSA archives** — `housecarl_bsa_list`, `housecarl_bsa_extract`, `housecarl_bsa_repack`.
+## Where this does not apply
 
-**Nexus (keyless, no browser)** — `housecarl_nexus_search`, `housecarl_nexus_mod`, `housecarl_nexus_check_updates`, `housecarl_nexus_identify`, `housecarl_nexus_graphql`. For a whole-order update check, start with `housecarl_update_status` (MO2's local update cache, no network), then confirm with `housecarl_nexus_check_updates`.
+Another game; installing or configuring MO2; gameplay advice with no record, file or INI in it. Two reaches the
+surface does not have today, both filed: `housecarl_check` with `findings=["dialogue"]` resolves against the
+active order, so a plugin not yet enabled cannot be dialogue-checked (#615); and a hand-composed raw mods-folder
+path is not refused in one sentence by `housecarl_place` or `housecarl_nif_inspect` (#617) — pass the mod
+folder a read-back named instead.
 
-**Setup** — `housecarl_set_mo2_instance`, `housecarl_set_tool_path` (point houseCARL at an external tool: the Papyrus compiler, BSArch, or the crash / Papyrus log folders).
+## The sidecar
 
-## Bundled helper skills
-
-Load the specialist skill before composing in its domain:
-
-- **Reference** — `mutagen-reference` (record schemas), `papyrus-reference` (Papyrus / SKSE function signatures).
-- **Runtime distribution grammars** — `skypatcher-authoring` (record edits), `spid-authoring` (spells / perks / items / factions / outfits → NPCs), `kid-authoring` (keywords → items).
-- **Content authoring / investigation** — `dialogue-authoring`, `facegen-diagnostics` (the dark-face NPC bug), `npc-appearance-copy` (copy a face onto another NPC or into a standalone clone), `open-animation-replacer` (Open Animation Replacer), `skse-plugin-authoring` (C++ SKSE plugin DLLs).
-- **Bulk planning** — `bulk-record-jobs` (catalogues, audits, link graphs, conflict surveys, fan-out extraction — many records into one structured deliverable).
-
-## FormID notes
-
-houseCARL tools use `XXXXXX:Plugin.esp` FormIDs — six hex digits, then the filename of the master that defines the record. SkyPatcher, SPID, and KID each use their own FormID syntax; consult their skills before writing INI lines.
-
-## Safety notes
-
-- houseCARL patches are reviewable output mods. Tell the user which patch was created or extended.
-- Don't invent schemas or field paths. If `mutagen-reference` has no entry for a type, say so directly rather than guessing.
-- Don't reach for record edits when the user explicitly wants a no-ESP / runtime distribution file — use SkyPatcher, SPID, or KID instead.
-- Never edit a source mod in place unless the user has explicitly opted into the in-place lane.
+Codex reads `agents/openai.yaml` beside this file for the display name and invocation policy; nothing in
+this body depends on it.

--- a/plugin/codex/housecarl/evals/evals.json
+++ b/plugin/codex/housecarl/evals/evals.json
@@ -1,0 +1,168 @@
+{
+  "skill_name": "housecarl (the Codex umbrella router)",
+  "reads": "dist/codex/skills/housecarl/SKILL.md — the packaged Codex tree, never plugin/codex/, so no run reads an authoring-tree file. scripts/build-plugin.ps1 strips evals/ from every shipped copy, so this file is a repository artifact the regrade reads and the body never points at it (dev/DECISIONS.md, 2026-09-07, rulings 2 and 3).",
+  "numbers_are_borrowed": "Every threshold, run count and split below is Anthropic's published skill-eval method. No OpenAI page states a harness, runner, trigger-rate metric or threshold for a Codex skill, and this bundle ships only to Codex, so the numbers are borrowed and labelled borrowed rather than presented as this host's own (checklist D5.20, 'no source').",
+  "baseline": "None. This skill has never carried an eval set, and the 2026-09 audit ran neither arm for it (audit-2026-09/SUMMARY.md:43, both cells 'not run') — the only row in the batch with no with-skill and no control log. There is nothing to carry forward; this file is the first measurement.",
+  "method": {
+    "arms": [
+      "with-skill — the packaged umbrella in the menu, the houseCARL MCP server attached and its instructions injected, as any real session has it",
+      "without-skill — the same query, the same menu minus this skill, the server still attached; a case that passes in both arms is not differentiating, and that is a finding rather than a pass"
+    ],
+    "runs_per_query": 3,
+    "trigger_rate_threshold": 0.5,
+    "split": "60/40 train / held-out; best iteration chosen by held-out score, at most 5 iterations. A fix generalises the category the failing query belongs to; it never pastes that query's own nouns into the description.",
+    "coexistence": "the reduced menu — the eleven sibling skills that install beside this one under ~/.agents/skills after the 2026-09-07 deletions",
+    "isolation": "one run with this skill alone in the menu",
+    "reported_separately": "triggering and output quality are two result sets, never one blended rate (checklist D5.19)",
+    "fresh_context": "each arm from a fresh context; the with-skill and without-skill runs are separate sessions (checklist D5.21)",
+    "failure_modes_named": [
+      "triggering accuracy — a positive below 0.5 or a negative above it",
+      "isolation — the router fires on a query no skill should own",
+      "coexistence — the router answers where a sibling owns the grammar, or a sibling's own description already routes the job and the router adds a hop",
+      "instruction following — the router loads and the session still writes before reading the winner and the schema",
+      "output quality — the deliverable arm below"
+    ],
+    "positives_cover": "one per routing destination the DESCRIPTION claims. Three of the eleven destinations have no positive — open-animation-replacer, npc-appearance-copy and papyrus-reference are reachable from the routing table but the description carries no animation, face-copy or signature-lookup term. That is deliberate: the description was not widened to chase them (its 611 characters are the measured fix for D2.21 / D3.5 / D4.59), and on both hosts those three siblings carry their own trigger descriptions beside this one. Recorded rather than papered over — verify row 9.11."
+  },
+  "evals": [
+    {
+      "id": 1,
+      "split": "train",
+      "prompt": "A bunch of NPCs from my follower mod have gone dark-faced since I compacted the plugin to ESL. What's actually winning?",
+      "expected_output": "the umbrella is loaded and routes to facegen-diagnostics before any call.",
+      "expectations": ["the skill is selected", "the route names facegen-diagnostics rather than composing a read first"]
+    },
+    {
+      "id": 2,
+      "split": "train",
+      "prompt": "I want to nerf every steel weapon's damage in my order without adding another ESP. What's the cleanest way?",
+      "expected_output": "the umbrella is loaded and routes to skypatcher-authoring.",
+      "expectations": ["the skill is selected", "the route reaches a no-ESP INI grammar rather than a patch plugin"]
+    },
+    {
+      "id": 3,
+      "split": "train",
+      "prompt": "write me a _DISTR.ini that gives every Forsworn a frost cloak spell",
+      "expected_output": "the umbrella is loaded and routes to spid-authoring.",
+      "expectations": ["the skill is selected", "the route names spid-authoring, not skypatcher-authoring"]
+    },
+    {
+      "id": 4,
+      "split": "train",
+      "prompt": "how do I tag all the mod-added dwarven armour with the vendor keyword using KID?",
+      "expected_output": "the umbrella is loaded and routes to kid-authoring.",
+      "expectations": ["the skill is selected", "the route names kid-authoring, keywords onto item records"]
+    },
+    {
+      "id": 5,
+      "split": "train",
+      "prompt": "I added a new greeting line to my follower quest and it never plays in game. Can you look at the dialogue?",
+      "expected_output": "the umbrella is loaded and routes to dialogue-authoring.",
+      "expectations": ["the skill is selected", "the route names dialogue-authoring before judging the INFO records"]
+    },
+    {
+      "id": 6,
+      "split": "train",
+      "prompt": "what fields does an ARMO record actually have, and what are the legal values for the armor type?",
+      "expected_output": "the umbrella is loaded and routes to mutagen-reference.",
+      "expectations": ["the skill is selected", "the route names mutagen-reference rather than answering the schema from memory"]
+    },
+    {
+      "id": 7,
+      "split": "train",
+      "prompt": "Give me a spreadsheet of every contested WEAP record in my 3800-plugin order and which mod wins each one.",
+      "expected_output": "the umbrella is loaded and routes to bulk-record-jobs before the first call.",
+      "expectations": ["the skill is selected", "the route names bulk-record-jobs, and the plan is sized before rows are read"]
+    },
+    {
+      "id": 8,
+      "split": "train",
+      "prompt": "my SKSE plugin dll builds fine but the game doesn't load it on AE, where do I even start",
+      "expected_output": "the umbrella is loaded and routes to skse-plugin-authoring.",
+      "expectations": ["the skill is selected", "the route names skse-plugin-authoring, not papyrus-reference"]
+    },
+    {
+      "id": 9,
+      "split": "train",
+      "prompt": "Which mods am I running that touch the Iron Sword, and what does the winner set its damage to?",
+      "expected_output": "the umbrella is loaded; the read order is followed — the winner and its conflict tree before any write.",
+      "expectations": ["the skill is selected", "no sibling is loaded — this is the router's own read step"]
+    },
+    {
+      "id": 10,
+      "split": "train",
+      "prompt": "Can you bump the carry weight on my custom backpack record and hand me a patch I can review?",
+      "expected_output": "the umbrella is loaded; the schema and the winner are read before the write, and the patch name is reported back.",
+      "expectations": ["the skill is selected", "the write lands in a new patch rather than in the source mod", "the answer tells the user to enable the patch in MO2"]
+    },
+    {
+      "id": 11,
+      "split": "held_out",
+      "prompt": "my Fallout 4 modlist keeps CTDing on load, can you sort out the plugin order?",
+      "expected_output": "the umbrella is not loaded; houseCARL is Skyrim Special Edition only.",
+      "expectations": ["the skill is not selected", "the near-miss: every noun but the game is in the description's trigger list"]
+    },
+    {
+      "id": 12,
+      "split": "held_out",
+      "prompt": "How do I install Mod Organizer 2 and point it at my Steam copy of Skyrim?",
+      "expected_output": "the umbrella is not loaded; installing and configuring MO2 is outside the data layer.",
+      "expectations": ["the skill is not selected", "the near-miss: MO2 is the first noun in the description"]
+    },
+    {
+      "id": 13,
+      "split": "held_out",
+      "prompt": "what's the best perk build for a stealth archer in Requiem?",
+      "expected_output": "the umbrella is not loaded; gameplay advice with no data-layer step.",
+      "expectations": ["the skill is not selected"]
+    },
+    {
+      "id": 14,
+      "split": "held_out",
+      "prompt": "write me an xEdit script that renames every editor ID in a plugin",
+      "expected_output": "the umbrella is not loaded; the Pascal scripting host is not this surface.",
+      "expectations": ["the skill is not selected", "the near-miss: records and plugins in a load order, through the wrong tool"]
+    },
+    {
+      "id": 15,
+      "split": "held_out",
+      "prompt": "how do I get Vortex to deploy my mods to the right folder?",
+      "expected_output": "the umbrella is not loaded; houseCARL reads Mod Organizer 2, and this is a different manager's deployment question.",
+      "expectations": ["the skill is not selected"]
+    },
+    {
+      "id": 16,
+      "split": "held_out",
+      "prompt": "what's a good armour mod to install next?",
+      "expected_output": "the umbrella is not loaded; a recommendation is not a data-layer step.",
+      "expectations": ["the skill is not selected", "the near-miss: 'armour' plus 'install' reads adjacent to a record type and a modlist"]
+    },
+    {
+      "id": 17,
+      "split": "train",
+      "prompt": "in Papyrus, what's the difference between a State and an Event, conceptually?",
+      "expected_output": "the umbrella is not loaded; a language question with no load order in it.",
+      "expectations": ["the skill is not selected", "the recorded soft edge: 'Papyrus' IS a description trigger term, so this is the hardest negative in the set — the boundary is the closing 'no data-layer step' clause, and if this case fails the fix is that clause, never dropping the term"]
+    },
+    {
+      "id": 18,
+      "split": "train",
+      "prompt": "I can't log in to my Nexus account, the download button does nothing",
+      "expected_output": "the umbrella is not loaded; an account and website problem, not a mod lookup.",
+      "expectations": ["the skill is not selected", "the near-miss: houseCARL does read Nexus keylessly, which is what makes an account question adjacent"]
+    }
+  ],
+  "output_quality_arm": {
+    "why_it_exists": "Ruling 3 makes the audit's own with/without task the output-quality arm. This skill has no such run — both audit cells are 'not run' — and it is the one measurement that answers whether the router earns its always-on listing at all (checklist rows D5.19, D5.21, D5.26, D5.52, all fails). The rewrite is not gradeable until it exists.",
+    "task": "On the live ARR 2.0 order (3,801 plugins), one prompt whose ROUTING is the whole difference, phrased the way a user would: \"A batch of NPCs from one of my follower mods came out grey-faced after I ESL-compacted a plugin. Sort out what actually wins and fix it.\"",
+    "arms": "control (no skill in the catalogue, the houseCARL MCP server attached and its instructions injected) and with-skill (told to load this skill first). One Opus agent, 40-call cap, one run each, fresh context.",
+    "beats_the_control_when": [
+      "1. The route is taken before the first call — the with-skill arm loads facegen-diagnostics and reaches for the record-versus-file precedence model before composing anything; the control does not, or reaches it late and after a wrong call.",
+      "2. Every call is live — no 1.x tool name is composed in the with-skill transcript, the direct test of the seventeen dead names against the packaged tree.",
+      "3. The deliverable differs measurably — something passes with the skill and fails without it."
+    ],
+    "gate": "All three, or the arm does not pass. A faster route to the same answer is not enough on its own: the pair is the only honest measure, and two skills in the 2026-09 audit had their self-reported value contradicted by their own controls.",
+    "if_the_control_matches": "The ruled outcome is not a smaller rewrite. It is FOLD-IN.md N9: the routing map is dropped rather than migrated, and item 27 decides whether the Codex bundle ships a router at all beside eleven skills that each describe themselves.",
+    "recorded_per_arm": ["pass rate", "total_tokens", "duration_ms", "houseCARL call count", "which skills were loaded and when"]
+  }
+}

--- a/plugin/codex/housecarl/evals/evals.json
+++ b/plugin/codex/housecarl/evals/evals.json
@@ -10,7 +10,7 @@
     ],
     "runs_per_query": 3,
     "trigger_rate_threshold": 0.5,
-    "split": "60/40 train / held-out; best iteration chosen by held-out score, at most 5 iterations. A fix generalises the category the failing query belongs to; it never pastes that query's own nouns into the description.",
+    "split": "11 train / 7 held out (≈60/40), positives and negatives on BOTH sides. An all-negative held-out set is the trap here: iteration is scored on it, and a description narrowed until the router stops firing scores perfectly against negatives alone, so the failure this set exists to catch would be the one it cannot see. Best iteration chosen by held-out score, at most 5 iterations. A fix generalises the category the failing query belongs to; it never pastes that query's own nouns into the description.",
     "coexistence": "the reduced menu — the eleven sibling skills that install beside this one under ~/.agents/skills after the 2026-09-07 deletions",
     "isolation": "one run with this skill alone in the menu",
     "reported_separately": "triggering and output quality are two result sets, never one blended rate (checklist D5.19)",
@@ -22,7 +22,8 @@
       "instruction following — the router loads and the session still writes before reading the winner and the schema",
       "output quality — the deliverable arm below"
     ],
-    "positives_cover": "one per routing destination the DESCRIPTION claims. Three of the eleven destinations have no positive — open-animation-replacer, npc-appearance-copy and papyrus-reference are reachable from the routing table but the description carries no animation, face-copy or signature-lookup term. That is deliberate: the description was not widened to chase them (its 611 characters are the measured fix for D2.21 / D3.5 / D4.59), and on both hosts those three siblings carry their own trigger descriptions beside this one. Recorded rather than papered over — verify row 9.11."
+    "positives_cover": "one per routing destination the DESCRIPTION claims. Three of the eleven destinations have no positive — open-animation-replacer, npc-appearance-copy and papyrus-reference are reachable from the routing table but the description carries no animation, face-copy or signature-lookup term. That is deliberate: the description was not widened to chase them (its 611 characters are the measured fix for D2.21 / D3.5 / D4.59), and on both hosts those three siblings carry their own trigger descriptions beside this one. Recorded rather than papered over — verify row 9.11.",
+    "trigger_gaps": "Nexus is the one capability no description in the bundle carries. The old description said 'look mods up on Nexus'; the rewrite drops it, and no sibling owns that grammar — the eleven routing rows are record, asset and script jobs. So on Codex 'which of my mods have updates on Nexus?' reaches housecarl_update_status and the housecarl_nexus_* tools only through the server's injected instructions, the dependency Q7 takes on faith. Left as a gap rather than closed by widening the description, and recorded here so the run measures it: whether it should be closed is the same question as whether the router earns its listing (item 27)."
   },
   "evals": [
     {
@@ -48,7 +49,7 @@
     },
     {
       "id": 4,
-      "split": "train",
+      "split": "held_out",
       "prompt": "how do I tag all the mod-added dwarven armour with the vendor keyword using KID?",
       "expected_output": "the umbrella is loaded and routes to kid-authoring.",
       "expectations": ["the skill is selected", "the route names kid-authoring, keywords onto item records"]
@@ -62,7 +63,7 @@
     },
     {
       "id": 6,
-      "split": "train",
+      "split": "held_out",
       "prompt": "what fields does an ARMO record actually have, and what are the legal values for the armor type?",
       "expected_output": "the umbrella is loaded and routes to mutagen-reference.",
       "expectations": ["the skill is selected", "the route names mutagen-reference rather than answering the schema from memory"]
@@ -76,7 +77,7 @@
     },
     {
       "id": 8,
-      "split": "train",
+      "split": "held_out",
       "prompt": "my SKSE plugin dll builds fine but the game doesn't load it on AE, where do I even start",
       "expected_output": "the umbrella is loaded and routes to skse-plugin-authoring.",
       "expectations": ["the skill is selected", "the route names skse-plugin-authoring, not papyrus-reference"]
@@ -90,21 +91,21 @@
     },
     {
       "id": 10,
-      "split": "train",
+      "split": "held_out",
       "prompt": "Can you bump the carry weight on my custom backpack record and hand me a patch I can review?",
       "expected_output": "the umbrella is loaded; the schema and the winner are read before the write, and the patch name is reported back.",
       "expectations": ["the skill is selected", "the write lands in a new patch rather than in the source mod", "the answer tells the user to enable the patch in MO2"]
     },
     {
       "id": 11,
-      "split": "held_out",
+      "split": "train",
       "prompt": "my Fallout 4 modlist keeps CTDing on load, can you sort out the plugin order?",
       "expected_output": "the umbrella is not loaded; houseCARL is Skyrim Special Edition only.",
       "expectations": ["the skill is not selected", "the near-miss: every noun but the game is in the description's trigger list"]
     },
     {
       "id": 12,
-      "split": "held_out",
+      "split": "train",
       "prompt": "How do I install Mod Organizer 2 and point it at my Steam copy of Skyrim?",
       "expected_output": "the umbrella is not loaded; installing and configuring MO2 is outside the data layer.",
       "expectations": ["the skill is not selected", "the near-miss: MO2 is the first noun in the description"]
@@ -118,14 +119,14 @@
     },
     {
       "id": 14,
-      "split": "held_out",
+      "split": "train",
       "prompt": "write me an xEdit script that renames every editor ID in a plugin",
       "expected_output": "the umbrella is not loaded; the Pascal scripting host is not this surface.",
       "expectations": ["the skill is not selected", "the near-miss: records and plugins in a load order, through the wrong tool"]
     },
     {
       "id": 15,
-      "split": "held_out",
+      "split": "train",
       "prompt": "how do I get Vortex to deploy my mods to the right folder?",
       "expected_output": "the umbrella is not loaded; houseCARL reads Mod Organizer 2, and this is a different manager's deployment question.",
       "expectations": ["the skill is not selected"]
@@ -139,7 +140,7 @@
     },
     {
       "id": 17,
-      "split": "train",
+      "split": "held_out",
       "prompt": "in Papyrus, what's the difference between a State and an Event, conceptually?",
       "expected_output": "the umbrella is not loaded; a language question with no load order in it.",
       "expectations": ["the skill is not selected", "the recorded soft edge: 'Papyrus' IS a description trigger term, so this is the hardest negative in the set — the boundary is the closing 'no data-layer step' clause, and if this case fails the fix is that clause, never dropping the term"]

--- a/src/housecarl-generator/CodexUmbrellaCoverageProbe.cs
+++ b/src/housecarl-generator/CodexUmbrellaCoverageProbe.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text.RegularExpressions;
 using ModelContextProtocol.Server;
 using HousecarlMcp;
 
@@ -7,20 +8,25 @@ namespace HousecarlGenerator;
 /// <summary>
 /// REGRESSION GUARD (standing CI instrument, self-contained) — CODEX UMBRELLA COVERAGE.
 ///
-/// The Codex packaging ships ONE umbrella routing skill (plugin/codex/housecarl/SKILL.md) that hand-lists
-/// houseCARL's MCP tools and helper skills. Unlike the 11 Claude Code skills — each its own trigger — the
-/// umbrella is Codex's single hand-maintained router, so nothing forced it to track the tool/skill surface: it
-/// silently drifted from full coverage to 9 of ~45 tools over ~2 months because adding a tool never touched it.
+/// The Codex packaging ships ONE umbrella routing skill (plugin/codex/housecarl/SKILL.md) that routes a job to
+/// the sibling skill that owns its grammar. Unlike the 11 Claude Code skills — each its own trigger — the
+/// umbrella is Codex's single hand-maintained router, so nothing forced it to track the skill surface.
 ///
-/// This guard makes that drift impossible by construction. It reflects the REAL [McpServerTool] names off the
-/// housecarl-mcp assembly — the authoritative registered set, not a source-text pattern a brittle grep can miss —
-/// and reads the REAL .claude/skills/* folders, then asserts EVERY one is referenced in the umbrella — or allow-listed as
-/// a deliberate omission. A session that adds housecarl_foo or a new skill and forgets the Codex router now gets
-/// a RED CI arm naming exactly what to add. Same "green only if the checker has teeth" shape as the other guards:
-/// RED arms feed a synthetic omission and assert it fires; the allow-list is proven to actually suppress.
+/// This guard makes that drift impossible by construction. It reads the REAL .claude/skills/* folders and asserts
+/// every one is referenced in the umbrella — or allow-listed as a deliberate omission — and it reflects the REAL
+/// [McpServerTool] names off the housecarl-mcp assembly (the authoritative registered set, not a source-text
+/// pattern a brittle grep can miss) to check the OTHER direction: no housecarl_* name the router writes may be a
+/// tool that does not exist. Same "green only if the checker has teeth" shape as the other guards: RED arms feed
+/// a synthetic violation and assert it fires; the allow-list is proven to actually suppress.
 ///
-///   INV1 — every current MCP tool name is referenced in the umbrella (or allow-listed).
+///   INV1 — every housecarl_* name the umbrella writes is a live MCP tool.
 ///   INV2 — every bundled skill slug is referenced in the umbrella (or allow-listed).
+///
+/// INV1 used to run the other way — every tool name had to appear in the router — and that is why CI stayed green
+/// while the router taught seventeen tools the 2.0 surface had retired: a catalogue can be complete and still be
+/// wrong. The 2026-09 rewrite deleted the catalogue (FOLD-IN.md F37: it restated the server's own injected
+/// instructions, which already end "each tool's own description carries the specifics"), so a router naming every
+/// tool is no longer the shape being defended. What is defended is that every name it does write resolves.
 ///
 /// Run: dotnet run --project src/housecarl-generator -- codex-umbrella-coverage-guard
 /// </summary>
@@ -28,9 +34,9 @@ public static class CodexUmbrellaCoverageProbe
 {
     static int _pass, _fail;
 
-    // Deliberate omissions from the Codex umbrella router. EMPTY by design — the umbrella covers the whole
-    // surface today. Add a name here ONLY with a one-line reason when a tool/skill is intentionally not routed by
-    // the umbrella; that keeps "not in the router" a conscious choice recorded here, never silent drift.
+    // Deliberate omissions from the Codex umbrella router's SKILL routing (INV2). EMPTY by design — the router
+    // has a row per bundled skill. Add a slug here ONLY with a one-line reason when a skill is intentionally not
+    // routed; that keeps "not in the router" a conscious choice recorded here, never silent drift.
     static readonly HashSet<string> Allow = new(StringComparer.Ordinal)
     {
         // (none)
@@ -41,7 +47,7 @@ public static class CodexUmbrellaCoverageProbe
     [CiProbe("codex-umbrella-coverage-guard")]
     public static int RunGuard(string[] args)
     {
-        Console.WriteLine("################  REGRESSION GUARD — Codex umbrella coverage (tools + skills referenced)  ################");
+        Console.WriteLine("################  REGRESSION GUARD — Codex umbrella coverage (every skill routed, every tool name live)  ################");
         Console.WriteLine();
         try
         {
@@ -81,19 +87,23 @@ public static class CodexUmbrellaCoverageProbe
             Check($"GUARD-SELF the boundary matcher tells apart every colliding name pair ({collisions.Count} pairs on this surface)",
                 falsePasses.Count == 0, falsePasses);
 
-            // INV1 — every tool referenced.
-            var missTools = MissingRefs(umbrella, tools, Allow);
-            Check("INV1-GREEN every MCP tool is referenced in the umbrella router", missTools.Count == 0,
-                missTools.Select(t => $"tool not routed by the Codex umbrella: {t} — add it to {UmbrellaPath.Replace('\\', '/')} (or Allow with a reason)").ToList());
+            // INV1 — every name the router writes resolves to a live tool.
+            var dead = DeadToolNames(umbrella, tools);
+            Check("INV1-GREEN every housecarl_* name the umbrella writes is a live MCP tool", dead.Count == 0,
+                dead.Select(t => $"the Codex umbrella names a tool that does not exist: {t} — fix {UmbrellaPath.Replace('\\', '/')} against the published surface").ToList());
 
             // INV2 — every skill referenced.
             var missSkills = MissingRefs(umbrella, skills, Allow);
             Check("INV2-GREEN every bundled skill is referenced in the umbrella router", missSkills.Count == 0,
                 missSkills.Select(s => $"skill not routed by the Codex umbrella: {s} — add it to {UmbrellaPath.Replace('\\', '/')} (or Allow with a reason)").ToList());
 
-            // RED arms — the checker must catch an omission, or it is toothless.
-            var redTool = MissingRefs("router text that mentions no tools", new[] { "housecarl_read_record" }, Empty());
-            Check("INV1-RED  a missing tool reference is caught", redTool.Contains("housecarl_read_record"), redTool, redArm: true);
+            // RED arms — the checker must catch a violation, or it is toothless.
+            var redTool = DeadToolNames("read the winner with `housecarl_read_record` first", tools);
+            Check("INV1-RED  a retired tool name in the router is caught", redTool.Contains("housecarl_read_record"), redTool, redArm: true);
+
+            // …and a live name must not be reported dead, or INV1 would fire on every honest router.
+            var liveTool = DeadToolNames("read the winner with `housecarl_records` first", tools);
+            Check("INV1-GREEN-SELF a live tool name is not reported dead", liveTool.Count == 0, liveTool, redArm: true);
 
             var redSkill = MissingRefs("router text that mentions no skills", new[] { "facegen-diagnostics" }, Empty());
             Check("INV2-RED  a missing skill reference is caught", redSkill.Contains("facegen-diagnostics"), redSkill, redArm: true);
@@ -169,6 +179,13 @@ public static class CodexUmbrellaCoverageProbe
     static List<string> MissingRefs(string umbrella, IEnumerable<string> required, ISet<string> allow)
         => required.Where(r => !allow.Contains(r) && !ReferencedAtBoundary(umbrella, r))
                    .OrderBy(r => r, StringComparer.Ordinal).ToList();
+
+    /// <summary>Every <c>housecarl_*</c> identifier the router writes that is NOT a reflected tool name — the
+    /// direction the old one-way check could not see. The sibling-skill form the router also writes is
+    /// <c>housecarl:&lt;skill&gt;</c>, which the underscore in this pattern excludes by construction.</summary>
+    static List<string> DeadToolNames(string umbrella, ISet<string> live)
+        => Regex.Matches(umbrella, "housecarl_[a-z0-9_]+").Select(m => m.Value).Distinct(StringComparer.Ordinal)
+                .Where(n => !live.Contains(n)).OrderBy(n => n, StringComparer.Ordinal).ToList();
 
     /// <summary>Does the text mention <paramref name="name"/> as a whole identifier — not as part of a LONGER
     /// required name? Both sides are checked (PR #311 round-2 review [low]: checking only the trailing side let a

--- a/src/housecarl-generator/CodexUmbrellaCoverageProbe.cs
+++ b/src/housecarl-generator/CodexUmbrellaCoverageProbe.cs
@@ -194,7 +194,8 @@ public static class CodexUmbrellaCoverageProbe
     /// The pattern matches any such identifier, tool-shaped or not, so the allow-list is the recorded exit for a
     /// <c>housecarl_*</c> name that is deliberately something else.</summary>
     static List<string> DeadToolNames(string umbrella, ISet<string> live, ISet<string> allow)
-        => Regex.Matches(umbrella, "housecarl_[a-z0-9_]+").Select(m => m.Value).Distinct(StringComparer.Ordinal)
+        => Regex.Matches(umbrella, "housecarl_[a-z0-9]+(?:_[a-z0-9]+)*", RegexOptions.IgnoreCase)
+                .Select(m => m.Value).Distinct(StringComparer.Ordinal)
                 .Where(n => !live.Contains(n) && !allow.Contains(n)).OrderBy(n => n, StringComparer.Ordinal).ToList();
 
     /// <summary>Does the text mention <paramref name="name"/> as a whole identifier — not as part of a LONGER

--- a/src/housecarl-generator/CodexUmbrellaCoverageProbe.cs
+++ b/src/housecarl-generator/CodexUmbrellaCoverageProbe.cs
@@ -19,7 +19,7 @@ namespace HousecarlGenerator;
 /// tool that does not exist. Same "green only if the checker has teeth" shape as the other guards: RED arms feed
 /// a synthetic violation and assert it fires; the allow-list is proven to actually suppress.
 ///
-///   INV1 — every housecarl_* name the umbrella writes is a live MCP tool.
+///   INV1 — every housecarl_* name the umbrella writes is a live MCP tool (or allow-listed).
 ///   INV2 — every bundled skill slug is referenced in the umbrella (or allow-listed).
 ///
 /// INV1 used to run the other way — every tool name had to appear in the router — and that is why CI stayed green
@@ -34,9 +34,10 @@ public static class CodexUmbrellaCoverageProbe
 {
     static int _pass, _fail;
 
-    // Deliberate omissions from the Codex umbrella router's SKILL routing (INV2). EMPTY by design — the router
-    // has a row per bundled skill. Add a slug here ONLY with a one-line reason when a skill is intentionally not
-    // routed; that keeps "not in the router" a conscious choice recorded here, never silent drift.
+    // Deliberate exceptions, for BOTH invariants. EMPTY by design. A skill slug here is a skill the router does
+    // not route (INV2); a housecarl_* identifier here is a name the router writes that is deliberately not a tool
+    // (INV1) — a manifest key like housecarl_artifact, a filename, a mod folder. Add either ONLY with a one-line
+    // reason, so an exception is a conscious choice recorded here rather than a guard edit or deleted prose.
     static readonly HashSet<string> Allow = new(StringComparer.Ordinal)
     {
         // (none)
@@ -88,7 +89,7 @@ public static class CodexUmbrellaCoverageProbe
                 falsePasses.Count == 0, falsePasses);
 
             // INV1 — every name the router writes resolves to a live tool.
-            var dead = DeadToolNames(umbrella, tools);
+            var dead = DeadToolNames(umbrella, tools, Allow);
             Check("INV1-GREEN every housecarl_* name the umbrella writes is a live MCP tool", dead.Count == 0,
                 dead.Select(t => $"the Codex umbrella names a tool that does not exist: {t} — fix {UmbrellaPath.Replace('\\', '/')} against the published surface").ToList());
 
@@ -98,12 +99,19 @@ public static class CodexUmbrellaCoverageProbe
                 missSkills.Select(s => $"skill not routed by the Codex umbrella: {s} — add it to {UmbrellaPath.Replace('\\', '/')} (or Allow with a reason)").ToList());
 
             // RED arms — the checker must catch a violation, or it is toothless.
-            var redTool = DeadToolNames("read the winner with `housecarl_read_record` first", tools);
+            var redTool = DeadToolNames("read the winner with `housecarl_read_record` first", tools, Empty());
             Check("INV1-RED  a retired tool name in the router is caught", redTool.Contains("housecarl_read_record"), redTool, redArm: true);
 
             // …and a live name must not be reported dead, or INV1 would fire on every honest router.
-            var liveTool = DeadToolNames("read the winner with `housecarl_records` first", tools);
+            var liveTool = DeadToolNames("read the winner with `housecarl_records` first", tools, Empty());
             Check("INV1-GREEN-SELF a live tool name is not reported dead", liveTool.Count == 0, liveTool, redArm: true);
+
+            // The allow-list suppresses on INV1 too, or a housecarl_* name that is deliberately NOT a tool — the
+            // bulk-job manifest key housecarl_artifact is one the router could legitimately quote — would leave
+            // deleting correct prose or editing this guard as the only ways out (PR #659 review).
+            var allowedTool = DeadToolNames("the manifest's first key is `housecarl_artifact`", tools,
+                new HashSet<string>(StringComparer.Ordinal) { "housecarl_artifact" });
+            Check("ALLOW-1   an allow-listed non-tool name is NOT reported dead", allowedTool.Count == 0, allowedTool, redArm: true);
 
             var redSkill = MissingRefs("router text that mentions no skills", new[] { "facegen-diagnostics" }, Empty());
             Check("INV2-RED  a missing skill reference is caught", redSkill.Contains("facegen-diagnostics"), redSkill, redArm: true);
@@ -132,7 +140,7 @@ public static class CodexUmbrellaCoverageProbe
             // The allow-list must actually suppress — else an Allow entry would be a lie.
             var allowed = MissingRefs("router text that mentions no tools", new[] { "housecarl_read_record" },
                 new HashSet<string>(StringComparer.Ordinal) { "housecarl_read_record" });
-            Check("ALLOW     an allow-listed name is NOT reported missing", allowed.Count == 0, allowed, redArm: true);
+            Check("ALLOW-2   an allow-listed name is NOT reported missing", allowed.Count == 0, allowed, redArm: true);
         }
         catch (Exception ex)
         {
@@ -180,12 +188,14 @@ public static class CodexUmbrellaCoverageProbe
         => required.Where(r => !allow.Contains(r) && !ReferencedAtBoundary(umbrella, r))
                    .OrderBy(r => r, StringComparer.Ordinal).ToList();
 
-    /// <summary>Every <c>housecarl_*</c> identifier the router writes that is NOT a reflected tool name — the
-    /// direction the old one-way check could not see. The sibling-skill form the router also writes is
-    /// <c>housecarl:&lt;skill&gt;</c>, which the underscore in this pattern excludes by construction.</summary>
-    static List<string> DeadToolNames(string umbrella, ISet<string> live)
+    /// <summary>Every <c>housecarl_*</c> identifier the router writes that is NOT a reflected tool name and NOT
+    /// allow-listed — the direction the old one-way check could not see. The sibling-skill form the router also
+    /// writes is <c>housecarl:&lt;skill&gt;</c>, which the underscore in this pattern excludes by construction.
+    /// The pattern matches any such identifier, tool-shaped or not, so the allow-list is the recorded exit for a
+    /// <c>housecarl_*</c> name that is deliberately something else.</summary>
+    static List<string> DeadToolNames(string umbrella, ISet<string> live, ISet<string> allow)
         => Regex.Matches(umbrella, "housecarl_[a-z0-9_]+").Select(m => m.Value).Distinct(StringComparer.Ordinal)
-                .Where(n => !live.Contains(n)).OrderBy(n => n, StringComparer.Ordinal).ToList();
+                .Where(n => !live.Contains(n) && !allow.Contains(n)).OrderBy(n => n, StringComparer.Ordinal).ToList();
 
     /// <summary>Does the text mention <paramref name="name"/> as a whole identifier — not as part of a LONGER
     /// required name? Both sides are checked (PR #311 round-2 review [low]: checking only the trailing side let a

--- a/src/housecarl-generator/PluginValidateProbe.cs
+++ b/src/housecarl-generator/PluginValidateProbe.cs
@@ -33,8 +33,11 @@ namespace HousecarlGenerator;
 ///          (JS) YAML parser: it reliably catches the colon-space class (RED-proven below), but the residual risk
 ///          is a false-NEGATIVE (YamlDotNet accepts what the real loader would drop). For the 11 bundled skills
 ///          the CI `claude plugin validate --strict` step closes that residual; for the Codex umbrella skill it
-///          does not, and this is the only check. (RED: the literal colon-space description that dropped
-///          dialogue-authoring; a frontmatter missing `description`; a file with no fence at all.)
+///          does not, and this is the only check. The description is also measured against the loader's
+///          MAX_DESCRIPTION_LENGTH: past it the tail of the trigger surface is truncated away silently, which
+///          the Codex umbrella shipped for a release with nothing red to say so. (RED: the literal colon-space
+///          description that dropped dialogue-authoring; a frontmatter missing `description`; a file with no
+///          fence at all; a description one character past the ceiling.)
 ///   INV2 — THE PLUGIN MANIFEST PARSES + CARRIES name/version. plugin.json is valid JSON with a non-empty
 ///          string name + version (the single source of truth the build stamps). (RED: a manifest missing
 ///          version.)
@@ -44,6 +47,10 @@ namespace HousecarlGenerator;
 public static class PluginValidateProbe
 {
     static int _pass, _fail;
+
+    /// <summary>The loader's MAX_DESCRIPTION_LENGTH. Past it the description is truncated, so the tail of the
+    /// trigger surface goes missing without any error.</summary>
+    const int MaxDescription = 1024;
 
     [CiProbe("plugin-validate-guard")]
     public static int RunGuard(string[] args)
@@ -85,6 +92,9 @@ public static class PluginValidateProbe
             RedSkill("INV1-RED  a file with no --- fence is caught",
                 "# Heading\nbody, no frontmatter\n",
                 s => s.Contains("frontmatter", StringComparison.OrdinalIgnoreCase));
+            RedSkill("INV1-RED  a description past the character ceiling is caught",
+                $"---\nname: x\ndescription: {new string('x', MaxDescription + 1)}\n---\n",
+                s => s.Contains("ceiling", StringComparison.OrdinalIgnoreCase));
 
             // ---------- INV2 — the plugin manifest parses + has name/version ----------
             var manifestPath = Path.Combine("plugin", ".claude-plugin", "plugin.json");
@@ -151,6 +161,12 @@ public static class PluginValidateProbe
             if (val is null || string.IsNullOrWhiteSpace(val.ToString()))
                 v.Add($"frontmatter missing a non-empty '{key}'");
         }
+        // The other end of the same field: a description PAST the loader's MAX_DESCRIPTION_LENGTH is the second
+        // defect this frontmatter shipped that CI could not see (PR #659 review — the Codex umbrella breached it
+        // by ~250 characters and was fixed by hand). Measured on the parsed string, so the folded YAML block a
+        // long description is written as counts the way the loader counts it.
+        if (map.TryGetValue("description", out var d) && d?.ToString() is { } text && text.Length > MaxDescription)
+            v.Add($"description is {text.Length} characters, past the {MaxDescription}-character ceiling — trim it");
         return v;
     }
 


### PR DESCRIPTION
Wave 4 of the skill rewrite: the Codex umbrella at `plugin/codex/housecarl`, built from the approved rewrite document and its verifier (110 rows checked, 14 overturned — each overturned row is taken as the verifier corrected it, listed below). The body catalogued the whole tool surface in ~39 lines, seventeen of those names retired with 1.x, under a sentence promising they "keep working through the 2.0 build" — a Codex session following it composed calls the server refuses by name, and the CI guard watching this file could not see it because it only checked that every tool appeared, never that every name written was real. The catalogue is deleted rather than moved (FOLD-IN F37: it restated the server's own injected instructions, which already end "each tool's own description carries the specifics", and ruling 4 bars a tool description as a destination), and so are the write-lane rules (F38) and the in-place prohibition (F39), which the server's own parameters and its `acknowledge=` consent gate already carry. What is left is what only a router can do: a row per bundled skill saying which job it owns and when to load it (eleven rows after ruling 6b, with no count written), the read-before-you-write order in four steps with one worked call and its result, the FormID form, the three lanes, an exclusion clause naming #615 and #617 for the two reaches the surface does not have, and one line for the `agents/openai.yaml` sidecar. The description goes from 1,267–1,273 characters to **611** against the 1,024 ceiling, opens on its trigger at offset 0 instead of offset ~863, drops the fourteen-name helper roster and the "even when the task looks like a single edit, load this first" clause that asserted a precedence no host enforces, and gains the batch `compatibility` line and a closing "Not for…" boundary. `evals/evals.json` is new — this skill has never had an eval set, and the 2026-09 audit ran neither arm for it, the only row in the batch with both cells "not run". Every 1.x call in the old body is migrated to the 2.0 call the document's table gives; every tool and parameter written in the tree appears verbatim in `surface/tools.md`. No issue is named as closing.

**Checks.** `scripts/build-plugin.ps1 -PluginTreeOnly` — leak-check clean, 12 skills / 227 markdown files across both trees, `evals/` stripped from the shipped Codex copy (`dist/codex/skills/housecarl/` ships `SKILL.md` + `agents/openai.yaml` and nothing else). `dotnet build -c Release` clean; tests **1894 passed, 0 failed** (`tier!=bridge`); generator `ci-all` **128/128**, the umbrella guard 13 arms green.

## The document's open questions

- **Q1 — does the router survive at all, and does the measurement come first? Left for Aaron.** No verdict was ruled ("The codex umbrella is item 27"), both audit arms are unrun, and D5.26/D5.50 make it the batch's strongest fold-or-delete candidate. This PR is the rewrite the document specifies; it does not argue the router should exist. The output-quality pair is written up in `evals/evals.json` and has not been run — if the control matches, the ruled outcome is FOLD-IN N9 (the map is dropped, not migrated), and that is a merge gate, not a rewrite of this branch.
- **Q2 — the sibling form on a Codex-only body. Decided as follows: ruled, not open** (verifier row 10.2). Ruling 1 states the form for every document in full knowledge of the two install lanes, so the body writes `housecarl:<skill>` with the one-line Codex note. Worth knowing for the review: the eleven siblings **do** install on Codex too, flat at `~/.agents/skills/<slug>` beside this one (`Program.cs`, the Codex install), so the note names a form the reader really sees there.
- **Q3 — directory submission or local install only? Left for Aaron.** Nothing in the tree assumes either. Ruling 7's packager PR already gave the Codex tree its `skills/` root, so the shape half is answered; submission would additionally make the eval case counts mandatory rather than borrowed.
- **Q4 — `policy.products` in `agents/openai.yaml`. Left for Aaron.** Unchanged in this PR; no source says it is mandatory.
- **Q5 — does the Codex bundle get `evals/evals.json` at all? Decided as follows: ruled, not open** (verifier row 10.5). Ruling 3 is one convention for all twelve. The file is authored, and what was genuinely open — that the numbers are Anthropic's — is recorded in the file itself under `numbers_are_borrowed`.
- **Q6 — the mandatory-framing enforcement route. Left for Aaron.** The "load this first" clause is deleted rather than backed; no `AGENTS.md` if/then rule is added, because the plugin tree ships none and adding one is a packaging change outside this document.
- **Q7 — do Codex sessions receive the same ServerInstructions? Left for Aaron, and it is the one dependency this PR takes on faith.** F1, F2 and F3 (the distributor routing, "nothing wins until enabled in MO2", the never-copy rule) left this body on the assumption that the injected instructions carry them. The Codex install registers the server in `~/.codex/config.toml`, so it should; if a Codex session does not receive the instructions string, three cross-skill facts are then in no file this bundle ships.

## The verifier's overturned rows, and how each was taken

- **3.12 `compatibility` wording** — corrected to the batch string ruled on 2026-09-08: "Requires the houseCARL MCP server and a configured Mod Organizer 2 instance." (76 characters). No second sentence: nothing here works offline.
- **3.7 / 3.13** — the description enumerates 15 terms, not 14, and its shape (third-person capability clause plus imperative trigger) **clears** D2.26 rather than standing as a departure. No text change; the claims were about the same string.
- **4.1 body budget** — the section table summed to 4,860 against its own stated ≤ 4,800. The stated budget wins: the body is **4,773 characters**, 59 content lines (74 including blank lines) against ≤ 70. The trims came out of prose, not out of a section.
- **6.1 / 6.2 / 6.4 / 6.18 / 7.5 site citations** — off-by-one line numbers in the *old* body, no migration target moved. Moot in the build: the old lines are deleted whole.
- **9.4 D1.15** — the clause claiming a sibling-name partial is dropped; it is graded conforms here.
- **9.6 D3.5** — recorded as **reduced and ruled**, not cleared: 620 characters ≈ 155 tokens clears both enforceable budgets and is still over the spec's "~50-100 tokens per skill" estimate.
- **9.11 the positive set** — the document's eight positives included an OAR case the description carries no term for. Decided as follows: **the positive set is re-cut against the terms the description actually carries**, and the description is left at its ruled 611 characters, because widening it is what D2.21 / D3.5 / D4.59 were failing on and both measurements feed the regrade gate. `evals/evals.json` records under `method.positives_cover` that three routing destinations — `open-animation-replacer`, `npc-appearance-copy`, `papyrus-reference` — have no positive, and why: each ships its own trigger description beside this one on both hosts.
- **10.2 / 10.5** — Q2 and Q5 recorded above as ruled rather than put to Aaron.

## Judgement calls worth a reviewer's eye

- **The CI guard changed direction, and that is the one change outside the skill.** `CodexUmbrellaCoverageProbe.cs`'s INV1 required every reflected tool name to be referenced in the router — the invariant a deleted catalogue makes unsatisfiable, and the reason `ci-all` was green through seventeen dead names (D5.51). It now asserts the reverse: every `housecarl_*` identifier the router writes resolves to a live `[McpServerTool]` name. INV2 (every bundled skill routed) is unchanged, the allow-list now suppresses skill slugs only, and the new arm has both teeth (a retired name in a synthetic router is caught) and a green-self arm (a live name is not reported dead).
- **The worked call is an `apply` with `readback=true`, not a read.** D5.35 graded the read half of the loop as the one well-built thing in the file and the write half as missing; the closing paragraph is the write half — the read-back is the written *file*, the patch name is auto-suffixed so it is reported back, and a refused call wrote nothing.
- **#617 is named as an issue but framed loosely**, as the verifier noted (row 4.10): it is a refusal-message gap rather than a job the surface cannot do. The body says the raw mods-folder path is not refused in one sentence and gives the move that works instead.
- **The eleven-row table writes no count**, per D4.43 — adding a skill is a row, never an arithmetic edit.

## Regrade

Five-checklist regrade of this branch as it stands on 2026-09-08, assembled in `dev/skill-validation/eval-2026-09/codex-umbrella/REGRADE.md` from the per-angle graders in `regrade/D1.md`–`D5.md`. This replaces the earlier regrade block, which was taken against a previous state of the worktree — the worked call has since been corrected to `012EB7:Skyrim.esm`, and D4.50 is no longer a factual fail.

| Angle | conforms | partial | fails | n/a | Total rows |
|---|---|---|---|---|---|
| D1 — discovery and packaging | 36 | 3 | 1 | 6 | 46 |
| D2 — frontmatter | 39 | 2 | 0 | 11 | 52 |
| D3 — loading and invocation | 20 | 3 | 0 | 10 | 33 |
| D4 — body, supporting files, style | 36 | 6 | 1 | 23 | 66 |
| D5 — validation and standing context | 32 | 8 | 5 | 8 | 53 |
| **Total** | **163** | **22** | **7** | **58** | **250** |

Fails by class: **0 factual-or-dead-call**, 1 packager-only (D1.28, release tagging, excluded by ruling 8), 6 other (D4.42, the ruled bare-tool-name convention; D5.19, D5.21, D5.26, D5.33, D5.52, the single absent eval run counted five times).

**Verdict: PASS** against the regrade half of the gate. D2 and D3 have zero fails. D4 and D5 have zero factual-or-dead-call fails — every one of the ten `housecarl_*` names and ten parameters the body writes is live on `surface/tools.md`, and the one file the body names ships beside it. D1 is clean except for D1.28, which ruling 8 excludes as item 30's walk. What remains is the bare-tool-name convention ruling 1 settled the other way, and five restatements of one absence: the eval set is authored and has not been run, which §9b–9c assign to the run rather than to this rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

