### PR TITLE
Make the check sweep's record-type scope a set

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **`housecarl_check`'s record-type scope is now the set-valued `types=`, the same spelling and value form
+  `housecarl_records` takes.** One type is a set of one, so `types=["Npc"]` sweeps what `type="Npc"` swept; a set
+  sweeps the union of its types in one pass and merges the findings, and the response's narrowing line names every
+  type in it. An unknown type is still refused by name, and the cost is what the parameter says it is: the scope is
+  applied at the record stream, so the types you did not name cost nothing.
 - **The note a write emits when a link target's plugin cannot be read now names what it counts: the distinct
   records the write links to in that plugin.** The values a write's link check needs are enumerated by the same
   schema walk that does the checking, and two slots naming one record are one record here. What the note says

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -17,7 +17,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
   `housecarl_records` takes.** One type is a set of one, so `types=["Npc"]` sweeps what `type="Npc"` swept; a set
   sweeps the union of its types in one pass and merges the findings, and the response's narrowing line names every
   type in it. An unknown type is still refused by name, and the cost is what the parameter says it is: the scope is
-  applied at the record stream, so the types you did not name cost nothing.
+  applied at the record stream, so the types you did not name cost nothing. A BLANK entry in a type set is refused
+  saying it is blank, on `housecarl_check` and `housecarl_records` alike; an empty or omitted set is the separate
+  thing it has always been (no narrowing). And because `limit=` is one listing budget spent in the order the types
+  stream, a cut listing under a multi-type scope now says which order it was spent in: a type absent from it is
+  unlisted, not clean.
 - **The note a write emits when a link target's plugin cannot be read now names what it counts: the distinct
   records the write links to in that plugin.** The values a write's link check needs are enumerated by the same
   schema walk that does the checking, and two slots naming one record are one record here. What the note says

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -19,9 +19,10 @@ saying it sets an expectation their install may contradict. Say what is known, a
   type in it. An unknown type is still refused by name, and the cost is what the parameter says it is: the scope is
   applied at the record stream, so the types you did not name cost nothing. A BLANK entry in a type set is refused
   saying it is blank, on `housecarl_check` and `housecarl_records` alike; an empty or omitted set is the separate
-  thing it has always been (no narrowing). And because `limit=` is one listing budget spent in the order the types
-  stream, a cut listing under a multi-type scope now says which order it was spent in: a type absent from it is
-  unlisted, not clean.
+  thing it has always been (no narrowing). And because the scope's types share ONE listing — filled plugin by plugin
+  and type by type inside each — a short listing under a multi-type scope now names the types sharing it (spelling
+  the arms an entry like `GMST` expands to) and the knob that cut it, `limit=` or `max_chars=`: a type absent from
+  the listing is unlisted, not clean.
 - **The note a write emits when a link target's plugin cannot be read now names what it counts: the distinct
   records the write links to in that plugin.** The values a write's link check needs are enumerated by the same
   schema walk that does the checking, and two slots naming one record are one record here. What the note says

--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -135,7 +135,7 @@ public static class ErrorCheck
         // Uncapped by limit= like the totals it decomposes; it costs one dictionary bump per dangling ref.
         var bySource = wantDangling ? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) : null;
         // WHICH plugins the link walk actually examined a record in, under the scope in force. A record scope
-        // (type=/formids=/editorid_contains=) can admit nothing from a plugin the sweep opened, and "swept" has to
+        // (types=/formids=/editorid_contains=) can admit nothing from a plugin the sweep opened, and "swept" has to
         // mean examined rather than opened — otherwise the baseline line reports vanilla as covered-and-clean when
         // the scope filtered every vanilla record out. The layer that applies the filter is the layer that knows.
         var examined = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -487,7 +487,8 @@ public static class ErrorCheck
                                     filterNote, classes, histogram is null ? null : SweepFindings.Histogram(histogram),
                                     countsOnly, view.Epoch,
                                     bySource is null ? null : SweepFindings.Histogram(bySource),
-                                    baselineDangling, baseSwept, nonBaseInScope, limit);
+                                    baselineDangling, baseSwept, nonBaseInScope, limit,
+                                    recordScope?.TypeOrder);
     }
 
     /// <summary>Bump the <c>counts_only=</c> dangling histogram for one broken target: keyed by the PLUGIN the target
@@ -607,7 +608,8 @@ public sealed record ErrorCheckResult(
     int BaselineDangling = 0,
     IReadOnlyList<string>? BaseMastersSwept = null,
     bool NonBaseInScope = false,
-    int Limit = 0)   // the listing budget this sweep was GIVEN. Carried so the response can name the knob it is telling the caller to raise without being passed it a second time — a render-side copy defaults, and a default that disagrees with the sweep puts a wrong number in front of the caller
+    int Limit = 0,   // the listing budget this sweep was GIVEN. Carried so the response can name the knob it is telling the caller to raise without being passed it a second time — a render-side copy defaults, and a default that disagrees with the sweep puts a wrong number in front of the caller
+    string? TypeScopeOrder = null)   // the scope's types, in the order the budget was spent on them, when it covered MORE than one; null otherwise. The listing budget is one counter, so a multi-type scope can list the first type and never reach the second, and the response says so rather than letting the narrowing line read as "the rest are clean"
 
 {
     public bool Success => Error is null;

--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -488,7 +488,7 @@ public static class ErrorCheck
                                     countsOnly, view.Epoch,
                                     bySource is null ? null : SweepFindings.Histogram(bySource),
                                     baselineDangling, baseSwept, nonBaseInScope, limit,
-                                    recordScope?.TypeOrder);
+                                    recordScope?.TypeScopeLabel);
     }
 
     /// <summary>Bump the <c>counts_only=</c> dangling histogram for one broken target: keyed by the PLUGIN the target
@@ -609,7 +609,7 @@ public sealed record ErrorCheckResult(
     IReadOnlyList<string>? BaseMastersSwept = null,
     bool NonBaseInScope = false,
     int Limit = 0,   // the listing budget this sweep was GIVEN. Carried so the response can name the knob it is telling the caller to raise without being passed it a second time — a render-side copy defaults, and a default that disagrees with the sweep puts a wrong number in front of the caller
-    string? TypeScopeOrder = null)   // the scope's types, in the order the budget was spent on them, when it covered MORE than one; null otherwise. The listing budget is one counter, so a multi-type scope can list the first type and never reach the second, and the response says so rather than letting the narrowing line read as "the rest are clean"
+    string? TypeScopeLabel = null)   // the scope's types, spelled with the arms any entry expanded to, when it covered MORE than one; null otherwise. There is ONE listing for the whole scope, filled plugin by plugin and type by type inside each, so a short listing can be missing any of those types entirely, and the response says so rather than letting the narrowing line read as "the rest are clean"
 
 {
     public bool Success => Error is null;

--- a/src/housecarl-core/ScriptPropertyCheck.cs
+++ b/src/housecarl-core/ScriptPropertyCheck.cs
@@ -389,7 +389,7 @@ public static class ScriptPropertyCheck
                                      totalNull, totalUnverifiable, capped, av.ReadIncomplete, view.ExcludedPlugins, null,
                                      filterNote, histogram is null ? null : SweepFindings.Histogram(histogram), countsOnly,
                                      classes, totalUnboundObject, totalUnboundScalar, propFilter, view.Epoch, limit,
-                                     offOrderScanned, collapsedUnverifiable);
+                                     offOrderScanned, collapsedUnverifiable, recordScope?.TypeOrder);
     }
 
     /// <summary>One record's fault, appended to the plugin's running scan-error line — the same sentence on both
@@ -590,7 +590,8 @@ public sealed record ScriptCheckResult(
     string? Epoch = null,   // the swept INDEXED build's fingerprint; null only on the pre-sweep refusals. OffOrderScanned files are located OUTSIDE the index — their content is not under this fingerprint, so the renders qualify the stamp when any were swept
     int Limit = 0,   // the finding budget this sweep was GIVEN, so the response names the knob to raise off the number actually used
     IReadOnlyList<string>? OffOrderScanned = null,   // the files swept OFF-ORDER: on disk, not in the active order — the pre-enable verify lane
-    int UnverifiableCollapsed = 0)   // records whose unverifiable note repeated one already listed for the same script class; counted in TotalUnverifiable, not listed again
+    int UnverifiableCollapsed = 0,   // records whose unverifiable note repeated one already listed for the same script class; counted in TotalUnverifiable, not listed again
+    string? TypeScopeOrder = null)   // the scope's types, in the order the budget was spent on them, when it covered MORE than one; null otherwise — the same rule the errors family carries, because both families spend one listing budget over one type stream
 {
     public bool Success => Error is null;
     public static ScriptCheckResult Fail(string error) =>

--- a/src/housecarl-core/ScriptPropertyCheck.cs
+++ b/src/housecarl-core/ScriptPropertyCheck.cs
@@ -389,7 +389,7 @@ public static class ScriptPropertyCheck
                                      totalNull, totalUnverifiable, capped, av.ReadIncomplete, view.ExcludedPlugins, null,
                                      filterNote, histogram is null ? null : SweepFindings.Histogram(histogram), countsOnly,
                                      classes, totalUnboundObject, totalUnboundScalar, propFilter, view.Epoch, limit,
-                                     offOrderScanned, collapsedUnverifiable, recordScope?.TypeOrder);
+                                     offOrderScanned, collapsedUnverifiable, recordScope?.TypeScopeLabel);
     }
 
     /// <summary>One record's fault, appended to the plugin's running scan-error line — the same sentence on both
@@ -591,7 +591,7 @@ public sealed record ScriptCheckResult(
     int Limit = 0,   // the finding budget this sweep was GIVEN, so the response names the knob to raise off the number actually used
     IReadOnlyList<string>? OffOrderScanned = null,   // the files swept OFF-ORDER: on disk, not in the active order — the pre-enable verify lane
     int UnverifiableCollapsed = 0,   // records whose unverifiable note repeated one already listed for the same script class; counted in TotalUnverifiable, not listed again
-    string? TypeScopeOrder = null)   // the scope's types, in the order the budget was spent on them, when it covered MORE than one; null otherwise — the same rule the errors family carries, because both families spend one listing budget over one type stream
+    string? TypeScopeLabel = null)   // the scope's types, spelled with any expanded arms, when it covered MORE than one; null otherwise — the same rule the errors family carries, because both families fill one listing over one record stream
 {
     public bool Success => Error is null;
     public static ScriptCheckResult Fail(string error) =>

--- a/src/housecarl-core/SweepScope.cs
+++ b/src/housecarl-core/SweepScope.cs
@@ -45,6 +45,13 @@ public sealed class SweepScope
         TypeLabel = Types is null ? null : typeLabel;
     }
 
