### PR TITLE
Type-check a FormLink target at apply pre-flight

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -26,11 +26,6 @@ saying it sets an expectation their install may contradict. Say what is known, a
   header says how many of its INIs matched and were expanded, so the header describes the listing under it. The cut
   notice no longer tells a caller who passed `filter=` to pass `filter=`. A blank or whitespace `filter=` is treated
   as no filter at every site, so it gives the overview instead of expanding every INI in the layer.
-- **`housecarl_apply` now refuses a FormLink pointed at a record of the wrong type.** Pre-flight checked that a
-  link value parsed as a FormID and nothing more, so setting an armor's `Race` to a keyword was accepted and wrote
-  a plugin that is valid on disk and wrong in game. The gate now resolves the FormID and compares that record's
-  type against the link's own target, naming the field, the type given and the types allowed. A field whose link
-  accepts any record, a null-clear, and a FormID no plugin in the order defines are not refused.
 - **`housecarl_apply` and `housecarl_create` now refuse a FormLink pointed at a record of the wrong type.**
   Pre-flight checked that a link value parsed as a FormID and nothing more, so setting an armor's `Race` to a
   keyword was accepted and wrote a plugin that is valid on disk and wrong in game. The gate now resolves the FormID

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -26,6 +26,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
   header says how many of its INIs matched and were expanded, so the header describes the listing under it. The cut
   notice no longer tells a caller who passed `filter=` to pass `filter=`. A blank or whitespace `filter=` is treated
   as no filter at every site, so it gives the overview instead of expanding every INI in the layer.
+- **`housecarl_apply` now refuses a FormLink pointed at a record of the wrong type.** Pre-flight checked that a
+  link value parsed as a FormID and nothing more, so setting an armor's `Race` to a keyword was accepted and wrote
+  a plugin that is valid on disk and wrong in game. The gate now resolves the FormID and compares that record's
+  type against the link's own target, naming the field, the type given and the types allowed. A field whose link
+  accepts any record, a null-clear, and a FormID no plugin in the order defines are not refused.
+
 - **`open-animation-replacer` now states how a DAR `_conditions.txt` chain binds, and that the DAR weapon-type
   numbers convert unchanged.** Both were marked unverified in its reference, and the skill told you to convert
   under one reading and say which. Both are now read off OAR's own source; the reference's §8 carries the rule,

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -31,6 +31,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
   a plugin that is valid on disk and wrong in game. The gate now resolves the FormID and compares that record's
   type against the link's own target, naming the field, the type given and the types allowed. A field whose link
   accepts any record, a null-clear, and a FormID no plugin in the order defines are not refused.
+- **`housecarl_apply` and `housecarl_create` now refuse a FormLink pointed at a record of the wrong type.**
+  Pre-flight checked that a link value parsed as a FormID and nothing more, so setting an armor's `Race` to a
+  keyword was accepted and wrote a plugin that is valid on disk and wrong in game. The gate now resolves the FormID
+  and compares that record's type against the link's own target, naming the field, the type given and the types
+  allowed. A field whose link accepts any record, a null-clear, a FormID no plugin in the order defines, and
+  removing a link already in a list are not refused.
 
 - **`open-animation-replacer` now states how a DAR `_conditions.txt` chain binds, and that the DAR weapon-type
   numbers convert unchanged.** Both were marked unverified in its reference, and the skill told you to convert

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -47,10 +47,20 @@ public sealed class CorpusRulebook
     readonly Corpus _corpus;
     /// <summary>Non-null only on a validate call the write path handed a load order to resolve link targets against.</summary>
     readonly LinkTargetLookup? _linkTargets;
-    /// <summary>Memo for the printed legal-type list, per link target type; only a refusal fills it.</summary>
+    /// <summary>Memo for the printed legal-type list, per link target type; only a refusal fills it. Real because a
+    /// write lane derives ONE link-target rulebook per call (<see cref="WithLinkTargets"/>) and validates every edit
+    /// through it, so a 200-op apply that names the same wrong target 200 times scans the corpus once. Unlocked: the
+    /// derived rulebook is a per-call object used on the calling thread, and the shared schema-only rulebook never
+    /// fills this (a refusal needs <see cref="_linkTargets"/>).</summary>
     readonly Dictionary<string, string> _linkTargetNames = new(StringComparer.Ordinal);
     CorpusRulebook(Corpus corpus, LinkTargetLookup? linkTargets = null)
         => (_corpus, _linkTargets) = (corpus, linkTargets);
+
+    /// <summary>This rulebook plus a load-order link-target resolver: the same corpus, with the FormLink TARGET TYPE
+    /// check turned on. Derived ONCE per write call, not per edit — the lookup rides on the rulebook rather than
+    /// through the recursion, so every value slot (a singular Set, a list element, a composed struct's field) sees it
+    /// without a parameter at each hop, and the memo above spans the whole call.</summary>
+    public CorpusRulebook WithLinkTargets(LinkTargetLookup linkTargets) => new(_corpus, linkTargets);
 
     /// <summary>Resolves a FormLink value (a FormID token) to the runtime type of the record it points at, or null
     /// when nothing in the load order carries it. Supplied by the write path, which holds the captured view; without
@@ -142,15 +152,11 @@ public sealed class CorpusRulebook
     /// resolves post-allocation. The set threads into composed StructSpec Fields/Sets too. Null (the override/set_field
     /// path) ⇒ an <c>@editorid</c> value is rejected loud — it has no meaning when there are no same-call
     /// creations.
