### PR TITLE
Say when a skypatcher_layer filter matches no INI

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -17,11 +17,15 @@ saying it sets an expectation their install may contradict. Say what is known, a
   whole-layer overview.** It answers with the filter, the match count (0 of N INIs), the type folders that are
   present, and a nearest-name suggestion where there is one, so a filter typo can no longer read as the layer's
   contents. The zero-match answer carries the scan notes (shadowed copies, undocumented subfolders) and the
-  read-incomplete caveat, which are often the reason nothing matched.
-- **`housecarl_skypatcher_layer`'s `filter=` now selects as well as expands: only the matching files are listed.**
-  A matching folder that sorts late is no longer cut by `max_chars` before it is reached, and the cut notice no
-  longer tells a caller who passed `filter=` to pass `filter=`. A blank or whitespace `filter=` is treated as no
-  filter at every site, so it gives the overview instead of expanding every INI in the layer.
+  read-incomplete caveat, which are often the reason nothing matched. That answer obeys `max_chars` like every
+  other one: its notes are cut with a notice saying how many of them are shown, and the caveats still render.
+- **`housecarl_skypatcher_layer`'s `filter=` now selects at the type-folder level: a folder with no match is
+  skipped, and a folder with one lists every file in apply order with the matching files expanded to their lines.**
+  The files sorting before and after a match — which is what decides whether its writes survive — stay in the
+  answer, and a matching folder that sorts late is no longer cut by `max_chars` before it is reached. Each folder's
+  header says how many of its INIs matched and were expanded, so the header describes the listing under it. The cut
+  notice no longer tells a caller who passed `filter=` to pass `filter=`. A blank or whitespace `filter=` is treated
+  as no filter at every site, so it gives the overview instead of expanding every INI in the layer.
 - **`open-animation-replacer` now states how a DAR `_conditions.txt` chain binds, and that the DAR weapon-type
   numbers convert unchanged.** Both were marked unverified in its reference, and the skill told you to convert
   under one reading and say which. Both are now read off OAR's own source; the reference's §8 carries the rule,

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,10 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **`housecarl_skypatcher_layer` with a `filter=` that matches no INI now says so instead of returning the
+  whole-layer overview.** It answers with the filter, the match count (0 of N INIs), the type folders that are
+  present, and a nearest-name suggestion where there is one, so a filter typo can no longer read as the layer's
+  contents. A filter that matches at least one INI is unchanged — it still expands those files to their lines.
 - **`open-animation-replacer` now states how a DAR `_conditions.txt` chain binds, and that the DAR weapon-type
   numbers convert unchanged.** Both were marked unverified in its reference, and the skill told you to convert
   under one reading and say which. Both are now read off OAR's own source; the reference's §8 carries the rule,

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -16,7 +16,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
 - **`housecarl_skypatcher_layer` with a `filter=` that matches no INI now says so instead of returning the
   whole-layer overview.** It answers with the filter, the match count (0 of N INIs), the type folders that are
   present, and a nearest-name suggestion where there is one, so a filter typo can no longer read as the layer's
-  contents. A filter that matches at least one INI is unchanged — it still expands those files to their lines.
+  contents. The zero-match answer carries the scan notes (shadowed copies, undocumented subfolders) and the
+  read-incomplete caveat, which are often the reason nothing matched.
+- **`housecarl_skypatcher_layer`'s `filter=` now selects as well as expands: only the matching files are listed.**
+  A matching folder that sorts late is no longer cut by `max_chars` before it is reached, and the cut notice no
+  longer tells a caller who passed `filter=` to pass `filter=`. A blank or whitespace `filter=` is treated as no
+  filter at every site, so it gives the overview instead of expanding every INI in the layer.
 - **`open-animation-replacer` now states how a DAR `_conditions.txt` chain binds, and that the DAR weapon-type
   numbers convert unchanged.** Both were marked unverified in its reference, and the skill told you to convert
   under one reading and say which. Both are now read off OAR's own source; the reference's §8 carries the rule,

--- a/src/housecarl-mcp-tests/SkyPatcherLayerFilterTests.cs
+++ b/src/housecarl-mcp-tests/SkyPatcherLayerFilterTests.cs
@@ -58,4 +58,91 @@ public sealed class SkyPatcherLayerFilterTests
         Assert.Contains("health=200", text);
         Assert.DoesNotContain("nothing matched", text);
     }
