### PR TITLE
Fix comments naming tools and probes that no longer exist

### DIFF
--- a/src/housecarl-core/DeletedRecordRule.cs
+++ b/src/housecarl-core/DeletedRecordRule.cs
@@ -33,7 +33,7 @@ namespace HousecarlCore;
 ///   • its FormKey — <see cref="RemapEngine.IdentifyExternalReferencers"/>'s external-OVERRIDER test is identity-only
 ///     (a deleted override of a record about to be renumbered is still a dependent worth warning about), so it runs
 ///     BEFORE this guard, not behind it.
-///   • its EditorID — cross_plugin_query's editoridContains= filter stays live (EDID is an early subrecord, read
+///   • its EditorID — the scan's editorid-contains filter stays live (EDID is an early subrecord, read
 ///     before the deep body parse that can throw).
 ///
 /// CONSEQUENCE: a deleted record whose body DOES parse and DOES link to a searched target is not returned by

--- a/src/housecarl-core/DialogueCheck.cs
+++ b/src/housecarl-core/DialogueCheck.cs
@@ -15,8 +15,8 @@ namespace HousecarlCore;
 public sealed record DialogueSeedResult(string Seed, DialogueValidationReport? Report, string? Refusal);
 
 /// <summary>
-/// The DIALOGUE family's result on the merged <c>check</c> surface: <c>housecarl_validate_dialogue</c>'s findings
-/// (its classes 1-7) over a seed list, aggregated so one response can carry several seeds' worth.
+/// The DIALOGUE family's result on the merged <c>check</c> surface: the dialogue validator's findings
+/// (classes 1-7) over a seed list, aggregated so one response can carry several seeds' worth.
 ///
 /// <para><b>Class 8 is deliberately absent.</b> The effective merged INFO order is an ordered sequence over the
 /// touching-plugin stack, not a findings list, so it lives on <c>records project=info_order</c>. Both surfaces share

--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -95,7 +95,7 @@ public sealed record SeqLintFinding(
     bool QuestIsSge, string DefiningPlugin, string WinnerPlugin, uint OnDiskFormId,
     bool SeqExists, bool? SeqContainsQuest, bool? SeqNewerThanPlugin, string? Note);
 
-/// <summary>The whole-validation report for one <c>housecarl_validate_dialogue</c> call: the resolved input
+/// <summary>The whole-validation report for one dialogue-validation call: the resolved input
 /// (<see cref="Input"/>, <see cref="InputKind"/> = "topic"/"quest"/"view"/"branch"/"error",
 /// <see cref="InputEditorId"/>) and the per-topic validations. A top-level recoverable miss (the FormID isn't in
 /// the order, or resolves to none of the four input types) is a NAMED <see cref="Error"/>; a mid-run throw is

--- a/src/housecarl-core/EffectChain.cs
+++ b/src/housecarl-core/EffectChain.cs
@@ -7,7 +7,7 @@ namespace HousecarlCore;
 /// <summary>
 /// The effect-chain resolver: given a MagicEffect (MGEF), find every record that APPLIES it and the
 /// magnitude/area/duration of the matching effect entry. It collapses the hand-trace
-/// "cross_plugin_query references=&lt;MGEF&gt; type=SPEL → read each hit's Effects[].Data → keep the entry whose
+/// "scan references=&lt;MGEF&gt; types=SPEL → read each hit's Effects[].Data → keep the entry whose
 /// BaseEffect is the MGEF, then repeat for ENCH/ALCH/SCRL/INGR" into one call. The inverse-by-magnitude of
 /// references=: that says WHICH carriers reference the effect; this says which entry, and at what strength.
 ///