+    /// <summary>The scope's types spelled for the response, but ONLY where the scope covers more than one — the
+    /// listing budget is one counter spent in the order these are streamed, so a multi-type scope can list the
+    /// first type and never reach the second. Null where one type (or none) is in force and that cannot happen.
+    /// <para>More than one TYPE, not more than one entry: one entry can expand to several arms (<c>Global</c> to
+    /// its int/float/short arms), and the budget is spent arm by arm there too.</para></summary>
+    public string? TypeOrder => Types is { Count: > 1 } ? TypeLabel : null;
+
     /// <summary>True when nothing is actually narrowed (every knob absent) — the caller can then pass null and keep the
     /// unscoped path byte-identical.</summary>
     public bool IsEmpty => Formids is null && EditorIdContains is null && Types is null;

--- a/src/housecarl-core/SweepScope.cs
+++ b/src/housecarl-core/SweepScope.cs
@@ -8,9 +8,8 @@ namespace HousecarlCore;
 /// The RECORD-level narrowing the sweep families (housecarl_check findings=["errors"] and ["scripts"]) share.
 /// A plugin-wide sweep of a script-heavy plugin renders past the tool-result token cap, so record-level scoping is
 /// what makes "did the unbound count for THESE few records change?" askable. The knobs deliberately reuse the sibling
-/// read tools' vocabulary: <see cref="Types"/> (cross_plugin_query's <c>type=</c>), <see cref="Formids"/>
-/// (batch_record_detail's <c>formids=</c>), and <see cref="EditorIdContains"/> (cross_plugin_query's
-/// <c>editorid_contains=</c>).
+/// read tools' vocabulary: <see cref="Types"/> (the records surface's set-valued <c>types=</c>), <see cref="Formids"/>
+/// (<c>formids=</c>), and <see cref="EditorIdContains"/> (<c>editorid_contains=</c>).
 ///
 /// <para><b>Narrowing narrows the NUMBERS.</b> A scoped sweep's totals are the totals FOR THE SCOPE, exactly as
 /// <c>plugins=</c> already behaves. The render therefore carries <see cref="Label"/> on its own line whenever
@@ -30,11 +29,11 @@ public sealed class SweepScope
     /// free pass).</summary>
     public string? EditorIdContains { get; }
 
-    /// <summary>The getter Type(s) to stream, or null for every record type. Resolved by the caller from the user's
-    /// <c>type=</c> string (the shared TypeLookup), so an unknown type fails loud before the sweep starts.</summary>
+    /// <summary>The getter Type(s) to stream, or null for every record type. Resolved by the caller as the UNION of
+    /// the user's <c>types=</c> set (the shared TypeLookup), so an unknown type fails loud before the sweep starts.</summary>
     public IReadOnlyList<Type>? Types { get; }
 
-    /// <summary>The user-facing spelling of <see cref="Types"/> (the raw <c>type=</c> string), for <see cref="Label"/>.</summary>
+    /// <summary>The user-facing spelling of <see cref="Types"/> (the raw <c>types=</c> entries), for <see cref="Label"/>.</summary>
     public string? TypeLabel { get; }
 
     public SweepScope(IReadOnlySet<FormKey>? formids, string? editorIdContains,
@@ -71,7 +70,7 @@ public sealed class SweepScope
         {
             if (IsEmpty) return null;
             var parts = new List<string>(3);
-            if (Types is not null) parts.Add($"type={TypeLabel}");
+            if (Types is not null) parts.Add($"types=[{TypeLabel}]");
             if (Formids is not null) parts.Add($"{Formids.Count} formid(s)");
             if (EditorIdContains is not null) parts.Add($"editorid_contains='{EditorIdContains}'");
             return string.Join(", ", parts);
@@ -79,10 +78,10 @@ public sealed class SweepScope
     }
 
     /// <summary>An OFF-ORDER file's record stream, type-scoped when the caller asked for one — the overlay
-    /// counterpart of <c>RecordsIn</c>'s getter-type filter, so a <c>type=</c> scope costs nothing per skipped
+    /// counterpart of <c>RecordsIn</c>'s getter-type filter, so a <c>types=</c> scope costs nothing per skipped
     /// record on that lane either. One home, because both sweep families walk an off-order file the same way.
     /// Through <see cref="RecordArms"/>, the same arm re-check the in-order lanes go through: without it an arm scope
-    /// (<c>type='GlobalShort'</c>) would sweep and count the whole GRUP here.</summary>
+    /// (<c>types=['GlobalShort']</c>) would sweep and count the whole GRUP here.</summary>
     public static IEnumerable<IMajorRecordGetter> RecordsFrom(ISkyrimModGetter ov, SweepScope? scope)
         => scope?.Types is { Count: > 0 } types
             ? RecordArms.OfTypes(ov, types)

--- a/src/housecarl-core/SweepScope.cs
+++ b/src/housecarl-core/SweepScope.cs
@@ -36,21 +36,44 @@ public sealed class SweepScope
     /// <summary>The user-facing spelling of <see cref="Types"/> (the raw <c>types=</c> entries), for <see cref="Label"/>.</summary>
     public string? TypeLabel { get; }
 
+    // The same entries with every one that EXPANDED spelling its arms ("GMST → GameSettingInt, ..."), for
+    // TypeScopeLabel. Null where the caller built no such spelling, and TypeLabel then stands in.
+    readonly string? _armLabel;
+
     public SweepScope(IReadOnlySet<FormKey>? formids, string? editorIdContains,
-                      IReadOnlyList<Type>? types, string? typeLabel)
+                      IReadOnlyList<Type>? types, string? typeLabel, string? armLabel = null)
     {
         Formids = formids is { Count: > 0 } ? formids : null;
         EditorIdContains = string.IsNullOrWhiteSpace(editorIdContains) ? null : editorIdContains.Trim();
         Types = types is { Count: > 0 } ? types : null;
         TypeLabel = Types is null ? null : typeLabel;
+        _armLabel = Types is null ? null : armLabel;
     }
 
-    /// <summary>The scope's types spelled for the response, but ONLY where the scope covers more than one — the
-    /// listing budget is one counter spent in the order these are streamed, so a multi-type scope can list the
-    /// first type and never reach the second. Null where one type (or none) is in force and that cannot happen.
-    /// <para>More than one TYPE, not more than one entry: one entry can expand to several arms (<c>Global</c> to
-    /// its int/float/short arms), and the budget is spent arm by arm there too.</para></summary>
-    public string? TypeOrder => Types is { Count: > 1 } ? TypeLabel : null;
+    /// <summary>The scope's types spelled for the short-listing rule, but ONLY where the scope covers more than one
+    /// — there is one listing for the whole scope, so with several types in it any one of them can come out short.
+    /// Null where a single type is in force and that cannot happen.
+    /// <para>More than one TYPE, not more than one entry: one entry can expand to several arms (<c>GMST</c> to its
+    /// int/float/string/bool arms), and the listing is shared across those arms too. Which is why this spells the
+    /// arms an entry expanded to: a rule about "any of those types" has to name types the reader can act on, and
+    /// <c>types=[GMST]</c> alone names none.</para></summary>
+    public string? TypeScopeLabel => Types is { Count: > 1 } ? (_armLabel ?? TypeLabel) : null;
+
+    /// <summary>One <c>types=</c> entry spelled with the arms it resolved to, where it resolved to more than one —
+    /// the polymorphic bases (<c>GMST</c>, <c>GLOB</c>) and the many-to-one signatures. A concrete entry is spelled
+    /// as itself.</summary>
+    public static string SpellTypeEntry(string entry, IReadOnlyList<Type> arms)
+        => arms.Count > 1 ? $"{entry} → {string.Join(", ", arms.Select(GetterName))}" : entry;
+
+    /// <summary>A getter interface's user-facing type name: <c>IGameSettingIntGetter</c> to <c>GameSettingInt</c>,
+    /// the catalog spelling <c>types=</c> itself takes.</summary>
+    static string GetterName(Type t)
+    {
+        var n = t.Name;
+        if (n.Length > 1 && n[0] == 'I' && char.IsUpper(n[1])) n = n[1..];
+        if (n.EndsWith("Getter", StringComparison.Ordinal)) n = n[..^"Getter".Length];
+        return n;
+    }
 
     /// <summary>True when nothing is actually narrowed (every knob absent) — the caller can then pass null and keep the
     /// unscoped path byte-identical.</summary>

--- a/src/housecarl-generator/CheckMergeProbe.cs
+++ b/src/housecarl-generator/CheckMergeProbe.cs
@@ -1424,8 +1424,8 @@ public static class CheckMergeProbe
 
         // …and the OTHER direction of the same rule: an input error off the SHARED trio refuses every family, so it
         // is still the whole call's answer rather than the same sentence printed twice.
