### PR TITLE
Say when a copy source sits in a disabled mod folder

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -28,6 +28,11 @@ saying it sets an expectation their install may contradict. Say what is known, a
   `project={"form":"fields", "fields":["PreviousDialog"]}` on the INFO says which shape it carries, and
   `project={"form":"info_order"}` on its topic says where the line lands.
 
+- **`housecarl_copy` says when the source it read from sits in a mod folder MO2 has switched off.** A
+  `from_source=` plugin found in a disabled mod folder is reported with the same sentence
+  `housecarl_place` and `housecarl_nif_inspect` already use, beside the line naming the folder. Nothing
+  about what is copied changes: the standalone claim under it is about what the patch masters, and it now
+  reads next to the fact that the game is not loading the source.
 - **`housecarl_create` refuses a dialogue branch with no `Flags` instead of filling one.** A `DialogBranch`
   created with no `Flags` is now refused in one sentence naming both values and what each does — `TopLevel`
   for a menu entry the player can pick, `0` for a scripted `Say()` topic that must stay hidden — and nothing

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -27,12 +27,14 @@ saying it sets an expectation their install may contradict. Say what is known, a
   `docs/dialogue.md`. Check a line before you re-list it —
   `project={"form":"fields", "fields":["PreviousDialog"]}` on the INFO says which shape it carries, and
   `project={"form":"info_order"}` on its topic says where the line lands.
-
-- **`housecarl_copy` says when the source it read from sits in a mod folder MO2 has switched off.** A
-  `from_source=` plugin found in a disabled mod folder is reported with the same sentence
-  `housecarl_place` and `housecarl_nif_inspect` already use, beside the line naming the folder. Nothing
-  about what is copied changes: the standalone claim under it is about what the patch masters, and it now
-  reads next to the fact that the game is not loading the source.
+- **`housecarl_copy` says which of the source folders it names the game is not loading.** Every arm of
+  `from_source=` that resolved into a mod folder the active profile does not load gets its own `note:` line
+  beside the sources it consulted — not just the arm the record was read from, since the folder a placement
+  is handed afterwards is often one of the others. A folder MO2 lists and has switched off is reported with
+  the sentence `housecarl_place` already uses; a folder MO2 has not registered gets its own, because there
+  is nothing in MO2's list to switch on for it. Nothing about what is copied changes: the standalone claim
+  under it is about what the patch masters, and it now reads next to the fact that the game is not loading
+  the source.
 - **`housecarl_create` refuses a dialogue branch with no `Flags` instead of filling one.** A `DialogBranch`
   created with no `Flags` is now refused in one sentence naming both values and what each does — `TopLevel`
   for a menu entry the player can pick, `0` for a scripted `Say()` topic that must stay hidden — and nothing

--- a/src/housecarl-core/SourceChain.cs
+++ b/src/housecarl-core/SourceChain.cs
@@ -61,13 +61,29 @@ public enum SourceLayerKind
     GameData,
 }
 
+/// <summary>Whether the active MO2 profile is loading a mod folder — the two ways it is not, kept apart because
+/// their remedies differ and a sentence that merges them sends the caller to do the wrong thing.</summary>
+public enum ModFolderStanding
+{
+    /// <summary>modlist.txt lists the folder and the profile has it switched ON — the game loads it.</summary>
+    Live = 0,
+    /// <summary>modlist.txt lists the folder with the profile's switch OFF. Remedy: switch it on, re-sort.</summary>
+    SwitchedOff,
+    /// <summary>modlist.txt does not mention the folder at all, so MO2 has not registered it — the state of a folder
+    /// houseCARL just wrote, before the refresh. Remedy: refresh MO2; there is nothing in MO2's list to switch on,
+    /// which is why this is not <see cref="SwitchedOff"/>.</summary>
+    Unregistered,
+}
+
 /// <summary>The layer a source's file sits in: which branch answered, the name that branch produced, and — for a
