### PR TITLE
Flag a dialogue topic whose Subtype contradicts its SNAM marker

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -35,8 +35,10 @@ saying it sets an expectation their install may contradict. Say what is known, a
 - **A dialogue topic whose numeric `Subtype` contradicts its SNAM marker is now flagged, and the marker is named
   as the authoritative one.** The engine buckets topics by SNAM; the numeric subtype is stale on topics authored
   before the Dragonborn-era Creation Kit inserted six `FlyingMount*` values into the enum, so a vanilla `HELO`
-  topic can read as `RechargeExit`. The dialogue check now warns on the disagreement, the text and JSON renders
-  label the pair (`subtype=… (stale)`, `subtype_marker=… (authoritative)`, `subtype_stale`), and the blank-marker
+  topic can read as `RechargeExit`. The dialogue check now warns on the disagreement — only for a topic a mod
+  defines or overrides, so a whole-quest check over vanilla topics stays quiet — and both renders label the pair
+  (`subtype=… (stale)`, `subtype_marker=… (authoritative)`, `subtype_stale`, `subtype_from_marker`) on every
+  topic. A non-blank marker houseCARL does not model is named rather than passed over, and the blank-marker
   advice says its recommended marker is derived from that unreliable field. Nothing is rewritten: no field on the
   record distinguishes the two numberings.
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -32,6 +32,13 @@ saying it sets an expectation their install may contradict. Say what is known, a
   and compares that record's type against the link's own target, naming the field, the type given and the types
   allowed. A field whose link accepts any record, a null-clear, a FormID no plugin in the order defines, and
   removing a link already in a list are not refused.
+- **A dialogue topic whose numeric `Subtype` contradicts its SNAM marker is now flagged, and the marker is named
+  as the authoritative one.** The engine buckets topics by SNAM; the numeric subtype is stale on topics authored
+  before the Dragonborn-era Creation Kit inserted six `FlyingMount*` values into the enum, so a vanilla `HELO`
+  topic can read as `RechargeExit`. The dialogue check now warns on the disagreement, the text and JSON renders
+  label the pair (`subtype=… (stale)`, `subtype_marker=… (authoritative)`, `subtype_stale`), and the blank-marker
+  advice says its recommended marker is derived from that unreliable field. Nothing is rewritten: no field on the
+  record distinguishes the two numberings.
 
 - **`open-animation-replacer` now states how a DAR `_conditions.txt` chain binds, and that the DAR weapon-type
   numbers convert unchanged.** Both were marked unverified in its reference, and the skill told you to convert

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -35,12 +35,17 @@ saying it sets an expectation their install may contradict. Say what is known, a
 - **A dialogue topic whose numeric `Subtype` contradicts its SNAM marker is now flagged, and the marker is named
   as the authoritative one.** The engine buckets topics by SNAM; the numeric subtype is stale on topics authored
   before the Dragonborn-era Creation Kit inserted six `FlyingMount*` values into the enum, so a vanilla `HELO`
-  topic can read as `RechargeExit`. The dialogue check now warns on the disagreement — only for a topic a mod
-  defines or overrides, so a whole-quest check over vanilla topics stays quiet — and both renders label the pair
-  (`subtype=… (stale)`, `subtype_marker=… (authoritative)`, `subtype_stale`, `subtype_from_marker`) on every
-  topic. A non-blank marker houseCARL does not model is named rather than passed over, and the blank-marker
-  advice says its recommended marker is derived from that unreliable field. Nothing is rewritten: no field on the
-  record distinguishes the two numberings.
+  topic can read as `RechargeExit`. The dialogue check now warns on the disagreement, and on a non-blank marker
+  houseCARL does not model. Both warnings are scoped to a pair the plugin itself states: a topic whose winner is
+  force-loaded content (the base masters, Creation Club, `_ResourcePack.esl` — the implicit group
+  `housecarl_load_order_status` lists) is passed over, and so is an override that carries the base record's pair
+  forward unchanged, so a whole-quest check over vanilla topics stays quiet. The labels are not scoped: both
+  renders show the pair (`subtype=… (stale)`, `subtype_marker=… (authoritative)`, `subtype_stale`,
+  `subtype_from_marker`) on every topic. The advice follows the numbers: a stored value exactly six below the
+  marker's modern index is the renumbering, and any other gap is two fields edited apart, where the warning says
+  the `Subtype` edit does nothing in game until SNAM is synced to it — which is what setting `Subtype` through
+  houseCARL does for you. Where a recommendation is derived from that unreliable field rather than from the base
+  record's SNAM, it says so. Nothing is rewritten: no field on the record distinguishes the two numberings.
 
 - **`open-animation-replacer` now states how a DAR `_conditions.txt` chain binds, and that the DAR weapon-type
   numbers convert unchanged.** Both were marked unverified in its reference, and the skill told you to convert

--- a/src/housecarl-core/DialogueSubtype.cs
+++ b/src/housecarl-core/DialogueSubtype.cs
@@ -181,6 +181,13 @@ public static class DialogueSubtype
     /// unmodeled (and "" for the one index Mutagen's enum omits). The honest label for a topic's subtype.</summary>
     public static string? NameForMarker(RecordType marker) => IndexForMarker(marker) is { } i ? NameAt(i) : null;
 
+    /// <summary>The best LABEL for the subtype a marker names, for a render or a message: Mutagen's enum name where
+    /// there is one, and the MARKER ITSELF for the one modeled row Mutagen's enum omits (index 3, FVDL) — never "",
+    /// which would hand a consumer nothing for a subtype this table can in fact name. null only when the marker is
+    /// blank or not one this table models, which is a different finding and says so in its own words.</summary>
+    public static string? LabelForMarker(RecordType marker) =>
+        IndexForMarker(marker) is { } i ? (NameAt(i) is { Length: > 0 } n ? n : Table[i].Marker) : null;
+
     /// <summary>True when a topic's numeric <c>Subtype</c> contradicts its SNAM marker — both modeled, and they name
     /// different subtypes. Bethesda renumbered the DATA\Subtype enum when the Dragonborn-era CK inserted six
     /// <c>FlyingMount*</c> values at index 20, so a topic authored before that stores a number six lower than the
@@ -189,6 +196,23 @@ public static class DialogueSubtype
     /// statement. Blank or unmodeled markers are NOT a disagreement — a blank one is its own finding.</summary>
     public static bool MarkerDisagreesWithSubtype(IDialogTopicGetter topic) =>
         IndexForMarker(topic.SubtypeName) is { } fromMarker && fromMarker != (int)topic.Subtype;
+
+    /// <summary>How many values the Dragonborn-era Creation Kit inserted at index 20 (the six <c>FlyingMount*</c>
+    /// rows), which is exactly how far a pre-Dragonborn DATA\Subtype sits below the modern table.</summary>
+    public const int RenumberOffset = 6;
+
+    /// <summary>The first modern index that also existed under the OLD numbering (20 + <see cref="RenumberOffset"/>).
+    /// A marker below this one names a subtype that predates the insertion or is one of the inserted rows, so it
+    /// cannot have been shifted and a disagreement there is not vintage.</summary>
+    public const int RenumberFirstShifted = 26;
+
+    /// <summary>Does a disagreeing pair carry the RENUMBERING signature — the marker's modern index sitting exactly
+    /// <see cref="RenumberOffset"/> above the stored number, at or above <see cref="RenumberFirstShifted"/>? True
+    /// means "old file, stale number, record not necessarily broken". False means the two fields were edited apart:
+    /// the numbers line up with no vintage that explains them, so the Subtype edit is an in-game no-op and the fix is
+    /// to sync SNAM. Asserting the vintage for EVERY mismatch would frame an authoring error as benign.</summary>
+    public static bool IsRenumberedVintage(int markerIndex, int subtypeValue) =>
+        markerIndex >= RenumberFirstShifted && markerIndex - subtypeValue == RenumberOffset;
 
     /// <summary>True when a topic's SNAM marker is empty/default (0000) OR whitespace-only — the malformed "no real
     /// marker" state. The single home for this test so the create path and the validator agree on what "no marker"

--- a/src/housecarl-core/DialogueSubtype.cs
+++ b/src/housecarl-core/DialogueSubtype.cs
@@ -166,6 +166,29 @@ public static class DialogueSubtype
     /// <summary>The 4-char SNAM marker for a <see cref="DialogTopic.SubtypeEnum"/>, or null if unmodeled.</summary>
     public static string? MarkerFor(DialogTopic.SubtypeEnum subtype) => MarkerFor((int)subtype);
 
+    /// <summary>Marker → subtype index, the reverse of the table. Ordinal (markers are fixed-case 4-char signatures).</summary>
+    static readonly Dictionary<string, int> ByMarker =
+        Table.Select((row, i) => (row.Marker, i)).ToDictionary(p => p.Marker, p => p.i, StringComparer.Ordinal);
+
+    /// <summary>The subtype index a 4-char SNAM marker names, or null when the marker is blank or not one this table
+    /// models. SNAM is the AUTHORITATIVE statement of a topic's subtype — the engine buckets by it — so this is the
+    /// lookup a reader should trust over <c>(int)DialogTopic.Subtype</c>.</summary>
+    public static int? IndexForMarker(RecordType marker) =>
+        !IsBlankMarker(marker) && ByMarker.TryGetValue(marker.Type, out var i) ? i : null;
+
+    /// <summary>Mutagen's SubtypeEnum name for the subtype a SNAM marker names, or null when the marker is blank or
+    /// unmodeled (and "" for the one index Mutagen's enum omits). The honest label for a topic's subtype.</summary>
+    public static string? NameForMarker(RecordType marker) => IndexForMarker(marker) is { } i ? NameAt(i) : null;
+
+    /// <summary>True when a topic's numeric <c>Subtype</c> contradicts its SNAM marker — both modeled, and they name
+    /// different subtypes. Bethesda renumbered the DATA\Subtype enum when the Dragonborn-era CK inserted six
+    /// <c>FlyingMount*</c> values at index 20, so a topic authored before that stores a number six lower than the
+    /// modern table and Mutagen labels it six entries too early. Nothing on the record distinguishes the two
+    /// numberings (form version does not: Dragonborn.esm mixes both at FormVersion 43), so SNAM is the only reliable
+    /// statement. Blank or unmodeled markers are NOT a disagreement — a blank one is its own finding.</summary>
+    public static bool MarkerDisagreesWithSubtype(IDialogTopicGetter topic) =>
+        IndexForMarker(topic.SubtypeName) is { } fromMarker && fromMarker != (int)topic.Subtype;
+
     /// <summary>True when a topic's SNAM marker is empty/default (0000) OR whitespace-only — the malformed "no real
     /// marker" state. The single home for this test so the create path and the validator agree on what "no marker"
     /// means. Whitespace counts as blank: it renders invisibly and buckets to a tag no real topic uses.</summary>

