### PR TITLE
Print every FormID token with the plugin's on-disk spelling

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -78,6 +78,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
   value" for all five.** A null field and the other arm of a union are not read faults, and a link that is set but
   points at a disabled plugin or a missing master is not unset: its remedy is to enable the plugin, not to widen
   the scope. The counts are now named separately.
+- **A FormID token now spells its plugin the way the file is spelled on disk, in every read.** A link's plugin
+  used to be spelled from the master list of whatever plugin held the link, and a token you passed in was echoed
+  as you typed it, so the same record could come back as `Skyrim.esm` in one read and `skyrim.esm` in another and
+  a join of two outputs missed those rows. Every token, and the `defined_in` grouping key, now prints the load
+  order's own spelling; a plugin the active order does not carry keeps the spelling it arrived with.
 - **`open-animation-replacer` now states how a DAR `_conditions.txt` chain binds, and that the DAR weapon-type
   numbers convert unchanged.** Both were marked unverified in its reference, and the skill told you to convert
   under one reading and say which. Both are now read off OAR's own source; the reference's §8 carries the rule,

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -111,11 +111,6 @@ saying it sets an expectation their install may contradict. Say what is known, a
   against the 1,024 ceiling it used to breach, and opens on its trigger. The CI guard that watched this file
   changed direction to match: it used to require every tool name to appear here, which is why it stayed green
   through all seventeen dead names, and now requires every `housecarl_*` name written here to be a live tool.
-- **A FormID token now spells its plugin the way the file is spelled on disk, in every read.** A link's plugin
-  used to be spelled from the master list of whatever plugin held the link, and a token you passed in was echoed
-  as you typed it, so the same record could come back as `Skyrim.esm` in one read and `skyrim.esm` in another and
-  a join of two outputs missed those rows. Every token, and the `defined_in` grouping key, now prints the load
-  order's own spelling; a plugin the order now loaded does not carry keeps the spelling it arrived with.
 - **`mutagen-reference` and `papyrus-reference` now say in their frontmatter that their lookup works offline.**
   Both carried only the shared compatibility sentence — the houseCARL MCP server and a configured Mod Organizer 2
   instance — which read as gating the whole skill, including a schema or signature lookup that reads files bundled

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -81,8 +81,10 @@ saying it sets an expectation their install may contradict. Say what is known, a
 - **A FormID token now spells its plugin the way the file is spelled on disk, in every read.** A link's plugin
   used to be spelled from the master list of whatever plugin held the link, and a token you passed in was echoed
   as you typed it, so the same record could come back as `Skyrim.esm` in one read and `skyrim.esm` in another and
-  a join of two outputs missed those rows. Every token, and the `defined_in` grouping key, now prints the load
-  order's own spelling; a plugin the active order does not carry keeps the spelling it arrived with.
+  a join of two outputs missed those rows. Every token now prints the load order's own spelling, and a
+  `defined_in` group is labelled with that spelling instead of whichever one arrived first — the counts were
+  never split, since the grouping already ignored case, but the label a caller joins on was unstable. A plugin
+  the active order does not carry keeps the spelling it arrived with.
 - **`open-animation-replacer` now states how a DAR `_conditions.txt` chain binds, and that the DAR weapon-type
   numbers convert unchanged.** Both were marked unverified in its reference, and the skill told you to convert
   under one reading and say which. Both are now read off OAR's own source; the reference's §8 carries the rule,

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -111,6 +111,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
   against the 1,024 ceiling it used to breach, and opens on its trigger. The CI guard that watched this file
   changed direction to match: it used to require every tool name to appear here, which is why it stayed green
   through all seventeen dead names, and now requires every `housecarl_*` name written here to be a live tool.
+- **A FormID token now spells its plugin the way the file is spelled on disk, in every read.** A link's plugin
+  used to be spelled from the master list of whatever plugin held the link, and a token you passed in was echoed
+  as you typed it, so the same record could come back as `Skyrim.esm` in one read and `skyrim.esm` in another and
+  a join of two outputs missed those rows. Every token, and the `defined_in` grouping key, now prints the load
+  order's own spelling; a plugin the order now loaded does not carry keeps the spelling it arrived with.
 - **`mutagen-reference` and `papyrus-reference` now say in their frontmatter that their lookup works offline.**
   Both carried only the shared compatibility sentence — the houseCARL MCP server and a configured Mod Organizer 2
   instance — which read as gating the whole skill, including a schema or signature lookup that reads files bundled

--- a/src/housecarl-core/ClosureCopy.cs
+++ b/src/housecarl-core/ClosureCopy.cs
@@ -139,7 +139,7 @@ public static class ClosureCopy
         foreach (var rec in scratch.EnumerateMajorRecords())
             if (!RemapEngine.TryAddToFlatGroup(patch, (IMajorRecord)rec))
                 return CopyResult.Fail(new CopyRefusal(CopyRefusalKind.Transplant,
-                    $"{RecordNaming.StripOverlay(rec.GetType().Name)} {rec.FormKey} could not be placed in the patch",
+                    $"{RecordNaming.StripOverlay(rec.GetType().Name)} {FormIdToken.Of(rec.FormKey)} could not be placed in the patch",
                     Key: rec.FormKey));
 
         var copied = nodes.Select(n => new CopiedRecord(
@@ -181,7 +181,7 @@ public static class ClosureCopy
                 if (singleLink.FormKeyNullable is not { } fk || fk.IsNull || !isBound(fk)) continue;
                 if (!IsNullableLink(val))
                     return new CopyRefusal(CopyRefusalKind.RequiredForeignLink,
-                        $"the record's REQUIRED field '{prop.Name}' points at {fk}, which is in the source universe " +
+                        $"the record's REQUIRED field '{prop.Name}' points at {FormIdToken.Of(fk)}, which is in the source universe " +
                         "being copied away from: it cannot be nulled without inventing data, and keeping it would " +
                         "silently master that plugin", prop.Name, fk);
                 continue;
@@ -191,7 +191,7 @@ public static class ClosureCopy
             {
                 var keys = sub.EnumerateFormLinks()
                     .Where(l => !l.FormKey.IsNull && isBound(l.FormKey))
-                    .Select(l => l.FormKey.ToString()).Distinct().ToList();
+                    .Select(l => FormIdToken.Of(l.FormKey)).Distinct().ToList();
                 if (keys.Count > 0)
                     return new CopyRefusal(CopyRefusalKind.UnclearableSubstruct,
                         $"the record's field '{prop.Name}' carries reference(s) into the source universe " +
@@ -220,10 +220,10 @@ public static class ClosureCopy
                 // Pass 1 has already proven this link is nullable; the else-branch is a backstop against the two
                 // passes ever disagreeing, not the primary refusal path.
                 if (TryNullLink(val))
-                    stripped.Add(new StripEntry(prop.Name, fk.ToString()));
+                    stripped.Add(new StripEntry(prop.Name, FormIdToken.Of(fk)));
                 else
                     return StripResult.Fail(new CopyRefusal(CopyRefusalKind.RequiredForeignLink,
-                        $"the record's REQUIRED field '{prop.Name}' points at {fk}, which is in the source universe " +
+                        $"the record's REQUIRED field '{prop.Name}' points at {FormIdToken.Of(fk)}, which is in the source universe " +
                         "being copied away from: it cannot be nulled without inventing data, and keeping it would " +
                         "silently master that plugin", prop.Name, fk));
                 continue;
@@ -244,7 +244,7 @@ public static class ClosureCopy
                     {
                         var keys = elc.EnumerateFormLinks()
                             .Where(l => !l.FormKey.IsNull && isBound(l.FormKey))
-                            .Select(l => l.FormKey.ToString()).Distinct().ToList();
+                            .Select(l => FormIdToken.Of(l.FormKey)).Distinct().ToList();
                         if (keys.Count > 0)
                         { list.RemoveAt(i); stripped.Add(new StripEntry($"{prop.Name}[{i}]", string.Join(", ", keys))); }
                     }
@@ -257,7 +257,7 @@ public static class ClosureCopy
             {
                 var keys = sub.EnumerateFormLinks()
                     .Where(l => !l.FormKey.IsNull && isBound(l.FormKey))
-                    .Select(l => l.FormKey.ToString()).Distinct().ToList();
+                    .Select(l => FormIdToken.Of(l.FormKey)).Distinct().ToList();
                 if (keys.Count == 0) continue;
                 // Nulling the property removes EVERYTHING on it, not just the bound link(s) that forced the removal.
                 // Marked so the render can say so: for VirtualMachineAdapter this is every script on the clone.
@@ -689,7 +689,7 @@ public static class ClosureCopy
                 live.Add(l.FormKey);
                 if (offender is null && l.FormKey.ModKey != patchModKey && !isOnOrder(l.FormKey.ModKey))
                     offender = new OffOrderHit(l.FormKey, rec.FormKey,
-                        $"{RecordNaming.StripOverlay(rec.GetType().Name)} '{rec.EditorID ?? "<no editorid>"}' ({rec.FormKey})");
+                        $"{RecordNaming.StripOverlay(rec.GetType().Name)} '{rec.EditorID ?? "<no editorid>"}' ({FormIdToken.Of(rec.FormKey)})");
             }
         }
         return (live, offender);

--- a/src/housecarl-core/ClosureCopy.cs
+++ b/src/housecarl-core/ClosureCopy.cs
@@ -238,7 +238,7 @@ public static class ClosureCopy
                     if (el is IFormLinkGetter elLink)
                     {
                         if (elLink.FormKeyNullable is { } lk && !lk.IsNull && isBound(lk))
-                        { list.RemoveAt(i); stripped.Add(new StripEntry($"{prop.Name}[{i}]", lk.ToString())); }
+                        { list.RemoveAt(i); stripped.Add(new StripEntry($"{prop.Name}[{i}]", FormIdToken.Of(lk))); }
                     }
                     else if (el is IFormLinkContainerGetter elc)
                     {

--- a/src/housecarl-core/ClosureWalk.cs
+++ b/src/housecarl-core/ClosureWalk.cs
@@ -433,7 +433,7 @@ public static class ClosureWalk
                         var at = path.IndexOf(next);
                         cycles.Add(new WalkCycle(
                             path.Skip(at).ToList(), next,
-                            labels.TryGetValue(key, out var lb) ? lb : key.ToString()));
+                            labels.TryGetValue(key, out var lb) ? lb : FormIdToken.Of(key)));
                     }
                     continue;
                 }

--- a/src/housecarl-core/ClosureWalk.cs
+++ b/src/housecarl-core/ClosureWalk.cs
@@ -360,7 +360,7 @@ public static class ClosureWalk
                 hit.ArmIndex, hit.Arm.Spelling,
                 ChainTo(key), pulledBy, depth));
 
-            var label = $"{typeName} {key} ({hit.Body.EditorID ?? "<no editorid>"})";
+            var label = $"{typeName} {FormIdToken.Of(key)} ({hit.Body.EditorID ?? "<no editorid>"})";
             labels[key] = label;
             var outgoing = new List<FormKey>();
             edges[key] = outgoing;

--- a/src/housecarl-core/ContainmentIndex.cs
+++ b/src/housecarl-core/ContainmentIndex.cs
@@ -138,10 +138,10 @@ public sealed class ContainmentIndex
                           $"from these properties only: {ChildBearingSurface()}");
         var winner = view.ResolveWinner(pk.Value);
         if (winner is null)
-            return (null, $"the containing record {pk.Value} is not in the active load order");
+            return (null, $"the containing record {FormIdToken.Of(pk.Value)} is not in the active load order");
         var body = view.GetRecord(session, winner.Value.WinnerPlugin, pk.Value);
         return body is null
-            ? (null, $"the containing record {pk.Value} would not fetch from its winner '{winner.Value.WinnerPlugin}'")
+            ? (null, $"the containing record {FormIdToken.Of(pk.Value)} would not fetch from its winner '{winner.Value.WinnerPlugin}'")
             : (body, null);
     };
 

--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -147,7 +147,7 @@ public static class DialogueValidate
     /// every member of the family is a CK-editor / byte-parity shape the game itself tolerates. All four gap
     /// surfaces (per-INFO, quest InputIssues, DLVW, DLBR) go through this so they cannot drift apart.</summary>
     static DialogueIssue GapIssue(string noun, FormKey fk, CkParityGap gap) =>
-        new(DialogueIssueSeverity.Warning, $"{noun} {fk} is missing the {gap.Subrecord} subrecord — {gap.Detail}");
+        new(DialogueIssueSeverity.Warning, $"{noun} {FormIdToken.Of(fk)} is missing the {gap.Subrecord} subrecord — {gap.Detail}");
 
     /// <summary>Resolve <paramref name="fk"/> to its load-order winner and validate the dialogue graph: a DIAL →
     /// validate that one topic; a QUST → fan out to EVERY topic the quest owns (a whole-order DIAL winner scan,
@@ -315,12 +315,12 @@ public static class DialogueValidate
             var win = view.ResolveWinner(fk);
             if (win is null)
                 return DialogueValidationReport.ForError(fk,
-                    $"{fk} is not in the active load order — nothing to validate. Pass a dialogue topic (DIAL) FormID to validate one topic, a quest (QUST) FormID to validate all of a quest's topics, or a dialogue view (DLVW) / branch (DLBR) FormID for a record-level CK-parity check.");
+                    $"{FormIdToken.Of(fk)} is not in the active load order — nothing to validate. Pass a dialogue topic (DIAL) FormID to validate one topic, a quest (QUST) FormID to validate all of a quest's topics, or a dialogue view (DLVW) / branch (DLBR) FormID for a record-level CK-parity check.");
 
             var body = view.GetRecord(session, win.Value.WinnerPlugin, fk);
             if (body is null)
                 return DialogueValidationReport.ForError(fk,
-                    $"{fk} resolves to a winner in {win.Value.WinnerPlugin} but its body could not be fetched (the plugin may have changed since the index was built) — re-run to rebuild and try again.");
+                    $"{FormIdToken.Of(fk)} resolves to a winner in {win.Value.WinnerPlugin} but its body could not be fetched (the plugin may have changed since the index was built) — re-run to rebuild and try again.");
 
             if (body is IDialogTopicGetter topic)
             {
@@ -402,7 +402,7 @@ public static class DialogueValidate
             }
 
             return DialogueValidationReport.ForError(fk,
-                $"{fk} resolves to a {RecordNaming.StripOverlay(body.GetType().Name)} in {win.Value.WinnerPlugin}, not a dialogue topic (DIAL), quest (QUST), dialogue view (DLVW), or dialogue branch (DLBR). Pass a DIAL FormID to validate one topic, a QUST FormID to validate every topic a quest owns, or a DLVW/DLBR FormID for a record-level CK-parity check.");
+                $"{FormIdToken.Of(fk)} resolves to a {RecordNaming.StripOverlay(body.GetType().Name)} in {win.Value.WinnerPlugin}, not a dialogue topic (DIAL), quest (QUST), dialogue view (DLVW), or dialogue branch (DLBR). Pass a DIAL FormID to validate one topic, a QUST FormID to validate every topic a quest owns, or a DLVW/DLBR FormID for a record-level CK-parity check.");
         }
         catch (Exception ex)
         {
@@ -631,7 +631,7 @@ public static class DialogueValidate
             foreach (var g in ownerQuest.TextDisplayGlobals)
                 if (!g.FormKey.IsNull && resolve(g.FormKey) is IGlobalGetter glob && glob.EditorID is { Length: > 0 } gid)
                     ownerTextGlobals.Add(gid);
-            ownerQuestLabel = $"the owning quest {ownerQuest.EditorID ?? ownerFk.ToString()}";
+            ownerQuestLabel = $"the owning quest {ownerQuest.EditorID ?? FormIdToken.Of(ownerFk)}";
         }
 
         // --- Per-INFO walk over the topic's LIVE INFOs. A deleted INFO is a REMOVED line — skip it entirely (don't
@@ -659,10 +659,10 @@ public static class DialogueValidate
             if (DialogueScriptCheck.HasResultFragment(info)) fragmentInfos++;
 
             // Text-encoding lint over this line's player-facing strings: its menu Prompt and each spoken row.
-            CheckEncoding(info.Prompt?.String, $"INFO {info.FormKey} Prompt", issues);
+            CheckEncoding(info.Prompt?.String, $"INFO {FormIdToken.Of(info.FormKey)} Prompt", issues);
             int rnum = 0;
             foreach (var resp in info.Responses)
-                CheckEncoding(resp.Text?.String, $"INFO {info.FormKey} response {++rnum} text", issues);
+                CheckEncoding(resp.Text?.String, $"INFO {FormIdToken.Of(info.FormKey)} response {++rnum} text", issues);
 
             // A `<Global=X>` tag in a Prompt/response renders as `[...]` in game unless X names a global in the owning
             // quest's TextDisplayGlobals. A silent failure — the record is byte-valid and the tag just fails to
@@ -675,7 +675,7 @@ public static class DialogueValidate
             var pnam = NonNull(info.PreviousDialog.FormKeyNullable);
             if (pnam is not null && BadRef(pnam.Value, "a dialogue line (INFO)", b => b is IDialogResponsesGetter) is { } pwhy)
                 issues.Add(new(DialogueIssueSeverity.Problem,
-                    $"INFO {info.FormKey} has a previous-link (PNAM -> {pnam.Value}) that {pwhy}."));
+                    $"INFO {FormIdToken.Of(info.FormKey)} has a previous-link (PNAM -> {pnam.Value}) that {pwhy}."));
 
             // LinkTo: the REAL conversation chain — this line hands off to the next topic(s). A set link to a missing
             // DialogTopic is a broken chain; an empty LinkTo is a normal terminal line (never flagged).
@@ -684,7 +684,7 @@ public static class DialogueValidate
                 var lk = link.FormKey;
                 if (!lk.IsNull && BadRef(lk, "a dialogue topic (DIAL)", b => b is IDialogTopicGetter) is { } lwhy)
                     issues.Add(new(DialogueIssueSeverity.Problem,
-                        $"INFO {info.FormKey} links (LinkTo) to {lk}, which {lwhy} — the conversation chain is broken."));
+                        $"INFO {FormIdToken.Of(info.FormKey)} links (LinkTo) to {lk}, which {lwhy} — the conversation chain is broken."));
             }
 
             if (info.Conditions.Count > 0)
@@ -828,7 +828,7 @@ public static class DialogueValidate
                 var name = m.Groups[1].Value.Trim();
                 if (name.Length == 0 || ownerTextGlobals.Contains(name) || !flagged.Add(name)) continue;
                 issues.Add(new(DialogueIssueSeverity.Warning,
-                    $"INFO {info.FormKey} {locus} uses the text-replacement tag {m.Value}, but {name} is not a "
+                    $"INFO {FormIdToken.Of(info.FormKey)} {locus} uses the text-replacement tag {m.Value}, but {name} is not a "
                     + $"global in {ownerQuestLabel}'s TextDisplayGlobals — in game the tag renders as [...] (the global is "
                     + $"never substituted). Add {name} to the quest's Text Display Globals."));
             }
@@ -891,10 +891,10 @@ public static class DialogueValidate
             {
                 if (data.Reference.IsNull)
                     issues.Add(new(DialogueIssueSeverity.Warning,
-                        $"INFO {info.FormKey} condition #{n} ({fn}) is set to Run On a specific reference, but no reference is set — it evaluates against nothing, so the gate never behaves as intended."));
+                        $"INFO {FormIdToken.Of(info.FormKey)} condition #{n} ({fn}) is set to Run On a specific reference, but no reference is set — it evaluates against nothing, so the gate never behaves as intended."));
                 else if (!inOrder(refKey) && !EngineImplicit.IsImplicit(refKey))
                     issues.Add(new(DialogueIssueSeverity.Warning,
-                        $"INFO {info.FormKey} condition #{n} ({fn}) Run On reference {refKey} is not in the active load order — the gate evaluates against nothing."));
+                        $"INFO {FormIdToken.Of(info.FormKey)} condition #{n} ({fn}) Run On reference {refKey} is not in the active load order — the gate evaluates against nothing."));
             }
 
             // 2. Dead alias index — only when the owning quest's alias set is known; else skip, never guess.
@@ -931,14 +931,14 @@ public static class DialogueValidate
                     : floiIsForm && WriteEngine.IsFormLinkOrIndex(p.PropertyType) ? WriteEngine.ReadFloiFormKey(v) : null;
                 if (paramFk is { } pk && !inOrder(pk) && !EngineImplicit.IsImplicit(pk))
                     issues.Add(new(DialogueIssueSeverity.Warning,
-                        $"INFO {info.FormKey} condition #{n} ({fn}) references {pk}, which is not in the active load order — a deleted/disabled form or a wrong FormID, so the condition can't evaluate as intended."));
+                        $"INFO {FormIdToken.Of(info.FormKey)} condition #{n} ({fn}) references {pk}, which is not in the active load order — a deleted/disabled form or a wrong FormID, so the condition can't evaluate as intended."));
             }
 
             // 4. Dangling global comparison value — a ConditionGlobal compared against a GLOB not in the order. The
             //    comparison value lives on the Condition, not the Data arm, so it's outside the param sweep above.
             if (cond is IConditionGlobalGetter cg && !cg.ComparisonValue.IsNull && !inOrder(cg.ComparisonValue.FormKey))
                 issues.Add(new(DialogueIssueSeverity.Warning,
-                    $"INFO {info.FormKey} condition #{n} ({fn}) compares against global {cg.ComparisonValue.FormKey}, which is not in the active load order."));
+                    $"INFO {FormIdToken.Of(info.FormKey)} condition #{n} ({fn}) compares against global {FormIdToken.Of(cg.ComparisonValue.FormKey)}, which is not in the active load order."));
 
             // 5. GetIsID pointed at a PLACED reference — the wrong KIND of form (a dangling one is already caught by
             //    lint 3). GetIsID compares the run-on actor's BASE form, so a placed-instance FormID can never match.
@@ -947,7 +947,7 @@ public static class DialogueValidate
             if (data is IGetIsIDConditionDataGetter gid && floiIsForm && WriteEngine.ReadFloiFormKey(gid.Object) is { } objFk
                 && inOrder(objFk) && resolve(objFk) is IPlacedGetter)
                 issues.Add(new(DialogueIssueSeverity.Warning,
-                    $"INFO {info.FormKey} condition #{n} (GetIsID) points at the placed reference {objFk}, but GetIsID compares the run-on actor's BASE form — pass the base NPC_/object, not a placed instance."));
+                    $"INFO {FormIdToken.Of(info.FormKey)} condition #{n} (GetIsID) points at the placed reference {objFk}, but GetIsID compares the run-on actor's BASE form — pass the base NPC_/object, not a placed instance."));
         }
     }
 

--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -466,7 +466,7 @@ public static class DialogueValidate
                 "DialogTopic.Quest is unset — this topic is not owned by a quest. Most dialogue topics are; an unowned topic may never present its lines in game. Verify this is intentional."));
         else if (BadRef(questFk.Value, "a quest (QUST)", b => b is IQuestGetter) is { } qwhy)
             issues.Add(new(DialogueIssueSeverity.Problem,
-                $"DialogTopic.Quest points at {questFk.Value}, which {qwhy} — the owning quest is unresolved."));
+                $"DialogTopic.Quest points at {FormIdToken.Of(questFk.Value)}, which {qwhy} — the owning quest is unresolved."));
 
         // --- Branch wiring: optional (many topics have none), but if set it must resolve to a real DLBR.
         var branchFk = NonNull(topic.Branch.FormKeyNullable);
@@ -675,7 +675,7 @@ public static class DialogueValidate
             var pnam = NonNull(info.PreviousDialog.FormKeyNullable);
             if (pnam is not null && BadRef(pnam.Value, "a dialogue line (INFO)", b => b is IDialogResponsesGetter) is { } pwhy)
                 issues.Add(new(DialogueIssueSeverity.Problem,
-                    $"INFO {FormIdToken.Of(info.FormKey)} has a previous-link (PNAM -> {pnam.Value}) that {pwhy}."));
+                    $"INFO {FormIdToken.Of(info.FormKey)} has a previous-link (PNAM -> {FormIdToken.Of(pnam.Value)}) that {pwhy}."));
 
             // LinkTo: the REAL conversation chain — this line hands off to the next topic(s). A set link to a missing
             // DialogTopic is a broken chain; an empty LinkTo is a normal terminal line (never flagged).
@@ -684,7 +684,7 @@ public static class DialogueValidate
                 var lk = link.FormKey;
                 if (!lk.IsNull && BadRef(lk, "a dialogue topic (DIAL)", b => b is IDialogTopicGetter) is { } lwhy)
                     issues.Add(new(DialogueIssueSeverity.Problem,
-                        $"INFO {FormIdToken.Of(info.FormKey)} links (LinkTo) to {lk}, which {lwhy} — the conversation chain is broken."));
+                        $"INFO {FormIdToken.Of(info.FormKey)} links (LinkTo) to {FormIdToken.Of(lk)}, which {lwhy} — the conversation chain is broken."));
             }
 
             if (info.Conditions.Count > 0)
@@ -894,7 +894,7 @@ public static class DialogueValidate
                         $"INFO {FormIdToken.Of(info.FormKey)} condition #{n} ({fn}) is set to Run On a specific reference, but no reference is set — it evaluates against nothing, so the gate never behaves as intended."));
                 else if (!inOrder(refKey) && !EngineImplicit.IsImplicit(refKey))
                     issues.Add(new(DialogueIssueSeverity.Warning,
-                        $"INFO {FormIdToken.Of(info.FormKey)} condition #{n} ({fn}) Run On reference {refKey} is not in the active load order — the gate evaluates against nothing."));
+                        $"INFO {FormIdToken.Of(info.FormKey)} condition #{n} ({fn}) Run On reference {FormIdToken.Of(refKey)} is not in the active load order — the gate evaluates against nothing."));
             }
 
             // 2. Dead alias index — only when the owning quest's alias set is known; else skip, never guess.
@@ -931,7 +931,7 @@ public static class DialogueValidate
                     : floiIsForm && WriteEngine.IsFormLinkOrIndex(p.PropertyType) ? WriteEngine.ReadFloiFormKey(v) : null;
                 if (paramFk is { } pk && !inOrder(pk) && !EngineImplicit.IsImplicit(pk))
                     issues.Add(new(DialogueIssueSeverity.Warning,
-                        $"INFO {FormIdToken.Of(info.FormKey)} condition #{n} ({fn}) references {pk}, which is not in the active load order — a deleted/disabled form or a wrong FormID, so the condition can't evaluate as intended."));
+                        $"INFO {FormIdToken.Of(info.FormKey)} condition #{n} ({fn}) references {FormIdToken.Of(pk)}, which is not in the active load order — a deleted/disabled form or a wrong FormID, so the condition can't evaluate as intended."));
             }
 
             // 4. Dangling global comparison value — a ConditionGlobal compared against a GLOB not in the order. The
