### PR TITLE
Harvest a write's link targets from the rulebook's own walk

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,10 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **The note a write emits when a link target's plugin cannot be read now counts FormLink values, not
+  FormID-shaped tokens.** The values a write's link check needs are enumerated by the same schema walk that does
+  the checking, so the count is of the actual FormLink slots the write sets. What the note says about the skip is
+  unchanged: those links are not type-checked, and the write proceeds.
 - **`housecarl_skypatcher_layer` with a `filter=` that matches no INI now says so instead of returning the
   whole-layer overview.** It answers with the filter, the match count (0 of N INIs), the type folders that are
   present, and a nearest-name suggestion where there is one, so a filter typo can no longer read as the layer's

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,10 +13,12 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
-- **The note a write emits when a link target's plugin cannot be read now counts FormLink values, not
-  FormID-shaped tokens.** The values a write's link check needs are enumerated by the same schema walk that does
-  the checking, so the count is of the actual FormLink slots the write sets. What the note says about the skip is
-  unchanged: those links are not type-checked, and the write proceeds.
+- **The note a write emits when a link target's plugin cannot be read now names what it counts: the distinct
+  records the write links to in that plugin.** The values a write's link check needs are enumerated by the same
+  schema walk that does the checking, and two slots naming one record are one record here. What the note says
+  about the skip is unchanged: those links are not type-checked, and the write proceeds. An in-place edit that has
+  both a bad `field_path` and a bad `from_plugin` now reports the source problem first, as the patch lane already
+  did, and the field-path problem on the re-run.
 - **`housecarl_skypatcher_layer` with a `filter=` that matches no INI now says so instead of returning the
   whole-layer overview.** It answers with the filter, the match count (0 of N INIs), the type folders that are
   present, and a nearest-name suggestion where there is one, so a filter typo can no longer read as the layer's

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -75,13 +75,25 @@ public sealed class CorpusRulebook
 
     /// <summary>Walk one write for its FormLink values, into the sink of the rulebook
     /// <see cref="WithLinkHarvest"/> derived. The walk is <see cref="Validate"/> itself, so the slots it reads are the
-    /// slots the check reads; its verdict is discarded here because the validating pass reports it. A write the walk
-    /// refuses early yields fewer values, which is harmless: that write is refused there too.</summary>
-    public void CollectLinkValues(WriteRequest req, IReadOnlyCollection<string>? siblingEditorIds = null)
+    /// slots the check reads, and its verdict is RETURNED: a write that contributed no value to the sink was decided
+    /// by a walk identical to the checking one (the sink takes a value at every point the link check would decide, and
+    /// at every gate whose answer depends on the sibling set), so the caller keeps this verdict and skips the second
+    /// walk. A write that DID contribute is re-walked against the resolved lookup. A write the walk refuses early
+    /// yields fewer values, which is harmless: that write is refused there too.</summary>
+    public string? CollectLinkValues(WriteRequest req, IReadOnlyCollection<string>? siblingEditorIds = null)
     {
         if (_linkSink is null)
             throw new InvalidOperationException("CollectLinkValues needs a rulebook derived by WithLinkHarvest.");
-        Validate(req, siblingEditorIds);
+        return Validate(req, siblingEditorIds);
+    }
+
+    /// <summary>HARVEST pass: record a same-call '@editorid' reference in the sink. Not a FormID (the link lookup
+    /// parses it to nothing and skips it) — it is here so the sink COUNT says this write's verdict depends on the
+    /// sibling set, which the create lane offers in full to the harvest and only up to the current spec to the check.
+    /// Without it a forward reference would be settled by the harvest's more permissive answer.</summary>
+    void HarvestSibling(string? value)
+    {
+        if (_linkSink is not null && value is not null) _linkSink.Add(value);
     }
 
     /// <summary>Resolves a FormLink value (a FormID token) to the runtime type of the record it points at, or null
