### PR TITLE
Stamp the setup exe and lead its errors with a sentence

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -18,6 +18,14 @@ saying it sets an expectation their install may contradict. Say what is known, a
   notes. The 1.x-to-2.0 tool-name mapping is the refusal
   itself: a retired name is refused with the sentence naming its successor, from `AliasTable.cs` in
   `src/housecarl-mcp/`.
+- **The setup program says which version it is installing, and leads every error with one sentence.** The
+  banner now reads `houseCARL <version>  ·  setup`, stamped from the same `plugin.json` version the server
+  reports. Each refusal — the plugin folder not being beside the program, a missing .NET runtime, a server
+  file in use — now opens with one plain sentence saying what went wrong and what to try, with the paths,
+  download links and the two-installer note indented below it; the runtime refusal names only the runtime
+  that is actually missing rather than listing both. Output is coloured unless it is redirected or
+  `NO_COLOR` is set.
+
 - **A refusal for an unknown field now names every field the record type has.** `housecarl_apply` and
   `housecarl_create` run the same pre-flight, and it used to name twelve fields and then `(+N more)` with no
   route from the call to the rest — a write call is the only place the surface shows a type's schema without

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -23,9 +23,8 @@ saying it sets an expectation their install may contradict. Say what is known, a
   reports. Each refusal — the plugin folder not being beside the program, a missing .NET runtime, a server
   file in use — now opens with one plain sentence saying what went wrong and what to try, with the paths,
   download links and the two-installer note indented below it; the runtime refusal names only the runtime
-  that is actually missing rather than listing both. Output is coloured unless it is redirected or
-  `NO_COLOR` is set.
-
+  that is actually missing rather than listing both. Output is coloured; when it is not, and why, is on `Ui`
+  in `src/housecarl-setup/Ui.cs`.
 - **A refusal for an unknown field now names every field the record type has.** `housecarl_apply` and
   `housecarl_create` run the same pre-flight, and it used to name twelve fields and then `(+N more)` with no
   route from the call to the rest — a write call is the only place the surface shows a type's schema without