@@ -947,7 +947,7 @@ public static class DialogueValidate
             if (data is IGetIsIDConditionDataGetter gid && floiIsForm && WriteEngine.ReadFloiFormKey(gid.Object) is { } objFk
                 && inOrder(objFk) && resolve(objFk) is IPlacedGetter)
                 issues.Add(new(DialogueIssueSeverity.Warning,
-                    $"INFO {FormIdToken.Of(info.FormKey)} condition #{n} (GetIsID) points at the placed reference {objFk}, but GetIsID compares the run-on actor's BASE form — pass the base NPC_/object, not a placed instance."));
+                    $"INFO {FormIdToken.Of(info.FormKey)} condition #{n} (GetIsID) points at the placed reference {FormIdToken.Of(objFk)}, but GetIsID compares the run-on actor's BASE form — pass the base NPC_/object, not a placed instance."));
         }
     }
 
@@ -959,5 +959,5 @@ public static class DialogueValidate
     /// owning quest — never a bare "invalid".</summary>
     static DialogueIssue AliasIssue(FormKey infoFk, int n, string fn, int idx, string verb, string aliasKind, string ownerQuestLabel) =>
         new(DialogueIssueSeverity.Warning,
-            $"INFO {infoFk} condition #{n} ({fn}) {verb} {ownerQuestLabel}'s {aliasKind} #{idx}, but that quest defines no alias with that ID — the gate evaluates against nothing.");
+            $"INFO {FormIdToken.Of(infoFk)} condition #{n} ({fn}) {verb} {ownerQuestLabel}'s {aliasKind} #{idx}, but that quest defines no alias with that ID — the gate evaluates against nothing.");
 }

--- a/src/housecarl-core/EffectChain.cs
+++ b/src/housecarl-core/EffectChain.cs
@@ -139,7 +139,7 @@ public static class EffectChain
                 catch (Exception ex)
                 {
                     unscannable++;
-                    if (samples.Count < 3) samples.Add($"{fk} — {ex.GetType().Name}: {ex.Message}");
+                    if (samples.Count < 3) samples.Add($"{FormIdToken.Of(fk)} — {ex.GetType().Name}: {ex.Message}");
                 }
             }
         }

--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -303,7 +303,7 @@ public static class ErrorCheck
                     catch (Exception ex)
                     {
                         unscannable++;
-                        if (unscannableSamples.Count < 3) unscannableSamples.Add($"{fk} — {ex.GetType().Name}: {ex.Message}");
+                        if (unscannableSamples.Count < 3) unscannableSamples.Add($"{FormIdToken.Of(fk)} — {ex.GetType().Name}: {ex.Message}");
                     }
                 }
             }
@@ -407,7 +407,7 @@ public static class ErrorCheck
                             catch (Exception ex)
                             {
                                 unscannable++;
-                                if (unscannableSamples.Count < 3) unscannableSamples.Add($"{rec.FormKey} — {ex.GetType().Name}: {ex.Message}");
+                                if (unscannableSamples.Count < 3) unscannableSamples.Add($"{FormIdToken.Of(rec.FormKey)} — {ex.GetType().Name}: {ex.Message}");
                             }
                         }
                     }

--- a/src/housecarl-core/FormIdToken.cs
+++ b/src/housecarl-core/FormIdToken.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using Mutagen.Bethesda.Plugins;
 
 namespace HousecarlCore;
@@ -16,27 +15,40 @@ namespace HousecarlCore;
 /// wrong answer to anything that joins them (#664).</para>
 ///
 /// <para>The canonical spelling is the load order's own: <see cref="LoadOrderResolver"/> publishes its plugin
-/// filenames (each <c>Path.GetFileName</c> of a real path) here as it builds. A name no order has published — an
-/// off-order plugin read straight from disk, a token naming a plugin that is not installed — keeps the spelling it
-/// arrived with, which for an off-order read is already the on-disk one. The table is process-wide because the
-/// print sites are static and deep (a reflected link value in <see cref="ReadEngine"/> has no load order to ask);
-/// one process serves one load order, and entries are additive and keyed case-insensitively, so a later build
-/// only ever corrects a spelling.</para>
+/// filenames (each <c>Path.GetFileName</c> of a real path) here as it builds. The table is REPLACED on every
+/// publish, not extended, so it is exactly the plugins of the order currently loaded — the server repoints at
+/// another MO2 instance or profile without a restart (<c>housecarl_set_mo2_instance</c>), and a name the new order
+/// does not carry must not keep the old order's spelling. A name the current table does not hold keeps the
+/// spelling it arrived with: an off-order plugin read straight from disk prints its on-disk name as read, and so
+/// does a token naming a plugin that is not installed.</para>
+///
+/// <para>The one case where an off-order read is respelled: the table is keyed case-insensitively, so an off-order
+/// file whose name matches an ACTIVE plugin's name in every way but case prints the active plugin's spelling. That
+/// is two files of one name on opposite arms — an edge the load order itself cannot address either, and the token
+/// is a load-order token, so it is spelled the way the load order spells that name.</para>
+///
+/// <para>The table is process-wide because the print sites are static and deep (a reflected link value in
+/// <see cref="ReadEngine"/> has no load order to ask); one process serves one load order AT A TIME, and the
+/// replace-on-publish above is what makes that true.</para>
 /// </summary>
 public static class FormIdToken
 {
-    static readonly ConcurrentDictionary<string, string> Canon = new(StringComparer.OrdinalIgnoreCase);
+    // Replaced whole on publish, never mutated in place: a reader either sees the old order's table or the new
+    // one's, never a half-swapped mix of the two.
+    static volatile Dictionary<string, string> Canon = new(StringComparer.OrdinalIgnoreCase);
 
-    /// <summary>Take these plugin filenames as canonical — called by <see cref="LoadOrderResolver.Build"/> with the
-    /// names it derived from the ordered paths.</summary>
+    /// <summary>Take these plugin filenames as canonical, REPLACING whatever order published before — called by
+    /// <see cref="LoadOrderResolver.Build"/> with the names it derived from the ordered paths.</summary>
     public static void Publish(IReadOnlyList<string> pluginFileNames)
     {
+        var next = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var n in pluginFileNames)
-            if (!string.IsNullOrEmpty(n)) Canon[n] = n;
+            if (!string.IsNullOrEmpty(n)) next[n] = n;
+        Canon = next;
     }
 
-    /// <summary>The canonical spelling of one plugin filename, or the name unchanged when no load order has
-    /// published it.</summary>
+    /// <summary>The canonical spelling of one plugin filename, or the name unchanged when the load order now
+    /// loaded does not carry it.</summary>
     public static string Plugin(string fileName)
         => Canon.TryGetValue(fileName, out var c) ? c : fileName;
 

--- a/src/housecarl-core/FormIdToken.cs
+++ b/src/housecarl-core/FormIdToken.cs
@@ -1,0 +1,55 @@
+using System.Collections.Concurrent;
+using Mutagen.Bethesda.Plugins;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// The ONE place a <c>XXXXXX:Plugin.esp</c> FormID token is spelled. Every print of a FormKey goes through
+/// <see cref="Of(FormKey)"/>, so a token carries the plugin's filename as it exists ON DISK — one canonical
+/// spelling — no matter where the FormKey came from.
+///
+/// <para>Why it is needed: a FormKey's ModKey is only as canonical as its source. A record's OWN key is spelled
+/// from the file Mutagen opened, but a LINK's key is spelled from the master list inside the plugin holding the
+/// link, which spells its masters however that plugin's author typed them, and a key parsed from a caller's token
+/// is spelled however the caller typed it. ModKey compares case-insensitively, so every lookup still lands — but
+/// the two spellings PRINT differently, and two reads of the same record then disagree in text, which is a silent
+/// wrong answer to anything that joins them (#664).</para>
+///
+/// <para>The canonical spelling is the load order's own: <see cref="LoadOrderResolver"/> publishes its plugin
+/// filenames (each <c>Path.GetFileName</c> of a real path) here as it builds. A name no order has published — an
+/// off-order plugin read straight from disk, a token naming a plugin that is not installed — keeps the spelling it
+/// arrived with, which for an off-order read is already the on-disk one. The table is process-wide because the
+/// print sites are static and deep (a reflected link value in <see cref="ReadEngine"/> has no load order to ask);
+/// one process serves one load order, and entries are additive and keyed case-insensitively, so a later build
+/// only ever corrects a spelling.</para>
+/// </summary>
+public static class FormIdToken
+{
+    static readonly ConcurrentDictionary<string, string> Canon = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Take these plugin filenames as canonical — called by <see cref="LoadOrderResolver.Build"/> with the
+    /// names it derived from the ordered paths.</summary>
+    public static void Publish(IReadOnlyList<string> pluginFileNames)
+    {
+        foreach (var n in pluginFileNames)
+            if (!string.IsNullOrEmpty(n)) Canon[n] = n;
+    }
+
+    /// <summary>The canonical spelling of one plugin filename, or the name unchanged when no load order has
+    /// published it.</summary>
+    public static string Plugin(string fileName)
+        => Canon.TryGetValue(fileName, out var c) ? c : fileName;
+
+    /// <summary>This FormKey as a token. Byte-for-byte <see cref="FormKey.ToString"/> except for the plugin half,
+    /// which is respelled canonically — so the local-ID formatting and the null form can never drift from
+    /// Mutagen's, and the token still parses back through <see cref="FormKey.Factory"/>.</summary>
+    public static string Of(FormKey fk)
+    {
+        var s = fk.ToString();
+        int i = s.LastIndexOf(':');
+        if (i < 0) return s;
+        var name = s[(i + 1)..];
+        var canon = Plugin(name);
+        return string.Equals(canon, name, StringComparison.Ordinal) ? s : string.Concat(s.AsSpan(0, i + 1), canon);
+    }
+}

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -577,6 +577,9 @@ public sealed class LoadOrderResolver : IDisposable
             stamps[i] = FileStamp.Of(p);
         }
 
+        // These names are the canonical spelling of every plugin in the order — every FormID token prints through them.
+        FormIdToken.Publish(names);
+
         return new LoadOrderResolver(paths, names, nameToIdx, stamps, explainAbsence);
     }
 
@@ -1071,7 +1074,7 @@ public sealed class LoadOrderResolver : IDisposable
                 var fk = rec.FormKey;
                 if (!s.Index.TryGetValue(fk, out var e))               // the FILE outran the snapshot (edited after the build) — name it, never skip
                     throw new InvalidOperationException(
-                        $"index staleness: '{pluginName}' yields {fk} which the current index build does not contain — the plugin changed since the index was built; re-run (the next call's freshness check rebuilds).");
+                        $"index staleness: '{pluginName}' yields {FormIdToken.Of(fk)} which the current index build does not contain — the plugin changed since the index was built; re-run (the next call's freshness check rebuilds).");
                 var touching = e.count == 1 ? new[] { _names[e.winner] } : Array.ConvertAll(s.Overriders[fk], i => _names[i]);
                 yield return new RecordStatus(fk, RecordNaming.StripOverlay(rec.GetType().Name),
                                               PluginWins: e.winner == idx, OverrideDepth: e.count, TouchingPlugins: touching);
@@ -1195,7 +1198,7 @@ public sealed class LoadOrderResolver : IDisposable
     {
         if (SeekBody(session.Overlay(overlayIdx), fk, getterType) is { } rec) return rec;
         throw new InvalidOperationException(
-            $"body-fetch inconsistency: {_names[overlayIdx]} is indexed as containing {fk} but did not yield it on re-enumeration.");
+            $"body-fetch inconsistency: {_names[overlayIdx]} is indexed as containing {FormIdToken.Of(fk)} but did not yield it on re-enumeration.");
     }
 
     // ---- Cross-query scan primitives -------------------

--- a/src/housecarl-core/OwnedChildLifecycle.cs
+++ b/src/housecarl-core/OwnedChildLifecycle.cs
@@ -151,20 +151,20 @@ public static class OwnedChildLifecycle
             if (slot.Shape == OwnedChildShape.Singular)
             {
                 if (!slot.Property.CanWrite)
-                    return $"'{slot.Describe()}' holds {slot.Child.FormKey} but is not settable, so the child cannot " +
+                    return $"'{slot.Describe()}' holds {FormIdToken.Of(slot.Child.FormKey)} but is not settable, so the child cannot " +
                            "be detached from its parent — surfaced, not swallowed (Q3).";
                 slot.Property.SetValue(slot.Parent, null);
                 return null;
             }
             if (slot.Container is null)
-                return $"'{slot.Describe()}' holds {slot.Child.FormKey} in no list this engine can drop it from — " +
+                return $"'{slot.Describe()}' holds {FormIdToken.Of(slot.Child.FormKey)} in no list this engine can drop it from — " +
                        "surfaced, not swallowed (Q3).";
             slot.Container.Remove(slot.Child);
             return null;
         }
         catch (Exception ex)
         {
-            return $"detaching {slot.Child.FormKey} from '{slot.Describe()}' threw ({ex.GetType().Name}: " +
+            return $"detaching {FormIdToken.Of(slot.Child.FormKey)} from '{slot.Describe()}' threw ({ex.GetType().Name}: " +
                    $"{ex.Message}) — surfaced, not swallowed (Q3).";
         }
     }

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -175,7 +175,7 @@ public static class ReadEngine
         if (target is null) { Console.Error.WriteLine($"error: not found in {Path.GetFileName(source)}"); return 1; }
 
         var typeName = RecordNaming.StripGetterInterface(WriteEngine.PrimaryGetter(target.GetType())?.Name ?? "I?Getter");
-        Console.WriteLine($"{typeName}  {target.FormKey}  ({target.EditorID ?? "<no editorid>"})");
+        Console.WriteLine($"{typeName}  {FormIdToken.Of(target.FormKey)}  ({target.EditorID ?? "<no editorid>"})");
 
         // --depth N (default 1): depth>=2 expands list/dict/substruct contents (descendable reads). With
         // --path it expands those targets; without, the whole-record dump. Routes through the SAME ReadFields
@@ -250,7 +250,7 @@ public static class ReadEngine
                 EmitWithDepth(on, string.Join(".", tail), d, fields, ref budget, p);
             }
         }
-        return new RecordFields(typeName, record.FormKey.ToString(), record.EditorID, fields);
+        return new RecordFields(typeName, FormIdToken.Of(record.FormKey), record.EditorID, fields);
     }
 
     /// <summary>The <c>*parent</c> containment step on a read path: strip the leading hops, climb to the record
@@ -900,13 +900,13 @@ public static class ReadEngine
         // reach it), and EditorID rides along when present, so a depth=2 owned-record list reads
         // "[DialogResponses 4D9A74:Plugin.esp editorid=…]" rather than a bare opaque [Type].
         if (val is IMajorRecordGetter mr)
-            return $"[{typeName} {mr.FormKey}{(string.IsNullOrEmpty(mr.EditorID) ? "" : $" editorid={mr.EditorID}")}]";
+            return $"[{typeName} {FormIdToken.Of(mr.FormKey)}{(string.IsNullOrEmpty(mr.EditorID) ? "" : $" editorid={mr.EditorID}")}]";
         foreach (var idName in IdentityFieldNames)
         {
             var p = t.GetProperty(idName, BindingFlags.Public | BindingFlags.Instance);
             if (p is null || p.GetIndexParameters().Length != 0) continue;
             object? iv; try { iv = p.GetValue(val); } catch { continue; }
-            var s = iv switch { null => null, string str => str, IFormLinkGetter fl => fl.FormKey.ToString(), _ => iv.ToString() };
+            var s = iv switch { null => null, string str => str, IFormLinkGetter fl => FormIdToken.Of(fl.FormKey), _ => iv.ToString() };
             if (string.IsNullOrEmpty(s)) continue;
             if (iv is IFormLinkGetter) refToken = s;
             return $"[{typeName}] {idName}={s}";
@@ -942,7 +942,7 @@ public static class ReadEngine
         try
         {
             if (only.GetValue(val) is not IFormLinkGetter fl) return null;
-            refToken = fl.FormKey.ToString();
+            refToken = FormIdToken.Of(fl.FormKey);
             return $"{only.Name}={refToken}";
         }
         catch { return null; }
@@ -1036,7 +1036,7 @@ public static class ReadEngine
         // link (FormKey.Null) is NOT a round-trippable token (the write surface sets links to a real
         // FormKey, never "Null"), so surface it as no-value — consistent with what Coerce accepts.
         if (val is IFormLinkGetter fl)
-            return fl.FormKey.IsNull ? LeafRead.None(NullLinkNote) : LeafRead.Value(fl.FormKey.ToString());
+            return fl.FormKey.IsNull ? LeafRead.None(NullLinkNote) : LeafRead.Value(FormIdToken.Of(fl.FormKey));
         // TranslatedString (FULL/DESC) — emit the resolved .String (the inverse of Coerce's implicit
         // `record.Name = "x"`). A genuinely-empty "" still round-trips as a value; a NULL .String is an
         // UNRESOLVED localized string (no .STRINGS entry for the target language in the workspace) and is
@@ -1189,7 +1189,7 @@ public static class ReadEngine
             case TimeOnly t: token = t.ToString("O", CultureInfo.InvariantCulture); return true;
             case char ch: token = ch.ToString(); return true;
             case string[] arr: token = string.Join(",", arr); return true;
-            case FormKey fk: token = fk.ToString(); return true;
+            case FormKey fk: token = FormIdToken.Of(fk); return true;
             case ModKey mk: token = mk.ToString(); return true;
             case RecordType rt: token = rt.ToString(); return true;
         }
@@ -1241,8 +1241,8 @@ public static class ReadEngine
             // Form mode. The binary overlay's FLOI is NOT itself a link — it carries the link in its
             // .Link property, the same accessor the write side reads (ReadFloiFormKey).
             // A present-but-null link stays a note, matching plain FormLink leaves.
-            if (val is IFormLinkGetter fl) return LeafRead.Value(fl.FormKey.ToString());
-            if (WriteEngine.ReadFloiFormKey(val) is { } fk) return LeafRead.Value(fk.ToString());
+            if (val is IFormLinkGetter fl) return LeafRead.Value(FormIdToken.Of(fl.FormKey));
+            if (WriteEngine.ReadFloiFormKey(val) is { } fk) return LeafRead.Value(FormIdToken.Of(fk));
             return LeafRead.Unreadable($"(floi: form mode, null or unreadable FormKey on {val.GetType().Name})");
         }
 

--- a/src/housecarl-core/RemapEngine.cs
+++ b/src/housecarl-core/RemapEngine.cs
@@ -238,7 +238,7 @@ public static class RemapEngine
                     catch (Exception ex)
                     {
                         unscannable++;
-                        if (unscannableSamples.Count < 5) unscannableSamples.Add($"{plugin} {fk} — {ex.GetType().Name}: {ex.Message}");
+                        if (unscannableSamples.Count < 5) unscannableSamples.Add($"{plugin} {FormIdToken.Of(fk)} — {ex.GetType().Name}: {ex.Message}");
                     }
                 }
                 if (!headerFaulted) scanned++;                           // counted only once the whole plugin has been read through, header included
@@ -365,13 +365,13 @@ public static class RemapEngine
             catch (Exception ex)
             {
                 return RenumberResult.Fail(
-                    $"could not duplicate {RecordNaming.StripOverlay(rec.GetType().Name)} {rec.FormKey} under {newKey} " +
+                    $"could not duplicate {RecordNaming.StripOverlay(rec.GetType().Name)} {FormIdToken.Of(rec.FormKey)} under {newKey} " +
                     $"({WriteEngine.Describe(ex)}) — the renumber is abandoned with nothing shippable (Q3).");
             }
 
             if (!TryAddToFlatGroup(target, dup))
                 return RenumberResult.Fail(
-                    $"{RecordNaming.StripOverlay(rec.GetType().Name)} {rec.FormKey} lives only in a NESTED group (Cell / placed " +
+                    $"{RecordNaming.StripOverlay(rec.GetType().Name)} {FormIdToken.Of(rec.FormKey)} lives only in a NESTED group (Cell / placed " +
                     "ref / INFO / navmesh / landscape), which has no flat top-level group to place the duplicate into. The nested " +
                     "duplicate-into placement is a later wave — refusing rather than silently dropping the record (Q3).");
 
@@ -458,7 +458,7 @@ public static class RemapEngine
                     var dup = RenumberOne(rec, dict, stats);
                     if (!TryAddToFlatGroup(target, dup))
                         return RenumberResult.Fail(
-                            $"{RecordNaming.StripOverlay(rec.GetType().Name)} {rec.FormKey} is a flat top-level record but no matching " +
+                            $"{RecordNaming.StripOverlay(rec.GetType().Name)} {FormIdToken.Of(rec.FormKey)} is a flat top-level record but no matching " +
                             $"group was found on the target mod to place its renumbered copy (engine inconsistency, Q3) — the renumber is abandoned with nothing shippable.");
                 }
             }
@@ -759,7 +759,7 @@ public static class RemapEngine
                             var dup = RenumberOne(rec, dict, stats, reg);
                             if (!TryAddToFlatGroup(target, dup))
                                 return MergeResult.Fail(
-                                    $"{RecordNaming.StripOverlay(rec.GetType().Name)} {rec.FormKey} (donor '{name}') is a flat top-level record but no " +
+                                    $"{RecordNaming.StripOverlay(rec.GetType().Name)} {FormIdToken.Of(rec.FormKey)} (donor '{name}') is a flat top-level record but no " +
                                     "matching group was found on the target mod to place its merged copy (engine inconsistency, Q3) — the merge is abandoned with nothing shippable.");
                         }
                     }
@@ -827,7 +827,7 @@ public static class RemapEngine
                     winner.GetType().GetProperty(prop.Name)?.GetValue(winner) as IList
                     ?? throw new InvalidOperationException(
                         $"cannot graft {what}: the winning donor's {RecordNaming.StripOverlay(winner.GetType().Name)} " +
-                        $"{winner.FormKey} has no settable record list '{prop.Name}' to receive it (Q3).");
+                        $"{FormIdToken.Of(winner.FormKey)} has no settable record list '{prop.Name}' to receive it (Q3).");
                 foreach (var el in seq)
                 {
                     if (el is IMajorRecordGetter childRec)
@@ -838,7 +838,7 @@ public static class RemapEngine
                             GraftMissingDescendants(childRec, placed, dict, stats, reg);
                             continue;
                         }
-                        WinnerList($"{RecordNaming.StripOverlay(childRec.GetType().Name)} {childRec.FormKey}")
+                        WinnerList($"{RecordNaming.StripOverlay(childRec.GetType().Name)} {FormIdToken.Of(childRec.FormKey)}")
                             .Add(RenumberOne(childRec, dict, stats, reg));
                     }
                     else if (el is IMajorRecordGetterEnumerable blockStruct)