-/// mod folder — whether MO2 has that folder switched ON.
-/// <para><paramref name="OwnerEnabled"/> defaults to true because every other layer is always live: the game's Data
-/// folder and MO2's overwrite are not things a profile turns off. It is false only for a mod folder the active
-/// profile has switched off, which is a fact a readback owes the caller — a source the game is not loading reads
-/// very differently beside a claim about what the artifact does or does not master.</para></summary>
-public sealed record SourceLayer(SourceLayerKind Kind, string Name, bool OwnerEnabled = true);
+/// mod folder — whether the active profile is loading that folder.
+/// <para><paramref name="Folder"/> is meaningful for <see cref="SourceLayerKind.ModFolder"/> alone; it defaults to
+/// <see cref="ModFolderStanding.Live"/> so the two layers that are never switched off — the game's Data folder and
+/// MO2's overwrite — need not state it. A producer that builds a mod-folder layer reads the standing from the
+/// profile, because a readback owes the caller the fact that the game is not loading the source it names.</para>
+/// </summary>
+public sealed record SourceLayer(
+    SourceLayerKind Kind, string Name, ModFolderStanding Folder = ModFolderStanding.Live);
 
 /// <summary>One element of an ordered source universe: the caller's own spelling, how it resolved, a human
 /// description of WHERE it resolved to, and the fetch itself.

--- a/src/housecarl-core/SourceChain.cs
+++ b/src/housecarl-core/SourceChain.cs
@@ -61,8 +61,13 @@ public enum SourceLayerKind
     GameData,
 }
 
-/// <summary>The layer a source's file sits in: which branch answered, and the name that branch produced.</summary>
-public sealed record SourceLayer(SourceLayerKind Kind, string Name);
+/// <summary>The layer a source's file sits in: which branch answered, the name that branch produced, and — for a
+/// mod folder — whether MO2 has that folder switched ON.
+/// <para><paramref name="OwnerEnabled"/> defaults to true because every other layer is always live: the game's Data
+/// folder and MO2's overwrite are not things a profile turns off. It is false only for a mod folder the active
+/// profile has switched off, which is a fact a readback owes the caller — a source the game is not loading reads
+/// very differently beside a claim about what the artifact does or does not master.</para></summary>
+public sealed record SourceLayer(SourceLayerKind Kind, string Name, bool OwnerEnabled = true);
 
 /// <summary>One element of an ordered source universe: the caller's own spelling, how it resolved, a human
 /// description of WHERE it resolved to, and the fetch itself.

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -2932,6 +2932,13 @@ public static class WriteSurfaceGuardProbe
                 kept: keptBoth,
                 assets: new[] { @"meshes\actors\character\facegendata\facegeom\CopySrc.esp\00000800.nif" },
                 srcs: manySources)),