@@ -121,7 +121,7 @@ public static class EffectChain
         {
             foreach (var (fk, _, body) in view.WinnerRecordsOfType(scope, unreadable))
             {
-                // PER-RECORD FAULT ISOLATION (twin of the cross_plugin_query scan): Match lazily parses subrecord
+                // PER-RECORD FAULT ISOLATION (twin of the records scan): Match lazily parses subrecord
                 // content, so ONE record Mutagen can't parse is excluded + accounted, not an opaque whole-call abort.
                 try
                 {

--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -5,10 +5,10 @@ using Mutagen.Bethesda.Skyrim;
 namespace HousecarlCore;
 
 /// <summary>
-/// The load-order integrity sweep (housecarl_check_errors): the data-layer twin of the Creation Kit's "Check For
+/// The load-order integrity sweep (the errors family on housecarl_check): the data-layer twin of the Creation Kit's "Check For
 /// Errors" / xEdit's error check. For each plugin in scope it walks EVERY record's FormLinks (Mutagen's own
 /// <see cref="IFormLinkContainerGetter.EnumerateFormLinks"/> — the by-construction link surface, the same one
-/// cross_plugin_query references= rides) and reports three error classes:
+/// the records scan's references= filter rides) and reports three error classes:
 ///   • DANGLING — a non-null FormLink whose target NO plugin in the active order defines (<see cref="LoadOrderResolver.IndexView.ResolveWinner"/>
 ///     is null): a broken reference in the resolvable order. Engine-implicit forms (PlayerRef 000014, Player 000007 —
 ///     hardcoded refs the index can't resolve but that are never actually broken) are exempted via <see cref="EngineImplicit"/>,
@@ -20,7 +20,7 @@ namespace HousecarlCore;
 ///     (<see cref="LoadOrderResolver.IndexView.ContainsPlugin"/> is false): the plugin's dependency is not installed /
 ///     enabled, the most common load-order break (and the root cause behind a cluster of that master's refs dangling).
 ///   • PARSE failures — per-record (a body whose link walk THROWS is excluded and accounted, never a silent skip — the
-///     fault-isolation twin of the cross_plugin_query scan) and whole-plugin (plugins the index build could not parse,
+///     fault-isolation twin of the records scan) and whole-plugin (plugins the index build could not parse,
 ///     surfaced via <see cref="LoadOrderResolver.IndexView.ExcludedPlugins"/>).
 ///
 /// WHY NOT the master-TABLE diff the CK/xEdit also show (declared-vs-used) — the honest scope boundary:
@@ -266,7 +266,7 @@ public static class ErrorCheck
                              ? view.RecordsIn(new[] { plugin }, recordScope?.Types)
                              : Enumerable.Empty<(FormKey, int, IMajorRecordGetter, string)>())
                 {
-                    // PER-RECORD FAULT ISOLATION (twin of the cross_plugin_query scan): EnumerateFormLinks lazily
+                    // PER-RECORD FAULT ISOLATION (twin of the records scan): EnumerateFormLinks lazily
                     // parses subrecord content, so ONE record Mutagen can't parse is excluded and accounted, never an
                     // opaque whole-call abort and never a silent skip.
                     try

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -9,7 +9,8 @@ namespace HousecarlCore;
 /// A field-VALUE predicate over a record body — the query-side complement to <see cref="ReadEngine"/>.
 ///
 /// <para>Where a records scan can already scope and shape results by a record's IDENTITY and LINKS
-/// (type / editorid_contains / references), a <see cref="FieldPredicateSet"/> filters by a field's VALUE:
+/// (types= / references=, and this same where= grammar's own 'editorid' term), a <see cref="FieldPredicateSet"/>
+/// filters by a field's VALUE:
 /// <c>"MagicSkill = Destruction"</c>, <c>"BasicStats.Damage &gt;= 50"</c>, <c>"Archetype.ActorValue = Infamy"</c>.
 /// Multiple predicates are ANDed (the wire is <c>where: string[]</c>).</para>
 ///

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -8,7 +8,7 @@ namespace HousecarlCore;
 /// <summary>
 /// A field-VALUE predicate over a record body — the query-side complement to <see cref="ReadEngine"/>.
 ///
-/// <para>Where <c>cross_plugin_query</c> can already scope and shape results by a record's IDENTITY and LINKS
+/// <para>Where a records scan can already scope and shape results by a record's IDENTITY and LINKS
 /// (type / editorid_contains / references), a <see cref="FieldPredicateSet"/> filters by a field's VALUE:
 /// <c>"MagicSkill = Destruction"</c>, <c>"BasicStats.Damage &gt;= 50"</c>, <c>"Archetype.ActorValue = Infamy"</c>.
 /// Multiple predicates are ANDed (the wire is <c>where: string[]</c>).</para>

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -1202,7 +1202,7 @@ public sealed class LoadOrderResolver : IDisposable
     }
 
     // ---- Cross-query scan primitives -------------------
-    //  These feed cross_plugin_query. Each is a SINGLE enumeration pass that yields the matching record's body
+    //  These feed the records cross-plugin scan. Each is a SINGLE enumeration pass that yields the matching record's body
     //  IN HAND: fetching each winner body separately instead costs a whole-overlay re-enumeration per candidate,
     //  which is minutes over a large type. The body the service filters on is this in-hand body; the resolver holds
     //  nothing past the yield. Each opens the CURRENT plugin, enumerates it, and DISPOSES it before moving to the

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -189,9 +189,9 @@ public static class ReadEngine
 
     /// <summary>The depth-1 container hint: appended to an unexpanded container/substruct summary so an agent turns
     /// the depth= knob instead of inventing a param. It names <c>depth=2</c>, which is only honest on a surface that
-    /// HAS a depth= parameter (read_record / batch_record_detail / read_plugin_file / cross_plugin_query text+json /
-    /// the CLI). A caller whose surface refuses depth passes its own redirect via <c>containerHint</c>
-    /// (cross_plugin_query's DENSE render names the text/json format hop — its positional cells refuse depth&gt;1),
+    /// HAS a depth= parameter (housecarl_records' read and scan lanes in text+json, and the CLI).
+    /// A caller whose surface refuses depth passes its own redirect via <c>containerHint</c>
+    /// (the scan's DENSE render names the text/json format hop — its positional cells refuse depth&gt;1),
     /// or null to suppress it (write read-backs, where the count IS the confirmation).</summary>
     public const string DepthExpandHint = " — pass depth=2 to expand";
 

--- a/src/housecarl-core/RemapEngine.cs
+++ b/src/housecarl-core/RemapEngine.cs
@@ -203,7 +203,7 @@ public static class RemapEngine
             {
                 foreach (var (fk, _, body, _) in view.RecordsIn(new[] { plugin }, null))
                 {
-                    // PER-RECORD fault isolation, as in cross_plugin_query and ErrorCheck: EnumerateFormLinks lazily
+                    // PER-RECORD fault isolation, as in the records scan and ErrorCheck: EnumerateFormLinks lazily
                     // parses subrecord content, so ONE record Mutagen can't parse is counted and sampled, never an
                     // opaque whole-call abort and never a silent skip.
                     try

--- a/src/housecarl-generator/BulkCreateGuardProbe.cs
+++ b/src/housecarl-generator/BulkCreateGuardProbe.cs
@@ -14,7 +14,8 @@ namespace HousecarlGenerator;
 /// synthetic MO2 instance in temp (the write-mutex-guard synth pattern: real ModOrganizer.ini + profile + a master
 /// mod), so the wire's NEW logic (type resolution from a string, parent/collection passthrough, per-record batch
 /// aggregation, MO2 folder-per-patch output) runs end-to-end. (The MCP argument binding above the service is generic
-/// SDK + already covered by binding-shim-guard; this drives the service methods directly, as write-mutex-guard does.)
+/// SDK + covered by the binding-shim tests in housecarl-mcp-tests; this drives the service methods directly, as
+/// write-mutex-guard does.)
 /// Run: dotnet run --project src/housecarl-generator -- bulk-create-guard
 ///
 /// Arms (ALL required):

--- a/src/housecarl-generator/BulkCreateGuardProbe.cs
+++ b/src/housecarl-generator/BulkCreateGuardProbe.cs
@@ -14,7 +14,8 @@ namespace HousecarlGenerator;
 /// synthetic MO2 instance in temp (the write-mutex-guard synth pattern: real ModOrganizer.ini + profile + a master
 /// mod), so the wire's NEW logic (type resolution from a string, parent/collection passthrough, per-record batch
 /// aggregation, MO2 folder-per-patch output) runs end-to-end. (The MCP argument binding above the service is generic
-/// SDK + covered by the binding-shim tests in housecarl-mcp-tests; this drives the service methods directly, as
+/// SDK + covered by the binding-shim tests in housecarl-mcp-tests (RecordsBindingShimTests,
+/// ToolCallShimWirePathTests, ToolCallShimCoercionTests); this drives the service methods directly, as
 /// write-mutex-guard does.)
 /// Run: dotnet run --project src/housecarl-generator -- bulk-create-guard
 ///

--- a/src/housecarl-generator/CreateGlobalProbe.cs
+++ b/src/housecarl-generator/CreateGlobalProbe.cs
@@ -35,7 +35,7 @@ namespace HousecarlGenerator;
 ///   G6  BASEREFUSE   — create RecordType='Global' (the bare abstract base) is REFUSED loud, the message NAMES the
 ///                      concrete arms, NOTHING written. (Green today as a regression guard, not a fix-proof — it keeps
 ///                      the loud-fail boundary loud after the fix opened the concrete-arm path beside it.)
-///   G7  READMAP      — the READ-SIDE base→arm mapping (LoadOrderService.BuildTypeLookup): a cross_plugin_query
+///   G7  READMAP      — the READ-SIDE base→arm mapping (LoadOrderService.BuildTypeLookup): a records scan with
 ///                      type='Global' over an order holding a GlobalFloat AND a GlobalInt resolves (no "unknown type")
 ///                      and returns BOTH — proving the abstract base NAME unions its concrete arms (the read-side twin
 ///                      of the create branch). The union spanning two DISTINCT arms is the observable form of the

--- a/src/housecarl-generator/CreateGlobalProbe.cs
+++ b/src/housecarl-generator/CreateGlobalProbe.cs
@@ -36,10 +36,10 @@ namespace HousecarlGenerator;
 ///                      concrete arms, NOTHING written. (Green today as a regression guard, not a fix-proof — it keeps
 ///                      the loud-fail boundary loud after the fix opened the concrete-arm path beside it.)
 ///   G7  READMAP      — the READ-SIDE base→arm mapping (LoadOrderService.BuildTypeLookup): a records scan with
-///                      type='Global' over an order holding a GlobalFloat AND a GlobalInt resolves (no "unknown type")
+///                      types=['Global'] over an order holding a GlobalFloat AND a GlobalInt resolves (no "unknown type")
 ///                      and returns BOTH — proving the abstract base NAME unions its concrete arms (the read-side twin
 ///                      of the create branch). The union spanning two DISTINCT arms is the observable form of the
-///                      "4 arms" by-construction claim. type='GameSetting' returns its GameSettingFloat (generality).
+///                      "4 arms" by-construction claim. types=['GameSetting'] returns its GameSettingFloat (generality).
 ///                      RED before the fix (BuildTypeLookup skipped polymorphic-base names → "unknown record type").
 /// </summary>
 public static class CreateGlobalProbe

--- a/src/housecarl-generator/DeletedLinkWalkProbe.cs
+++ b/src/housecarl-generator/DeletedLinkWalkProbe.cs
@@ -26,7 +26,7 @@ namespace HousecarlGenerator;
 /// record with an EMPTY body — the clean case, not the wild one), so both are written normally and then patched on
 /// disk via <see cref="ProbeBytes"/>: the Deleted header flag OR-ed on, and (crash arm) one EPFT byte corrupted.
 ///
-///   check_errors — HcDlwGhost.esm (on disk, NOT loaded → every ref into it fails to resolve) + HcDlwErr.esp:
+///   errors family — HcDlwGhost.esm (on disk, NOT loaded → every ref into it fails to resolve) + HcDlwErr.esp:
 ///     LiveDangler (NPC, Race → the ghost race)  — CONTROL: a live dangling ref the sweep must STILL report.
 ///     DeadDangler (NPC, same link, Deleted)     — SEMANTIC arm: must NOT be reported dangling.
 ///     DeadThrower (PERK, EPFT corrupt, Deleted) — CRASH arm: must NOT be accounted unscannable.
@@ -80,7 +80,7 @@ public static class DeletedLinkWalkProbe
     }
 
     // =====================================================================================
-    //  housecarl_check_errors — ErrorCheck.Run
+    //  the errors family — ErrorCheck.Run
     // =====================================================================================
     static int CheckErrorsArms(string tmpDir, Action<string, bool, string?> Check)
     {

--- a/src/housecarl-generator/DeletedLinkWalkProbe.cs
+++ b/src/housecarl-generator/DeletedLinkWalkProbe.cs
@@ -8,8 +8,8 @@ namespace HousecarlGenerator;
 
 /// <summary>
 /// SELF-CONTAINED CI REGRESSION GUARD (<c>deleted-link-walk-guard</c>) for #279 — the DELETED-record rule in the two
-/// link walkers that <c>deleted-record-scan-guard</c> (#276, cross_plugin_query) does NOT cover:
-///   • <see cref="ErrorCheck.Run"/> — housecarl_check_errors' dangling-ref sweep.
+/// link walkers that <c>deleted-record-scan-guard</c> (#276, the records scan) does NOT cover:
+///   • <see cref="ErrorCheck.Run"/> — the errors family's dangling-ref sweep.
 ///   • <see cref="RemapEngine.IdentifyExternalReferencers"/> — the compact/merge dependency scan.
 /// All three now route through <see cref="DeletedRecordRule.HasNoLiveBody"/>; this pins the two new ones so the set
 /// can't drift back apart.

--- a/src/housecarl-generator/DialogueCkParityGuardProbe.cs
+++ b/src/housecarl-generator/DialogueCkParityGuardProbe.cs
@@ -20,7 +20,7 @@ namespace HousecarlGenerator;
 ///   • the create-path NON-OVERRIDE — an explicit value is never clobbered,
 ///   • the QUALIFYING VALUES — FavorLevel=None, materialized Flags, DNAM=00, ENAM=00000000 (S1); Category=Player,
 ///     Priority=50, NextAliasID=max+1/0, objective Flags=0 (S2) — the CK's own defaults, byte-verified vs vanilla,
-///   • the BNAM lint — housecarl_validate_dialogue WARNS a Custom topic with no Branch (the CK-views-crash catch),
+///   • the BNAM lint — the dialogue validator WARNS a Custom topic with no Branch (the CK-views-crash catch),
 ///     and does NOT warn a Custom topic that HAS a branch.
 /// Driven over a synthetic MO2 instance in temp (the dialogue-subtype-marker-guard synth pattern; no game files needed).
 /// Run: dotnet run --project src/housecarl-generator -- dialogue-ckparity-guard

--- a/src/housecarl-generator/DialogueSubtypeMarkerGuardProbe.cs
+++ b/src/housecarl-generator/DialogueSubtypeMarkerGuardProbe.cs
@@ -13,7 +13,7 @@ namespace HousecarlGenerator;
 ///   • the authoritative index→marker table (DialogueSubtype) — structural shape + the reporter-confirmed anchors,
 ///   • the create-path AUTO-FILL — create a topic through the service and read the written SNAM back off disk,
 ///   • the create-path NON-OVERRIDE — an explicit SubtypeName is never clobbered,
-///   • the validator ESCALATION — housecarl_validate_dialogue reports a blank marker as a PROBLEM, not a neutral fact.
+///   • the validator ESCALATION — the dialogue validator reports a blank marker as a PROBLEM, not a neutral fact.
 /// Driven over a synthetic MO2 instance in temp (the bulk-create-guard synth pattern; no game files needed).
 /// Run: dotnet run --project src/housecarl-generator -- dialogue-subtype-marker-guard
 ///

--- a/src/housecarl-generator/DialogueValidateGuardProbe.cs
+++ b/src/housecarl-generator/DialogueValidateGuardProbe.cs
@@ -9,7 +9,7 @@ namespace HousecarlGenerator;
 
 /// <summary>
 /// SELF-CONTAINED CI REGRESSION GUARD for the on-demand dialogue-graph validator (nested-dialogue plan §3.6, Layer B
-/// unit C part C2 — housecarl_validate_dialogue). Drives the REAL core path (DialogueValidate.Run) against a SYNTHESIZED
+/// unit C part C2 — the dialogue findings family). Drives the REAL core path (DialogueValidate.Run) against a SYNTHESIZED
 /// master in TEMP — NO Skyrim.esm, so it runs in CI. The master carries one topic per validation shape, a quest that
 /// owns two topics (the fan-out), a weapon (the wrong-type reject) + a not-in-order FormKey (the absent reject).
 /// Run: dotnet run --project src/housecarl-generator -- dialogue-validate-guard

--- a/src/housecarl-generator/EffectChainProbe.cs
+++ b/src/housecarl-generator/EffectChainProbe.cs
@@ -12,7 +12,7 @@ namespace HousecarlGenerator;
 /// SYNTHESIZED 1-plugin order in TEMP — NO Skyrim.esm, so it runs in CI.
 ///
 /// THE GAP (reproduced by construction): there was no one call from a MagicEffect to "applied by these records, at
-/// these magnitudes" — you re-ran cross_plugin_query references=&lt;MGEF&gt; for SPEL, then ENCH, ALCH, SCRL, INGR, and
+/// these magnitudes" — you re-ran a scan with references=&lt;MGEF&gt; for SPEL, then ENCH, ALCH, SCRL, INGR, and
 /// hand-read each hit's matching Effects[].Data. Resolve collapses that into one verb.
 ///
 /// THE FIX (generic by construction): the five effect-bearing records share ONE element type (IEffectGetter), so
@@ -42,7 +42,7 @@ namespace HousecarlGenerator;
 ///
 /// COVERAGE NOTE (Q3 — name what this guard LEANS ON rather than re-proves; PR #107 review): the fixture is ONE
 /// plugin, so the winner-only scan (WinnerRecordsOfType) and the per-row winner= are exercised only at depth 0. Both
-/// are the SAME shared primitive cross_plugin_query uses, multi-plugin-proven in source-display-guard +
+/// are the SAME shared primitive the records scan uses, multi-plugin-proven in source-display-guard +
 /// snapshot-view-guard — so override/winner behavior is covered transitively, not re-proven here. The MATCH-ALL-FIVE
 /// arm is the canary for a sixth effect-bearing record (it would simply not be scanned).
 ///

--- a/src/housecarl-generator/EpochGuardProbe.cs
+++ b/src/housecarl-generator/EpochGuardProbe.cs
@@ -19,7 +19,7 @@ namespace HousecarlGenerator;
 ///   2  SENSITIVITY — a content edit (mtime change, NEWER or OLDER — the restored-backup case must not be
 ///      invisible), a reorder, and a set change each produce a DIFFERENT epoch; RefreshIfStale over an
 ///      unchanged order keeps it.
-///   3  STAMPS — every index-backed lane carries the capture's epoch: cross_plugin_query (incl. the Fail path
+///   3  STAMPS — every index-backed lane carries the capture's epoch: the records scan (incl. the Fail path
 ///      staying null — a refusal that never consulted a build must not invent one), batch (ONE epoch for the
 ///      whole batch; a malformed-formid row carries none), single read (refusals INCLUDED — "not present" is an
 ///      answer about a build), resolve (out-epoch), effect_chain, status. The diff, check_errors and
@@ -201,7 +201,7 @@ internal static class EpochGuardProbe
                 Check(IsEpochToken(current), $"Stats() names the current build epoch — '{current}'");
                 Check(svc.StatusData().Epoch == current, "StatusData carries the same epoch (the status line's source)");
 
-                // cross_plugin_query — outcome stamp + all three renders + the Fail path
+                // the records scan — outcome stamp + all three renders + the Fail path
                 var q = svc.CrossQuery("WEAP", null, null, false, null, null, 500);
                 Check(q.Epoch == current, "cross_plugin_query outcome stamps the scanned build");
                 Check(Wire.RenderCrossQuery(svc, q, null, 0).Contains($"epoch={current}"), "…text render carries epoch=<hex> in the header");

--- a/src/housecarl-generator/PerkRefsProbe.cs
+++ b/src/housecarl-generator/PerkRefsProbe.cs
@@ -266,7 +266,7 @@ public static class PerkRefsProbe
     public static int RunDiagnose(string[] args)
     {
         // --mo2 <instanceDir>: sweep the WHOLE load order through the PRODUCT stream (WinnerRecordsOfType),
-        // the exact loop cross_plugin_query runs. Without it: a quick single-plugin sweep of Skyrim.esm.
+        // the exact loop the records scan runs. Without it: a quick single-plugin sweep of Skyrim.esm.
         var f = HousecarlCore.WriteEngine.ParseFlags(args);
         if (f.GetValueOrDefault("mo2") is { } instanceDir) return DiagnoseFullOrder(instanceDir);
 

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -150,7 +150,7 @@ if (args.Length > 0 && args[0] == "remove-create-probe") return RemoveCreateProb
 // Remove-record recon: whole-record removal via mod.Remove(FormKey) — flat, nested, and not-found semantics.
 if (args.Length > 0 && args[0] == "remove-record-probe") return RemoveRecordProbe.RunProbe(args[1..]);
 
-// Drive WritePatchBuilder.RemoveRecords, the core housecarl_remove_record calls, against a real, large load order.
+// Drive WritePatchBuilder.RemoveRecords, the core housecarl_remove calls, against a real, large load order.
 if (args.Length > 0 && args[0] == "remove-proof") return RemoveProof.RunRemoveProof(args[1..]);
 
 // Create recon: generic AddNew dispatch, FormID allocation, fields-via-ApplyVerb, and the nested/abstract-T scope fork.

--- a/src/housecarl-generator/RemoveProof.cs
+++ b/src/housecarl-generator/RemoveProof.cs
@@ -8,7 +8,7 @@ using HousecarlCore;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// Build proof for <see cref="WritePatchBuilder.RemoveRecords"/>, the core the <c>housecarl_remove_record</c> tool
+/// Build proof for <see cref="WritePatchBuilder.RemoveRecords"/>, the core the <c>housecarl_remove</c> tool
 /// calls. It must drive the same code path the tool does, or it proves nothing about it. Each check SEEDS a patch
 /// carrying real override(s) — the only records a removal can target — then removes through the core and re-reads
 /// from disk:

--- a/src/housecarl-generator/SchemaFlattenProbe.cs
+++ b/src/housecarl-generator/SchemaFlattenProbe.cs
@@ -9,12 +9,12 @@ namespace HousecarlGenerator;
 /// REGRESSION GUARD for <see cref="ToolSchemas"/>'s <c>$ref</c> flattening (#451) — the MECHANISM. Most arms run
 /// over synthetic documents; ARM 6 drives the real strict reader and ARM 7 reads every registered tool's real
 /// pre-flatten schema, so the scope is no longer synthetic throughout.
-/// <c>binding-shim-guard</c>'s SCHEMA arms cover the invariant on the real published surface, which
+/// <c>PublishedSchemaShapeTests</c> covers the no-<c>$ref</c> invariant on the real served surface, which
 /// exercises only the one shape today's DTOs generate (a positional back-reference carrying a description and an
 /// empty <c>items</c> placeholder). Three of the cases below — <c>$defs</c> recursion, mutual recursion, an
 /// unresolvable pointer — have no end-to-end producer and would otherwise ship unproven. The placeholder-sibling
 /// merge (ARM 4) DOES have one: 20 of the 30 pre-fix published refs carried that empty <c>items</c>, and deleting
-/// the merge reddens <c>binding-shim-guard</c> unaided. It is kept here because this is where the merge rule is
+/// the merge reddens that suite unaided. It is kept here because this is where the merge rule is
 /// stated, not because nothing else would catch it.
 ///
 /// These arms pin the mechanism's stated behaviour; they do NOT establish general JSON Schema conformance. What is

--- a/src/housecarl-generator/SeqStalenessProbe.cs
+++ b/src/housecarl-generator/SeqStalenessProbe.cs
@@ -6,7 +6,7 @@ using HousecarlCore;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// SELF-CONTAINED CI REGRESSION GUARD for the SEQ staleness/coverage lint (1.3.1 item 7 — housecarl_validate_dialogue).
+/// SELF-CONTAINED CI REGRESSION GUARD for the SEQ staleness/coverage lint (1.3.1 item 7 — the dialogue findings family).
 /// Drives the REAL core path (DialogueValidate.Run) over a synthetic load order of base masters — each with a
 /// start-game-enabled quest — plus planted / omitted / aged .seq files under a temp Data root. NO Skyrim.esm, so it
 /// runs in CI. Asserts the per-quest SeqLintFinding the validator attaches to the report.

--- a/src/housecarl-generator/SourceDisplayProbe.cs
+++ b/src/housecarl-generator/SourceDisplayProbe.cs
@@ -8,7 +8,7 @@ namespace HousecarlGenerator;
 
 /// <summary>
 /// REGRESSION GUARD (standing CI instrument) for the winner-vs-source DISPLAY fix (session-review wishlist #8):
-/// <c>cross_plugin_query</c>'s per-match render must show the body the scan FILTERED — under <c>plugins=[X]</c> the
+/// the records scan's per-match render must show the body the scan FILTERED — under <c>plugins=[X]</c> the
 /// scoped plugin's OWN override, under <c>type=</c> the load-order winner — and never silently the winner under a
 /// <c>plugins=</c> scope (the pre-existing bug: filter on X's value, display the winner's, which can CONTRADICT the
 /// filter you typed).

--- a/src/housecarl-generator/ValuePredicateProbe.cs
+++ b/src/housecarl-generator/ValuePredicateProbe.cs
@@ -7,7 +7,7 @@ using HousecarlCore;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// REGRESSION GUARD (standing CI instrument) for the field-value query predicate (cross_plugin_query where=).
+/// REGRESSION GUARD (standing CI instrument) for the field-value query predicate (the records scan's where=).
 ///
 /// Self-contained, in the pattern of <c>depth-leak-guard</c> / <c>pkcu-regression</c>: synthesizes records IN
 /// MEMORY with KNOWN field values, runs the product evaluator (<see cref="FieldPredicateSet"/>), and asserts the

--- a/src/housecarl-mcp/AliasTable.cs
+++ b/src/housecarl-mcp/AliasTable.cs
@@ -3,7 +3,8 @@ namespace HousecarlMcp;
 /// <summary>The retired tool names and the successor each call is redirected to in words. The old → new
 /// PARAMETER table that stood beside them was build scaffolding and was deleted at 2.0.0 (SPEC §5.4
 /// amendment 2026-09-06): a 1.x parameter name is now refused by name like any other unknown one. These rows
-/// stay, because a call to a 1.x TOOL name is the error rule applied to an unknown name, not old-name
+/// TOOL-name rows are NOT scaffolding and have no removal date — they stay past 2.0.0, because a call to a
+/// 1.x TOOL name is the error rule applied to an unknown name, not old-name
 /// acceptance — nothing is accepted, redirected or executed, the call is refused with one sentence naming its
 /// 2.0 successor. Without them the caller gets the SDK's bare "Unknown tool" and no way forward.</summary>
 internal static class AliasTable

--- a/src/housecarl-mcp/AliasTable.cs
+++ b/src/housecarl-mcp/AliasTable.cs
@@ -2,7 +2,7 @@ namespace HousecarlMcp;
 
 /// <summary>The retired tool names and the successor each call is redirected to in words. The old → new
 /// PARAMETER table that stood beside them was build scaffolding and was deleted at 2.0.0 (SPEC §5.4
-/// amendment 2026-09-06): a 1.x parameter name is now refused by name like any other unknown one. These rows
+/// amendment 2026-09-06): a 1.x parameter name is now refused by name like any other unknown one. The
 /// TOOL-name rows are NOT scaffolding and have no removal date — they stay past 2.0.0, because a call to a
 /// 1.x TOOL name is the error rule applied to an unknown name, not old-name
 /// acceptance — nothing is accepted, redirected or executed, the call is refused with one sentence naming its

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -419,7 +419,7 @@ static class JsonWire
     internal const int ChildUnionMemberCap = 100;
 
     /// <summary>Serialize a resolved record: identity + winner/override_depth/source + the fields array. Shared by
-    /// read_record, batch_record_detail, and the cross_plugin_query detail path (one shape, no drift). <paramref
+    /// housecarl_records' single-record, batch and scan detail paths (one shape, no drift). <paramref
     /// name="matches"/> carries the multi-target references= un-merge when present.</summary>
     /// <param name="childFields">Collects the annotated field paths this record's array carried, for the
     /// response-level clause. Batch/query lanes pass ONE set across their rows and state the clause after the
@@ -458,8 +458,8 @@ static class JsonWire
         if (fields.Count > 0) w.WriteString("owned_child_note", ReadSentences.OwnedChildClause(fields, unioned));
     }
 
-    // ---- housecarl_batch_record_detail --------------------------------------------------------------
-    /// <summary>batch_record_detail as JSON: <c>{count, records:[…], rendered, truncated}</c>. A bad/absent formid is
+    // ---- housecarl_records: the batch read ----------------------------------------------------------
+    /// <summary>A batch read as JSON: <c>{count, records:[…], rendered, truncated}</c>. A bad/absent formid is
     /// a per-item <c>{formid,error}</c> so the batch survives. Truncation drops trailing records and flags it — the
     /// document stays valid JSON, and count is exact.</summary>
     public static string RenderBatch(IReadOnlyList<ReadOutcome> outcomes, int maxChars)
@@ -1103,8 +1103,8 @@ static class JsonWire
         return Finish(ms);
     }
 
-    // ---- housecarl_cross_plugin_query ---------------------------------------------------------------
-    /// <summary>cross_plugin_query as JSON — three shapes matching the text render: group_by count table
+    // ---- housecarl_records: the cross-plugin scan ---------------------------------------------------
+    /// <summary>A cross-plugin scan as JSON — three shapes matching the text render: group_by count table
     /// (<c>{group_by, total, groups:[…]}</c>), detail rows (full record objects with fields), or summary rows
     /// (<c>{formid,type,editorid,winner,override_depth}</c>). The accounting (total/capped/notes/truncated) rides
     /// in-band. The detail path threads resolve_names through the SAME ResolveRead the text render uses, so the two
@@ -1242,7 +1242,7 @@ static class JsonWire
             : $"field values are each match's SCOPED plugin's OWN version, NOT the live load-order winner — pass {wf} for load-order truth.";
     }
 
-    // ---- housecarl_cross_plugin_query format=dense --------------------------------------------------
+    // ---- housecarl_records: the cross-plugin scan, format=dense ------------------------------------
     /// <summary>The columnar render: a <c>columns</c> array once, then ONE positional row array per match —
     /// <c>[formid, editorid, field values…]</c> under fields= (plus a <c>source</c> column under a plugins= scope,
     /// naming the body each row's values were read from), <c>[formid, type, editorid, winner, override_depth]</c>

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2600,7 +2600,7 @@ public sealed partial class LoadOrderService : IDisposable
     /// formid named twice in one batch pays once; the projection and the <c>plugin=</c> scope are fixed for a whole
     /// call, so the record is the whole key.
     /// <para>Its presence is also the SWITCH: a lane that hands one in gets the union, a lane that hands null gets
-    /// the index-only note. The scan lanes (<c>cross_plugin_query</c> detail rows, the dense grid, the artifact
+    /// the index-only note. The scan lanes (the scan's detail rows, the dense grid, the artifact
     /// spill of a scan) discover their row count rather than being handed it, so a body-per-toucher per row is a
     /// cost the caller never asked for — they state the index-only tier and name the formids lane, which assembles
     /// the union for records the caller named.</para></summary>
@@ -2666,7 +2666,7 @@ public sealed partial class LoadOrderService : IDisposable
     internal const int ConflictDiffDepth = 16;
 
     /// <summary>A header-only summary for one record (winner + type + editorid, no field dump) — the compact
-    /// one-line-per-match view cross_plugin_query uses by default. One winner-body fetch; holds nothing.</summary>
+    /// one-line-per-match view a cross-plugin scan uses by default. One winner-body fetch; holds nothing.</summary>
     public RecordSummary ResolveSummary(FormKey fk)
     {
         var resolver = Resolver;
@@ -8617,9 +8617,7 @@ public sealed partial class LoadOrderService : IDisposable
         var byEsp = OwnedFoldersHolding(espName)
             .Select(p => Path.GetDirectoryName(p)!).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
         if (byEsp.Count == 1) return byEsp[0];
-        // Known wrong for one class of caller: this arm and the folder catch-all below both say "pass into=", which a
-        // tool that declares no into= parameter cannot do — such a caller gets an unknown-parameter refusal instead.
-        // Unfixed here; the remedy needs the calling surface's own vocabulary, like laneClause below.
+        // Ambiguous: refuse and name every candidate folder as a ready-to-paste into= value.
         if (byEsp.Count > 1)
             throw new InvalidOperationException(
                 $"cannot extend: {byEsp.Count} houseCARL folders carry '{espName}' — ambiguous, refusing to guess. " +
@@ -9390,7 +9388,7 @@ public sealed record ReadOutcome(
     public static ReadOutcome Fail(FormKey fk, string error) => new(fk, null, null, null, 0, null, error);
 }
 
-/// <summary>The outcome of a cross_plugin_query. <see cref="Error"/> non-null ⇒ the query was rejected (with a
+/// <summary>The outcome of a cross-plugin scan. <see cref="Error"/> non-null ⇒ the query was rejected (with a
 /// recoverable, named reason — bad filter combo / unknown type / plugin not in order). Otherwise <see cref="Keys"/>
 /// are the matched FormKeys (at most `limit`); <see cref="Prefilled"/> (parallel to Keys) carries the in-hand
 /// summaries for the type/plugins paths, or is null for the conflicts_only-alone path (the renderer fills those
@@ -9435,11 +9433,11 @@ public sealed record CrossQueryOutcome(
     public static CrossQueryOutcome Fail(string error) => new(Array.Empty<FormKey>(), null, 0, false, error);
 }
 
-/// <summary>One row of a cross_plugin_query <c>group_by=</c> aggregation: a group key (winner plugin / record type /
+/// <summary>One row of a scan's <c>group_by=</c> aggregation: a group key (winner plugin / record type /
 /// defining plugin) and how many matches fell in it. Emitted instead of per-match lines when group_by is set.</summary>
 public sealed record GroupCount(string Key, int Count);
 
-/// <summary>A compact, header-only record summary (no field dump) — the per-match line cross_plugin_query emits
+/// <summary>A compact, header-only record summary (no field dump) — the per-match line a scan emits
 /// by default. <see cref="Error"/> non-null ⇒ the winner couldn't be summarised (named, recoverable).</summary>
 public sealed record RecordSummary(FormKey FormKey, string Type, string? EditorId, string Winner, int OverrideDepth, string? Error)
 {


### PR DESCRIPTION
Comments only, no behaviour change, no CHANGELOG line. Four stale comments were found false today: the extend refusal in `LoadOrderService.ResolveOwnedPatchFolder` carried a "known wrong / unfixed here" note about a caller (`housecarl_remove_record`) that no longer exists, since `housecarl_remove` declares `into=` (#377); `BulkCreateGuardProbe` and `SchemaFlattenProbe` claimed a `binding-shim-guard` probe deleted at fd31979f; and `AliasTable`'s header could be read as retiring the tool-name rows at 2.0.0, when only the parameter table was scaffolding and the tool rows stay past 2.0.0. While there, a sweep of `src/` fixed the other comments naming a retired tool in the present tense; comments that name one as history, deliberate fixtures, and probe console output were left alone.

What changed:

- `src/housecarl-mcp/LoadOrderService.cs` — the extend-refusal note replaced with one line saying what the refusal does; four doc comments renamed `cross_plugin_query` to the records scan.
- `src/housecarl-generator/BulkCreateGuardProbe.cs`, `SchemaFlattenProbe.cs` — the deleted probe replaced by what covers those invariants now (the binding-shim tests, and `PublishedSchemaShapeTests`).
- `src/housecarl-mcp/AliasTable.cs` — the header now says the TOOL-name rows are not scaffolding and stay past 2.0.0.
- `src/housecarl-mcp/JsonWire.cs` — four section headers / summaries renamed off `batch_record_detail` and `cross_plugin_query` onto `housecarl_records`.
- `src/housecarl-core/` — `DeletedRecordRule.cs`, `EffectChain.cs`, `ErrorCheck.cs` (also `housecarl_check_errors` → the errors family on `housecarl_check`), `FieldPredicate.cs`, `LoadOrderResolver.cs`, `ReadEngine.cs` (the depth= hint no longer names four retired tools), `RemapEngine.cs`, `DialogueCheck.cs`, `DialogueValidate.cs`.
- `src/housecarl-generator/` — `Program.cs` and `RemoveProof.cs` (`housecarl_remove_record` → `housecarl_remove`), `DeletedLinkWalkProbe.cs`, `EffectChainProbe.cs`, `EpochGuardProbe.cs`, `SourceDisplayProbe.cs`, `ValuePredicateProbe.cs`, `CreateGlobalProbe.cs`, `PerkRefsProbe.cs`, and the four dialogue guards that named `housecarl_validate_dialogue` in the present tense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