@@ -866,8 +866,8 @@ public static class RemapEngine
         var prop = winner.GetType().GetProperty(propName);
         if (prop is null || !prop.CanWrite)
             throw new InvalidOperationException(
-                $"cannot graft {RecordNaming.StripOverlay(child.GetType().Name)} {child.FormKey}: the winning donor's " +
-                $"{RecordNaming.StripOverlay(winner.GetType().Name)} {winner.FormKey} has no settable '{propName}' slot to receive it (Q3).");
+                $"cannot graft {RecordNaming.StripOverlay(child.GetType().Name)} {FormIdToken.Of(child.FormKey)}: the winning donor's " +
+                $"{RecordNaming.StripOverlay(winner.GetType().Name)} {FormIdToken.Of(winner.FormKey)} has no settable '{propName}' slot to receive it (Q3).");
         if (prop.GetValue(winner) is IMajorRecord occupant)
         {
             // The winner already carries its OWN (different) record in this slot — the winner's structure wins wholesale;

--- a/src/housecarl-core/ScriptPropertyCheck.cs
+++ b/src/housecarl-core/ScriptPropertyCheck.cs
@@ -396,7 +396,7 @@ public static class ScriptPropertyCheck
     /// lanes, so an off-order file's unreadable adapter reads exactly as an indexed one's.</summary>
     static string RecordFault(string? soFar, FormKey fk, Exception ex)
         => (soFar is null ? "" : soFar + "; ")
-         + $"a record's script adapter could not be read ({fk} — {ex.GetType().Name}: {ex.Message})";
+         + $"a record's script adapter could not be read ({FormIdToken.Of(fk)} — {ex.GetType().Name}: {ex.Message})";
 
     /// <summary>Every script attachment on the record: the adapter's own <see cref="IAVirtualMachineAdapterGetter.Scripts"/>
     /// PLUS, for a QUEST, each alias's scripts (<see cref="IQuestAdapterGetter.Aliases"/> →

--- a/src/housecarl-core/SkyPatcherConflicts.cs
+++ b/src/housecarl-core/SkyPatcherConflicts.cs
@@ -286,7 +286,7 @@ public static class SkyPatcherConflicts
             if (IsBarePrimary(cls))
                 foreach (var v in seg.Values)
                     tokens.Add(v.Address is { IsFormId: true } a && SkyPatcherOverlay.TryFormKey(a, out var fk)
-                        ? fk.ToString()
+                        ? FormIdToken.Of(fk)
                         : v.Raw.ToLowerInvariant());
             else
                 conditional = true;   // Excluded-primary, crosscutting, restrictTo, gates — narrows applicability

--- a/src/housecarl-core/SkyPatcherOverlay.cs
+++ b/src/housecarl-core/SkyPatcherOverlay.cs
@@ -569,7 +569,7 @@ public static class SkyPatcherOverlay
                 var hay = resolver.ReadWinnerLeaf(donor.Value, spec.Paths[0]);
                 if (hay is null)
                 {
-                    warn.Add($"ds:{cls.BaseKey}:{donor}", $"filter '{cls.BaseKey}' — could not read '{spec.Paths[0]}' off {donor}'s winner; whether the line applies is UNRESOLVED.");
+                    warn.Add($"ds:{cls.BaseKey}:{donor}", $"filter '{cls.BaseKey}' — could not read '{spec.Paths[0]}' off {FormIdToken.Of(donor.Value)}'s winner; whether the line applies is UNRESOLVED.");
                     return FilterVerdict.Unresolved;
                 }
                 return ContainsVerdict(seg, conn, hay) ? FilterVerdict.Match : FilterVerdict.NoMatch;
@@ -581,7 +581,7 @@ public static class SkyPatcherOverlay
                 var mine = resolver.KeywordsOf(donor.Value);
                 if (mine is null)
                 {
-                    warn.Add($"dk:{cls.BaseKey}:{donor}", $"filter '{cls.BaseKey}' — could not read the keywords of {donor}'s winner; whether the line applies is UNRESOLVED.");
+                    warn.Add($"dk:{cls.BaseKey}:{donor}", $"filter '{cls.BaseKey}' — could not read the keywords of {FormIdToken.Of(donor.Value)}'s winner; whether the line applies is UNRESOLVED.");
                     return FilterVerdict.Unresolved;
                 }
                 return KeywordVerdict(mine, seg, cls.BaseKey, conn, resolver, warn);
@@ -1173,7 +1173,7 @@ public static class SkyPatcherOverlay
 
         string token;
         if (v.IsNameLiteral) token = v.NameText!;                       // rename literal, wrapper stripped
-        else if (v.Address is { IsFormId: true } a && TryFormKey(a, out var fk1)) token = FormIdToken.Of(fk1);
+        else if (v.Address is { IsFormId: true } a && TryFormKey(a, out var fk1)) token = fk1.ToString();
         else if (map.ValueMap is { } vm && vm.TryGetValue(v.Raw, out var mapped)) token = mapped;
         else if (map.FormType is not null)
         {

--- a/src/housecarl-core/SkyPatcherOverlay.cs
+++ b/src/housecarl-core/SkyPatcherOverlay.cs
@@ -216,7 +216,7 @@ public static class SkyPatcherOverlay
         return new SkyPatcherOverlayResult(applied, directives, warnings, matched, unresolvedSkips);
     }
 
-    static string Ident(FormKey fk, string? editorId) => editorId is null ? fk.ToString() : $"{fk} ({editorId})";
+    static string Ident(FormKey fk, string? editorId) => editorId is null ? FormIdToken.Of(fk) : $"{FormIdToken.Of(fk)} ({editorId})";
 
     static string HardReason(SkyPatcherOpDef op) => op.Shape switch
     {
@@ -374,7 +374,7 @@ public static class SkyPatcherOverlay
                 if (resolver.WinnerPluginOf(fk) is { } winner
                     && seg.Values.Any(v => v.Raw.Equals(winner, StringComparison.OrdinalIgnoreCase)) != inSet)
                 {
-                    warn.Add($"mn:{fk}", $"filterByModNames{conn}: the record's defining master ('{origin}') and winning override ('{winner}') disagree on membership — which one the DLL tests is unverified, so whether the line applies is UNRESOLVED.");
+                    warn.Add($"mn:{FormIdToken.Of(fk)}", $"filterByModNames{conn}: the record's defining master ('{origin}') and winning override ('{winner}') disagree on membership — which one the DLL tests is unverified, so whether the line applies is UNRESOLVED.");
                     return FilterVerdict.Unresolved;
                 }
                 bool ok = conn is "Excluded" or "Exclude" ? !inSet : inSet;
@@ -401,7 +401,7 @@ public static class SkyPatcherOverlay
                 var winner = resolver.WinnerPluginOf(fk);
                 if (winner is null)
                 {
-                    warn.Add($"ov:{fk}", $"modNamesLastOverridden{conn}: could not resolve the winning override plugin of {fk} — whether the line yields is UNRESOLVED.");
+                    warn.Add($"ov:{FormIdToken.Of(fk)}", $"modNamesLastOverridden{conn}: could not resolve the winning override plugin of {FormIdToken.Of(fk)} — whether the line yields is UNRESOLVED.");
                     return FilterVerdict.Unresolved;
                 }
                 bool hit = seg.Values.Any(v => v.Raw.Equals(winner, StringComparison.OrdinalIgnoreCase));
@@ -1173,7 +1173,7 @@ public static class SkyPatcherOverlay
 
         string token;
         if (v.IsNameLiteral) token = v.NameText!;                       // rename literal, wrapper stripped
-        else if (v.Address is { IsFormId: true } a && TryFormKey(a, out var fk1)) token = fk1.ToString();
+        else if (v.Address is { IsFormId: true } a && TryFormKey(a, out var fk1)) token = FormIdToken.Of(fk1);
         else if (map.ValueMap is { } vm && vm.TryGetValue(v.Raw, out var mapped)) token = mapped;
         else if (map.FormType is not null)
         {

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -494,7 +494,7 @@ public static class WriteEngine
         if (linkedGetter is null) return null;
         foreach (var rec in mod.EnumerateMajorRecords())
             if (linkedGetter.IsInstanceOfType(rec) && rec.FormKey != current && !rec.FormKey.IsNull)
-                return FormIdToken.Of(rec.FormKey);
+                return rec.FormKey.ToString();
         return null;
     }
 

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -150,7 +150,7 @@ public static class WriteEngine
             Console.Error.WriteLine($"error: no {type} with {(editorid is not null ? "EditorID '" + editorid + "'" : "FormKey " + formkeyRaw)} in {Path.GetFileName(source)}.");
             return 1;
         }
-        Console.WriteLine($"Resolved:      {target.FormKey} ({target.EditorID ?? "<no editorid>"})");
+        Console.WriteLine($"Resolved:      {FormIdToken.Of(target.FormKey)} ({target.EditorID ?? "<no editorid>"})");
         foreach (var r in reqs)
             Console.WriteLine($"  before: {string.Join('.', r.Path)}{(r.Key is not null ? "[" + r.Key + "]" : "")} = {ReadLeafDisplay(target, r.Path, r.Key)}");
         Console.WriteLine();
@@ -176,7 +176,7 @@ public static class WriteEngine
         try { patchRecord = GenericGetOrAddAsOverride(patchMod, target, sourceCache); }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"error: could not override {type} {target.FormKey} — {ex.Message}");
+            Console.Error.WriteLine($"error: could not override {type} {FormIdToken.Of(target.FormKey)} — {ex.Message}");
             return 1;
         }
         foreach (var r in reqs) ApplyVerb(patchRecord, r);
@@ -248,7 +248,7 @@ public static class WriteEngine
             var val = leaf.GetValue(current);
             if (val is null) return "(null)";
             static string Fmt(object? o) =>
-                o is null ? "(null)" : o is IFormLinkGetter fl ? fl.FormKey.ToString() : o.ToString() ?? "(null)";
+                o is null ? "(null)" : o is IFormLinkGetter fl ? FormIdToken.Of(fl.FormKey) : o.ToString() ?? "(null)";
             if (key is not null)
             {
                 if (val is System.Collections.IDictionary dd)
@@ -309,7 +309,7 @@ public static class WriteEngine
         if (target is null) { Console.Error.WriteLine($"error: not found in {Path.GetFileName(source)}"); return 1; }
 
         var typeName = RecordNaming.StripGetterInterface(PrimaryGetter(target.GetType())?.Name ?? "I?Getter");
-        Console.WriteLine($"{typeName}  {target.FormKey}  ({target.EditorID ?? "<no editorid>"})");
+        Console.WriteLine($"{typeName}  {FormIdToken.Of(target.FormKey)}  ({target.EditorID ?? "<no editorid>"})");
         foreach (var p in paths)
             Console.WriteLine($"  {p} = {ReadLeafDisplay(target, p.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries), null)}");
 
@@ -394,7 +394,7 @@ public static class WriteEngine
         var ownerCatalog = RecordNaming.StripGetterInterface(PrimaryGetter(owner.GetType())?.Name ?? "I?Getter");
         Console.WriteLine($"Source plugin: {source}");
         Console.WriteLine($"Output patch:  {outPath}  (ModKey {name}.esp)");
-        Console.WriteLine($"Condition:     {ownerCatalog} {owner.FormKey} ({owner.EditorID ?? "<no editorid>"}) . {condField}[{condIndex}] . {armCatalog}.{floiProp}");
+        Console.WriteLine($"Condition:     {ownerCatalog} {FormIdToken.Of(owner.FormKey)} ({owner.EditorID ?? "<no editorid>"}) . {condField}[{condIndex}] . {armCatalog}.{floiProp}");
         Console.WriteLine($"Re-target:     {oldTarget}  ->  {newTarget}   (form mode)");
         Console.WriteLine();
 
@@ -408,7 +408,7 @@ public static class WriteEngine
         var patchMod = new SkyrimMod(new ModKey(name, ModType.Plugin), SkyrimRelease.SkyrimSE);
         IMajorRecord ov;
         try { ov = GenericGetOrAddAsOverride(patchMod, owner, cache); }
-        catch (Exception ex) { Console.Error.WriteLine($"error: could not override {ownerCatalog} {owner.FormKey} — {ex.Message}"); return 1; }
+        catch (Exception ex) { Console.Error.WriteLine($"error: could not override {ownerCatalog} {FormIdToken.Of(owner.FormKey)} — {ex.Message}"); return 1; }
         object arm;
         try { arm = NavigateToConditionArm(ov, condField, condIndex); }
         catch (Exception ex) { Console.Error.WriteLine($"error: could not navigate to the condition arm — {ex.Message}"); return 1; }
@@ -445,7 +445,7 @@ public static class WriteEngine
 
         var ok = sourceUnchanged && readBack is { } rb && !rb.IsNull;
         Console.WriteLine(ok
-            ? $"=== CONDITION PATCH WRITTEN — open {Path.GetFileName(outPath)} in xEdit: {ownerCatalog} {owner.FormKey}, condition #{condIndex}, confirm the target is now {newTarget}. Original untouched. ==="
+            ? $"=== CONDITION PATCH WRITTEN — open {Path.GetFileName(outPath)} in xEdit: {ownerCatalog} {FormIdToken.Of(owner.FormKey)}, condition #{condIndex}, confirm the target is now {newTarget}. Original untouched. ==="
             : "=== FAIL — see above ===");
         return ok ? 0 : 1;
     }
@@ -494,7 +494,7 @@ public static class WriteEngine
         if (linkedGetter is null) return null;
         foreach (var rec in mod.EnumerateMajorRecords())
             if (linkedGetter.IsInstanceOfType(rec) && rec.FormKey != current && !rec.FormKey.IsNull)
-                return rec.FormKey.ToString();
+                return FormIdToken.Of(rec.FormKey);
         return null;
     }
 
@@ -569,7 +569,7 @@ public static class WriteEngine
         try { carry = CaptureChildGroup(record); return null; }
         catch (Exception ex)
         {
-            return $"cannot forward {record.FormKey}: reading the child records under the version the destination " +
+            return $"cannot forward {FormIdToken.Of(record.FormKey)}: reading the child records under the version the destination " +
                    $"already carries threw ({ex.GetType().Name}: {ex.Message}) — surfaced, not swallowed (Q3). " +
                    untouchedClause;
         }
@@ -600,7 +600,7 @@ public static class WriteEngine
             if (arrived > 0)
             {
                 var sample = string.Join(", ", ChildNamesOf(fresh, 5)) + (arrived > 5 ? ", …" : "");
-                return $"cannot forward {fresh.FormKey}: the forwarded copy arrived carrying {arrived} child record(s) "
+                return $"cannot forward {FormIdToken.Of(fresh.FormKey)}: the forwarded copy arrived carrying {arrived} child record(s) "
                      + $"of its own ({sample}), " + (carry.IsEmpty
                          ? "which a forward does not mean — it asserts the source's FIELDS and leaves the source's own "
                            + "children in the source's plugin, so houseCARL refuses rather than silently import them (Q3). "
@@ -620,7 +620,7 @@ public static class WriteEngine
             // reflected set that would restore them is empty, and that disagreement is exactly the silent loss.
             var after = ChildCountOf(fresh);
             if (after != carry.Count)
-                return $"cannot forward {fresh.FormKey}: it carries {carry.Count} child record(s) " +
+                return $"cannot forward {FormIdToken.Of(fresh.FormKey)}: it carries {carry.Count} child record(s) " +
                        $"({string.Join(", ", carry.Names)}{(carry.Count > carry.Names.Count ? ", …" : "")}) and {after} " +
                        "are on the record after the replace — houseCARL will not write a plugin whose child records it " +
                        $"cannot account for (Q3). {untouchedClause} Please report this with the record type.";
@@ -628,7 +628,7 @@ public static class WriteEngine
         }
         catch (Exception ex)
         {
-            return $"cannot preserve the {carry.Count} child record(s) under {fresh.FormKey}: carrying them across " +
+            return $"cannot preserve the {carry.Count} child record(s) under {FormIdToken.Of(fresh.FormKey)}: carrying them across " +
                    $"the replace threw ({ex.GetType().Name}: {ex.Message}) — surfaced, not swallowed (Q3). " +
                    untouchedClause;
         }
@@ -644,7 +644,7 @@ public static class WriteEngine
     /// <summary>Up to <paramref name="max"/> child records of <paramref name="record"/>, named for a message.</summary>
     internal static List<string> ChildNamesOf(IMajorRecordGetter record, int max) =>
         record is IMajorRecordGetterEnumerable e
-            ? e.EnumerateMajorRecords().Take(max).Select(r => r.EditorID ?? r.FormKey.ToString()).ToList()
+            ? e.EnumerateMajorRecords().Take(max).Select(r => r.EditorID ?? FormIdToken.Of(r.FormKey)).ToList()
             : new List<string>();
 
     /// <summary>The settable properties of <paramref name="t"/> that can REACH an owned major record, MEMOIZED per type
@@ -810,7 +810,7 @@ public static class WriteEngine
     {
         if (sourceLinkCache is null)
             throw new InvalidOperationException(
-                $"Record {source.FormKey} ({source.GetType().Name}) is in a nested group (no flat SkyrimGroup<T>) " +
+                $"Record {FormIdToken.Of(source.FormKey)} ({source.GetType().Name}) is in a nested group (no flat SkyrimGroup<T>) " +
                 "and needs the source link cache to reconstruct its parent chain — pass sourceLinkCache " +
                 "(sourceMod.ToImmutableLinkCache()) to GenericGetOrAddAsOverride. Surfaced, not guessed (Q3).");
 
@@ -840,17 +840,17 @@ public static class WriteEngine
         catch (TargetInvocationException tie)
         {
             throw new InvalidOperationException(
-                $"Nested record {source.FormKey} ({source.GetType().Name}) not found in the source cache — " +
+                $"Nested record {FormIdToken.Of(source.FormKey)} ({source.GetType().Name}) not found in the source cache — " +
                 "cannot reconstruct its parent chain (fail-closed, Q3).", tie.InnerException ?? tie);
         }
         if (ctx is null)
             throw new InvalidOperationException(
-                $"ResolveContext returned null for nested record {source.FormKey} — not found in the source cache.");
+                $"ResolveContext returned null for nested record {FormIdToken.Of(source.FormKey)} — not found in the source cache.");
 
         var goao = ctx.GetType().GetMethods(BindingFlags.Public | BindingFlags.Instance)
             .FirstOrDefault(m => m.Name == "GetOrAddAsOverride" && m.GetParameters().Length == 1
                 && m.GetParameters()[0].ParameterType.IsInstanceOfType(patchMod))
-            ?? throw new InvalidOperationException($"Nested context for {source.FormKey} has no GetOrAddAsOverride(mod).");
+            ?? throw new InvalidOperationException($"Nested context for {FormIdToken.Of(source.FormKey)} has no GetOrAddAsOverride(mod).");
 
         return (IMajorRecord)goao.Invoke(ctx, new object[] { patchMod })!;
     }
@@ -1078,7 +1078,7 @@ public static class WriteEngine
                 var foreign = matches.FirstOrDefault(r => r.FormKey.ModKey != patchMod.ModKey);
                 if (foreign is not null)
                     throw new InvalidOperationException(
-                        $"create refused: this patch already carries an OVERRIDE of {foreign.FormKey} whose editorid is '{editorId}' — " +
+                        $"create refused: this patch already carries an OVERRIDE of {FormIdToken.Of(foreign.FormKey)} whose editorid is '{editorId}' — " +
                         $"re-creating over an override would blank the original plugin's record. Pick a different editorid for the new record, " +
                         "or edit the override's fields with " + ToolNames.Apply + ".");
                 if (matches.Count > 1)
@@ -1482,7 +1482,7 @@ public static class WriteEngine
         // looking at; this one asks the copy about to be written, and catches a difference between the two.
         if (shape == OwnedChildShape.Singular && prop!.GetValue(parentInPatch) is IMajorRecordGetter occupant)
             throw new InvalidOperationException(
-                $"nested create: '{parentName}.{prop.Name}' already holds a {childType.Name} ({occupant.FormKey}" +
+                $"nested create: '{parentName}.{prop.Name}' already holds a {childType.Name} ({FormIdToken.Of(occupant.FormKey)}" +
                 (occupant.EditorID is { } oe ? $" editorid={oe}" : "") + ") and it holds exactly one, so there is no " +
                 "room to create another. Edit the one that is there by its own FormID, or remove it first with " +
                 ToolNames.Remove + " and create again.");
@@ -1591,7 +1591,7 @@ public static class WriteEngine
         foreach (var existing in patchMod.EnumerateMajorRecords())
             if (recordType.IsInstanceOfType(existing) && string.Equals(existing.EditorID, editorId, StringComparison.Ordinal))
                 throw new InvalidOperationException(
-                    $"a {recordType.Name} with editorid '{editorId}' already exists in this patch ({existing.FormKey}); creating " +
+                    $"a {recordType.Name} with editorid '{editorId}' already exists in this patch ({FormIdToken.Of(existing.FormKey)}); creating " +
                     $"it again would duplicate it. {recordType.Name} create does not upsert here — edit the existing record, or " +
                     "use a different editorid.");
     }
@@ -2101,7 +2101,7 @@ public static class WriteEngine
             // a directly-assignable immutable reference (string, MemorySlice…) — safe to share while the source overlay lives
             if (pt.IsInstanceOfType(srcVal)) { prop.SetValue(parent, srcVal); return; }
             // a settable FormLink slot (rare) — build the matching concrete from the source key
-            if (srcVal is IFormLinkGetter sfl && TryFormLink(sfl.FormKey.ToString(), Nullable.GetUnderlyingType(pt) ?? pt, out var mk)
+            if (srcVal is IFormLinkGetter sfl && TryFormLink(FormIdToken.Of(sfl.FormKey), Nullable.GetUnderlyingType(pt) ?? pt, out var mk)
                 && mk is not null && pt.IsInstanceOfType(mk)) { prop.SetValue(parent, mk); return; }
             throw new ExpectedApplyRejectionException(
                 $"CopyFrom cannot assign a {Pretty(srcVal.GetType())} into settable '{prop.Name}' ({Pretty(pt)}) — a field kind CopyFrom doesn't transplant yet (a clean refusal, not a silent skip).");

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1084,7 +1084,7 @@ public static class WriteEngine
                 if (matches.Count > 1)
                     throw new InvalidOperationException(
                         $"create refused: this patch carries {matches.Count} records with editorid '{editorId}' " +
-                        $"({string.Join(", ", matches.Select(m => m.FormKey))}) — duplicate residue from re-running creates on a pre-fix houseCARL. " +
+                        $"({string.Join(", ", matches.Select(m => FormIdToken.Of(m.FormKey)))}) — duplicate residue from re-running creates on a pre-fix houseCARL. " +
                         "External references may point at either copy, so which survives is your call: remove the extra(s) with " + ToolNames.Remove + ", then re-run.");
                 var existing = matches[0];
                 if (!CanCreateType(typeName, out var reason)) throw new InvalidOperationException(reason);
@@ -1102,7 +1102,7 @@ public static class WriteEngine
                 // IS a cross-type collision — different concrete records).
                 if (!UpsertWouldReplace(patchMod, typeName, matches))
                     throw new InvalidOperationException(
-                        $"upsert refused: existing record '{editorId}' ({formKey}) is a {existing.GetType().Name}, not a {typeName} — " +
+                        $"upsert refused: existing record '{editorId}' ({FormIdToken.Of(formKey)}) is a {existing.GetType().Name}, not a {typeName} — " +
                         "an EditorID collision across record types is a real authoring error, surfaced not swallowed (Q3).");
 
                 // An arm re-adds through Add(T), not the abstract-base InvokeAddNewWithFormKey (which can't close AddNew<T>).
@@ -1157,7 +1157,7 @@ public static class WriteEngine
             var result = instance.Invoke(group, new object[] { formKey });
             if (result is false)
                 throw new InvalidOperationException(
-                    $"Remove({formKey}) reported nothing removed — the matched record vanished between match and replace " +
+                    $"Remove({FormIdToken.Of(formKey)}) reported nothing removed — the matched record vanished between match and replace " +
                     "(engine inconsistency, surfaced not swallowed).");
             return;
         }
@@ -2101,7 +2101,7 @@ public static class WriteEngine
             // a directly-assignable immutable reference (string, MemorySlice…) — safe to share while the source overlay lives
             if (pt.IsInstanceOfType(srcVal)) { prop.SetValue(parent, srcVal); return; }
             // a settable FormLink slot (rare) — build the matching concrete from the source key
-            if (srcVal is IFormLinkGetter sfl && TryFormLink(FormIdToken.Of(sfl.FormKey), Nullable.GetUnderlyingType(pt) ?? pt, out var mk)
+            if (srcVal is IFormLinkGetter sfl && TryFormLink(sfl.FormKey.ToString(), Nullable.GetUnderlyingType(pt) ?? pt, out var mk)
                 && mk is not null && pt.IsInstanceOfType(mk)) { prop.SetValue(parent, mk); return; }
             throw new ExpectedApplyRejectionException(
                 $"CopyFrom cannot assign a {Pretty(srcVal.GetType())} into settable '{prop.Name}' ({Pretty(pt)}) — a field kind CopyFrom doesn't transplant yet (a clean refusal, not a silent skip).");

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -454,7 +454,7 @@ public static class WritePatchBuilder
             if (w is not null)
             {
                 body = view.GetRecord(session, w.Value.WinnerPlugin, e.Target);
-                if (body is null) { problems.Add($"{e.Target}: winner '{w.Value.WinnerPlugin}' did not yield it on fetch (a load-order inconsistency)."); continue; }
+                if (body is null) { problems.Add($"{FormIdToken.Of(e.Target)}: winner '{w.Value.WinnerPlugin}' did not yield it on fetch (a load-order inconsistency)."); continue; }
                 winnerPlugin = w.Value.WinnerPlugin;
             }
             else
@@ -471,7 +471,7 @@ public static class WritePatchBuilder
                 }
                 if (patchLocal is null)
                 {
-                    problems.Add($"{e.Target}: not present in the load order ({view.PluginCount} plugins)"
+                    problems.Add($"{FormIdToken.Of(e.Target)}: not present in the load order ({view.PluginCount} plugins)"
                         + (extend
                             ? $", and not a record '{fileName}' (the patch being extended) itself defines — a record " +
                               "the patch merely OVERRIDES resolves via the load order, so its defining plugin must be enabled."
@@ -496,18 +496,18 @@ public static class WritePatchBuilder
                 if (TryOffOrderCopyBody(copyFromSources, e, view, out var offSrc))
                     srcBody = offSrc;
                 else if (string.IsNullOrWhiteSpace(srcPlugin))
-                { problems.Add($"{e.Target}: CopyFrom is missing from_plugin (internal — the mapper should have caught this)."); continue; }
+                { problems.Add($"{FormIdToken.Of(e.Target)}: CopyFrom is missing from_plugin (internal — the mapper should have caught this)."); continue; }
                 else if (string.Equals(srcPlugin, fileName, StringComparison.OrdinalIgnoreCase))
-                { problems.Add($"{e.Target}: CopyFrom from_plugin '{srcPlugin}' is the output patch itself — name the OTHER plugin whose version to copy from."); continue; }
+                { problems.Add($"{FormIdToken.Of(e.Target)}: CopyFrom from_plugin '{srcPlugin}' is the output patch itself — name the OTHER plugin whose version to copy from."); continue; }
                 else if (!view.ContainsPlugin(srcPlugin))
                 // Deliberately NO AbsenceClause here: the service pre-resolves every off-order CopyFrom source before
                 // Apply — a source that is merely unticked / in a disabled mod / shadowed is LOCATED and supplied via
                 // copyFromSources above, and one that cannot be located aborts the whole call earlier. So the only
                 // name reaching this arm has no on-disk copy at all, which the explainer cannot explain — it would pay
                 // a profile parse plus a whole-install sweep, per edit, for nothing the message does not already say.
-                { problems.Add($"{e.Target}: CopyFrom source '{srcPlugin}' is not in the load order (and no plugin file by that name was located on disk) — name an active plugin, or a plugin file present on disk."); continue; }
+                { problems.Add($"{FormIdToken.Of(e.Target)}: CopyFrom source '{srcPlugin}' is not in the load order (and no plugin file by that name was located on disk) — name an active plugin, or a plugin file present on disk."); continue; }
                 else if (view.ExcludedPlugins.TryGetValue(srcPlugin, out var why))
-                { problems.Add($"{e.Target}: CopyFrom source '{srcPlugin}' was excluded from this session ({why}) — its records aren't resolvable."); continue; }
+                { problems.Add($"{FormIdToken.Of(e.Target)}: CopyFrom source '{srcPlugin}' was excluded from this session ({why}) — its records aren't resolvable."); continue; }
                 else
                 {
                     srcBody = view.GetRecord(session, srcPlugin, e.CopySource);
@@ -529,7 +529,7 @@ public static class WritePatchBuilder
                 Key = e.Key, Value = e.Value, Values = e.Values, Entries = e.Entries, Struct = e.Struct, Structs = e.Structs,
             };
             var label = Label(req);
-            if (linkRulebook.Validate(req) is { } reject) { problems.Add($"{recType} {e.Target} [{label}]: {reject}"); continue; }
+            if (linkRulebook.Validate(req) is { } reject) { problems.Add($"{recType} {FormIdToken.Of(e.Target)} [{label}]: {reject}"); continue; }
             resolved.Add((e, body, winnerPlugin, patchLocal, req, label, srcBody));
         }
         if (problems.Count > 0)
@@ -570,7 +570,7 @@ public static class WritePatchBuilder
                 // key): render its clean guidance, NOT the gate/apply-inconsistency wrapper. All-or-nothing still holds —
                 // the whole call is refused and no file is written.
                 return PatchOutcome.Fail(
-                    $"refused applying [{label}] to {req.RecordType} {e.Target} — {ex.Message} (no patch written)");
+                    $"refused applying [{label}] to {req.RecordType} {FormIdToken.Of(e.Target)} — {ex.Message} (no patch written)");
             }
             catch (MalformedTargetDataException ex)
             {
@@ -579,12 +579,12 @@ public static class WritePatchBuilder
                 // … a real inconsistency" wrapper, which would mislabel pre-existing bad source data as an engine bug.
                 // All-or-nothing holds — no file written.
                 return PatchOutcome.Fail(
-                    $"refused applying [{label}] to {req.RecordType} {e.Target} — {ex.Message} (no patch written)");
+                    $"refused applying [{label}] to {req.RecordType} {FormIdToken.Of(e.Target)} — {ex.Message} (no patch written)");
             }
             catch (Exception ex)
             {
                 return PatchOutcome.Fail(
-                    $"engine error applying [{label}] to {req.RecordType} {e.Target}: pre-flight ACCEPTED it but the apply " +
+                    $"engine error applying [{label}] to {req.RecordType} {FormIdToken.Of(e.Target)}: pre-flight ACCEPTED it but the apply " +
                     $"threw — a real inconsistency, surfaced not swallowed (Q3): {ex.GetType().Name}: {ex.Message}");
             }
         }