-    /// <para><paramref name="linkTargets"/> (the write path, which has the load order) turns on the FormLink TARGET
-    /// TYPE check: a link whose FormID resolves to a record the field cannot point at is refused. It is carried on a
-    /// per-call copy of the rulebook rather than threaded through the recursion, so every value slot — a singular
-    /// Set, a list element, a composed struct's field — sees it without a parameter at each hop.</para></summary>
-    public string? Validate(WriteRequest req, IReadOnlyCollection<string>? siblingEditorIds = null,
-        LinkTargetLookup? linkTargets = null)
+    /// <para>The FormLink TARGET TYPE check — a link whose FormID resolves to a record the field cannot point at is
+    /// refused — runs only on a rulebook derived by <see cref="WithLinkTargets"/>, which the write path (the one with
+    /// a load order) builds once per call.</para></summary>
+    public string? Validate(WriteRequest req, IReadOnlyCollection<string>? siblingEditorIds = null)
     {
-        if (linkTargets is not null && !ReferenceEquals(linkTargets, _linkTargets))
-            return new CorpusRulebook(_corpus, linkTargets).Validate(req, siblingEditorIds);
         // (1) resolve the record, then validate rooted at it. ValidateFromType is shared with StructSpec validation
         // (a build-from-parts spec's nested writes) so the record path and the composition path can never disagree.
         var recType = Type(req.RecordType);
@@ -1145,26 +1151,23 @@ public sealed class CorpusRulebook
     /// or non-record link).</summary>
     string AllowedLinkTypes(FieldSchema leaf, Type target, string aq)
     {
-        lock (_linkTargetNames)
+        if (_linkTargetNames.TryGetValue(aq, out var cached)) return cached;
+        var names = new List<string>();
+        foreach (var ts in _corpus.Types.Values)
+            if (ts.Kind == "record" && WriteEngine.ResolveType(ts.GetterInterfaceAssemblyQualified) is { } gi
+                && target.IsAssignableFrom(gi))
+                names.Add(ts.Name);
+        names.Sort(StringComparer.Ordinal);
+        var bare = RecordNaming.StripInterfaceToConcrete(leaf.FormLinkTarget ?? target.Name);
+        const int cap = 12;
+        var phrase = names.Count switch
         {
-            if (_linkTargetNames.TryGetValue(aq, out var cached)) return cached;
-            var names = new List<string>();
-            foreach (var ts in _corpus.Types.Values)
-                if (ts.Kind == "record" && WriteEngine.ResolveType(ts.GetterInterfaceAssemblyQualified) is { } gi
-                    && target.IsAssignableFrom(gi))
-                    names.Add(ts.Name);
-            names.Sort(StringComparer.Ordinal);
-            var bare = RecordNaming.StripInterfaceToConcrete(leaf.FormLinkTarget ?? target.Name);
-            const int cap = 12;
-            var phrase = names.Count switch
-            {
-                0 => bare,
-                1 => names[0],
-                _ when names.Count <= cap => "one of: " + string.Join(", ", names),
-                _ => $"any {bare} record ({names.Count} record types qualify)",
-            };
-            return _linkTargetNames[aq] = phrase;
-        }
+            0 => bare,
+            1 => names[0],
+            _ when names.Count <= cap => "one of: " + string.Join(", ", names),
+            _ => $"any {bare} record ({names.Count} record types qualify)",
+        };
+        return _linkTargetNames[aq] = phrase;
     }
 
     /// <summary>The loud per-element rejection for a malformed FormLink collection ELEMENT — the SAME legal-set copy

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -45,7 +45,17 @@ public sealed class StructSpec
 public sealed class CorpusRulebook
 {
     readonly Corpus _corpus;
-    CorpusRulebook(Corpus corpus) => _corpus = corpus;
+    /// <summary>Non-null only on a validate call the write path handed a load order to resolve link targets against.</summary>
+    readonly LinkTargetLookup? _linkTargets;
+    /// <summary>Memo for the printed legal-type list, per link target type; only a refusal fills it.</summary>
+    readonly Dictionary<string, string> _linkTargetNames = new(StringComparer.Ordinal);
+    CorpusRulebook(Corpus corpus, LinkTargetLookup? linkTargets = null)
+        => (_corpus, _linkTargets) = (corpus, linkTargets);
+
+    /// <summary>Resolves a FormLink value (a FormID token) to the runtime type of the record it points at, or null
+    /// when nothing in the load order carries it. Supplied by the write path, which holds the captured view; without
+    /// one the schema-only rulebook cannot know what a FormID points at, so the link TYPE check does not run.</summary>
+    public delegate Type? LinkTargetLookup(string formIdToken);
 
     /// <summary>The legal shapes of a condition FormLinkOrIndex target value — shared by the nested-sets
     /// (<see cref="ValidateFromType"/>) and the flat-fields (<see cref="CheckValue"/>) rejects so the two compose entry
@@ -131,9 +141,16 @@ public sealed class CorpusRulebook
     /// quest): a FormLink value of the form <c>@editorid</c> in that set is accepted as a forward-ref the create path
     /// resolves post-allocation. The set threads into composed StructSpec Fields/Sets too. Null (the override/set_field
     /// path) ⇒ an <c>@editorid</c> value is rejected loud — it has no meaning when there are no same-call
-    /// creations.</summary>
-    public string? Validate(WriteRequest req, IReadOnlyCollection<string>? siblingEditorIds = null)
+    /// creations.
+    /// <para><paramref name="linkTargets"/> (the write path, which has the load order) turns on the FormLink TARGET
+    /// TYPE check: a link whose FormID resolves to a record the field cannot point at is refused. It is carried on a
+    /// per-call copy of the rulebook rather than threaded through the recursion, so every value slot — a singular
+    /// Set, a list element, a composed struct's field — sees it without a parameter at each hop.</para></summary>
+    public string? Validate(WriteRequest req, IReadOnlyCollection<string>? siblingEditorIds = null,
+        LinkTargetLookup? linkTargets = null)
     {
+        if (linkTargets is not null && !ReferenceEquals(linkTargets, _linkTargets))
+            return new CorpusRulebook(_corpus, linkTargets).Validate(req, siblingEditorIds);
         // (1) resolve the record, then validate rooted at it. ValidateFromType is shared with StructSpec validation
         // (a build-from-parts spec's nested writes) so the record path and the composition path can never disagree.
         var recType = Type(req.RecordType);
@@ -680,6 +697,7 @@ public sealed class CorpusRulebook
                                "declare it before the record that references it (in spec order).";
                 }
                 else if (!WriteEngine.IsValidFormLinkValue(v)) return FormLinkElementReject(v, leaf);
+                else if (LinkTypeRefusal(leaf, v, "element") is { } mixedTypeErr) return mixedTypeErr;
             }
             return null;
         }
@@ -765,7 +783,8 @@ public sealed class CorpusRulebook
                 // apply. A null-synonym clears the link; otherwise it must parse as a FormKey. The recognizer is
                 // SHARED with the engine apply path (no drift).
                 if (leaf.Cardinality == "formlink")
-                    return WriteEngine.IsValidFormLinkValue(req.Value) ? null
+                    return WriteEngine.IsValidFormLinkValue(req.Value)
+                        ? LinkTypeRefusal(leaf, req.Value, "target")
                         : $"Illegal FormLink target '{req.Value}' for '{leaf.Name}': expected a FormID " +
                           "(XXXXXX:Plugin.esp) or a null-clear ('0', '00000000', 'Null', '000000:Null').";
                 return CoercibilityReject(leaf);
@@ -825,6 +844,12 @@ public sealed class CorpusRulebook
                 if (!WriteEngine.IsValidFormLinkValue(v)) return FormLinkElementReject(v, leaf);
             foreach (var kv in req.Entries ?? new())
                 if (!WriteEngine.IsValidFormLinkValue(kv.Value)) return FormLinkElementReject(kv.Value, leaf);
+            // …and the TYPE of every element whose shape just passed, by the same slot-faithful sweep.
+            if (LinkTypeRefusal(leaf, req.Value, "element") is { } elemTypeErr) return elemTypeErr;
+            foreach (var v in req.Values ?? Array.Empty<string>())
+                if (LinkTypeRefusal(leaf, v, "element") is { } valsTypeErr) return valsTypeErr;
+            foreach (var kv in req.Entries ?? new())
+                if (LinkTypeRefusal(leaf, kv.Value, "element") is { } entTypeErr) return entTypeErr;
         }
         // NON-FORMLINK coercible-element collection value-SHAPE — the value twin of the formlink block above and of the
         // dict-Set value block (which gates dict Set's value but not the other collection verbs). A list Add/SetAtIndex/
@@ -1047,6 +1072,8 @@ public sealed class CorpusRulebook
             }
             if (CheckValue(af.Type, f.Value, $"'{f.Key}' on '{spec.Type}'",
                     af.MutableTypeAssemblyQualified ?? af.GetterTypeAssemblyQualified) is { } e) return e;
+            // A composed field is a link slot like any other — a leveled-list entry's Reference is set here, not at a leaf.
+            if (af.Cardinality == "formlink" && LinkTypeRefusal(af, f.Value, "target") is { } linkErr) return linkErr;
         }
         // With no ctor_args the type still has to be BUILDABLE: either it has a parameterless constructor, or the
         // fields just checked satisfy one of its constructors (a discriminator arm). WriteEngine.TryRecognizeInstantiable
@@ -1077,6 +1104,65 @@ public sealed class CorpusRulebook
                    "navigate into it and Set a sub-field.";
         return $"'{leaf.Name}' ({leaf.Type}) needs a typed-value spec, not a plain value (e.g. a condition " +
                "FormLinkOrIndex target). Known deferred surface — surfaced, never silently accepted.";