+            // A source read out of a mod folder MO2 has switched OFF. The note is about the arm the RECORD came
+            // from, so the disabled folder has to be the first arm to reach it.
+            CopyTools.Render(Make(false, null, Array.Empty<StripEntry>(), srcs: new[]
+            {
+                new SourceArmRef("Disabled.esp", SourceArmKind.File,
+                    new SourceLayer(SourceLayerKind.ModFolder, "ASwitchedOffMod", OwnerEnabled: false)),
+            })),
             // …and the two REFUSAL sentences that were method-form and outside the content net entirely.
             CopyTools.Render(ClosureCopyOutcome.Fail(
                 walk: new WalkRefusal(WalkRefusalKind.SourceMiss, new FormKey(src, 0x820), "Npc.HeadParts",

--- a/src/housecarl-generator/WriteSurfaceGuardProbe.cs
+++ b/src/housecarl-generator/WriteSurfaceGuardProbe.cs
@@ -2932,12 +2932,17 @@ public static class WriteSurfaceGuardProbe
                 kept: keptBoth,
                 assets: new[] { @"meshes\actors\character\facegendata\facegeom\CopySrc.esp\00000800.nif" },
                 srcs: manySources)),
-            // A source read out of a mod folder MO2 has switched OFF. The note is about the arm the RECORD came
-            // from, so the disabled folder has to be the first arm to reach it.
+            // Sources the game is not loading: the arm the record came from, a SECOND switched-off arm it did not
+            // come from, and a folder MO2 has not registered — three lines, because every such arm says so and the
+            // unregistered one gets its own clause.
             CopyTools.Render(Make(false, null, Array.Empty<StripEntry>(), srcs: new[]
             {
                 new SourceArmRef("Disabled.esp", SourceArmKind.File,
-                    new SourceLayer(SourceLayerKind.ModFolder, "ASwitchedOffMod", OwnerEnabled: false)),
+                    new SourceLayer(SourceLayerKind.ModFolder, "ASwitchedOffMod", ModFolderStanding.SwitchedOff)),
+                new SourceArmRef("AlsoOff.esp", SourceArmKind.File,
+                    new SourceLayer(SourceLayerKind.ModFolder, "AnotherSwitchedOffMod", ModFolderStanding.SwitchedOff)),
+                new SourceArmRef("Fresh.esp", SourceArmKind.File,
+                    new SourceLayer(SourceLayerKind.ModFolder, "AnUnregisteredMod", ModFolderStanding.Unregistered)),
             })),
             // …and the two REFUSAL sentences that were method-form and outside the content net entirely.
             CopyTools.Render(ClosureCopyOutcome.Fail(

--- a/src/housecarl-mcp-tests/CopySourceFolderReadbackTests.cs
+++ b/src/housecarl-mcp-tests/CopySourceFolderReadbackTests.cs
@@ -25,6 +25,11 @@ public sealed class TwoDisabledDonorsWorld : IDisposable
     /// the world is asked for it, because it is a collision, not the ordinary shape.</summary>
     public const string ReservedNameFolder = "Data";
 
+    /// <summary>A folder modlist.txt does not mention at all — on disk, never registered by MO2. The state of a
+    /// folder written since the last refresh, and NOT the same as a switched-off one: there is nothing in MO2's
+    /// list to switch on.</summary>
+    public const string UnregisteredFolder = "AnUnregisteredMod";
+
     public string Root { get; }
     public string ModsDir { get; }
     public LoadOrderService Svc { get; }
@@ -38,7 +43,9 @@ public sealed class TwoDisabledDonorsWorld : IDisposable
     /// shape, where the source resolves through the active order and still lives in exactly one mod folder.</param>
     /// <param name="reservedNameOverride">Also ship the override plugin from a second, disabled mod folder literally
     /// named <c>Data</c>.</param>
-    public TwoDisabledDonorsWorld(bool enableDefining = false, bool reservedNameOverride = false)
+    /// <param name="unregisteredOverride">Also ship an override plugin from a folder modlist.txt never mentions.</param>
+    public TwoDisabledDonorsWorld(bool enableDefining = false, bool reservedNameOverride = false,
+                                 bool unregisteredOverride = false)
     {
         Root = Path.Combine(Path.GetTempPath(), "hc-two-donors-" + Guid.NewGuid().ToString("N"));
         var instance = Path.Combine(Root, "inst");
@@ -82,6 +89,15 @@ public sealed class TwoDisabledDonorsWorld : IDisposable
             var collideFace = Path.Combine(ModsDir, ReservedNameFolder, FaceGenPath.For(DonorNpc, FaceGenSlot.Mesh));
             Directory.CreateDirectory(Path.GetDirectoryName(collideFace)!);
             File.WriteAllBytes(collideFace, Encoding.ASCII.GetBytes("FACEGEN-IN-THE-RESERVED-NAME-FOLDER"));
+        }
+
+        // …and the same override from a folder the profile's mod list never mentions, so the locate judges it
+        // unregistered rather than switched off.
+        if (unregisteredOverride)
+        {
+            var fresh = new SkyrimMod(new ModKey("Fresh", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            fresh.Npcs.GetOrAddAsOverride(npc);
+            Write(fresh, UnregisteredFolder, baseMod, donor);
         }
 
         // The ONLY copy of the FaceGen, beside the DEFINING plugin — the second arm's folder.
@@ -165,6 +181,19 @@ public sealed class CopySourceFolderReadbackTests : IDisposable
 
         Assert.False(r.StartsWith("error:", StringComparison.Ordinal), "refused: " + r.Split('\n')[0]);
         Assert.Contains($"'{TwoDisabledDonorsWorld.OverrideFolder}' is a mod folder that is NOT enabled in MO2", r);
+    }
+
+    /// <summary>…and so does the OTHER disabled arm, the one the record did NOT come from. That folder is the one a
+    /// caller acts on next — it ships the FaceGen — so leaving it unqualified is what would read as a live folder.</summary>
+    [Fact]
+    public void EveryDisabledSourceArmSaysSoNotJustTheOneTheRecordCameFrom()
+    {
+        var r = Copy("HcTwoBothSaid");
+
+        Assert.False(r.StartsWith("error:", StringComparison.Ordinal), "refused: " + r.Split('\n')[0]);
+        Assert.Contains($"'{TwoDisabledDonorsWorld.DefiningFolder}' is a mod folder that is NOT enabled in MO2", r);
+        // One line each, same clause, and no more than one per folder.
+        Assert.Equal(2, r.Split('\n').Count(l => l.StartsWith("note: '", StringComparison.Ordinal)));
     }
 
     /// <summary>The claim that matters: the folder the readback names for an arm is the folder that actually holds
@@ -274,6 +303,36 @@ public sealed class CopyEnabledDonorFolderTests : IDisposable
         Assert.False(r.StartsWith("error:", StringComparison.Ordinal), "refused: " + r.Split('\n')[0]);
         Assert.Contains("winner (from the active load order)", r);
         Assert.DoesNotContain("winner (from the active load order,", r);
+    }
+}
+
+/// <summary>#703, the other way a source folder is not loaded: modlist.txt never mentions it. It gets its own true
+/// sentence — MO2 has no entry to enable, so "NOT enabled in MO2" would be false and "switch it on" a remedy that
+/// does not exist.</summary>
+[Trait("tier", "integration")]
+public sealed class CopyUnregisteredSourceFolderTests : IDisposable
+{
+    readonly TwoDisabledDonorsWorld _w = new(unregisteredOverride: true);
+
+    public void Dispose() => _w.Dispose();
+
+    static readonly string[] Seeds = { "HeadParts", "HairColor", "HeadTexture", "WornArmor" };
+
+    [Fact]
+    public void AnUnregisteredSourceFolderIsSaidToBeUnregisteredNotDisabled()
+    {
+        var r = CopyTools.Copy(
+            _w.Svc, _w.Fid(_w.DonorNpc), new[] { "Fresh.esp", "Donor.esp" }, Seeds,
+            new[] { "Race:refuse" }, null, "HcFreshClone", "HcFreshFolder", null);
+
+        Assert.False(r.StartsWith("error:", StringComparison.Ordinal), "refused: " + r.Split('\n')[0]);
+        var line = r.Split('\n').Single(l => l.StartsWith($"note: '{TwoDisabledDonorsWorld.UnregisteredFolder}'",
+                                                          StringComparison.Ordinal));
+        Assert.Contains("MO2 has NOT registered", line);
+        Assert.Contains("refresh MO2", line);
+        Assert.DoesNotContain("NOT enabled in MO2", line);
+        // …while the switched-off arm beside it keeps the clause whose remedy it really has.
+        Assert.Contains($"'{TwoDisabledDonorsWorld.DefiningFolder}' is a mod folder that is NOT enabled in MO2", r);
     }
 }
 

--- a/src/housecarl-mcp-tests/CopySourceFolderReadbackTests.cs
+++ b/src/housecarl-mcp-tests/CopySourceFolderReadbackTests.cs
@@ -156,6 +156,17 @@ public sealed class CopySourceFolderReadbackTests : IDisposable
         Assert.Contains("the source record was read from Override.esp", r);
     }
 