@@ -657,8 +657,8 @@ public static class WritePatchBuilder
     /// record" would point at the wrong one half the time.</summary>
     static string CopySourceMissing(PatchEdit e, string srcPlugin) =>
         e.FromTarget is null
-            ? $"{e.Target}: CopyFrom source '{srcPlugin}' is in the load order but does NOT define or override this record — there is no version of it there to copy."
-            : $"{e.Target}: CopyFrom source '{srcPlugin}' is in the load order but does NOT define or override the SOURCE record {e.CopySource} — there is no version of it there to copy from.";
+            ? $"{FormIdToken.Of(e.Target)}: CopyFrom source '{srcPlugin}' is in the load order but does NOT define or override this record — there is no version of it there to copy."
+            : $"{FormIdToken.Of(e.Target)}: CopyFrom source '{srcPlugin}' is in the load order but does NOT define or override the SOURCE record {FormIdToken.Of(e.CopySource)} — there is no version of it there to copy from.";
 
     /// <summary>Does this edit's CopyFrom source resolve through the service's OFF-ORDER pre-locate? The arm is decided
     /// from <paramref name="view"/> — THIS call's capture — rather than from the dictionary alone, so the body used is
@@ -780,7 +780,7 @@ public static class WritePatchBuilder
         var w = view.ResolveWinner(e.CopySource);
         if (w is null)
         {
-            error = $"{e.Target}: the source record {e.CopySource} is not present in the load order ({view.PluginCount} plugins), " +
+            error = $"{FormIdToken.Of(e.Target)}: the source record {FormIdToken.Of(e.CopySource)} is not present in the load order ({view.PluginCount} plugins), " +
                     "so there is no winning version of it to copy from. Enable the plugin that defines it, or name a specific " +
                     "plugin in from_source.";
             return null;
@@ -799,7 +799,7 @@ public static class WritePatchBuilder
         var srcType = RecordNaming.StripOverlay(srcBody.GetType().Name);
         var tgtType = RecordNaming.StripOverlay(targetBody.GetType().Name);
         if (string.Equals(srcType, tgtType, StringComparison.Ordinal)) return null;
-        return $"{e.Target}: cannot copy from {e.CopySource} — the source is a {srcType} and the target is a {tgtType}. " +
+        return $"{FormIdToken.Of(e.Target)}: cannot copy from {FormIdToken.Of(e.CopySource)} — the source is a {srcType} and the target is a {tgtType}. " +
                "A field bundle copies between records of the SAME record type (a field path means different things on " +
                "different types); pair each target with a source of its own type.";
     }
@@ -913,7 +913,7 @@ public static class WritePatchBuilder
             var body = view.GetRecord(session, targetName, e.Target);
             if (body is null)
             {
-                problems.Add($"{e.Target}: '{targetName}' does not define or override this record — in-place edits only what the " +
+                problems.Add($"{FormIdToken.Of(e.Target)}: '{targetName}' does not define or override this record — in-place edits only what the " +
                              "file OWNS. To change a record defined in another plugin, use the default patch lane (a new override) instead.");
                 continue;
             }
@@ -924,7 +924,7 @@ public static class WritePatchBuilder
                 Key = e.Key, Value = e.Value, Values = e.Values, Entries = e.Entries, Struct = e.Struct, Structs = e.Structs,
             };
             var label = Label(req);
-            if (linkRulebook.Validate(req) is { } reject) { problems.Add($"{recType} {e.Target} [{label}]: {reject}"); continue; }
+            if (linkRulebook.Validate(req) is { } reject) { problems.Add($"{recType} {FormIdToken.Of(e.Target)} [{label}]: {reject}"); continue; }
 
             // CopyFrom SOURCE resolution — the same contract Apply enforces, on this lane too: the lane axis is
             // uniform, so every write verb must compose with in_place. Without this a CopyFrom op reaches ApplyVerb,
@@ -940,13 +940,13 @@ public static class WritePatchBuilder
                 if (TryOffOrderCopyBody(copyFromSources, e, view, out var offSrc))
                     srcBody = offSrc;
                 else if (string.IsNullOrWhiteSpace(srcPlugin))
-                { problems.Add($"{e.Target}: CopyFrom is missing from_plugin (internal — the mapper should have caught this)."); continue; }
+                { problems.Add($"{FormIdToken.Of(e.Target)}: CopyFrom is missing from_plugin (internal — the mapper should have caught this)."); continue; }
                 else if (e.FromTarget is null && string.Equals(srcPlugin, targetName, StringComparison.OrdinalIgnoreCase))
-                { problems.Add($"{e.Target}: CopyFrom from_plugin '{srcPlugin}' is the in-place target itself — copying this record's own field onto itself is a no-op; name the OTHER plugin whose version to copy from."); continue; }
+                { problems.Add($"{FormIdToken.Of(e.Target)}: CopyFrom from_plugin '{srcPlugin}' is the in-place target itself — copying this record's own field onto itself is a no-op; name the OTHER plugin whose version to copy from."); continue; }
                 else if (!view.ContainsPlugin(srcPlugin))
-                { problems.Add($"{e.Target}: CopyFrom source '{srcPlugin}' is not in the load order (and no plugin file by that name was located on disk) — name an active plugin, or a plugin file present on disk."); continue; }
+                { problems.Add($"{FormIdToken.Of(e.Target)}: CopyFrom source '{srcPlugin}' is not in the load order (and no plugin file by that name was located on disk) — name an active plugin, or a plugin file present on disk."); continue; }
                 else if (view.ExcludedPlugins.TryGetValue(srcPlugin, out var cfWhy))
-                { problems.Add($"{e.Target}: CopyFrom source '{srcPlugin}' was excluded from this session ({cfWhy}) — its records aren't resolvable."); continue; }
+                { problems.Add($"{FormIdToken.Of(e.Target)}: CopyFrom source '{srcPlugin}' was excluded from this session ({cfWhy}) — its records aren't resolvable."); continue; }
                 else
                 {
                     srcBody = view.GetRecord(session, srcPlugin, e.CopySource);
@@ -1047,17 +1047,17 @@ public static class WritePatchBuilder
             catch (ExpectedApplyRejectionException ex)
             {
                 return PatchOutcome.Fail(
-                    $"refused applying [{label}] to {req.RecordType} {e.Target} — {ex.Message} (the file is untouched)");
+                    $"refused applying [{label}] to {req.RecordType} {FormIdToken.Of(e.Target)} — {ex.Message} (the file is untouched)");
             }
             catch (MalformedTargetDataException ex)
             {
                 return PatchOutcome.Fail(
-                    $"refused applying [{label}] to {req.RecordType} {e.Target} — {ex.Message} (the file is untouched)");
+                    $"refused applying [{label}] to {req.RecordType} {FormIdToken.Of(e.Target)} — {ex.Message} (the file is untouched)");
             }
             catch (Exception ex)
             {
                 return PatchOutcome.Fail(
-                    $"engine error applying [{label}] to {req.RecordType} {e.Target}: pre-flight ACCEPTED it but the apply " +
+                    $"engine error applying [{label}] to {req.RecordType} {FormIdToken.Of(e.Target)}: pre-flight ACCEPTED it but the apply " +
                     $"threw — a real inconsistency, surfaced not swallowed (Q3): {ex.GetType().Name}: {ex.Message}");
             }
         }
@@ -1714,7 +1714,7 @@ public static class WritePatchBuilder
         foreach (var s in specs)
         {
             if (!seen.Add(s.Target))
-            { problems.Add($"{s.Target}: forwarded more than once in this call — name each target once (one source per record)."); continue; }
+            { problems.Add($"{FormIdToken.Of(s.Target)}: forwarded more than once in this call — name each target once (one source per record)."); continue; }
             // Is the source THE FILE THIS CALL IS ABOUT TO WRITE? Judged by NAME for an in-order source (a filename is
             // unique in an order, so the name IS the identity) and by FULL-PATH identity for an off-order one: source=
             // can be a direct path, and two install copies legitimately share a filename — refusing on the name alone
@@ -1727,8 +1727,8 @@ public static class WritePatchBuilder
             if (sourceIsSelf)
             {
                 problems.Add(selfIsTarget
-                    ? $"{s.Target}: {sourceParam} '{s.FromPlugin}' is the in-place target itself — forwarding a plugin's own version into itself is a no-op; name the OTHER plugin whose version you want carried in."
-                    : $"{s.Target}: {sourceParam} '{s.FromPlugin}' is the output patch itself — forwarding a patch's own version into itself is a no-op; name the EARLIER plugin whose version you want to re-assert.");
+                    ? $"{FormIdToken.Of(s.Target)}: {sourceParam} '{s.FromPlugin}' is the in-place target itself — forwarding a plugin's own version into itself is a no-op; name the OTHER plugin whose version you want carried in."
+                    : $"{FormIdToken.Of(s.Target)}: {sourceParam} '{s.FromPlugin}' is the output patch itself — forwarding a patch's own version into itself is a no-op; name the EARLIER plugin whose version you want to re-assert.");
                 continue;
             }
             // The record's ORIGIN plugin must be active whatever the source is: the patch overrides the ORIGIN FormKey,
@@ -1744,7 +1744,7 @@ public static class WritePatchBuilder
             // self-forward guard just used.
             var originMaster = s.Target.ModKey.FileName.String;
             if (!string.Equals(originMaster, fileName, StringComparison.OrdinalIgnoreCase) && !view.ContainsPlugin(originMaster))
-            { problems.Add($"{s.Target}: the record ORIGINATES in '{originMaster}', which is not active — a forward overrides the record's origin FormKey, so the patch would need '{originMaster}' as a master. Enable it first (forwarding copies FROM source, but it cannot invent the origin master).{Absence(originMaster)}"); continue; }
+            { problems.Add($"{FormIdToken.Of(s.Target)}: the record ORIGINATES in '{originMaster}', which is not active — a forward overrides the record's origin FormKey, so the patch would need '{originMaster}' as a master. Enable it first (forwarding copies FROM source, but it cannot invent the origin master).{Absence(originMaster)}"); continue; }
             IMajorRecordGetter? body;
             bool offOrderBody = IsOffOrderSource(offOrder, s, view);
             if (offOrderBody)
@@ -1752,17 +1752,17 @@ public static class WritePatchBuilder
                 // Pre-fetched by the service off the file's own overlay; a record the file doesn't define was already
                 // refused there, so a miss here would be an engine inconsistency rather than a user error.
                 if (!offOrder!.Bodies.TryGetValue(s.Target, out body) || body is null)
-                { problems.Add($"{s.Target}: source plugin '{s.FromPlugin}' resolved off-order ({offOrder.Path}) but its body was not pre-fetched — surfaced, not skipped (Q3)."); continue; }
+                { problems.Add($"{FormIdToken.Of(s.Target)}: source plugin '{s.FromPlugin}' resolved off-order ({offOrder.Path}) but its body was not pre-fetched — surfaced, not skipped (Q3)."); continue; }
             }
             else
             {
                 if (!view.ContainsPlugin(s.FromPlugin))
-                { problems.Add($"{s.Target}: source plugin '{s.FromPlugin}' is not in the load order — name an active plugin that defines or overrides this record.{Absence(s.FromPlugin)}"); continue; }
+                { problems.Add($"{FormIdToken.Of(s.Target)}: source plugin '{s.FromPlugin}' is not in the load order — name an active plugin that defines or overrides this record.{Absence(s.FromPlugin)}"); continue; }
                 if (view.ExcludedPlugins.TryGetValue(s.FromPlugin, out var why))
-                { problems.Add($"{s.Target}: source plugin '{s.FromPlugin}' was excluded from this session ({why}) — its records aren't resolvable."); continue; }
+                { problems.Add($"{FormIdToken.Of(s.Target)}: source plugin '{s.FromPlugin}' was excluded from this session ({why}) — its records aren't resolvable."); continue; }
                 body = view.GetRecord(session, s.FromPlugin, s.Target);
                 if (body is null)
-                { problems.Add($"{s.Target}: source plugin '{s.FromPlugin}' is in the load order but does NOT define or override this record (it doesn't touch it) — there is no version of it there to forward."); continue; }
+                { problems.Add($"{FormIdToken.Of(s.Target)}: source plugin '{s.FromPlugin}' is in the load order but does NOT define or override this record (it doesn't touch it) — there is no version of it there to forward."); continue; }
             }
             var w = view.ResolveWinner(s.Target);
             // An OFF-ORDER source is by definition not in the order, so it can never BE the winner — wasWinner is false
@@ -1912,7 +1912,7 @@ public static class WritePatchBuilder
                     ((IMajorRecordEnumerable)targetMod).Remove(spec.Target, WriteEngine.RemovalTypeFor(existing), throwIfUnknown: true);
                     if (targetMod.EnumerateMajorRecords().Any(x => x.FormKey == spec.Target))
                         return ForwardOutcome.Fail(
-                            $"cannot replace {spec.Target}: '{fileName}' already carries this record and its existing " +
+                            $"cannot replace {FormIdToken.Of(spec.Target)}: '{fileName}' already carries this record and its existing " +
                             "version could not be dropped before the copy (the engine no-op'd without throwing) — " +
                             "surfaced, not a silent skip (Q3); your original is UNTOUCHED.");
                     replaced = true;
@@ -1927,7 +1927,7 @@ public static class WritePatchBuilder
             catch (Exception ex)
             {
                 return ForwardOutcome.Fail(
-                    $"engine error forwarding {spec.Target} from '{spec.FromPlugin}': the source resolved but the " +
+                    $"engine error forwarding {FormIdToken.Of(spec.Target)} from '{spec.FromPlugin}': the source resolved but the " +
                     $"override-copy threw — a real inconsistency, surfaced not swallowed (Q3): {ex.GetType().Name}: {ex.Message}. Your original is UNTOUCHED.");
             }
         }
@@ -2412,7 +2412,7 @@ public static class WritePatchBuilder
                     // copy, else GetOrAdd would silently return the old record again.
                     if (patchMod.EnumerateMajorRecords().Any(x => x.FormKey == spec.Target))
                         return ForwardOutcome.Fail(
-                            $"cannot replace {spec.Target}: the patch already carries this record and its existing " +
+                            $"cannot replace {FormIdToken.Of(spec.Target)}: the patch already carries this record and its existing " +
                             "override could not be dropped before the copy (the engine no-op'd without throwing) — " +
                             "surfaced, not a silent skip (Q3); nothing was serialized (the extended patch's on-disk file is untouched).");
                     replaced = true;
@@ -2427,7 +2427,7 @@ public static class WritePatchBuilder
             catch (Exception ex)
             {
                 return ForwardOutcome.Fail(
-                    $"engine error forwarding {spec.Target} from '{spec.FromPlugin}': the source resolved but the " +
+                    $"engine error forwarding {FormIdToken.Of(spec.Target)} from '{spec.FromPlugin}': the source resolved but the " +
                     $"override-copy threw — a real inconsistency, surfaced not swallowed (Q3): {ex.GetType().Name}: {ex.Message}");
             }
         }
@@ -3129,7 +3129,7 @@ public static class WritePatchBuilder
                     {
                         parentType = WriteEngine.ResolveConcreteRecordType(RecordNaming.StripOverlay(ownParent.GetType().Name));
                         parentPlans[i] = (null, null, null, ownParent);
-                        parentHosts[i] = $"{RecordNaming.StripOverlay(ownParent.GetType().Name)} {parentFk} is the target plugin's OWN record — it hosts the child directly (nothing copied in, no master added)";
+                        parentHosts[i] = $"{RecordNaming.StripOverlay(ownParent.GetType().Name)} {FormIdToken.Of(parentFk)} is the target plugin's OWN record — it hosts the child directly (nothing copied in, no master added)";
                     }
                     else if (AlreadyCarried(parentFk) is { } already)
                     {
@@ -3142,7 +3142,7 @@ public static class WritePatchBuilder
                         // REPORTED as the host — a provenance line that lies.
                         parentType = WriteEngine.ResolveConcreteRecordType(RecordNaming.StripOverlay(already.GetType().Name));
                         parentPlans[i] = (null, null, null, already);
-                        parentHosts[i] = $"{RecordNaming.StripOverlay(already.GetType().Name)} {parentFk} was already carried by this artifact — its existing record hosts the child (nothing copied in)";
+                        parentHosts[i] = $"{RecordNaming.StripOverlay(already.GetType().Name)} {FormIdToken.Of(parentFk)} was already carried by this artifact — its existing record hosts the child (nothing copied in)";
                     }
                     else if (view.ResolveWinner(parentFk) is { } w)
                     {
@@ -3171,13 +3171,13 @@ public static class WritePatchBuilder
                         // N, against the bigger file. The real fix for that would be an index, not a memo.
                         var fromDefiner = ParentBodyFrom(definer, parentFk);
                         var parentBody = fromDefiner ?? ParentBodyFrom(w.WinnerPlugin, parentFk);
-                        if (parentBody is null) { problems.Add($"{s.RecordType} '{s.EditorId}': parent {parentFk} winner '{w.WinnerPlugin}' did not yield it on fetch (a load-order inconsistency)."); continue; }
+                        if (parentBody is null) { problems.Add($"{s.RecordType} '{s.EditorId}': parent {FormIdToken.Of(parentFk)} winner '{w.WinnerPlugin}' did not yield it on fetch (a load-order inconsistency)."); continue; }
                         var readFrom = fromDefiner is not null ? definer : w.WinnerPlugin;
                         parentType = WriteEngine.ResolveConcreteRecordType(RecordNaming.StripOverlay(parentBody.GetType().Name));
                         parentPlans[i] = (parentBody, readFrom, null, null);
                         bool overWinner = fromDefiner is not null && !string.Equals(readFrom, w.WinnerPlugin, StringComparison.OrdinalIgnoreCase);
                         parentContested[i] = overWinner;
-                        parentHosts[i] = $"{RecordNaming.StripOverlay(parentBody.GetType().Name)} {parentFk} hosted from '{readFrom}'"
+                        parentHosts[i] = $"{RecordNaming.StripOverlay(parentBody.GetType().Name)} {FormIdToken.Of(parentFk)} hosted from '{readFrom}'"
                             + (fromDefiner is null
                                 ? $" (the load-order WINNER — its defining plugin '{definer}' does not carry it: an injected or excluded parent)"
                                 : !overWinner
@@ -3209,7 +3209,7 @@ public static class WritePatchBuilder
                     {
                         // Genuinely absent from the load order AND the destination — a loud refusal, never a
                         // misleading "wrong FormID". Name the one-call workaround for the common new-topic case.
-                        problems.Add($"{s.RecordType} '{s.EditorId}': parent {parentFk} is not present in the load order"
+                        problems.Add($"{s.RecordType} '{s.EditorId}': parent {FormIdToken.Of(parentFk)} is not present in the load order"
                             + (extend ? " or this patch" : "") + (inPlace ? " or the target plugin" : "") + " — name an existing parent, or create the parent and this "
                             + "child in ONE call (a same-call sibling parent, by the parent's editorid).");
                         continue;
@@ -3576,7 +3576,7 @@ public static class WritePatchBuilder
         string? One(string? v)
         {
             if (err is not null || !WriteEngine.IsSameCallSiblingRef(v, out var ed)) return v;
-            if (created.TryGetValue(ed, out var rec)) return FormIdToken.Of(rec.FormKey);
+            if (created.TryGetValue(ed, out var rec)) return rec.FormKey.ToString();
             err = $"internal: same-call reference '@{ed}' on {onWhat} resolved to no record created in this call — " +
                   "pre-flight should have caught it; surfaced, not swallowed (Q3).";
             return v;
@@ -3635,7 +3635,7 @@ public static class WritePatchBuilder
                     if (!created.TryGetValue(ed, out var rec))
                         return (sp, $"internal: same-call reference '@{ed}' on {onWhat} resolved to no record created " +
                                     "in this call — pre-flight should have caught it; surfaced, not swallowed (Q3).");
-                    nf[kv.Key] = FormIdToken.Of(rec.FormKey);
+                    nf[kv.Key] = rec.FormKey.ToString();
                 }
                 else nf[kv.Key] = kv.Value;
             }

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -836,7 +836,7 @@ public static class WritePatchBuilder
                         $"{marker} — you set Subtype={dt.Subtype}; the game buckets by the SNAM marker, so it was synced to match (#131 — otherwise the Subtype change is a silent no-op)"));
                     break;
                 case MarkerFill.Unmodeled:
-                    return $"cannot set Subtype on DialogTopic {fk}: no SNAM marker is modeled for Subtype={dt.Subtype} " +
+                    return $"cannot set Subtype on DialogTopic {FormIdToken.Of(fk)}: no SNAM marker is modeled for Subtype={dt.Subtype} " +
                            $"((int){(int)dt.Subtype}, outside the known 0..{DialogueSubtype.Count - 1}). Use a valid Subtype, or set SubtypeName explicitly";
             }
         }
@@ -1212,12 +1212,12 @@ public static class WritePatchBuilder
                 // NO FormLinks doesn't cross this walk — that class still surfaces only at the real serialize, which
                 // the dry-run footer discloses.
                 if (WriteEngine.RootNullArm(ex) is not null)
-                    return $"dry run caught what the real write would fail on: {rec.FormKey} carries a required modeled " +
+                    return $"dry run caught what the real write would fail on: {FormIdToken.Of(rec.FormKey)} carries a required modeled " +
                            "sub-field left null (the same null-dereference Mutagen's writer refuses at serialize). The " +
                            "cause is a COMPOSED record that left a required polymorphic sub-field unset — e.g. a Condition " +
                            "composed without its Data arm, or a leveled-list / effect element missing a required part. " +
                            "Compose that sub-field too (select the arm via compose). Nothing was written.";
-                return $"dry run: enumerating {rec.FormKey}'s references threw ({ex.GetType().Name}: {ex.Message}) — " +
+                return $"dry run: enumerating {FormIdToken.Of(rec.FormKey)}'s references threw ({ex.GetType().Name}: {ex.Message}) — " +
                        "the would-be content could not be fully checked; the real write would hit the same data. Nothing was written.";
             }
         }
@@ -1391,7 +1391,7 @@ public static class WritePatchBuilder
             if (!carried.TryGetValue(fk, out var info))
             {
                 problems.Add(
-                    $"{fk}: not carried by patch '{fileName}' — only a record the patch ITSELF defines (a created record " +
+                    $"{FormIdToken.Of(fk)}: not carried by patch '{fileName}' — only a record the patch ITSELF defines (a created record " +
                     "or an accumulated override) can be removed; a master's record can't be literally removed, only its " +
                     "override dropped (and this patch has no override of it).");
                 continue;
@@ -1482,9 +1482,9 @@ public static class WritePatchBuilder
             if (!OwnedChildLifecycle.TryFindSlot(mod, fk, out var slot)) continue;
             var unnamed = OwnedChildLifecycle.DescendantsOf(slot.Child).Where(d => !named.Contains(d.FormKey)).ToList();
             if (unnamed.Count > 0)
-                return $"removing {fk} means detaching it from '{slot.Describe()}', which takes the "
+                return $"removing {FormIdToken.Of(fk)} means detaching it from '{slot.Describe()}', which takes the "
                      + $"{unnamed.Count} record(s) under it with it — and you named none of them: "
-                     + string.Join(", ", unnamed.Take(5).Select(d => $"{d.FormKey}{(d.EditorID is { } e ? $" ({e})" : "")}"))
+                     + string.Join(", ", unnamed.Take(5).Select(d => $"{FormIdToken.Of(d.FormKey)}{(d.EditorID is { } e ? $" ({e})" : "")}"))
                      + (unnamed.Count > 5 ? $", and {unnamed.Count - 5} more" : "")
                      + ". Name them in the same call so the removal reports every record it drops, or leave this one.";
             if (OwnedChildLifecycle.Detach(slot) is { } err) return err;
@@ -1596,7 +1596,7 @@ public static class WritePatchBuilder
             if (!carried.TryGetValue(fk, out var info))
             {
                 problems.Add(
-                    $"{fk}: not carried by '{fileName}' — in-place removes only a record the file ITSELF defines or " +
+                    $"{FormIdToken.Of(fk)}: not carried by '{fileName}' — in-place removes only a record the file ITSELF defines or " +
                     "overrides. To stop ANOTHER plugin's record from winning, use the default patch lane (forward the " +
                     "master version, or override it) instead.");
                 continue;
@@ -2803,7 +2803,7 @@ public static class WritePatchBuilder
                 if (!link.FormKey.IsNull && donorSet.Contains(link.FormKey.ModKey))
                 {
                     danglingCount++;
-                    if (dangling.Count < 10) dangling.Add($"{rec.FormKey} → {link.FormKey}");
+                    if (dangling.Count < 10) dangling.Add($"{FormIdToken.Of(rec.FormKey)} → {FormIdToken.Of(link.FormKey)}");
                 }
         if (danglingCount > 0)
             return MergeBuildResult.Fail(
@@ -3054,7 +3054,7 @@ public static class WritePatchBuilder
         string ClashReason(string wantType, IReadOnlyList<IMajorRecord> clash)
         {
             if (clash.FirstOrDefault(r => r.FormKey.ModKey != patchMod.ModKey) is { } foreign)
-                return $"{fileName} carries an override of {foreign.FormKey} under that editorid — re-creating over an "
+                return $"{fileName} carries an override of {FormIdToken.Of(foreign.FormKey)} under that editorid — re-creating over an "
                      + $"override would blank the original plugin's record. Edit it with {ToolNames.Apply}, or pick another editorid.";
             if (clash.Count > 1)
                 return $"{fileName} defines {clash.Count} records with that editorid "
@@ -3252,7 +3252,7 @@ public static class WritePatchBuilder
                         ?? (plan.patchParent is not null && FormKey.TryFactory(s.ParentRef!, out var orderFk) ? OrderBodyOf(orderFk) : null);
                     if ((Occupant(plan.patchParent) ?? Occupant(inOrder)) is { } occupant)
                     {
-                        problems.Add($"{s.RecordType} '{s.EditorId}': '{parentType.Name}.{slotName}' already holds a {s.RecordType} ({occupant.FormKey}"
+                        problems.Add($"{s.RecordType} '{s.EditorId}': '{parentType.Name}.{slotName}' already holds a {s.RecordType} ({FormIdToken.Of(occupant.FormKey)}"
                             + (occupant.EditorID is { } oe ? $" editorid={oe}" : "") + ") and it holds exactly one, so there is no room to create another. "
                             + "Edit the one that is there by its own FormID, or remove it first and create again.");
                         continue;
@@ -3375,19 +3375,19 @@ public static class WritePatchBuilder
                     // EXPECTED apply-time refusal (live state pre-flight can't see — e.g. a duplicate dict key): clean
                     // guidance, NOT the inconsistency wrapper. Whole call still refused, nothing serialized.
                     return CreateOutcome.Fail(
-                        $"refused applying [{Label(req)}] to new {s.RecordType} '{s.EditorId}' ({rec.FormKey}) — {ex.Message} (nothing created)");
+                        $"refused applying [{Label(req)}] to new {s.RecordType} '{s.EditorId}' ({FormIdToken.Of(rec.FormKey)}) — {ex.Message} (nothing created)");
                 }
                 catch (MalformedTargetDataException ex)
                 {
                     // The target record's own data is malformed (present-but-null element/entry) — render it
                     // accurately, NOT under the inconsistency wrapper. Whole call refused, nothing serialized.
                     return CreateOutcome.Fail(
-                        $"refused applying [{Label(req)}] to new {s.RecordType} '{s.EditorId}' ({rec.FormKey}) — {ex.Message} (nothing created)");
+                        $"refused applying [{Label(req)}] to new {s.RecordType} '{s.EditorId}' ({FormIdToken.Of(rec.FormKey)}) — {ex.Message} (nothing created)");
                 }
                 catch (Exception ex)
                 {
                     return CreateOutcome.Fail(
-                        $"engine error applying [{Label(req)}] to new {s.RecordType} '{s.EditorId}' ({rec.FormKey}): " +
+                        $"engine error applying [{Label(req)}] to new {s.RecordType} '{s.EditorId}' ({FormIdToken.Of(rec.FormKey)}): " +
                         $"pre-flight ACCEPTED it but the apply threw — a real inconsistency, surfaced not swallowed (Q3): {ex.GetType().Name}: {ex.Message}");
                 }
             }
@@ -3553,8 +3553,8 @@ public static class WritePatchBuilder
                         ? $"{walkError} — this was a DRY RUN read of the in-memory would-be content; nothing was written."
                         : $"{walkError} — the WRITE ITSELF SUCCEEDED (the patch was serialized and re-opened); inspect the patch in xEdit; do not re-issue the ops.")
                     : (inMemory
-                        ? $"the in-memory would-be content did not yield {fk} — a real inconsistency, surfaced not swallowed (Q3); nothing was written."
-                        : $"the written file did not yield {fk} on re-open — a real inconsistency, surfaced not swallowed (Q3); inspect the patch in xEdit.")));
+                        ? $"the in-memory would-be content did not yield {FormIdToken.Of(fk)} — a real inconsistency, surfaced not swallowed (Q3); nothing was written."
+                        : $"the written file did not yield {FormIdToken.Of(fk)} on re-open — a real inconsistency, surfaced not swallowed (Q3); inspect the patch in xEdit.")));
         return result;
     }
 
