### PR TITLE
List every legal field in the unknown-field refusal

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **A refusal for an unknown field now lists every field the record type has.** The `housecarl_create`
+  pre-flight used to name twelve fields and then `(+N more)`, with nothing on the surface showing the rest
+  — for a record type with no instance in the load order that refusal is the only place the schema is
+  visible. It now lists all of them up to forty names, and past that names the `mutagen-reference` skill
+  as where the remainder is.
 - **`housecarl_create` refuses a dialogue branch with no `Flags` instead of filling one.** A `DialogBranch`
   created with no `Flags` is now refused in one sentence naming both values and what each does — `TopLevel`
   for a menu entry the player can pick, `0` for a scripted `Say()` topic that must stay hidden — and nothing

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,11 +13,13 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
-- **A refusal for an unknown field now lists every field the record type has.** The `housecarl_create`
-  pre-flight used to name twelve fields and then `(+N more)`, with nothing on the surface showing the rest
-  — for a record type with no instance in the load order that refusal is the only place the schema is
-  visible. It now lists all of them up to forty names, and past that names the `mutagen-reference` skill
-  as where the remainder is.
+- **A refusal for an unknown field now names every field the record type has.** `housecarl_apply` and
+  `housecarl_create` run the same pre-flight, and it used to name twelve fields and then `(+N more)` with no
+  route from the call to the rest — a write call is the only place the surface shows a type's schema without
+  an instance of that type in the load order, so the cut ended there. It now names them all, and where the
+  list is too long to be a sentence it cuts and says in the same sentence that the `mutagen-reference` skill
+  carries the remainder. Where the cut falls, and what it is set against, is on `FieldListCap` in
+  `src/housecarl-core/CorpusRulebook.cs`.
 - **`housecarl_create` refuses a dialogue branch with no `Flags` instead of filling one.** A `DialogBranch`
   created with no `Flags` is now refused in one sentence naming both values and what each does — `TopLevel`
   for a menu entry the player can pick, `0` for a scripted `Say()` topic that must stay hidden — and nothing

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -1370,10 +1370,18 @@ public sealed class CorpusRulebook
                   $"that arm: {h.Slot}='{h.Path}', key='{h.Key}' — {WriteVerbs.HowToPlaceOneAt(shape)}."
             : "Read the element first to learn its concrete arm, then target a field whose shape is unambiguous.";
 