--- a/scripts/build-plugin.ps1
+++ b/scripts/build-plugin.ps1
@@ -257,7 +257,9 @@ Copy-Item (Join-Path $PackagingSrc 'marketplace.json') (Join-Path $MpDir 'market
 # Windows) and say exactly which is missing. Trimming is safe HERE (setup uses only the
 # System.Text.Json DOM, no reflection serialization) - the server's trimming ban is untouched.
 Step '9/12' 'Publish the setup utility (houseCARL-Setup.exe) into dist/'
-dotnet publish $SetupProj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=true -p:EnableCompressionInSingleFile=true -p:DebugType=None -p:DebugSymbols=false -o $PkgRoot
+# -p:Version stamps the plugin.json version into the exe, which the setup banner reads back off its own
+# assembly (one version home; an unstamped dev build says 0.0.0-dev), exactly as step 2 does for the server.
+dotnet publish $SetupProj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=true -p:EnableCompressionInSingleFile=true -p:Version=$Version -p:DebugType=None -p:DebugSymbols=false -o $PkgRoot
 if ($LASTEXITCODE -ne 0) { throw "setup-utility publish failed (exit $LASTEXITCODE)" }
 $SetupExe = Join-Path $PkgRoot 'houseCARL-Setup.exe'
 if (-not (Test-Path $SetupExe)) { throw "setup utility not produced at $SetupExe" }

--- a/src/housecarl-setup/Program.cs
+++ b/src/housecarl-setup/Program.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -77,8 +78,9 @@ public static class Program
 
         try
         {
-            Console.WriteLine("houseCARL setup");
-            Console.WriteLine("===============");
+            Console.WriteLine();
+            Console.WriteLine("  houseCARL " + SetupVersion() + "  ·  setup");
+            Console.WriteLine("  " + new string('─', 63));
             Console.WriteLine();
 
             // Locate the plugin shipped beside this program.
@@ -510,6 +512,18 @@ public static class Program
         Console.WriteLine("     Mod Organizer 2 folder (the one containing ModOrganizer.ini).");
         if (target is Target.Both)
             Console.WriteLine("   - (Each host runs its own server copy, so you'll set the MO2 folder once per host.)");
+    }
+
+    /// <summary>This exe's own stamped version, with any "+sha" metadata trimmed. build-plugin.ps1 passes
+    /// -p:Version from plugin.json at publish, so the banner and the shipped server report the same number;
+    /// an unstamped dev build says 0.0.0-dev rather than the 1.0.0 the SDK defaults to.</summary>
+    private static string SetupVersion()
+    {
+        string? info = typeof(Program).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (string.IsNullOrWhiteSpace(info)) return "0.0.0-dev";
+        int plus = info.IndexOf('+');
+        return plus > 0 ? info[..plus] : info;
     }
 
     private static int Finish(int exitCode)

--- a/src/housecarl-setup/Program.cs
+++ b/src/housecarl-setup/Program.cs
@@ -90,9 +90,10 @@ public static class Program
             string srcSkills   = Path.Combine(pluginSrc, "skills");
             if (!File.Exists(srcManifest) || !File.Exists(srcExe) || !Directory.Exists(srcSkills))
             {
-                Console.Error.WriteLine("ERROR: couldn't find the houseCARL plugin next to this program.");
-                Console.Error.WriteLine("  Looked in: " + pluginSrc);
-                Console.Error.WriteLine("  Keep this program in the same folder as the unzipped 'housecarl' folder, then run it again.");
+                Ui.Problem(
+                    "The houseCARL plugin folder is not next to this program, so there is nothing to install — "
+                    + "keep this program beside the unzipped 'housecarl' folder and run it again.",
+                    "Looked in:  " + pluginSrc);
                 return Finish(1);
             }
 
@@ -109,25 +110,7 @@ public static class Program
                 List<string> missing = MissingServerRuntimes();
                 if (missing.Count > 0)
                 {
-                    Console.Error.WriteLine("ERROR: the houseCARL server needs .NET runtime(s) that are not installed:");
-                    if (missing.Contains("Microsoft.NETCore.App"))
-                        Console.Error.WriteLine("    - .NET Runtime " + ServerRuntimeMajor + ".x           (Microsoft.NETCore.App)");
-                    if (missing.Contains("Microsoft.AspNetCore.App"))
-                        Console.Error.WriteLine("    - ASP.NET Core Runtime " + ServerRuntimeMajor + ".x   (Microsoft.AspNetCore.App)");
-                    Console.Error.WriteLine();
-                    Console.Error.WriteLine("  Both come from the same page:");
-                    Console.Error.WriteLine("    https://dotnet.microsoft.com/download/dotnet/" + ServerRuntimeMajor + ".0");
-                    Console.Error.WriteLine("  NOTE: they are two separate installers, and the ASP.NET Core Runtime");
-                    Console.Error.WriteLine("  installer does NOT include the base .NET Runtime -- you need both.");
-                    Console.Error.WriteLine("  Or via winget:");
-                    if (missing.Contains("Microsoft.NETCore.App"))
-                        Console.Error.WriteLine("    winget install Microsoft.DotNet.Runtime." + ServerRuntimeMajor);
-                    if (missing.Contains("Microsoft.AspNetCore.App"))
-                        Console.Error.WriteLine("    winget install Microsoft.DotNet.AspNetCore." + ServerRuntimeMajor);
-                    Console.Error.WriteLine();
-                    Console.Error.WriteLine("  Install the missing runtime(s), then run this setup again. (If you're sure");
-                    Console.Error.WriteLine("  your setup is fine -- e.g. a custom dotnet location -- re-run this setup");
-                    Console.Error.WriteLine("  with --skip-runtime-check.)");
+                    ReportMissingRuntimes(missing);
                     return Finish(1);
                 }
                 Ui.Ok(".NET Runtime " + ServerRuntimeMajor + " + ASP.NET Core Runtime " + ServerRuntimeMajor + ": found.");
@@ -151,16 +134,17 @@ public static class Program
             InstallResult result = TryInstall(target.Value, pluginSrc, home, homeOverride);
             if (result.Outcome == InstallOutcome.ServerInUse)
             {
-                Console.Error.WriteLine("ERROR: houseCARL is already installed and a server file is in use, so it");
-                Console.Error.WriteLine("       can't be updated right now.");
-                if (result.Message is not null)
-                    Console.Error.WriteLine("  " + result.Message);
-                Console.Error.WriteLine();
-                Console.Error.WriteLine("  Fully quit Claude Code AND Codex -- every desktop window, every terminal");
-                Console.Error.WriteLine("  session, and any background session -- then run this setup again.");
-                Console.Error.WriteLine(result.RefusedBeforeAnyCopy
-                    ? "  Nothing was changed."
-                    : "  The update was stopped partway; re-running after you quit will finish it.");
+                string sentence = result.RefusedBeforeAnyCopy
+                    ? "A houseCARL server file is in use, so setup stopped before changing anything — fully quit "
+                      + "Claude Code and Codex, then run this setup again."
+                    : "A houseCARL file went into use partway through the update, so setup stopped — fully quit "
+                      + "Claude Code and Codex, then run this setup again to finish it.";
+                List<string> detail = new();
+                if (result.Message is not null) detail.Add(result.Message);
+                detail.Add("");
+                detail.Add("\"Fully\" means every desktop window, every terminal session, and any");
+                detail.Add("background session.");
+                Ui.Problem(sentence, detail.ToArray());
                 return Finish(1);
             }
 
@@ -169,11 +153,56 @@ public static class Program
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine();
-            Console.Error.WriteLine("ERROR: houseCARL setup did not complete.");
-            Console.Error.WriteLine("  " + ex.Message);
+            Ui.Problem(
+                "houseCARL setup stopped on an error it did not expect — the line below is what Windows "
+                + "reported, and running the setup again is the first thing to try.",
+                ex.Message);
             return Finish(1);
         }