--- a/src/housecarl-core/DialogueSubtype.cs
+++ b/src/housecarl-core/DialogueSubtype.cs
@@ -14,8 +14,9 @@ namespace HousecarlCore;
 //
 // The table below is sourced from xEdit's record definition, not derived: the name↔marker mapping is not a
 // blind echo (Custom→CUST but ShootBow→FIWE), Mutagen does not model it, and it cannot be scraped from
-// vanilla because Bethesda's own DATA\Subtype numbers are unreliable (many HELO topics ship with DATA≠79) —
-// which is why xEdit ignores DATA\Subtype and treats SNAM as the required master field. Rows are the join of
+// vanilla because Bethesda's own DATA\Subtype numbers are stale under the Dragonborn-era renumbering (many HELO
+// topics ship with DATA≠79 — see MarkerDisagreesWithSubtype), which is why xEdit ignores DATA\Subtype and treats
+// SNAM as the required master field. Rows are the join of
 // xEdit's DATA\Subtype index→name enum and its 4-char-signature→name enum, matched by subtype name.
 // Mutagen's SubtypeEnum integer values equal these indices, so the lookup key is (int)DialogTopic.Subtype.
 

--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -68,6 +68,12 @@ public sealed record TopicValidation(
     /// (the topic resolved to no touching plugins). This is the one view that shows a pure REORDER, which changes
     /// which line plays while leaving every field identical — see <see cref="DialogueInfoOrder"/>.</summary>
     public InfoOrderView? InfoOrder { get; init; }
+
+    /// <summary>True when <see cref="Subtype"/> (the numeric DATA field) names a different subtype than
+    /// <see cref="SubtypeName"/> (the SNAM marker). The marker is authoritative — the engine buckets by it — so a
+    /// render must label the pair rather than show the number bare. See
+    /// <see cref="DialogueSubtype.MarkerDisagreesWithSubtype"/> for why the number goes stale.</summary>
+    public bool SubtypeDisagreesWithMarker { get; init; }
 }
 
 /// <summary>The SEQ staleness/coverage lint result for a QUEST-input validation; null for a non-SGE quest or a DIAL
@@ -461,8 +467,14 @@ public static class DialogueValidate
         {
             var expected = DialogueSubtype.MarkerFor((int)topic.Subtype);
             bool isOverride = !string.Equals(topic.FormKey.ModKey.FileName.String, winnerPlugin, StringComparison.OrdinalIgnoreCase);
+            // The recommended marker is DERIVED from the numeric Subtype, which is unreliable on a topic authored
+            // before the Dragonborn-era CK renumbered the enum (see DialogueSubtype.MarkerDisagreesWithSubtype). With
+            // SNAM blank there is nothing to cross-check it against, so the advice says where it came from and points
+            // at the base record's marker rather than asserting a number-derived tag is right.
+            var derived = $" That marker is derived from the numeric Subtype, which is stale on topics authored before "
+                        + "the Dragonborn-era Creation Kit renumbered the subtype enum — check the base record's SNAM before writing it.";
             var fix = expected is not null
-                ? $"Set it to {expected} (the marker for Subtype={topic.Subtype}); houseCARL's create tools now auto-fill it, or {ToolNames.Apply} on SubtypeName with value={expected}."
+                ? $"Set it to {expected} (the marker for Subtype={topic.Subtype}); houseCARL's create tools now auto-fill it, or {ToolNames.Apply} on SubtypeName with value={expected}.{derived}"
                 : $"Set it to the correct 4-char marker for Subtype={topic.Subtype} via {ToolNames.Apply} on SubtypeName.";
             issues.Add(isOverride
                 ? new(DialogueIssueSeverity.Warning,
@@ -472,6 +484,24 @@ public static class DialogueValidate
                 : new(DialogueIssueSeverity.Problem,
                     "DialogTopic.SubtypeName (the SNAM subtype marker) is empty (0000) — the game buckets topics by this 4-char marker, "
                     + $"and this plugin DEFINES the topic, so a blank marker is a load CTD on load (#131); the record is malformed. {fix}"));
+        }
+
+        // --- Subtype vs SNAM disagreement: the numeric DATA\Subtype says one thing and the SNAM marker another.
+        //     SNAM wins — the engine buckets by the marker, and xEdit marks DATA\Subtype cpIgnore for the same reason.
+        //     The usual cause is age, not damage: the Dragonborn-era CK inserted six FlyingMount* subtypes at index 20,
+        //     so a topic authored before that stores a number six lower than the modern enum and every reader (Mutagen,
+        //     xEdit, houseCARL) labels it six entries too early. No field distinguishes the two numberings, so this is
+        //     reported, never "fixed" — rewriting DATA\Subtype here would be a guess at what the author meant.
+        else if (DialogueSubtype.MarkerDisagreesWithSubtype(topic))
+        {
+            var fromMarker = DialogueSubtype.NameForMarker(topic.SubtypeName);
+            issues.Add(new(DialogueIssueSeverity.Warning,
+                $"DialogTopic.Subtype reads {topic.Subtype} ((int){(int)topic.Subtype}) but the SNAM marker is "
+                + $"{topic.SubtypeName.Type}{(string.IsNullOrEmpty(fromMarker) ? "" : $" ({fromMarker})")} — they disagree, and the MARKER is "
+                + "authoritative: the game buckets topics by SNAM. The record is not necessarily broken; Bethesda renumbered the "
+                + "numeric subtype enum when the Dragonborn-era Creation Kit inserted six FlyingMount* values at index 20, so a "
+                + "topic authored before that stores a number six lower than the modern table and every reader labels it too early. "
+                + $"Treat this topic's subtype as {(string.IsNullOrEmpty(fromMarker) ? topic.SubtypeName.Type : fromMarker)}, not {topic.Subtype}."));
         }
 
         // Static condition lints need the owning quest's reference-alias IDs — resolved ONCE here off the load-order
@@ -569,7 +599,10 @@ public static class DialogueValidate
         return new TopicValidation(
             topic.FormKey, edid, winnerPlugin, infoCount, conditioned, deleted, fragmentInfos,
             topic.Category.ToString(), topic.Subtype.ToString(), DescribeSubtypeName(topic.SubtypeName),
-            issues, voiceLines, voiceUndet, scriptFindings);
+            issues, voiceLines, voiceUndet, scriptFindings)
+        {
+            SubtypeDisagreesWithMarker = DialogueSubtype.MarkerDisagreesWithSubtype(topic),
+        };
     }
 
     /// <summary>SEQ staleness/coverage lint for a QUEST input: if the quest is Start-Game-Enabled, does its DEFINING

--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -74,6 +74,11 @@ public sealed record TopicValidation(
     /// render must label the pair rather than show the number bare. See
     /// <see cref="DialogueSubtype.MarkerDisagreesWithSubtype"/> for why the number goes stale.</summary>
     public bool SubtypeDisagreesWithMarker { get; init; }
+
+    /// <summary>The subtype name the SNAM marker itself names — the honest label when <see cref="Subtype"/> is stale.
+    /// "" when the marker is blank or not one <see cref="DialogueSubtype"/> models, so a consumer never has to
+    /// re-implement the marker→name table to read past a disagreement.</summary>
+    public string SubtypeFromMarker { get; init; } = "";
 }
 
 /// <summary>The SEQ staleness/coverage lint result for a QUEST-input validation; null for a non-SGE quest or a DIAL
@@ -463,19 +468,22 @@ public static class DialogueValidate
         //         not a confirmed crash → Warning. Don't cry "guaranteed CTD" over working content.
         //     The blank test is DialogueSubtype's, shared with the create-path auto-fill so they can't drift, and the
         //     expected marker is named so the fix is a copy-paste rather than a bare "invalid".