-        var sharedRefusal = CheckTools.CheckTool(svc, findings: new[] { "errors", "scripts" }, type: "NOSUCHTYPE");
-        Arm("ORCH-A-SHARED-INPUT-REFUSAL-STILL-REFUSES-THE-CALL: an unknown type= is malformed input for every family that could have run, so the response is ONE error NAMING THE TYPE IT REFUSED — the arm that keeps the cell above from passing by making every refusal family-local",
+        var sharedRefusal = CheckTools.CheckTool(svc, findings: new[] { "errors", "scripts" }, types: new[] { "NOSUCHTYPE" });
+        Arm("ORCH-A-SHARED-INPUT-REFUSAL-STILL-REFUSES-THE-CALL: an unknown types= entry is malformed input for every family that could have run, so the response is ONE error NAMING THE TYPE IT REFUSED — the arm that keeps the cell above from passing by making every refusal family-local",
             sharedRefusal.StartsWith("error", StringComparison.OrdinalIgnoreCase)
             // The GROUND, not just that something began with "error". Asked without it, this cell passed on a tree
             // with no generated/corpus.json at all: the guard's own internal-failure string starts with "error" and
@@ -1435,13 +1435,13 @@ public static class CheckMergeProbe
             && Count(sharedRefusal, "\n[errors] ") == 0,
             Trim(sharedRefusal));
 
-        // ---- THE SHARED INPUTS, ON A CALL WHOSE FAMILY NONE OF THEM SCOPE. type= / formids= / exclude= were parsed
+        // ---- THE SHARED INPUTS, ON A CALL WHOSE FAMILY NONE OF THEM SCOPE. types= / formids= / exclude= were parsed
         //      inside the two SWEEP families' service entries, which the merged tool calls only where its family
         //      was selected — so findings=['dialogue'] ran with nothing ever looking at them and a typo'd
         //      narrowing came back as an ordinary dialogue answer (Aaron's review of PR #399, finding 3).
         var dlgSeeds = new[] { "0F1AC1:HcOrch.esp" };
         var dlgControl = CheckTools.CheckTool(svc, findings: new[] { "dialogue" }, seeds: dlgSeeds);
-        var dlgBadType = CheckTools.CheckTool(svc, findings: new[] { "dialogue" }, seeds: dlgSeeds, type: "NOSUCHTYPE");
+        var dlgBadType = CheckTools.CheckTool(svc, findings: new[] { "dialogue" }, seeds: dlgSeeds, types: new[] { "NOSUCHTYPE" });
         var dlgBadFormid = CheckTools.CheckTool(svc, findings: new[] { "dialogue" }, seeds: dlgSeeds,
                                                 formids: new[] { "not-a-formid" });
         var dlgBadExclude = CheckTools.CheckTool(svc, findings: new[] { "dialogue" }, seeds: dlgSeeds,
@@ -1449,7 +1449,7 @@ public static class CheckMergeProbe
         // …and the refusal is a DOCUMENT in json, not a bare string — the whole reason it renders through the
         // normal refusal path instead of returning early from the tool.
         var dlgBadTypeJson = CheckTools.CheckTool(svc, findings: new[] { "dialogue" }, seeds: dlgSeeds,
-                                                  type: "NOSUCHTYPE", format: "json");
+                                                  types: new[] { "NOSUCHTYPE" }, format: "json");
         bool refusalIsADocument;
         try
         {
@@ -1457,7 +1457,7 @@ public static class CheckMergeProbe
             refusalIsADocument = Str(d.RootElement, "error") is { } e && e.Contains("NOSUCHTYPE", StringComparison.Ordinal);
         }
         catch { refusalIsADocument = false; }
-        Arm("ORCH-SHARED-INPUT-IS-CHECKED-BEFORE-FAMILY-DISPATCH: on findings=['dialogue'] — the one family none of them scope — a bad type=, a malformed formids= token and an exclude= value that is neither a filename nor a group each refuse the WHOLE call by name, in both transports, while the same call without them answers. Parsed inside the sweep families' own entries, none of the three was ever looked at",
+        Arm("ORCH-SHARED-INPUT-IS-CHECKED-BEFORE-FAMILY-DISPATCH: on findings=['dialogue'] — the one family none of them scope — a bad types=, a malformed formids= token and an exclude= value that is neither a filename nor a group each refuse the WHOLE call by name, in both transports, while the same call without them answers. Parsed inside the sweep families' own entries, none of the three was ever looked at",
             dlgBadType.StartsWith("error", StringComparison.OrdinalIgnoreCase)
             && dlgBadType.Contains("NOSUCHTYPE", StringComparison.Ordinal)
             && dlgBadFormid.StartsWith("error", StringComparison.OrdinalIgnoreCase)

--- a/src/housecarl-mcp-tests/CheckTypesSetTests.cs
+++ b/src/housecarl-mcp-tests/CheckTypesSetTests.cs
@@ -1,0 +1,61 @@
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// <c>housecarl_check</c>'s record-type scope is a SET: a sweep over N types is the sweep over each, findings
+/// merged, and one type is a set of one. The two subjects are the master's NPC_ and WEAP, one dangling ref each.
+/// </summary>
+[Collection("type-arms")]
+[Trait("tier", "integration")]
+public sealed class CheckTypesSetTests
+{
+    readonly TypeArmWorld _w;
+    public CheckTypesSetTests(TypeArmFixture f) => _w = f.W;
+
+    /// <summary>The set is the union: both types' findings come back from one call.</summary>
+    [Fact]
+    public void ASweepOverTwoTypesReportsBothTypesFindings()
+    {
+        var r = _w.Svc.CheckErrors(new[] { _w.MasterName }, 1000, types: new[] { "Npc", "Weapon" });
+
+        Assert.Null(r.Error);
+        Assert.Equal(2, r.TotalDangling);
+        var ids = r.Reports.SelectMany(p => p.Dangling).Select(d => d.SourceEditorId).ToList();
+        Assert.Contains(TypeArmWorld.SweepNpc, ids);
+        Assert.Contains(TypeArmWorld.SweepWeapon, ids);
+    }
+
+    /// <summary>One type is a set of one, and it still answers over that type alone — the arm that keeps the union
+    /// above from passing on a scope that stopped narrowing.</summary>
+    [Fact]
+    public void ASweepOverOneTypeStillAnswersOverThatTypeAlone()
+    {
+        var r = _w.Svc.CheckErrors(new[] { _w.MasterName }, 1000, types: new[] { "Npc" });
+
+        Assert.Null(r.Error);
+        Assert.Equal(1, r.TotalDangling);
+        var ids = r.Reports.SelectMany(p => p.Dangling).Select(d => d.SourceEditorId).ToList();
+        Assert.Contains(TypeArmWorld.SweepNpc, ids);
+        Assert.DoesNotContain(TypeArmWorld.SweepWeapon, ids);
+    }
+
+    /// <summary>The applied narrowing is spelled with both types, so a count can never read as the wider claim.</summary>
+    [Fact]
+    public void TheRenderNamesEveryTypeInTheSet()
+    {
+        var r = _w.Svc.CheckErrors(new[] { _w.MasterName }, 1000, types: new[] { "Npc", "Weapon" });
+
+        Assert.Contains("types=[Npc, Weapon]", r.FilterNote);
+    }
+
+    /// <summary>An unknown entry refuses the whole sweep by name, the way the records surface refuses one.</summary>
+    [Fact]
+    public void AnUnknownTypeInTheSetRefusesTheSweepByName()
+    {
+        var r = _w.Svc.CheckErrors(new[] { _w.MasterName }, 1000, types: new[] { "Npc", "NOSUCHTYPE" });
+
+        Assert.Contains("NOSUCHTYPE", r.Error);
+        Assert.Empty(r.Reports);
+    }
+}

--- a/src/housecarl-mcp-tests/CheckTypesSetTests.cs
+++ b/src/housecarl-mcp-tests/CheckTypesSetTests.cs
@@ -1,3 +1,4 @@
+using HousecarlMcp;
 using Xunit;
 
 namespace HousecarlMcpTests;
@@ -57,5 +58,80 @@ public sealed class CheckTypesSetTests
 
         Assert.Contains("NOSUCHTYPE", r.Error);
         Assert.Empty(r.Reports);
+    }
+
+    /// <summary>A BLANK entry names no type, so it is refused SAYING it is blank rather than quoted back as an
+    /// unknown type ''. An empty set is a different thing (no narrowing) and is not this.</summary>
+    [Fact]
+    public void ABlankTypeInTheSetIsRefusedAsBlank()
+    {
+        var r = _w.Svc.CheckErrors(new[] { _w.MasterName }, 1000, types: new[] { "" });
+
+        Assert.Contains("blank record type", r.Error);
+        Assert.DoesNotContain("unknown record type", r.Error);
+        Assert.Empty(r.Reports);
+    }
+
+    /// <summary>One rule, not two: the records surface refuses the same blank entry with the same sentence, so a
+    /// caller cannot learn one grammar on one surface and meet another on the other.</summary>
+    [Fact]
+    public void TheRecordsSurfaceRefusesABlankTypeTheSameWay()
+    {
+        var r = RecordsTools.Records(_w.Svc, types: new[] { "" });
+
+        Assert.Contains("blank record type", r, StringComparison.Ordinal);
+        Assert.DoesNotContain("unknown record type", r, StringComparison.Ordinal);
+    }
+
+    /// <summary>limit= is ONE listing budget spent in the order the types stream, so a two-type sweep with room for
+    /// one finding lists the NPC_ and never reaches the WEAP. The response says so: absent from the listing means
+    /// unlisted, not clean.</summary>
+    [Fact]
+    public void ACutMultiTypeListingSaysTheBudgetWasSpentInTypeOrder()
+    {
+        var r = _w.Svc.CheckErrors(new[] { _w.MasterName }, 1, types: new[] { "Npc", "Weapon" });
+        var text = CheckErrorsFixtures.Text(r, 80_000);
+
+        Assert.Equal(2, r.TotalDangling);                                  // the totals are never capped
+        Assert.Single(r.Reports.SelectMany(p => p.Dangling));              // the listing carried one of them
+        Assert.Contains("types=[Npc, Weapon]", text, StringComparison.Ordinal);
+        Assert.Contains("unlisted, not clean", text, StringComparison.Ordinal);
+    }
+
+    /// <summary>A budget that dropped nothing leaves the listing complete for every type in the scope, so the rule
+    /// is not stated — a warning about a hole that is not there reads as one that is.</summary>
+    [Fact]
+    public void AnUncutMultiTypeListingStatesNoTypeOrderRule()
+    {
+        var text = CheckErrorsFixtures.Text(
+            _w.Svc.CheckErrors(new[] { _w.MasterName }, 1000, types: new[] { "Npc", "Weapon" }), 80_000);
+
+        Assert.DoesNotContain("unlisted, not clean", text, StringComparison.Ordinal);
+    }
+
+    /// <summary>With ONE type in scope the budget cannot have stopped before another type, so a cut listing states
+    /// no type-order rule either — the rule is about the set, not about the cut.</summary>
+    [Fact]
+    public void ACutSingleTypeListingStatesNoTypeOrderRule()
+    {
+        var r = _w.Svc.CheckErrors(new[] { _w.MasterName }, 0, types: new[] { "Npc" });
+        var text = CheckErrorsFixtures.Text(r, 80_000);
+
+        Assert.Equal(1, r.TotalDangling);
+        Assert.Empty(r.Reports.SelectMany(p => p.Dangling));                // the budget listed none of it
+        Assert.DoesNotContain("unlisted, not clean", text, StringComparison.Ordinal);
+    }
+
+    /// <summary>The json twin carries the same fact under the same test, so the two transports cannot disagree
+    /// about which budget was spent how.</summary>
+    [Fact]
+    public void TheJsonTwinCarriesTheTypeOrderTheBudgetWasSpentIn()
+    {
+        var json = CheckErrorsFixtures.Json(
+            _w.Svc.CheckErrors(new[] { _w.MasterName }, 1, types: new[] { "Npc", "Weapon" }), 80_000);
+
+        Assert.Equal("Npc, Weapon",
+                     CheckErrorsFixtures.ErrorsFamily(json).GetProperty("accounting")
+                                        .GetProperty("limit_spent_in_type_order").GetString());
     }
 }

--- a/src/housecarl-mcp-tests/CheckTypesSetTests.cs
+++ b/src/housecarl-mcp-tests/CheckTypesSetTests.cs
@@ -1,3 +1,6 @@
+using System.Text.Json;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
 using HousecarlMcp;
 using Xunit;
 
@@ -83,25 +86,77 @@ public sealed class CheckTypesSetTests
         Assert.DoesNotContain("unknown record type", r, StringComparison.Ordinal);
     }
 