+    }
+
+    // ---- FormLink TARGET TYPE ---------------------------------------------------------------------------------
+    //  The value-SHAPE checks above prove a FormID parses; they say nothing about WHAT it points at. A link set to a
+    //  record of the wrong type serializes fine and is wrong in game — the silent failure this gate closes. The
+    //  allowed set is not written down anywhere: the generator stamps every formlink field with its Mutagen link
+    //  target interface (FormLinkTargetAssemblyQualified), so "is this record allowed here" is one IsAssignableFrom
+    //  against the resolved record's own runtime type, and the printed legal names are the corpus record types that
+    //  satisfy the same interface. A field whose link accepts any record (IMajorRecordGetter and friends) admits
+    //  everything by construction, so it is never refused. An unresolvable FormID is not type-checked: the order
+    //  cannot say what it is, and a link to a record that is not present is the dangling-reference check's business.
+
+    /// <summary>The refusal when a FormLink value points at a record type the field cannot link to, else null.
+    /// <paramref name="slot"/> reads "target" for a singular link and "element" for a collection one.</summary>
+    string? LinkTypeRefusal(FieldSchema leaf, string? value, string slot)
+    {
+        if (_linkTargets is null || value is null) return null;
+        if (WriteEngine.IsFormKeyNullSynonym(value)) return null;              // a clear points at nothing
+        if (leaf.FormLinkTargetAssemblyQualified is not { } aq) return null;
+        if (WriteEngine.ResolveType(aq) is not { } target) return null;
+        if (_linkTargets(value) is not { } actual) return null;                // the order cannot say — never a guess
+        if (target.IsAssignableFrom(actual)) return null;
+        return $"Illegal FormLink {slot} '{value}' for '{leaf.Name}': that record is a " +
+               $"{RecordNaming.StripOverlay(actual.Name)}, but '{leaf.Name}' links to {AllowedLinkTypes(leaf, target, aq)}.";
+    }
+
+    /// <summary>The record types the corpus says satisfy a link target interface, as one printed phrase. Capped, so
+    /// a wide base does not answer with a hundred names; falls back to the interface's own bare name where no
+    /// modeled record satisfies it (an owned-child or non-record link).</summary>
+    string AllowedLinkTypes(FieldSchema leaf, Type target, string aq)
+    {
+        lock (_linkTargetNames)
+        {
+            if (_linkTargetNames.TryGetValue(aq, out var cached)) return cached;
+            var names = new List<string>();
+            foreach (var ts in _corpus.Types.Values)
+                if (ts.Kind == "record" && WriteEngine.ResolveType(ts.GetterInterfaceAssemblyQualified) is { } gi
+                    && target.IsAssignableFrom(gi))
+                    names.Add(ts.Name);
+            names.Sort(StringComparer.Ordinal);
+            const int cap = 12;
+            var phrase = names.Count switch
+            {
+                0 => BareTargetName(leaf.FormLinkTarget ?? target.Name),
+                1 => names[0],
+                _ when names.Count <= cap => "one of: " + string.Join(", ", names),
+                _ => $"one of {names.Count} types: " + string.Join(", ", names.Take(cap)) + ", …",
+            };
+            return _linkTargetNames[aq] = phrase;
+        }
+    }
+
+    /// <summary>A Mutagen getter interface name as the record name it stands for: IRaceGetter -> Race.</summary>
+    static string BareTargetName(string interfaceName)
+    {
+        var n = interfaceName;
+        if (n.Length > 1 && n[0] == 'I' && char.IsUpper(n[1])) n = n[1..];
+        if (n.EndsWith("Getter", StringComparison.Ordinal)) n = n[..^"Getter".Length];
+        return n;
     }
 
     /// <summary>The loud per-element rejection for a malformed FormLink collection ELEMENT — the SAME legal-set copy

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -697,6 +697,8 @@ public sealed class CorpusRulebook
                                "declare it before the record that references it (in spec order).";
                 }
                 else if (!WriteEngine.IsValidFormLinkValue(v)) return FormLinkElementReject(v, leaf);
+                // A literal FormID mixed in beside the siblings: the create lane hands the same lookup the apply
+                // lanes do, so it is type-checked here. A sibling is not — its record does not exist yet.
                 else if (LinkTypeRefusal(leaf, v, "element") is { } mixedTypeErr) return mixedTypeErr;
             }
             return null;
@@ -844,12 +846,18 @@ public sealed class CorpusRulebook
                 if (!WriteEngine.IsValidFormLinkValue(v)) return FormLinkElementReject(v, leaf);
             foreach (var kv in req.Entries ?? new())
                 if (!WriteEngine.IsValidFormLinkValue(kv.Value)) return FormLinkElementReject(kv.Value, leaf);
-            // …and the TYPE of every element whose shape just passed, by the same slot-faithful sweep.
-            if (LinkTypeRefusal(leaf, req.Value, "element") is { } elemTypeErr) return elemTypeErr;
-            foreach (var v in req.Values ?? Array.Empty<string>())
-                if (LinkTypeRefusal(leaf, v, "element") is { } valsTypeErr) return valsTypeErr;
-            foreach (var kv in req.Entries ?? new())
-                if (LinkTypeRefusal(leaf, kv.Value, "element") is { } entTypeErr) return entTypeErr;
+            // …and the TYPE of every element whose shape just passed, by the same slot-faithful sweep — but scoped,
+            // as the non-formlink twin below is, to the verbs that PUT a value IN. Remove is exempt at every slot: it
+            // takes an element OUT, and a list already carrying a wrong-typed link (written by another mod) is exactly
+            // what the caller needs to be able to remove. Gating it would refuse the one call that repairs the list.
+            if (req.Verb is "Add" or "SetAtIndex" or "InsertAtIndex"
+                && LinkTypeRefusal(leaf, req.Value, "element") is { } elemTypeErr) return elemTypeErr;
+            if (req.Verb is "ReplaceAll")
+                foreach (var v in req.Values ?? Array.Empty<string>())
+                    if (LinkTypeRefusal(leaf, v, "element") is { } valsTypeErr) return valsTypeErr;
+            if (req.Verb is "Merge" or "ReplaceAll")
+                foreach (var kv in req.Entries ?? new())
+                    if (LinkTypeRefusal(leaf, kv.Value, "element") is { } entTypeErr) return entTypeErr;
         }
         // NON-FORMLINK coercible-element collection value-SHAPE — the value twin of the formlink block above and of the
         // dict-Set value block (which gates dict Set's value but not the other collection verbs). A list Add/SetAtIndex/
@@ -1130,9 +1138,11 @@ public sealed class CorpusRulebook
                $"{RecordNaming.StripOverlay(actual.Name)}, but '{leaf.Name}' links to {AllowedLinkTypes(leaf, target, aq)}.";
     }
 
-    /// <summary>The record types the corpus says satisfy a link target interface, as one printed phrase. Capped, so
-    /// a wide base does not answer with a hundred names; falls back to the interface's own bare name where no
-    /// modeled record satisfies it (an owned-child or non-record link).</summary>
+    /// <summary>The record types the corpus says satisfy a link target interface, as one printed phrase. Few enough
+    /// to act on, they are all named; past the cap an alphabetical sample is worse than useless (the caller cannot
+    /// tell whether their type is in the unprinted tail), so the phrase names the target's own kind and how many
+    /// types it covers. Falls back to the interface's bare name where no modeled record satisfies it (an owned-child
+    /// or non-record link).</summary>
     string AllowedLinkTypes(FieldSchema leaf, Type target, string aq)
     {
         lock (_linkTargetNames)
@@ -1144,25 +1154,17 @@ public sealed class CorpusRulebook
                     && target.IsAssignableFrom(gi))
                     names.Add(ts.Name);
             names.Sort(StringComparer.Ordinal);