+        // Ownership of the record the check actually reads, shared by every SNAM finding below.
+        bool isOverride = !string.Equals(topic.FormKey.ModKey.FileName.String, winnerPlugin, StringComparison.OrdinalIgnoreCase);
+        // A base-game master's own winning record is content the modder neither wrote nor can act on.
+        bool modAuthored = !ErrorCheck.IsBaseMaster(winnerPlugin);
         if (DialogueSubtype.IsBlankMarker(topic.SubtypeName))
         {
             var expected = DialogueSubtype.MarkerFor((int)topic.Subtype);
-            bool isOverride = !string.Equals(topic.FormKey.ModKey.FileName.String, winnerPlugin, StringComparison.OrdinalIgnoreCase);
-            // The recommended marker is DERIVED from the numeric Subtype, which is unreliable on a topic authored
+            // Both arms recommend a marker DERIVED from the numeric Subtype, which is unreliable on a topic authored
             // before the Dragonborn-era CK renumbered the enum (see DialogueSubtype.MarkerDisagreesWithSubtype). With
             // SNAM blank there is nothing to cross-check it against, so the advice says where it came from and points
             // at the base record's marker rather than asserting a number-derived tag is right.
-            var derived = $" That marker is derived from the numeric Subtype, which is stale on topics authored before "
-                        + "the Dragonborn-era Creation Kit renumbered the subtype enum — check the base record's SNAM before writing it.";
-            var fix = expected is not null
-                ? $"Set it to {expected} (the marker for Subtype={topic.Subtype}); houseCARL's create tools now auto-fill it, or {ToolNames.Apply} on SubtypeName with value={expected}.{derived}"
-                : $"Set it to the correct 4-char marker for Subtype={topic.Subtype} via {ToolNames.Apply} on SubtypeName.";
+            const string derived = " That comes from the numeric Subtype, which is stale on topics authored before the "
+                + "Dragonborn-era Creation Kit renumbered the subtype enum — check the base record's SNAM before writing it.";
+            var fix = (expected is not null
+                ? $"Set it to {expected} (the marker for Subtype={topic.Subtype}); houseCARL's create tools now auto-fill it, or {ToolNames.Apply} on SubtypeName with value={expected}."
+                : $"Set it to the correct 4-char marker for Subtype={topic.Subtype} via {ToolNames.Apply} on SubtypeName.") + derived;
             issues.Add(isOverride
                 ? new(DialogueIssueSeverity.Warning,
                     $"DialogTopic.SubtypeName (the SNAM subtype marker) is empty (0000) on this OVERRIDE of {topic.FormKey.ModKey.FileName} — "
@@ -492,7 +500,11 @@ public static class DialogueValidate
         //     so a topic authored before that stores a number six lower than the modern enum and every reader (Mutagen,
         //     xEdit, houseCARL) labels it six entries too early. No field distinguishes the two numberings, so this is
         //     reported, never "fixed" — rewriting DATA\Subtype here would be a guess at what the author meant.
-        else if (DialogueSubtype.MarkerDisagreesWithSubtype(topic))
+        //     Scoped to a record a mod defines or overrides (Aaron's ruling): a base master's own topic read through
+        //     the order carries Bethesda's stale number, which the modder cannot act on and which would fill a
+        //     whole-quest check with the same warning. There the verdict still rides the render's "(stale)" /
+        //     "(authoritative)" labels and the JSON's subtype_stale / subtype_from_marker fields.
+        else if (modAuthored && DialogueSubtype.MarkerDisagreesWithSubtype(topic))
         {
             var fromMarker = DialogueSubtype.NameForMarker(topic.SubtypeName);
             issues.Add(new(DialogueIssueSeverity.Warning,
@@ -502,6 +514,19 @@ public static class DialogueValidate
                 + "numeric subtype enum when the Dragonborn-era Creation Kit inserted six FlyingMount* values at index 20, so a "
                 + "topic authored before that stores a number six lower than the modern table and every reader labels it too early. "
                 + $"Treat this topic's subtype as {(string.IsNullOrEmpty(fromMarker) ? topic.SubtypeName.Type : fromMarker)}, not {topic.Subtype}."));
+        }
+
+        // --- A non-blank marker this table does not model: not a disagreement (there is nothing to compare) and not
+        //     blank, so it would otherwise pass both checks in silence while the engine buckets the topic to a tag no
+        //     dialogue handler reads. Same ownership gate as the disagreement above.
+        else if (modAuthored && DialogueSubtype.IndexForMarker(topic.SubtypeName) is null)
+        {
+            issues.Add(new(DialogueIssueSeverity.Warning,
+                $"DialogTopic.SubtypeName (the SNAM subtype marker) is {topic.SubtypeName.Type}, which is not a marker houseCARL "
+                + "models — the game buckets topics by this 4-char tag, so an invented or mis-cased one (the tags are fixed case: "
+                + "HELO, not helo) puts the topic in a bucket no dialogue handler reads and it never plays. Set it to the marker for "
+                + $"the intended subtype (Subtype reads {topic.Subtype}) via {ToolNames.Apply} on SubtypeName — or, if {topic.SubtypeName.Type} "
+                + "is a real marker, report it: houseCARL's table is missing a row."));
         }
 
         // Static condition lints need the owning quest's reference-alias IDs — resolved ONCE here off the load-order
@@ -602,6 +627,7 @@ public static class DialogueValidate
             issues, voiceLines, voiceUndet, scriptFindings)
         {
             SubtypeDisagreesWithMarker = DialogueSubtype.MarkerDisagreesWithSubtype(topic),
+            SubtypeFromMarker = DialogueSubtype.NameForMarker(topic.SubtypeName) ?? "",
         };
     }
 

--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -76,8 +76,9 @@ public sealed record TopicValidation(
     public bool SubtypeDisagreesWithMarker { get; init; }
 
     /// <summary>The subtype name the SNAM marker itself names — the honest label when <see cref="Subtype"/> is stale.
-    /// "" when the marker is blank or not one <see cref="DialogueSubtype"/> models, so a consumer never has to
-    /// re-implement the marker→name table to read past a disagreement.</summary>
+    /// The MARKER itself for the one modeled row Mutagen's enum leaves unnamed (index 3, FVDL), so a consumer never
+    /// has to re-implement the marker→name table to read past a disagreement. "" only when the marker is blank or not
+    /// one <see cref="DialogueSubtype"/> models — the cases where there is genuinely nothing to name.</summary>
     public string SubtypeFromMarker { get; init; } = "";
 }
 
@@ -256,8 +257,12 @@ public static class DialogueValidate
     /// <param name="pinned">the build to read, when a CALLER has already pinned one — a seed sweep validating several
     /// records in one response hands its own view down so every seed reads the build the response stamps. Null pins one
     /// here, which is what a single validation wants.</param>
+    /// <param name="forceLoaded">the force-loaded plugin names beyond the base masters (Creation Club,
+    /// <c>_ResourcePack.esl</c>) — the implicit group housecarl_load_order_status shows. Null when the caller cannot
+    /// read an MO2 composition; see <see cref="ValidateTopic"/>'s parameter of the same name for what that costs.</param>
     public static DialogueValidationReport Run(LoadOrderResolver resolver, AssetResolver assets, FormKey fk,
-                                               LoadOrderResolver.IndexView? pinned = null)
+                                               LoadOrderResolver.IndexView? pinned = null,
+                                               IReadOnlyCollection<string>? forceLoaded = null)
     {
         try
         {
@@ -282,6 +287,20 @@ public static class DialogueValidate
             // ValidateTopic.BadRef.
             bool InOrder(FormKey k) => !k.IsNull && view.ResolveWinner(k) is not null;
 
+            // The topic's copy in its DEFINING master, for the SNAM ownership gate: what an override inherited, so a
+            // pair the base record already carried is never blamed on the plugin that copied it forward. A TYPED DIAL
+            // seek (never the flat scan), cached per FormKey, and asked for only by a finding that is about to fire —
+            // so a clean order pays nothing and the quest fan-out pays at most one seek per already-suspect topic.
+            var baseCache = new Dictionary<FormKey, IDialogTopicGetter?>();
+            IDialogTopicGetter? BaseCopy(FormKey k)
+            {
+                if (baseCache.TryGetValue(k, out var c)) return c;
+                var g = view.GetRecord(session, k.ModKey.FileName.String, k, typeof(IDialogTopicGetter))
+                        as IDialogTopicGetter;
+                baseCache[k] = g;
+                return g;
+            }
+
 
             // Load every needed topic's per-plugin child lists in ONE typed DIAL pass per contributing plugin.
             // Deliberately NOT view.GetRecord per (topic, plugin): that is an UNINDEXED whole-overlay scan, so a
@@ -305,7 +324,7 @@ public static class DialogueValidate
 
             if (body is IDialogTopicGetter topic)
             {
-                var tv = ValidateTopic(topic, win.Value.WinnerPlugin, InOrder, Resolve, av)
+                var tv = ValidateTopic(topic, win.Value.WinnerPlugin, InOrder, Resolve, av, BaseCopy, forceLoaded)
                     with { InfoOrder = OrdersFor(new[] { fk }).GetValueOrDefault(fk) };
                 return new DialogueValidationReport(fk, "topic", topic.EditorID ?? "", win.Value.WinnerPlugin, new[] { tv })
                     { ReadIncomplete = av.ReadIncomplete };
@@ -332,7 +351,7 @@ public static class DialogueValidate
                     if (tbody is not IDialogTopicGetter dt) continue;
                     if (NonNull(dt.Quest.FormKeyNullable) is not { } qk || qk != fk) continue;
                     var wp = view.ResolveWinner(tfk)?.WinnerPlugin ?? win.Value.WinnerPlugin;
-                    topics.Add(ValidateTopic(dt, wp, InOrder, Resolve, av));
+                    topics.Add(ValidateTopic(dt, wp, InOrder, Resolve, av, BaseCopy, forceLoaded));
                 }
 
                 // Effective INFO order for EVERY topic in one batch, built AFTER the winner scan closes — never
@@ -405,8 +424,16 @@ public static class DialogueValidate
     /// References are vetted by <paramref name="inOrder"/> first (a cheap O(1) index lookup — a dangling/missing target,
     /// the common breakage, costs no body fetch); only a PRESENT target pays <paramref name="resolve"/> to name a wrong
     /// type. The voice/script reuse still uses <paramref name="resolve"/> for the speaker/quest bodies it must read.</summary>
+    /// <param name="baseCopy">the topic's body as its DEFINING master holds it — what an override inherited — or null
+    /// when that copy cannot be read. Only ever asked for on a record the SNAM checks are about to warn on.</param>
+    /// <param name="forceLoaded">the force-loaded plugin names beyond the base masters (Creation Club,
+    /// <c>_ResourcePack.esl</c>) — <c>Mo2Composition.ImplicitPluginNames</c>, the same grouping
+    /// housecarl_load_order_status shows as implicit. Null means the caller has no MO2 composition to read (a
+    /// synthesized order in a probe), and the ownership gate then knows only the five base masters: a force-loaded
+    /// plugin's own topic would warn where it should stay quiet — a louder answer, never a quieter one.</param>
     internal static TopicValidation ValidateTopic(IDialogTopicGetter topic, string winnerPlugin,
-        Func<FormKey, bool> inOrder, Func<FormKey, IMajorRecordGetter?> resolve, AssetResolver.AssetView assetView)
+        Func<FormKey, bool> inOrder, Func<FormKey, IMajorRecordGetter?> resolve, AssetResolver.AssetView assetView,
+        Func<FormKey, IDialogTopicGetter?> baseCopy, IReadOnlyCollection<string>? forceLoaded)
     {
         var edid = topic.EditorID ?? "";
         var issues = new List<DialogueIssue>();
@@ -470,17 +497,36 @@ public static class DialogueValidate
         //     expected marker is named so the fix is a copy-paste rather than a bare "invalid".
         // Ownership of the record the check actually reads, shared by every SNAM finding below.
         bool isOverride = !string.Equals(topic.FormKey.ModKey.FileName.String, winnerPlugin, StringComparison.OrdinalIgnoreCase);
-        // A base-game master's own winning record is content the modder neither wrote nor can act on.
-        bool modAuthored = !ErrorCheck.IsBaseMaster(winnerPlugin);
+        // Content the modder neither wrote nor can act on: the base masters PLUS the rest of the force-loaded set
+        // (Creation Club, _ResourcePack.esl), which is the same grouping housecarl_load_order_status calls implicit —
+        // reused via forceLoaded rather than re-listed here. See the parameter's own note for the unknowable case.
+        bool modAuthored = !ErrorCheck.IsBaseMaster(winnerPlugin)
+            && !(forceLoaded?.Contains(winnerPlugin, StringComparer.OrdinalIgnoreCase) ?? false);
+
+        // The (Subtype, SNAM) pair on the topic's copy in its DEFINING master — what an override INHERITED. Read once,
+        // and only for a finding that needs it, so the common clean topic pays nothing: the defining master is a
+        // different plugin from the winner whenever isOverride holds, so this never re-enters the plugin a quest
+        // fan-out is scanning. Null when the topic is not an override or the base copy cannot be read.
+        (int Subtype, RecordType Marker)? basePairCache = null;
+        bool basePairRead = false;
+        (int Subtype, RecordType Marker)? BasePair()
+        {
+            if (basePairRead) return basePairCache;
+            basePairRead = true;
+            if (isOverride && baseCopy(topic.FormKey) is { } b) basePairCache = ((int)b.Subtype, b.SubtypeName);
+            return basePairCache;
+        }
+
+        // The caveat every recommendation DERIVED from the numeric Subtype must carry: that field is unreliable on a
+        // topic authored before the Dragonborn-era CK renumbered the enum (see DialogueSubtype.MarkerDisagreesWithSubtype),
+        // so the advice says where it came from and points at the base record's marker rather than asserting a
+        // number-derived tag is right. Shared by the blank arm and the unmodeled-marker arm's fallback.
+        const string derived = " That comes from the numeric Subtype, which is stale on topics authored before the "
+            + "Dragonborn-era Creation Kit renumbered the subtype enum — check the base record's SNAM before writing it.";
+
         if (DialogueSubtype.IsBlankMarker(topic.SubtypeName))
         {
             var expected = DialogueSubtype.MarkerFor((int)topic.Subtype);
-            // Both arms recommend a marker DERIVED from the numeric Subtype, which is unreliable on a topic authored
-            // before the Dragonborn-era CK renumbered the enum (see DialogueSubtype.MarkerDisagreesWithSubtype). With
-            // SNAM blank there is nothing to cross-check it against, so the advice says where it came from and points
-            // at the base record's marker rather than asserting a number-derived tag is right.
-            const string derived = " That comes from the numeric Subtype, which is stale on topics authored before the "
-                + "Dragonborn-era Creation Kit renumbered the subtype enum — check the base record's SNAM before writing it.";
             var fix = (expected is not null
                 ? $"Set it to {expected} (the marker for Subtype={topic.Subtype}); houseCARL's create tools now auto-fill it, or {ToolNames.Apply} on SubtypeName with value={expected}."
                 : $"Set it to the correct 4-char marker for Subtype={topic.Subtype} via {ToolNames.Apply} on SubtypeName.") + derived;
@@ -500,20 +546,44 @@ public static class DialogueValidate
         //     so a topic authored before that stores a number six lower than the modern enum and every reader (Mutagen,
         //     xEdit, houseCARL) labels it six entries too early. No field distinguishes the two numberings, so this is
         //     reported, never "fixed" — rewriting DATA\Subtype here would be a guess at what the author meant.
-        //     Scoped to a record a mod defines or overrides (Aaron's ruling): a base master's own topic read through
-        //     the order carries Bethesda's stale number, which the modder cannot act on and which would fill a
-        //     whole-quest check with the same warning. There the verdict still rides the render's "(stale)" /
-        //     "(authoritative)" labels and the JSON's subtype_stale / subtype_from_marker fields.
-        else if (modAuthored && DialogueSubtype.MarkerDisagreesWithSubtype(topic))
+        //     Scoped to a record a mod actually AUTHORED the pair on (Aaron's ruling): a force-loaded plugin's own
+        //     topic (base masters, Creation Club, _ResourcePack.esl) carries Bethesda's stale number, and so does an
+        //     override that copies the base record's pair forward verbatim — neither is something the modder wrote or
+        //     can act on, and both would fill a whole-quest check with the same warning. There the verdict still rides
+        //     the render's "(stale)" / "(authoritative)" labels and the JSON's subtype_stale / subtype_from_marker
+        //     fields, which are ungated.
+        //     WHICH advice is given turns on the renumbering signature, never on an assumption: a stored number
+        //     exactly six below the marker's modern index is vintage, and anything else is two fields edited apart —
+        //     a real authoring error whose Subtype edit does nothing in game until SNAM is synced.
+        else if (DialogueSubtype.MarkerDisagreesWithSubtype(topic))
         {
-            var fromMarker = DialogueSubtype.NameForMarker(topic.SubtypeName);
-            issues.Add(new(DialogueIssueSeverity.Warning,
-                $"DialogTopic.Subtype reads {topic.Subtype} ((int){(int)topic.Subtype}) but the SNAM marker is "
-                + $"{topic.SubtypeName.Type}{(string.IsNullOrEmpty(fromMarker) ? "" : $" ({fromMarker})")} — they disagree, and the MARKER is "
-                + "authoritative: the game buckets topics by SNAM. The record is not necessarily broken; Bethesda renumbered the "
-                + "numeric subtype enum when the Dragonborn-era Creation Kit inserted six FlyingMount* values at index 20, so a "
-                + "topic authored before that stores a number six lower than the modern table and every reader labels it too early. "
-                + $"Treat this topic's subtype as {(string.IsNullOrEmpty(fromMarker) ? topic.SubtypeName.Type : fromMarker)}, not {topic.Subtype}."));
+            // An inherited pair is the base record's statement, not this plugin's: the override changed neither field.
+            bool inherited = BasePair() is { } b
+                && b.Subtype == (int)topic.Subtype
+                && string.Equals(b.Marker.Type, topic.SubtypeName.Type, StringComparison.Ordinal);
+            int fromIndex = DialogueSubtype.IndexForMarker(topic.SubtypeName)!.Value;
+            var fromMarker = DialogueSubtype.LabelForMarker(topic.SubtypeName)!;
+            if (modAuthored && !inherited)
+            {
+                var head = $"DialogTopic.Subtype reads {topic.Subtype} ((int){(int)topic.Subtype}) but the SNAM marker is "
+                    + $"{topic.SubtypeName.Type} ({fromMarker}) — they disagree, and the MARKER is authoritative: the game "
+                    + "buckets topics by SNAM. ";
+                if (DialogueSubtype.IsRenumberedVintage(fromIndex, (int)topic.Subtype))
+                    issues.Add(new(DialogueIssueSeverity.Warning, head
+                        + $"The numbers carry the renumbering signature (stored exactly {DialogueSubtype.RenumberOffset} below the "
+                        + "marker's modern index), so the record is not necessarily broken: Bethesda's Dragonborn-era Creation Kit "
+                        + $"inserted {DialogueSubtype.RenumberOffset} FlyingMount* values at index 20, and a topic authored before that "
+                        + "stores the older, lower number which every reader labels too early. "
+                        + $"Treat this topic's subtype as {fromMarker}, not {topic.Subtype}."));
+                else
+                    issues.Add(new(DialogueIssueSeverity.Warning, head
+                        + "The numbers do NOT carry the Dragonborn-era renumbering signature, so this is not an old file: the two "
+                        + $"fields were edited apart. The topic still buckets as {fromMarker}, which makes the Subtype value an "
+                        + $"in-game no-op. If {fromMarker} is the intended subtype, set Subtype to it and leave SNAM alone; if "
+                        + $"{topic.Subtype} is, sync SNAM to "
+                        + $"{DialogueSubtype.MarkerFor((int)topic.Subtype) ?? $"the marker for {topic.Subtype}"} via "
+                        + $"{ToolNames.Apply} on SubtypeName — setting Subtype through houseCARL does that sync for you."));
+            }
         }
 
         // --- A non-blank marker this table does not model: not a disagreement (there is nothing to compare) and not
@@ -521,12 +591,23 @@ public static class DialogueValidate
         //     dialogue handler reads. Same ownership gate as the disagreement above.
         else if (modAuthored && DialogueSubtype.IndexForMarker(topic.SubtypeName) is null)
         {
+            // What to set it TO. The base record's SNAM first when this is an override and that marker is modeled: SNAM
+            // is the authoritative statement of a topic's bucket, so an inherited marker beats anything derived from
+            // the numeric Subtype — which is the field this whole check exists because it is unreliable. Only with no
+            // base copy, or a base marker as unmodeled as this one, does the advice fall back to Subtype, and then it
+            // carries the same caveat the blank arm does.
+            var expected = DialogueSubtype.MarkerFor((int)topic.Subtype);
+            var fix = BasePair() is { } b && DialogueSubtype.LabelForMarker(b.Marker) is { } baseName
+                ? $"Set it to {b.Marker.Type} ({baseName}) — the marker on the base record in {topic.FormKey.ModKey.FileName}, "
+                  + $"which is the bucket this override inherits — via {ToolNames.Apply} on SubtypeName."
+                : expected is not null
+                    ? $"Set it to {expected} (the marker for Subtype={topic.Subtype}) via {ToolNames.Apply} on SubtypeName." + derived
+                    : $"Set it to the correct 4-char marker for Subtype={topic.Subtype} via {ToolNames.Apply} on SubtypeName.";
             issues.Add(new(DialogueIssueSeverity.Warning,
                 $"DialogTopic.SubtypeName (the SNAM subtype marker) is {topic.SubtypeName.Type}, which is not a marker houseCARL "
                 + "models — the game buckets topics by this 4-char tag, so an invented or mis-cased one (the tags are fixed case: "
-                + "HELO, not helo) puts the topic in a bucket no dialogue handler reads and it never plays. Set it to the marker for "
-                + $"the intended subtype (Subtype reads {topic.Subtype}) via {ToolNames.Apply} on SubtypeName — or, if {topic.SubtypeName.Type} "
-                + "is a real marker, report it: houseCARL's table is missing a row."));
+                + $"HELO, not helo) puts the topic in a bucket no dialogue handler reads and it never plays. {fix} Or, if "
+                + $"{topic.SubtypeName.Type} is a real marker, report it: houseCARL's table is missing a row."));
         }
 
         // Static condition lints need the owning quest's reference-alias IDs — resolved ONCE here off the load-order
@@ -627,7 +708,7 @@ public static class DialogueValidate
             issues, voiceLines, voiceUndet, scriptFindings)
         {
             SubtypeDisagreesWithMarker = DialogueSubtype.MarkerDisagreesWithSubtype(topic),
-            SubtypeFromMarker = DialogueSubtype.NameForMarker(topic.SubtypeName) ?? "",
+            SubtypeFromMarker = DialogueSubtype.LabelForMarker(topic.SubtypeName) ?? "",
         };
     }
 

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -808,9 +808,10 @@ public static class WritePatchBuilder
     /// DialogTopic this call edited where it SET <c>Subtype</c> but NOT <c>SubtypeName</c>, sync the SNAM marker to
     /// the new Subtype — otherwise the change is a silent in-game no-op, because the engine buckets topics by the SNAM
     /// marker and a stale marker keeps the old bucket. It fires ONLY when Subtype was actively set in THIS call, so it