+    }
+
+    /// <summary>
+    /// The runtime refusal, sentence-first and naming only the runtime that is actually missing. The
+    /// two-installer trap is the hard-won part and stays, but below the sentence: the ASP.NET Core installer
+    /// does NOT carry the base .NET Runtime, so a machine can have one and not the other.
+    /// </summary>
+    private static void ReportMissingRuntimes(List<string> missing)
+    {
+        bool baseMissing = missing.Contains("Microsoft.NETCore.App");
+        bool aspMissing  = missing.Contains("Microsoft.AspNetCore.App");
+        string dotnetName = ".NET Runtime " + ServerRuntimeMajor;
+        string aspName    = "ASP.NET Core Runtime " + ServerRuntimeMajor;
+
+        string sentence = baseMissing && aspMissing
+            ? "houseCARL needs the " + dotnetName + " and the " + aspName + ", and neither is installed on this "
+              + "machine — install them and run this setup again."
+            : "houseCARL needs the " + (baseMissing ? dotnetName : aspName) + ", which is not installed on this "
+              + "machine — install it and run this setup again.";
+
+        List<string> detail = new()
+        {
+            "https://dotnet.microsoft.com/download/dotnet/" + ServerRuntimeMajor + ".0",
+        };
+        if (baseMissing) detail.Add("or:  winget install Microsoft.DotNet.Runtime." + ServerRuntimeMajor);
+        if (aspMissing)  detail.Add("or:  winget install Microsoft.DotNet.AspNetCore." + ServerRuntimeMajor);
+        detail.Add("");
+
+        if (baseMissing && aspMissing)
+        {
+            detail.Add("They are two separate installers, and the ASP.NET Core one does not include");
+            detail.Add("the base .NET Runtime, so you need both.");
+        }
+        else
+        {
+            detail.Add("The " + (baseMissing ? aspName : dotnetName) + " is already here. They are two separate");
+            detail.Add("installers and the ASP.NET Core one does not include the base .NET Runtime,");
+            detail.Add("so this is the only piece missing.");
+        }
+
+        detail.Add("");
+        detail.Add("(Custom dotnet location? Re-run with --skip-runtime-check.)");
+
+        Ui.Problem(sentence, detail.ToArray());
     }
 
     // ---- non-interactive install (the probeable seam under the prompt) -----
@@ -203,7 +232,7 @@ public static class Program
         foreach (string destExe in destExes)
             if (ServerExeInUse(destExe))
                 return new InstallResult(InstallOutcome.ServerInUse,
-                        "Can't update the server here — it looks like it's running (or the file is locked/read-only): " + destExe)
+                        "In use, or locked / read-only:  " + destExe)
                     { RefusedBeforeAnyCopy = true };
 
         // Leftover skill folders the prune could not delete. Cleanup never fails an otherwise good install, so
@@ -220,7 +249,7 @@ public static class Program
             // The try wraps the copy AND the host-config registration, so the locked file may be the server
             // exe/DLL or a config file (e.g. ~/.codex/config.toml open in an editor) — name both honestly.
             return new InstallResult(InstallOutcome.ServerInUse,
-                "A houseCARL file was in use during the update (the server, or a config file it writes).");
+                "The file was the server, or a config file setup writes.");
         }
 
         ReportKeptBack(keptBack);