+    /// <summary>How many field names this refusal prints before it cuts. For a type with no instance in the load
+    /// order the refusal is the only on-surface schema source, so it lists every field up to this cap — which all
+    /// but a couple of dozen modeled types are under — and past it names where the rest are.</summary>
+    const int FieldListCap = 40;
+
     string FieldNotFound(TypeSchema owner, string name)
     {
-        var sample = owner.Fields.Select(f => f.Name).Take(12).ToList();
-        var more = owner.Fields.Count > sample.Count ? $", … (+{owner.Fields.Count - sample.Count} more)" : "";
+        var sample = owner.Fields.Select(f => f.Name).Take(FieldListCap).ToList();
+        var more = owner.Fields.Count > sample.Count
+            ? $", … (+{owner.Fields.Count - sample.Count} more — the full field list for '{owner.Name}' is in the " +
+              "mutagen-reference skill)"
+            : "";
         var arms = owner is { Kind: "polymorphic-base", Arms.Count: > 0 }
             ? $" Also searched its arms ({string.Join(", ", owner.Arms!.Where(a => a != owner.Name))})."
             : "";

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -1370,15 +1370,25 @@ public sealed class CorpusRulebook
                   $"that arm: {h.Slot}='{h.Path}', key='{h.Key}' — {WriteVerbs.HowToPlaceOneAt(shape)}."
             : "Read the element first to learn its concrete arm, then target a field whose shape is unambiguous.";
 
-    /// <summary>How many field names this refusal prints before it cuts. For a type with no instance in the load
-    /// order the refusal is the only on-surface schema source, so it lists every field up to this cap — which all
-    /// but a couple of dozen modeled types are under — and past it names where the rest are.</summary>
+    /// <summary>How many field names this refusal prints before it cuts. A write call is the only place on the
+    /// surface that shows a type's schema without an instance of it in the load order, so the refusal lists every
+    /// field up to this cap and past it names where the rest are. The cap sits above every common record type
+    /// (Weapon, Armor, the Placed* family, Cell) and below the handful that are pages long (Race, Weather,
+    /// EffectShader).</summary>
     const int FieldListCap = 40;
+
+    /// <summary>How far past the cap a type may run and still print whole. The pointer costs ~90 characters to buy
+    /// back names averaging ~15, so a cut only pays once it hides about six of them — without this, a type a name
+    /// or two over the cap would hide one field behind a sentence longer than the field. Lets the cap be a
+    /// judgement about sentence length rather than a number that has to sit clear of wherever the corpus's type
+    /// sizes happen to cluster.</summary>
+    const int FieldListCapSlack = 6;
 
     string FieldNotFound(TypeSchema owner, string name)
     {
-        var sample = owner.Fields.Select(f => f.Name).Take(FieldListCap).ToList();
-        var more = owner.Fields.Count > sample.Count
+        var cuts = owner.Fields.Count > FieldListCap + FieldListCapSlack;
+        var sample = owner.Fields.Select(f => f.Name).Take(cuts ? FieldListCap : owner.Fields.Count).ToList();
+        var more = cuts
             ? $", … (+{owner.Fields.Count - sample.Count} more — the full field list for '{owner.Name}' is in the " +
               "mutagen-reference skill)"
             : "";

--- a/src/housecarl-mcp-tests/FieldNotFoundListTests.cs
+++ b/src/housecarl-mcp-tests/FieldNotFoundListTests.cs
@@ -4,9 +4,10 @@ using Xunit;
 namespace HousecarlMcpTests;
 
 /// <summary>
-/// The pre-flight refusal for an unknown field is the only on-surface schema source for a record type with no
-/// instance in the load order, so it must not cut the list short with nowhere to look for the rest (#688). It now
-/// lists every field up to a cap, and past the cap names the mutagen-reference skill.
+/// A write call is the only place on the surface that shows a record type's schema without an instance of it in
+/// the load order, so its pre-flight refusal for an unknown field must not cut the list short with nowhere to look
+/// for the rest (#688). It now lists every field up to a cap plus a slack, and past that names the
+/// mutagen-reference skill.
 ///
 /// <para>Corpus-only, so it needs no records — the world is here for the generated corpus
 /// <c>CorpusRulebook.CorpusPath</c> points at.</para>
@@ -27,6 +28,15 @@ public sealed class FieldNotFoundListTests : BulkRecordsTestBase
         return r!;
     }
 
+    /// <summary>Every field name the corpus carries for <paramref name="recordType"/> must appear in the refusal —
+    /// "cuts nothing" said directly, rather than by the absence of one literal from the message.</summary>
+    static void AssertNamesEveryField(string recordType, string refusal)
+    {
+        var fields = CorpusRulebook.LoadCorpus().Types[recordType].Fields.Select(f => f.Name).ToList();
+        Assert.NotEmpty(fields);
+        foreach (var f in fields) Assert.Contains(f, refusal);
+    }
+
     /// <summary>The reported call: a PlacedArrow create with a bad field. Its 29 fields all fit under the cap, so
     /// the refusal names every one of them — including 'Reflections', the field fourteen further probe calls never
     /// reached behind the old cut at twelve.</summary>
@@ -37,7 +47,20 @@ public sealed class FieldNotFoundListTests : BulkRecordsTestBase
 
         Assert.Contains("Reflections", r);
         Assert.Contains("VirtualMachineAdapter", r);
-        Assert.DoesNotContain("more)", r);
+        AssertNamesEveryField("PlacedArrow", r);
+    }
+
+    /// <summary>A type just past the cap prints whole rather than hiding a name behind a pointer longer than the
+    /// name: Weapon runs 41 fields, one over the cap and inside the slack, so nothing is cut and the caller reads
+    /// the field a bare cap would have hidden ('VirtualMachineAdapter', last of the alphabetical list) in the
+    /// refusal itself.</summary>
+    [Fact]
+    public void ATypeInsideTheSlackPrintsWholeRatherThanHidingAName()
+    {
+        var r = Refusal("Weapon", "NoSuchField");
+
+        Assert.DoesNotContain("mutagen-reference", r);
+        AssertNamesEveryField("Weapon", r);
     }
 
     /// <summary>Past the cap the list still cuts — 83 names is not a sentence — but the same sentence says where