-    /// never rewrites the SNAM of a topic whose subtype the call didn't touch — which is what keeps it off the
-    /// countless vanilla topics whose DATA\Subtype is legitimately noisy (a blanket "SubtypeName != marker" lint would
-    /// false-positive on those). Adds a report op on a real change, never silent; returns a non-null error to FAIL the
+    /// never rewrites the SNAM of a topic whose subtype the call didn't touch — the countless vanilla topics whose
+    /// DATA\Subtype is stale under the Dragonborn-era renumbering are read as the marker says and left alone (the
+    /// validator only WARNS on that disagreement, and only for a record a mod authored). Adds a report op on a real
+    /// change, never silent; returns a non-null error to FAIL the
     /// whole call on an unmodeled Subtype (never leave a mismatched/blank marker), else null. <paramref name="mod"/>
     /// is the mutable mod the overrides live in.</summary>
     static string? SyncEditedTopicMarkers(SkyrimMod mod, IReadOnlyList<PatchEdit> edits, List<OpResult> ops)

--- a/src/housecarl-mcp-tests/DialogueFamilyTests.cs
+++ b/src/housecarl-mcp-tests/DialogueFamilyTests.cs
@@ -295,6 +295,54 @@ public sealed class DialogueFamilyTests
         Assert.DoesNotContain("epoch=", Wire.RenderCheck(new CheckSweep(DialogueSel(), Dialogue: unseeded), 20000));
     }
 