@@ -666,6 +678,7 @@ public sealed class CorpusRulebook
         // stay refused loud below. Both gates sit ahead of the cardinality branches.
         if (WriteEngine.IsSameCallSiblingRef(req.Value, out var sibEdid))
         {
+            HarvestSibling(req.Value);
             if (siblingEditorIds is null)
                 return $"'{req.Value}' for '{leaf.Name}': a '@editorid' reference names a record being created in the " +
                        "SAME " + ToolNames.Create + " call — when editing an existing record " +
@@ -719,6 +732,7 @@ public sealed class CorpusRulebook
             {
                 if (WriteEngine.IsSameCallSiblingRef(v, out var vEd))
                 {
+                    HarvestSibling(v);
                     if (!siblingEditorIds.Contains(vEd))
                         return $"Same-call reference '@{vEd}' for '{leaf.Name}': no record with editorid '{vEd}' is " +
                                "created EARLIER in this call (a record may also reference ITSELF by its own editorid) — " +
@@ -1093,6 +1107,7 @@ public sealed class CorpusRulebook
             // BEFORE CheckValue, which would otherwise reject the '@' token as a malformed FormLink.
             if (WriteEngine.IsSameCallSiblingRef(f.Value, out var fEd))
             {
+                HarvestSibling(f.Value);
                 if (siblingEditorIds is null)
                     return $"a '@editorid' reference for '{f.Key}' on '{spec.Type}' names a record being created in the " +
                            "SAME " + ToolNames.Create + " call — when editing an existing record " +

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -53,14 +53,36 @@ public sealed class CorpusRulebook
     /// derived rulebook is a per-call object used on the calling thread, and the shared schema-only rulebook never
     /// fills this (a refusal needs <see cref="_linkTargets"/>).</summary>
     readonly Dictionary<string, string> _linkTargetNames = new(StringComparer.Ordinal);
-    CorpusRulebook(Corpus corpus, LinkTargetLookup? linkTargets = null)
-        => (_corpus, _linkTargets) = (corpus, linkTargets);
+    /// <summary>Non-null only on a HARVEST rulebook (<see cref="WithLinkHarvest"/>): the walk collects the FormLink
+    /// values it reaches instead of type-checking them.</summary>
+    readonly ICollection<string>? _linkSink;
+    CorpusRulebook(Corpus corpus, LinkTargetLookup? linkTargets = null, ICollection<string>? linkSink = null)
+        => (_corpus, _linkTargets, _linkSink) = (corpus, linkTargets, linkSink);
 
     /// <summary>This rulebook plus a load-order link-target resolver: the same corpus, with the FormLink TARGET TYPE
     /// check turned on. Derived ONCE per write call, not per edit — the lookup rides on the rulebook rather than
     /// through the recursion, so every value slot (a singular Set, a list element, a composed struct's field) sees it
     /// without a parameter at each hop, and the memo above spans the whole call.</summary>
     public CorpusRulebook WithLinkTargets(LinkTargetLookup linkTargets) => new(_corpus, linkTargets);
+
+    /// <summary>This rulebook in HARVEST mode: the same walk, with every FormLink value it reaches added to
+    /// <paramref name="sink"/> and nothing type-checked (there is no lookup yet — that is what the harvest feeds).
+    /// The write path runs this pass first to learn which records it must resolve, then derives the checking rulebook
+    /// with <see cref="WithLinkTargets"/>. ONE walk decides both what is resolved and what is checked, so a link slot
+    /// added to the validator is prefetched by construction — a hand-written slot list on the caller's side would
+    /// drift, and a slot it missed would go silently unchecked.</summary>
+    public CorpusRulebook WithLinkHarvest(ICollection<string> sink) => new(_corpus, null, sink);
+
+    /// <summary>Walk one write for its FormLink values, into the sink of the rulebook
+    /// <see cref="WithLinkHarvest"/> derived. The walk is <see cref="Validate"/> itself, so the slots it reads are the
+    /// slots the check reads; its verdict is discarded here because the validating pass reports it. A write the walk
+    /// refuses early yields fewer values, which is harmless: that write is refused there too.</summary>
+    public void CollectLinkValues(WriteRequest req, IReadOnlyCollection<string>? siblingEditorIds = null)
+    {
+        if (_linkSink is null)
+            throw new InvalidOperationException("CollectLinkValues needs a rulebook derived by WithLinkHarvest.");
+        Validate(req, siblingEditorIds);
+    }
 
     /// <summary>Resolves a FormLink value (a FormID token) to the runtime type of the record it points at, or null
     /// when nothing in the load order carries it. Supplied by the write path, which holds the captured view; without
@@ -1134,9 +1156,13 @@ public sealed class CorpusRulebook
     /// <paramref name="slot"/> reads "target" for a singular link and "element" for a collection one.</summary>
     string? LinkTypeRefusal(FieldSchema leaf, string? value, string slot)
     {
-        if (_linkTargets is null || value is null) return null;
+        if (value is null) return null;
         if (WriteEngine.IsFormKeyNullSynonym(value)) return null;              // a clear points at nothing
         if (leaf.FormLinkTargetAssemblyQualified is not { } aq) return null;
+        // HARVEST pass: this slot IS a FormLink one, so its value is what the check will need resolved. Collected
+        // here, at the single place the check reads a link value, so the two can't name different slots.
+        if (_linkSink is not null) { _linkSink.Add(value); return null; }
+        if (_linkTargets is null) return null;
         if (WriteEngine.ResolveType(aq) is not { } target) return null;
         if (_linkTargets(value) is not { } actual) return null;                // the order cannot say — never a guess
         if (target.IsAssignableFrom(actual)) return null;

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -435,26 +435,33 @@ public static class WritePatchBuilder
         //     session, never an arbitrary un-enabled plugin, so no winner-confusion hazard arises. ---
         var view = resolver.Capture();
         epoch = view.Stamp;                                               // stamped on every outcome from here down
+        // The FormLink values this call sets are harvested by the RULEBOOK's own walk (CollectLinkValues), so the set
+        // resolved below is exactly the set the check reads — no second, hand-written list of value slots to drift
+        // from it. The walk needs each edit's record TYPE, which only the resolve loop can derive, so Phase 1 runs in
+        // two passes: resolve + harvest per edit, then validate every staged edit against the lookup the harvest fed.
         var linkTokens = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var e in edits) HarvestLinkTokens(e.Value, e.Values, e.Entries, e.Struct, e.Structs, linkTokens);
-        var (linkTypes, linkNote) = LinkTypeLookup(view, session, linkTokens);
-        var linkRulebook = rulebook.WithLinkTargets(linkTypes);
-        var resolved = new List<(PatchEdit edit, IMajorRecordGetter? body, string? winnerPlugin, IMajorRecord? patchLocal, WriteRequest req, string label, IMajorRecordGetter? srcBody)>(edits.Count);
-        var problems = new List<string>();
+        var harvestRulebook = rulebook.WithLinkHarvest(linkTokens);
+        var staged = new List<(int order, PatchEdit edit, IMajorRecordGetter? body, string? winnerPlugin, IMajorRecord? patchLocal, WriteRequest req, string label, IMajorRecordGetter? srcBody)>(edits.Count);
+        // Ordered, so a report mixing a resolve problem with a pre-flight one still reads in the caller's edit order
+        // even though the two are decided in different passes.
+        var problems = new List<(int Order, string Message)>();
         // Records the extended patch DEFINES (FormKey in the patch's own master space — created by a prior into=
         // call), built lazily ONCE on the first load-order miss, not per miss.
         // Deliberately NOT every record the patch contains: an override the patch merely CARRIES resolves via the
         // load order like any other record, so a target whose defining plugin is disabled stays a loud refusal —
         // never a silent edit of the patch's possibly-stale override copy.
         Dictionary<FormKey, IMajorRecord>? patchDefined = null;
+        int order = -1;
+        void Problem(string message) => problems.Add((order, message));
         foreach (var e in edits)
         {
+            order++;
             IMajorRecordGetter? body = null; string? winnerPlugin = null; IMajorRecord? patchLocal = null;
             var w = view.ResolveWinner(e.Target);
             if (w is not null)
             {
                 body = view.GetRecord(session, w.Value.WinnerPlugin, e.Target);
-                if (body is null) { problems.Add($"{FormIdToken.Of(e.Target)}: winner '{w.Value.WinnerPlugin}' did not yield it on fetch (a load-order inconsistency)."); continue; }
+                if (body is null) { Problem($"{FormIdToken.Of(e.Target)}: winner '{w.Value.WinnerPlugin}' did not yield it on fetch (a load-order inconsistency)."); continue; }
                 winnerPlugin = w.Value.WinnerPlugin;
             }
             else
@@ -471,7 +478,7 @@ public static class WritePatchBuilder
                 }
                 if (patchLocal is null)
                 {
-                    problems.Add($"{FormIdToken.Of(e.Target)}: not present in the load order ({view.PluginCount} plugins)"
+                    Problem($"{FormIdToken.Of(e.Target)}: not present in the load order ({view.PluginCount} plugins)"
                         + (extend
                             ? $", and not a record '{fileName}' (the patch being extended) itself defines — a record " +
                               "the patch merely OVERRIDES resolves via the load order, so its defining plugin must be enabled."
@@ -491,35 +498,35 @@ public static class WritePatchBuilder
                 // resolved here, where the one captured view lives, so the default reads the same build every other
                 // decision in this call reads.
                 var srcPlugin = ResolveCopyPole(e, view, out var poleErr);
-                if (poleErr is not null) { problems.Add(poleErr); continue; }
+                if (poleErr is not null) { Problem(poleErr); continue; }
 
                 if (TryOffOrderCopyBody(copyFromSources, e, view, out var offSrc))
                     srcBody = offSrc;
                 else if (string.IsNullOrWhiteSpace(srcPlugin))
-                { problems.Add($"{FormIdToken.Of(e.Target)}: CopyFrom is missing from_plugin (internal — the mapper should have caught this)."); continue; }
+                { Problem($"{FormIdToken.Of(e.Target)}: CopyFrom is missing from_plugin (internal — the mapper should have caught this)."); continue; }
                 else if (string.Equals(srcPlugin, fileName, StringComparison.OrdinalIgnoreCase))
-                { problems.Add($"{FormIdToken.Of(e.Target)}: CopyFrom from_plugin '{srcPlugin}' is the output patch itself — name the OTHER plugin whose version to copy from."); continue; }
+                { Problem($"{FormIdToken.Of(e.Target)}: CopyFrom from_plugin '{srcPlugin}' is the output patch itself — name the OTHER plugin whose version to copy from."); continue; }
                 else if (!view.ContainsPlugin(srcPlugin))
                 // Deliberately NO AbsenceClause here: the service pre-resolves every off-order CopyFrom source before
                 // Apply — a source that is merely unticked / in a disabled mod / shadowed is LOCATED and supplied via
                 // copyFromSources above, and one that cannot be located aborts the whole call earlier. So the only
                 // name reaching this arm has no on-disk copy at all, which the explainer cannot explain — it would pay
                 // a profile parse plus a whole-install sweep, per edit, for nothing the message does not already say.
-                { problems.Add($"{FormIdToken.Of(e.Target)}: CopyFrom source '{srcPlugin}' is not in the load order (and no plugin file by that name was located on disk) — name an active plugin, or a plugin file present on disk."); continue; }
+                { Problem($"{FormIdToken.Of(e.Target)}: CopyFrom source '{srcPlugin}' is not in the load order (and no plugin file by that name was located on disk) — name an active plugin, or a plugin file present on disk."); continue; }
                 else if (view.ExcludedPlugins.TryGetValue(srcPlugin, out var why))
-                { problems.Add($"{FormIdToken.Of(e.Target)}: CopyFrom source '{srcPlugin}' was excluded from this session ({why}) — its records aren't resolvable."); continue; }
+                { Problem($"{FormIdToken.Of(e.Target)}: CopyFrom source '{srcPlugin}' was excluded from this session ({why}) — its records aren't resolvable."); continue; }
                 else
                 {
                     srcBody = view.GetRecord(session, srcPlugin, e.CopySource);
                     if (srcBody is null)
-                    { problems.Add(CopySourceMissing(e, srcPlugin)); continue; }
+                    { Problem(CopySourceMissing(e, srcPlugin)); continue; }
                 }
                 // The same-runtime-record-type gate. A same-FormKey copy passes by construction (one record, one
                 // type); a CROSS-record pair is the case that can disagree, and a cross-type transplant is refused BY
                 // NAME here rather than reaching CopyField, where the mismatch would surface as a property-shaped
                 // "no field X on Y" that points away from the real cause.
                 if (CrossTypeRefusal(e, srcBody, patchLocal ?? (object?)body) is { } typeErr)
-                { problems.Add(typeErr); continue; }
+                { Problem(typeErr); continue; }
             }
 
             var recType = RecordNaming.StripOverlay((patchLocal ?? (object)body!).GetType().Name);
@@ -529,13 +536,28 @@ public static class WritePatchBuilder
                 Key = e.Key, Value = e.Value, Values = e.Values, Entries = e.Entries, Struct = e.Struct, Structs = e.Structs,
             };
             var label = Label(req);
-            if (linkRulebook.Validate(req) is { } reject) { problems.Add($"{recType} {FormIdToken.Of(e.Target)} [{label}]: {reject}"); continue; }
-            resolved.Add((e, body, winnerPlugin, patchLocal, req, label, srcBody));
+            harvestRulebook.CollectLinkValues(req);
+            staged.Add((order, e, body, winnerPlugin, patchLocal, req, label, srcBody));
+        }
+
+        // --- Phase 1b: resolve the harvested link targets ONCE, then pre-flight every staged edit through the
+        //     rulebook that can type-check them. ---
+        var (linkTypes, linkNote) = LinkTypeLookup(view, session, linkTokens);
+        var linkRulebook = rulebook.WithLinkTargets(linkTypes);
+        var resolved = new List<(PatchEdit edit, IMajorRecordGetter? body, string? winnerPlugin, IMajorRecord? patchLocal, WriteRequest req, string label, IMajorRecordGetter? srcBody)>(staged.Count);
+        foreach (var s in staged)
+        {
+            if (linkRulebook.Validate(s.req) is { } reject)
+            { problems.Add((s.order, $"{s.req.RecordType} {FormIdToken.Of(s.edit.Target)} [{s.label}]: {reject}")); continue; }
+            resolved.Add((s.edit, s.body, s.winnerPlugin, s.patchLocal, s.req, s.label, s.srcBody));
         }
         if (problems.Count > 0)
+        {
+            problems.Sort((a, b) => a.Order.CompareTo(b.Order));
             return PatchOutcome.Fail(
                 $"refused — {problems.Count} of {edits.Count} edit(s) rejected by resolve/pre-flight; NO patch written:\n  - "
-                + string.Join("\n  - ", problems));
+                + string.Join("\n  - ", problems.Select(p => p.Message)));
+        }
 
         // --- Phase 3: override each winner into the ONE patch mod, then apply. A flat record needs no link cache; a
         //     NESTED record (Cell/Placed*/INFO/Navmesh/Landscape) gets the winner overlay's cache built on demand
@@ -684,8 +706,10 @@ public static class WritePatchBuilder
     }
 
     /// <summary>The pre-flight's link-TARGET resolver: a FormLink value in, the runtime type of the record it points
-    /// at out. Every token the call could ask about is resolved UP FRONT, grouped by winner plugin, so a plugin is
-    /// walked ONCE however many links name it — a per-token seek would walk it once per link (a 200-entry leveled
+    /// at out. The tokens come from the rulebook's own harvest pass (CorpusRulebook.CollectLinkValues), which walks a
+    /// write exactly as the check does — so the set resolved here is the set the check reads, and a link slot the
+    /// validator gains is prefetched without anything being added on this side. Every token is resolved UP FRONT,
+    /// grouped by winner plugin, so a plugin is walked ONCE however many links name it — a per-token seek would walk it once per link (a 200-entry leveled
     /// list into Skyrim.esm is 200 full enumerations). Answers off the call's ONE captured view, so the type a link
     /// is checked against is the same build every other decision in the write reads. Null for a token that does not
     /// parse, that the order does not carry, or that the harvest did not offer — pre-flight then does not type-check
@@ -717,7 +741,7 @@ public static class WritePatchBuilder
             catch (PluginUnreadableException ex)
             {
                 (skipped ??= new List<string>()).Add(
-                    $"{keys.Count} FormID value(s) in this write resolve to '{plugin}', whose link targets were NOT " +
+                    $"{keys.Count} FormLink value(s) in this write resolve to '{plugin}', whose link targets were NOT " +
                     $"type-checked: {ex.Message}");
                 continue;
             }
@@ -725,31 +749,6 @@ public static class WritePatchBuilder
         }
         return (token => keyOf.TryGetValue(token, out var fk) && types.TryGetValue(fk, out var t) ? t : null,
                 skipped is null ? null : string.Join(" ", skipped));
-    }
-
-    /// <summary>Every value slot a pre-flight link check can read, harvested into one token set — the singular value,
-    /// a ReplaceAll's contents, a dict's entry values, and a composed struct's own fields and nested writes. The SAME
-    /// slots the rulebook's formlink sweeps read, so what it asks about is what was prefetched. Over-collecting costs
-    /// nothing (the plugin is walked once either way); a slot missed here leaves that one link unchecked, which is
-    /// the behaviour before the gate existed, never a wrong refusal.</summary>
-    static void HarvestLinkTokens(string? value, IReadOnlyList<string>? values, Dictionary<string, string>? entries,
-                                  StructSpec? one, IEnumerable<StructSpec>? many, HashSet<string> into)
-    {
-        if (value is not null) into.Add(value);
-        foreach (var v in values ?? Array.Empty<string>()) if (v is not null) into.Add(v);
-        if (entries is not null) foreach (var kv in entries) if (kv.Value is not null) into.Add(kv.Value);
-        if (one is not null) HarvestStructTokens(one, into);
-        foreach (var s in many ?? Array.Empty<StructSpec>()) HarvestStructTokens(s, into);
-    }
-
-    static void HarvestLinkTokens(WriteRequest req, HashSet<string> into)
-        => HarvestLinkTokens(req.Value, req.Values, req.Entries, req.Struct, req.Structs, into);
-
-    static void HarvestStructTokens(StructSpec spec, HashSet<string> into)
-    {
-        if (spec.Fields is not null) foreach (var kv in spec.Fields) if (kv.Value is not null) into.Add(kv.Value);
-        foreach (var a in spec.CtorArgs ?? Array.Empty<string>()) if (a is not null) into.Add(a);
-        foreach (var r in spec.Sets ?? new()) HarvestLinkTokens(r, into);
     }
 
     /// <summary>Does this edit's CopyFrom source need the OFF-ORDER on-disk locate — i.e. is it a CopyFrom naming a
@@ -901,20 +900,23 @@ public static class WritePatchBuilder
                 $"cannot edit '{targetName}' in place: it was EXCLUDED from this session ({excluded}) — houseCARL won't " +
                 "re-serialize a plugin it can't fully parse (that would risk dropping the record it couldn't read, Q3). The file is UNTOUCHED.");
 