-    /// <summary>limit= is ONE listing budget spent in the order the types stream, so a two-type sweep with room for
-    /// one finding lists the NPC_ and never reaches the WEAP. The response says so: absent from the listing means
-    /// unlisted, not clean.</summary>
+    /// <summary>The scope's types share ONE listing, filled plugin by plugin and type by type inside each — so a
+    /// two-type sweep with room for one finding can be missing either type. The response says that, and it does NOT
+    /// claim the budget went in the order the types were named: the sweep runs plugin-major, so it never does.</summary>
     [Fact]
-    public void ACutMultiTypeListingSaysTheBudgetWasSpentInTypeOrder()
+    public void ACutMultiTypeListingSaysTheTypesShareOneListing()
     {
         var r = _w.Svc.CheckErrors(new[] { _w.MasterName }, 1, types: new[] { "Npc", "Weapon" });
         var text = CheckErrorsFixtures.Text(r, 80_000);
 
         Assert.Equal(2, r.TotalDangling);                                  // the totals are never capped
         Assert.Single(r.Reports.SelectMany(p => p.Dangling));              // the listing carried one of them
-        Assert.Contains("types=[Npc, Weapon]", text, StringComparison.Ordinal);
+        Assert.Contains("ONE listing for every type in the scope (types=[Npc, Weapon])", text, StringComparison.Ordinal);
+        Assert.Contains("plugin by plugin (non-base plugins first, base masters last)", text, StringComparison.Ordinal);
         Assert.Contains("unlisted, not clean", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("in the order", text, StringComparison.Ordinal);
     }
 
-    /// <summary>A budget that dropped nothing leaves the listing complete for every type in the scope, so the rule
-    /// is not stated — a warning about a hole that is not there reads as one that is.</summary>
+    /// <summary>The knob the rule points at is the one that actually cut the listing: here the budget, so it names
+    /// limit= and not max_chars=, which dropped nothing.</summary>
     [Fact]
-    public void AnUncutMultiTypeListingStatesNoTypeOrderRule()
+    public void ABudgetCutNamesLimitAsTheKnobThatFired()
+    {
+        var text = CheckErrorsFixtures.Text(
+            _w.Svc.CheckErrors(new[] { _w.MasterName }, 1, types: new[] { "Npc", "Weapon" }), 80_000);
+
+        Assert.Contains("and limit= cut it short", text, StringComparison.Ordinal);
+    }
+
+    /// <summary>max_chars cuts the same one listing in the same order the budget does, so it hides a whole type the
+    /// same way and fires the same rule — naming max_chars=, the knob that actually fired, with limit= innocent at
+    /// 1000. The cap is searched for rather than pinned: only a PARTIAL cut is the shape under test.</summary>
+    [Fact]
+    public void AMaxCharsCutFiresTheRuleAndNamesMaxCharsAsTheKnob()
+    {
+        var r = _w.Svc.CheckErrors(new[] { _w.MasterName }, 1000, types: new[] { "Npc", "Weapon" });
+        Assert.Equal(2, r.TotalDangling);
+
+        // Each lane reserves its own room, so the cap that cuts one need not cut the other: each is searched for
+        // the cut on its own terms and then asked what it says about it.
+        string? cutText = null;
+        for (int cap = 400; cap <= 20_000; cap += 25)
+        {
+            var t = CheckErrorsFixtures.Text(r, cap);
+            if (!t.Contains("did not fit this response", StringComparison.Ordinal)) continue;
+            cutText = t;
+            break;
+        }
+        Assert.True(cutText is not null, "no cap in 400..20000 cut this listing by max_chars alone");
+        Assert.DoesNotContain("the listing budget (limit=", cutText!, StringComparison.Ordinal);
+        Assert.Contains("and max_chars= cut it short", cutText!, StringComparison.Ordinal);
+        Assert.Contains("unlisted, not clean", cutText!, StringComparison.Ordinal);
+
+        JsonElement acct = default;
+        for (int cap = 400; cap <= 20_000; cap += 25)
+        {
+            var fam = CheckErrorsFixtures.ErrorsFamily(CheckErrorsFixtures.Json(r, cap));
+            if (!fam.TryGetProperty("plugins", out var pl) || pl.GetArrayLength() == 0) continue;
+            var a = fam.GetProperty("accounting");
+            if (a.GetProperty("dangling_missing_by_response_cut").GetInt32() == 0) continue;
+            acct = a;
+            break;
+        }
+        Assert.Equal(0, acct.GetProperty("dangling_missing_by_budget").GetInt32());
+        Assert.Equal("Npc, Weapon", acct.GetProperty("listing_short_across_types").GetString());
+        Assert.Equal("max_chars=", acct.GetProperty("listing_short_by").GetString());
+    }
+
+    /// <summary>A listing that dropped nothing is complete for every type in the scope, so the rule is not stated —
+    /// a warning about a hole that is not there reads as one that is.</summary>
+    [Fact]
+    public void AnUncutMultiTypeListingStatesNoTypeScopeRule()
     {
         var text = CheckErrorsFixtures.Text(
             _w.Svc.CheckErrors(new[] { _w.MasterName }, 1000, types: new[] { "Npc", "Weapon" }), 80_000);
@@ -109,10 +164,10 @@ public sealed class CheckTypesSetTests
         Assert.DoesNotContain("unlisted, not clean", text, StringComparison.Ordinal);
     }
 
-    /// <summary>With ONE type in scope the budget cannot have stopped before another type, so a cut listing states
-    /// no type-order rule either — the rule is about the set, not about the cut.</summary>
+    /// <summary>ONE concrete type in scope shares its listing with nothing, so a cut listing states no type-scope
+    /// rule either — the rule is about the set, not about the cut.</summary>
     [Fact]
-    public void ACutSingleTypeListingStatesNoTypeOrderRule()
+    public void ACutSingleTypeListingStatesNoTypeScopeRule()
     {
         var r = _w.Svc.CheckErrors(new[] { _w.MasterName }, 0, types: new[] { "Npc" });
         var text = CheckErrorsFixtures.Text(r, 80_000);
@@ -122,16 +177,46 @@ public sealed class CheckTypesSetTests
         Assert.DoesNotContain("unlisted, not clean", text, StringComparison.Ordinal);
     }
 
-    /// <summary>The json twin carries the same fact under the same test, so the two transports cannot disagree
-    /// about which budget was spent how.</summary>
+    /// <summary>An entry that EXPANDS is spelled with the arms it expanded to, so the rule names types the reader
+    /// can act on: types=[GMST] alone names none of the things that can be short.</summary>
     [Fact]
-    public void TheJsonTwinCarriesTheTypeOrderTheBudgetWasSpentIn()
+    public void AnExpandingTypeEntryIsSpelledWithItsArms()
+    {
+        // GMST carries no links of its own, so the two link-bearing types are what the budget of 1 cuts.
+        var text = CheckErrorsFixtures.Text(
+            _w.Svc.CheckErrors(new[] { _w.MasterName }, 1, types: new[] { "GMST", "Npc", "Weapon" }), 80_000);
+
+        Assert.Contains("GMST → GameSetting", text, StringComparison.Ordinal);   // the arms all share that prefix
+        Assert.Contains("GameSettingInt", text, StringComparison.Ordinal);
+        Assert.Contains("GameSettingFloat", text, StringComparison.Ordinal);
+        Assert.Contains("unlisted, not clean", text, StringComparison.Ordinal);
+    }
+
+    /// <summary>ONE entry is enough where that entry is a polymorphic base: it resolves to several types that share
+    /// the listing, so the scope label is spelled and the rule can fire. One CONCRETE entry resolves to one type and
+    /// is not labelled at all — the gate is on the types, not on the entries.</summary>
+    [Fact]
+    public void AOneEntryPolymorphicBaseIsLabelledWithItsArms()
+    {
+        var arms = new[] { typeof(IGameSettingIntGetter), typeof(IGameSettingFloatGetter) };
+        var expanded = new SweepScope(null, null, arms, "GMST", SweepScope.SpellTypeEntry("GMST", arms));
+        Assert.Equal("GMST → GameSettingInt, GameSettingFloat", expanded.TypeScopeLabel);
+
+        var one = new[] { typeof(INpcGetter) };
+        var concrete = new SweepScope(null, null, one, "Npc", SweepScope.SpellTypeEntry("Npc", one));
+        Assert.Null(concrete.TypeScopeLabel);
+    }
+
+    /// <summary>The json twin carries the same two facts under the same test, so the two transports cannot disagree
+    /// about which listing was short or which knob cut it.</summary>
+    [Fact]
+    public void TheJsonTwinCarriesTheTypesSharingTheListingAndTheKnob()
     {
         var json = CheckErrorsFixtures.Json(
             _w.Svc.CheckErrors(new[] { _w.MasterName }, 1, types: new[] { "Npc", "Weapon" }), 80_000);
+        var acct = CheckErrorsFixtures.ErrorsFamily(json).GetProperty("accounting");
 
-        Assert.Equal("Npc, Weapon",
-                     CheckErrorsFixtures.ErrorsFamily(json).GetProperty("accounting")
-                                        .GetProperty("limit_spent_in_type_order").GetString());
+        Assert.Equal("Npc, Weapon", acct.GetProperty("listing_short_across_types").GetString());
+        Assert.Equal("limit=", acct.GetProperty("listing_short_by").GetString());
     }
 }

--- a/src/housecarl-mcp-tests/RecordsTypeArmTests.cs
+++ b/src/housecarl-mcp-tests/RecordsTypeArmTests.cs
@@ -61,13 +61,13 @@ public sealed class RecordsTypeArmTests
     }
 
     /// <summary>The errors sweep's off-order lane runs a third enumeration of its own, so it needs the same arm