+    // ---- Subtype vs SNAM (#660) -------------------------------------------------------------------------
+    // A topic whose numeric Subtype contradicts its SNAM marker is flagged, and both renders say the marker is
+    // the one to believe. A topic where the two agree says nothing.
+
+    [Fact]
+    public void ATopicWhoseSubtypeContradictsItsMarkerSaysTheMarkerWins()
+    {
+        var r = CheckDialogue(Svc, W.StaleSubtypeTopic);
+        var block = SeedBlock(r, Fid(W.StaleSubtypeTopic));
+
+        Assert.Contains("subtype=RechargeExit (stale)", block);
+        Assert.Contains("subtype_marker=HELO (authoritative)", block);
+        Assert.Contains("the MARKER is authoritative", block);
+        Assert.Contains("Treat this topic's subtype as Hello, not RechargeExit", block);
+    }
+
+    [Fact]
+    public void ATopicWhoseSubtypeMatchesItsMarkerIsNotFlagged()
+    {
+        var r = CheckDialogue(Svc, W.AgreeingSubtypeTopic);
+        var block = SeedBlock(r, Fid(W.AgreeingSubtypeTopic));
+
+        Assert.Contains("subtype=Hello", block);
+        Assert.DoesNotContain("(stale)", block);
+        Assert.DoesNotContain("authoritative", block);
+    }
+
+    /// <summary>The JSON transport carries the same verdict as a flag, so a consumer never parses it out of prose.</summary>
+    [Fact]
+    public void TheJsonSweepFlagsAStaleSubtype()
+    {
+        bool Stale(Mutagen.Bethesda.Plugins.FormKey topic)
+        {
+            var result = Svc.CheckDialogue(new[] { Fid(topic) }, 1000);
+            Assert.Null(result.Error);
+            var json = JsonDocument.Parse(JsonWire.RenderCheck(new CheckSweep(DialogueSel(), Dialogue: result), 20000));
+            var row = json.RootElement.GetProperty("families")
+                          .GetProperty(SweepFamilySelection.Token(SweepFamily.Dialogue))
+                          .GetProperty("seeds").EnumerateArray()
+                          .SelectMany(s => s.GetProperty("topics").EnumerateArray())
+                          .Single(t => t.GetProperty("topic").GetString() == topic.ToString());
+            return row.GetProperty("subtype_stale").GetBoolean();
+        }
+
+        Assert.True(Stale(W.StaleSubtypeTopic));
+        Assert.False(Stale(W.AgreeingSubtypeTopic));
+    }
+
     /// <summary>Everything AFTER the seed prefix the sweep echoes — the composed refusal itself. The sweep writes
     /// "{seed}: {refusal}.", and the seed is "&lt;id&gt;:&lt;definer&gt;", so a plugin name found anywhere in the
     /// whole response may be the seed's own echo rather than the failure's subject.</summary>

--- a/src/housecarl-mcp-tests/DialogueFamilyTests.cs
+++ b/src/housecarl-mcp-tests/DialogueFamilyTests.cs
@@ -343,6 +343,58 @@ public sealed class DialogueFamilyTests
         Assert.False(Stale(W.AgreeingSubtypeTopic));
     }
 
+    /// <summary>The JSON carries the marker-derived NAME too, so a consumer reading past a stale subtype never has to
+    /// re-implement the marker→name table.</summary>
+    [Fact]
+    public void TheJsonSweepNamesTheSubtypeTheMarkerGives()
+    {
+        var result = Svc.CheckDialogue(new[] { Fid(W.StaleSubtypeTopic) }, 1000);
+        Assert.Null(result.Error);
+        var json = JsonDocument.Parse(JsonWire.RenderCheck(new CheckSweep(DialogueSel(), Dialogue: result), 20000));
+        var row = json.RootElement.GetProperty("families")
+                      .GetProperty(SweepFamilySelection.Token(SweepFamily.Dialogue))
+                      .GetProperty("seeds").EnumerateArray()
+                      .SelectMany(s => s.GetProperty("topics").EnumerateArray())
+                      .Single(t => t.GetProperty("topic").GetString() == W.StaleSubtypeTopic.ToString());
+
+        Assert.Equal("RechargeExit", row.GetProperty("subtype").GetString());
+        Assert.Equal("Hello", row.GetProperty("subtype_from_marker").GetString());
+    }
+
+    /// <summary>The ownership gate (Aaron's ruling): the disagreement is a WARNING only on a record a mod defines or
+    /// overrides. A base master's own topic, touched by nothing, is Bethesda's stale number — labelled, never warned
+    /// about, so a whole-quest check over vanilla topics stays quiet.</summary>
+    [Fact]
+    public void AVanillaTopicNoPluginTouchesIsLabelledButNotWarnedAbout()
+    {
+        var block = SeedBlock(CheckDialogue(Svc, W.VanillaStaleTopic), Fid(W.VanillaStaleTopic));
+
+        Assert.Contains("subtype=RechargeExit (stale)", block);
+        Assert.Contains("subtype_marker=HELO (authoritative)", block);
+        Assert.DoesNotContain("the MARKER is authoritative", block);
+    }
+
+    /// <summary>…and the same vanilla topic DOES warn once a plugin overrides it, carrying the stale number forward.</summary>
+    [Fact]
+    public void AnOverrideCarryingAStaleSubtypeForwardIsWarnedAbout()
+    {
+        var block = SeedBlock(CheckDialogue(Svc, W.VanillaStaleOverriddenTopic), Fid(W.VanillaStaleOverriddenTopic));
+
+        Assert.Contains("the MARKER is authoritative", block);
+        Assert.Contains("Treat this topic's subtype as Hello, not RechargeExit", block);
+    }
+
+    /// <summary>A non-blank marker the table does not model is neither blank nor a disagreement — it must still be
+    /// named, not fall through both checks in silence.</summary>
+    [Fact]
+    public void AMarkerTheTableDoesNotModelIsNamed()
+    {
+        var block = SeedBlock(CheckDialogue(Svc, W.UnmodeledMarkerTopic), Fid(W.UnmodeledMarkerTopic));
+
+        Assert.Contains("is ZZZZ, which is not a marker houseCARL models", block);
+        Assert.Contains("never plays", block);
+    }
+
     /// <summary>Everything AFTER the seed prefix the sweep echoes — the composed refusal itself. The sweep writes
     /// "{seed}: {refusal}.", and the seed is "&lt;id&gt;:&lt;definer&gt;", so a plugin name found anywhere in the
     /// whole response may be the seed's own echo rather than the failure's subject.</summary>