@@ -597,19 +626,22 @@ public static class Program
     /// rather than left as a silently skipped step.</summary>
     private static void ReportNoSkillsShipped(string host)
     {
-        Console.WriteLine("[" + host + "] this package has no skills folder, so no installed skill was removed");
-        Console.WriteLine("      (a package ships skills; unzip the download again if this is not what you expect)");
+        Ui.Note(
+            "This package has no skills folder, so setup removed no installed " + host + " skill.",
+            "A package always ships skills, so unzip the download again if this is not",
+            "what you expect.");
     }
 
     /// <summary>Said at the end of an otherwise finished install: the folders the prune could not delete.</summary>
     private static void ReportKeptBack(List<string> keptBack)
     {
         if (keptBack.Count == 0) return;
-        Console.WriteLine("NOTE: houseCARL installed, but these old skill folders could not be deleted (a file in");
-        Console.WriteLine("      them is read-only or open) — delete them by hand so they stop loading:");
-        foreach (string dir in keptBack)
-            Console.WriteLine("      - " + dir);
-        Console.WriteLine();
+        List<string> detail = new(keptBack.Select(dir => "- " + dir)) { "" };
+        detail.Add("A file in each is read-only or held open. Nothing else was affected.");
+        Ui.Note(
+            "houseCARL is installed, but these old skill folders could not be deleted — delete them by "
+            + "hand so they stop loading:",
+            detail.ToArray());
     }
 
     // ---- file copy --------------------------------------------------------

--- a/src/housecarl-setup/Program.cs
+++ b/src/housecarl-setup/Program.cs
@@ -172,8 +172,8 @@ public static class Program
         catch (Exception ex)
         {
             Ui.Problem(
-                "houseCARL setup stopped on an error it did not expect — the line below is what Windows "
-                + "reported, and running the setup again is the first thing to try.",
+                "houseCARL setup hit an error it does not have a fix for and stopped before finishing — the "
+                + "line below is what the failure reported, and the steps above it are how far it got.",
                 ex.Message);
             return Finish(1);
         }

--- a/src/housecarl-setup/Program.cs
+++ b/src/housecarl-setup/Program.cs
@@ -78,10 +78,7 @@ public static class Program
 
         try
         {
-            Console.WriteLine();
-            Console.WriteLine("  houseCARL " + SetupVersion() + "  ·  setup");
-            Console.WriteLine("  " + new string('─', 63));
-            Console.WriteLine();
+            Ui.Banner(SetupVersion());
 
             // Locate the plugin shipped beside this program.
             string pkgDir      = AppContext.BaseDirectory;
@@ -133,7 +130,7 @@ public static class Program
                     Console.Error.WriteLine("  with --skip-runtime-check.)");
                     return Finish(1);
                 }
-                Console.WriteLine("[check] .NET Runtime " + ServerRuntimeMajor + " + ASP.NET Core Runtime " + ServerRuntimeMajor + ": found.");
+                Ui.Ok(".NET Runtime " + ServerRuntimeMajor + " + ASP.NET Core Runtime " + ServerRuntimeMajor + ": found.");
                 Console.WriteLine();
             }
 
@@ -362,8 +359,7 @@ public static class Program
         Console.WriteLine();
         while (true)
         {
-            Console.Write("Enter 1, 2, or 3 (or q to quit): ");
-            string? s = Console.ReadLine();
+            string? s = Ui.Prompt("Enter 1, 2, or 3 (or q to quit): ");
             if (s is null) return null;        // no interactive input (redirected) - treat as cancel
             switch (s.Trim().ToLowerInvariant())
             {
@@ -384,8 +380,7 @@ public static class Program
         string destExe    = ClaudeDestExe(home);
         string claudeJson = Path.Combine(home, ".claude.json");
 
-        Console.WriteLine("[Claude Code] installing skills + server");
-        Console.WriteLine("      -> " + skillsDest);
+        Ui.Step("Claude Code", "installing skills + server", skillsDest);
         CopyDirectory(pluginSrc, skillsDest);
 
         // CopyDirectory only overwrites, so a skill dropped since the installed version would survive an
@@ -409,8 +404,7 @@ public static class Program
             ReportRemoved("Claude Code", installedSkills, RemoveSkillDirs(installedSkills, stale, keptBack).Removed);
         }
 
-        Console.WriteLine("[Claude Code] registering the MCP server");
-        Console.WriteLine("      -> " + claudeJson);
+        Ui.Step("Claude Code", "registering the MCP server", claudeJson);
         RegisterClaudeMcpServer(claudeJson, McpServerName, destExe);
         Console.WriteLine();
     }