-    /// re-check: without it a <c>type='GlobalShort'</c> sweep of a file holding no GlobalShort walks and counts the
+    /// re-check: without it a <c>types=['GlobalShort']</c> sweep of a file holding no GlobalShort walks and counts the
     /// whole GLOB group. <c>BaseMastersSwept</c> is what that lane's examined set reaches — a swept off-order base
     /// master is listed there, one whose every record the scope filtered out is not.</summary>
     [Fact]
     public void AnArmTypeFilterOnTheOffOrderSweepExaminesThatArmAlone()
     {
-        var swept = _w.Svc.CheckErrors(new[] { TypeArmWorld.OffOrderName }, 1000, type: "GlobalShort");
+        var swept = _w.Svc.CheckErrors(new[] { TypeArmWorld.OffOrderName }, 1000, types: new[] { "GlobalShort" });
 
         Assert.Null(swept.Error);
         Assert.Contains(TypeArmWorld.OffOrderName, swept.OffOrderScanned!);   // the file WAS located and opened
@@ -79,7 +79,7 @@ public sealed class RecordsTypeArmTests
     [Fact]
     public void TheArmTheOffOrderFileHoldsIsExamined()
     {
-        var swept = _w.Svc.CheckErrors(new[] { TypeArmWorld.OffOrderName }, 1000, type: "GlobalFloat");
+        var swept = _w.Svc.CheckErrors(new[] { TypeArmWorld.OffOrderName }, 1000, types: new[] { "GlobalFloat" });
 
         Assert.Null(swept.Error);
         Assert.Contains(TypeArmWorld.OffOrderName, swept.BaseMastersSwept!);

--- a/src/housecarl-mcp-tests/TypeArmWorld.cs
+++ b/src/housecarl-mcp-tests/TypeArmWorld.cs
@@ -10,10 +10,11 @@ using Xunit;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// A world of ABSTRACT-GROUP records only: one GLOB group holding all three of Mutagen's concrete arms
-/// (GlobalShort / GlobalInt / GlobalFloat) and one GMST group holding two of its own. Mutagen models these groups as
-/// an abstract base with concrete subclasses, so a type filter naming an arm is the only case where the resolved
-/// getter type is narrower than the GRUP a typed enumeration seeks.
+/// The TYPE-FILTER world: one GLOB group holding all three of Mutagen's concrete arms (GlobalShort / GlobalInt /
+/// GlobalFloat) and one GMST group holding two of its own. Mutagen models these groups as an abstract base with
+/// concrete subclasses, so a type filter naming an arm is the only case where the resolved getter type is narrower
+/// than the GRUP a typed enumeration seeks. Beside them, one NPC_ and one WEAP each carrying a dangling FormLink,
+/// so a sweep's <c>types=</c> SET has two types that each contribute a finding.
 ///
 /// <para>Its own world: the shared records and bulk worlds carry no globals, and adding any would move counts their
 /// tests assert.</para>
@@ -24,7 +25,7 @@ public sealed class TypeArmWorld : IDisposable
     public string MasterName { get; }
     public LoadOrderService Svc { get; }
 
-    /// <summary>The two GlobalShort records — what a <c>type='GlobalShort'</c> filter must return, and all it must
+    /// <summary>The two GlobalShort records — what a <c>types=['GlobalShort']</c> filter must return, and all it must
     /// return.</summary>
     public const string Short1 = "HcArmShortA";
     public const string Short2 = "HcArmShortB";
@@ -40,10 +41,16 @@ public sealed class TypeArmWorld : IDisposable
     /// record stream. Named for a base-game master because <c>BaseMastersSwept</c> is what exposes that lane's
     /// "examined" set to a test: a swept off-order base master is listed there, and one whose every record a scope
     /// filtered out is not. It holds a GlobalFloat and a GlobalInt and deliberately NO GlobalShort, so a
-    /// <c>type='GlobalShort'</c> sweep of it must examine nothing.</summary>
+    /// <c>types=['GlobalShort']</c> sweep of it must examine nothing.</summary>
     public const string OffOrderName = "Update.esm";
     public const string OffOrderFloat = "HcArmOffFloat";
     public const string OffOrderInt = "HcArmOffInt";
+
+    /// <summary>One NPC_ and one WEAP in the master, each carrying a single dangling FormLink — the two types the
+    /// sweep's set-valued <c>types=</c> tests select over. Globals carry no links at all, so a set whose arms both
+    /// contribute a finding needs records that do.</summary>
+    public const string SweepNpc = "HcArmSweepNpc";
+    public const string SweepWeapon = "HcArmSweepWeapon";
 
     readonly string _priorCorpusPath;
 
@@ -62,6 +69,11 @@ public sealed class TypeArmWorld : IDisposable
         master.Globals.Add(new GlobalShort(master.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = Short2, Data = 2 });
         master.Globals.Add(new GlobalInt(master.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = Int1, Data = 3 });
         master.Globals.Add(new GlobalFloat(master.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = Float1, Data = 4.5f });
+
+        // Two link-bearing records of different types, one dangling ref each: the set-valued types= sweep's subjects.
+        var deadFk = FormKey.Factory("0E0E0E:" + MasterName);
+        var npc = master.Npcs.AddNew(); npc.EditorID = SweepNpc; npc.Race.SetTo(deadFk);
+        var weap = master.Weapons.AddNew(); weap.EditorID = SweepWeapon; weap.ObjectEffect.SetTo(deadFk);
 
         master.GameSettings.Add(new GameSettingInt(master.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = GmstInt, Data = 7 });
         master.GameSettings.Add(new GameSettingFloat(master.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = GmstFloat, Data = 8.5f });

--- a/src/housecarl-mcp/AliasTable.cs
+++ b/src/housecarl-mcp/AliasTable.cs
@@ -59,7 +59,7 @@ internal static class AliasTable
         // rather than a finding and lives on records — a row naming only the sweep would send the caller asking
         // "why does the wrong line play" to a surface that deliberately does not answer it.
         ("housecarl_check_errors",
-         "absorbed into " + ToolNames.Check + ": the same sweep is findings=[\"errors\"], which is also the DEFAULT when findings= is omitted. type=/formids=/editorid_contains=/exclude=/counts_only=/limit=/max_chars=/format= are unchanged; the response is sectioned per family and states which families it did not run."),
+         "absorbed into " + ToolNames.Check + ": the same sweep is findings=[\"errors\"], which is also the DEFAULT when findings= is omitted. type= is SET-VALUED types= (one type is a set of one; a set sweeps their union); formids=/editorid_contains=/exclude=/counts_only=/limit=/max_chars=/format= are unchanged; the response is sectioned per family and states which families it did not run."),
         ("housecarl_validate_scripts",
          "absorbed into " + ToolNames.Check + ": findings=[\"scripts\"] (or a class inside it — 'unbound_object', 'unbound_scalar', 'unbound', 'bound_null'). property_contains= and the record scope are unchanged, exclude= now scopes this family too, and the record listing is under the max_chars bound it was not under before."),
 

--- a/src/housecarl-mcp/CheckAccounting.cs
+++ b/src/housecarl-mcp/CheckAccounting.cs
@@ -41,11 +41,11 @@ internal sealed class CheckAccounting
     // What this lane closes with. Families state different boundaries and the render reserves room per family for
     // the one that will actually be written, so the boundary is read from here rather than chosen at the render.
     readonly string _boundary;
-    // The scope's types where it covered more than one, null otherwise. The listing budget is ONE counter spent in
-    // the order those types are streamed, so a listing that names two types can carry only the first — stated as a
-    // rule wherever the budget dropped something, because the sweep tallies findings by source and target plugin
-    // and never by type, and a per-type count here would be one this response does not have.
-    readonly string? _typeOrder;
+    // The scope's types where it covered more than one, spelled with any expanded arms; null otherwise. There is ONE
+    // listing for the whole scope, so a listing that names two types can carry only one of them — stated as a rule
+    // wherever the listing came out short, because the sweep tallies findings by source and target plugin and never
+    // by type, and a per-type count here would be one this response does not have.
+    readonly string? _typeScope;
 
     /// <summary>Build the accounting for one response, declaring the subjects this lane has.
     ///
@@ -67,7 +67,7 @@ internal sealed class CheckAccounting
         _limit = r.Limit;
         _boundary = ReadSentences.SweepBoundary;
         _bySource = r.DanglingBySource ?? Array.Empty<SweepCount>();
-        _typeOrder = r.TypeScopeOrder;
+        _typeScope = r.TypeScopeLabel;
         _budgetListed = r.Reports.Sum(p => p.Dangling.Count);
         // A refused family declares nothing: a family-local refusal renders as its own section, so this writer is
         // reachable with a failed result, and declaring subjects anyway asserts completeness over a sweep that
@@ -91,7 +91,7 @@ internal sealed class CheckAccounting
         _limit = r.Limit;
         _boundary = ReadSentences.SweepScriptBoundary;
         _bySource = Array.Empty<SweepCount>();
-        _typeOrder = r.TypeScopeOrder;
+        _typeScope = r.TypeScopeLabel;
         // Both measured off the result: the totals the sweep counted regardless of the cap, and the findings the
         // reports actually carry.
         _scriptFindingsFound = r.CountsOnly ? 0 : r.TotalUnbound + r.TotalNullObject;
@@ -299,12 +299,28 @@ internal sealed class CheckAccounting
 
     int Shown(Values v, SweepSubject s) => v.Emitted.TryGetValue(s, out var e) ? e : 0;
 
-    /// <summary>Does this rendering have to state the type-order rule? Only where a multi-type scope was in force
-    /// AND this family's listing budget actually dropped findings — with nothing dropped, the listing IS the whole
-    /// answer for every type in the scope and the rule would warn about a hole that is not there. The worst case
-    /// takes it whenever the scope had one, so the reserve bounds the sentence it can write.</summary>
-    bool TypeOrderShort(Values v)
-        => _typeOrder is not null && (v.Worst || v.ByBudget > 0 || ScriptOmittedByBudget > 0);
+    /// <summary>Findings this family's listing BUDGET never admitted, in either family.</summary>
+    bool ShortByBudget(Values v) => v.ByBudget > 0 || ScriptOmittedByBudget > 0;
+
+    /// <summary>Findings the budget admitted and this response's max_chars then could not fit, in either family.
+    /// The render cuts the same one stream in the same order the budget does, so it can hide a whole type the same
+    /// way — which is why the rule below takes it and not the budget alone.</summary>
+    bool ShortByCut(Values v) => v.ByCut > 0 || Short(v, SweepSubject.ScriptRecords);
+
+    /// <summary>Does this rendering have to state the type-scope rule? Only where a multi-type scope was in force
+    /// AND this family's listing actually came out short — with nothing dropped, the listing IS the whole answer
+    /// for every type in the scope and the rule would warn about a hole that is not there. The worst case takes it
+    /// whenever the scope had one, so the reserve bounds the sentence it can write.</summary>
+    bool TypeScopeShort(Values v)
+        => _typeScope is not null && (v.Worst || ShortByBudget(v) || ShortByCut(v));
+
+    /// <summary>The knob the type-scope rule tells the caller to raise: the one that actually cut this listing, or
+    /// both where both did. The worst case takes the both-spelling, which is the longest, so the reserve bounds it.
+    /// Naming the wrong knob is the whole failure this answers — a listing cut by max_chars is not fixed by
+    /// raising limit=.</summary>
+    string ShortKnob(Values v)
+        => v.Worst || (ShortByBudget(v) && ShortByCut(v)) ? ReadSentences.SweepKnobBoth
+           : ShortByBudget(v) ? ReadSentences.SweepKnobLimit : ReadSentences.SweepKnobMaxChars;
 
     // ---- the text lane ------------------------------------------------------------------------------
 
@@ -399,11 +415,11 @@ internal sealed class CheckAccounting
             sb.Append(string.Format(ReadSentences.SweepUnreadCut, Shown(v, SweepSubject.UnreadRows),
                                     Found(SweepSubject.UnreadRows)));
 
-        // The type-scope rule, wherever the listing budget dropped something under a scope covering more than one
-        // type. It is about the ORDER the one budget was spent in, not about any count, so it is stated as a rule:
-        // the sweep tallies by source and target plugin and never by type, and naming a per-type count here would
-        // be naming a number this response does not have.
-        if (TypeOrderShort(v)) sb.Append(string.Format(ReadSentences.SweepTypeOrderRule, _typeOrder));
+        // The type-scope rule, wherever this listing came out short under a scope covering more than one type —
+        // by the budget, by max_chars, or by both, and it names which. It is about the ONE listing the scope's
+        // types share, not about any count, so it is stated as a rule: the sweep tallies by source and target
+        // plugin and never by type, and naming a per-type count here would be a number this response does not have.
+        if (TypeScopeShort(v)) sb.Append(string.Format(ReadSentences.SweepTypeScopeRule, _typeScope, ShortKnob(v)));
 
         if (v.Roster.Count > 0)
         {
@@ -545,9 +561,13 @@ internal sealed class CheckAccounting
         // states how many of them this response named too.
         if (Has(SweepSubject.DialogueSeedRefusals))
             w.WriteNumber("seeds_unreachable_named", Shown(v, SweepSubject.DialogueSeedRefusals));
-        // The text lane's type-order rule, in this transport's terms and under the same test, so the two lanes
-        // cannot say different things about the same budget.
-        if (TypeOrderShort(v)) w.WriteString("limit_spent_in_type_order", _typeOrder);
+        // The text lane's type-scope rule, in this transport's terms and under the same test, so the two lanes
+        // cannot say different things about the same listing: the types that shared it, and the knob that cut it.
+        if (TypeScopeShort(v))
+        {
+            w.WriteString("listing_short_across_types", _typeScope);
+            w.WriteString("listing_short_by", ShortKnob(v));
+        }
         // A fact about the CALL rather than about any subject, so every lane writes it: the cap it was given.
         w.WriteNumber("max_chars", _cap);
         // The same rule as at the head of this method, applied to the three blocks below: a field named for a

--- a/src/housecarl-mcp/CheckAccounting.cs
+++ b/src/housecarl-mcp/CheckAccounting.cs
@@ -41,6 +41,11 @@ internal sealed class CheckAccounting
     // What this lane closes with. Families state different boundaries and the render reserves room per family for
     // the one that will actually be written, so the boundary is read from here rather than chosen at the render.
     readonly string _boundary;
+    // The scope's types where it covered more than one, null otherwise. The listing budget is ONE counter spent in
+    // the order those types are streamed, so a listing that names two types can carry only the first — stated as a
+    // rule wherever the budget dropped something, because the sweep tallies findings by source and target plugin
+    // and never by type, and a per-type count here would be one this response does not have.
+    readonly string? _typeOrder;
 
     /// <summary>Build the accounting for one response, declaring the subjects this lane has.
     ///
@@ -62,6 +67,7 @@ internal sealed class CheckAccounting
         _limit = r.Limit;
         _boundary = ReadSentences.SweepBoundary;
         _bySource = r.DanglingBySource ?? Array.Empty<SweepCount>();
+        _typeOrder = r.TypeScopeOrder;
         _budgetListed = r.Reports.Sum(p => p.Dangling.Count);
         // A refused family declares nothing: a family-local refusal renders as its own section, so this writer is
         // reachable with a failed result, and declaring subjects anyway asserts completeness over a sweep that
@@ -85,6 +91,7 @@ internal sealed class CheckAccounting
         _limit = r.Limit;
         _boundary = ReadSentences.SweepScriptBoundary;
         _bySource = Array.Empty<SweepCount>();
+        _typeOrder = r.TypeScopeOrder;
         // Both measured off the result: the totals the sweep counted regardless of the cap, and the findings the
         // reports actually carry.
         _scriptFindingsFound = r.CountsOnly ? 0 : r.TotalUnbound + r.TotalNullObject;
@@ -292,6 +299,13 @@ internal sealed class CheckAccounting
 
     int Shown(Values v, SweepSubject s) => v.Emitted.TryGetValue(s, out var e) ? e : 0;
 
+    /// <summary>Does this rendering have to state the type-order rule? Only where a multi-type scope was in force
+    /// AND this family's listing budget actually dropped findings — with nothing dropped, the listing IS the whole
+    /// answer for every type in the scope and the rule would warn about a hole that is not there. The worst case
+    /// takes it whenever the scope had one, so the reserve bounds the sentence it can write.</summary>
+    bool TypeOrderShort(Values v)
+        => _typeOrder is not null && (v.Worst || v.ByBudget > 0 || ScriptOmittedByBudget > 0);
+
     // ---- the text lane ------------------------------------------------------------------------------
 
     /// <summary>The accounting as the text transport states it, or null where there is nothing to account for.
@@ -384,6 +398,12 @@ internal sealed class CheckAccounting
         if (Short(v, SweepSubject.UnreadRows))
             sb.Append(string.Format(ReadSentences.SweepUnreadCut, Shown(v, SweepSubject.UnreadRows),
                                     Found(SweepSubject.UnreadRows)));
+
+        // The type-scope rule, wherever the listing budget dropped something under a scope covering more than one
+        // type. It is about the ORDER the one budget was spent in, not about any count, so it is stated as a rule:
+        // the sweep tallies by source and target plugin and never by type, and naming a per-type count here would
+        // be naming a number this response does not have.
+        if (TypeOrderShort(v)) sb.Append(string.Format(ReadSentences.SweepTypeOrderRule, _typeOrder));
 
         if (v.Roster.Count > 0)
         {
@@ -525,6 +545,9 @@ internal sealed class CheckAccounting
         // states how many of them this response named too.
         if (Has(SweepSubject.DialogueSeedRefusals))
             w.WriteNumber("seeds_unreachable_named", Shown(v, SweepSubject.DialogueSeedRefusals));
+        // The text lane's type-order rule, in this transport's terms and under the same test, so the two lanes
+        // cannot say different things about the same budget.
+        if (TypeOrderShort(v)) w.WriteString("limit_spent_in_type_order", _typeOrder);
         // A fact about the CALL rather than about any subject, so every lane writes it: the cap it was given.
         w.WriteNumber("max_chars", _cap);
         // The same rule as at the head of this method, applied to the three blocks below: a field named for a

--- a/src/housecarl-mcp/CheckTools.cs
+++ b/src/housecarl-mcp/CheckTools.cs
@@ -149,6 +149,9 @@ public static class CheckTools
         [Description("Optional. Max findings to list per family (default 1000). The TRUE totals are always " +
              "reported; over the cap the response says so, and for the errors family says how many plugins lost " +
              "entries, names the ones that lost the most (a count each), and states how many it did not name. " +
+             "It is ONE budget per family, spent in the order the records stream — so under a MULTI-TYPE types= " +
+             "scope it can be spent entirely on the first type and never reach the second. The response says so " +
+             "whenever the budget dropped anything: a type absent from the listing is UNLISTED, not clean. " +
              "BASELINE (errors family): the base-game masters carry permanent vanilla dangling refs no load order " +
              "can fix, so the response splits them out of the total and spends limit= on every other plugin FIRST " +
              "— vanilla cannot crowd mod findings out of the listing. Master-table findings and unverifiable " +

--- a/src/housecarl-mcp/CheckTools.cs
+++ b/src/housecarl-mcp/CheckTools.cs
@@ -38,7 +38,7 @@ public static class CheckTools
          "(dialogue graph validation over SEEDED topics and quests). findings= takes whole families or the classes " +
          "inside them, and carries what each family reports, what it does NOT, and what the default runs — omitted, " +
          "it runs the errors family alone. " +
-         "SCOPE: the two SWEPT families share one — plugins= (off-order files included) / type= / formids= / " +
+         "SCOPE: the two SWEPT families share one — plugins= (off-order files included) / types= / formids= / " +
          "editorid_contains= / exclude=, plus property_contains= on the scripts family. The dialogue family is " +
          "SEEDED instead: seeds= names what to validate, and no plugin scope narrows it. Narrowing narrows the " +
          "COUNTS too: they are always the counts for the scope actually swept, and the response says so. " +
@@ -61,8 +61,8 @@ public static class CheckTools
              "sweep the WHOLE active order — thorough but heavier; scope to one plugin for a fast, focused check " +
              "like the CK's per-plugin 'Check For Errors'.")]
             string[]? plugins = null,
-        [Description("Optional. Record type to sweep — a 4-char signature ('WEAP') or catalog name ('Weapon'). Applied at the record STREAM, so it is the CHEAPEST scope: skipped records cost nothing (no link walk, no .pex chain read). An unknown type is refused, naming what is expected.")]
-            string? type = null,
+        [Description("Optional. Record types to sweep — signatures ('WEAP') or catalog names ('Weapon'); one type is a set of one, and the sweep is the sweep over their UNION with the findings merged. Applied at the record STREAM, so it is the CHEAPEST scope: skipped records cost nothing (no link walk, no .pex chain read), and a two-type sweep costs the two type groups, not the order. An unknown type is refused by name, naming what is expected.")]
+            string[]? types = null,
         [Description("Optional. Sweep ONLY these records ('0BCC84:Skyrim.esm', …) — the re-check-these-few pass after a fix, which limit= cannot do. A malformed token refuses the call before the sweep runs.")]
             string[]? formids = null,
         [Description("Optional. Sweep only records whose EditorID contains this substring (case-insensitive). A record with no EditorID never matches.")]
@@ -166,7 +166,7 @@ public static class CheckTools
              "DIAL validates one topic; a QUST validates EVERY topic that quest owns (plus the quest's own " +
              "CK-parity subrecords and its .seq, checked once); a DLVW or DLBR runs a record-level CK-parity check " +
              "— a bare DLVW crashes the CK's Dialogue Views editor. This family is SEEDED, not swept — " +
-             "plugins=/type=/formids=/editorid_contains=/exclude= do not scope it — and findings=['dialogue'] with " +
+             "plugins=/types=/formids=/editorid_contains=/exclude= do not scope it — and findings=['dialogue'] with " +
              "no seeds is REFUSED on cost, never widened to the whole order (a whole-order pass is a per-topic " +
              "graph walk across every touching plugin, and the order this bound was measured on carries 82,343 " +
              "dialogue topics). limit= caps how many seeds one call expands.")]
@@ -184,7 +184,7 @@ public static class CheckTools
         // parse these in their own service entries, which a dialogue-only call never reaches. Rendered through the
         // normal refusal path rather than returned as a bare string, so format='json' still gets a document.
         // See SweepSharedInput for the split: syntax refuses here, scope matching stays family-local.
-        if (SweepSharedInput.Error(svc, plugins, type, formids, editorid_contains, exclude) is { } inputErr)
+        if (SweepSharedInput.Error(svc, plugins, types, formids, editorid_contains, exclude) is { } inputErr)
         {
             var refusal = new CheckSweep(selection, SharedInputError: inputErr);
             return json ? JsonWire.RenderCheck(refusal, max_chars, lim) : Wire.RenderCheck(refusal, max_chars, lim);
@@ -201,11 +201,11 @@ public static class CheckTools
         ErrorCheckResult? errors = null;
         ScriptCheckResult? scripts = null;
         if (selection.Ran.Contains(SweepFamily.Errors))
-            errors = svc.CheckErrors(plugins, lim, formids, editorid_contains, type,
+            errors = svc.CheckErrors(plugins, lim, formids, editorid_contains, types,
                                      SweepFindings.Tokens(selection.ErrorClasses), counts_only, exclude, offOrderMemo);
         if (selection.Ran.Contains(SweepFamily.Scripts))
             scripts = svc.ValidateScripts(plugins, lim, formids, editorid_contains,
-                                          type, property_contains, SweepFindings.Tokens(selection.ScriptClasses),
+                                          types, property_contains, SweepFindings.Tokens(selection.ScriptClasses),
                                           counts_only, exclude, offOrderMemo);
         DialogueCheckResult? dialogue = null;
         if (selection.Ran.Contains(SweepFamily.Dialogue))

--- a/src/housecarl-mcp/CheckTools.cs
+++ b/src/housecarl-mcp/CheckTools.cs
@@ -149,9 +149,10 @@ public static class CheckTools
         [Description("Optional. Max findings to list per family (default 1000). The TRUE totals are always " +
              "reported; over the cap the response says so, and for the errors family says how many plugins lost " +
              "entries, names the ones that lost the most (a count each), and states how many it did not name. " +
-             "It is ONE budget per family, spent in the order the records stream — so under a MULTI-TYPE types= " +
-             "scope it can be spent entirely on the first type and never reach the second. The response says so " +
-             "whenever the budget dropped anything: a type absent from the listing is UNLISTED, not clean. " +
+             "It is ONE listing per family for every type in scope, filled plugin by plugin and type by type " +
+             "inside each — so under a MULTI-TYPE types= scope ANY of those types can be short in it. The " +
+             "response says so whenever the listing came out short, and names the knob that cut it (limit= or " +
+             "max_chars=): a type absent from the listing is UNLISTED, not clean. " +
              "BASELINE (errors family): the base-game masters carry permanent vanilla dangling refs no load order " +
              "can fix, so the response splits them out of the total and spends limit= on every other plugin FIRST " +
              "— vanilla cannot crowd mod findings out of the listing. Master-table findings and unverifiable " +

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -9260,9 +9260,17 @@ public sealed class LoadOrderService : IDisposable
         return union;
     }
 
-    /// <summary>A user type string to its getter Types. Throws, naming the bad input and what is expected.</summary>
+    /// <summary>A user type string to its getter Types. Throws, naming the bad input and what is expected.
+    /// <para>A BLANK entry is refused as blank, in this one place, so every surface that takes a type set — the
+    /// records surface and the check sweep alike — states the same rule: an entry that names no type is refused
+    /// saying it is blank, never quoted back as an unknown type <c>''</c>. An empty or absent SET is a different
+    /// thing (no narrowing) and is handled by the callers.</para></summary>
     IReadOnlyList<Type> ResolveTypeFilter(string type)
     {
+        if (type.Trim().Length == 0)
+            throw new ArgumentException(
+                "a blank record type — pass a 4-char signature (e.g. 'WEAP') or a catalog name (e.g. 'Weapon'), " +
+                "or omit the parameter to leave the types unnarrowed.");
         if (TypeLookup.TryGetValue(type.Trim(), out var types)) return types;
         throw new ArgumentException(
             $"unknown record type '{type}'. Expected a 4-char signature (e.g. 'WEAP') or a catalog name (e.g. 'Weapon').");

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4431,18 +4431,7 @@ public sealed class LoadOrderService : IDisposable
                 return CrossQueryOutcome.Fail(ArtifactEpochMismatch(demand, view.Epoch)) with { Stamp = view.Stamp };
 
         IReadOnlyList<Type>? types;
-        try
-        {
-            if (hasType)
-            {
-                var union = new List<Type>();
-                foreach (var ts in typeSet!)
-                    foreach (var t in ResolveTypeFilter(ts.Trim()))
-                        if (!union.Contains(t)) union.Add(t);
-                types = union;
-            }
-            else types = null;
-        }
+        try { types = ResolveTypeFilterSet(hasType ? typeSet : null); }
         catch (ArgumentException ex) { return CrossQueryOutcome.Fail(ex.Message); }   // unknown type
 
         if (predicate is not null && hasType && QuantifierShapeRefusal(typeSet!, predicate) is { } qerr)
@@ -4912,18 +4901,7 @@ public sealed class LoadOrderService : IDisposable
                 return CrossQueryOutcome.Fail(ArtifactEpochMismatch(demand, view.Epoch)) with { Stamp = view.Stamp };
 
         IReadOnlyList<Type>? types;
-        try
-        {
-            if (typeSet is { Count: > 0 })
-            {
-                var union = new List<Type>();
-                foreach (var ts in typeSet)
-                    foreach (var t in ResolveTypeFilter(ts.Trim()))
-                        if (!union.Contains(t)) union.Add(t);
-                types = union;
-            }
-            else types = null;
-        }
+        try { types = ResolveTypeFilterSet(typeSet); }
         catch (ArgumentException ex) { return CrossQueryOutcome.Fail(ex.Message); }
 
         if (predicate is not null && typeSet is { Count: > 0 } && QuantifierShapeRefusal(typeSet, predicate) is { } qerr)
@@ -5113,11 +5091,11 @@ public sealed class LoadOrderService : IDisposable
     /// typed values.</para></summary>
     public ErrorCheckResult CheckErrors(IReadOnlyList<string>? plugins, int limit,
                                         IReadOnlyList<string>? formids = null, string? editoridContains = null,
-                                        string? type = null, IReadOnlyList<string>? findings = null,
+                                        IReadOnlyList<string>? types = null, IReadOnlyList<string>? findings = null,
                                         bool countsOnly = false, IReadOnlyList<string>? exclude = null,
                                         SweepOffOrderMemo? offOrderMemo = null)
     {
-        var (recordScope, scopeErr) = BuildSweepScope(formids, editoridContains, type);
+        var (recordScope, scopeErr) = BuildSweepScope(formids, editoridContains, types);
         if (scopeErr is not null) return ErrorCheckResult.Fail(scopeErr);
         if (!SweepFindings.TryParseErrorClasses(findings, out var classes, out var classErr))
             return ErrorCheckResult.Fail(classErr!);
@@ -5221,14 +5199,16 @@ public sealed class LoadOrderService : IDisposable
     /// (<see cref="SweepSharedInput"/>). The scope itself belongs to whichever family is about to sweep with it;
     /// what is shared is the judgement that a value is malformed, and that judgement has to be reachable without
     /// selecting a family that uses it.</summary>
-    internal string? SweepScopeError(IReadOnlyList<string>? formids, string? editoridContains, string? type)
-        => BuildSweepScope(formids, editoridContains, type).Error;
+    internal string? SweepScopeError(IReadOnlyList<string>? formids, string? editoridContains,
+                                     IReadOnlyList<string>? types)
+        => BuildSweepScope(formids, editoridContains, types).Error;
 
     /// <summary>Parse the sweep families' shared record-scope params into a <see cref="SweepScope"/>: FormID tokens,
-    /// an EditorID substring, and a record type resolved through the same type lookup the scan uses. Every malformed
-    /// input is a named refusal returned before the sweep starts, never a scope that silently matched nothing.
-    /// Returns (null, null) when nothing was narrowed, so the unscoped path stays untouched.</summary>
-    (SweepScope? Scope, string? Error) BuildSweepScope(IReadOnlyList<string>? formids, string? editoridContains, string? type)
+    /// an EditorID substring, and a record type SET resolved through the same type lookup the scan uses. Every
+    /// malformed input is a named refusal returned before the sweep starts, never a scope that silently matched
+    /// nothing. Returns (null, null) when nothing was narrowed, so the unscoped path stays untouched.</summary>
+    (SweepScope? Scope, string? Error) BuildSweepScope(IReadOnlyList<string>? formids, string? editoridContains,
+                                                       IReadOnlyList<string>? typeSet)
     {
         HashSet<FormKey>? keys = null;
         if (formids is { Count: > 0 })
@@ -5244,12 +5224,14 @@ public sealed class LoadOrderService : IDisposable
             }
         }
 
+        // The set is the union of its entries, resolved the way records= resolves types= — one type is a set of one.
         IReadOnlyList<Type>? types = null;
-        var typeLabel = type?.Trim();
-        if (!string.IsNullOrEmpty(typeLabel))
+        string? typeLabel = null;
+        if (typeSet is { Count: > 0 })
         {
-            try { types = ResolveTypeFilter(typeLabel); }
+            try { types = ResolveTypeFilterSet(typeSet); }
             catch (ArgumentException ex) { return (null, ex.Message); }
+            typeLabel = string.Join(", ", typeSet.Select(t => (t ?? "").Trim()));
         }
 
         var scope = new SweepScope(keys, editoridContains, types, typeLabel);
@@ -5270,12 +5252,12 @@ public sealed class LoadOrderService : IDisposable
     /// has just written.</para></summary>
     public ScriptCheckResult ValidateScripts(IReadOnlyList<string>? plugins, int limit,
                                              IReadOnlyList<string>? formids = null, string? editoridContains = null,
-                                             string? type = null, string? propertyContains = null,
+                                             IReadOnlyList<string>? types = null, string? propertyContains = null,
                                              IReadOnlyList<string>? findings = null, bool countsOnly = false,
                                              IReadOnlyList<string>? exclude = null,
                                              SweepOffOrderMemo? offOrderMemo = null)
     {
-        var (recordScope, scopeErr) = BuildSweepScope(formids, editoridContains, type);
+        var (recordScope, scopeErr) = BuildSweepScope(formids, editoridContains, types);
         if (scopeErr is not null) return ScriptCheckResult.Fail(scopeErr);
         if (!SweepFindings.TryParseScriptClasses(findings, out var classes, out var classErr))
             return ScriptCheckResult.Fail(classErr!);
@@ -9263,6 +9245,19 @@ public sealed class LoadOrderService : IDisposable
                     Add(ts.Name, at);
         }
         return lookup;
+    }
+
+    /// <summary>A user type SET to its getter Types: the union of each entry's resolution, in order, deduped — one
+    /// grammar with the singular form, since every entry goes through <see cref="ResolveTypeFilter"/> and an unknown
+    /// one throws naming itself. Null for an absent or empty set, so the unnarrowed path stays untouched.</summary>
+    IReadOnlyList<Type>? ResolveTypeFilterSet(IReadOnlyList<string>? types)
+    {
+        if (types is not { Count: > 0 }) return null;
+        var union = new List<Type>();
+        foreach (var ts in types)
+            foreach (var t in ResolveTypeFilter((ts ?? "").Trim()))
+                if (!union.Contains(t)) union.Add(t);
+        return union;
     }
 
     /// <summary>A user type string to its getter Types. Throws, naming the bad input and what is expected.</summary>

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -5227,14 +5227,15 @@ public sealed class LoadOrderService : IDisposable
         // The set is the union of its entries, resolved the way records= resolves types= — one type is a set of one.
         IReadOnlyList<Type>? types = null;
         string? typeLabel = null;
+        string? armLabel = null;
         if (typeSet is { Count: > 0 })
         {
-            try { types = ResolveTypeFilterSet(typeSet); }
+            try { types = ResolveTypeFilterSet(typeSet, out armLabel); }
             catch (ArgumentException ex) { return (null, ex.Message); }
             typeLabel = string.Join(", ", typeSet.Select(t => (t ?? "").Trim()));
         }
 
-        var scope = new SweepScope(keys, editoridContains, types, typeLabel);
+        var scope = new SweepScope(keys, editoridContains, types, typeLabel, armLabel);
         return (scope.IsEmpty ? null : scope, null);
     }
 
@@ -9250,13 +9251,26 @@ public sealed class LoadOrderService : IDisposable
     /// <summary>A user type SET to its getter Types: the union of each entry's resolution, in order, deduped — one
     /// grammar with the singular form, since every entry goes through <see cref="ResolveTypeFilter"/> and an unknown
     /// one throws naming itself. Null for an absent or empty set, so the unnarrowed path stays untouched.</summary>
-    IReadOnlyList<Type>? ResolveTypeFilterSet(IReadOnlyList<string>? types)
+    IReadOnlyList<Type>? ResolveTypeFilterSet(IReadOnlyList<string>? types) => ResolveTypeFilterSet(types, out _);
+
+    /// <summary>The same resolution, also spelling each entry with the arms it expanded to
+    /// (<see cref="SweepScope.SpellTypeEntry"/>) — the label a response needs when it has to name the types that
+    /// share one listing, since an entry like <c>GMST</c> names none of them by itself.</summary>
+    IReadOnlyList<Type>? ResolveTypeFilterSet(IReadOnlyList<string>? types, out string? armLabel)
     {
+        armLabel = null;
         if (types is not { Count: > 0 }) return null;
         var union = new List<Type>();
+        var spelled = new List<string>(types.Count);
         foreach (var ts in types)
-            foreach (var t in ResolveTypeFilter((ts ?? "").Trim()))
+        {
+            var entry = (ts ?? "").Trim();
+            var arms = ResolveTypeFilter(entry);
+            foreach (var t in arms)
                 if (!union.Contains(t)) union.Add(t);
+            spelled.Add(SweepScope.SpellTypeEntry(entry, arms));
+        }
+        armLabel = string.Join(", ", spelled);
         return union;
     }
 

--- a/src/housecarl-mcp/ReadSentences.cs
+++ b/src/housecarl-mcp/ReadSentences.cs
@@ -277,15 +277,29 @@ internal static class ReadSentences
     [MustState("not named here")]
     internal const string SweepRosterCut = " (the {0} largest of {1}; the rest are not named here)";
 
-    /// <summary>The type-scope rule, stated wherever a MULTI-TYPE scope was in force and the listing budget dropped
-    /// something. The budget is one counter spent in the order the scope's types are streamed, so a type later in
-    /// that order can be missing from the listing entirely — and a listing that names two types while showing one
-    /// otherwise reads as "the other one is clean".</summary>
-    [MustState("limit=", "unlisted", "not clean")]
-    internal const string SweepTypeOrderRule =
-        " limit= is ONE listing budget, spent in the order the scope's types are streamed (types=[{0}]), so a type " +
-        "later in that order can be absent from the listing above: absent there means unlisted, not clean. Sweep " +
-        "that type alone, or raise limit=.";
+    /// <summary>The type-scope rule, stated wherever a MULTI-TYPE scope was in force and the listing above came out
+    /// short. There is ONE listing for every type in the scope, and it is filled plugin by plugin (non-base plugins
+    /// first, base masters last) with the scope's types streamed inside each plugin — so no type is finished before
+    /// the next begins, and ANY of them can be missing from a short listing. A listing that names two types while
+    /// showing one otherwise reads as "the other one is clean". <c>{1}</c> is the knob that cut it.</summary>
+    [MustState("ONE listing", "unlisted", "not clean")]
+    internal const string SweepTypeScopeRule =
+        " There is ONE listing for every type in the scope (types=[{0}]), filled plugin by plugin (non-base plugins " +
+        "first, base masters last) and type by type inside each, and {1} cut it short — so ANY of those types can be " +
+        "missing from it: absent there means unlisted, not clean. Sweep that type alone, or raise {1}.";
+
+    /// <summary>The knob names the type-scope rule points at, one per cause. Consts rather than literals at the
+    /// render so the sentence and its reserve name the same knob, and the both-causes spelling is the longest.</summary>
+    [MustState("limit=")]
+    internal const string SweepKnobLimit = "limit=";
+
+    /// <inheritdoc cref="SweepKnobLimit"/>
+    [MustState("max_chars=")]
+    internal const string SweepKnobMaxChars = "max_chars=";
+
+    /// <inheritdoc cref="SweepKnobLimit"/>
+    [MustState("limit=", "max_chars=")]
+    internal const string SweepKnobBoth = "limit= and max_chars=";
 
     /// <summary>A rule about the listing rather than a claim about this response's contents, stated wherever a
     /// roster is: it tells the reader that a plugin with no section of its own is still in that roster.</summary>

--- a/src/housecarl-mcp/ReadSentences.cs
+++ b/src/housecarl-mcp/ReadSentences.cs
@@ -277,6 +277,16 @@ internal static class ReadSentences
     [MustState("not named here")]
     internal const string SweepRosterCut = " (the {0} largest of {1}; the rest are not named here)";
 
+    /// <summary>The type-scope rule, stated wherever a MULTI-TYPE scope was in force and the listing budget dropped
+    /// something. The budget is one counter spent in the order the scope's types are streamed, so a type later in
+    /// that order can be missing from the listing entirely — and a listing that names two types while showing one
+    /// otherwise reads as "the other one is clean".</summary>
+    [MustState("limit=", "unlisted", "not clean")]
+    internal const string SweepTypeOrderRule =
+        " limit= is ONE listing budget, spent in the order the scope's types are streamed (types=[{0}]), so a type " +
+        "later in that order can be absent from the listing above: absent there means unlisted, not clean. Sweep " +
+        "that type alone, or raise limit=.";
+
     /// <summary>A rule about the listing rather than a claim about this response's contents, stated wherever a
     /// roster is: it tells the reader that a plugin with no section of its own is still in that roster.</summary>
     [MustState("no section of its own")]

--- a/src/housecarl-mcp/SweepSharedInput.cs
+++ b/src/housecarl-mcp/SweepSharedInput.cs
@@ -25,9 +25,9 @@ internal static class SweepSharedInput
 
     /// <summary>The whole call's refusal where a shared input is malformed, or null where every one of them parses.
     /// Checked in the order a caller reads the parameters, so a call with two bad values names the first.</summary>
-    /// <param name="svc">the service, for the record-scope parse — <c>type=</c> resolves through the same
-    /// TypeLookup <c>cross_plugin_query</c> uses, which lives there.</param>
-    internal static string? Error(LoadOrderService svc, IReadOnlyList<string>? plugins, string? type,
+    /// <param name="svc">the service, for the record-scope parse — <c>types=</c> resolves through the same
+    /// TypeLookup the records surface uses, which lives there.</param>
+    internal static string? Error(LoadOrderService svc, IReadOnlyList<string>? plugins, IReadOnlyList<string>? types,
                                   IReadOnlyList<string>? formids, string? editoridContains,
                                   IReadOnlyList<string>? exclude)
     {
@@ -36,7 +36,7 @@ internal static class SweepSharedInput
                 if ((name ?? "").Trim().Length == 0)
                     return BlankPluginName;
 
-        if (svc.SweepScopeError(formids, editoridContains, type) is { } scopeErr) return scopeErr;
+        if (svc.SweepScopeError(formids, editoridContains, types) is { } scopeErr) return scopeErr;
 
         // Syntax only — see the split above. Resolve is handed an empty implicit set deliberately: neither value it
         // can refuse depends on what `implicit` expands to, and expanding it would read the MO2 composition for a

--- a/src/housecarl-mcp/SweepSharedInput.cs
+++ b/src/housecarl-mcp/SweepSharedInput.cs
@@ -6,7 +6,7 @@ namespace HousecarlMcp;
 /// What every findings family agrees is malformed, validated once before the merged <c>check</c> surface dispatches
 /// to any of them.
 ///
-/// <para>The families parse <c>type=</c>, <c>formids=</c>, <c>plugins=</c> and <c>exclude=</c> themselves, but the
+/// <para>The families parse <c>types=</c>, <c>formids=</c>, <c>plugins=</c> and <c>exclude=</c> themselves, but the
 /// merged tool calls a family only where it was selected — so a selection none of those parameters scope would run
 /// with nothing ever looking at them, and a typo'd narrowing would come back as an ordinary answer.</para>
 ///


### PR DESCRIPTION
Aaron's ruling of 2026-09-09 (dev/DECISIONS.md): `housecarl_check`'s scalar `type=` becomes the set-valued `types=` per the 2.0 spec's §5.1 rule that every selector is set-valued and one value is a set of one, core plumbing included. This does that. The parameter now takes a list of record type signatures or catalog names — the same value form and the same lookup `housecarl_records`' `types=` takes — and a sweep over N types is the sweep over each with the findings merged: the resolved types are the union of the entries, handed to the record stream exactly as the single type was, so the types you did not name still cost nothing per skipped record. A single value still works as a set of one, an unknown entry is still refused by name, and the response's narrowing line now names every type in the set. The union resolve itself is one helper (`ResolveTypeFilterSet`) that the records scan's two call sites and the sweep scope now share, so there is one grammar rather than three copies of the same loop. The parameter description, the `check_errors` alias row and the merged tool's scope lines are updated to match; no skill, eval or doc spelled `check(... type=`.

Tests: a two-type sweep reporting both types' findings, a one-type sweep still answering over that type alone, the narrowing line naming both types, and an unknown entry refusing the sweep by name. The type-filter world gains one NPC_ and one WEAP with a dangling link each, since its globals carry no links for a sweep to find.

Build, `dotnet test --filter "tier!=bridge"` (1967 passed), `ci-all` (128/128) and `scripts/build-plugin.ps1 -PluginTreeOnly` all clean.

Note: PR #685 renames other tools' parameters and does not touch check; nothing here depends on it.