+            var bare = RecordNaming.StripInterfaceToConcrete(leaf.FormLinkTarget ?? target.Name);
             const int cap = 12;
             var phrase = names.Count switch
             {
-                0 => BareTargetName(leaf.FormLinkTarget ?? target.Name),
+                0 => bare,
                 1 => names[0],
                 _ when names.Count <= cap => "one of: " + string.Join(", ", names),
-                _ => $"one of {names.Count} types: " + string.Join(", ", names.Take(cap)) + ", …",
+                _ => $"any {bare} record ({names.Count} record types qualify)",
             };
             return _linkTargetNames[aq] = phrase;
         }
-    }
-
-    /// <summary>A Mutagen getter interface name as the record name it stands for: IRaceGetter -> Race.</summary>
-    static string BareTargetName(string interfaceName)
-    {
-        var n = interfaceName;
-        if (n.Length > 1 && n[0] == 'I' && char.IsUpper(n[1])) n = n[1..];
-        if (n.EndsWith("Getter", StringComparison.Ordinal)) n = n[..^"Getter".Length];
-        return n;
     }
 
     /// <summary>The loud per-element rejection for a malformed FormLink collection ELEMENT — the SAME legal-set copy

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -435,6 +435,7 @@ public static class WritePatchBuilder
         //     session, never an arbitrary un-enabled plugin, so no winner-confusion hazard arises. ---
         var view = resolver.Capture();
         epoch = view.Stamp;                                               // stamped on every outcome from here down
+        var linkTypes = LinkTypeLookup(view, session);
         var resolved = new List<(PatchEdit edit, IMajorRecordGetter? body, string? winnerPlugin, IMajorRecord? patchLocal, WriteRequest req, string label, IMajorRecordGetter? srcBody)>(edits.Count);
         var problems = new List<string>();
         // Records the extended patch DEFINES (FormKey in the patch's own master space — created by a prior into=
@@ -525,7 +526,7 @@ public static class WritePatchBuilder
                 Key = e.Key, Value = e.Value, Values = e.Values, Entries = e.Entries, Struct = e.Struct, Structs = e.Structs,
             };
             var label = Label(req);
-            if (rulebook.Validate(req) is { } reject) { problems.Add($"{recType} {e.Target} [{label}]: {reject}"); continue; }
+            if (rulebook.Validate(req, null, linkTypes) is { } reject) { problems.Add($"{recType} {e.Target} [{label}]: {reject}"); continue; }
             resolved.Add((e, body, winnerPlugin, patchLocal, req, label, srcBody));
         }
         if (problems.Count > 0)
@@ -672,6 +673,24 @@ public static class WritePatchBuilder
         return copyFromSources is not null
             && IsOffOrderCopySource(e, view)
             && copyFromSources.TryGetValue(e, out body);
+    }
+
+    /// <summary>The pre-flight's link-TARGET resolver: a FormLink value in, the runtime type of the record it points
+    /// at out. Answers off the call's ONE captured view, so the type a link is checked against is the same build
+    /// every other decision in the write reads, and memoizes per call because one list edit can name a FormID many
+    /// times. Null for a token that does not parse or that the order does not carry — pre-flight then does not
+    /// type-check that link rather than refusing on a guess.</summary>
+    static CorpusRulebook.LinkTargetLookup LinkTypeLookup(LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session)
+    {
+        var memo = new Dictionary<string, Type?>(StringComparer.OrdinalIgnoreCase);
+        return token =>
+        {
+            if (memo.TryGetValue(token, out var hit)) return hit;
+            Type? type = null;
+            if (FormKey.TryFactory(token, out var fk) && view.ResolveWinner(fk) is { } w)
+                type = view.GetRecord(session, w.WinnerPlugin, fk)?.GetType();
+            return memo[token] = type;
+        };
     }
 
     /// <summary>Does this edit's CopyFrom source need the OFF-ORDER on-disk locate — i.e. is it a CopyFrom naming a
@@ -822,6 +841,7 @@ public static class WritePatchBuilder
                 $"cannot edit '{targetName}' in place: it was EXCLUDED from this session ({excluded}) — houseCARL won't " +
                 "re-serialize a plugin it can't fully parse (that would risk dropping the record it couldn't read, Q3). The file is UNTOUCHED.");
 
+        var linkTypes = LinkTypeLookup(view, session);
         var resolved = new List<(PatchEdit edit, IMajorRecordGetter body, WriteRequest req, string label, IMajorRecordGetter? srcBody, bool selfSource)>(edits.Count);
         var problems = new List<string>();
         foreach (var e in edits)
@@ -841,7 +861,7 @@ public static class WritePatchBuilder
                 Key = e.Key, Value = e.Value, Values = e.Values, Entries = e.Entries, Struct = e.Struct, Structs = e.Structs,
             };
             var label = Label(req);
-            if (rulebook.Validate(req) is { } reject) { problems.Add($"{recType} {e.Target} [{label}]: {reject}"); continue; }
+            if (rulebook.Validate(req, null, linkTypes) is { } reject) { problems.Add($"{recType} {e.Target} [{label}]: {reject}"); continue; }
 
             // CopyFrom SOURCE resolution — the same contract Apply enforces, on this lane too: the lane axis is
             // uniform, so every write verb must compose with in_place. Without this a CopyFrom op reaches ApplyVerb,

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -435,7 +435,10 @@ public static class WritePatchBuilder
         //     session, never an arbitrary un-enabled plugin, so no winner-confusion hazard arises. ---
         var view = resolver.Capture();
         epoch = view.Stamp;                                               // stamped on every outcome from here down
-        var linkTypes = LinkTypeLookup(view, session);
+        var linkTokens = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var e in edits) HarvestLinkTokens(e.Value, e.Values, e.Entries, e.Struct, e.Structs, linkTokens);
+        var (linkTypes, linkRefusal) = LinkTypeLookup(view, session, linkTokens);
+        if (linkRefusal is not null) return PatchOutcome.Fail(linkRefusal);
         var resolved = new List<(PatchEdit edit, IMajorRecordGetter? body, string? winnerPlugin, IMajorRecord? patchLocal, WriteRequest req, string label, IMajorRecordGetter? srcBody)>(edits.Count);
         var problems = new List<string>();
         // Records the extended patch DEFINES (FormKey in the patch's own master space — created by a prior into=
@@ -676,21 +679,65 @@ public static class WritePatchBuilder
     }
 
     /// <summary>The pre-flight's link-TARGET resolver: a FormLink value in, the runtime type of the record it points