--- a/src/housecarl-mcp-tests/DialogueFamilyTests.cs
+++ b/src/housecarl-mcp-tests/DialogueFamilyTests.cs
@@ -374,14 +374,63 @@ public sealed class DialogueFamilyTests
         Assert.DoesNotContain("the MARKER is authoritative", block);
     }
 
-    /// <summary>…and the same vanilla topic DOES warn once a plugin overrides it, carrying the stale number forward.</summary>
+    /// <summary>…and an override that copies that pair forward UNCHANGED stays quiet too: the override changed
+    /// neither field, so the stale number is still Bethesda's statement and still nothing the modder can act on.
+    /// The labels are ungated, so the render still says which field to believe.</summary>
     [Fact]
-    public void AnOverrideCarryingAStaleSubtypeForwardIsWarnedAbout()
+    public void AnOverrideInheritingAStaleSubtypeIsNotWarnedAbout()
     {
         var block = SeedBlock(CheckDialogue(Svc, W.VanillaStaleOverriddenTopic), Fid(W.VanillaStaleOverriddenTopic));
 
+        Assert.Contains("subtype=RechargeExit (stale)", block);
+        Assert.Contains("subtype_marker=HELO (authoritative)", block);
+        Assert.DoesNotContain("the MARKER is authoritative", block);
+    }
+
+    /// <summary>Force-loaded content is not the modder's either: a Creation Club plugin (in loadorder.txt, absent
+    /// from plugins.txt) authoring the contradicting pair itself is still passed over, because the gate is the
+    /// implicit group the load-order status shows, not the five base masters.</summary>
+    [Fact]
+    public void ACreationClubOverrideAuthoringTheMismatchIsNotWarnedAbout()
+    {
+        var block = SeedBlock(CheckDialogue(Svc, W.CcOverriddenTopic), Fid(W.CcOverriddenTopic));
+
+        Assert.Contains("subtype=Custom (stale)", block);
+        Assert.DoesNotContain("the MARKER is authoritative", block);
+    }
+
+    /// <summary>A gap the Dragonborn renumbering cannot explain is two fields edited apart, not an old file: the
+    /// warning says the Subtype edit does nothing in game and names the sync, rather than framing an authoring
+    /// error as benign vintage.</summary>
+    [Fact]
+    public void AMismatchWithoutTheRenumberingSignatureSaysTheSubtypeEditIsANoOp()
+    {
+        var block = SeedBlock(CheckDialogue(Svc, W.EditedApartSubtypeTopic), Fid(W.EditedApartSubtypeTopic));
+
         Assert.Contains("the MARKER is authoritative", block);
-        Assert.Contains("Treat this topic's subtype as Hello, not RechargeExit", block);
+        Assert.Contains("do NOT carry the Dragonborn-era renumbering signature", block);
+        Assert.Contains("in-game no-op", block);
+        Assert.Contains("sync SNAM to CUST", block);
+        Assert.DoesNotContain("not necessarily broken", block);
+    }
+
+    /// <summary>The one modeled row Mutagen's enum leaves unnamed (index 3, FVDL) is named by its MARKER, in the
+    /// prose and in the JSON — never handed back as an empty string.</summary>
+    [Fact]
+    public void TheMarkerNamesItselfWhereMutagensEnumHasNoNameForIt()
+    {
+        var result = Svc.CheckDialogue(new[] { Fid(W.FvdlMarkerTopic) }, 1000);
+        Assert.Null(result.Error);
+        Assert.Contains("buckets as FVDL", SeedBlock(
+            Wire.RenderCheck(new CheckSweep(DialogueSel(), Dialogue: result), 20000), Fid(W.FvdlMarkerTopic)));
+
+        var json = JsonDocument.Parse(JsonWire.RenderCheck(new CheckSweep(DialogueSel(), Dialogue: result), 20000));
+        var row = json.RootElement.GetProperty("families")
+                      .GetProperty(SweepFamilySelection.Token(SweepFamily.Dialogue))
+                      .GetProperty("seeds").EnumerateArray()
+                      .SelectMany(s => s.GetProperty("topics").EnumerateArray())
+                      .Single(t => t.GetProperty("topic").GetString() == W.FvdlMarkerTopic.ToString());
+        Assert.Equal("FVDL", row.GetProperty("subtype_from_marker").GetString());
     }
 
     /// <summary>A non-blank marker the table does not model is neither blank nor a disagreement — it must still be

--- a/src/housecarl-mcp-tests/DialogueWorld.cs
+++ b/src/housecarl-mcp-tests/DialogueWorld.cs
@@ -54,6 +54,13 @@ public sealed class DialogueWorld : IDisposable
     public FormKey BranchOk { get; }
     public FormKey QuestOk { get; }
 