@@ -3576,7 +3576,7 @@ public static class WritePatchBuilder
         string? One(string? v)
         {
             if (err is not null || !WriteEngine.IsSameCallSiblingRef(v, out var ed)) return v;
-            if (created.TryGetValue(ed, out var rec)) return rec.FormKey.ToString();
+            if (created.TryGetValue(ed, out var rec)) return FormIdToken.Of(rec.FormKey);
             err = $"internal: same-call reference '@{ed}' on {onWhat} resolved to no record created in this call — " +
                   "pre-flight should have caught it; surfaced, not swallowed (Q3).";
             return v;
@@ -3635,7 +3635,7 @@ public static class WritePatchBuilder
                     if (!created.TryGetValue(ed, out var rec))
                         return (sp, $"internal: same-call reference '@{ed}' on {onWhat} resolved to no record created " +
                                     "in this call — pre-flight should have caught it; surfaced, not swallowed (Q3).");
-                    nf[kv.Key] = rec.FormKey.ToString();
+                    nf[kv.Key] = FormIdToken.Of(rec.FormKey);
                 }
                 else nf[kv.Key] = kv.Value;
             }

--- a/src/housecarl-mcp-tests/FormIdTokenCaseTests.cs
+++ b/src/housecarl-mcp-tests/FormIdTokenCaseTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
@@ -139,5 +140,91 @@ public sealed class FormIdTokenCaseTests : IDisposable
 
         Assert.Equal(direct, throughTheLink, StringComparer.Ordinal);
         Assert.Equal($"{_w.Race.ID:X6}:{Path.GetFileName(_w.MasterPath)}", direct);
+    }
+
+    /// <summary>The write's read-back rows are what a caller joins its next read against, so they must spell the
+    /// plugin the load order's way even when the caller typed the FormID in another case.</summary>
+    [Fact]
+    public void TheWriteReadbackSpellsThePluginTheOrdersWayNotTheWayTheCallerTypedIt()
+    {
+        var typedLowercase = $"{_w.Npc.ID:X6}:{MasterCaseDriftWorld.PatchName.ToLowerInvariant()}";
+        var ops = JsonDocument.Parse(
+            $"[{{\"formid\":\"{typedLowercase}\",\"field_path\":\"Height\",\"value\":\"1.1\"}}]").RootElement;
+
+        var json = ApplyTools.Apply(_w.Svc, ops: ops, patch: "HcCaseWrite", readback: true, format: "json");
+
+        // Both the op row and the read-back row spell it the order's way, so the two join and so does the next read.
+        Assert.Equal(2, Regex.Matches(json, $"\"formid\": \"{_w.Npc.ID:X6}:{MasterCaseDriftWorld.PatchName}\"").Count);
+        Assert.DoesNotContain(typedLowercase, json);
+    }
+
+    /// <summary>A walk's node labels name the parent of every child row (pulled_by), so a label built from the
+    /// caller's own spelling would leave the table unable to join a child back to its parent.</summary>
+    [Fact]
+    public void AWalksNodeLabelsSpellThePluginTheOrdersWay()
+    {
+        var typedLowercase = $"{_w.Npc.ID:X6}:{MasterCaseDriftWorld.PatchName.ToLowerInvariant()}";
+
+        var json = RecordsTools.Records(_w.Svc,
+            formids: new[] { typedLowercase },
+            walk: new RecordsTools.RecordsWalk { depth = 2 },
+            project: new RecordsTools.RecordsProject { form = "chain" },
+            format: "json");
+
+        Assert.Contains(MasterCaseDriftWorld.PatchName, json);
+        Assert.DoesNotContain(typedLowercase, json);
+    }
+
+    /// <summary>The text render is a join surface too — a modder pastes a printed token into the next call — so it
+    /// spells the plugin the order's way rather than echoing the case the caller typed.</summary>
+    [Fact]
+    public void TheTextRenderSpellsThePluginTheOrdersWay()
+    {
+        var typedLowercase = $"{_w.Npc.ID:X6}:{MasterCaseDriftWorld.PatchName.ToLowerInvariant()}";
+
+        var text = RecordsTools.Records(_w.Svc, formids: new[] { typedLowercase });
+
+        Assert.Contains($"{_w.Npc.ID:X6}:{MasterCaseDriftWorld.PatchName}", text);
+        Assert.DoesNotContain(typedLowercase, text);
+    }
+
+    /// <summary>A read that failed still names the record, and that row is the one a caller retries from — so the
+    /// error line spells the plugin the same way a successful row would.</summary>
+    [Fact]
+    public void AFailedReadsTextRowSpellsThePluginTheOrdersWay()
+    {
+        var missingLowercase = $"FFFFFF:{MasterCaseDriftWorld.PatchName.ToLowerInvariant()}";
+
+        var text = RecordsTools.Records(_w.Svc, formids: new[] { missingLowercase });
+
+        Assert.Contains($"FFFFFF:{MasterCaseDriftWorld.PatchName}", text);
+        Assert.DoesNotContain(missingLowercase, text);
+    }
+}
+
+/// <summary>The canonical table is the plugins of the order LOADED NOW. The server repoints at another MO2
+/// instance without a restart, so a publish REPLACES the table: a name the new order does not carry must fall
+/// back to its own spelling rather than keep the old order's.</summary>
+[Trait("tier", "unit")]
+public sealed class FormIdTokenPublishTests
+{
+    [Fact]
+    public void ARebuildReplacesTheTableRatherThanAddingToIt()
+    {
+        try
+        {
+            FormIdToken.Publish(new[] { "AwesomeMod.esp", "Shared.esp" });
+            Assert.Equal("AwesomeMod.esp", FormIdToken.Plugin("awesomemod.esp"));
+
+            // The new instance does not carry AwesomeMod.esp at all — an off-order read of it must print its own
+            // spelling, not the spelling the previous instance published.
+            FormIdToken.Publish(new[] { "Shared.esp" });
+            Assert.Equal("awesomemod.esp", FormIdToken.Plugin("awesomemod.esp"));
+            Assert.Equal("Shared.esp", FormIdToken.Plugin("SHARED.ESP"));
+        }
+        finally
+        {
+            FormIdToken.Publish(Array.Empty<string>());   // a fresh process's table; the next build republishes
+        }
     }
 }

--- a/src/housecarl-mcp-tests/FormIdTokenCaseTests.cs
+++ b/src/housecarl-mcp-tests/FormIdTokenCaseTests.cs
@@ -1,0 +1,143 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlGenerator;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>A world whose patch plugin spells its master in a DIFFERENT CASE from the file on disk — the shape
+/// every real load order has, because a plugin's master list carries whatever its author typed. The master's
+/// records are read two ways: straight off the master (Mutagen spells that key from the file it opened) and
+/// through the patch's link into it (spelled from the patch's master list).</summary>
+public sealed class MasterCaseDriftWorld : IDisposable
+{
+    public const string MasterName = "HcCaseMaster.esm";     // the spelling ON DISK — the canonical one
+    public const string PatchName = "HcCasePatch.esp";
+    const string MasterInMasterList = "hccasemaster.esm";    // what the patch's header says instead
+
+    public string Root { get; }
+    public string MasterPath { get; }
+    public string PatchPath { get; }
+    public LoadOrderService Svc { get; }
+    public FormKey Race { get; }
+    public FormKey Npc { get; }
+
+    readonly string _priorCorpusPath;
+
+    public MasterCaseDriftWorld()
+    {
+        _priorCorpusPath = CorpusRulebook.CorpusPath;    // a process-global this world repoints and restores
+        Root = Path.Combine(Path.GetTempPath(), "hc-case-drift-" + Guid.NewGuid().ToString("N"));
+        var instance = Path.Combine(Root, "inst");
+        var masterDir = Path.Combine(instance, "mods", "CaseMaster");
+        var patchDir = Path.Combine(instance, "mods", "CasePatch");
+        Directory.CreateDirectory(masterDir);
+        Directory.CreateDirectory(patchDir);
+        Directory.CreateDirectory(Path.Combine(Root, "game", "Data"));
+
+        var master = new SkyrimMod(new ModKey("HcCaseMaster", ModType.Master), SkyrimRelease.SkyrimSE);
+        var race = master.Races.AddNew();
+        race.EditorID = "HcCaseRace";
+        Race = race.FormKey;
+        MasterPath = Path.Combine(masterDir, MasterName);
+        master.BeginWrite.ToPath(MasterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+        var patch = new SkyrimMod(new ModKey("HcCasePatch", ModType.Plugin), SkyrimRelease.SkyrimSE);
+        var npc = patch.Npcs.AddNew();
+        npc.EditorID = "HcCaseNpc";
+        npc.Race.SetTo(Race);
+        Npc = npc.FormKey;
+        PatchPath = Path.Combine(patchDir, PatchName);
+        patch.BeginWrite.ToPath(PatchPath).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
+
+        LowercaseTheMasterEntry(PatchPath);
+
+        var genDir = Path.Combine(Root, "corpus-gen");
+        CorpusGenerator.GenerateAll(genDir, Path.Combine(Root, "corpus-ref"));
+        CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json");
+
+        File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(Root, "game").Replace(@"\", @"\\") + ")\r\n");
+        var prof = Path.Combine(instance, "profiles", "Default");
+        Directory.CreateDirectory(prof);
+        File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + MasterName + "\r\n" + PatchName + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*" + MasterName + "\r\n*" + PatchName + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n+CasePatch\r\n+CaseMaster\r\n");
+
+        var store = new UserConfigStore(Path.Combine(Root, "user.json"));
+        Svc = LoadOrderService.WithInstance(instance, 0, store);
+    }
+
+    /// <summary>Respell the MAST entry in the plugin's header to lowercase — same length, so the file stays valid.</summary>
+    static void LowercaseTheMasterEntry(string path)
+    {
+        var bytes = File.ReadAllBytes(path);
+        var want = Encoding.ASCII.GetBytes(MasterName);
+        var to = Encoding.ASCII.GetBytes(MasterInMasterList);
+        int at = IndexOf(bytes, want);
+        if (at < 0) throw new InvalidOperationException($"'{MasterName}' is not spelled in {Path.GetFileName(path)}'s header.");
+        Array.Copy(to, 0, bytes, at, to.Length);
+        File.WriteAllBytes(path, bytes);
+    }
+
+    static int IndexOf(byte[] haystack, byte[] needle)
+    {
+        for (int i = 0; i + needle.Length <= haystack.Length; i++)
+        {
+            int j = 0;
+            while (j < needle.Length && haystack[i + j] == needle[j]) j++;
+            if (j == needle.Length) return i;
+        }
+        return -1;
+    }
+
+    public void Dispose()
+    {
+        CorpusRulebook.CorpusPath = _priorCorpusPath;
+        Svc.Dispose();
+        try { Directory.Delete(Root, true); } catch { /* temp cleanup best-effort */ }
+    }
+}
+
+/// <summary>A FormID token spells its plugin the way the file is spelled on disk, whichever read produced it —
+/// so two reads of the same record hand back the same string and a join of them lines up (#664).</summary>
+[Trait("tier", "integration")]
+public sealed class FormIdTokenCaseTests : IDisposable
+{
+    readonly MasterCaseDriftWorld _w = new();
+
+    public void Dispose() => _w.Dispose();
+
+    /// <summary>The one token in this response that names the master, however either half is spelled.</summary>
+    static string MasterToken(string text)
+    {
+        var m = Regex.Match(text, "[0-9A-F]{6}:" + Regex.Escape(MasterCaseDriftWorld.MasterName), RegexOptions.IgnoreCase);
+        Assert.True(m.Success, $"no token naming {MasterCaseDriftWorld.MasterName} in: {text}");
+        return m.Value;
+    }
+
+    [Fact]
+    public void TheSameRecordSpellsItsPluginTheSameWayReadDirectlyAndReadThroughALink()
+    {
+        // The bug's precondition: the patch's own header names the master in another case.
+        Assert.Contains("hccasemaster.esm", Encoding.ASCII.GetString(File.ReadAllBytes(_w.PatchPath)));
+
+        var scanned = RecordsTools.Records(_w.Svc, types: new[] { "RACE" }, format: "json");
+        var linked = RecordsTools.Records(_w.Svc,
+            formids: new[] { $"{_w.Npc.ID:X6}:{MasterCaseDriftWorld.PatchName}" },
+            project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "Race" } },
+            format: "json");
+
+        var direct = MasterToken(scanned);
+        var throughTheLink = MasterToken(linked);
+
+        Assert.Equal(direct, throughTheLink, StringComparer.Ordinal);
+        Assert.Equal($"{_w.Race.ID:X6}:{Path.GetFileName(_w.MasterPath)}", direct);
+    }
+}

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -169,7 +169,7 @@ internal static class Artifacts
                 if (o.Error is not null)
                     writer.WriteRow((w, _) =>
                     {
-                        w.WriteStartObject(); w.WriteString("formid", fk.ToString()); w.WriteString("error", o.Error);
+                        w.WriteStartObject(); w.WriteString("formid", FormIdToken.Of(fk)); w.WriteString("error", o.Error);
                         if (matches is not null) w.WriteString("matches", matches);
                         w.WriteEndObject();
                     });