+    /// <summary>#703: the folder the source came out of is switched off in MO2, and the readback says so — the
+    /// standalone claim beside it is about mastering, not about whether the game loads the source.</summary>
+    [Fact]
+    public void TheReadbackSaysTheSourceFolderIsNotEnabledInMo2()
+    {
+        var r = Copy("HcTwoDisabledSaid");
+
+        Assert.False(r.StartsWith("error:", StringComparison.Ordinal), "refused: " + r.Split('\n')[0]);
+        Assert.Contains($"'{TwoDisabledDonorsWorld.OverrideFolder}' is a mod folder that is NOT enabled in MO2", r);
+    }
+
     /// <summary>The claim that matters: the folder the readback names for an arm is the folder that actually holds
     /// that plugin's files. Proven by following it — the placement that names it lands the FaceGen's real bytes,
     /// and the folder of the arm the RECORD came from does not supply the file at all.</summary>
@@ -228,6 +239,16 @@ public sealed class CopyEnabledDonorFolderTests : IDisposable
         Assert.False(r.StartsWith("error:", StringComparison.Ordinal), "refused: " + r.Split('\n')[0]);
         Assert.Contains(
             $"Donor.esp (from the active load order, MO2 mod folder \"{TwoDisabledDonorsWorld.DefiningFolder}\")", r);