+        // Two passes, exactly as the patch lane: the rulebook's own walk harvests each staged edit's FormLink values
+        // (it needs the record type the resolve below derives), then one lookup answers the pre-flight for all of them.
         var linkTokens = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var e in edits) HarvestLinkTokens(e.Value, e.Values, e.Entries, e.Struct, e.Structs, linkTokens);
-        var (linkTypes, linkNote) = LinkTypeLookup(view, session, linkTokens);
-        var linkRulebook = rulebook.WithLinkTargets(linkTypes);
-        var resolved = new List<(PatchEdit edit, IMajorRecordGetter body, WriteRequest req, string label, IMajorRecordGetter? srcBody, bool selfSource)>(edits.Count);
-        var problems = new List<string>();
+        var harvestRulebook = rulebook.WithLinkHarvest(linkTokens);
+        var staged = new List<(int order, PatchEdit edit, IMajorRecordGetter body, WriteRequest req, string label, IMajorRecordGetter? srcBody, bool selfSource)>(edits.Count);
+        var problems = new List<(int Order, string Message)>();
+        int order = -1;
+        void Problem(string message) => problems.Add((order, message));
         foreach (var e in edits)
         {
+            order++;
             bool selfSource = false;   // the copy source lives in the TARGET's own file — see the lifetime note below
             var body = view.GetRecord(session, targetName, e.Target);
             if (body is null)
             {
-                problems.Add($"{FormIdToken.Of(e.Target)}: '{targetName}' does not define or override this record — in-place edits only what the " +
-                             "file OWNS. To change a record defined in another plugin, use the default patch lane (a new override) instead.");
+                Problem($"{FormIdToken.Of(e.Target)}: '{targetName}' does not define or override this record — in-place edits only what the " +
+                        "file OWNS. To change a record defined in another plugin, use the default patch lane (a new override) instead.");
                 continue;
             }
             var recType = RecordNaming.StripOverlay(body.GetType().Name);
@@ -924,7 +926,7 @@ public static class WritePatchBuilder
                 Key = e.Key, Value = e.Value, Values = e.Values, Entries = e.Entries, Struct = e.Struct, Structs = e.Structs,
             };
             var label = Label(req);