+
+    static SkyPatcherLayerData TwoFolders() =>
+        Layer(new SkyPatcherDiscovery.FolderScan("npc", Catalog: null, PatchingEnabled: true,
+                  Files: new[] { Ini("npc", "Bandits.ini", "Bandit Overhaul") }),
+              new SkyPatcherDiscovery.FolderScan("weapon", Catalog: null, PatchingEnabled: true,
+                  Files: new[] { Ini("weapon", "Blades.ini", "Weapon Overhaul") }));
+
+    [Fact]
+    public void AFilterListsOnlyTheMatchingFolder()
+    {
+        var text = SkyPatcherWire.RenderLayer(TwoFolders(), "weapon", 80_000);
+
+        Assert.Contains("Blades.ini", text);
+        Assert.DoesNotContain("Bandits.ini", text);           // filter= selects, it does not merely expand
+        Assert.Contains("1 of 2 INI(s) match", text);
+    }
+
+    /// <summary>A layer whose matching folder sorts after enough inventory to be cut by a modest max_chars.</summary>
+    static SkyPatcherLayerData LateMatchLayer() =>
+        Layer(new SkyPatcherDiscovery.FolderScan("npc", Catalog: null, PatchingEnabled: true,
+                  Files: Enumerable.Range(1, 10).Select(i => Ini("npc", $"Bandits{i}.ini", "Bandit Overhaul")).ToArray()),
+              new SkyPatcherDiscovery.FolderScan("weapon", Catalog: null, PatchingEnabled: true,
+                  Files: new[] { Ini("weapon", "Blades.ini", "Weapon Overhaul") }));
+
+    /// <summary>A cap landing exactly on the second folder's boundary in the unfiltered render.</summary>
+    static int CapAtTheWeaponFolder() =>
+        SkyPatcherWire.RenderLayer(LateMatchLayer(), null, 1_000_000).IndexOf("\nweapon:", StringComparison.Ordinal);
+
+    [Fact]
+    public void AMatchingFolderIsNotLostToTheCapAndTheCutNoticeDoesNotSuggestAFilter()
+    {
+        var text = SkyPatcherWire.RenderLayer(LateMatchLayer(), "weapon", CapAtTheWeaponFolder());
+
+        Assert.Contains("Blades.ini", text);                  // selection puts the late match inside the same cap
+        Assert.DoesNotContain("pass filter=", text);          // never recommend what the caller already passed
+    }
+
+    [Fact]
+    public void AnUnfilteredCutStillSuggestsAFilter()
+    {
+        var text = SkyPatcherWire.RenderLayer(LateMatchLayer(), null, CapAtTheWeaponFolder());
+
+        Assert.DoesNotContain("Blades.ini", text);
+        Assert.Contains("pass filter=", text);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ABlankFilterIsNoFilterAtBothSites(string filter)
+    {
+        var text = SkyPatcherWire.RenderLayer(TwoFolders(), filter, 80_000);
+
+        Assert.Contains("Bandits.ini", text);                 // not a zero match
+        Assert.Contains("Blades.ini", text);
+        Assert.DoesNotContain("health=200", text);            // and not a whole-layer expansion either
+        Assert.DoesNotContain("INI(s) match", text);
+    }
+
+    [Fact]
+    public void ZeroMatchStillRendersTheScanNotes()
+    {
+        var d = OneNpcFolder();
+        var withNotes = d with
+        {
+            Scan = new SkyPatcherDiscovery.LayerScan(d.Scan.Folders,
+                new[] { "subfolder 'npcs' is not a documented SkyPatcher record type" },
+                ReadIncomplete: false, new Dictionary<string, bool>()),
+            NoOpNotes = new[] { "a replay note" },
+        };
+
+        var text = SkyPatcherWire.RenderLayer(withNotes, "weapon", 80_000);
+
+        Assert.Contains("not a documented SkyPatcher record type", text);
+        Assert.Contains("a replay note", text);
+    }
+
+    [Fact]
+    public void AnEmptyLayerWithAnIncompleteReadIsNotCalledEmpty()
+    {
+        var d = Layer() with { ReadIncomplete = true };
+
+        var text = SkyPatcherWire.RenderLayer(d, "weapon", 80_000);
+
+        Assert.DoesNotContain("no SkyPatcher INIs at all", text);
+        Assert.Contains("the read was incomplete", text);
+    }
 }

