### PR TITLE
Render a present-but-null nullable link apart from an absent one

### DIFF
--- a/docs/dialogue.md
+++ b/docs/dialogue.md
@@ -36,9 +36,9 @@ housecarl_records(formids=["02707A:Skyrim.esm"], project={"form":"info_order"})
 ```
 
 A line the order marks *pinned first by its own PNAM marker* carries that present-zero PNAM: leave it alone.
-The record read cannot answer this for you — an absent PNAM and a present-zero one both render
-`PreviousDialog = (null link)` under `project={"form":"everything"}`, and only `info_order`'s placement tells
-them apart (#697).
+The record read says which shape a line carries: under `project={"form":"everything"}` a present-zero PNAM reads
+`PreviousDialog = (null link, subrecord present)` and an absent one reads `PreviousDialog = (null link)`. The
+placement `info_order` reports is still what tells you where the line actually lands.
 
 Take the line at the target's position minus one and write that FormID into the override's `PreviousDialog`.
 Adding a **new** line re-lists nothing and needs no PNAM for the lines around it.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -22,10 +22,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
   `src/housecarl-core/CorpusRulebook.cs`.
 - **A record read tells a present-but-zero link apart from an absent one.** A nullable link whose subrecord is
   present carrying FormID zero now reads `(null link, subrecord present)`; an absent subrecord still reads
-  `(null link)`. The two mean opposite things on an INFO's `PreviousDialog` (PNAM): present-zero is the "I am
-  first" marker that pins the line to the head of its topic, absent appends it to the tail. Check a line before
-  you re-list it — `project={"form":"fields", "fields":["PreviousDialog"]}` on the INFO says which shape it
-  carries, and `project={"form":"info_order"}` on its topic says where the line lands.
+  `(null link)`. A `where=["PreviousDialog exists"]` sweep and the conflict diff make the same split. The two shapes mean opposite
+  things on an INFO's `PreviousDialog` (PNAM), and how to re-list a line without moving it is in
+  `docs/dialogue.md`. Check a line before you re-list it —
+  `project={"form":"fields", "fields":["PreviousDialog"]}` on the INFO says which shape it carries, and
+  `project={"form":"info_order"}` on its topic says where the line lands.
 
 - **`housecarl_create` refuses a dialogue branch with no `Flags` instead of filling one.** A `DialogBranch`
   created with no `Flags` is now refused in one sentence naming both values and what each does — `TopLevel`

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -20,6 +20,13 @@ saying it sets an expectation their install may contradict. Say what is known, a
   list is too long to be a sentence it cuts and says in the same sentence that the `mutagen-reference` skill
   carries the remainder. Where the cut falls, and what it is set against, is on `FieldListCap` in
   `src/housecarl-core/CorpusRulebook.cs`.
+- **A record read tells a present-but-zero link apart from an absent one.** A nullable link whose subrecord is
+  present carrying FormID zero now reads `(null link, subrecord present)`; an absent subrecord still reads
+  `(null link)`. The two mean opposite things on an INFO's `PreviousDialog` (PNAM): present-zero is the "I am
+  first" marker that pins the line to the head of its topic, absent appends it to the tail. Check a line before
+  you re-list it — `project={"form":"fields", "fields":["PreviousDialog"]}` on the INFO says which shape it
+  carries, and `project={"form":"info_order"}` on its topic says where the line lands.
+
 - **`housecarl_create` refuses a dialogue branch with no `Flags` instead of filling one.** A `DialogBranch`
   created with no `Flags` is now refused in one sentence naming both values and what each does — `TopLevel`
   for a menu entry the player can pick, `0` for a scripted `Say()` topic that must stay hidden — and nothing

--- a/src/housecarl-core/DialogueCkParity.cs
+++ b/src/housecarl-core/DialogueCkParity.cs
@@ -449,9 +449,9 @@ public static class DialogueCkParity
 
     // --- QUST presence predicates: the single home for "does this Quest carry the CK-parity subrecord?", consulted
     //     by BOTH ApplyQuestDefaults (fills when absent) and MissingQuestDefaults (flags when absent), so they cannot
-    //     drift. The alias VTCK test reads FormKeyNullable, not the rendered value: an ABSENT VTCK and a present null-link
-    //     both render "(null link)" (ReadEngine.NullLinkNote — a null FormKey), so only FormKeyNullable distinguishes
-    //     "author set no voice types" (null → fill) from "author set the null link / a real list" (non-null → keep). ---
+    //     drift. The alias VTCK test reads FormKeyNullable, not the rendered value (the render tells the two apart too
+    //     since #697 — NullLinkNote vs PresentNullLinkNote — but it is a display string, not this decision's input). It
+    //     separates "author set no voice types" (null → fill) from "author set the null link / a real list" (non-null → keep). ---
     static bool HasNextAliasID(IQuestGetter quest) => quest.NextAliasID is not null;                 // ANAM
     static bool HasObjectiveFlags(IQuestObjectiveGetter objective) => objective.Flags is not null;   // FNAM
     static bool HasAliasFlags(IQuestAliasGetter alias) => alias.Flags is not null;                    // FNAM (alias)

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -1189,13 +1189,17 @@ public sealed class FieldPredicateSet
     /// summary (note starts with '[') is Present UNLESS it is an EMPTY list/dict (<see cref="ReadEngine.LeafRead.ContainerCount"/>
     /// == 0) — a modeled-but-empty field carries nothing, so it is Absent (the crucial empty-vs-carried split the
     /// display note alone can't give). A "(no field…" note is NoField, "(unreadable…" is Unreadable, and every other
-    /// no-value note ((absent)/(null link)/(unresolved…)) is a valid-but-unset Absent.</summary>
+    /// no-value note ((absent)/(null link)/(unresolved…)) is a valid-but-unset Absent. The one no-value note that
+    /// is PRESENT is <see cref="ReadEngine.PresentNullLinkNote"/>: the subrecord is on the record, which is what
+    /// <c>exists</c> asks about, and it is a carried fact (an INFO's "I am first" PNAM) — so `missing:PreviousDialog`
+    /// must not match a head-marked line (#697), the same split the read render and <c>FieldsDiff</c> make.</summary>
     static Presence ClassifyPresence(ReadEngine.LeafRead leaf)
     {
         if (leaf.HasValue) return Presence.Present;
         var note = leaf.Note ?? "";
         if (note.StartsWith("(no field", StringComparison.Ordinal)) return Presence.NoField;
         if (note.StartsWith("(unreadable", StringComparison.Ordinal)) return Presence.Unreadable;
+        if (note == ReadEngine.PresentNullLinkNote) return Presence.Present;   // subrecord present, carrying zero
         if (note.Length > 0 && note[0] == '[')
             return leaf.ContainerCount is 0 ? Presence.Absent : Presence.Present;   // empty list/dict → absent; substruct (null count) → present
         return Presence.Absent;   // (absent) / (null link) / (unresolved localized string) — a valid, unset field

--- a/src/housecarl-core/FieldsDiff.cs
+++ b/src/housecarl-core/FieldsDiff.cs
@@ -63,7 +63,10 @@ public static class FieldsDiff
     /// <summary>True when a CleanLines value is a read-engine "no value here" note sentinel — the field is
     /// modeled but the contributor carries nothing (absent optional, or a present-but-null link). Treated as a
     /// first-class state, never compared as if it were a real token value. References the <see cref="ReadEngine"/>
-    /// constants directly (same assembly) — single source of truth, compile-time coupling, no drift.</summary>
+    /// constants directly (same assembly) — single source of truth, compile-time coupling, no drift.
+    /// <para><see cref="ReadEngine.PresentNullLinkNote"/> is deliberately NOT here: a nullable link whose subrecord
+    /// is present with FormID zero is a carried fact (an INFO's "I am first" PNAM), so it must delta against a side
+    /// that carries nothing rather than collapse into the same "no value here" state.</para></summary>
     static bool IsAbsentSentinel(string val) =>
         val == ReadEngine.AbsentNote || val == ReadEngine.NullLinkNote || val == ReadEngine.UnresolvedStringNote;
 

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -124,10 +124,14 @@ public static class ReadEngine
     /// without matching prose: the 'rows' fold drops this one and keeps the rest.</remarks>
     public const string AbsentNote = "(absent)";
 
-    /// <summary>A present-but-null FormLink (FormKey.Null) — modeled, but carrying no target. Not a
-    /// round-trippable token (the write surface sets links to a real FormKey, never "Null"), so surfaced as
-    /// a note. Distinct from <see cref="AbsentNote"/> (a wholly absent optional); the conflict diff treats
-    /// both as "no value here" (see <c>FieldsDiff.IsAbsentSentinel</c>).</summary>
+    /// <summary>A FormLink carrying no target, in the two shapes that mean the same thing: a NON-nullable link
+    /// holding FormID zero (its subrecord is always on disk, so zero is the only way it says "nothing"), or a
+    /// NULLABLE link whose subrecord is ABSENT. A nullable link whose subrecord is PRESENT with zero means the
+    /// opposite and renders <see cref="PresentNullLinkNote"/> instead (#697). Not a round-trippable token (the
+    /// write surface sets links to a real FormKey, never "Null"), so surfaced as a note. Distinct from
+    /// <see cref="AbsentNote"/> (a wholly absent optional); the conflict diff treats both of those as "no value
+    /// here" (see <c>FieldsDiff.IsAbsentSentinel</c>), which <see cref="PresentNullLinkNote"/> is deliberately
+    /// not part of.</summary>
     internal const string NullLinkNote = "(null link)";
 
     /// <summary>A NULLABLE FormLink whose subrecord is PRESENT on the record and carries FormID zero — the shape

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -130,6 +130,14 @@ public static class ReadEngine
     /// both as "no value here" (see <c>FieldsDiff.IsAbsentSentinel</c>).</summary>
     internal const string NullLinkNote = "(null link)";
 
+    /// <summary>A NULLABLE FormLink whose subrecord is PRESENT on the record and carries FormID zero — the shape
+    /// an INFO's PNAM takes as the "I am first" marker, and a QUST alias's VTCK as "no voice types". It has a null
+    /// FormKey like an ABSENT nullable link, so both used to render <see cref="NullLinkNote"/> and a modder reading
+    /// the record was told there was nothing to preserve (#697). Told apart here by <c>FormKeyNullable</c>, which is
+    /// null only when the subrecord is absent — the same test <c>DialogueInfoOrder.LineOf</c> makes. No value (the
+    /// write surface sets links to a real FormKey, never "Null"), so still a note.</summary>
+    internal const string PresentNullLinkNote = "(null link, subrecord present)";
+
     /// <summary>A present <c>TranslatedString</c> (FULL/DESC/…) whose <c>.String</c> resolves to null — a localized
     /// string whose <c>.STRINGS</c> entry for the target language is not in the workspace: genuinely absent, NOT the
     /// cleaned-masters case <see cref="LoadOrderResolver.OpenOverlay"/>'s strings source resolves. Surfaced as a
@@ -1036,7 +1044,14 @@ public static class ReadEngine
         // link (FormKey.Null) is NOT a round-trippable token (the write surface sets links to a real
         // FormKey, never "Null"), so surface it as no-value — consistent with what Coerce accepts.
         if (val is IFormLinkGetter fl)
-            return fl.FormKey.IsNull ? LeafRead.None(NullLinkNote) : LeafRead.Value(FormIdToken.Of(fl.FormKey));
+        {
+            if (!fl.FormKey.IsNull) return LeafRead.Value(FormIdToken.Of(fl.FormKey));
+            // Null FormKey: on a NULLABLE link that is two different facts. FormKeyNullable is null only when the
+            // subrecord is ABSENT; a subrecord PRESENT with FormID zero keeps a (null) FormKey there. They mean
+            // opposite things (an INFO's PNAM: append to the tail vs pin to the head), so they render apart (#697).
+            bool nullable = WriteEngine.ClosedInterface(val.GetType(), typeof(IFormLinkNullableGetter<>)) is not null;
+            return LeafRead.None(nullable && fl.FormKeyNullable is not null ? PresentNullLinkNote : NullLinkNote);
+        }
         // TranslatedString (FULL/DESC) — emit the resolved .String (the inverse of Coerce's implicit
         // `record.Name = "x"`). A genuinely-empty "" still round-trips as a value; a NULL .String is an
         // UNRESOLVED localized string (no .STRINGS entry for the target language in the workspace) and is

--- a/src/housecarl-generator/ConflictDiffProbe.cs
+++ b/src/housecarl-generator/ConflictDiffProbe.cs
@@ -133,9 +133,12 @@ public static class ConflictDiffProbe
         // ---- I (PR-G, item 4.3): a NULLABLE FORMLINK the contributor (master) doesn't carry but the winner
         //      does. The empirically-confirmed render is "SharedCrimeFactionList: ABSENT here (winner has …)" —
         //      a FIRST-CLASS absent state, NOT the pre-fix phantom "=(absent) (winner …)" value delta. The null
-        //      formlink reads through the read engine's "(absent)" sentinel; the symmetric "(null link)"
-        //      sentinel (a present-but-FormKey.Null link) is handled identically by construction
-        //      (IsAbsentSentinel covers both). ----
+        //      formlink reads through the read engine's "(absent)" sentinel, as does "(null link)" (a link with
+        //      no target) — IsAbsentSentinel covers both. It does NOT cover "(null link, subrecord present)": a
+        //      nullable link whose subrecord is on the record carrying zero is a carried fact, so it deltas
+        //      against a side carrying nothing rather than collapsing (the decision lives on
+        //      FieldsDiff.IsAbsentSentinel; measured by PresentNullLinkRenderTests). This fixture is
+        //      Mutagen-authored, so its links carry the ABSENT shape and never reach that branch. ----
         var dI = DiffOf(svc, resolver, fI.FormKey);
         Check("I: an absent nullable formlink renders as a FIRST-CLASS ABSENT state, not a phantom value delta",
               dI.Complete

--- a/src/housecarl-mcp-tests/PresentNullLinkRenderTests.cs
+++ b/src/housecarl-mcp-tests/PresentNullLinkRenderTests.cs
@@ -1,6 +1,7 @@
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
 using HousecarlMcp;
 using Xunit;
 
@@ -118,5 +119,60 @@ public sealed class PresentNullLinkRenderTests : IDisposable
         Assert.Contains("(null link, subrecord present)", marked);
         Assert.DoesNotContain("(null link, subrecord present)", plain);
         Assert.Contains("(null link)", plain);
+    }
+
+    /// <summary>The same split on the QUERY axis: `exists`/`missing` is the surface a modder sweeps a topic with,
+    /// so a head-marked line must answer exists — the subrecord IS on the record — and only the plain line must
+    /// answer missing. Collapsing them here would hand back the opposite of the read.</summary>
+    [Fact]
+    public void PresenceSweepsTellTheTwoShapesApart()
+    {
+        string Sweep(string predicate) =>
+            RecordsTools.Records(_w.Svc, formids: new[] { Fid(_w.MarkedLine), Fid(_w.PlainLine) },
+                                 where: new[] { predicate },
+                                 project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "EditorID" } });
+
+        var exists = Sweep("PreviousDialog exists");
+        Assert.Contains("HcPnlMarked", exists);
+        Assert.DoesNotContain("HcPnlPlain", exists);
+
+        var missing = Sweep("PreviousDialog missing");
+        Assert.Contains("HcPnlPlain", missing);
+        Assert.DoesNotContain("HcPnlMarked", missing);
+    }
+}
+
+/// <summary>The conflict-diff half of #697, driven at <see cref="FieldsDiff"/> directly: the present-zero note is
+/// deliberately NOT an absent sentinel, so a side carrying the head marker deltas against a side carrying nothing
+/// instead of both collapsing into the same "no value here" state. Nothing else pins that exclusion — adding the
+/// note to <c>IsAbsentSentinel</c> would otherwise leave a green suite and the collapse back on the conflict tree.</summary>
+[Trait("tier", "unit")]
+public sealed class PresentNullLinkDiffTests
+{
+    const string PresentZero = "(null link, subrecord present)";
+    const string Absent = "(absent)";
+
+    static RecordFields Info(string pnamNote) =>
+        new("INFO", "000800:A.esm", "HcInfo",
+            new[] { new FieldValue("EditorID", true, "HcInfo", null),
+                    new FieldValue("PreviousDialog", false, null, pnamNote, Present: false) });
+
+    [Fact]
+    public void ACarriedHeadMarkerDeltasAgainstASideCarryingNothing()
+    {
+        var d = FieldsDiff.Compare(Info(PresentZero), Info(Absent));
+
+        Assert.Contains(d.Deltas, x => x.StartsWith("PreviousDialog=" + PresentZero, StringComparison.Ordinal));
+        Assert.DoesNotContain(d.Deltas, x => x.Contains("ABSENT here", StringComparison.Ordinal));
+    }
+
+    /// <summary>The pole-symmetric half, and the reason the exclusion is one-sided rather than a rename: two
+    /// genuinely-absent sides still agree, so nothing new is reported where nothing changed.</summary>
+    [Fact]
+    public void TwoAbsentSidesStillCollapse()
+    {
+        var d = FieldsDiff.Compare(Info(Absent), Info(Absent));
+
+        Assert.DoesNotContain(d.Deltas, x => x.StartsWith("PreviousDialog", StringComparison.Ordinal));
     }
 }

--- a/src/housecarl-mcp-tests/PresentNullLinkRenderTests.cs
+++ b/src/housecarl-mcp-tests/PresentNullLinkRenderTests.cs
@@ -1,0 +1,122 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlMcp;
+using Xunit;
+
+namespace HousecarlMcpTests;
+
+/// <summary>A one-plugin world holding a topic with the two PNAM shapes side by side: one INFO whose PNAM
+/// subrecord is PRESENT with FormID zero (the "I am first" head marker), one with no PNAM subrecord at all.
+///
+/// <para>The zero PNAM is byte-patched onto the written plugin, not authored: Mutagen's writer emits NO subrecord
+/// for a null link, so a writer-authored version of this fixture would carry the ABSENT shape twice and the test
+/// would pass without measuring anything. The patch counter is asserted for exactly that reason.</para></summary>
+public sealed class PresentNullLinkWorld : IDisposable
+{
+    public const string PluginName = "HcPnlMaster.esp";
+
+    public string Root { get; }
+    public LoadOrderService Svc { get; }
+
+    /// <summary>The INFO whose PNAM subrecord is present and zero — the head marker.</summary>
+    public FormKey MarkedLine { get; }
+
+    /// <summary>The INFO carrying no PNAM subrecord.</summary>
+    public FormKey PlainLine { get; }
+
+    public PresentNullLinkWorld()
+    {
+        Root = Path.Combine(Path.GetTempPath(), "hc-present-null-link-" + Guid.NewGuid().ToString("N"));
+        var instance = Path.Combine(Root, "inst");
+        var modDir = Path.Combine(instance, "mods", "PnlMod");
+        Directory.CreateDirectory(modDir);
+        Directory.CreateDirectory(Path.Combine(Root, "game", "Data"));
+
+        var mod = new SkyrimMod(ModKey.FromNameAndExtension(PluginName), SkyrimRelease.SkyrimSE);
+        var topic = mod.DialogTopics.AddNew(); topic.EditorID = "HcPnlTopic";
+        var plain = new DialogResponses(mod.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "HcPnlPlain" };
+        var marked = new DialogResponses(mod.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "HcPnlMarked" };
+        // Only the marked line gets a PNAM at all, so the byte patch below can zero every PNAM in the file and
+        // still leave the plain line's ABSENT shape untouched.
+        marked.PreviousDialog.SetTo(plain.FormKey);
+        topic.Responses.Add(plain);
+        topic.Responses.Add(marked);
+        PlainLine = plain.FormKey;
+        MarkedLine = marked.FormKey;
+
+        var path = Path.Combine(modDir, PluginName);
+        mod.BeginWrite.ToPath(path).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        // The plugin masters nothing, so its own records' FormIDs are stored with master index 0 — the raw
+        // subrecord payload the marked line's PNAM carries, and what makes the patch hit that PNAM and not the
+        // topic's own (unrelated, also 4-byte) PNAM priority field.
+        Assert.Equal(1, ZeroPnamPointingAt(path, plain.FormKey.ID));
+
+        File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(Root, "game").Replace(@"\", @"\\") + ")\r\n");
+        var prof = Path.Combine(instance, "profiles", "Default");
+        Directory.CreateDirectory(prof);
+        File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + PluginName + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*" + PluginName + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n+PnlMod\r\n");
+
+        var store = new UserConfigStore(Path.Combine(Root, "user.json"));
+        Svc = LoadOrderService.WithInstance(instance, 0, store);
+    }
+
+    /// <summary>Zero the 4 data bytes of every 4-byte PNAM subrecord in a plugin whose payload is
+    /// <paramref name="targetId"/>, in place; returns how many were patched. The shape real CK / xEdit-filled
+    /// plugins carry and Mutagen's writer will not emit.</summary>
+    static int ZeroPnamPointingAt(string path, uint targetId)
+    {
+        var bytes = File.ReadAllBytes(path);
+        int patched = 0;
+        for (int i = 0; i + 10 <= bytes.Length; i++)
+        {
+            if (bytes[i] != (byte)'P' || bytes[i + 1] != (byte)'N' || bytes[i + 2] != (byte)'A' || bytes[i + 3] != (byte)'M')
+                continue;
+            if (BitConverter.ToUInt16(bytes, i + 4) != 4) continue;          // size field must be 4
+            if (BitConverter.ToUInt32(bytes, i + 6) != targetId) continue;   // …and the link this INFO's PNAM holds
+            bytes[i + 6] = bytes[i + 7] = bytes[i + 8] = bytes[i + 9] = 0;
+            patched++;
+            i += 9;
+        }
+        File.WriteAllBytes(path, bytes);
+        return patched;
+    }
+
+    public void Dispose()
+    {
+        Svc.Dispose();
+        try { Directory.Delete(Root, true); } catch { /* temp cleanup best-effort */ }
+    }
+}
+
+/// <summary>#697: a nullable link whose subrecord is PRESENT with FormID zero means the opposite of an absent one
+/// (an INFO's PNAM: pinned to the head vs appended to the tail), so a record read must not render them alike.</summary>
+[Trait("tier", "integration")]
+public sealed class PresentNullLinkRenderTests : IDisposable
+{
+    readonly PresentNullLinkWorld _w = new();
+
+    public void Dispose() => _w.Dispose();
+
+    static string Fid(FormKey fk) => $"{fk.ID:X6}:{fk.ModKey.FileName}";
+
+    string ReadPnam(FormKey fk) =>
+        RecordsTools.Records(_w.Svc, formids: new[] { Fid(fk) },
+                             project: new RecordsTools.RecordsProject
+                             { form = "fields", fields = new[] { "PreviousDialog" } });
+
+    [Fact]
+    public void APresentZeroPnamRendersApartFromAnAbsentOne()
+    {
+        var marked = ReadPnam(_w.MarkedLine);
+        var plain = ReadPnam(_w.PlainLine);
+
+        Assert.Contains("(null link, subrecord present)", marked);
+        Assert.DoesNotContain("(null link, subrecord present)", plain);
+        Assert.Contains("(null link)", plain);
+    }
+}


### PR DESCRIPTION
The read engine turned any FormLink with a null FormKey into `(null link)`, so a nullable link whose subrecord is present carrying FormID zero collapsed with one that is absent — and on an INFO those two mean opposite things: present-zero is the "I am first" marker that pins the line to the head of its topic, absent appends it to the tail, so a modder reading the record to see whether there was a PNAM to preserve was told there was none. The leaf read now asks `FormKeyNullable` (the same test `DialogueInfoOrder.LineOf` makes) on links typed `IFormLinkNullableGetter<T>` and renders a present-but-null one as `(null link, subrecord present)`. `(null link)` is kept for the absent case, which is what the existing tests and probes already assert. No new parsing. `FieldsDiff` deliberately does not treat the new note as an absent sentinel: a carried head marker should delta against a side that carries nothing rather than collapse again. The dialogue doc's PNAM recipe now says the record read answers the question, and a new integration test drives both shapes on one INFO (the present-zero PNAM is byte-patched onto the written fixture, since Mutagen's writer emits no subrecord for a null link).

Closes #697

Full suite 1916 passed, `ci-all` 127/127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