@@ -435,12 +429,10 @@ public static class Program
             : codexHomeEnv;
         string configToml = Path.Combine(codexHome, "config.toml");
 
-        Console.WriteLine("[Codex] installing the server");
-        Console.WriteLine("      -> " + serverDest);
+        Ui.Step("Codex", "installing the server", serverDest);
         CopyDirectory(Path.Combine(pluginSrc, "server"), serverDest);
 
-        Console.WriteLine("[Codex] installing skills");
-        Console.WriteLine("      -> " + skillsRoot);
+        Ui.Step("Codex", "installing skills", skillsRoot);
         string skillsSrc = Path.Combine(pluginSrc, "skills");
         if (Directory.Exists(skillsSrc))
             foreach (string skillDir in Directory.GetDirectories(skillsSrc))
@@ -457,8 +449,7 @@ public static class Program
         if (shipsUmbrella)
         {
             string umbrellaDest = Path.Combine(skillsRoot, PluginFolderName);
-            Console.WriteLine("[Codex] installing the houseCARL umbrella skill");
-            Console.WriteLine("      -> " + umbrellaDest);
+            Ui.Step("Codex", "installing the houseCARL umbrella skill", umbrellaDest);
             CopyDirectory(umbrellaSrc, umbrellaDest);
         }
 
@@ -491,8 +482,7 @@ public static class Program
             File.WriteAllLines(recordPath, installedNames.Concat(prune.Failed));
         }
 
-        Console.WriteLine("[Codex] registering the MCP server");
-        Console.WriteLine("      -> " + configToml);
+        Ui.Step("Codex", "registering the MCP server", configToml);
         RegisterCodexMcpServer(configToml, McpServerName, destExe);
         Console.WriteLine();
     }
@@ -598,10 +588,9 @@ public static class Program
     private static void ReportRemoved(string host, string skillsRoot, List<string> removed)
     {
         if (removed.Count == 0) return;
-        Console.WriteLine("[" + host + "] removed skills this version no longer ships");
-        Console.WriteLine("      -> " + skillsRoot);
+        Ui.Step(host, "removed skills this version no longer ships", skillsRoot);
         foreach (string name in removed)
-            Console.WriteLine("      - " + name);
+            Ui.Bullet(name);
     }
 
     /// <summary>Said when the package has no skills folder: the prune is refused, and the reason is stated

--- a/src/housecarl-setup/Program.cs
+++ b/src/housecarl-setup/Program.cs
@@ -90,10 +90,28 @@ public static class Program
             string srcSkills   = Path.Combine(pluginSrc, "skills");
             if (!File.Exists(srcManifest) || !File.Exists(srcExe) || !Directory.Exists(srcSkills))
             {
-                Ui.Problem(
-                    "The houseCARL plugin folder is not next to this program, so there is nothing to install — "
-                    + "keep this program beside the unzipped 'housecarl' folder and run it again.",
-                    "Looked in:  " + pluginSrc);
+                if (!Directory.Exists(pluginSrc))
+                {
+                    Ui.Problem(
+                        "The houseCARL plugin folder is not next to this program, so there is nothing to "
+                        + "install — keep this program beside the unzipped 'housecarl' folder and run it again.",
+                        "Looked in:  " + pluginSrc);
+                }
+                else
+                {
+                    // The folder is there, so this is an incomplete unzip: name the piece that is missing.
+                    string missingWhat = !File.Exists(srcManifest) ? "manifest"
+                                       : !File.Exists(srcExe)      ? "server"
+                                       :                             "skills folder";
+                    string missingPath = !File.Exists(srcManifest) ? srcManifest
+                                       : !File.Exists(srcExe)      ? srcExe
+                                       :                             srcSkills;
+                    Ui.Problem(
+                        "The houseCARL plugin folder beside this program is missing its " + missingWhat
+                        + ", so the download did not unzip completely — unzip it again and run this setup.",
+                        "Looked in:  " + pluginSrc,
+                        "Missing:    " + missingPath);
+                }
                 return Finish(1);
             }
 