-            if (linkRulebook.Validate(req) is { } reject) { problems.Add($"{recType} {FormIdToken.Of(e.Target)} [{label}]: {reject}"); continue; }
+            harvestRulebook.CollectLinkValues(req);
 
             // CopyFrom SOURCE resolution — the same contract Apply enforces, on this lane too: the lane axis is
             // uniform, so every write verb must compose with in_place. Without this a CopyFrom op reaches ApplyVerb,
@@ -935,22 +937,22 @@ public static class WritePatchBuilder
             if (string.Equals(e.Verb, "CopyFrom", StringComparison.Ordinal))
             {
                 var srcPlugin = ResolveCopyPole(e, view, out var poleErr);
-                if (poleErr is not null) { problems.Add(poleErr); continue; }
+                if (poleErr is not null) { Problem(poleErr); continue; }
 
                 if (TryOffOrderCopyBody(copyFromSources, e, view, out var offSrc))
                     srcBody = offSrc;
                 else if (string.IsNullOrWhiteSpace(srcPlugin))
-                { problems.Add($"{FormIdToken.Of(e.Target)}: CopyFrom is missing from_plugin (internal — the mapper should have caught this)."); continue; }
+                { Problem($"{FormIdToken.Of(e.Target)}: CopyFrom is missing from_plugin (internal — the mapper should have caught this)."); continue; }
                 else if (e.FromTarget is null && string.Equals(srcPlugin, targetName, StringComparison.OrdinalIgnoreCase))
-                { problems.Add($"{FormIdToken.Of(e.Target)}: CopyFrom from_plugin '{srcPlugin}' is the in-place target itself — copying this record's own field onto itself is a no-op; name the OTHER plugin whose version to copy from."); continue; }
+                { Problem($"{FormIdToken.Of(e.Target)}: CopyFrom from_plugin '{srcPlugin}' is the in-place target itself — copying this record's own field onto itself is a no-op; name the OTHER plugin whose version to copy from."); continue; }
                 else if (!view.ContainsPlugin(srcPlugin))
-                { problems.Add($"{FormIdToken.Of(e.Target)}: CopyFrom source '{srcPlugin}' is not in the load order (and no plugin file by that name was located on disk) — name an active plugin, or a plugin file present on disk."); continue; }
+                { Problem($"{FormIdToken.Of(e.Target)}: CopyFrom source '{srcPlugin}' is not in the load order (and no plugin file by that name was located on disk) — name an active plugin, or a plugin file present on disk."); continue; }
                 else if (view.ExcludedPlugins.TryGetValue(srcPlugin, out var cfWhy))
-                { problems.Add($"{FormIdToken.Of(e.Target)}: CopyFrom source '{srcPlugin}' was excluded from this session ({cfWhy}) — its records aren't resolvable."); continue; }
+                { Problem($"{FormIdToken.Of(e.Target)}: CopyFrom source '{srcPlugin}' was excluded from this session ({cfWhy}) — its records aren't resolvable."); continue; }
                 else
                 {
                     srcBody = view.GetRecord(session, srcPlugin, e.CopySource);
-                    if (srcBody is null) { problems.Add(CopySourceMissing(e, srcPlugin)); continue; }
+                    if (srcBody is null) { Problem(CopySourceMissing(e, srcPlugin)); continue; }
                     // LIFETIME: a source resolved out of the TARGET's own file comes from a session
                     // overlay that Phase 4 disposes (ReleaseOverlay, before WriteInPlace) — while CopyField's
                     // contract is that the source overlay outlives the serialize, because TransplantValue shares
@@ -961,14 +963,28 @@ public static class WritePatchBuilder
                     // Deliberately not refused: copying between two records of the same file is a legitimate job.
                     if (string.Equals(srcPlugin, targetName, StringComparison.OrdinalIgnoreCase)) selfSource = true;
                 }
-                if (CrossTypeRefusal(e, srcBody, body) is { } typeErr) { problems.Add(typeErr); continue; }
+                if (CrossTypeRefusal(e, srcBody, body) is { } typeErr) { Problem(typeErr); continue; }
             }