+    }
+
+    /// <summary>…and an enabled donor gets no such note: the folder is on, so saying it is off would be false.</summary>
+    [Fact]
+    public void AnEnabledSourceFolderIsNotCalledDisabled()
+    {
+        var r = Copy("Donor.esp", "HcEnabledNotDisabled");
+
+        Assert.False(r.StartsWith("error:", StringComparison.Ordinal), "refused: " + r.Split('\n')[0]);
+        Assert.DoesNotContain("NOT enabled in MO2", r);
     }
 
     /// <summary>…and the folder it names is the one that really holds that plugin's FaceGen — the same proof the

--- a/src/housecarl-mcp/CopyTools.cs
+++ b/src/housecarl-mcp/CopyTools.cs
@@ -149,7 +149,12 @@ public static class CopyTools
         // Which source produced the record the caller ASKED for. Needed in both modes: the source record is not
         // among the internalized rows in either, so nothing else names where its own body came from.
         if (o.FromArm is { } fromArm)
+        {
             sb.Append(WriteSentences.CopyFromArmLead).Append(WriteSentences.CopyArm(fromArm)).Append(".\n");
+            // The source folder is switched off in MO2, which the standalone claim below is read against.
+            if (fromArm.Layer is { Kind: SourceLayerKind.ModFolder, OwnerEnabled: false } off)
+                sb.Append(WriteSentences.CopySourceOffOrderFolder(off.Name)).Append('\n');
+        }
         sb.Append(WriteSentences.NewOrExtendedArtifact(o.Extended, Path.GetFileName(o.OutPath!), o.Bytes,
             Path.GetFileName(Path.GetDirectoryName(o.OutPath!)!)));
 

--- a/src/housecarl-mcp/CopyTools.cs
+++ b/src/housecarl-mcp/CopyTools.cs
@@ -149,12 +149,15 @@ public static class CopyTools
         // Which source produced the record the caller ASKED for. Needed in both modes: the source record is not
         // among the internalized rows in either, so nothing else names where its own body came from.
         if (o.FromArm is { } fromArm)
-        {
             sb.Append(WriteSentences.CopyFromArmLead).Append(WriteSentences.CopyArm(fromArm)).Append(".\n");
-            // The source folder is switched off in MO2, which the standalone claim below is read against.
-            if (fromArm.Layer is { Kind: SourceLayerKind.ModFolder, OwnerEnabled: false } off)
-                sb.Append(WriteSentences.CopySourceOffOrderFolder(off.Name)).Append('\n');
-        }
+        // One line per source arm the game is not loading — EVERY such arm, not just the one the record came from:
+        // the caller acts on the others too (the folder a placement is handed is often not the from arm's), so an
+        // unqualified arm reads as a live folder. Deduped by folder, since two arms can share one.
+        foreach (var off in o.SourcesConsulted
+                     .Select(a => a.Layer)
+                     .Where(l => l is { Kind: SourceLayerKind.ModFolder } && l.Folder != ModFolderStanding.Live)
+                     .DistinctBy(l => (l!.Name, l.Folder)))
+            sb.Append(WriteSentences.CopySourceOffOrderFolder(off!.Name, off.Folder)).Append('\n');
         sb.Append(WriteSentences.NewOrExtendedArtifact(o.Extended, Path.GetFileName(o.OutPath!), o.Bytes,
             Path.GetFileName(Path.GetDirectoryName(o.OutPath!)!)));
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -5781,6 +5781,10 @@ public sealed partial class LoadOrderService : IDisposable
             // out of `where`: a mod folder's name is what a following asset placement passes as its provider, and
             // the BRANCH travels with it so the sentence never calls a mod folder the layer it merely spells like.
             var layer = InstallLayerOfPath(loc.Path!, modsDir, overwriteDir, dataDir);