--- a/src/housecarl-setup/Ui.cs
+++ b/src/housecarl-setup/Ui.cs
@@ -1,0 +1,111 @@
+namespace HousecarlSetup;
+
+/// <summary>
+/// Everything the setup run puts on screen: the banner, the step log, the notes, the problem blocks and the
+/// one prompt. It lives here so <see cref="Program"/> stays the install logic and presentation is one file to
+/// read and one file to change.
+///
+/// Hand-rolled on purpose. The setup exe ships single-file, trimmed and self-contained, with zero package
+/// references, and the notices generator only walks the server publish - a console library here would ship
+/// unattributed. Colour is set through <see cref="Console.ForegroundColor"/> (no escape codes in the text), so
+/// a run whose output is captured gets the same characters a coloured run does.
+///
+/// Colour is off when the stream is redirected or NO_COLOR is set, per https://no-color.org.
+/// </summary>
+public static class Ui
+{
+    private const int RuleWidth = 63;
+
+    private static readonly bool NoColor =
+        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("NO_COLOR"));
+
+    private static readonly bool OutColor = !NoColor && !Console.IsOutputRedirected;
+    private static readonly bool ErrColor = !NoColor && !Console.IsErrorRedirected;
+
+    /// <summary>The header: the product name, its version and what this program is.</summary>
+    public static void Banner(string version)
+    {
+        Console.WriteLine();
+        Console.Write("  ");
+        Paint(OutColor, ConsoleColor.White, () => Console.Write("houseCARL"));
+        Paint(OutColor, ConsoleColor.DarkGray, () => Console.Write(" " + version + "  ·  setup"));
+        Console.WriteLine();
+        Rule();
+        Console.WriteLine();
+    }
+
+    /// <summary>A horizontal divider the width of the banner.</summary>
+    public static void Rule()
+        => Paint(OutColor, ConsoleColor.DarkGray, () => Console.WriteLine("  " + new string('─', RuleWidth)));
+
+    /// <summary>One step of the run: what is being done for which host, and the paths it touches.</summary>
+    public static void Step(string host, string what, params string[] paths)
+    {
+        Paint(OutColor, ConsoleColor.Cyan, () => Console.Write("[" + host + "] "));
+        Console.WriteLine(what);
+        foreach (string path in paths)
+            Console.WriteLine("      -> " + path);
+    }
+
+    /// <summary>An item under the step above it.</summary>
+    public static void Bullet(string text) => Console.WriteLine("      - " + text);
+
+    /// <summary>A check that passed.</summary>
+    public static void Ok(string text)
+    {
+        Paint(OutColor, ConsoleColor.Green, () => Console.Write("[check] "));
+        Console.WriteLine(text);
+    }
+
+    /// <summary>
+    /// A run that did not do what was asked: one plain sentence saying what went wrong and what to try, then
+    /// the detail - paths, links, the file that is in the way - indented under it. Goes to stderr, because it
+    /// is the failure.
+    /// </summary>
+    public static void Problem(string sentence, params string[] details)
+    {
+        Console.Error.WriteLine();
+        Paint(ErrColor, ConsoleColor.Red, () => Console.Error.WriteLine("  " + sentence));
+        WriteDetails(Console.Error, details);
+    }
+
+    /// <summary>
+    /// The same sentence-first shape for something that did not stop the run - a step that was skipped, or a
+    /// leftover the cleanup could not take. Goes to stdout, because the install still happened.
+    /// </summary>
+    public static void Note(string sentence, params string[] details)
+    {
+        Console.WriteLine();
+        Paint(OutColor, ConsoleColor.Yellow, () => Console.WriteLine("  " + sentence));
+        WriteDetails(Console.Out, details);
+    }
+
+    /// <summary>Ask a question and read the answer; null when there is no interactive input.</summary>
+    public static string? Prompt(string question)
+    {
+        Console.Write(question);
+        return Console.ReadLine();
+    }
+
+    // An empty detail line is a deliberate blank between paragraphs, so it is written without the indent.
+    private static void WriteDetails(TextWriter w, string[] details)
+    {
+        if (details.Length > 0) w.WriteLine();
+        foreach (string d in details)
+            w.WriteLine(d.Length == 0 ? "" : "      " + d);
+        w.WriteLine();
+    }
+
+    // Colour is a console attribute, not text, so the writer sees the same characters either way.
+    private static void Paint(bool colored, ConsoleColor color, Action write)
+    {
+        if (!colored) { write(); return; }
+        ConsoleColor prev = Console.ForegroundColor;
+        try
+        {
+            Console.ForegroundColor = color;
+            write();
+        }
+        finally { Console.ForegroundColor = prev; }
+    }
+}