-            resolved.Add((e, body, req, label, srcBody, selfSource));
+            staged.Add((order, e, body, req, label, srcBody, selfSource));
+        }
+
+        // --- Phase 1b: one resolve of the harvested link targets, then pre-flight every staged edit against it. ---
+        var (linkTypes, linkNote) = LinkTypeLookup(view, session, linkTokens);
+        var linkRulebook = rulebook.WithLinkTargets(linkTypes);
+        var resolved = new List<(PatchEdit edit, IMajorRecordGetter body, WriteRequest req, string label, IMajorRecordGetter? srcBody, bool selfSource)>(staged.Count);
+        foreach (var s in staged)
+        {
+            if (linkRulebook.Validate(s.req) is { } reject)
+            { problems.Add((s.order, $"{s.req.RecordType} {FormIdToken.Of(s.edit.Target)} [{s.label}]: {reject}")); continue; }
+            resolved.Add((s.edit, s.body, s.req, s.label, s.srcBody, s.selfSource));
         }
         if (problems.Count > 0)
+        {
+            problems.Sort((a, b) => a.Order.CompareTo(b.Order));
             return PatchOutcome.Fail(
                 $"refused — {problems.Count} of {edits.Count} edit(s) rejected by resolve/pre-flight; '{fileName}' is UNTOUCHED:\n  - "
-                + string.Join("\n  - ", problems));
+                + string.Join("\n  - ", problems.Select(p => p.Message)));
+        }
 
         // --- Phase 2: open the TARGET mutably. EAGER, the SINGLE plugin only — NEVER the load order (eager-loading the
         //     whole order costs 12–14 GB of RAM). CreateFromBinary is the same call Apply's extend path uses; an
@@ -2922,8 +2938,14 @@ public static class WritePatchBuilder
         // The link-TARGET types this call's edits name, resolved once — the same gate the two apply lanes run, on the
         // lane that authors brand-new records. A '@editorid' sibling ref points at a record that does not exist yet,
         // so it resolves to nothing and is not type-checked; a literal FormID beside it is.