-    /// at out. Answers off the call's ONE captured view, so the type a link is checked against is the same build
-    /// every other decision in the write reads, and memoizes per call because one list edit can name a FormID many
-    /// times. Null for a token that does not parse or that the order does not carry — pre-flight then does not
-    /// type-check that link rather than refusing on a guess.</summary>
-    static CorpusRulebook.LinkTargetLookup LinkTypeLookup(LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session)
+    /// at out. Every token the call could ask about is resolved UP FRONT, grouped by winner plugin, so a plugin is
+    /// walked ONCE however many links name it — a per-token seek would walk it once per link (a 200-entry leveled
+    /// list into Skyrim.esm is 200 full enumerations). Answers off the call's ONE captured view, so the type a link
+    /// is checked against is the same build every other decision in the write reads. Null for a token that does not
+    /// parse, that the order does not carry, or that the harvest did not offer — pre-flight then does not type-check
+    /// that link rather than refusing on a guess. A plugin that cannot be opened is the returned refusal, not a
+    /// throw: the write names it and stops.</summary>
+    static (CorpusRulebook.LinkTargetLookup lookup, string? refusal) LinkTypeLookup(
+        LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session, IReadOnlyCollection<string> tokens)
     {
-        var memo = new Dictionary<string, Type?>(StringComparer.OrdinalIgnoreCase);
-        return token =>
+        var keyOf = new Dictionary<string, FormKey>(StringComparer.OrdinalIgnoreCase);
+        var byPlugin = new Dictionary<string, HashSet<FormKey>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var t in tokens)
         {
-            if (memo.TryGetValue(token, out var hit)) return hit;
-            Type? type = null;
-            if (FormKey.TryFactory(token, out var fk) && view.ResolveWinner(fk) is { } w)
-                type = view.GetRecord(session, w.WinnerPlugin, fk)?.GetType();
-            return memo[token] = type;
-        };
+            if (!FormKey.TryFactory(t, out var fk) || fk == FormKey.Null) continue;
+            keyOf[t] = fk;
+            if (view.ResolveWinner(fk) is not { } w) continue;
+            if (!byPlugin.TryGetValue(w.WinnerPlugin, out var set)) byPlugin[w.WinnerPlugin] = set = new HashSet<FormKey>();
+            set.Add(fk);
+        }
+        var types = new Dictionary<FormKey, Type>();
+        foreach (var (plugin, keys) in byPlugin)
+        {
+            var sink = new Dictionary<FormKey, IMajorRecordGetter>();
+            try { view.CollectRecords(session, plugin, keys, null, sink); }
+            catch (Exception ex)
+            {
+                return (_ => null,
+                    $"cannot check this write's FormLink targets: '{plugin}' defines {keys.Count} of them and could not be " +
+                    $"read ({WriteEngine.Describe(ex)}) — close whatever holds it open and re-run. NOTHING was written.");
+            }
+            foreach (var kv in sink) types[kv.Key] = kv.Value.GetType();
+        }
+        return (token => keyOf.TryGetValue(token, out var fk) && types.TryGetValue(fk, out var t) ? t : null, null);
+    }
+
+    /// <summary>Every value slot a pre-flight link check can read, harvested into one token set — the singular value,
+    /// a ReplaceAll's contents, a dict's entry values, and a composed struct's own fields and nested writes. The SAME
+    /// slots the rulebook's formlink sweeps read, so what it asks about is what was prefetched. Over-collecting costs
+    /// nothing (the plugin is walked once either way); a slot missed here leaves that one link unchecked, which is
+    /// the behaviour before the gate existed, never a wrong refusal.</summary>
+    static void HarvestLinkTokens(string? value, IReadOnlyList<string>? values, Dictionary<string, string>? entries,
+                                  StructSpec? one, IEnumerable<StructSpec>? many, HashSet<string> into)
+    {
+        if (value is not null) into.Add(value);
+        foreach (var v in values ?? Array.Empty<string>()) if (v is not null) into.Add(v);
+        if (entries is not null) foreach (var kv in entries) if (kv.Value is not null) into.Add(kv.Value);
+        if (one is not null) HarvestStructTokens(one, into);
+        foreach (var s in many ?? Array.Empty<StructSpec>()) HarvestStructTokens(s, into);
+    }
+
+    static void HarvestLinkTokens(WriteRequest req, HashSet<string> into)
+        => HarvestLinkTokens(req.Value, req.Values, req.Entries, req.Struct, req.Structs, into);
+
+    static void HarvestStructTokens(StructSpec spec, HashSet<string> into)
+    {
+        if (spec.Fields is not null) foreach (var kv in spec.Fields) if (kv.Value is not null) into.Add(kv.Value);
+        foreach (var a in spec.CtorArgs ?? Array.Empty<string>()) if (a is not null) into.Add(a);
+        foreach (var r in spec.Sets ?? new()) HarvestLinkTokens(r, into);
     }
 
     /// <summary>Does this edit's CopyFrom source need the OFF-ORDER on-disk locate — i.e. is it a CopyFrom naming a
@@ -841,7 +888,10 @@ public static class WritePatchBuilder
                 $"cannot edit '{targetName}' in place: it was EXCLUDED from this session ({excluded}) — houseCARL won't " +
                 "re-serialize a plugin it can't fully parse (that would risk dropping the record it couldn't read, Q3). The file is UNTOUCHED.");
 
-        var linkTypes = LinkTypeLookup(view, session);
+        var linkTokens = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var e in edits) HarvestLinkTokens(e.Value, e.Values, e.Entries, e.Struct, e.Structs, linkTokens);
+        var (linkTypes, linkRefusal) = LinkTypeLookup(view, session, linkTokens);
+        if (linkRefusal is not null) return PatchOutcome.Fail(linkRefusal);
         var resolved = new List<(PatchEdit edit, IMajorRecordGetter body, WriteRequest req, string label, IMajorRecordGetter? srcBody, bool selfSource)>(edits.Count);
         var problems = new List<string>();
         foreach (var e in edits)
@@ -2856,6 +2906,14 @@ public static class WritePatchBuilder
         var view = resolver.Capture();
         epoch = view.Stamp;                                               // stamped on every outcome from here down
 
+        // The link-TARGET types this call's edits name, resolved once — the same gate the two apply lanes run, on the
+        // lane that authors brand-new records. A '@editorid' sibling ref points at a record that does not exist yet,
+        // so it resolves to nothing and is not type-checked; a literal FormID beside it is.
+        var linkTokens = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var s in specs) foreach (var req in s.Edits) HarvestLinkTokens(req, linkTokens);
+        var (linkTypes, linkRefusal) = LinkTypeLookup(view, session, linkTokens);
+        if (linkRefusal is not null) return CreateOutcome.Fail(linkRefusal);
+
         // --- Phase 0: open the destination FIRST — moved AHEAD of pre-flight so a FormKey parent can resolve from it (a
         //     parent created in a PRIOR into= call, or — in place — a parent the target itself owns). CreateFromBinary reads
         //     the file fully into memory and holds NO handle at rest (the active-patch self-lock invariant is untouched —
@@ -3197,7 +3255,7 @@ public static class WritePatchBuilder
                 // siblingEditorIds = priorEditorIds: a "@editorid" FormLink value is accepted iff that editorid was
                 // declared in an EARLIER spec of THIS call OR is the record itself (resolved to its real FormKey in
                 // Phase 3); else rejected loud.
-                if (rulebook.Validate(req, priorEditorIds) is { } reject) problems.Add($"{s.RecordType} '{s.EditorId}' [{Label(req)}]: {reject}");
+                if (rulebook.Validate(req, priorEditorIds, linkTypes) is { } reject) problems.Add($"{s.RecordType} '{s.EditorId}' [{Label(req)}]: {reject}");
         }
         if (problems.Count > 0)
             return CreateOutcome.Fail(

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -437,8 +437,8 @@ public static class WritePatchBuilder
         epoch = view.Stamp;                                               // stamped on every outcome from here down
         var linkTokens = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var e in edits) HarvestLinkTokens(e.Value, e.Values, e.Entries, e.Struct, e.Structs, linkTokens);