--- a/src/housecarl-setup/Ui.cs
+++ b/src/housecarl-setup/Ui.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace HousecarlSetup;
 
 /// <summary>
@@ -21,6 +23,16 @@ public static class Ui
 
     private static readonly bool OutColor = !NoColor && !Console.IsOutputRedirected;
     private static readonly bool ErrColor = !NoColor && !Console.IsErrorRedirected;
+
+    // A double-clicked console runs an OEM code page, which has no em dash, so the sentences below would go
+    // out best-fit mapped. A redirected stream is left alone (its reader chose the encoding), and a run with
+    // no console handle throws here, which is not a reason to stop installing.
+    static Ui()
+    {
+        if (Console.IsOutputRedirected && Console.IsErrorRedirected) return;
+        try { Console.OutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false); }
+        catch (Exception) { }
+    }
 
     /// <summary>The header: the product name, its version and what this program is.</summary>
     public static void Banner(string version)

--- a/src/housecarl-setup/housecarl-setup.csproj
+++ b/src/housecarl-setup/housecarl-setup.csproj
@@ -19,6 +19,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>HousecarlSetup</RootNamespace>
     <AssemblyName>houseCARL-Setup</AssemblyName>
+    <!-- What Explorer's file-properties pane shows. The version is stamped at publish by build-plugin.ps1
+         (-p:Version from plugin.json), and the banner reads it back off this assembly - one version home. -->
+    <AssemblyTitle>houseCARL Setup</AssemblyTitle>
+    <Product>houseCARL</Product>
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 

--- a/src/housecarl-setup/housecarl-setup.csproj
+++ b/src/housecarl-setup/housecarl-setup.csproj
@@ -23,6 +23,9 @@
          (-p:Version from plugin.json), and the banner reads it back off this assembly - one version home. -->
     <AssemblyTitle>houseCARL Setup</AssemblyTitle>
     <Product>houseCARL</Product>
+    <!-- Banner version truth: build-plugin.ps1 overrides with -p:Version from plugin.json (the single
+         version home), so an unstamped local build says 0.0.0-dev instead of the SDK's default 1.0.0. -->
+    <Version>0.0.0-dev</Version>
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 


### PR DESCRIPTION
The installer gets the first of three presentation passes agreed for 2.0.0. The setup exe is now stamped with the release version the way the server already was (`build-plugin.ps1` step 9 passes `-p:Version` from `plugin.json`, the csproj carries `AssemblyTitle`/`Product` and defaults to `0.0.0-dev`), and the banner reads that version back off its own assembly so there is one version home instead of a hard-coded string.

The output that carries presentation — the banner, the rule, the step/ok lines, the notes, the refusals and the menu prompt — moved out of `Program.cs` into a new `src/housecarl-setup/Ui.cs`, a small static class with `Banner`, `Rule`, `Step`, `Ok`, `Note`, `Problem` and `Prompt`, colour set through `Console.ForegroundColor` and turned off when the stream is redirected or `NO_COLOR` is set, no new package references. `Ui` also sets `Console.OutputEncoding` to UTF-8 once, in a try/catch and only when a console is attached, so the banner rule and the em dashes render on a double-clicked run. Program.cs keeps its 31 plain `Console.*` calls — the `--help` text, the host menu, the NEXT block, the blank-line spacing and the "press any key" — because none of them are coloured or shaped, and routing them through `Ui` would only add a layer.

On top of that every refusal was rewritten to lead with one plain sentence saying what went wrong and what to try, with the paths, download links and the two-installer trap indented below it; the runtime pre-flight now names only the runtime that is actually missing instead of printing both, the missing-package refusal names which piece is absent (manifest, server exe or skills folder) and tells the reader to unzip again rather than to move the program, and the locked-file refusal names the exe that is holding things up. `TryInstall` is untouched, so `SetupSkillPruneProbe` and `SetupUpdateLockProbe` stay green without edits, and `--help` is unchanged.

PR A of three for the installer polish; the detection/plan screen and uninstall follow. No issue to close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