+        // Harvested by the RULEBOOK's own walk, the one that will do the checking — a create's edits are already
+        // rooted at the declared type, so the walk runs before any of Phase 1. Every editorid in the call is offered
+        // as a sibling so the walk reaches the same slots the per-spec validation will; a '@editorid' value resolves
+        // to no FormKey and is skipped by the lookup, exactly as it is skipped by the check.
         var linkTokens = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var s in specs) foreach (var req in s.Edits) HarvestLinkTokens(req, linkTokens);
+        var allEditorIds = specs.Select(s => s.EditorId).Where(x => !string.IsNullOrWhiteSpace(x)).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var harvestRulebook = rulebook.WithLinkHarvest(linkTokens);
+        foreach (var s in specs) foreach (var req in s.Edits) harvestRulebook.CollectLinkValues(req, allEditorIds);
         var (linkTypes, linkNote) = LinkTypeLookup(view, session, linkTokens);
         var linkRulebook = rulebook.WithLinkTargets(linkTypes);
 

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -441,7 +441,7 @@ public static class WritePatchBuilder
         // two passes: resolve + harvest per edit, then validate every staged edit against the lookup the harvest fed.
         var linkTokens = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var harvestRulebook = rulebook.WithLinkHarvest(linkTokens);
-        var staged = new List<(int order, PatchEdit edit, IMajorRecordGetter? body, string? winnerPlugin, IMajorRecord? patchLocal, WriteRequest req, string label, IMajorRecordGetter? srcBody)>(edits.Count);
+        var staged = new List<(int order, PatchEdit edit, IMajorRecordGetter? body, string? winnerPlugin, IMajorRecord? patchLocal, WriteRequest req, string label, IMajorRecordGetter? srcBody, string? harvestVerdict, bool carriesLinks)>(edits.Count);
         // Ordered, so a report mixing a resolve problem with a pre-flight one still reads in the caller's edit order
         // even though the two are decided in different passes.
         var problems = new List<(int Order, string Message)>();
@@ -536,18 +536,24 @@ public static class WritePatchBuilder
                 Key = e.Key, Value = e.Value, Values = e.Values, Entries = e.Entries, Struct = e.Struct, Structs = e.Structs,
             };
             var label = Label(req);
-            harvestRulebook.CollectLinkValues(req);
-            staged.Add((order, e, body, winnerPlugin, patchLocal, req, label, srcBody));
+            // The harvest walk IS a validate, so its verdict is kept along with whether this edit put anything in the
+            // sink — an edit that put nothing in needs no second walk (see the Phase 1b note).
+            var sunk = linkTokens.Count;
+            var harvestVerdict = harvestRulebook.CollectLinkValues(req);
+            staged.Add((order, e, body, winnerPlugin, patchLocal, req, label, srcBody, harvestVerdict, linkTokens.Count != sunk));
         }
 
         // --- Phase 1b: resolve the harvested link targets ONCE, then pre-flight every staged edit through the
-        //     rulebook that can type-check them. ---
+        //     rulebook that can type-check them. Only an edit that CONTRIBUTED a value is walked again: the sink takes
+        //     one at every point the link check decides, so an edit that contributed none was walked identically
+        //     already and the harvest's verdict is the pre-flight answer. The double walk is paid by the edits that
+        //     carry links, not by every edit in a 2000-op call. ---
         var (linkTypes, linkNote) = LinkTypeLookup(view, session, linkTokens);
         var linkRulebook = rulebook.WithLinkTargets(linkTypes);
         var resolved = new List<(PatchEdit edit, IMajorRecordGetter? body, string? winnerPlugin, IMajorRecord? patchLocal, WriteRequest req, string label, IMajorRecordGetter? srcBody)>(staged.Count);
         foreach (var s in staged)
         {
-            if (linkRulebook.Validate(s.req) is { } reject)
+            if ((s.carriesLinks ? linkRulebook.Validate(s.req) : s.harvestVerdict) is { } reject)
             { problems.Add((s.order, $"{s.req.RecordType} {FormIdToken.Of(s.edit.Target)} [{s.label}]: {reject}")); continue; }
             resolved.Add((s.edit, s.body, s.winnerPlugin, s.patchLocal, s.req, s.label, s.srcBody));
         }
@@ -905,7 +911,7 @@ public static class WritePatchBuilder
         // (it needs the record type the resolve below derives), then one lookup answers the pre-flight for all of them.
         var linkTokens = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var harvestRulebook = rulebook.WithLinkHarvest(linkTokens);
-        var staged = new List<(int order, PatchEdit edit, IMajorRecordGetter body, WriteRequest req, string label, IMajorRecordGetter? srcBody, bool selfSource)>(edits.Count);
+        var staged = new List<(int order, PatchEdit edit, IMajorRecordGetter body, WriteRequest req, string label, IMajorRecordGetter? srcBody, bool selfSource, string? harvestVerdict, bool carriesLinks)>(edits.Count);
         var problems = new List<(int Order, string Message)>();
         int order = -1;
         void Problem(string message) => problems.Add((order, message));
@@ -967,17 +973,19 @@ public static class WritePatchBuilder
             }
             // Last, as on the patch lane: an edit already rejected above is never pre-flighted, so harvesting its
             // links would walk a plugin for a check that will not run.
-            harvestRulebook.CollectLinkValues(req);
-            staged.Add((order, e, body, req, label, srcBody, selfSource));
+            var sunk = linkTokens.Count;
+            var harvestVerdict = harvestRulebook.CollectLinkValues(req);
+            staged.Add((order, e, body, req, label, srcBody, selfSource, harvestVerdict, linkTokens.Count != sunk));
         }
 