@@ -261,7 +261,7 @@ internal static class Artifacts
             if (o.Error is not null)
                 writer.WriteRow((w, _) =>
                 {
-                    w.WriteStartObject(); w.WriteString("formid", o.FormKey.ToString()); w.WriteString("error", o.Error);
+                    w.WriteStartObject(); w.WriteString("formid", FormIdToken.Of(o.FormKey)); w.WriteString("error", o.Error);
                     if (hit is not null) w.WriteString("matches", hit);
                     w.WriteEndObject();
                 });

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -365,7 +365,7 @@ internal static class Artifacts
                 {
                     w.WriteStartObject();
                     w.WriteString("seed", seed);
-                    w.WriteString("formid", row.Carrier.ToString());
+                    w.WriteString("formid", FormIdToken.Of(row.Carrier));
                     w.WriteString("type", row.Type);
                     if (row.EditorId is not null) w.WriteString("editorid", row.EditorId);
                     w.WriteString("winner", row.Winner);

--- a/src/housecarl-mcp/DialogueSweepRender.cs
+++ b/src/housecarl-mcp/DialogueSweepRender.cs
@@ -285,7 +285,7 @@ internal static class DialogueSweepRender
     static void WriteTopicRow(Utf8JsonWriter w, TopicValidation t)
     {
         w.WriteStartObject();
-        w.WriteString("topic", t.Topic.ToString());
+        w.WriteString("topic", FormIdToken.Of(t.Topic));
         w.WriteString("editor_id", t.TopicEditorId);
         w.WriteString("winner_plugin", t.WinnerPlugin);
         w.WriteNumber("info_count", t.InfoCount);
@@ -307,7 +307,7 @@ internal static class DialogueSweepRender
         {
             if (l.FuzPresent) continue;
             w.WriteStartObject();
-            w.WriteString("info", l.Info.ToString());
+            w.WriteString("info", FormIdToken.Of(l.Info));
             w.WriteNumber("response", l.ResponseNumber);
             w.WriteString("fuz_path", l.FuzPath);
             w.WriteBoolean("lip_present", l.LipPresent);
@@ -319,7 +319,7 @@ internal static class DialogueSweepRender
         {
             if (f.Status == ScriptBindingStatus.BoundAndCompiled) continue;
             w.WriteStartObject();
-            w.WriteString("info", f.Info.ToString());
+            w.WriteString("info", FormIdToken.Of(f.Info));
             w.WriteString("status", f.Status.ToString());
             w.WriteString("detail", f.Detail);
             w.WriteEndObject();

--- a/src/housecarl-mcp/DialogueTools.cs
+++ b/src/housecarl-mcp/DialogueTools.cs
@@ -32,7 +32,7 @@ internal static class DialogueWire
                                      bool includeInfoOrder = true)
     {
         string pad = indent ? "  " : "";
-        sb.Append(pad).Append("topic ").Append(Edid(t.TopicEditorId)).Append(" (").Append(t.Topic).Append(')')
+        sb.Append(pad).Append("topic ").Append(Edid(t.TopicEditorId)).Append(" (").Append(FormIdToken.Of(t.Topic)).Append(')')
           .Append(" — winner ").Append(t.WinnerPlugin).Append('\n');
         sb.Append(pad).Append("  ").Append(t.InfoCount).Append(t.InfoCount == 1 ? " INFO record" : " INFO records");
         if (t.ConditionedInfoCount > 0) sb.Append("; ").Append(t.ConditionedInfoCount).Append(" carry conditions (CTDA)");
@@ -158,7 +158,7 @@ internal static class DialogueWire
         foreach (var e in listAll ? io.Order : moved)
         {
             if (sb.Length >= cap) { sb.Append(pad).Append("    ... [truncated at max_chars]\n"); return false; }
-            sb.Append(pad).Append("    #").Append(e.Index + 1).Append("  ").Append(e.Info);
+            sb.Append(pad).Append("    #").Append(e.Index + 1).Append("  ").Append(FormIdToken.Of(e.Info));
             if (e.Deleted) sb.Append("  (deleted)");
             if (e.Moved) sb.Append("  MOVED from #").Append(e.OriginIndex!.Value + 1);
             // Gated on BaselineTrusted: with a shifted baseline the definer's own lines have no OriginIndex, and
@@ -183,7 +183,7 @@ internal static class DialogueWire
             sb.Append(pad).Append("  [!] ").Append(io.Complete ? "" : "as far as could be read, ").Append(moved.Count)
               .Append(moved.Count == 1 ? " line sits" : " lines sit")
               .Append(" at a different position than this topic's defining plugin laid down — the biggest shift is ")
-              .Append(w.Info).Append(" #").Append(w.OriginIndex!.Value + 1).Append(" -> #").Append(w.Index + 1)
+              .Append(FormIdToken.Of(w.Info)).Append(" #").Append(w.OriginIndex!.Value + 1).Append(" -> #").Append(w.Index + 1)
               .Append(", moved there by ").Append(w.PlacedBy)
               .Append(". Re-listing a line appends it to the BOTTOM unless the plugin also carries that line's PNAM. Nothing is dropped — but a line the game now reaches later can be pre-empted by any earlier line whose conditions also pass, so the wrong line answers.\n");
         }
@@ -218,7 +218,7 @@ internal static class DialogueWire
         foreach (var l in silent)
         {
             if (sb.Length >= cap) { sb.Append(pad).Append("    ... [truncated at max_chars]\n"); return; }
-            sb.Append(pad).Append("    [!] WILL BE SILENT  ").Append(l.Info).Append(" resp ").Append(l.ResponseNumber)
+            sb.Append(pad).Append("    [!] WILL BE SILENT  ").Append(FormIdToken.Of(l.Info)).Append(" resp ").Append(l.ResponseNumber)
               .Append(" — no .fuz at ").Append(l.FuzPath).Append("  (place the audio here)");
             if (!l.LipPresent) sb.Append("; .lip also absent");
             sb.Append('\n');
@@ -246,14 +246,14 @@ internal static class DialogueWire
         foreach (var f in bad)
         {
             if (sb.Length >= cap) { sb.Append(pad).Append("    ... [truncated at max_chars]\n"); return; }
-            sb.Append(pad).Append("    [!] WILL NOT FIRE  ").Append(f.Info).Append("  — ").Append(f.Detail);
+            sb.Append(pad).Append("    [!] WILL NOT FIRE  ").Append(FormIdToken.Of(f.Info)).Append("  — ").Append(f.Detail);
             if (f.MissingPex.Count > 0) sb.Append("  (missing: ").Append(string.Join(", ", f.MissingPex)).Append(')');
             sb.Append('\n');
         }
         foreach (var f in undet)
         {
             if (sb.Length >= cap) { sb.Append(pad).Append("    ... [truncated at max_chars]\n"); return; }
-            sb.Append(pad).Append("    [?] ").Append(f.Info).Append("  — ").Append(f.Detail).Append('\n');
+            sb.Append(pad).Append("    [?] ").Append(FormIdToken.Of(f.Info)).Append("  — ").Append(f.Detail).Append('\n');
         }
     }
 

--- a/src/housecarl-mcp/FormIdDoor.cs
+++ b/src/housecarl-mcp/FormIdDoor.cs
@@ -52,7 +52,7 @@ internal sealed class FormIdDoor
             throw new WriteRefusal(
                 $"'{(raw ?? "").Trim()}' is a runtime FormID, which houseCARL accepts for reading but not for " +
                 $"writing, because it names a slot in the load order as it stands rather than a record — write to " +
-                $"'{fk.ID:X6}:{fk.ModKey.FileName}' instead.");
+                $"'{FormIdToken.Of(fk)}' instead.");
         return fk;
     }
 

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -232,7 +232,7 @@ static class JsonWire
         {
             if (Over(w, ms, cap)) { truncated = true; break; }
             w.WriteStartObject();
-            w.WriteString("formid", r.Target.ToString());
+            w.WriteString("formid", FormIdToken.Of(r.Target));
             if (r.Error is not null) w.WriteString("error", r.Error);
             else
             {
@@ -403,7 +403,7 @@ static class JsonWire
         int room = (int)Math.Max(0, cap - ms.Length) / ChildUnionMemberBytes;
         int listed = Math.Min(u.Members.Count, Math.Min(ChildUnionMemberCap, room));
         w.WriteStartArray("members");
-        for (int i = 0; i < listed; i++) w.WriteStringValue(u.Members[i].ToString());
+        for (int i = 0; i < listed; i++) w.WriteStringValue(FormIdToken.Of(u.Members[i]));
         w.WriteEndArray();
         if (u.Members.Count > listed) w.WriteNumber("members_omitted", u.Members.Count - listed);
         w.WriteEndObject();
@@ -990,7 +990,7 @@ static class JsonWire
                     w.Flush();
                     if (ms.Length >= cap) { truncated = true; break; }
                     w.WriteStartObject();
-                    w.WriteString("formid", row.Carrier.ToString());
+                    w.WriteString("formid", FormIdToken.Of(row.Carrier));
                     w.WriteString("type", row.Type);
                     WriteNullable(w, "editorid", row.EditorId);
                     w.WriteString("winner", row.Winner);
@@ -1054,7 +1054,7 @@ static class JsonWire
             }
             w.WriteStartObject();
             w.WriteNumber("position", e.Index + 1);
-            w.WriteString("info", e.Info.ToString());
+            w.WriteString("info", FormIdToken.Of(e.Info));
             w.WriteString("placed_by", e.PlacedBy);
             if (e.Deleted) w.WriteBoolean("deleted", true);
             if (e.Moved) { w.WriteBoolean("moved", true); w.WriteNumber("origin_position", e.OriginIndex!.Value + 1); }
@@ -1619,10 +1619,10 @@ static class JsonWire
     static void WriteDanglingEntry(Utf8JsonWriter w, DanglingRef d)
     {
         w.WriteStartObject();
-        w.WriteString("source", d.Source.ToString());
+        w.WriteString("source", FormIdToken.Of(d.Source));
         w.WriteString("source_type", d.SourceType);
         WriteNullable(w, "source_editorid", d.SourceEditorId);
-        w.WriteString("target", d.Target.ToString());
+        w.WriteString("target", FormIdToken.Of(d.Target));
         w.WriteEndObject();
     }
 
@@ -2139,7 +2139,7 @@ static class JsonWire
             w.WriteEndObject();
             return;
         }
-        w.WriteString("formid", rec.Record.ToString());
+        w.WriteString("formid", FormIdToken.Of(rec.Record));
         w.WriteString("type", rec.RecordType);
         WriteNullable(w, "editorid", rec.EditorId);
         w.WriteString("plugin", rec.Plugin);
@@ -2443,7 +2443,7 @@ static class JsonWire
             {
                 if (Over(w, ms, cap)) { truncated = true; break; }
                 w.WriteStartObject();
-                w.WriteString("formid", op.Target.ToString());
+                w.WriteString("formid", FormIdToken.Of(op.Target));
                 w.WriteString("record_type", op.RecordType);
                 w.WriteString("label", op.Label);
                 w.WriteBoolean("applied", op.Applied);
@@ -2716,7 +2716,7 @@ static class JsonWire
             {
                 if (Over(w, ms, cap)) { truncated = true; break; }
                 w.WriteStartObject();
-                w.WriteString("formid", r.Target.ToString());
+                w.WriteString("formid", FormIdToken.Of(r.Target));
                 w.WriteString("record_type", r.RecordType);
                 WriteNullable(w, "editorid", r.EditorId);
                 w.WriteEndObject();
@@ -2797,7 +2797,7 @@ static class JsonWire
             {
                 if (Over(w, ms, cap)) { truncated = true; break; }
                 w.WriteStartObject();
-                w.WriteString("formid", f.Target.ToString());
+                w.WriteString("formid", FormIdToken.Of(f.Target));
                 w.WriteString("record_type", f.RecordType);
                 WriteNullable(w, "editorid", f.EditorId);
                 w.WriteString("source", f.FromPlugin);
@@ -3080,7 +3080,7 @@ static class JsonWire
         {
             if (Over(w, ms, cap)) { truncated = true; blockCut = true; break; }
             w.WriteStartObject();
-            w.WriteString("info", l.Info.ToString());
+            w.WriteString("info", FormIdToken.Of(l.Info));
             WriteNullable(w, "topic_editorid", l.TopicEditorId);
             w.WriteNumber("response", l.ResponseNumber);
             w.WriteBoolean("fuz_present", l.FuzPresent);
@@ -3101,7 +3101,7 @@ static class JsonWire
         {
             if (Over(w, ms, cap)) { truncated = true; blockCut = true; break; }
             w.WriteStartObject();
-            w.WriteString("info", u.Info.ToString());
+            w.WriteString("info", FormIdToken.Of(u.Info));
             WriteNullable(w, "topic_editorid", u.TopicEditorId);
             w.WriteString("reason", u.Reason);
             w.WriteEndObject();
@@ -3159,7 +3159,7 @@ static class JsonWire
         {
             if (Over(w, ms, cap)) { truncated = true; blockCut = true; break; }
             w.WriteStartObject();
-            w.WriteString("info", f.Info.ToString());
+            w.WriteString("info", FormIdToken.Of(f.Info));
             WriteNullable(w, "topic_editorid", f.TopicEditorId);
             w.WriteString("status", f.Status.ToString());
             w.WriteString("detail", f.Detail);
@@ -3188,7 +3188,7 @@ static class JsonWire
         {
             if (Over(w, ms, cap)) { truncated = true; blockCut = true; break; }
             w.WriteStartObject();
-            w.WriteString("cell", c.Cell.ToString());
+            w.WriteString("cell", FormIdToken.Of(c.Cell));
             w.WriteString("editorid", c.EditorId);
             w.WriteBoolean("interior", c.Interior);
             WriteStringArray(w, "must_provide", c.MustProvide);

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -502,7 +502,7 @@ static class JsonWire
                 if (ms.Length >= cap) { rowsTruncated = true; break; }
                 var o = outcomes[i];
                 string? hit = matches is { } mt && i < mt.Count ? mt[i] : null;   // multi-target references= un-merge
-                if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", o.FormKey.ToString()); w.WriteString("error", o.Error); if (hit is not null) w.WriteString("matches", hit); w.WriteEndObject(); }
+                if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", FormIdToken.Of(o.FormKey)); w.WriteString("error", o.Error); if (hit is not null) w.WriteString("matches", hit); w.WriteEndObject(); }
                 else WriteReadRecord(w, o, ms, cap, hit, childFields: childFields, levers: levers);
                 rendered++;
             }
@@ -590,7 +590,7 @@ static class JsonWire
                 w.Flush();
                 if (ms.Length >= cap) { rowsTruncated = true; break; }
                 w.WriteStartObject();
-                w.WriteString("formid", o.FormKey.ToString());
+                w.WriteString("formid", FormIdToken.Of(o.FormKey));
                 WriteRuntime(w, o.RuntimeFormId, o.RuntimeFormIdNote);
                 if (o.Error is not null) w.WriteString("error", o.Error);
                 else
@@ -1186,7 +1186,7 @@ static class JsonWire
                         // "source" field still names the body read, so the json carries the same source/winner truth.
                         // Pinned to the scan's build — the document's epoch names ONE build.
                         var o = reader!.Row(i);   // a collapsed cell names the caller's own expansion knob
-                        if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", fk.ToString()); w.WriteString("error", o.Error); if (matches is not null) w.WriteString("matches", matches); w.WriteEndObject(); }
+                        if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", FormIdToken.Of(fk)); w.WriteString("error", o.Error); if (matches is not null) w.WriteString("matches", matches); w.WriteEndObject(); }
                         else { WriteReadRecord(w, o, ms, cap, matches, childFields: childFields, levers: levers); childUnioned |= o.OwnedChildUnioned; }
                     }
                     else
@@ -1322,7 +1322,7 @@ static class JsonWire
                     if (detail)
                     {
                         var o = reader!.Row(i);   // dense refuses depth>1 unless a quantifier asks for it; pinned to the scan's build
-                        if (o.Error is not null) { (errors ??= new()).Add((fk.ToString(), o.Error)); rendered++; continue; }
+                        if (o.Error is not null) { (errors ??= new()).Add((FormIdToken.Of(fk), o.Error)); rendered++; continue; }
                         var r = o.Record!;
                         if (fold is not null)
                         {
@@ -1330,7 +1330,7 @@ static class JsonWire
                             // one row per element and repeats its identity columns on each. The unquantified
                             // columns keep their own single cell, which is the same cell an unfolded call renders.
                             var (cols, carried, ferr) = fold.Columns(r);
-                            if (ferr is not null) { (errors ??= new()).Add((fk.ToString(), ferr)); rendered++; continue; }
+                            if (ferr is not null) { (errors ??= new()).Add((FormIdToken.Of(fk), ferr)); rendered++; continue; }
                             // A row is keyed by its ELEMENT KEY, never by its place in the column: a sub-path
                             // column skips an element whose arm does not carry it, and by position that cell
                             // would land beside a different element's row and read as that element's value. The key
@@ -1407,9 +1407,9 @@ static class JsonWire
                     else
                     {
                         var m = q.Prefilled is not null ? q.Prefilled[i] : svc.ResolveSummaryOn(q, fk);   // pinned to the scan's build
-                        if (m.Error is not null) { (errors ??= new()).Add((m.FormKey.ToString(), m.Error)); rendered++; continue; }
+                        if (m.Error is not null) { (errors ??= new()).Add((FormIdToken.Of(m.FormKey), m.Error)); rendered++; continue; }
                         w.WriteStartArray();
-                        w.WriteStringValue(m.FormKey.ToString());
+                        w.WriteStringValue(FormIdToken.Of(m.FormKey));
                         WriteCell(w, RuntimeCell(m.RuntimeFormId, m.RuntimeFormIdNote));
                         w.WriteStringValue(m.Type);
                         WriteCell(w, m.EditorId);
@@ -1473,7 +1473,7 @@ static class JsonWire
     internal static void WriteSummaryRow(Utf8JsonWriter w, RecordSummary m, string? matches)
     {
         w.WriteStartObject();
-        w.WriteString("formid", m.FormKey.ToString());
+        w.WriteString("formid", FormIdToken.Of(m.FormKey));
         WriteRuntime(w, m.RuntimeFormId, m.RuntimeFormIdNote);
         if (m.Error is not null) w.WriteString("error", m.Error);
         else
@@ -2546,7 +2546,7 @@ static class JsonWire
             {
                 if (Over(w, ms, cap)) { truncated = true; break; }
                 w.WriteStartObject();
-                w.WriteString("formid", c.FormKey.ToString());
+                w.WriteString("formid", FormIdToken.Of(c.FormKey));
                 w.WriteString("record_type", c.RecordType);
                 w.WriteString("editorid", c.EditorId);
                 // A replace is never silent (the CreatedRecord contract): the same fact the text render puts in

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -622,8 +622,8 @@ public sealed class LoadOrderService : IDisposable
             return new SkseAuditedRef(r, SkseRefVerdict.Unparseable, $"'{r.Plugin}' is not a valid plugin name");
         var fk = new FormKey(mk, r.LocalId!.Value);
         return index.ResolveWinner(fk) is not null
-            ? new SkseAuditedRef(r, SkseRefVerdict.Ok, fk.ToString())
-            : new SkseAuditedRef(r, SkseRefVerdict.Dangling, $"{fk} resolves to no record in '{r.Plugin}'");
+            ? new SkseAuditedRef(r, SkseRefVerdict.Ok, FormIdToken.Of(fk))
+            : new SkseAuditedRef(r, SkseRefVerdict.Dangling, $"{FormIdToken.Of(fk)} resolves to no record in '{r.Plugin}'");
     }
 
     /// <summary>Decode a config file's bytes to text, honoring a BOM (UTF-8/16) when present (real shipped configs carry
@@ -989,13 +989,13 @@ public sealed class LoadOrderService : IDisposable
 
         var body = view.GetRecord(session, winner.Value.WinnerPlugin, fk);
         if (body is null)
-            return (null, winner.Value.WinnerPlugin, null, none, $"Winner '{winner.Value.WinnerPlugin}' did not yield {fk} on fetch — a load-order inconsistency.", null);
+            return (null, winner.Value.WinnerPlugin, null, none, $"Winner '{winner.Value.WinnerPlugin}' did not yield {FormIdToken.Of(fk)} on fetch — a load-order inconsistency.", null);
 
         var typeName = ReadEngine.ReadFields(body, new[] { "EditorID" }).Type;   // the same type naming every read tool reports
         var maps = fieldMap.ForRecordType(typeName);
         if (maps.Count == 0)
             return (typeName, winner.Value.WinnerPlugin, body.EditorID, none,
-                $"Record type '{typeName}' is not a SkyPatcher-patchable type (or has no field map) — the SkyPatcher layer cannot touch {fk}.", null);
+                $"Record type '{typeName}' is not a SkyPatcher-patchable type (or has no field map) — the SkyPatcher layer cannot touch {FormIdToken.Of(fk)}.", null);
 
         // The running copy: the winner overridden into an in-memory scratch mod (never written to disk).
         // Nested-group types (CELL / REFR / INFO…) need the source link cache to rebuild their parent
@@ -1011,7 +1011,7 @@ public sealed class LoadOrderService : IDisposable
         catch (Exception ex)
         {
             return (typeName, winner.Value.WinnerPlugin, body.EditorID, none,
-                $"Could not materialize a mutable copy of {fk} ({typeName}) for the replay — {ex.GetType().Name}: {ex.Message}", null);
+                $"Could not materialize a mutable copy of {FormIdToken.Of(fk)} ({typeName}) for the replay — {ex.GetType().Name}: {ex.Message}", null);
         }
 
         // Watch this record's own EditorID lookups: only a replay that actually read from a table missing a
@@ -1046,7 +1046,7 @@ public sealed class LoadOrderService : IDisposable
         // Named as the record's error rather than answered wrong.
         if (spr is { ConsumedIncompleteTable: true })
             return (typeName, winner.Value.WinnerPlugin, body.EditorID, none,
-                $"the SkyPatcher replay of {fk} resolved an EditorID against the load order, and "
+                $"the SkyPatcher replay of {FormIdToken.Of(fk)} resolved an EditorID against the load order, and "
                 + string.Join(" ", spr.Unreadable.Select(u => u.Message).Distinct()), null);
 
         return (typeName, winner.Value.WinnerPlugin, body.EditorID, folders, null, copy);
@@ -1139,7 +1139,7 @@ public sealed class LoadOrderService : IDisposable
                     var map = fieldMap.For(fo.Subfolder, r.TypeName!);
                     foreach (var a in res.Applied)
                         if (SkyPatcherConflicts.IsNoOpWrite(a, map))
-                            noOps.Add(new SkyPatcherNoOpWrite(fo.Subfolder, fk.ToString(), r.EditorId,
+                            noOps.Add(new SkyPatcherNoOpWrite(fo.Subfolder, FormIdToken.Of(fk), r.EditorId,
                                 a.FieldPath, a.File, a.LineNumber, a.Op, a.RawValue, a.Before!));
                 }
             }
@@ -2429,14 +2429,14 @@ public sealed class LoadOrderService : IDisposable
         if (rec is null)
         {
             if (plugin is null)
-                return ReadOutcome.Fail(fk, $"Winner '{winner.Value.WinnerPlugin}' did not yield {fk} on fetch — a load-order inconsistency.");
+                return ReadOutcome.Fail(fk, $"Winner '{winner.Value.WinnerPlugin}' did not yield {FormIdToken.Of(fk)} on fetch — a load-order inconsistency.");
             // An untouched record under a named plugin refuses by naming the actual touchers: a bare "does not
             // define" reads as "my write was lost", and the touching list is the actionable fact. The ?? is
             // defensive — the non-null winner above proves the fk is in the index — but the nullable return became
             // a real NRE on the off-order sibling, so the guard stays.
             var touchers = view.TouchingPlugins(fk) ?? Array.Empty<string>();
             return ReadOutcome.Fail(fk,
-                $"Plugin '{plugin}' does not touch {fk} — it has no version of this record. " +
+                $"Plugin '{plugin}' does not touch {FormIdToken.Of(fk)} — it has no version of this record. " +
                 $"Touched by (load order, winner last): {string.Join(", ", touchers)}.");
         }
 
@@ -2627,9 +2627,9 @@ public sealed class LoadOrderService : IDisposable
     static string UnresolvedFormId(LoadOrderResolver.IndexView view, FormKey fk,
                                    Dictionary<string, string>? absenceMemo = null)
     {
-        var defining = fk.ModKey.FileName.ToString();
+        var defining = FormIdToken.Plugin(fk.ModKey.FileName.String);
         if (view.ExcludedPlugins.TryGetValue(defining, out var why))
-            return $"FormID {fk} is not resolvable: its plugin '{defining}' was excluded from this session: {why}";
+            return $"FormID {FormIdToken.Of(fk)} is not resolvable: its plugin '{defining}' was excluded from this session: {why}";
         if (view.ContainsPlugin(defining))
         {
             var esl = view.IsLightFlagged(defining)
@@ -2653,7 +2653,7 @@ public sealed class LoadOrderService : IDisposable
             tail = hint + "." + absence;
             if (absenceMemo is not null) absenceMemo[defining] = tail;
         }
-        return $"FormID {fk} is not present in the load order ({view.PluginCount} plugins): its plugin '{defining}' " +
+        return $"FormID {FormIdToken.Of(fk)} is not present in the load order ({view.PluginCount} plugins): its plugin '{defining}' " +
                $"is not in the order{tail}";
     }
 
@@ -2674,12 +2674,12 @@ public sealed class LoadOrderService : IDisposable
     static RecordSummary ResolveSummary(LoadOrderResolver resolver, LoadOrderResolver.IndexView view, FormKey fk)
     {
         var w = view.ResolveWinner(fk);
-        if (w is null) return new RecordSummary(fk, "?", null, "?", 0, $"{fk} not in the load order");
+        if (w is null) return new RecordSummary(fk, "?", null, "?", 0, $"{FormIdToken.Of(fk)} not in the load order");
         using var session = resolver.OpenSession();
         var body = view.GetRecord(session, w.Value.WinnerPlugin, fk);
         if (body is null)
             return new RecordSummary(fk, "?", null, w.Value.WinnerPlugin, w.Value.OverrideDepth,
-                $"winner '{w.Value.WinnerPlugin}' did not yield {fk} on fetch");
+                $"winner '{w.Value.WinnerPlugin}' did not yield {FormIdToken.Of(fk)} on fetch");
         return new RecordSummary(fk, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID,
                                  w.Value.WinnerPlugin, w.Value.OverrideDepth, null)
                .WithRuntime(view.RuntimeAddressOf(fk));
@@ -2793,16 +2793,16 @@ public sealed class LoadOrderService : IDisposable
         var w = view.ResolveWinner(fk);
         if (w is null)
             result = EngineImplicit.TryDescribe(fk, out var eiType, out var eiEditorId)
-                ? new ResolvedRef(fk.ToString(), Resolved: true, Type: eiType, EditorId: eiEditorId, Winner: "<engine>")   // engine-implicit: hardcoded, real, defined by no plugin
+                ? new ResolvedRef(FormIdToken.Of(fk), Resolved: true, Type: eiType, EditorId: eiEditorId, Winner: "<engine>")   // engine-implicit: hardcoded, real, defined by no plugin
                 // Valid FormKey, no active plugin defines it. The reason is the three-cause sentence every other
                 // lane states, so the identity form's row says WHICH cause instead of a bare "not present".
-                : new ResolvedRef(fk.ToString(), Resolved: false, Error: UnresolvedFormId(view, fk, memo.Absences));
+                : new ResolvedRef(FormIdToken.Of(fk), Resolved: false, Error: UnresolvedFormId(view, fk, memo.Absences));
         else
         {
             var body = view.GetRecord(session, w.Value.WinnerPlugin, fk);
             result = body is null
-                ? new ResolvedRef(fk.ToString(), Resolved: false, Winner: w.Value.WinnerPlugin)   // winner named but the fetch didn't yield it
-                : new ResolvedRef(fk.ToString(), Resolved: true, Type: RecordNaming.StripOverlay(body.GetType().Name),
+                ? new ResolvedRef(FormIdToken.Of(fk), Resolved: false, Winner: w.Value.WinnerPlugin)   // winner named but the fetch didn't yield it
+                : new ResolvedRef(FormIdToken.Of(fk), Resolved: true, Type: RecordNaming.StripOverlay(body.GetType().Name),
                                   EditorId: body.EditorID, Name: ReadDisplayName(body), Winner: w.Value.WinnerPlugin);
         }
         memo.Refs[fk] = result;
@@ -3209,7 +3209,7 @@ public sealed class LoadOrderService : IDisposable
                     // so the ?? is load-bearing, not defensive.
                     IReadOnlyList<string> touchers = view.TouchingPlugins(fk) ?? Array.Empty<string>();
                     results[index] = ReadOutcome.Fail(fk,
-                        $"file '{plugin}' ({poleWhere}) does not define or override {fk} — it has no version of this record. " +
+                        $"file '{plugin}' ({poleWhere}) does not define or override {FormIdToken.Of(fk)} — it has no version of this record. " +
                         (touchers.Count > 0
                             ? $"Touched by (active order, winner last): {string.Join(", ", touchers)}."
                             : "No active plugin touches it either."))
@@ -3317,12 +3317,12 @@ public sealed class LoadOrderService : IDisposable
             var fk = fkOpt!.Value;
 
             var s = sReader(fk, null);
-            if (s.Error is not null) { rows.Add(new DeltaRow(fk.ToString(), s.Pole, null, null, null, null, "subject: " + s.Error)); continue; }
+            if (s.Error is not null) { rows.Add(new DeltaRow(FormIdToken.Of(fk), s.Pole, null, null, null, null, "subject: " + s.Error)); continue; }
             // previous_provider is measured from the SUBJECT, so hand the reference reader the subject's resolved
             // plugin for this record and it anchors on the right stack position. The off-order subject is already
             // refused for the whole call above.
             var r = rReader(fk, s.Pole!.Plugin);
-            if (r.Error is not null) { rows.Add(new DeltaRow(fk.ToString(), s.Pole, r.Pole, null, r.StackAbove, null, "versus: " + r.Error)); continue; }
+            if (r.Error is not null) { rows.Add(new DeltaRow(FormIdToken.Of(fk), s.Pole, r.Pole, null, r.StackAbove, null, "versus: " + r.Error)); continue; }
 
             string? note = string.Equals(s.Pole.Plugin, r.Pole!.Plugin, StringComparison.OrdinalIgnoreCase) && s.Pole.Where == r.Pole.Where
                 ? "the two poles resolved to the SAME provider — the diff is trivially empty by construction"
@@ -3330,7 +3330,7 @@ public sealed class LoadOrderService : IDisposable
             // Two copies of one filename on opposite arms: the delta line names the off-order side's mod folder, or
             // the reader cannot tell which side a value came from without the pole lines above.
             var diff = FieldsDiff.Compare(s.Fields!, r.Fields!, referenceLabel: r.Pole.LabelVersus(s.Pole.Plugin));
-            rows.Add(new DeltaRow(fk.ToString(), s.Pole, r.Pole, diff, r.StackAbove, note, null));
+            rows.Add(new DeltaRow(FormIdToken.Of(fk), s.Pole, r.Pole, diff, r.StackAbove, note, null));
         }
         return rows;
     }
@@ -3369,7 +3369,7 @@ public sealed class LoadOrderService : IDisposable
                         return new PoleReading(null, null, null, UnresolvedFormId(view, fk));
                     var body = view.GetRecord(session, w.Value.WinnerPlugin, fk);
                     if (body is null)
-                        return new PoleReading(null, null, null, $"the winner body of {fk} could not be read from '{w.Value.WinnerPlugin}'.");
+                        return new PoleReading(null, null, null, $"the winner body of {FormIdToken.Of(fk)} could not be read from '{w.Value.WinnerPlugin}'.");
                     return new PoleReading(ReadEngine.ReadFields(body, fields, ConflictDiffDepth, parentOf: hop),
                                            new DiffPole(w.Value.WinnerPlugin, "winner (active order)", true,
                                                         RecordNaming.StripOverlay(body.GetType().Name), body.EditorID), null, null);
@@ -3383,21 +3383,21 @@ public sealed class LoadOrderService : IDisposable
                 {
                     var touchers = view.TouchingPlugins(fk) ?? Array.Empty<string>();
                     if (touchers.Count == 0)
-                        return new PoleReading(null, null, null, $"no active plugin touches {fk} — there is no provider stack to measure previous_provider in.");
+                        return new PoleReading(null, null, null, $"no active plugin touches {FormIdToken.Of(fk)} — there is no provider stack to measure previous_provider in.");
                     int idx = -1;
                     for (int i = 0; i < touchers.Count; i++)
                         if (string.Equals(touchers[i], subjectPlugin, StringComparison.OrdinalIgnoreCase)) { idx = i; break; }
                     if (idx < 0)   // the subject doesn't touch the record at all
                         return new PoleReading(null, null, null,
-                            $"the subject '{subjectPlugin}' does not touch {fk}, so it has no position to measure previous_provider from. " +
+                            $"the subject '{subjectPlugin}' does not touch {FormIdToken.Of(fk)}, so it has no position to measure previous_provider from. " +
                             $"Touched by (active order, winner last): {string.Join(", ", touchers)}.");
                     if (idx == 0)  // the subject IS the origin; never a silent empty diff
                         return new PoleReading(null, null, null,
-                            $"no previous provider — '{subjectPlugin}' DEFINES {fk} (bottom of the touching list); there is nothing beneath it to compare against.");
+                            $"no previous provider — '{subjectPlugin}' DEFINES {FormIdToken.Of(fk)} (bottom of the touching list); there is nothing beneath it to compare against.");
                     var refPlugin = touchers[idx - 1];
                     var body = view.GetRecord(session, refPlugin, fk);
                     if (body is null)
-                        return new PoleReading(null, null, null, $"the previous provider '{refPlugin}' of {fk} could not be read.");
+                        return new PoleReading(null, null, null, $"the previous provider '{refPlugin}' of {FormIdToken.Of(fk)} could not be read.");
                     // Mid-stack subject: what sits above is surfaced as neutral fact, never advice.
                     IReadOnlyList<string>? above = idx < touchers.Count - 1 ? touchers.Skip(idx + 1).ToList() : null;
                     return new PoleReading(ReadEngine.ReadFields(body, fields, ConflictDiffDepth, parentOf: hop),
@@ -3428,7 +3428,7 @@ public sealed class LoadOrderService : IDisposable
                             // Name the actual touchers, never a silent absence.
                             var touchers = view.TouchingPlugins(fk) ?? Array.Empty<string>();
                             return new PoleReading(null, null, null,
-                                $"'{arm.Plugin}' does not define or override {fk} — it has no version of this record. " +
+                                $"'{arm.Plugin}' does not define or override {FormIdToken.Of(fk)} — it has no version of this record. " +
                                 (touchers.Count > 0
                                     ? $"Touched by (active order, winner last): {string.Join(", ", touchers)}."
                                     : "No active plugin touches it either."));
@@ -3451,7 +3451,7 @@ public sealed class LoadOrderService : IDisposable
                     {
                         var touchers = view.TouchingPlugins(fk) ?? Array.Empty<string>();
                         return new PoleReading(null, null, null,
-                            $"file '{arm.Plugin}' ({arm.Where}) does not define or override {fk} — it has no version of this record. " +
+                            $"file '{arm.Plugin}' ({arm.Where}) does not define or override {FormIdToken.Of(fk)} — it has no version of this record. " +
                             (touchers.Count > 0
                                 ? $"Touched by (active order, winner last): {string.Join(", ", touchers)}."
                                 : "No active plugin touches it either."));
@@ -3494,7 +3494,7 @@ public sealed class LoadOrderService : IDisposable
                 var w = view.ResolveWinner(fk);
                 if (w is null) return new PoleReading(null, null, null, UnresolvedFormId(view, fk));
                 var body = view.GetRecord(session, w.Value.WinnerPlugin, fk);
-                if (body is null) return new PoleReading(null, null, null, $"the winner body of {fk} could not be read from '{w.Value.WinnerPlugin}'.");
+                if (body is null) return new PoleReading(null, null, null, $"the winner body of {FormIdToken.Of(fk)} could not be read from '{w.Value.WinnerPlugin}'.");
                 return new PoleReading(ReadEngine.ReadFields(body, fields, ConflictDiffDepth, parentOf: hop),
                                        new DiffPole(w.Value.WinnerPlugin, "skypatcher overlay (pre) = winner", true,
                                                     RecordNaming.StripOverlay(body.GetType().Name), body.EditorID), null, null);
@@ -3791,15 +3791,15 @@ public sealed class LoadOrderService : IDisposable
             var touchers = view.TouchingPlugins(fk) ?? Array.Empty<string>();
             if (touchers.Count == 0)
             {
-                rows.Add(new TreeRow(fk.ToString(), null, null, Array.Empty<string>(), null, Array.Empty<TreeNodeDelta>(),
+                rows.Add(new TreeRow(FormIdToken.Of(fk), null, null, Array.Empty<string>(), null, Array.Empty<TreeNodeDelta>(),
                                      UnresolvedFormId(view, fk), Array.Empty<ChildDeclarers>()));
                 continue;
             }
             var tree = ResolveTreePinned(new ViewPin(resolver, view), fk, fields);
             if (tree is null || tree.Nodes.Count == 0)
             {
-                rows.Add(new TreeRow(fk.ToString(), null, null, touchers, null, Array.Empty<TreeNodeDelta>(),
-                                     $"the provider bodies of {fk} could not be read.", Array.Empty<ChildDeclarers>()));
+                rows.Add(new TreeRow(FormIdToken.Of(fk), null, null, touchers, null, Array.Empty<TreeNodeDelta>(),
+                                     $"the provider bodies of {FormIdToken.Of(fk)} could not be read.", Array.Empty<ChildDeclarers>()));
                 continue;
             }
 
@@ -3814,7 +3814,7 @@ public sealed class LoadOrderService : IDisposable
                 var r = refReader(fk, null);
                 if (r.Error is not null)
                 {
-                    rows.Add(new TreeRow(fk.ToString(), tree.Winner.Record.Type, tree.Winner.Record.EditorId,
+                    rows.Add(new TreeRow(FormIdToken.Of(fk), tree.Winner.Record.Type, tree.Winner.Record.EditorId,
                                          touchers, null, Array.Empty<TreeNodeDelta>(), "versus: " + r.Error,
                                          Array.Empty<ChildDeclarers>()));
                     continue;
@@ -3843,7 +3843,7 @@ public sealed class LoadOrderService : IDisposable
                 var d = FieldsDiff.Compare(node.Record, refFields!, referenceLabel: refLabel);
                 nodes.Add(new TreeNodeDelta(node.Plugin, isWinner, false, d.Deltas, d.AgreedCount, d.Complete, null));
             }
-            rows.Add(new TreeRow(fk.ToString(), tree.Winner.Record.Type, tree.Winner.Record.EditorId,
+            rows.Add(new TreeRow(FormIdToken.Of(fk), tree.Winner.Record.Type, tree.Winner.Record.EditorId,
                                  touchers, refLabel, nodes, null, tree.ChildDeclarers));
         }
         return rows;
@@ -4009,7 +4009,7 @@ public sealed class LoadOrderService : IDisposable
                 // Fetch returns null for two conditions and they need different sentences: no winner at all (the
                 // three-cause unresolved sentence), or a named winner whose body did not come back on fetch.
                 var seedWin = view.ResolveWinner(seedFk);
-                rows[i] = new WalkSeedResult(seedFk.ToString(), null, null, Array.Empty<WalkNodeRow>(), Array.Empty<string>(), null, null,
+                rows[i] = new WalkSeedResult(FormIdToken.Of(seedFk), null, null, Array.Empty<WalkNodeRow>(), Array.Empty<string>(), null, null,
                     seedWin is null
                         ? UnresolvedFormId(view, seedFk) + " Nothing to walk from."
                         : $"the winner body of {seedFk} could not be read from '{seedWin.Value.WinnerPlugin}' — nothing to walk from.");
@@ -4101,7 +4101,7 @@ public sealed class LoadOrderService : IDisposable
                     var body = Fetch(key);
                     if (body is null)
                     {
-                        st.Nodes.Add(new WalkNodeRow(key.ToString(), null, null, hop, pulledBy, "kept",
+                        st.Nodes.Add(new WalkNodeRow(FormIdToken.Of(key), null, null, hop, pulledBy, "kept",
                                                      "unresolved — no active plugin defines this target (a missing endpoint)"));
                         continue;
                     }
@@ -4116,11 +4116,11 @@ public sealed class LoadOrderService : IDisposable
                             refusal = $"the walk reached a {type} ({key}, via {pulledBy}) — a node class this call excludes with severity 'refuse'. Nothing is returned for this call.";
                             return Array.Empty<WalkSeedResult>();
                         }
-                        st.Nodes.Add(new WalkNodeRow(key.ToString(), type, body.EditorID, hop, pulledBy, "kept", $"excluded ({type}, severity stop) — recorded as a boundary, not entered"));
+                        st.Nodes.Add(new WalkNodeRow(FormIdToken.Of(key), type, body.EditorID, hop, pulledBy, "kept", $"excluded ({type}, severity stop) — recorded as a boundary, not entered"));
                         continue;
                     }
                     bool atCap = hop >= depth;
-                    st.Nodes.Add(new WalkNodeRow(key.ToString(), type, body.EditorID, hop, pulledBy,
+                    st.Nodes.Add(new WalkNodeRow(FormIdToken.Of(key), type, body.EditorID, hop, pulledBy,
                                                  atCap ? "kept" : "expanded",
                                                  atCap ? $"at the walk.depth cap ({depth}) — not entered" : null));
                     if (atCap)
@@ -4146,7 +4146,7 @@ public sealed class LoadOrderService : IDisposable
             if (followSegs is { Length: 1 } && followSegs[0].Equals("Template", StringComparison.OrdinalIgnoreCase)
                 && st.Body is INpcGetter seedNpc)
                 templateReport = NpcTemplateReport(Fetch, seedNpc, st.Key);
-            results.Add(new WalkSeedResult(st.Key.ToString(), st.Type, st.Body.EditorID, st.Nodes, st.Cycles, st.Truncation, templateReport, null));
+            results.Add(new WalkSeedResult(FormIdToken.Of(st.Key), st.Type, st.Body.EditorID, st.Nodes, st.Cycles, st.Truncation, templateReport, null));
         }
         return results;
     }
@@ -4164,7 +4164,7 @@ public sealed class LoadOrderService : IDisposable
             var name = flag.ToString();
             if (!seed.Configuration.TemplateFlags.HasFlag(flag))
             {
-                report.Add(new NpcTemplateCategory(name, false, seedFk.ToString(), seed.EditorID,
+                report.Add(new NpcTemplateCategory(name, false, FormIdToken.Of(seedFk), seed.EditorID,
                                                    "local data ACTIVE (flag clear)"));
                 continue;
             }
@@ -4181,11 +4181,11 @@ public sealed class LoadOrderService : IDisposable
                 var body = fetch(nextKey);
                 if (body is null) { note = $"template target {nextKey} is unresolved — the chain is broken here"; break; }
                 if (body is ILeveledNpcGetter lvln)
-                { provKey = nextKey.ToString(); provEid = lvln.EditorID; note = "a LEVELED actor — the concrete provider is rolled at runtime"; break; }
+                { provKey = FormIdToken.Of(nextKey); provEid = lvln.EditorID; note = "a LEVELED actor — the concrete provider is rolled at runtime"; break; }
                 if (body is not INpcGetter npc)
                 { note = $"template target {nextKey} is a {RecordNaming.StripOverlay(body.GetType().Name)}, not an NPC or leveled actor"; break; }
                 if (!npc.Configuration.TemplateFlags.HasFlag(flag))
-                { provKey = nextKey.ToString(); provEid = npc.EditorID; break; }
+                { provKey = FormIdToken.Of(nextKey); provEid = npc.EditorID; break; }
                 cur = npc;
             }
             report.Add(new NpcTemplateCategory(name, true, provKey, provEid, note));
@@ -4235,26 +4235,26 @@ public sealed class LoadOrderService : IDisposable
             var win = view.ResolveWinner(fk);
             if (win is null)
             {
-                rows.Add(new InfoOrderRow(fk.ToString(), null, null, null, null, UnresolvedFormId(view, fk)));
+                rows.Add(new InfoOrderRow(FormIdToken.Of(fk), null, null, null, null, UnresolvedFormId(view, fk)));
                 continue;
             }
             var body = view.GetRecord(session, win.Value.WinnerPlugin, fk);
             if (body is null)
             {
-                rows.Add(new InfoOrderRow(fk.ToString(), null, null, win.Value.WinnerPlugin, null,
-                                          $"the winner body of {fk} could not be read from '{win.Value.WinnerPlugin}'."));
+                rows.Add(new InfoOrderRow(FormIdToken.Of(fk), null, null, win.Value.WinnerPlugin, null,
+                                          $"the winner body of {FormIdToken.Of(fk)} could not be read from '{win.Value.WinnerPlugin}'."));
                 continue;
             }
             if (body is not Mutagen.Bethesda.Skyrim.IDialogTopicGetter)
             {
                 var typeName = RecordNaming.StripOverlay(body.GetType().Name);
-                rows.Add(new InfoOrderRow(fk.ToString(), typeName, body.EditorID, win.Value.WinnerPlugin, null,
-                    $"{fk} is a {typeName}, and the info_order form renders the merged INFO sequence of a DIALOGUE TOPIC (DIAL). " +
+                rows.Add(new InfoOrderRow(FormIdToken.Of(fk), typeName, body.EditorID, win.Value.WinnerPlugin, null,
+                    $"{FormIdToken.Of(fk)} is a {typeName}, and the info_order form renders the merged INFO sequence of a DIALOGUE TOPIC (DIAL). " +
                     "For a quest's topics, select them by composition: types=[\"DIAL\"] where=[\"Quest = " + fk + "\"]."));
                 continue;
             }
             dialRows.Add((rows.Count, fk));
-            rows.Add(new InfoOrderRow(fk.ToString(), RecordNaming.StripOverlay(body.GetType().Name), body.EditorID,
+            rows.Add(new InfoOrderRow(FormIdToken.Of(fk), RecordNaming.StripOverlay(body.GetType().Name), body.EditorID,
                                       win.Value.WinnerPlugin, null, null));
             if (dialSeen.Add(fk)) dialFks.Add(fk);
         }
@@ -4500,7 +4500,7 @@ public sealed class LoadOrderService : IDisposable
                         {
                             unscannable++;
                             if (unscannableSamples.Count < 3)
-                                unscannableSamples.Add($"{fk} — winner '{w.Value.WinnerPlugin}' did not yield the record on fetch");
+                                unscannableSamples.Add($"{FormIdToken.Of(fk)} — winner '{w.Value.WinnerPlugin}' did not yield the record on fetch");
                             continue;
                         }
                         if (conflictsOnly && (view.TouchingPlugins(fk)?.Count ?? 0) <= 1) continue;
@@ -4528,7 +4528,7 @@ public sealed class LoadOrderService : IDisposable
                         if (groups is not null)
                         {
                             var gk = groupBy == "type" ? RecordNaming.StripOverlay(body.GetType().Name)
-                                   : groupBy == "defined_in" ? fk.ModKey.FileName.ToString()
+                                   : groupBy == "defined_in" ? FormIdToken.Plugin(fk.ModKey.FileName.String)
                                    : w.Value.WinnerPlugin;
                             groups[gk] = groups.GetValueOrDefault(gk) + 1;
                         }
@@ -4546,7 +4546,7 @@ public sealed class LoadOrderService : IDisposable
                     {
                         unscannable++;
                         if (unscannableSamples.Count < 3)
-                            unscannableSamples.Add($"{fk} — {ex.GetType().Name}: {ex.Message}");
+                            unscannableSamples.Add($"{FormIdToken.Of(fk)} — {ex.GetType().Name}: {ex.Message}");
                     }
                 }
             }
@@ -4716,7 +4716,7 @@ public sealed class LoadOrderService : IDisposable
                         if (groups is not null)                                   // group_by=: aggregate over all matches, no keys or prefill, no limit cap
                         {
                             var gk = groupBy == "type" ? RecordNaming.StripOverlay(filterBody.GetType().Name)
-                                   : groupBy == "defined_in" ? fk.ModKey.FileName.ToString()
+                                   : groupBy == "defined_in" ? FormIdToken.Plugin(fk.ModKey.FileName.String)
                                    : view.ResolveWinner(fk)?.WinnerPlugin ?? "?";  // "winner"
                             groups[gk] = groups.GetValueOrDefault(gk) + 1;
                         }
@@ -4737,7 +4737,7 @@ public sealed class LoadOrderService : IDisposable
                     {
                         unscannable++;
                         if (unscannableSamples.Count < 3)
-                            unscannableSamples.Add($"{fk}{(source is null ? "" : $" in {source}")} — {ex.GetType().Name}: {ex.Message}");
+                            unscannableSamples.Add($"{FormIdToken.Of(fk)}{(source is null ? "" : $" in {source}")} — {ex.GetType().Name}: {ex.Message}");
                     }
                     return true;
                 }
@@ -4767,7 +4767,7 @@ public sealed class LoadOrderService : IDisposable
                     // group_by=winner here does an index-level ResolveWinner per conflict key — a resolve, not a body
                     // parse, and unavoidable for the aggregate, since the non-group path defers the winner to the
                     // renderer, which only fetches the capped rows. Deliberate: accuracy over speed.
-                    var gk = groupBy == "defined_in" ? fk.ModKey.FileName.ToString() : view.ResolveWinner(fk)?.WinnerPlugin ?? "?";
+                    var gk = groupBy == "defined_in" ? FormIdToken.Plugin(fk.ModKey.FileName.String) : view.ResolveWinner(fk)?.WinnerPlugin ?? "?";
                     groups[gk] = groups.GetValueOrDefault(gk) + 1;
                 }
                 else if (total > offset && keys.Count < limit) { keys.Add(fk); sources.Add(null); }   // no scoped plugin → display the winner; offset= skips the first N
@@ -5019,7 +5019,7 @@ public sealed class LoadOrderService : IDisposable
                     if (groups is not null)
                     {
                         var gk = groupBy == "type" ? RecordNaming.StripOverlay(rec.GetType().Name)
-                               : groupBy == "defined_in" ? fk.ModKey.FileName.ToString()
+                               : groupBy == "defined_in" ? FormIdToken.Plugin(fk.ModKey.FileName.String)
                                : view.ResolveWinner(fk)?.WinnerPlugin ?? "(not in the active order)";
                         groups[gk] = groups.GetValueOrDefault(gk) + 1;
                     }
@@ -5038,7 +5038,7 @@ public sealed class LoadOrderService : IDisposable
                 {
                     unscannable++;
                     if (unscannableSamples.Count < 3)
-                        unscannableSamples.Add($"{fk} in {pole.Plugin} — {ex.GetType().Name}: {ex.Message}");
+                        unscannableSamples.Add($"{FormIdToken.Of(fk)} in {pole.Plugin} — {ex.GetType().Name}: {ex.Message}");
                 }
             }
         }
@@ -5620,13 +5620,13 @@ public sealed class LoadOrderService : IDisposable
             var renamed = missing.Where(k => k.ModKey != ov.ModKey && selfIds.Contains(k.ID)).ToList();
             var hint = renamed.Count == 0 ? "" :
                 $"\n  NOTE: this file DOES carry {(renamed.Count == 1 ? "that FormID" : "those FormIDs")} — but under its own " +
-                $"name, as {string.Join(", ", renamed.Take(3).Select(k => $"{k.ID:X6}:{ov.ModKey.FileName}"))}. A plugin's records are keyed by its " +
+                $"name, as {string.Join(", ", renamed.Take(3).Select(k => FormIdToken.Of(new FormKey(ov.ModKey, k.ID))))}. A plugin's records are keyed by its " +
                 "FILENAME, so a copy saved under a different name is a DIFFERENT plugin. Keep the original filename and " +
                 "park the copy in another folder, or name the FormIDs as this file spells them.";
             (ov as IDisposable)?.Dispose();
             error = $"refused — source file '{fromPlugin}' ({loc.Where}) does NOT define or override {missing.Count} of the " +
                     $"{specs.Count} record(s) named; there is no version of them there to forward, and NOTHING was written:\n  - " +
-                    string.Join("\n  - ", missing.Select(k => k.ToString())) + hint;
+                    string.Join("\n  - ", missing.Select(k => FormIdToken.Of(k))) + hint;
             return null;
         }
 
@@ -6224,7 +6224,7 @@ public sealed class LoadOrderService : IDisposable
             if (seqSource?.LooseFilePath is not { } seqPath) return null;      // no .seq, or a BSA-only one (bytes uncheckable here) → nothing to flag
             var uncovered = SeqFile.UncoveredSgeQuests(targetPath, File.ReadAllBytes(seqPath));
             if (uncovered.Count == 0) return null;                            // the .seq still lists every SGE quest → not staled
-            var names = string.Join(", ", uncovered.Select(q => q.EditorId ?? q.FormKey.ToString()));
+            var names = string.Join(", ", uncovered.Select(q => q.EditorId ?? FormIdToken.Of(q.FormKey)));
             bool one = uncovered.Count == 1;
             return $"the .seq for '{targetName}' no longer lists {(one ? "its start-game-enabled quest" : $"{uncovered.Count} of its start-game-enabled quests")} "
                  + $"at {(one ? "its" : "their")} current on-disk FormID(s) ({names}), so {(one ? "it" : "they")} would silently never start on a fresh save "

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -3977,7 +3977,7 @@ public sealed class LoadOrderService : IDisposable
                 }
                 if (i == hops - 1 && hops == segs.Length) return new List<FormKey> { pk.Value };
                 var up = Fetch(pk.Value);
-                if (up is null) { note = $"(the containing record {pk.Value} would not fetch)"; return new List<FormKey>(); }
+                if (up is null) { note = $"(the containing record {FormIdToken.Of(pk.Value)} would not fetch)"; return new List<FormKey>(); }
                 body = up;
             }
 
@@ -4012,7 +4012,7 @@ public sealed class LoadOrderService : IDisposable
                 rows[i] = new WalkSeedResult(FormIdToken.Of(seedFk), null, null, Array.Empty<WalkNodeRow>(), Array.Empty<string>(), null, null,
                     seedWin is null
                         ? UnresolvedFormId(view, seedFk) + " Nothing to walk from."
-                        : $"the winner body of {seedFk} could not be read from '{seedWin.Value.WinnerPlugin}' — nothing to walk from.");
+                        : $"the winner body of {FormIdToken.Of(seedFk)} could not be read from '{seedWin.Value.WinnerPlugin}' — nothing to walk from.");
                 continue;
             }
             var seedType = TypeOf(seedBody);
@@ -4021,7 +4021,7 @@ public sealed class LoadOrderService : IDisposable
                 Key = seedFk,
                 Body = seedBody,
                 Type = seedType,
-                Label = $"{seedType} {seedFk} ({seedBody.EditorID ?? "<no editorid>"})",
+                Label = $"{seedType} {FormIdToken.Of(seedFk)} ({seedBody.EditorID ?? "<no editorid>"})",
                 Visited = new HashSet<FormKey> { seedFk },
             };
 
@@ -4089,7 +4089,7 @@ public sealed class LoadOrderService : IDisposable
                     {
                         // A named-follow walk is a linear chain per seed, so a revisit IS a cycle: recorded and named,
                         // never looped and never silently stopped. Closure walks dedupe on the visited set instead.
-                        if (followSegs is not null) st.Cycles.Add($"{pulledBy} -> {key} (already on this chain)");
+                        if (followSegs is not null) st.Cycles.Add($"{pulledBy} -> {FormIdToken.Of(key)} (already on this chain)");
                         continue;
                     }
                     if (st.Nodes.Count >= maxNodes)
@@ -4113,7 +4113,7 @@ public sealed class LoadOrderService : IDisposable
                         // seed IN SEED ORDER that reaches the class at the SHALLOWEST hop any seed reaches it.
                         if (excl.Refuse)
                         {
-                            refusal = $"the walk reached a {type} ({key}, via {pulledBy}) — a node class this call excludes with severity 'refuse'. Nothing is returned for this call.";
+                            refusal = $"the walk reached a {type} ({FormIdToken.Of(key)}, via {pulledBy}) — a node class this call excludes with severity 'refuse'. Nothing is returned for this call.";
                             return Array.Empty<WalkSeedResult>();
                         }
                         st.Nodes.Add(new WalkNodeRow(FormIdToken.Of(key), type, body.EditorID, hop, pulledBy, "kept", $"excluded ({type}, severity stop) — recorded as a boundary, not entered"));
@@ -4128,7 +4128,7 @@ public sealed class LoadOrderService : IDisposable
                         st.Truncation ??= $"walk reached its depth cap ({depth}) on at least one chain — nodes at the cap are recorded, not entered; raise walk.depth to walk deeper.";
                         continue;
                     }
-                    var label = $"{type} {key} ({body.EditorID ?? "<no editorid>"})";
+                    var label = $"{type} {FormIdToken.Of(key)} ({body.EditorID ?? "<no editorid>"})";
                     foreach (var l in LinksOf(body, followSegs, out _))
                         if (!l.IsNull) st.Frontier.Enqueue((l, hop + 1, label));
                 }
@@ -4250,7 +4250,7 @@ public sealed class LoadOrderService : IDisposable
                 var typeName = RecordNaming.StripOverlay(body.GetType().Name);
                 rows.Add(new InfoOrderRow(FormIdToken.Of(fk), typeName, body.EditorID, win.Value.WinnerPlugin, null,
                     $"{FormIdToken.Of(fk)} is a {typeName}, and the info_order form renders the merged INFO sequence of a DIALOGUE TOPIC (DIAL). " +
-                    "For a quest's topics, select them by composition: types=[\"DIAL\"] where=[\"Quest = " + fk + "\"]."));
+                    "For a quest's topics, select them by composition: types=[\"DIAL\"] where=[\"Quest = " + FormIdToken.Of(fk) + "\"]."));
                 continue;
             }
             dialRows.Add((rows.Count, fk));
@@ -5451,22 +5451,22 @@ public sealed class LoadOrderService : IDisposable
                 comp = Mo2LoadOrder.ReadComposition(profileDir);
             }
             var loc = LocatePluginFileOnDisk(comp, modsDir, dataDir, overwriteDir, e.FromPlugin!, null);
-            if (loc.Error is not null) { problems.Add($"{e.Target}: CopyFrom source '{e.FromPlugin}' is not in the load order and {loc.Error}"); continue; }
-            if (loc.Ambiguous is not null) { problems.Add($"{e.Target}: CopyFrom source '{e.FromPlugin}' matches several mod folders on disk — pass an exact path to disambiguate."); continue; }
+            if (loc.Error is not null) { problems.Add($"{FormIdToken.Of(e.Target)}: CopyFrom source '{e.FromPlugin}' is not in the load order and {loc.Error}"); continue; }
+            if (loc.Ambiguous is not null) { problems.Add($"{FormIdToken.Of(e.Target)}: CopyFrom source '{e.FromPlugin}' matches several mod folders on disk — pass an exact path to disambiguate."); continue; }
             ISkyrimModGetter ov;
             try { ov = LoadOrderResolver.OpenOverlay(loc.Path!, string.IsNullOrEmpty(dataDir) ? null : dataDir); }
-            catch (Exception ex) { problems.Add($"{e.Target}: CopyFrom source file '{e.FromPlugin}' could not be opened as a Skyrim plugin ({ex.Message})."); continue; }
+            catch (Exception ex) { problems.Add($"{FormIdToken.Of(e.Target)}: CopyFrom source file '{e.FromPlugin}' could not be opened as a Skyrim plugin ({ex.Message})."); continue; }
             IMajorRecordGetter? body;
             try { body = ov.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == e.CopySource); }
-            catch (Exception ex) { (ov as IDisposable)?.Dispose(); problems.Add($"{e.Target}: CopyFrom source file '{e.FromPlugin}' could not be read ({ex.Message})."); continue; }
+            catch (Exception ex) { (ov as IDisposable)?.Dispose(); problems.Add($"{FormIdToken.Of(e.Target)}: CopyFrom source file '{e.FromPlugin}' could not be read ({ex.Message})."); continue; }
             if (body is null)
             {
                 (ov as IDisposable)?.Dispose();
                 // Name WHICH record the file is missing: the target's own version for a same-record copy, or the
                 // zip's source record for a cross-record one — "this record" would point at the wrong one.
                 problems.Add(e.FromTarget is null
-                    ? $"{e.Target}: CopyFrom source file '{e.FromPlugin}' does not define or override this record — there is no version of it there to copy."
-                    : $"{e.Target}: CopyFrom source file '{e.FromPlugin}' does not define or override the SOURCE record {e.CopySource} — there is no version of it there to copy from.");
+                    ? $"{FormIdToken.Of(e.Target)}: CopyFrom source file '{e.FromPlugin}' does not define or override this record — there is no version of it there to copy."
+                    : $"{FormIdToken.Of(e.Target)}: CopyFrom source file '{e.FromPlugin}' does not define or override the SOURCE record {FormIdToken.Of(e.CopySource)} — there is no version of it there to copy from.");
                 continue;
             }
             (overlays ??= new()).Add((IDisposable)ov);

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using HousecarlCore;
 using Mutagen.Bethesda.Plugins;
 
 namespace HousecarlMcp;