--- a/src/housecarl-mcp-tests/SkyPatcherLayerFilterTests.cs
+++ b/src/housecarl-mcp-tests/SkyPatcherLayerFilterTests.cs
@@ -9,11 +9,11 @@ namespace HousecarlMcpTests;
 [Trait("tier", "unit")]
 public sealed class SkyPatcherLayerFilterTests
 {
-    static SkyPatcherDiscovery.IniFile Ini(string subfolder, string name, string provider) =>
+    static SkyPatcherDiscovery.IniFile Ini(string subfolder, string name, string provider, string value = "200") =>
         new(RelPath: subfolder + "\\" + name, Subfolder: subfolder, SortKey: name, WinningProvider: provider,
             LooseFilePath: "C:\\mods\\" + provider + "\\" + name, ShadowedProviders: Array.Empty<string>(),
             GatePlugin: null, NotApplied: null,
-            Lines: new[] { new SkyPatcherLine("filterByNpcs=Skyrim.esm|1A696:health=200", SkyPatcherLineKind.Patch,
+            Lines: new[] { new SkyPatcherLine("filterByNpcs=Skyrim.esm|1A696:health=" + value, SkyPatcherLineKind.Patch,
                                               Array.Empty<SkyPatcherSegment>(), null) });
 
     static SkyPatcherLayerData Layer(params SkyPatcherDiscovery.FolderScan[] folders) =>
@@ -71,8 +71,51 @@ public sealed class SkyPatcherLayerFilterTests
         var text = SkyPatcherWire.RenderLayer(TwoFolders(), "weapon", 80_000);
 
         Assert.Contains("Blades.ini", text);
-        Assert.DoesNotContain("Bandits.ini", text);           // filter= selects, it does not merely expand
+        Assert.DoesNotContain("Bandits.ini", text);           // filter= selects at the folder level, it does not merely expand
         Assert.Contains("1 of 2 INI(s) match", text);
+        Assert.Contains("in 1 of 2 type folder(s)", text);
+    }
+
+    /// <summary>One folder, one matching file, a sibling on each side of it in apply order.</summary>
+    static SkyPatcherLayerData FolderWithNeighbours() =>
+        Layer(new SkyPatcherDiscovery.FolderScan("npc", Catalog: null, PatchingEnabled: true,
+                  Files: new[]
+                  {
+                      Ini("npc", "aa_Before.ini", "Bandit Overhaul", "111"),
+                      Ini("npc", "zz_MyPatch.ini", "My Patch", "222"),
+                      Ini("npc", "zzz_After.ini", "Late Overhaul", "333"),
+                  }));
+
+    [Fact]
+    public void AMatchedFilesSiblingsAreStillListedUnexpanded()
+    {
+        var text = SkyPatcherWire.RenderLayer(FolderWithNeighbours(), "zz_MyPatch.ini", 80_000);
+
+        Assert.Contains("aa_Before.ini", text);               // where the match sorts is the answer the filter is for
+        Assert.Contains("zz_MyPatch.ini", text);
+        Assert.Contains("zzz_After.ini", text);
+        Assert.Contains("health=222", text);                  // only the match expands to its lines
+        Assert.DoesNotContain("health=111", text);
+        Assert.DoesNotContain("health=333", text);
+        Assert.True(text.IndexOf("  - aa_Before.ini", StringComparison.Ordinal)
+                    < text.IndexOf("  - zz_MyPatch.ini", StringComparison.Ordinal));   // apply order, not match-first
+    }
+
+    [Fact]
+    public void TheFolderHeaderCountsWhatIsExpandedUnderIt()
+    {
+        var text = SkyPatcherWire.RenderLayer(FolderWithNeighbours(), "zz_MyPatch.ini", 80_000);
+
+        Assert.Contains("npc: 3 INI(s) (1 matching, expanded), 3 patch line(s)", text);
+    }
+
+    [Fact]
+    public void AnUnfilteredFolderHeaderCarriesNoMatchCount()
+    {
+        var text = SkyPatcherWire.RenderLayer(FolderWithNeighbours(), null, 80_000);
+
+        Assert.Contains("npc: 3 INI(s), 3 patch line(s)", text);
+        Assert.DoesNotContain("matching, expanded", text);
     }
 
     /// <summary>A layer whose matching folder sorts after enough inventory to be cut by a modest max_chars.</summary>
@@ -133,6 +176,43 @@ public sealed class SkyPatcherLayerFilterTests
 
         Assert.Contains("not a documented SkyPatcher record type", text);
         Assert.Contains("a replay note", text);
+    }
+
+    [Fact]
+    public void ZeroMatchCutsItsNotesAtMaxCharsWithANotice()
+    {
+        var d = OneNpcFolder();
+        var withNotes = d with
+        {
+            Scan = new SkyPatcherDiscovery.LayerScan(d.Scan.Folders,
+                Enumerable.Range(1, 40).Select(i => $"scan note {i} " + new string('x', 200)).ToArray(),
+                ReadIncomplete: false, new Dictionary<string, bool>()),
+        };
+
+        var full = SkyPatcherWire.RenderLayer(withNotes, "weapon", 1_000_000);
+        var text = SkyPatcherWire.RenderLayer(withNotes, "weapon", 2_000);
+
+        Assert.True(full.Length > 5_000);                     // the unbounded answer really is far over the cap
+        Assert.True(text.Length < full.Length);               // max_chars is honoured on the zero-match path too
+        Assert.Contains("of 40 note(s); raise max_chars", text);
+        Assert.DoesNotContain("scan note 40 ", text);
+    }
+
+    [Fact]
+    public void ZeroMatchAlwaysRendersTheCaveatsEvenPastTheCap()
+    {
+        var d = OneNpcFolder();
+        var withNotes = d with
+        {
+            Scan = new SkyPatcherDiscovery.LayerScan(d.Scan.Folders,
+                Enumerable.Range(1, 40).Select(i => $"scan note {i} " + new string('x', 200)).ToArray(),
+                ReadIncomplete: false, new Dictionary<string, bool>()),
+            ReadIncomplete = true,
+        };
+
+        var text = SkyPatcherWire.RenderLayer(withNotes, "weapon", 2_000);
+
+        Assert.Contains("a BSA failed to read", text);        // a cut must never swallow the incomplete-read warning
     }
 
     [Fact]

--- a/src/housecarl-mcp-tests/SkyPatcherLayerFilterTests.cs
+++ b/src/housecarl-mcp-tests/SkyPatcherLayerFilterTests.cs
@@ -1,0 +1,61 @@
+using HousecarlCore;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>housecarl_skypatcher_layer's filter=. A filter that matches no INI must say so; returning the
+/// unfiltered overview instead is indistinguishable from a call that passed no filter at all.</summary>
+[Trait("tier", "unit")]
+public sealed class SkyPatcherLayerFilterTests
+{
+    static SkyPatcherDiscovery.IniFile Ini(string subfolder, string name, string provider) =>
+        new(RelPath: subfolder + "\\" + name, Subfolder: subfolder, SortKey: name, WinningProvider: provider,
+            LooseFilePath: "C:\\mods\\" + provider + "\\" + name, ShadowedProviders: Array.Empty<string>(),
+            GatePlugin: null, NotApplied: null,
+            Lines: new[] { new SkyPatcherLine("filterByNpcs=Skyrim.esm|1A696:health=200", SkyPatcherLineKind.Patch,
+                                              Array.Empty<SkyPatcherSegment>(), null) });
+
+    static SkyPatcherLayerData Layer(params SkyPatcherDiscovery.FolderScan[] folders) =>
+        new(new SkyPatcherDiscovery.LayerScan(folders, Array.Empty<string>(), ReadIncomplete: false,
+                new Dictionary<string, bool>()),
+            Conflicts: Array.Empty<SkyPatcherConflicts.SkyPatcherConflict>(),
+            Itms: Array.Empty<SkyPatcherConflicts.SkyPatcherItm>(),
+            Duplicates: Array.Empty<SkyPatcherConflicts.SkyPatcherDuplicate>(),
+            NoOps: Array.Empty<SkyPatcherNoOpWrite>(), NoOpNotes: Array.Empty<string>(),
+            ReadIncomplete: false, AssetWarnings: Array.Empty<string>(), ProfileName: "Default");
+
+    static SkyPatcherLayerData OneNpcFolder() =>
+        Layer(new SkyPatcherDiscovery.FolderScan("npc", Catalog: null, PatchingEnabled: true,
+                  Files: new[] { Ini("npc", "Bandits.ini", "Bandit Overhaul") }));
+
+    [Fact]
+    public void AFilterMatchingNoIniSaysSoInsteadOfTheOverview()
+    {
+        var text = SkyPatcherWire.RenderLayer(OneNpcFolder(), "weapon", 80_000);
+
+        Assert.Contains("0 of 1 INI(s) match", text);
+        Assert.Contains("'weapon'", text);
+        Assert.Contains("npc", text);                        // the folders that ARE there
+        Assert.DoesNotContain("Bandits.ini", text);          // not the overview under another name
+    }
+
+    [Fact]
+    public void AFilterMatchingNothingInAnEmptyLayerSaysTheLayerIsEmpty()
+    {
+        var text = SkyPatcherWire.RenderLayer(Layer(), "weapon", 80_000);
+
+        Assert.Contains("0 of 0 INI(s) match", text);
+        Assert.Contains("no SkyPatcher INIs at all", text);
+    }
+
+    [Fact]
+    public void AFilterThatMatchesStillExpandsTheFile()
+    {
+        var text = SkyPatcherWire.RenderLayer(OneNpcFolder(), "npc", 80_000);
+
+        Assert.Contains("Bandits.ini", text);
+        Assert.Contains("health=200", text);
+        Assert.DoesNotContain("nothing matched", text);
+    }
+}

--- a/src/housecarl-mcp/SkyPatcherTools.cs
+++ b/src/housecarl-mcp/SkyPatcherTools.cs
@@ -55,6 +55,9 @@ static class SkyPatcherWire
     {
         var sb = new StringBuilder();
         var folders = d.Scan.Folders;
+        // A filter matching nothing must never fall through to the unfiltered overview — that reads as the whole layer.
+        if (filter is { Length: > 0 } && !folders.Any(f => f.Files.Any(x => Matches(filter, f, x))))
+            return ZeroMatch(d, filter);
         int files = folders.Sum(f => f.Files.Count);
         int applied = folders.Sum(f => f.PatchingEnabled ? f.Files.Count(x => x.NotApplied is null) : 0);
         int lines = folders.Sum(f => f.Files.Sum(x => x.Lines.Count(l => l.Kind == SkyPatcherLineKind.Patch)));
@@ -72,8 +75,6 @@ static class SkyPatcherWire
           .Append(d.NoOps.Count).Append(" no-op write(s)\n");
         if (folders.Count == 0)
             sb.Append("\nno SkyPatcher INIs in the active order (no Data\\SKSE\\Plugins\\SkyPatcher content, or SkyPatcher itself is not installed).\n");
-
-        bool In(string? s) => filter is null || (s is not null && s.Contains(filter, StringComparison.OrdinalIgnoreCase));
 
         foreach (var f in folders)
         {
@@ -93,7 +94,7 @@ static class SkyPatcherWire
                 if (file.ShadowedProviders.Count > 0) sb.Append("  [!] shadows same-path copies from ").Append(string.Join(", ", file.ShadowedProviders));
                 sb.Append('\n');
                 // filter= match (folder, provider, or filename) expands the file to its patch lines.
-                bool expand = filter is not null && (In(f.Subfolder) || In(file.WinningProvider) || In(file.RelPath));
+                bool expand = filter is not null && Matches(filter, f, file);
                 if (expand)
                     for (int i = 0; i < file.Lines.Count; i++)
                     {
@@ -208,6 +209,37 @@ static class SkyPatcherWire
         }
         AppendCaveats(sb, d.ReadIncomplete, d.AssetWarnings);
         sb.Append("\n→ " + ToolNames.Records + " formids=['<FormID>'] source={\"overlay\": \"skypatcher\", \"state\": \"post\"} for one record's computed post-SkyPatcher state; filter='<folder/mod/file>' to expand files to their lines.");
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    /// <summary>The filter's match domain: the file's type folder, its providing mod, or its path/filename.</summary>
+    static bool Matches(string filter, SkyPatcherDiscovery.FolderScan folder, SkyPatcherDiscovery.IniFile file)
+    {
+        bool In(string? s) => s is not null && s.Contains(filter, StringComparison.OrdinalIgnoreCase);
+        return In(folder.Subfolder) || In(file.WinningProvider) || In(file.RelPath);
+    }
+
+    /// <summary>What a filter matching no INI returns: the count (zero), what the filter is matched against, and the
+    /// folders that are there. Never the overview — an unfiltered dump would read as the filter's own result.</summary>
+    static string ZeroMatch(SkyPatcherLayerData d, string filter)
+    {
+        var folders = d.Scan.Folders;
+        int files = folders.Sum(f => f.Files.Count);
+        var sb = new StringBuilder();
+        sb.Append("SkyPatcher layer — filter '").Append(filter).Append("' — 0 of ").Append(files)
+          .Append(" INI(s) match [profile '").Append(d.ProfileName).Append("']\n\n");
+        if (folders.Count == 0)
+            sb.Append("nothing matched: the active order has no SkyPatcher INIs at all (no Data\\SKSE\\Plugins\\SkyPatcher content, or SkyPatcher itself is not installed).\n");
+        else
+        {
+            sb.Append("nothing matched: no type folder, providing mod, or INI filename contains '").Append(filter).Append("'.")
+              .Append(PluginNameSuggest.DidYouMean(filter, folders.Select(f => f.Subfolder)
+                  .Concat(folders.SelectMany(f => f.Files).Select(x => x.WinningProvider).Where(p => p is not null)!)
+                  .Concat(folders.SelectMany(f => f.Files).Select(x => x.SortKey))))
+              .Append(" The type folder(s) present are: ").Append(string.Join(", ", folders.Select(f => f.Subfolder)))
+              .Append(". Omit filter= for the whole-layer overview.\n");
+        }
+        AppendCaveats(sb, d.ReadIncomplete, d.AssetWarnings);
         return sb.ToString().TrimEnd('\n');
     }
 

--- a/src/housecarl-mcp/SkyPatcherTools.cs
+++ b/src/housecarl-mcp/SkyPatcherTools.cs
@@ -28,20 +28,20 @@ public static class SkyPatcherTools
          "and NO-OP WRITES (true ITM — the replay shows the SET writes the value the record already has). " +
          "Entries whose applicability " +
          "also hangs on other filters are flagged conditional rather than guessed. Pass filter= a type folder, mod, " +
-         "or filename substring to expand matching files to their patch lines. For ONE record's computed " +
+         "or filename substring to list only the matching files, expanded to their patch lines. For ONE record's computed " +
          "post-SkyPatcher state use " + ToolNames.Records + " formids=[\"<FormID>\"] source={\"overlay\": \"skypatcher\", \"state\": \"post\"} — source= is a version pole, not a selection, so the read needs formids= (or a scan scope). " +
          "Read-only.")]
     public static string SkyPatcherLayer(
         LoadOrderService svc,
         [Description("Optional. A type-folder (e.g. 'weapon'), providing-mod, or INI filename substring (case-insensitive). " +
-            "Expands the matching files to their individual patch lines. Omit for the whole-layer overview.")]
+            "Lists only the matching files, expanded to their individual patch lines. Omit for the whole-layer overview.")]
             string? filter = null,
         [Description("Optional. Max characters before lists are cut with an explicit notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool(ToolNames.SkypatcherLayer, () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         var data = svc.SkyPatcherLayer();
-        return SkyPatcherWire.RenderLayer(data, filter?.Trim(), max_chars > 0 ? max_chars : 80_000);
+        return SkyPatcherWire.RenderLayer(data, filter, max_chars > 0 ? max_chars : 80_000);
     });
 }
 
