### PR TITLE
Record why QuestFormVersion 255 stays on a new quest

### DIFF
--- a/src/housecarl-core/DialogueCkParity.cs
+++ b/src/housecarl-core/DialogueCkParity.cs
@@ -58,6 +58,14 @@ namespace HousecarlCore;
 //  struct this fills. Materialising Flags to all-zero does NOT set Goodbye — a conversation-ending line still
 //  needs Flags.Flags = Goodbye set explicitly (that's an authoring choice, not a CK-parity default). The
 //  dialogue-authoring skill carries that semantic.
+//
+//  QUST QuestFormVersion (DNAM byte 3) is NOT a parity field and must not be added here (measured for #661).
+//  Mutagen defaults it to 255 (0xFF), which is what a new QUST written here carries — and 255 is what the CK
+//  itself writes on a NEW quest: 793 of the 817 quests DEFINED IN six CK-authored mods carry 255, and
+//  LegacyoftheDragonborn/Wyrmstooth/ccbgssse003-zombies are 366 for 366. Vanilla Skyrim.esm writes 0, not 65
+//  (1,697 of 1,811; the other 114 carry uninitialised junk — 25, 101, 108, 111, 204). 65 shows up mostly where
+//  the CK RE-SAVES an existing quest (USSEP: 517 of the 653 it touches). xEdit declares the byte
+//  wbInteger('Form Version', itU8, nil, cpIgnore) — cpIgnore, excluded from conflict detection outright.
 // ======================================================================
 
 /// <summary>One CK-parity field that was default-populated on create: a human-readable <see cref="Label"/> (the


### PR DESCRIPTION
#661 asks for `housecarl_create` to write QuestFormVersion 65 on a new QUST instead of 255, on the premise that 65 is what vanilla quests and the Creation Kit carry. Measured against a live 1,400-plugin load order, that premise does not hold, so the code is unchanged and the measurement is written down instead. Vanilla Skyrim.esm writes 0, not 65: 1,697 of its 1,811 quests carry 0, and the other 114 carry uninitialised junk (25, 101, 108, 111, 204). For a NEW quest the Creation Kit writes 255, which is exactly what houseCARL writes today: 793 of the 817 quests defined in six CK-authored mods carry 255, and Legacy of the Dragonborn, Wyrmstooth and ccbgssse003-zombies are 366 for 366. 65 turns up mostly where the CK re-saves a quest that already existed (USSEP carries it on 517 of the 653 quests it touches, over vanilla originals that carry 0). Mutagen's own `Quest.QuestFormVersion` default is 255, and xEdit declares the byte `wbInteger('Form Version', itU8, nil, cpIgnore)` -- cpIgnore, excluded from conflict detection outright. Writing 65 would replace the value the CK writes with one it does not, on a field xEdit tells everyone to ignore.

Nothing in the create path (or copy, or forward) sets this field, so all three lanes already agree: create takes Mutagen's 255, copy and forward carry the source's value through. No test comes with this -- there is no fix for one to fail before, and standards/TESTING.md says a test that cannot fail is not a test. No changelog line either: no user-visible behaviour changed. What lands is a note in the header of `DialogueCkParity.cs`, the file that lists every QUST field houseCARL default-populates for CK parity, saying why QuestFormVersion is not one of them and carrying the numbers -- so the next reader does not add it on the same premise.

Closes #661