+            // A mod folder the profile has switched OFF travels as such, so a readback can say the game is not
+            // loading this source instead of naming the folder as though it were live.
+            if (layer is { Kind: SourceLayerKind.ModFolder } && loc.Served == ServedStanding.ModDisabled)
+                layer = layer with { OwnerEnabled = false };
             arms.Add(new SourceArm(spelling, SourceArmKind.File, where,
                 fk => cache.TryResolve(fk, out var body) ? body : null, layer));
         }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -5781,10 +5781,16 @@ public sealed partial class LoadOrderService : IDisposable
             // out of `where`: a mod folder's name is what a following asset placement passes as its provider, and
             // the BRANCH travels with it so the sentence never calls a mod folder the layer it merely spells like.
             var layer = InstallLayerOfPath(loc.Path!, modsDir, overwriteDir, dataDir);
-            // A mod folder the profile has switched OFF travels as such, so a readback can say the game is not
-            // loading this source instead of naming the folder as though it were live.
-            if (layer is { Kind: SourceLayerKind.ModFolder } && loc.Served == ServedStanding.ModDisabled)
-                layer = layer with { OwnerEnabled = false };
+            // A mod folder the profile is not loading travels as such, so a readback can say the game is not loading
+            // this source instead of naming the folder as though it were live. Both off standings are carried: an
+            // unregistered folder is as unloaded as a switched-off one, and its remedy is the other one.
+            if (layer is { Kind: SourceLayerKind.ModFolder })
+                layer = loc.Served switch
+                {
+                    ServedStanding.ModDisabled => layer with { Folder = ModFolderStanding.SwitchedOff },
+                    ServedStanding.ModUnregisteredLayer => layer with { Folder = ModFolderStanding.Unregistered },
+                    _ => layer,
+                };
             arms.Add(new SourceArm(spelling, SourceArmKind.File, where,
                 fk => cache.TryResolve(fk, out var body) ? body : null, layer));
         }

--- a/src/housecarl-mcp/WriteSentences.cs
+++ b/src/housecarl-mcp/WriteSentences.cs
@@ -401,10 +401,13 @@ internal static class WriteSentences
     [MustState("read from")]
     internal const string CopyFromArmLead = "the source record was read from ";
 
-    /// <summary>…and that the folder it came out of is switched OFF in MO2. Said beside the provenance because the
-    /// standalone claim below reads differently once the caller knows the game is not loading the source at all.</summary>
-    internal static string CopySourceOffOrderFolder(string folder) =>
-        $"note: '{folder}' is {OffOrderModFolder}.";
+    /// <summary>…and, for ONE source arm, that the game is not loading the mod folder it came out of. Said beside the
+    /// sources so no arm the readback names reads as a live folder, and because the standalone claim below reads
+    /// differently once the caller knows the game is not loading a source at all. The two off standings get their
+    /// own clause: their remedies differ, and there is nothing in MO2's list to switch on for an unregistered
+    /// folder.</summary>
+    internal static string CopySourceOffOrderFolder(string folder, ModFolderStanding standing) =>
+        $"note: '{folder}' is {(standing == ModFolderStanding.Unregistered ? UnregisteredModFolder : OffOrderModFolder)}.";
 
     // ---- the copied records' asset paths -------------------------------------------------------------
     /// <summary>The asset paths the copied records reference, and the route to acting on them: copy enumerates, and
@@ -613,6 +616,15 @@ internal static class WriteSentences
     [MustState("NOT enabled in MO2")]
     internal const string OffOrderModFolder =
         "a mod folder that is NOT enabled in MO2 — you named it, so houseCARL read it off disk";