-        var (linkTypes, linkRefusal) = LinkTypeLookup(view, session, linkTokens);
-        if (linkRefusal is not null) return PatchOutcome.Fail(linkRefusal);
+        var (linkTypes, linkNote) = LinkTypeLookup(view, session, linkTokens);
+        var linkRulebook = rulebook.WithLinkTargets(linkTypes);
         var resolved = new List<(PatchEdit edit, IMajorRecordGetter? body, string? winnerPlugin, IMajorRecord? patchLocal, WriteRequest req, string label, IMajorRecordGetter? srcBody)>(edits.Count);
         var problems = new List<string>();
         // Records the extended patch DEFINES (FormKey in the patch's own master space — created by a prior into=
@@ -529,7 +529,7 @@ public static class WritePatchBuilder
                 Key = e.Key, Value = e.Value, Values = e.Values, Entries = e.Entries, Struct = e.Struct, Structs = e.Structs,
             };
             var label = Label(req);
-            if (rulebook.Validate(req, null, linkTypes) is { } reject) { problems.Add($"{recType} {e.Target} [{label}]: {reject}"); continue; }
+            if (linkRulebook.Validate(req) is { } reject) { problems.Add($"{recType} {e.Target} [{label}]: {reject}"); continue; }
             resolved.Add((e, body, winnerPlugin, patchLocal, req, label, srcBody));
         }
         if (problems.Count > 0)
@@ -608,7 +608,7 @@ public static class WritePatchBuilder
             return new PatchOutcome(true, null, outPath, extend, wouldMasters, ops, 0)
             {
                 DryRun = true, ReadBack = dryBack,
-                Note = mastersBefore is null ? null : MasterGrowWouldNote(fileName, mastersBefore, wouldMasters),
+                Note = JoinNotes(linkNote, mastersBefore is null ? null : MasterGrowWouldNote(fileName, mastersBefore, wouldMasters)),
             };
         }
 
@@ -643,8 +643,13 @@ public static class WritePatchBuilder
         finally { (back as IDisposable)?.Dispose(); }
 
         return new PatchOutcome(true, null, outPath, extend, masters, ops, bytes)
-            { ReadBack = readBack, Note = mastersBefore is null ? null : MasterGrowNote(fileName, mastersBefore, masters) };
+            { ReadBack = readBack, Note = JoinNotes(linkNote, mastersBefore is null ? null : MasterGrowNote(fileName, mastersBefore, masters)) };
     }
+
+    /// <summary>Two honesty notes on one outcome, in one string — either may be null, and two nulls stay null so an
+    /// outcome with nothing to add carries no note.</summary>
+    static string? JoinNotes(string? a, string? b) =>
+        a is null ? b : b is null ? a : a + " " + b;
 
     /// <summary>The "source plugin doesn't carry the record to copy" refusal, worded for the lane that hit it: a
     /// SAME-record copy names the target; a cross-record copy names the SOURCE record and the target it was being
@@ -684,9 +689,11 @@ public static class WritePatchBuilder
     /// list into Skyrim.esm is 200 full enumerations). Answers off the call's ONE captured view, so the type a link
     /// is checked against is the same build every other decision in the write reads. Null for a token that does not
     /// parse, that the order does not carry, or that the harvest did not offer — pre-flight then does not type-check
-    /// that link rather than refusing on a guess. A plugin that cannot be opened is the returned refusal, not a
-    /// throw: the write names it and stops.</summary>
-    static (CorpusRulebook.LinkTargetLookup lookup, string? refusal) LinkTypeLookup(
+    /// that link rather than refusing on a guess. A plugin that cannot be OPENED is skipped on the same terms, and
+    /// said so in the returned note: the check is an extra, so a link it cannot read goes unchecked exactly as an
+    /// unresolvable FormID does, never a refusal of a write that was legal before this gate existed. Only the open is
+    /// caught; a fault from the walk below is a different problem and is left to the caller.</summary>
+    static (CorpusRulebook.LinkTargetLookup lookup, string? note) LinkTypeLookup(
         LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session, IReadOnlyCollection<string> tokens)
     {
         var keyOf = new Dictionary<string, FormKey>(StringComparer.OrdinalIgnoreCase);
@@ -700,19 +707,24 @@ public static class WritePatchBuilder
             set.Add(fk);
         }
         var types = new Dictionary<FormKey, Type>();
+        List<string>? skipped = null;
         foreach (var (plugin, keys) in byPlugin)
         {
             var sink = new Dictionary<FormKey, IMajorRecordGetter>();
+            // The exception carries the right sentence for its own fault (held open vs. changed under the index), so
+            // the note quotes it rather than guessing at a remedy.
             try { view.CollectRecords(session, plugin, keys, null, sink); }
-            catch (Exception ex)
+            catch (PluginUnreadableException ex)
             {
-                return (_ => null,
-                    $"cannot check this write's FormLink targets: '{plugin}' defines {keys.Count} of them and could not be " +
-                    $"read ({WriteEngine.Describe(ex)}) — close whatever holds it open and re-run. NOTHING was written.");
+                (skipped ??= new List<string>()).Add(
+                    $"{keys.Count} FormID value(s) in this write resolve to '{plugin}', whose link targets were NOT " +
+                    $"type-checked: {ex.Message}");
+                continue;
             }
             foreach (var kv in sink) types[kv.Key] = kv.Value.GetType();
         }
-        return (token => keyOf.TryGetValue(token, out var fk) && types.TryGetValue(fk, out var t) ? t : null, null);
+        return (token => keyOf.TryGetValue(token, out var fk) && types.TryGetValue(fk, out var t) ? t : null,
+                skipped is null ? null : string.Join(" ", skipped));
     }
 
     /// <summary>Every value slot a pre-flight link check can read, harvested into one token set — the singular value,
@@ -890,8 +902,8 @@ public static class WritePatchBuilder
 
         var linkTokens = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var e in edits) HarvestLinkTokens(e.Value, e.Values, e.Entries, e.Struct, e.Structs, linkTokens);
-        var (linkTypes, linkRefusal) = LinkTypeLookup(view, session, linkTokens);
-        if (linkRefusal is not null) return PatchOutcome.Fail(linkRefusal);
+        var (linkTypes, linkNote) = LinkTypeLookup(view, session, linkTokens);
+        var linkRulebook = rulebook.WithLinkTargets(linkTypes);
         var resolved = new List<(PatchEdit edit, IMajorRecordGetter body, WriteRequest req, string label, IMajorRecordGetter? srcBody, bool selfSource)>(edits.Count);
         var problems = new List<string>();
         foreach (var e in edits)
@@ -911,7 +923,7 @@ public static class WritePatchBuilder
                 Key = e.Key, Value = e.Value, Values = e.Values, Entries = e.Entries, Struct = e.Struct, Structs = e.Structs,
             };
             var label = Label(req);
-            if (rulebook.Validate(req, null, linkTypes) is { } reject) { problems.Add($"{recType} {e.Target} [{label}]: {reject}"); continue; }
+            if (linkRulebook.Validate(req) is { } reject) { problems.Add($"{recType} {e.Target} [{label}]: {reject}"); continue; }
 
             // CopyFrom SOURCE resolution — the same contract Apply enforces, on this lane too: the lane axis is
             // uniform, so every write verb must compose with in_place. Without this a CopyFrom op reaches ApplyVerb,
@@ -1067,7 +1079,7 @@ public static class WritePatchBuilder
             return new PatchOutcome(true, null, targetPath, false, wouldMasters, ops, 0)
             {
                 DryRun = true, InPlace = true, ReadBack = dryBack,
-                Note = MasterGrowWouldNote(fileName, mastersBefore, wouldMasters),
+                Note = JoinNotes(linkNote, MasterGrowWouldNote(fileName, mastersBefore, wouldMasters)),
             };
         }
 