+    /// <summary>The #660 shape: numeric Subtype = RechargeExit (73) beside SNAM = HELO (Hello, 79) — a topic
+    /// carrying the pre-Dragonborn numbering, six low. The marker is authoritative.</summary>
+    public FormKey StaleSubtypeTopic { get; }
+
+    /// <summary>The control: Subtype and SNAM naming the same subtype, so a topic that agrees is never labelled.</summary>
+    public FormKey AgreeingSubtypeTopic { get; }
+
     public DialogueWorld()
     {
         Root = Path.Combine(Path.GetTempPath(), "hc-dialogue-tests-" + Guid.NewGuid().ToString("N"));
@@ -72,6 +79,17 @@ public sealed class DialogueWorld : IDisposable
         var info = new FormKey[8];
         for (int i = 0; i < 8; i++) { var r = NewInfo($"HcDvLine{i}"); info[i] = r.FormKey; topic.Responses.Add(r); }
         Info = info;
+
+        // Subtype-vs-SNAM pair (#660): one topic carrying the pre-Dragonborn numbering (RechargeExit=73 under
+        // SNAM HELO, six low) and one where the two agree.
+        var stale = master.DialogTopics.AddNew(); stale.EditorID = "HcDvStaleSubtype";
+        stale.Subtype = DialogTopic.SubtypeEnum.RechargeExit;
+        stale.SubtypeName = new RecordType("HELO");
+        StaleSubtypeTopic = stale.FormKey;
+        var agree = master.DialogTopics.AddNew(); agree.EditorID = "HcDvAgreeingSubtype";
+        agree.Subtype = DialogTopic.SubtypeEnum.Hello;
+        agree.SubtypeName = new RecordType("HELO");
+        AgreeingSubtypeTopic = agree.FormKey;
 
         // CK-parity-complete seeds — the no-false-positive lock for V1 (a real authored view/branch/quest never
         // renders as a gap).

--- a/src/housecarl-mcp-tests/DialogueWorld.cs
+++ b/src/housecarl-mcp-tests/DialogueWorld.cs
@@ -10,7 +10,8 @@ namespace HousecarlMcpTests;
 /// <summary>
 /// The synthetic MO2 world the dialogue family's info-order and CK-parity facts are driven against.
 ///
-/// <para>Three plugins: <see cref="MasterName"/> (the topic + the CK-parity-complete view/branch/quest seeds),
+/// <para>Four plugins: <see cref="VanillaName"/> (a base master by filename, carrying the stale-subtype topics the
+/// SNAM ownership gate reads as "not the modder's"), <see cref="MasterName"/> (the topic + the CK-parity-complete view/branch/quest seeds),
 /// <see cref="MidName"/> (re-lists 6 of the topic's 8 INFOs, PNAM-chained, in reverse — moves nothing),
 /// <see cref="LastName"/> — the WINNER — (re-lists ONLY INFO 0 with no PNAM, which evicts it to the
 /// tail).</para>
@@ -29,6 +30,9 @@ namespace HousecarlMcpTests;
 /// </summary>
 public sealed class DialogueWorld : IDisposable
 {
+    /// <summary>A base master BY FILENAME — what <see cref="ErrorCheck.BaseMasters"/> matches on, so its own records
+    /// are the "vanilla, not the modder's" side of the SNAM ownership gate.</summary>
+    public const string VanillaName = "Skyrim.esm";
     public const string MasterName = "HcDvMaster.esp";
     public const string MidName = "HcDvMid.esp";
     public const string LastName = "HcDvLast.esp";
@@ -61,6 +65,18 @@ public sealed class DialogueWorld : IDisposable
     /// <summary>The control: Subtype and SNAM naming the same subtype, so a topic that agrees is never labelled.</summary>
     public FormKey AgreeingSubtypeTopic { get; }
 
+    /// <summary>The same stale shape in the base master <see cref="VanillaName"/>, touched by nothing — Bethesda's own
+    /// number, which the modder cannot act on, so the check stays quiet about it.</summary>
+    public FormKey VanillaStaleTopic { get; }
+
+    /// <summary>A stale base-master topic that <see cref="LastName"/> OVERRIDES, carrying the stale number forward —
+    /// now a record a mod authored, so the check warns.</summary>
+    public FormKey VanillaStaleOverriddenTopic { get; }
+
+    /// <summary>A topic whose SNAM is a non-blank marker the table does not model (<c>ZZZZ</c>) — neither blank nor a
+    /// disagreement, and silently unbucketed in game if nothing says so.</summary>
+    public FormKey UnmodeledMarkerTopic { get; }
+
     public DialogueWorld()
     {
         Root = Path.Combine(Path.GetTempPath(), "hc-dialogue-tests-" + Guid.NewGuid().ToString("N"));
@@ -69,6 +85,18 @@ public sealed class DialogueWorld : IDisposable
         var masterKey = ModKey.FromNameAndExtension(MasterName);
         var midKey = ModKey.FromNameAndExtension(MidName);
         var lastKey = ModKey.FromNameAndExtension(LastName);
+
+        // The base master, by filename: two topics carrying the pre-Dragonborn numbering, one of which LastMod
+        // overrides. Which side of the SNAM ownership gate a record falls on is decided by this filename.
+        var sky = new SkyrimMod(new ModKey("Skyrim", ModType.Master), SkyrimRelease.SkyrimSE);
+        var vanillaStale = sky.DialogTopics.AddNew(); vanillaStale.EditorID = "HcDvVanillaStale";
+        vanillaStale.Subtype = DialogTopic.SubtypeEnum.RechargeExit;
+        vanillaStale.SubtypeName = new RecordType("HELO");
+        VanillaStaleTopic = vanillaStale.FormKey;
+        var vanillaOver = sky.DialogTopics.AddNew(); vanillaOver.EditorID = "HcDvVanillaStaleOverridden";
+        vanillaOver.Subtype = DialogTopic.SubtypeEnum.RechargeExit;
+        vanillaOver.SubtypeName = new RecordType("HELO");
+        VanillaStaleOverriddenTopic = vanillaOver.FormKey;
 
         var master = new SkyrimMod(masterKey, SkyrimRelease.SkyrimSE);
 
@@ -90,6 +118,11 @@ public sealed class DialogueWorld : IDisposable
         agree.Subtype = DialogTopic.SubtypeEnum.Hello;
         agree.SubtypeName = new RecordType("HELO");
         AgreeingSubtypeTopic = agree.FormKey;
+        // A non-blank marker the table does not model — the silent-fallthrough case.
+        var unmodeled = master.DialogTopics.AddNew(); unmodeled.EditorID = "HcDvUnmodeledMarker";
+        unmodeled.Subtype = DialogTopic.SubtypeEnum.Hello;
+        unmodeled.SubtypeName = new RecordType("ZZZZ");
+        UnmodeledMarkerTopic = unmodeled.FormKey;
 
         // CK-parity-complete seeds — the no-false-positive lock for V1 (a real authored view/branch/quest never
         // renders as a gap).
@@ -103,12 +136,14 @@ public sealed class DialogueWorld : IDisposable
 
         Instance = Path.Combine(Root, "inst");
         var mods = Path.Combine(Instance, "mods");
+        Directory.CreateDirectory(Path.Combine(mods, "VanillaStub"));
         Directory.CreateDirectory(Path.Combine(mods, "MasterMod"));
         Directory.CreateDirectory(Path.Combine(mods, "MidMod"));
         Directory.CreateDirectory(Path.Combine(mods, "LastMod"));
         MasterPath = Path.Combine(mods, "MasterMod", MasterName);
         MidPath = Path.Combine(mods, "MidMod", MidName);
         LastPath = Path.Combine(mods, "LastMod", LastName);
+        sky.BeginWrite.ToPath(Path.Combine(mods, "VanillaStub", VanillaName)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
         master.BeginWrite.ToPath(MasterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
 
         // MID: re-lists INFOs 2..7, PNAM-chained, in REVERSE — moves nothing (a well-behaved patch).
@@ -128,16 +163,19 @@ public sealed class DialogueWorld : IDisposable
         var lastTopic = (IDialogTopic)WriteEngine.GenericGetOrAddAsOverride(last, topic);
         lastTopic.Responses.Clear();
         lastTopic.Responses.Add(new DialogResponses(info[0], SkyrimRelease.SkyrimSE) { EditorID = "HcDvLine0" });
-        last.BeginWrite.ToPath(LastPath).WithLoadOrder(new ISkyrimModGetter[] { master, mid }).Write();
+        // …and overrides one stale base-master topic, carrying the stale number forward: now a mod's own record.
+        WriteEngine.GenericGetOrAddAsOverride(last, vanillaOver);
+        last.BeginWrite.ToPath(LastPath).WithLoadOrder(new ISkyrimModGetter[] { sky, master, mid }).Write();
 
         File.WriteAllText(Path.Combine(Instance, "ModOrganizer.ini"),
             "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
             + Path.Combine(Root, "game").Replace(@"\", @"\\") + ")\r\n");
         var prof = Path.Combine(Instance, "profiles", "Default");
         Directory.CreateDirectory(prof);
-        File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + MasterName + "\r\n" + MidName + "\r\n" + LastName + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "loadorder.txt"),
+            "# header\r\n" + VanillaName + "\r\n" + MasterName + "\r\n" + MidName + "\r\n" + LastName + "\r\n");
         File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*" + MasterName + "\r\n*" + MidName + "\r\n*" + LastName + "\r\n");
-        File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n+LastMod\r\n+MidMod\r\n+MasterMod\r\n");
+        File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n+LastMod\r\n+MidMod\r\n+MasterMod\r\n+VanillaStub\r\n");
 
         var store = new UserConfigStore(Path.Combine(Root, "user.json"));
         Svc = LoadOrderService.WithInstance(Instance, 0, store);

--- a/src/housecarl-mcp-tests/DialogueWorld.cs
+++ b/src/housecarl-mcp-tests/DialogueWorld.cs
@@ -37,6 +37,10 @@ public sealed class DialogueWorld : IDisposable
     public const string MidName = "HcDvMid.esp";
     public const string LastName = "HcDvLast.esp";
 
+    /// <summary>Creation Club content: in loadorder.txt, absent from plugins.txt, so it is FORCE-LOADED — the
+    /// implicit group the load-order status shows, and content the modder no more authored than a base master's.</summary>
+    public const string CcName = "ccHcTest.esl";
+
     public string Root { get; }
     public string Instance { get; }
     public string MasterPath { get; }
@@ -69,9 +73,21 @@ public sealed class DialogueWorld : IDisposable
     /// number, which the modder cannot act on, so the check stays quiet about it.</summary>
     public FormKey VanillaStaleTopic { get; }
 
-    /// <summary>A stale base-master topic that <see cref="LastName"/> OVERRIDES, carrying the stale number forward —
-    /// now a record a mod authored, so the check warns.</summary>
+    /// <summary>A stale base-master topic that <see cref="LastName"/> OVERRIDES, carrying the base record's pair
+    /// forward UNCHANGED — Bethesda's number still, not the override's statement, so the check stays quiet.</summary>
     public FormKey VanillaStaleOverriddenTopic { get; }
+
+    /// <summary>A base-master topic whose pair AGREES, overridden by the force-loaded <see cref="CcName"/> with a
+    /// contradicting Subtype: a pair that plugin really did author, kept quiet only by who force-loads it.</summary>
+    public FormKey CcOverriddenTopic { get; }
+
+    /// <summary>Two fields edited apart, not an old file: Subtype=Custom (0) beside SNAM=HELO (79), a gap the
+    /// Dragonborn renumbering cannot explain. The Subtype edit is an in-game no-op until SNAM is synced.</summary>
+    public FormKey EditedApartSubtypeTopic { get; }
+
+    /// <summary>SNAM=FVDL — index 3, the one modeled row Mutagen's enum leaves unnamed — beside Subtype=Custom, so a
+    /// render has to name the subtype from the marker itself rather than hand back nothing.</summary>
+    public FormKey FvdlMarkerTopic { get; }
 
     /// <summary>A topic whose SNAM is a non-blank marker the table does not model (<c>ZZZZ</c>) — neither blank nor a
     /// disagreement, and silently unbucketed in game if nothing says so.</summary>
@@ -97,6 +113,11 @@ public sealed class DialogueWorld : IDisposable
         vanillaOver.Subtype = DialogTopic.SubtypeEnum.RechargeExit;
         vanillaOver.SubtypeName = new RecordType("HELO");
         VanillaStaleOverriddenTopic = vanillaOver.FormKey;
+        // …and one whose pair AGREES, for the Creation Club override to contradict on its own account.
+        var ccBase = sky.DialogTopics.AddNew(); ccBase.EditorID = "HcDvCcOverridden";
+        ccBase.Subtype = DialogTopic.SubtypeEnum.Hello;
+        ccBase.SubtypeName = new RecordType("HELO");
+        CcOverriddenTopic = ccBase.FormKey;
 
         var master = new SkyrimMod(masterKey, SkyrimRelease.SkyrimSE);
 
@@ -118,6 +139,16 @@ public sealed class DialogueWorld : IDisposable
         agree.Subtype = DialogTopic.SubtypeEnum.Hello;
         agree.SubtypeName = new RecordType("HELO");
         AgreeingSubtypeTopic = agree.FormKey;
+        // Two fields edited apart: Custom (0) beside HELO (79) is a gap no renumbering explains.
+        var apart = master.DialogTopics.AddNew(); apart.EditorID = "HcDvEditedApart";
+        apart.Subtype = DialogTopic.SubtypeEnum.Custom;
+        apart.SubtypeName = new RecordType("HELO");
+        EditedApartSubtypeTopic = apart.FormKey;
+        // The row Mutagen's enum omits (index 3) — the marker is the only name there is.
+        var fvdl = master.DialogTopics.AddNew(); fvdl.EditorID = "HcDvFvdlMarker";
+        fvdl.Subtype = DialogTopic.SubtypeEnum.Custom;
+        fvdl.SubtypeName = new RecordType("FVDL");
+        FvdlMarkerTopic = fvdl.FormKey;
         // A non-blank marker the table does not model — the silent-fallthrough case.
         var unmodeled = master.DialogTopics.AddNew(); unmodeled.EditorID = "HcDvUnmodeledMarker";
         unmodeled.Subtype = DialogTopic.SubtypeEnum.Hello;
@@ -167,15 +198,26 @@ public sealed class DialogueWorld : IDisposable
         WriteEngine.GenericGetOrAddAsOverride(last, vanillaOver);
         last.BeginWrite.ToPath(LastPath).WithLoadOrder(new ISkyrimModGetter[] { sky, master, mid }).Write();
 
+        // CC (force-loaded, and the winner of its topic): overrides an AGREEING base topic with a contradicting
+        // Subtype, so the pair is this plugin's own — only who force-loads it keeps the check quiet.
+        var cc = new SkyrimMod(ModKey.FromNameAndExtension(CcName), SkyrimRelease.SkyrimSE);
+        var ccTopic = (IDialogTopic)WriteEngine.GenericGetOrAddAsOverride(cc, ccBase);
+        ccTopic.Subtype = DialogTopic.SubtypeEnum.Custom;
+        Directory.CreateDirectory(Path.Combine(mods, "CcMod"));
+        cc.BeginWrite.ToPath(Path.Combine(mods, "CcMod", CcName))
+          .WithLoadOrder(new ISkyrimModGetter[] { sky, master, mid, last }).Write();
+
         File.WriteAllText(Path.Combine(Instance, "ModOrganizer.ini"),
             "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
             + Path.Combine(Root, "game").Replace(@"\", @"\\") + ")\r\n");
         var prof = Path.Combine(Instance, "profiles", "Default");
         Directory.CreateDirectory(prof);
         File.WriteAllText(Path.Combine(prof, "loadorder.txt"),
-            "# header\r\n" + VanillaName + "\r\n" + MasterName + "\r\n" + MidName + "\r\n" + LastName + "\r\n");
+            "# header\r\n" + VanillaName + "\r\n" + MasterName + "\r\n" + MidName + "\r\n" + LastName + "\r\n"
+            + CcName + "\r\n");
+        // Neither the base master nor the CC plugin is listed here — that absence is what makes them force-loaded.
         File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*" + MasterName + "\r\n*" + MidName + "\r\n*" + LastName + "\r\n");
-        File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n+LastMod\r\n+MidMod\r\n+MasterMod\r\n+VanillaStub\r\n");
+        File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n+CcMod\r\n+LastMod\r\n+MidMod\r\n+MasterMod\r\n+VanillaStub\r\n");
 
         var store = new UserConfigStore(Path.Combine(Root, "user.json"));
         Svc = LoadOrderService.WithInstance(Instance, 0, store);

--- a/src/housecarl-mcp/DialogueSweepRender.cs
+++ b/src/housecarl-mcp/DialogueSweepRender.cs
@@ -298,6 +298,9 @@ internal static class DialogueSweepRender
         // The marker is authoritative when the two disagree — the engine buckets by SNAM and the numeric subtype goes
         // stale on pre-Dragonborn topics. Emitted always so a consumer never has to infer it from the issues text.
         w.WriteBoolean("subtype_stale", t.SubtypeDisagreesWithMarker);
+        // The marker-derived name beside the flag, so JSON carries the same verdict the text render spells out and no
+        // consumer re-implements the marker→name table. "" when the marker is blank or unmodeled.
+        w.WriteString("subtype_from_marker", t.SubtypeFromMarker);
         WriteIssues(w, "issues", t.Issues);
         w.WriteStartArray("silent_lines");
         foreach (var l in t.VoiceLines)

--- a/src/housecarl-mcp/DialogueSweepRender.cs
+++ b/src/housecarl-mcp/DialogueSweepRender.cs
@@ -295,6 +295,9 @@ internal static class DialogueSweepRender
         w.WriteString("category", t.Category);
         w.WriteString("subtype", t.Subtype);
         w.WriteString("subtype_marker", t.SubtypeName);
+        // The marker is authoritative when the two disagree — the engine buckets by SNAM and the numeric subtype goes
+        // stale on pre-Dragonborn topics. Emitted always so a consumer never has to infer it from the issues text.
+        w.WriteBoolean("subtype_stale", t.SubtypeDisagreesWithMarker);
         WriteIssues(w, "issues", t.Issues);
         w.WriteStartArray("silent_lines");
         foreach (var l in t.VoiceLines)

--- a/src/housecarl-mcp/DialogueTools.cs
+++ b/src/housecarl-mcp/DialogueTools.cs
@@ -38,8 +38,12 @@ internal static class DialogueWire
         if (t.ConditionedInfoCount > 0) sb.Append("; ").Append(t.ConditionedInfoCount).Append(" carry conditions (CTDA)");
         if (t.DeletedInfoCount > 0) sb.Append("; ").Append(t.DeletedInfoCount).Append(" deleted line(s) skipped");
         sb.Append('\n');
+        // When the numeric subtype and the SNAM marker disagree, say which one to believe: the engine buckets topics
+        // by the marker, and the number goes stale on pre-Dragonborn topics (DialogueSubtype.MarkerDisagreesWithSubtype).
         sb.Append(pad).Append("  category=").Append(t.Category).Append("  subtype=").Append(t.Subtype)
-          .Append("  subtype_marker=").Append(t.SubtypeName).Append('\n');
+          .Append(t.SubtypeDisagreesWithMarker ? " (stale)" : "")
+          .Append("  subtype_marker=").Append(t.SubtypeName)
+          .Append(t.SubtypeDisagreesWithMarker ? " (authoritative)" : "").Append('\n');
 
         // Whether a Papyrus.log entry is even possible for a line: a result-script fragment runs code that can surface
         // in the log, while a plain voiced line has no code path. Always shown for a topic with live INFOs.

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2325,7 +2325,18 @@ public sealed class LoadOrderService : IDisposable
     /// a verify step: a mid-run resolve or asset failure rides
     /// <see cref="DialogueValidationReport.CheckError"/>, and a not-in-order or wrong-type input is a named
     /// <see cref="DialogueValidationReport.Error"/>.</summary>
-    public DialogueValidationReport ValidateDialogue(FormKey fk) => DialogueValidate.Run(Resolver, Assets, fk);
+    public DialogueValidationReport ValidateDialogue(FormKey fk)
+        => DialogueValidate.Run(Resolver, Assets, fk, null, ForceLoadedPluginNames());
+
+    /// <summary>The force-loaded plugin names — base masters aside, the Creation Club and <c>_ResourcePack.esl</c>
+    /// plugins the load-order status groups as implicit — for a check that must not blame a modder for content they
+    /// did not author. Null, never an empty set, when the MO2 profile cannot be read: a check told "nothing is
+    /// force-loaded" would warn on that content, and the caller says which way it then errs.</summary>
+    IReadOnlyCollection<string>? ForceLoadedPluginNames()
+    {
+        var (names, err) = ImplicitPluginNames();
+        return err is null ? names : null;
+    }
 
     /// <summary>The merged <c>check</c> surface's dialogue family: <see cref="ValidateDialogue"/> over a seed list,
     /// tallied for one section of a merged response. Deliberately thin — the family's own grammar (seed parse,
@@ -2346,7 +2357,10 @@ public sealed class LoadOrderService : IDisposable
             var view = resolver.Capture();
             // The seed door is pinned to that same view: a door of its own would capture a second build on the first
             // runtime FormID, so the seeds could name records from a build other than the one the response stamps.
-            return new DialogueSweep.Binding(fk => DialogueValidate.Run(resolver, assets, fk, view),
+            // Read once for the whole sweep, for the same reason the resolver and view are: every seed's ownership
+            // gate reads one composition, so one response cannot mix two answers to "who force-loads this".
+            var forceLoaded = ForceLoadedPluginNames();
+            return new DialogueSweep.Binding(fk => DialogueValidate.Run(resolver, assets, fk, view, forceLoaded),
                                              FormIdDoor.On(view).Parse, view.Epoch);
         }, seeds, limit, countsOnly);
 


### PR DESCRIPTION
A DIAL carries its subtype twice: the numeric DATA subtype field and the 4-char SNAM marker. SNAM is authoritative — the engine buckets topics by it — and the number is stale on any topic authored before the Dragonborn-era Creation Kit inserted six `FlyingMount*` values at index 20, so a vanilla `HELO` topic reads back as `RechargeExit`. Nothing on the record distinguishes the two numberings (form version does not: Dragonborn.esm mixes both at FormVersion 43), so this is reported, never rewritten. The dialogue check now warns when the two disagree, naming the marker as the one to believe and the renumbering as the cause; both renders label the pair (`subtype=... (stale)` / `subtype_marker=... (authoritative)` in text, `subtype_stale` in JSON); and the blank-SNAM advice, which derives its recommended marker from that same unreliable field, now says so and points at the base record's marker. The generic `project=fields` render is untouched — a per-record special case there is the hand-written coverage the cornerstones forbid.

Covered by three tests on the dialogue world, which gains a topic with the #660 shape (Subtype=RechargeExit under SNAM=HELO) and an agreeing control: the warning and the text labels, the no-false-positive control, and the JSON flag.

Part of #660. The upstream half — teaching Mutagen to derive `Subtype` from SNAM, or expose a resolved one (Mutagen-Modding/Mutagen#590) — is separate and stays open; this is the houseCARL-side mitigation and does not depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)