+
+    /// <summary>…and the OTHER way the game is not loading a named folder: modlist.txt does not mention it at all.
+    /// It cannot borrow the sentence above — "NOT enabled in MO2" is false for a folder MO2 has no entry to enable,
+    /// and "switch it on" is a remedy that does not exist here — so it says the state and the remedy MO2 actually
+    /// has, the wording the locate lane already uses for this standing.</summary>
+    [MustState("NOT registered", "refresh MO2")]
+    internal const string UnregisteredModFolder =
+        "a mod folder MO2 has NOT registered — nothing in MO2's list to switch on; refresh MO2 to pick it up. You "
+        + "named the folder, so houseCARL read it off disk";
 
     /// <summary>The provenance line for bytes read out of a mod the active profile does NOT include. About the SOURCE
     /// and nothing else: the placed copy's own "does not win until you enable + sort" is the render's separate,

--- a/src/housecarl-mcp/WriteSentences.cs
+++ b/src/housecarl-mcp/WriteSentences.cs
@@ -401,6 +401,11 @@ internal static class WriteSentences
     [MustState("read from")]
     internal const string CopyFromArmLead = "the source record was read from ";
 
+    /// <summary>…and that the folder it came out of is switched OFF in MO2. Said beside the provenance because the
+    /// standalone claim below reads differently once the caller knows the game is not loading the source at all.</summary>
+    internal static string CopySourceOffOrderFolder(string folder) =>
+        $"note: '{folder}' is {OffOrderModFolder}.";
+
     // ---- the copied records' asset paths -------------------------------------------------------------
     /// <summary>The asset paths the copied records reference, and the route to acting on them: copy enumerates, and
     /// never fetches, places or judges. The absent-reads clause is load-bearing — <c>from_source=</c> can read a
@@ -602,6 +607,13 @@ internal static class WriteSentences
             : "")
       + PlaceSourcePoleSpelling;
 
+    /// <summary>The one fact every surface that reads from a NAMED source owes: the bytes came out of a mod folder
+    /// MO2 has switched off, and that is not an error because the caller named it. Shared by the placement lane and
+    /// the closure copy's readback so the sentence cannot drift between them.</summary>
+    [MustState("NOT enabled in MO2")]
+    internal const string OffOrderModFolder =
+        "a mod folder that is NOT enabled in MO2 — you named it, so houseCARL read it off disk";
+
     /// <summary>The provenance line for bytes read out of a mod the active profile does NOT include. About the SOURCE
     /// and nothing else: the placed copy's own "does not win until you enable + sort" is the render's separate,
     /// unconditional line, and neither fact may be stated twice.</summary>
@@ -611,8 +623,8 @@ internal static class WriteSentences
         ? $"read from '{provider}', out of a root archive the engine does NOT load (no active plugin binds it) — you "
         + "named the mod, so houseCARL looked inside its own archives; the bytes are that mod's, and nothing about "
         + "that archive has to change for the copy just placed"
-        : $"read from '{provider}', a mod folder that is NOT enabled in MO2 — you named it, so houseCARL read it off "
-        + "disk; the bytes are that mod's, and enabling it is not required for the copy just placed";
+        : $"read from '{provider}', {OffOrderModFolder}; the bytes are that mod's, and enabling it is not required "
+        + "for the copy just placed";
 
     /// <summary>The both-slots expansion's own constraint on the pole. A FormID with no kind derives TWO destination
     /// paths, so an explicit source= (one file) cannot serve them — but the pole can, because it names whose copy


### PR DESCRIPTION
`housecarl_copy` reads a `from_source=` plugin straight off disk when it sits in a mod folder MO2 has switched off, but the report only named the folder and then claimed the patch is standalone — the reader was never told the game is not loading the source at all, so the standalone claim had nothing to be read against. The MO2 layer a source arm resolved from now carries whether that folder is switched on, set from the locate's own `ModDisabled` standing, and the copy readback says so in one line beside the provenance. The sentence is the one `housecarl_place` and `housecarl_nif_inspect` already print, pulled out of the place helper into a shared constant so the three cannot drift; the place text is unchanged byte for byte. Nothing about what is copied, internalized or mastered changes. Covered by a test on the existing two-disabled-donors world (it fails without the render change) plus a negative one on the enabled-donor world, and by the sentence-reach net in `write-surface-guard`.

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)