@@ -272,7 +273,7 @@ static class Wire
             sb.Append('\n');
             // The scan render's exact line, so a reverse lookup un-merges the same way whichever form answered it.
             if (matches is { } mt && i < mt.Count && mt[i] is { } hit)
-                sb.Append("  ").Append(o.FormKey).Append("  matches=").Append(hit).Append('\n');
+                sb.Append("  ").Append(FormIdToken.Of(o.FormKey)).Append("  matches=").Append(hit).Append('\n');
             if (o.Error is not null) sb.Append("error: ").Append(o.Error).Append('\n');
             else AppendRecordBlock(sb, o, new RenderCap(cap, budget), notes, lv);
             // Whole records only, and the clause this record earned goes back with it: the clauses already earned are
@@ -400,7 +401,7 @@ static class Wire
             else
             {
                 var m = q.Prefilled is not null ? q.Prefilled[i] : svc.ResolveSummaryOn(q, fk);   // lazy fill for conflicts-only, pinned to the scan's build
-                sb.Append("  ").Append(m.FormKey);
+                sb.Append("  ").Append(FormIdToken.Of(m.FormKey));
                 if (m.Error is not null) sb.Append("  error=").Append(m.Error).Append('\n');
                 else
                 {
@@ -503,7 +504,7 @@ static class Wire
         if (r.Error is not null) return "error: " + r.Error + Wire.EpochLine(r.Stamp);
         int cap = room.Cap;
         var sb = new StringBuilder();
-        sb.Append("chain for ").Append(r.Mgef).Append(" (").Append(r.MgefEditorId).Append(", MagicEffect): ")
+        sb.Append("chain for ").Append(FormIdToken.Of(r.Mgef)).Append(" (").Append(r.MgefEditorId).Append(", MagicEffect): ")
           .Append(r.Total).Append(r.Total == 1 ? " carrier row" : " carrier rows");
         if (r.Capped) sb.Append(" (showing first ").Append(r.Rows.Count).Append("; raise ").Append(carrierBound).Append(" or narrow to see more)");
         if (r.Stamp is not null) sb.Append(Wire.EpochInline(r.Stamp));
@@ -536,7 +537,7 @@ static class Wire
             {
                 // Composed before it is priced, so the cut notice lands inside the budget rather than a character
                 // past the row that crossed it.
-                string line = "  " + row.Carrier
+                string line = "  " + FormIdToken.Of(row.Carrier)
                               + "  " + (row.EditorId ?? "<none>")
                               + "  winner=" + row.Winner
                               + "  mag=" + row.Magnitude.ToString(System.Globalization.CultureInfo.InvariantCulture)
@@ -1050,7 +1051,7 @@ static class Wire
 
         var sb = new StringBuilder();
         sb.Append('\n').Append(rec.Unbound.Count > 0 ? "[UNBOUND] " : "[CHECK] ")
-          .Append(rec.Record).Append(" (").Append(rec.RecordType);
+          .Append(FormIdToken.Of(rec.Record)).Append(" (").Append(rec.RecordType);
         if (!string.IsNullOrEmpty(rec.EditorId)) sb.Append(" '").Append(rec.EditorId).Append('\'');
         sb.Append(") in ").Append(rec.Plugin).Append('\n');
 

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -1360,7 +1360,7 @@ public static class RecordsTools
             //      rendering the chain or reading the reached set, seam-checked throughout. ----
             if (walk is not null && outcome.Error is null && outcome.Groups is null)
             {
-                var seedKeys = outcome.Keys.Select(FormIdToken.Of).ToArray();
+                var seedKeys = outcome.Keys.Select(k => k.ToString()).ToArray();
                 envelope.Add(new("total", outcome.Total.ToString()));
                 headerLine += $"\n{outcome.Total} match(es) selected by the scan as walk seeds";
                 expectEpoch = outcome.Epoch;
@@ -1384,7 +1384,7 @@ public static class RecordsTools
             //      Two captures meet here, so the seam is epoch-compared and the halves can never mix builds.
             if (comparisonForm && outcome.Error is null && outcome.Groups is null)
             {
-                var cmpKeys = outcome.Keys.Select(FormIdToken.Of).ToList();
+                var cmpKeys = outcome.Keys.Select(k => k.ToString()).ToList();
                 envelope.Add(new("total", outcome.Total.ToString()));
                 headerLine += $"\n{outcome.Total} match(es) selected by the scan";
                 if (form == "delta")
@@ -1421,7 +1421,7 @@ public static class RecordsTools
             //      epoch-compared like every two-capture form. ----
             if (form == "info_order" && outcome.Error is null && outcome.Groups is null)
             {
-                var ioKeys = outcome.Keys.Select(FormIdToken.Of).ToList();
+                var ioKeys = outcome.Keys.Select(k => k.ToString()).ToList();
                 envelope.Add(new("total", outcome.Total.ToString()));
                 headerLine += $"\n{outcome.Total} match(es) selected by the scan";
                 var ioRows = svc.InfoOrderBatch(ioKeys, null, out var ioRefusal, out var ioEpoch);
@@ -1443,7 +1443,7 @@ public static class RecordsTools
             // it takes the lane too — except under dense, whose own render carries the per-element rows.
             if (bodyLaneForm && !counts_only && outcome.Error is null && outcome.Groups is null)
             {
-                var keys = outcome.Keys.Select(FormIdToken.Of).ToList();
+                var keys = outcome.Keys.Select(k => k.ToString()).ToList();
                 IReadOnlyList<ReadOutcome> bodies;
                 // This lane READS a body per row exactly as the scan render does, so it is clocked the same way and
                 // reports the same render_ms — the bound is one number over both lanes only if both are measured.
@@ -1679,7 +1679,7 @@ public static class RecordsTools
             // Comparisons over the file's matches: the file IS the subject pole (its version of each match).
             if (comparisonForm && outcome.Error is null && outcome.Groups is null)
             {
-                var cmpKeys = outcome.Keys.Select(FormIdToken.Of).ToList();
+                var cmpKeys = outcome.Keys.Select(k => k.ToString()).ToList();
                 envelope.Add(new("total", outcome.Total.ToString()));
                 headerLine += $"\n{outcome.Total} match(es) selected from the file";
                 if (form == "delta")
@@ -1717,7 +1717,7 @@ public static class RecordsTools
             // fields/everything over the file's matches: bodies via the one-pole batch (it reads the FILE).
             if (form is ("fields" or "rows" or "everything") && !counts_only && outcome.Error is null && outcome.Groups is null)
             {
-                var keys = outcome.Keys.Select(FormIdToken.Of).ToList();
+                var keys = outcome.Keys.Select(k => k.ToString()).ToList();
                 // The render bound is on the row cost, not on where the row came from: a row here reads a body
                 // exactly as the in-order lane's does, so it refuses on the same numbers before reading one.
                 if (RenderBudget.Refuse(keys.Count, form == "everything") is { } offTooBig)

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -2504,10 +2504,10 @@ public static class RecordsTools
         {
             if (manifestOnly) break;
             int mark = sb.Length;
-            if (o.Error is not null) sb.Append(o.FormKey).Append("  error=").Append(o.Error).Append('\n');
+            if (o.Error is not null) sb.Append(FormIdToken.Of(o.FormKey)).Append("  error=").Append(o.Error).Append('\n');
             else
             {
-                sb.Append(o.FormKey);
+                sb.Append(FormIdToken.Of(o.FormKey));
                 Wire.AppendRuntime(sb, o.RuntimeFormId, o.RuntimeFormIdNote);
                 sb.Append("  ").Append(o.Record!.Type)
                   .Append("  ").Append(o.Record.EditorId ?? "<no editorid>")

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -804,7 +804,7 @@ public static class RecordsTools
                     catch (Exception ex) { results.Add((raw?.Trim() ?? "", EffectChainResult.Fail($"bad FormID '{raw}': {ex.Message}"))); continue; }
                     // The per-seed carrier bound is the walk's own reach budget; limit=/offset= stay the SEED
                     // window, never a second silent cut on the carrier axis.
-                    results.Add((fk.ToString(), svc.ResolveEffectChain(fk, types, walkMaxNodes)));
+                    results.Add((FormIdToken.Of(fk), svc.ResolveEffectChain(fk, types, walkMaxNodes)));
                 }
                 // One build for the whole batch: each seed's resolve captures its own view, so the stamps must
                 // agree, and an @artifact seed list's epoch demand must match that build.
@@ -852,7 +852,7 @@ public static class RecordsTools
                         if (carrierSeen.Add(r.Seed)) carrierSel.Add(r.Seed);
                         foreach (var row in r.Result.Rows)
                         {
-                            var key = row.Carrier.ToString();
+                            var key = FormIdToken.Of(row.Carrier);
                             if (carrierSeen.Add(key)) carrierSel.Add(key);
                         }
                     }
@@ -1360,7 +1360,7 @@ public static class RecordsTools
             //      rendering the chain or reading the reached set, seam-checked throughout. ----
             if (walk is not null && outcome.Error is null && outcome.Groups is null)
             {
-                var seedKeys = outcome.Keys.Select(k => k.ToString()).ToArray();
+                var seedKeys = outcome.Keys.Select(FormIdToken.Of).ToArray();
                 envelope.Add(new("total", outcome.Total.ToString()));
                 headerLine += $"\n{outcome.Total} match(es) selected by the scan as walk seeds";
                 expectEpoch = outcome.Epoch;
@@ -1384,7 +1384,7 @@ public static class RecordsTools
             //      Two captures meet here, so the seam is epoch-compared and the halves can never mix builds.
             if (comparisonForm && outcome.Error is null && outcome.Groups is null)
             {
-                var cmpKeys = outcome.Keys.Select(k => k.ToString()).ToList();
+                var cmpKeys = outcome.Keys.Select(FormIdToken.Of).ToList();
                 envelope.Add(new("total", outcome.Total.ToString()));
                 headerLine += $"\n{outcome.Total} match(es) selected by the scan";
                 if (form == "delta")
@@ -1421,7 +1421,7 @@ public static class RecordsTools
             //      epoch-compared like every two-capture form. ----
             if (form == "info_order" && outcome.Error is null && outcome.Groups is null)
             {
-                var ioKeys = outcome.Keys.Select(k => k.ToString()).ToList();
+                var ioKeys = outcome.Keys.Select(FormIdToken.Of).ToList();
                 envelope.Add(new("total", outcome.Total.ToString()));
                 headerLine += $"\n{outcome.Total} match(es) selected by the scan";
                 var ioRows = svc.InfoOrderBatch(ioKeys, null, out var ioRefusal, out var ioEpoch);
@@ -1443,7 +1443,7 @@ public static class RecordsTools
             // it takes the lane too — except under dense, whose own render carries the per-element rows.
             if (bodyLaneForm && !counts_only && outcome.Error is null && outcome.Groups is null)
             {
-                var keys = outcome.Keys.Select(k => k.ToString()).ToList();
+                var keys = outcome.Keys.Select(FormIdToken.Of).ToList();
                 IReadOnlyList<ReadOutcome> bodies;
                 // This lane READS a body per row exactly as the scan render does, so it is clocked the same way and
                 // reports the same render_ms — the bound is one number over both lanes only if both are measured.
@@ -1679,7 +1679,7 @@ public static class RecordsTools
             // Comparisons over the file's matches: the file IS the subject pole (its version of each match).
             if (comparisonForm && outcome.Error is null && outcome.Groups is null)
             {
-                var cmpKeys = outcome.Keys.Select(k => k.ToString()).ToList();
+                var cmpKeys = outcome.Keys.Select(FormIdToken.Of).ToList();
                 envelope.Add(new("total", outcome.Total.ToString()));
                 headerLine += $"\n{outcome.Total} match(es) selected from the file";
                 if (form == "delta")
@@ -1717,7 +1717,7 @@ public static class RecordsTools
             // fields/everything over the file's matches: bodies via the one-pole batch (it reads the FILE).
             if (form is ("fields" or "rows" or "everything") && !counts_only && outcome.Error is null && outcome.Groups is null)
             {
-                var keys = outcome.Keys.Select(k => k.ToString()).ToList();
+                var keys = outcome.Keys.Select(FormIdToken.Of).ToList();
                 // The render bound is on the row cost, not on where the row came from: a row here reads a body
                 // exactly as the in-order lane's does, so it refuses on the same numbers before reading one.
                 if (RenderBudget.Refuse(keys.Count, form == "everything") is { } offTooBig)
@@ -2550,7 +2550,7 @@ public static class RecordsTools
             var key = gb switch
             {
                 "type" => o.Record!.Type,
-                "defined_in" => o.FormKey.ModKey.FileName.ToString(),
+                "defined_in" => FormIdToken.Plugin(o.FormKey.ModKey.FileName.String),
                 _ => o.WinnerPlugin ?? "?",
             };
             groups[key] = groups.GetValueOrDefault(key) + 1;

--- a/src/housecarl-mcp/ReverseWalkBatch.cs
+++ b/src/housecarl-mcp/ReverseWalkBatch.cs
@@ -113,7 +113,7 @@ public static class ReverseWalkBatch
         // Seeds first, then each hop in order: the selection reads in walk order, and the render says the seeds
         // are in it.
         var selection = new List<string>(seedKeys.Count);
-        foreach (var k in seedKeys) selection.Add(k.ToString());
+        foreach (var k in seedKeys) selection.Add(FormIdToken.Of(k));
         foreach (var hop in hops)
             foreach (var k in hop.Reached) selection.Add(k.ToString());
 

--- a/src/housecarl-mcp/ReverseWalkBatch.cs
+++ b/src/housecarl-mcp/ReverseWalkBatch.cs
@@ -115,7 +115,7 @@ public static class ReverseWalkBatch
         var selection = new List<string>(seedKeys.Count);
         foreach (var k in seedKeys) selection.Add(FormIdToken.Of(k));
         foreach (var hop in hops)
-            foreach (var k in hop.Reached) selection.Add(k.ToString());
+            foreach (var k in hop.Reached) selection.Add(FormIdToken.Of(k));
 
         return new Result(hops, selection, seedKeys.Count, capped,
                           new DropCensus(noLink.Count, unreadable, noLiveBody, noWinner), built.Note, stamp, null);

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -149,7 +149,7 @@ public static class WriteTools
                 break;
             }
             var op = o.Ops[i];
-            sb.Append("  ").Append(op.RecordType).Append(' ').Append(op.Target).Append("  ").Append(op.Label)
+            sb.Append("  ").Append(op.RecordType).Append(' ').Append(FormIdToken.Of(op.Target)).Append("  ").Append(op.Label)
               .Append(op.After is not null ? "  -> " + op.After : "  -> applied").Append(ApplyNote(op)).Append('\n');
         }
         // The .fuz/.lip and result-script checks run on CREATE of dialogue lines, not on edits to existing ones, so an
@@ -212,7 +212,7 @@ public static class WriteTools
                 break;
             }
             var op = o.Ops[i];
-            sb.Append("  ").Append(op.RecordType).Append(' ').Append(op.Target).Append("  ").Append(op.Label)
+            sb.Append("  ").Append(op.RecordType).Append(' ').Append(FormIdToken.Of(op.Target)).Append("  ").Append(op.Label)
               .Append(op.After is not null ? "  -> would become " + op.After : "  -> would apply").Append(ApplyNote(op)).Append('\n');
         }
         if (fullDump && o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars, dryRun: true);
@@ -246,7 +246,7 @@ public static class WriteTools
                 return;
             }
             var r = rb[i];
-            if (r.Error is not null) { sb.Append("  ").Append(r.Target).Append("  error: ").Append(r.Error).Append('\n'); continue; }
+            if (r.Error is not null) { sb.Append("  ").Append(FormIdToken.Of(r.Target)).Append("  error: ").Append(r.Error).Append('\n'); continue; }
             var rec = r.Record!;
             sb.Append("  ").Append(rec.Type).Append(' ').Append(rec.FormKey).Append("  editorid=").Append(rec.EditorId ?? "<none>").Append('\n');
             foreach (var f in rec.Fields)
@@ -287,7 +287,7 @@ public static class WriteTools
             var r = rb[i];
             // A re-read that failed is a real inconsistency — surface it LOUD and NAMED (the whole reason the in-place
             // verify is forced on), never counted as clean.
-            if (r.Error is not null) { sb.Append("  ✗ ").Append(r.Target).Append(" — ").Append(r.Error).Append('\n'); continue; }
+            if (r.Error is not null) { sb.Append("  ✗ ").Append(FormIdToken.Of(r.Target)).Append(" — ").Append(r.Error).Append('\n'); continue; }
             var rec = r.Record!;
             sb.Append("  ✓ ").Append(rec.Type).Append(' ').Append(rec.FormKey)
               .Append(" — re-read clean (").Append(rec.Fields.Count).Append(" field(s))");
@@ -362,7 +362,7 @@ public static class WriteTools
                 break;
             }
             var r = o.Removed[i];
-            sb.Append("  - ").Append(r.RecordType).Append(' ').Append(r.Target).Append("  ")
+            sb.Append("  - ").Append(r.RecordType).Append(' ').Append(FormIdToken.Of(r.Target)).Append("  ")
               .Append(r.EditorId ?? "<no editorid>").Append('\n');
         }
         sb.Append(WriteSentences.Masters(o.Masters));
@@ -435,7 +435,7 @@ public static class WriteTools
                 break;
             }
             var f = o.Forwarded[fi];
-            sb.Append("  ").Append(f.RecordType).Append(' ').Append(f.Target).Append("  ").Append(f.EditorId ?? "<no editorid>")
+            sb.Append("  ").Append(f.RecordType).Append(' ').Append(FormIdToken.Of(f.Target)).Append("  ").Append(f.EditorId ?? "<no editorid>")
               .Append(o.DryRun ? "  — would be copied from " : "  — copied from ").Append(f.FromPlugin);
             // The sentence has to match what the replace does: the FIELDS are replaced and everything nested under the
             // record is carried across, so this must not read as a clean revert. The count is stated rather than
@@ -693,7 +693,7 @@ public static class WriteTools
         {
             sb.Append("cross-donor conflicts (").Append(o.Conflicts.Count).Append(") — each resolved to the LOAD-ORDER WINNER (the losing version is NOT in the merge; any un-relisted nested children were grafted):\n");
             foreach (var c in o.Conflicts.Take(25))
-                sb.Append("  ").Append(c.RecordType).Append(' ').Append(c.Key).Append("  ").Append(c.WinnerDonor).Append(" won over ").Append(c.LoserDonor).Append('\n');
+                sb.Append("  ").Append(c.RecordType).Append(' ').Append(FormIdToken.Of(c.Key)).Append("  ").Append(c.WinnerDonor).Append(" won over ").Append(c.LoserDonor).Append('\n');
             if (o.Conflicts.Count > 25) sb.Append("  … (+").Append(o.Conflicts.Count - 25).Append(" more)\n");
         }
 
@@ -911,7 +911,7 @@ public static class WriteTools
             }
             var c = o.Created[ci];
             listed++;
-            sb.Append("  ").Append(c.RecordType).Append(' ').Append(c.FormKey).Append("  ").Append(c.EditorId);
+            sb.Append("  ").Append(c.RecordType).Append(' ').Append(FormIdToken.Of(c.FormKey)).Append("  ").Append(c.EditorId);
             // "this patch" belongs to the artifact lanes; in place the file is the caller's own plugin, and naming it a
             // patch would misread as houseCARL's.
             if (c.ReplacedExisting) sb.Append("  [REPLACED: ").Append(o.InPlace ? file : "this patch")
@@ -1012,7 +1012,7 @@ public static class WriteTools
         foreach (var l in report.Lines)
         {
             if (sb.Length >= cap) { AppendVoiceTrunc(sb, rendered, total, cap); return; }
-            var who = string.IsNullOrEmpty(l.TopicEditorId) ? l.Info.ToString() : $"{l.TopicEditorId} ({l.Info})";
+            var who = string.IsNullOrEmpty(l.TopicEditorId) ? FormIdToken.Of(l.Info) : $"{l.TopicEditorId} ({FormIdToken.Of(l.Info)})";
             if (l.FuzPresent)
             {
                 sb.Append("  OK   ").Append(who).Append(" resp ").Append(l.ResponseNumber)
@@ -1034,7 +1034,7 @@ public static class WriteTools
         foreach (var u in report.Undetermined)
         {
             if (sb.Length >= cap) { AppendVoiceTrunc(sb, rendered, total, cap); return; }
-            var who = string.IsNullOrEmpty(u.TopicEditorId) ? u.Info.ToString() : $"{u.TopicEditorId} ({u.Info})";
+            var who = string.IsNullOrEmpty(u.TopicEditorId) ? FormIdToken.Of(u.Info) : $"{u.TopicEditorId} ({FormIdToken.Of(u.Info)})";
             sb.Append("  [?] ").Append(who).Append("  — ").Append(u.Reason).Append('\n');
             rendered++;
         }
@@ -1068,7 +1068,7 @@ public static class WriteTools
         foreach (var c in report.Cells)
         {
             if (sb.Length >= cap) { cut = true; break; }
-            sb.Append("  ").Append(c.Interior ? "INTERIOR " : "EXTERIOR ").Append(c.EditorId).Append(" (").Append(c.Cell).Append("):\n");
+            sb.Append("  ").Append(c.Interior ? "INTERIOR " : "EXTERIOR ").Append(c.EditorId).Append(" (").Append(FormIdToken.Of(c.Cell)).Append("):\n");
             foreach (var m in c.MustProvide)
             {
                 if (sb.Length >= cap) { cut = true; break; }
@@ -1112,7 +1112,7 @@ public static class WriteTools
                   .Append(" line(s) at max_chars=").Append(cap).Append("; ").Append(WriteSentences.Twins.ReportBlockCut).Append("]\n");
                 return;
             }
-            var who = string.IsNullOrEmpty(f.TopicEditorId) ? f.Info.ToString() : $"{f.TopicEditorId} ({f.Info})";
+            var who = string.IsNullOrEmpty(f.TopicEditorId) ? FormIdToken.Of(f.Info) : $"{f.TopicEditorId} ({FormIdToken.Of(f.Info)})";
             switch (f.Status)
             {
                 case ScriptBindingStatus.BoundAndCompiled:


### PR DESCRIPTION
A FormID token used to spell its plugin in whatever case its FormKey happened to carry. A record read straight off a plugin got the on-disk spelling, because Mutagen names the overlay from the file it opened; a link into that plugin got whatever the holding plugin's master list says, because that is where the link's ModKey comes from; and a token the caller passed in was echoed as typed. ModKey compares case-insensitively, so every lookup still landed and nothing looked wrong — but two reads of the same record printed two different strings, and a local join of two `housecarl_records` outputs silently dropped those rows. This adds one place a token is spelled, `FormIdToken` in housecarl-core: `Of(FormKey)` returns Mutagen's own `ToString()` with only the plugin half respelled from the load order's canonical names, so the local-ID format and the null form cannot drift and the token still parses back.

`LoadOrderResolver.Build` publishes its plugin filenames (each a `Path.GetFileName` of a real path) as it builds, and a publish **replaces** the table rather than extending it: the server repoints at another MO2 instance or profile without a restart (`housecarl_set_mo2_instance`, and a profile change rebuilds the resolver), so a name the new order does not carry must not keep the old order's spelling. A name the current table does not hold keeps the spelling it arrived with — an off-order plugin read straight from disk prints its on-disk name as read, and so does a token naming a plugin that is not installed. The one exception is deliberate and documented on the class: the table is keyed case-insensitively, so an off-order file matching an ACTIVE plugin's name in every way but case prints the active plugin's spelling, because the token is a load-order token. The table is process-wide because the print sites are static and deep (a reflected link value in `ReadEngine` has no load order to ask); it is a `volatile` field swapped whole, so a reader sees one order's table or the other's, never a mix.

Site inventory (296 calls through the seam: 290 `Of`, 6 `Plugin`):

- **Already canonical, unchanged in behaviour:** `LoadOrderResolver.RuntimeToFormKey`'s two `FormKey.Factory($"{…:X6}:{_names[p]}")` calls — they build a key from the canonical table itself, and are parse inputs rather than prints. Winner and toucher plugin names (`WinnerPlugin`, touching lists) likewise come from `_names`. A record's own identity read off an overlay was already canonical; it now goes through the seam anyway, so it cannot drift later.
- **Changed — routed through the seam:** core `ClosureCopy`, `ClosureWalk`, `ContainmentIndex`, `DialogueValidate`, `EffectChain`, `ErrorCheck`, `OwnedChildLifecycle`, `ReadEngine`, `RemapEngine`, `ScriptPropertyCheck`, `SkyPatcherConflicts`, `SkyPatcherOverlay`, `WriteEngine`, `WritePatchBuilder`; server `Artifacts`, `DialogueSweepRender`, `DialogueTools`, `FormIdDoor`, `JsonWire`, `LoadOrderService`, `ReadTools`, `RecordsTools`, `ReverseWalkBatch`, `WriteTools`. That covers `formid` in every row and artifact — including the write's read-back rows, the removed and forwarded rows, and the effect-chain carriers — plus link values and `NoteRef` in the fields form, walk nodes and their `pulled_by` labels and cycle strings, delta and tree rows, dangling-ref sources and targets, dialogue topic/INFO/voice/script-finding rows, the cell-shell rows, merge conflicts, the owned-child union members, the reverse walk's reached keys, and the sentences that hand a token back to paste.
- **Parse inputs take the raw key, never the seam.** `FormIdToken.Of` is for prints only, so a value fed back into a parse uses `FormKey.ToString()`: CopyFrom's settable-FormLink rebuild in `WriteEngine`, the two same-call `@editorid` references in `WritePatchBuilder`, and both arms of the SkyPatcher value token, which is handed to `WriteEngine.ApplyVerb` as a `WriteRequest.Value` (the applied-op row prints the INI's own text and the read-back leaf, which routes through `ReadEngine`). The same holds on the read side: the key lists a scan hands to the walk, delta, tree, `info_order` and body-batch lanes in `RecordsTools`, and the condition-patch target `WriteEngine.PickSameTypeTarget` picks, are all re-parsed by their callee and so take `FormKey.ToString()` too. The one place a token is both printed and fed back is the reverse carrier walk's selection, which IS the `selection` the caller reads and pastes, so it stays canonical. This keeps the write path independent of a display helper.
- **Two sites formatted a token by hand** rather than calling `ToString()` — the runtime-FormID write refusal in `FormIdDoor` and the renamed-copy note in `LoadOrderService` — and both now go through the seam; nothing is left building `"{ID:X6}:{plugin}"` by hand outside the resolver's two parse-input calls above.
- **`defined_in` grouping** (`RecordsTools` and four sites in `LoadOrderService`) is not a token but is a plugin-name join key with the same drift, so it goes through `FormIdToken.Plugin`.
- **Not routed, on purpose:** `FaceGenPath` and `VoicePath` spell `ModKey.FileName` into a path on disk, not a token — the folder is named by the Creation Kit and matched case-insensitively, so respelling it there would be a behaviour change with nothing to gain. Plugin names printed from a plugin's own master references (`ErrorCheck`'s missing-master lists) are the same class of drift on a name that is not a FormID token; that is a separate question from this issue and is left alone. A refusal that echoes the FormID string the caller typed (`ApplyTools`' assignment-pair checks) keeps the caller's own text, so they can find the line they wrote.

Cover: `FormIdTokenCaseTests` builds a world whose patch's header names its master in lowercase (written normally, then the MAST entry respelled in place — same length, so the file stays valid). It asserts that reading the master's RACE directly and through the patch's link yields the same string; that a write against a lowercase-typed FormID comes back with both the op row and the read-back row spelled the order's way; that a walk's node labels do the same; and that the text render of a read, and of a read that failed, spell the plugin the order's way rather than echoing the case typed. `FormIdTokenPublishTests` publishes two orders and asserts a name the second does not carry falls back to its own spelling.

`dotnet test` 1900 passed / 0 failed; `ci-all` 128/128. Edits are formatting only, so #678's parsing changes should merge alongside; the one overlap is the single refusal line inside `FormIdDoor.Parse`.

Closes #664