@@ -1136,7 +1148,7 @@ public static class WritePatchBuilder
         finally { (back as IDisposable)?.Dispose(); }
 
         return new PatchOutcome(true, null, targetPath, false, masters, reported, bytes)
-            { ReadBack = readBack, InPlace = true, Note = MasterGrowNote(fileName, mastersBefore, masters) };
+            { ReadBack = readBack, InPlace = true, Note = JoinNotes(linkNote, MasterGrowNote(fileName, mastersBefore, masters)) };
     }
 
     /// <summary>The explicit re-sort note when an in-place write GREW the target's master header: Skyrim loads a
@@ -2911,8 +2923,8 @@ public static class WritePatchBuilder
         // so it resolves to nothing and is not type-checked; a literal FormID beside it is.
         var linkTokens = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var s in specs) foreach (var req in s.Edits) HarvestLinkTokens(req, linkTokens);
-        var (linkTypes, linkRefusal) = LinkTypeLookup(view, session, linkTokens);
-        if (linkRefusal is not null) return CreateOutcome.Fail(linkRefusal);
+        var (linkTypes, linkNote) = LinkTypeLookup(view, session, linkTokens);
+        var linkRulebook = rulebook.WithLinkTargets(linkTypes);
 
         // --- Phase 0: open the destination FIRST — moved AHEAD of pre-flight so a FormKey parent can resolve from it (a
         //     parent created in a PRIOR into= call, or — in place — a parent the target itself owns). CreateFromBinary reads
@@ -3255,7 +3267,7 @@ public static class WritePatchBuilder
                 // siblingEditorIds = priorEditorIds: a "@editorid" FormLink value is accepted iff that editorid was
                 // declared in an EARLIER spec of THIS call OR is the record itself (resolved to its real FormKey in
                 // Phase 3); else rejected loud.
-                if (rulebook.Validate(req, priorEditorIds, linkTypes) is { } reject) problems.Add($"{s.RecordType} '{s.EditorId}' [{Label(req)}]: {reject}");
+                if (linkRulebook.Validate(req, priorEditorIds) is { } reject) problems.Add($"{s.RecordType} '{s.EditorId}' [{Label(req)}]: {reject}");
         }
         if (problems.Count > 0)
             return CreateOutcome.Fail(
@@ -3486,7 +3498,7 @@ public static class WritePatchBuilder
         return new CreateOutcome(true, null, outPath, extend, created, masters, bytes)
         {
             ReadBack = readBack, InPlace = inPlace,
-            Note = mastersBefore is null ? null : MasterGrowNote(fileName, mastersBefore, masters),
+            Note = JoinNotes(linkNote, mastersBefore is null ? null : MasterGrowNote(fileName, mastersBefore, masters)),
         };
     }
 

--- a/src/housecarl-generator/ApplyGuardProbe.cs
+++ b/src/housecarl-generator/ApplyGuardProbe.cs
@@ -505,7 +505,7 @@ public static class ApplyGuardProbe
             onePath is not null && ReadSubject(onePath, fx.SubjectKey).Dmg == 55, one);
 
         // op= is the verb name (§5.1) — an Add on a list, on the winner that has NO keywords
-        var kwFid = $"{fx.DonorWeaponFid}";   // any FormID resolvable as a link value is enough for the Add to be legal
+        var kwFid = fx.KeywordFid;   // a Keyword, because pre-flight type-checks what a link points at
         var add = ApplyTools.Apply(fx.Svc, ops: Json($$"""[{"formid":"{{fx.SubjectFid}}","field_path":"Keywords","op":"Add","value":"{{kwFid}}"}]"""),
             patch: "ApAdd");
         var addPath = PatchPathFrom(fx, add);

--- a/src/housecarl-mcp-tests/FormLinkTargetTypeTests.cs
+++ b/src/housecarl-mcp-tests/FormLinkTargetTypeTests.cs
@@ -1,0 +1,62 @@
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// A FormLink set to a record of the WRONG type (#663). Pre-flight checked that the value parsed as a FormID and
+/// stopped there, so pointing an armor's Race at a spell passed and wrote a plugin that is valid on disk and wrong
+/// in game. The gate now resolves the FormID and compares the record's own type against the link's Mutagen target.
+///
+/// <para>Dry runs: the shared world must stay unwritten.</para>
+/// </summary>
+[Collection("records")]
+[Trait("tier", "integration")]
+public sealed class FormLinkTargetTypeTests : RecordsTestBase
+{
+    public FormLinkTargetTypeTests(RecordsFixture f) : base(f) { }
+
+    string Apply(string formid, string path, string op, string value) => ApplyTools.Apply(Svc,
+        ops: Je($@"[{{""formid"":""{formid}"",""field_path"":""{path}"",""op"":""{op}"",""value"":""{value}""}}]"),
+        dry_run: true);
+
+    /// <summary>The reported shape: a singular link handed a record of another type is refused, naming the field,
+    /// what the FormID actually is, and what the field takes.</summary>
+    [Fact]
+    public void ASingularLinkToTheWrongRecordTypeIsRefused()
+    {
+        var r = Apply(Fid(W.Armor), "Race", "Set", Fid(W.SpellA));
+
+        Refused(r, "'Race'", "is a Spell", "links to Race");
+    }
+
+    /// <summary>…and the same value added to a link LIST, which is the other half of the reported call.</summary>
+    [Fact]
+    public void AListElementLinkToTheWrongRecordTypeIsRefused()
+    {
+        var r = Apply(Fid(W.Armor), "Keywords", "Add", Fid(W.SpellA));
+
+        Refused(r, "'Keywords'", "is a Spell", "links to Keyword");
+    }
+
+    /// <summary>A link handed the type it declares still lands — the check refuses a mismatch, not a FormID.</summary>
+    [Fact]
+    public void ALinkToTheDeclaredTypeStillPasses()
+        => Served(Apply(Fid(W.Weapons[0]), "Template", "Set", Fid(W.Weapons[1])), "Set Template");
+
+    /// <summary>A FormList's Items link to any record at all, so nothing put in one is a type mismatch.</summary>
+    [Fact]
+    public void ALinkThatAcceptsAnyRecordIsNotRefused()
+        => Served(Apply(Fid(W.BigList), "Items", "Add", Fid(W.Armor)), "Add Items");
+
+    /// <summary>A FormID no plugin in the order defines is not type-checked: the order cannot say what it is, and a
+    /// link to a record that is not there is the dangling-reference check's business, not this gate's.</summary>
+    [Fact]
+    public void AnUnresolvableTargetIsNotTypeChecked()
+        => Served(Apply(Fid(W.Armor), "Race", "Set", "ABCDEF:" + W.MasterName), "Set Race");
+
+    /// <summary>A null-clear points at nothing, so it is not a wrong type.</summary>
+    [Fact]
+    public void ANullClearIsNotTypeChecked()
+        => Served(Apply(Fid(W.Armor), "Race", "Set", "Null"), "Set Race");
+}

--- a/src/housecarl-mcp-tests/FormLinkTargetTypeTests.cs
+++ b/src/housecarl-mcp-tests/FormLinkTargetTypeTests.cs
@@ -59,4 +59,80 @@ public sealed class FormLinkTargetTypeTests : RecordsTestBase
     [Fact]
     public void ANullClearIsNotTypeChecked()
         => Served(Apply(Fid(W.Armor), "Race", "Set", "Null"), "Set Race");