-        // --- Phase 1b: one resolve of the harvested link targets, then pre-flight every staged edit against it. ---
+        // --- Phase 1b: one resolve of the harvested link targets, then pre-flight every staged edit against it —
+        //     re-walking only the edits that contributed a link value, exactly as the patch lane does. ---
         var (linkTypes, linkNote) = LinkTypeLookup(view, session, linkTokens);
         var linkRulebook = rulebook.WithLinkTargets(linkTypes);
         var resolved = new List<(PatchEdit edit, IMajorRecordGetter body, WriteRequest req, string label, IMajorRecordGetter? srcBody, bool selfSource)>(staged.Count);
         foreach (var s in staged)
         {
-            if (linkRulebook.Validate(s.req) is { } reject)
+            if ((s.carriesLinks ? linkRulebook.Validate(s.req) : s.harvestVerdict) is { } reject)
             { problems.Add((s.order, $"{s.req.RecordType} {FormIdToken.Of(s.edit.Target)} [{s.label}]: {reject}")); continue; }
             resolved.Add((s.edit, s.body, s.req, s.label, s.srcBody, s.selfSource));
         }
@@ -2948,7 +2956,17 @@ public static class WritePatchBuilder
         var linkTokens = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var allEditorIds = specs.Select(s => s.EditorId).Where(x => !string.IsNullOrWhiteSpace(x)).ToHashSet(StringComparer.OrdinalIgnoreCase);
         var harvestRulebook = rulebook.WithLinkHarvest(linkTokens);
-        foreach (var s in specs) foreach (var req in s.Edits) harvestRulebook.CollectLinkValues(req, allEditorIds);
+        // The harvest walk IS a validate, so an edit that put nothing in the sink is already decided and Phase 1 does
+        // not walk it again (the sink takes a value at every point the check decides, and at every gate that reads the
+        // sibling set — so a '@editorid' edit, whose two passes see different sibling sets, always re-walks).
+        var harvestVerdicts = new Dictionary<WriteRequest, string?>();
+        foreach (var s in specs)
+            foreach (var req in s.Edits)
+            {
+                var sunk = linkTokens.Count;
+                var verdict = harvestRulebook.CollectLinkValues(req, allEditorIds);
+                if (linkTokens.Count == sunk) harvestVerdicts[req] = verdict;
+            }
         var (linkTypes, linkNote) = LinkTypeLookup(view, session, linkTokens);
         var linkRulebook = rulebook.WithLinkTargets(linkTypes);
 
@@ -3290,10 +3308,14 @@ public static class WritePatchBuilder
             }
 
             foreach (var req in s.Edits)
+            {
                 // siblingEditorIds = priorEditorIds: a "@editorid" FormLink value is accepted iff that editorid was
                 // declared in an EARLIER spec of THIS call OR is the record itself (resolved to its real FormKey in
-                // Phase 3); else rejected loud.
-                if (linkRulebook.Validate(req, priorEditorIds) is { } reject) problems.Add($"{s.RecordType} '{s.EditorId}' [{Label(req)}]: {reject}");
+                // Phase 3); else rejected loud. An edit the harvest settled (it contributed nothing to the sink, so
+                // its walk was the same walk) keeps that verdict instead of being walked a second time.
+                var reject = harvestVerdicts.TryGetValue(req, out var settled) ? settled : linkRulebook.Validate(req, priorEditorIds);
+                if (reject is not null) problems.Add($"{s.RecordType} '{s.EditorId}' [{Label(req)}]: {reject}");
+            }
         }
         if (problems.Count > 0)
             return CreateOutcome.Fail(

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -926,7 +926,6 @@ public static class WritePatchBuilder
                 Key = e.Key, Value = e.Value, Values = e.Values, Entries = e.Entries, Struct = e.Struct, Structs = e.Structs,
             };
             var label = Label(req);
-            harvestRulebook.CollectLinkValues(req);
 
             // CopyFrom SOURCE resolution — the same contract Apply enforces, on this lane too: the lane axis is
             // uniform, so every write verb must compose with in_place. Without this a CopyFrom op reaches ApplyVerb,
@@ -965,6 +964,9 @@ public static class WritePatchBuilder
                 }
                 if (CrossTypeRefusal(e, srcBody, body) is { } typeErr) { Problem(typeErr); continue; }
             }
+            // Last, as on the patch lane: an edit already rejected above is never pre-flighted, so harvesting its
+            // links would walk a plugin for a check that will not run.
+            harvestRulebook.CollectLinkValues(req);
             staged.Add((order, e, body, req, label, srcBody, selfSource));
         }
 

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -741,8 +741,9 @@ public static class WritePatchBuilder
             catch (PluginUnreadableException ex)
             {
                 (skipped ??= new List<string>()).Add(
-                    $"{keys.Count} FormLink value(s) in this write resolve to '{plugin}', whose link targets were NOT " +
-                    $"type-checked: {ex.Message}");
+                    // keys is the DISTINCT FormKeys, so the note counts records, not the write's link value slots.
+                    $"this write links to {keys.Count} distinct record(s) in '{plugin}', whose types were NOT " +
+                    $"checked: {ex.Message}");
                 continue;
             }
             foreach (var kv in sink) types[kv.Key] = kv.Value.GetType();

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -971,8 +971,8 @@ public static class WritePatchBuilder
                 }
                 if (CrossTypeRefusal(e, srcBody, body) is { } typeErr) { Problem(typeErr); continue; }
             }
-            // Last, as on the patch lane: an edit already rejected above is never pre-flighted, so harvesting its
-            // links would walk a plugin for a check that will not run.
+            // Last, as on the patch lane, for the MESSAGE ORDER: an edit with both a bad from_plugin and a bad
+            // field_path is rejected above and reports the source problem first, which is what the patch lane does.
             var sunk = linkTokens.Count;
             var harvestVerdict = harvestRulebook.CollectLinkValues(req);
             staged.Add((order, e, body, req, label, srcBody, selfSource, harvestVerdict, linkTokens.Count != sunk));

--- a/src/housecarl-mcp-tests/FormLinkTargetTypeTests.cs
+++ b/src/housecarl-mcp-tests/FormLinkTargetTypeTests.cs
@@ -84,6 +84,21 @@ public sealed class FormLinkTargetTypeTests : RecordsTestBase
         Refused(r, "'BaseEffect'", "is a Spell", "links to MagicEffect");
     }
 