@@ -55,9 +55,10 @@ static class SkyPatcherWire
     {
         var sb = new StringBuilder();
         var folders = d.Scan.Folders;
+        filter = string.IsNullOrWhiteSpace(filter) ? null : filter.Trim();   // a blank filter is no filter, never a match-everything
         // A filter matching nothing must never fall through to the unfiltered overview — that reads as the whole layer.
-        if (filter is { Length: > 0 } && !folders.Any(f => f.Files.Any(x => Matches(filter, f, x))))
-            return ZeroMatch(d, filter);
+        if (filter is { } zero && !folders.Any(f => f.Files.Any(x => Matches(zero, f, x))))
+            return ZeroMatch(d, zero);
         int files = folders.Sum(f => f.Files.Count);
         int applied = folders.Sum(f => f.PatchingEnabled ? f.Files.Count(x => x.NotApplied is null) : 0);
         int lines = folders.Sum(f => f.Files.Sum(x => x.Lines.Count(l => l.Kind == SkyPatcherLineKind.Patch)));
@@ -75,10 +76,22 @@ static class SkyPatcherWire
           .Append(d.NoOps.Count).Append(" no-op write(s)\n");
         if (folders.Count == 0)
             sb.Append("\nno SkyPatcher INIs in the active order (no Data\\SKSE\\Plugins\\SkyPatcher content, or SkyPatcher itself is not installed).\n");
+        // filter= selects as well as expands: only matching files are listed, so a late-sorting match is never cut by the cap.
+        if (filter is { } hdr)
+            sb.Append("filter '").Append(hdr).Append("' — ")
+              .Append(folders.Sum(f => f.Files.Count(x => Matches(hdr, f, x)))).Append(" of ").Append(files)
+              .Append(" INI(s) match; only those are listed below (the counts above are the whole layer).\n");
 
         foreach (var f in folders)
         {
-            if (sb.Length >= cap) { sb.Append("... [remaining folders omitted at max_chars — raise it or pass filter=]\n"); break; }
+            if (filter is { } sel && !f.Files.Any(x => Matches(sel, f, x))) continue;
+            if (sb.Length >= cap)
+            {
+                sb.Append(filter is null
+                    ? "... [remaining folders omitted at max_chars — raise it or pass filter=]\n"
+                    : "... [remaining matching folders omitted at max_chars — raise it or narrow filter=]\n");
+                break;
+            }
             int fLines = f.Files.Sum(x => x.Lines.Count(l => l.Kind == SkyPatcherLineKind.Patch));
             sb.Append("\n").Append(f.Subfolder).Append(": ").Append(f.Files.Count).Append(" INI(s), ").Append(fLines).Append(" patch line(s)");
             if (!f.PatchingEnabled) sb.Append("  [!] toggled OFF in SkyPatcher.ini — the DLL skips this whole folder");
@@ -86,6 +99,9 @@ static class SkyPatcherWire
             sb.Append('\n');
             foreach (var file in f.Files)
             {
+                // filter= match (folder, provider, or filename) selects the file and expands it to its patch lines.
+                bool expand = filter is { } q && Matches(q, f, file);
+                if (filter is not null && !expand) continue;
                 if (sb.Length >= cap) { sb.Append("  ... [cut at max_chars]\n"); break; }
                 int n = file.Lines.Count(l => l.Kind == SkyPatcherLineKind.Patch);
                 sb.Append("  - ").Append(file.SortKey).Append("  (").Append(n).Append(" line(s)) ← ").Append(file.WinningProvider ?? "(no provider)");
@@ -93,8 +109,6 @@ static class SkyPatcherWire
                 if (file.NotApplied is not null) sb.Append("  [!] NOT applied: ").Append(file.NotApplied);
                 if (file.ShadowedProviders.Count > 0) sb.Append("  [!] shadows same-path copies from ").Append(string.Join(", ", file.ShadowedProviders));
                 sb.Append('\n');
-                // filter= match (folder, provider, or filename) expands the file to its patch lines.
-                bool expand = filter is not null && Matches(filter, f, file);
                 if (expand)
                     for (int i = 0; i < file.Lines.Count; i++)
                     {
@@ -208,7 +222,7 @@ static class SkyPatcherWire
             sb.Append("[!] ").Append(note).Append('\n');
         }
         AppendCaveats(sb, d.ReadIncomplete, d.AssetWarnings);
-        sb.Append("\n→ " + ToolNames.Records + " formids=['<FormID>'] source={\"overlay\": \"skypatcher\", \"state\": \"post\"} for one record's computed post-SkyPatcher state; filter='<folder/mod/file>' to expand files to their lines.");
+        sb.Append("\n→ " + ToolNames.Records + " formids=['<FormID>'] source={\"overlay\": \"skypatcher\", \"state\": \"post\"} for one record's computed post-SkyPatcher state; filter='<folder/mod/file>' to list just those files, expanded to their lines.");
         return sb.ToString().TrimEnd('\n');
     }
 
@@ -229,7 +243,9 @@ static class SkyPatcherWire
         sb.Append("SkyPatcher layer — filter '").Append(filter).Append("' — 0 of ").Append(files)
           .Append(" INI(s) match [profile '").Append(d.ProfileName).Append("']\n\n");
         if (folders.Count == 0)
-            sb.Append("nothing matched: the active order has no SkyPatcher INIs at all (no Data\\SKSE\\Plugins\\SkyPatcher content, or SkyPatcher itself is not installed).\n");
+            sb.Append(d.ReadIncomplete
+                ? "nothing matched: no SkyPatcher INIs were found, and the read was incomplete (below), so the layer is not necessarily empty.\n"
+                : "nothing matched: the active order has no SkyPatcher INIs at all (no Data\\SKSE\\Plugins\\SkyPatcher content, or SkyPatcher itself is not installed).\n");
         else
         {
             sb.Append("nothing matched: no type folder, providing mod, or INI filename contains '").Append(filter).Append("'.")
@@ -239,6 +255,9 @@ static class SkyPatcherWire
               .Append(" The type folder(s) present are: ").Append(string.Join(", ", folders.Select(f => f.Subfolder)))
               .Append(". Omit filter= for the whole-layer overview.\n");
         }
+        // The scan notes (shadowed copies, undocumented subfolders) are often why the filter matched nothing.
+        foreach (var note in d.NoOpNotes) sb.Append("[!] ").Append(note).Append('\n');
+        foreach (var note in d.Scan.Notes) sb.Append("[!] ").Append(note).Append('\n');
         AppendCaveats(sb, d.ReadIncomplete, d.AssetWarnings);
         return sb.ToString().TrimEnd('\n');
     }

--- a/src/housecarl-mcp/SkyPatcherTools.cs
+++ b/src/housecarl-mcp/SkyPatcherTools.cs
@@ -28,13 +28,16 @@ public static class SkyPatcherTools
          "and NO-OP WRITES (true ITM — the replay shows the SET writes the value the record already has). " +
          "Entries whose applicability " +
          "also hangs on other filters are flagged conditional rather than guessed. Pass filter= a type folder, mod, " +
-         "or filename substring to list only the matching files, expanded to their patch lines. For ONE record's computed " +
+         "or filename substring to narrow to the type folders that hold a match — each still listed in full apply order, " +
+         "so the files sorting before and after a match stay visible, with the matching files expanded to their patch " +
+         "lines. For ONE record's computed " +
          "post-SkyPatcher state use " + ToolNames.Records + " formids=[\"<FormID>\"] source={\"overlay\": \"skypatcher\", \"state\": \"post\"} — source= is a version pole, not a selection, so the read needs formids= (or a scan scope). " +
          "Read-only.")]
     public static string SkyPatcherLayer(
         LoadOrderService svc,
         [Description("Optional. A type-folder (e.g. 'weapon'), providing-mod, or INI filename substring (case-insensitive). " +
-            "Lists only the matching files, expanded to their individual patch lines. Omit for the whole-layer overview.")]
+            "Lists only the type folders holding a match, each in full apply order so the files sorting around a match " +
+            "stay visible, with the matching files expanded to their individual patch lines. Omit for the whole-layer overview.")]
             string? filter = null,
         [Description("Optional. Max characters before lists are cut with an explicit notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool(ToolNames.SkypatcherLayer, () =>
@@ -58,7 +61,7 @@ static class SkyPatcherWire
         filter = string.IsNullOrWhiteSpace(filter) ? null : filter.Trim();   // a blank filter is no filter, never a match-everything
         // A filter matching nothing must never fall through to the unfiltered overview — that reads as the whole layer.
         if (filter is { } zero && !folders.Any(f => f.Files.Any(x => Matches(zero, f, x))))
-            return ZeroMatch(d, zero);
+            return ZeroMatch(d, zero, cap);
         int files = folders.Sum(f => f.Files.Count);
         int applied = folders.Sum(f => f.PatchingEnabled ? f.Files.Count(x => x.NotApplied is null) : 0);
         int lines = folders.Sum(f => f.Files.Sum(x => x.Lines.Count(l => l.Kind == SkyPatcherLineKind.Patch)));
@@ -76,11 +79,15 @@ static class SkyPatcherWire
           .Append(d.NoOps.Count).Append(" no-op write(s)\n");
         if (folders.Count == 0)
             sb.Append("\nno SkyPatcher INIs in the active order (no Data\\SKSE\\Plugins\\SkyPatcher content, or SkyPatcher itself is not installed).\n");
-        // filter= selects as well as expands: only matching files are listed, so a late-sorting match is never cut by the cap.
+        // filter= selects at the FOLDER level: a folder with no match is skipped, so a late-sorting match is never cut by
+        // the cap, and a matching folder still lists every file in apply order so the neighbours around a match stay visible.
         if (filter is { } hdr)
             sb.Append("filter '").Append(hdr).Append("' — ")
               .Append(folders.Sum(f => f.Files.Count(x => Matches(hdr, f, x)))).Append(" of ").Append(files)
-              .Append(" INI(s) match; only those are listed below (the counts above are the whole layer).\n");
+              .Append(" INI(s) match, in ").Append(folders.Count(f => f.Files.Any(x => Matches(hdr, f, x))))
+              .Append(" of ").Append(folders.Count)
+              .Append(" type folder(s); only those folders are listed below, each in full apply order with the matching " +
+                      "files expanded to their lines (the counts above are the whole layer).\n");
 
         foreach (var f in folders)
         {
@@ -93,15 +100,17 @@ static class SkyPatcherWire
                 break;
             }
             int fLines = f.Files.Sum(x => x.Lines.Count(l => l.Kind == SkyPatcherLineKind.Patch));
-            sb.Append("\n").Append(f.Subfolder).Append(": ").Append(f.Files.Count).Append(" INI(s), ").Append(fLines).Append(" patch line(s)");
+            int fMatched = filter is { } fq ? f.Files.Count(x => Matches(fq, f, x)) : f.Files.Count;
+            sb.Append("\n").Append(f.Subfolder).Append(": ").Append(f.Files.Count).Append(" INI(s)");
+            if (fMatched != f.Files.Count) sb.Append(" (").Append(fMatched).Append(" matching, expanded)");   // the header must describe the listing under it
+            sb.Append(", ").Append(fLines).Append(" patch line(s)");
             if (!f.PatchingEnabled) sb.Append("  [!] toggled OFF in SkyPatcher.ini — the DLL skips this whole folder");
             if (f.Catalog is null) sb.Append("  [!] not a documented SkyPatcher record type — content listed, not interpreted");
             sb.Append('\n');
             foreach (var file in f.Files)
             {
-                // filter= match (folder, provider, or filename) selects the file and expands it to its patch lines.
+                // Every file of a selected folder is listed — a match's neighbours are where it sorts; only a match expands.
                 bool expand = filter is { } q && Matches(q, f, file);
-                if (filter is not null && !expand) continue;
                 if (sb.Length >= cap) { sb.Append("  ... [cut at max_chars]\n"); break; }
                 int n = file.Lines.Count(l => l.Kind == SkyPatcherLineKind.Patch);
                 sb.Append("  - ").Append(file.SortKey).Append("  (").Append(n).Append(" line(s)) ← ").Append(file.WinningProvider ?? "(no provider)");
@@ -222,7 +231,7 @@ static class SkyPatcherWire
             sb.Append("[!] ").Append(note).Append('\n');
         }
         AppendCaveats(sb, d.ReadIncomplete, d.AssetWarnings);
-        sb.Append("\n→ " + ToolNames.Records + " formids=['<FormID>'] source={\"overlay\": \"skypatcher\", \"state\": \"post\"} for one record's computed post-SkyPatcher state; filter='<folder/mod/file>' to list just those files, expanded to their lines.");
+        sb.Append("\n→ " + ToolNames.Records + " formids=['<FormID>'] source={\"overlay\": \"skypatcher\", \"state\": \"post\"} for one record's computed post-SkyPatcher state; filter='<folder/mod/file>' for just the type folders holding a match, each listed in full apply order with the matching files expanded to their lines.");
         return sb.ToString().TrimEnd('\n');
     }
 
@@ -235,7 +244,7 @@ static class SkyPatcherWire
 
     /// <summary>What a filter matching no INI returns: the count (zero), what the filter is matched against, and the
     /// folders that are there. Never the overview — an unfiltered dump would read as the filter's own result.</summary>
-    static string ZeroMatch(SkyPatcherLayerData d, string filter)
+    static string ZeroMatch(SkyPatcherLayerData d, string filter, int cap)
     {
         var folders = d.Scan.Folders;
         int files = folders.Sum(f => f.Files.Count);
@@ -256,9 +265,16 @@ static class SkyPatcherWire
               .Append(". Omit filter= for the whole-layer overview.\n");
         }
         // The scan notes (shadowed copies, undocumented subfolders) are often why the filter matched nothing.
-        foreach (var note in d.NoOpNotes) sb.Append("[!] ").Append(note).Append('\n');
-        foreach (var note in d.Scan.Notes) sb.Append("[!] ").Append(note).Append('\n');
-        AppendCaveats(sb, d.ReadIncomplete, d.AssetWarnings);
+        int notes = d.NoOpNotes.Count + d.Scan.Notes.Count, shownNotes = 0;
+        foreach (var note in d.NoOpNotes.Concat(d.Scan.Notes))
+        {
+            if (sb.Length >= cap) break;
+            sb.Append("[!] ").Append(note).Append('\n');
+            shownNotes++;
+        }
+        if (shownNotes < notes)
+            sb.Append("... [showing ").Append(shownNotes).Append(" of ").Append(notes).Append(" note(s); raise max_chars]\n");
+        AppendCaveats(sb, d.ReadIncomplete, d.AssetWarnings);   // always rendered, as in the filtered and unfiltered renders
         return sb.ToString().TrimEnd('\n');
     }
 


### PR DESCRIPTION
`housecarl_skypatcher_layer filter=weapon` on an order with no weapon type folder returned the whole-layer overview, cut at max_chars — indistinguishable from a call that passed no filter, so a typo or a folder that is not there read as the layer's contents. The render now checks the filter's own match domain (type folder, providing mod, INI path/filename) before it writes anything: zero matches returns one plain statement — the filter, `0 of N INI(s) match`, the type folders that are present, a nearest-name suggestion where one clears the bar, and to omit `filter=` for the overview — plus the usual caveats, so an incomplete read still says so. An empty layer says the order has no SkyPatcher INIs at all rather than listing nothing. A filter with at least one match is unchanged. `filter=` is the tool's only selection parameter (`max_chars` is transport), so there is no second fall-through of this shape here.

Covered by three unit tests over the renderer: the zero-match answer, the empty-layer wording, and a control that a matching filter still expands the file to its lines. The first two fail on the code before this change.

Build clean; 1897 tests pass; ci-all 128/128.

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)