+
+    /// <summary>A composed struct's own FormLink field is a link slot like any other — an Effect built with a
+    /// BaseEffect that is not a magic effect is refused at the compose, not at a leaf.</summary>
+    [Fact]
+    public void AComposedStructFieldLinkToTheWrongRecordTypeIsRefused()
+    {
+        var r = ApplyTools.Apply(Svc,
+            ops: Je($@"[{{""formid"":""{Fid(W.SpellA)}"",""field_path"":""Effects"",""op"":""Add"",""compose"":
+                {{""type"":""Effect"",""fields"":{{""BaseEffect"":""{Fid(W.SpellB)}""}}}}}}]"),
+            dry_run: true);
+
+        Refused(r, "'BaseEffect'", "is a Spell", "links to MagicEffect");
+    }
+
+    /// <summary>Removing a link is exempt: a list may already carry a wrong-typed FormID (another mod wrote it), and
+    /// the Remove that repairs it must not be refused for naming the very type it is taking out. The call still
+    /// fails — this armor has no Keywords at all — but on the LIST, never on the value's type.</summary>
+    [Fact]
+    public void RemovingALinkByValueIsNotTypeChecked()
+    {
+        var r = Apply(Fid(W.Armor), "Keywords", "Remove", Fid(W.SpellA));
+
+        Refused(r, "nothing to remove");
+        Assert.DoesNotContain("links to Keyword", r);
+    }
+
+    /// <summary>The create lane runs the same gate: a brand-new record whose link names the wrong type is refused
+    /// before anything is allocated.</summary>
+    [Fact]
+    public void ACreatedRecordsLinkToTheWrongRecordTypeIsRefused()
+    {
+        var o = Svc.CreateRecordsBatch(
+            new[]
+            {
+                new CreateOp
+                {
+                    RecordType = "Armor", Editorid = "HcLinkTypeArmor",
+                    Operations = new[] { new BulkOp { FieldPath = "Race", Verb = "Set", Value = Fid(W.SpellA) } },
+                },
+            },
+            "HcLinkTypeCreatePatch", null);
+
+        Assert.False(o.Success);
+        Assert.Contains("'Race'", o.Error);
+        Assert.Contains("is a Spell", o.Error);
+        Assert.Contains("links to Race", o.Error);
+    }
+
+    /// <summary>A create's ReplaceAll may mix same-call '@editorid' siblings with literal FormIDs. The sibling has no
+    /// record yet, so it is not type-checked; the literal beside it is.</summary>
+    [Fact]
+    public void ALiteralBesideASameCallSiblingIsTypeChecked()
+    {
+        var o = Svc.CreateRecordsBatch(
+            new[]
+            {
+                new CreateOp { RecordType = "Keyword", Editorid = "HcLinkTypeKw" },
+                new CreateOp
+                {
+                    RecordType = "Armor", Editorid = "HcLinkTypeArmor2",
+                    Operations = new[]
+                    {
+                        new BulkOp
+                        {
+                            FieldPath = "Keywords", Verb = "ReplaceAll",
+                            Values = new[] { "@HcLinkTypeKw", Fid(W.SpellA) },
+                        },
+                    },
+                },
+            },
+            "HcLinkTypeSiblingPatch", null);
+
+        Assert.False(o.Success);
+        Assert.Contains("is a Spell", o.Error);
+        Assert.Contains("links to Keyword", o.Error);
+    }
 }

--- a/src/housecarl-mcp-tests/FormLinkTargetTypeTests.cs
+++ b/src/housecarl-mcp-tests/FormLinkTargetTypeTests.cs
@@ -16,6 +16,17 @@ public sealed class FormLinkTargetTypeTests : RecordsTestBase
 {
     public FormLinkTargetTypeTests(RecordsFixture f) : base(f) { }
 
+    /// <summary>The create lane's own version of "the shared world must stay unwritten": CreateRecordsBatch has no
+    /// dry_run, so a refused create is only clean if it wrote no patch. Removes the mod folder first if a regression
+    /// left one, so one broken gate fails its own test instead of cascading into every later test in the
+    /// collection.</summary>
+    void AssertNoPatchWritten(string patchStem)
+    {
+        var left = Directory.EnumerateDirectories(W.ModsDir, "houseCARL - " + patchStem + "*").ToList();
+        foreach (var dir in left) Directory.Delete(dir, recursive: true);
+        Assert.Empty(left);
+    }
+
     string Apply(string formid, string path, string op, string value) => ApplyTools.Apply(Svc,
         ops: Je($@"[{{""formid"":""{formid}"",""field_path"":""{path}"",""op"":""{op}"",""value"":""{value}""}}]"),
         dry_run: true);
@@ -105,6 +116,7 @@ public sealed class FormLinkTargetTypeTests : RecordsTestBase
         Assert.Contains("'Race'", o.Error);
         Assert.Contains("is a Spell", o.Error);
         Assert.Contains("links to Race", o.Error);
+        AssertNoPatchWritten("HcLinkTypeCreatePatch");
     }
 
     /// <summary>A create's ReplaceAll may mix same-call '@editorid' siblings with literal FormIDs. The sibling has no
@@ -134,5 +146,6 @@ public sealed class FormLinkTargetTypeTests : RecordsTestBase
         Assert.False(o.Success);
         Assert.Contains("is a Spell", o.Error);
         Assert.Contains("links to Keyword", o.Error);
+        AssertNoPatchWritten("HcLinkTypeSiblingPatch");
     }
 }


### PR DESCRIPTION
housecarl_apply's pre-flight proved a link value parsed as a FormID and said nothing about what it pointed at, so setting an armor's `Race`, `ObjectEffect` or `TemplateArmor` to a keyword passed and wrote a plugin that is valid on disk and wrong in game. The generator already stamps every formlink field with its Mutagen link target interface, so the check needed no new data: the rulebook takes an optional lookup from the write path (which holds the call's one captured view), resolves each link value to the record it points at, and refuses when that record's runtime type does not satisfy the field's target. The refusal names the field, the type given and the types allowed, and the allowed names are the corpus record types that satisfy the same interface, so nothing about them is hand-written. Where more types qualify than fit in a sentence it names the kind and the count instead. A field whose link accepts any record, a null-clear, and a FormID no plugin in the order defines are all left alone — the last because the order cannot say what it is, which is the dangling-reference check's business. So is a Remove: taking a link out never needs the target to be legal, and a list another mod wrote a bad link into is exactly what a caller needs to be able to repair.

The lookup rides on a per-call copy of the rulebook rather than a parameter at every hop, so all three value slots see it: a singular Set, a link list's elements, and a composed struct's field. All three write lanes pass it — the patch lane, in place, and create.

Resolving the targets is a prefetch, not a seek per link: each lane harvests the FormID-shaped tokens out of its own value slots, groups them by winner plugin, and collects them in one walk of each plugin, so a 200-entry leveled-list ReplaceAll into Skyrim.esm reads that plugin once. A plugin the write does not otherwise touch that cannot be opened is one sentence naming it, not a throw.

One existing probe assertion changed: apply-guard added a weapon FormID to a Keywords list on the note that "any FormID resolvable as a link value is enough", which is the bug; it now uses the fixture's own keyword, which was already there for the other link arms.

Ten tests against the built server: the two reported shapes refuse, a composed struct's own link field refuses, a create's link refuses and so does a literal FormID mixed beside a same-call `@editorid` sibling, a Remove by a wrong-typed value is not refused for its type, a link to its declared type still lands, a FormList's any-record Items is not refused, and neither an unresolvable target nor a null-clear is type-checked.

Closes #663