+    /// <summary>A link two composition levels down — a composed struct's NESTED set into a sub-struct's own FormLink
+    /// field — is checked like any other. The value slots are enumerated by the rulebook's own walk, so a slot the
+    /// check reads is a slot the harvest resolved; nothing here depends on a hand-kept list of where links can sit.</summary>
+    [Fact]
+    public void ANestedComposedLinkToTheWrongRecordTypeIsRefused()
+    {
+        var r = ApplyTools.Apply(Svc,
+            ops: Je($@"[{{""formid"":""{Fid(W.NpcParent)}"",""field_path"":""Items"",""op"":""Add"",""compose"":
+                {{""type"":""ContainerEntry"",""sets"":[{{""path"":""Item.Item"",""value"":""{Fid(W.SpellA)}""}},
+                {{""path"":""Item.Count"",""value"":""1""}}]}}}}]"),
+            dry_run: true);
+
+        Refused(r, "'Item'", "is a Spell");
+    }
+
     /// <summary>Removing a link is exempt: a list may already carry a wrong-typed FormID (another mod wrote it), and
     /// the Remove that repairs it must not be refused for naming the very type it is taking out. The call still
     /// fails — this armor has no Keywords at all — but on the LIST, never on the value's type.</summary>

--- a/src/housecarl-mcp-tests/LinkHarvestSkipTests.cs
+++ b/src/housecarl-mcp-tests/LinkHarvestSkipTests.cs
@@ -1,0 +1,74 @@
+using HousecarlCore;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// The pre-flight walks a write once when it carries no link. The harvest pass IS a validate, so a second walk in
+/// Phase 1b would double the cost of every edit in a bulk call; the write lanes keep the harvest's verdict for any
+/// edit that put nothing in the sink and re-walk only the ones that did. These pin the premise: what goes in the
+/// sink, and that the harvest's verdict is the checking pass's verdict for a link-free edit.
+///
+/// <para>Corpus-only, so it needs no records — the world is here for the generated corpus
+/// <c>CorpusRulebook.CorpusPath</c> points at.</para>
+/// </summary>
+[Trait("tier", "integration")]
+[Collection("bulk-records")]
+public sealed class LinkHarvestSkipTests : BulkRecordsTestBase
+{
+    public LinkHarvestSkipTests(BulkRecordsFixture f) : base(f) { }
+
+    static WriteRequest Req(string type, string[] path, string verb, string? value = null)
+        => new() { RecordType = type, Path = path, Verb = verb, Value = value };
+
+    /// <summary>Harvest one write; hand back what it put in the sink and the verdict it reached.</summary>
+    static (List<string> sunk, string? verdict) Harvest(WriteRequest req, IReadOnlyCollection<string>? siblings = null)
+    {
+        var sink = new List<string>();
+        var verdict = CorpusRulebook.Load().WithLinkHarvest(sink).CollectLinkValues(req, siblings);
+        return (sink, verdict);
+    }
+
+    /// <summary>A write with no FormLink in it contributes nothing — which is the signal the lanes skip on.</summary>
+    [Fact]
+    public void ALinkFreeWriteContributesNothingToTheSink()
+        => Assert.Empty(Harvest(Req("Armor", new[] { "Value" }, "Set", "100")).sunk);
+
+    /// <summary>…and the harvest's verdict on it is the verdict the checking walk reaches, so the skipped second
+    /// walk costs the caller no accuracy. The legal write.</summary>
+    [Fact]
+    public void ALinkFreeWriteGetsTheSameVerdictFromBothWalks()
+    {
+        var req = Req("Armor", new[] { "Value" }, "Set", "100");
+
+        Assert.Equal(CorpusRulebook.Load().Validate(req), Harvest(req).verdict);
+    }
+
+    /// <summary>The same for a REFUSED one: a bad field path is reported off the harvest walk, word for word.</summary>
+    [Fact]
+    public void ALinkFreeRefusalIsTheSameSentenceFromBothWalks()
+    {
+        var req = Req("Armor", new[] { "NoSuchField" }, "Set", "100");
+        var (sunk, verdict) = Harvest(req);
+
+        Assert.Empty(sunk);
+        Assert.NotNull(verdict);
+        Assert.Equal(CorpusRulebook.Load().Validate(req), verdict);
+    }
+
+    /// <summary>A write that DOES set a link contributes its value, so its lane pays the second walk — the one that
+    /// can type-check the target once the lookup exists.</summary>
+    [Fact]
+    public void AFormLinkWriteContributesItsValue()
+        => Assert.Equal(new[] { "000019:Skyrim.esm" },
+                        Harvest(Req("Armor", new[] { "Race" }, "Set", "000019:Skyrim.esm")).sunk);
+
+    /// <summary>A same-call '@editorid' reference contributes too. It is not a FormID and the link lookup skips it;
+    /// it is in the sink so the create lane never settles a forward reference on the harvest's answer, which sees
+    /// EVERY editorid in the call where the check sees only the ones declared earlier.</summary>
+    [Fact]
+    public void ASameCallSiblingReferenceContributesToo()
+        => Assert.Equal(new[] { "@LaterRace" },
+                        Harvest(Req("Armor", new[] { "Race" }, "Set", "@LaterRace"),
+                                new[] { "LaterRace" }).sunk);
+}


### PR DESCRIPTION
#679 added the FormLink target type-check, and prefetched the records it needs with a hand-written sweep of the value slots a write can carry (value, values, dict entries, a compose's fields/ctor_args/nested sets). That sweep mirrored by hand what the rulebook does when it validates, so a link slot added to the validator and not to it would resolve to null and go unchecked — a silent return to pre-#679 behaviour — and the unreadable-plugin note had to say "FormID value(s)" because the sweep could not tell a link value from any other string.

The rulebook now enumerates them itself. `WithLinkHarvest` derives a harvest rulebook whose `CollectLinkValues` runs the ordinary `Validate` walk with the link check in collect mode: at the one place the check reads a link value, the value is added to the sink instead. One walk decides both what gets resolved and what gets checked, so the two cannot name different slots, and the hand-written sweep is gone. The apply lanes need each edit's record type before they can walk it, so both now run Phase 1 in two passes — resolve and harvest per edit, then pre-flight every staged edit against the one lookup the harvest fed; problems carry their edit index so a report mixing a resolve problem with a pre-flight one still reads in edit order. The create lane's edits are already rooted at the declared type, so it harvests up front as before. Once-per-plugin resolution and the unreadable-plugin skip are unchanged, and the note now counts FormLink values truthfully.

Test: a link two composition levels down — a composed `ContainerEntry`'s nested set into `Item.Item` — pointing at a spell is refused. The existing FormLinkTargetTypeTests stay green. 1952 tests, 128/128 probes.

Relates to #679 and #663.