--- a/src/housecarl-mcp-tests/FieldNotFoundListTests.cs
+++ b/src/housecarl-mcp-tests/FieldNotFoundListTests.cs
@@ -1,0 +1,53 @@
+using HousecarlCore;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>
+/// The pre-flight refusal for an unknown field is the only on-surface schema source for a record type with no
+/// instance in the load order, so it must not cut the list short with nowhere to look for the rest (#688). It now
+/// lists every field up to a cap, and past the cap names the mutagen-reference skill.
+///
+/// <para>Corpus-only, so it needs no records — the world is here for the generated corpus
+/// <c>CorpusRulebook.CorpusPath</c> points at.</para>
+/// </summary>
+[Trait("tier", "integration")]
+[Collection("bulk-records")]
+public sealed class FieldNotFoundListTests : BulkRecordsTestBase
+{
+    public FieldNotFoundListTests(BulkRecordsFixture f) : base(f) { }
+
+    static string Refusal(string recordType, string field)
+    {
+        var r = CorpusRulebook.Load().Validate(new WriteRequest
+        {
+            RecordType = recordType, Path = new[] { field }, Verb = "Set", Value = "1",
+        });
+        Assert.NotNull(r);
+        return r!;
+    }
+
+    /// <summary>The reported call: a PlacedArrow create with a bad field. Its 29 fields all fit under the cap, so
+    /// the refusal names every one of them — including 'Reflections', the field fourteen further probe calls never
+    /// reached behind the old cut at twelve.</summary>
+    [Fact]
+    public void AShortTypeListsEveryFieldAndCutsNothing()
+    {
+        var r = Refusal("PlacedArrow", "NoSuchField");
+
+        Assert.Contains("Reflections", r);
+        Assert.Contains("VirtualMachineAdapter", r);
+        Assert.DoesNotContain("more)", r);
+    }
+
+    /// <summary>Past the cap the list still cuts — 83 names is not a sentence — but the same sentence says where
+    /// the rest are, so the caller is never left with an unreachable remainder.</summary>
+    [Fact]
+    public void ALongTypeCutsButNamesWhereTheRestAre()
+    {
+        var r = Refusal("Race", "NoSuchField");
+
+        Assert.Contains("more —", r);
+        Assert.Contains("mutagen-reference", r);
+    }
+}


### PR DESCRIPTION
The `housecarl_create` pre-flight refusal for an unknown field named twelve legal fields and then `(+N more)`, and nothing else on the surface showed the rest: for a record type with no instance in the load order that refusal is the only place the schema is visible, so a `PlacedArrow` create left seventeen fields unreachable and fourteen further probe calls never found `Reflections`. The refusal now prints every field up to a cap of forty names — all but a couple of dozen modeled types are under it, and the median type has nine fields — and past the cap it keeps the cut but says in the same sentence that the full list is in the `mutagen-reference` skill. It is still one sentence, no new tool or parameter, and the cut helper is local to this message, so no other refusal changes. A new test drives the reported call (a PARW create with a bad field) and asserts the full list, plus the capped `Race` case that names where the rest are.

Closes #688

Changelog line added under `## Unreleased` in `plugin/CHANGELOG.md`.

Build clean; `dotnet test src/housecarl-mcp-tests -c Release --no-build --filter "tier!=bridge"` 1917/1917 passed; `ci-all` 127/127 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
