### PR TITLE
Show what setup found and what it will write

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -33,11 +33,19 @@ saying it sets an expectation their install may contradict. Say what is known, a
 - **The setup program says what it found, then what it is about to write, and waits for a yes.** Before it
   copies anything it prints what is on the machine — each host, whether houseCARL is installed for it and at
   what version, and the .NET runtimes — and then the plan: one line per destination, naming the exact path,
-  labelled install or upgrade per host. The plan reads the destinations from the same path helpers the
-  install writes to, on `Program` in `src/housecarl-setup/Program.cs`, so the plan and the install cannot
-  disagree. Enter proceeds and `q` quits, on `--claude`, `--codex` and `--both` runs too; `--yes` goes
-  straight on, and what else skips the stop is on `Confirmed` in that file. Where exactly one host is found,
-  Enter at the menu picks it.
+  and a per-host label from `Plan.HostAction` in `src/housecarl-setup/Plan.cs`, which compares the installed
+  version against the package's rather than only testing them for equality. The plan reads the destinations
+  from the same path helpers the install writes to, on `Program` in `src/housecarl-setup/Program.cs`, so the
+  plan and the install cannot disagree, and it says that an upgrade deletes the skill folders this version no
+  longer ships. Enter proceeds and `q` quits, on `--claude`, `--codex` and `--both` runs too; `--yes` is the
+  one way past the confirm, on `Confirm` in that file. Where exactly one host is found, Enter at the menu
+  picks it.
+- **Setup refuses a question it has nobody to ask instead of answering it.** A run whose input is redirected
+  used to take the missing keypress as a yes at the plan and as a cancel at the host menu. Both now refuse
+  with one sentence naming the flag that answers the question in advance — `--claude`, `--codex` or `--both`
+  for the host, `--yes` for the confirm — and `--help` says so. A host is also reported found only on a file
+  the host itself writes, not on a directory bearing its name; which files those are is on `Detect` in
+  `src/housecarl-setup/Detect.cs`.
 - **A refusal for an unknown field now names every field the record type has.** `housecarl_apply` and
   `housecarl_create` run the same pre-flight, and it used to name twelve fields and then `(+N more)` with no
   route from the call to the rest — a write call is the only place the surface shows a type's schema without

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -30,6 +30,14 @@ saying it sets an expectation their install may contradict. Say what is known, a
   download links and the two-installer note indented below it; the runtime refusal names only the runtime
   that is actually missing rather than listing both. Output is coloured; when it is not, and why, is on `Ui`
   in `src/housecarl-setup/Ui.cs`.
+- **The setup program says what it found, then what it is about to write, and waits for a yes.** Before it
+  copies anything it prints what is on the machine — each host, whether houseCARL is installed for it and at
+  what version, and the .NET runtimes — and then the plan: one line per destination, naming the exact path,
+  labelled install or upgrade per host. The plan reads the destinations from the same path helpers the
+  install writes to, on `Program` in `src/housecarl-setup/Program.cs`, so the plan and the install cannot
+  disagree. Enter proceeds and `q` quits, on `--claude`, `--codex` and `--both` runs too; `--yes` goes
+  straight on, and what else skips the stop is on `Confirmed` in that file. Where exactly one host is found,
+  Enter at the menu picks it.
 - **A refusal for an unknown field now names every field the record type has.** `housecarl_apply` and
   `housecarl_create` run the same pre-flight, and it used to name twelve fields and then `(+N more)` with no
   route from the call to the rest — a write call is the only place the surface shows a type's schema without

--- a/src/housecarl-generator/SetupSkillPruneProbe.cs
+++ b/src/housecarl-generator/SetupSkillPruneProbe.cs
@@ -50,8 +50,10 @@ internal static class SetupSkillPruneProbe
         string src  = Path.Combine(pkg, "housecarl");
         string home = Path.Combine(root, "home");
 
-        string claudeSkills = Path.Combine(home, ".claude", "skills", "housecarl", "skills");
-        string codexSkills  = Path.Combine(home, ".agents", "skills");
+        // Asked of the installer's own path helpers, not rebuilt here, so the guard cannot certify a
+        // destination the installer has since moved away from.
+        string claudeSkills = Path.Combine(SetupProgram.ClaudeSkillsDest(home), "skills");
+        string codexSkills  = SetupProgram.CodexSkillsRoot(home);
 
         // Where the packager puts the umbrella, read out of scripts/build-plugin.ps1 — the same authority the
         // setup-update-lock probe reads, so the fixture ships it where the installer looks for it.
@@ -107,7 +109,7 @@ internal static class SetupSkillPruneProbe
             // ---- T5: a leftover the prune cannot delete ----
             Console.WriteLine();
             Console.WriteLine("--- T5: a read-only leftover cannot be deleted, and the install finishes anyway ---");
-            string recordPath = Path.Combine(home, "houseCARL", "installed-skills.txt");
+            string recordPath = SetupProgram.CodexSkillRecord(home, home);
             Check(File.Exists(recordPath), "the Codex install recorded what it put in the shared dir");
             Check(File.ReadAllLines(recordPath).Contains("housecarl"), "the umbrella folder is on the record");
 
@@ -119,8 +121,8 @@ internal static class SetupSkillPruneProbe
 
             // Delete both host configs first, so their reappearance proves the registration ran AFTER the
             // failed prune rather than surviving from the earlier install.
-            string claudeJson = Path.Combine(home, ".claude.json");
-            string codexToml  = Path.Combine(home, ".codex", "config.toml");
+            string claudeJson = SetupProgram.ClaudeJson(home);
+            string codexToml  = SetupProgram.CodexConfigToml(home);
             File.Delete(claudeJson);
             File.Delete(codexToml);
 

--- a/src/housecarl-generator/SetupUpdateLockProbe.cs
+++ b/src/housecarl-generator/SetupUpdateLockProbe.cs
@@ -54,14 +54,15 @@ internal static class SetupUpdateLockProbe
         string src  = Path.Combine(pkg, "housecarl");  // pluginSrc (beside it lives codex/skills/housecarl)
         string home = Path.Combine(root, "home");      // stand-in for the user profile
 
-        // The destinations TryInstall computes (mirrored here for the lock-holding + assertions).
-        string claudeExe = Path.Combine(home, ".claude", "skills", "housecarl", "server", "housecarl-mcp.exe");
-        string claudeDll = Path.Combine(home, ".claude", "skills", "housecarl", "server", "Mutagen.Bethesda.dll");
-        string codexExe  = Path.Combine(home, "houseCARL", "server", "housecarl-mcp.exe");
-        string sentinel  = Path.Combine(home, ".claude", "skills", "housecarl", "skills", "demo-skill", "SKILL.md");
+        // The destinations TryInstall computes, asked of the installer's OWN path helpers rather than rebuilt
+        // here: a guard holding a second copy of the paths would follow the installer wherever it went.
+        string claudeExe = SetupProgram.ClaudeDestExe(home);
+        string claudeDll = Path.Combine(Path.GetDirectoryName(claudeExe)!, "Mutagen.Bethesda.dll");
+        string codexExe  = SetupProgram.CodexDestExe(home, home);
+        string sentinel  = Path.Combine(SetupProgram.ClaudeSkillsDest(home), "skills", "demo-skill", "SKILL.md");
         // The Codex umbrella's install destination: the packager path and the installer path must agree,
         // or InstallForCodex's Directory.Exists guard skips the copy and says nothing.
-        string umbrella  = Path.Combine(home, ".agents", "skills", "housecarl", "SKILL.md");
+        string umbrella  = Path.Combine(SetupProgram.CodexSkillsRoot(home), "housecarl", "SKILL.md");
         // Where the PACKAGER puts it, read from the packaging script rather than restated here - restating
         // it would pin the installer against this file's opinion, not against what actually ships.
         var (codexPkgPath, codexPathWhy) = CodexPackagePath();

--- a/src/housecarl-setup/Detect.cs
+++ b/src/housecarl-setup/Detect.cs
@@ -1,0 +1,88 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace HousecarlSetup;
+
+/// <summary>
+/// What is already on this machine, read before setup writes anything: which hosts are here, whether houseCARL
+/// is installed for each, and at what version. It is its own file because it is its own job - <see cref="Program"/>
+/// stays the install, and the paths it reads come from <see cref="Program"/>'s path helpers so a destination
+/// cannot drift between what is reported and what is written.
+///
+/// Reading only. Nothing here creates a directory or a file, so a run that is cancelled at the plan leaves the
+/// machine exactly as it found it.
+/// </summary>
+public static class Detect
+{
+    /// <summary>One host as it stands before the install.</summary>
+    /// <param name="Name">The host's name, as the menu and the plan say it.</param>
+    /// <param name="Present">True when the host itself is on this machine.</param>
+    /// <param name="Installed">True when houseCARL is already installed for it.</param>
+    /// <param name="InstalledVersion">The installed version, or null when it is installed but unreadable.</param>
+    public sealed record HostState(string Name, bool Present, bool Installed, string? InstalledVersion)
+    {
+        /// <summary>The right-hand side of this host's row in the detection block and the menu.</summary>
+        public string Summary =>
+            !Present    ? "not found"
+            : !Installed ? "found  ·  houseCARL not installed"
+            : InstalledVersion is null ? "found  ·  houseCARL installed"
+            :                            "found  ·  houseCARL " + InstalledVersion + " installed";
+    }
+
+    /// <summary>Claude Code: the desktop app keeps ~/.claude.json and ~/.claude, and either one is it being here.
+    /// The installed version is the copied plugin's own manifest, which is the file that shipped it.</summary>
+    public static HostState Claude(string home)
+    {
+        bool present = File.Exists(Program.ClaudeJson(home)) || Directory.Exists(Path.Combine(home, ".claude"));
+        string dest  = Program.ClaudeSkillsDest(home);
+        bool installed = File.Exists(Program.ClaudeDestExe(home)) || Directory.Exists(dest);
+        string? version = installed
+            ? PluginVersion(Path.Combine(dest, ".claude-plugin", "plugin.json"))
+            : null;
+        return new HostState("Claude Code", present, installed, version);
+    }
+
+    /// <summary>Codex: ~/.codex (or CODEX_HOME) is it being here. A Codex install copies the server but not the
+    /// plugin manifest, so the version comes off the installed server exe, which build-plugin.ps1 stamps.</summary>
+    public static HostState Codex(string home, string? homeOverride)
+    {
+        bool present = Directory.Exists(Program.CodexConfigHome(home));
+        string destExe = Program.CodexDestExe(home, homeOverride);
+        bool installed = File.Exists(destExe);
+        string? version = installed ? ExeVersion(destExe) : null;
+        return new HostState("Codex", present, installed, version);
+    }
+
+    /// <summary>The "version" of a plugin.json, or null when the file is absent, unreadable or has no version.</summary>
+    public static string? PluginVersion(string pluginJsonPath)
+    {
+        if (!File.Exists(pluginJsonPath)) return null;
+        try
+        {
+            using JsonDocument doc = JsonDocument.Parse(File.ReadAllText(pluginJsonPath));
+            return doc.RootElement.TryGetProperty("version", out JsonElement v) && v.ValueKind == JsonValueKind.String
+                ? v.GetString()
+                : null;
+        }
+        catch (Exception ex) when (ex is IOException or JsonException or UnauthorizedAccessException)
+        {
+            return null; // an unreadable manifest is "installed, version unknown", never a stopped run
+        }
+    }
+
+    /// <summary>The product version stamped into an exe, with any "+sha" metadata trimmed; null when unreadable.</summary>
+    private static string? ExeVersion(string exePath)
+    {
+        try
+        {
+            string? v = FileVersionInfo.GetVersionInfo(exePath).ProductVersion;
+            if (string.IsNullOrWhiteSpace(v)) return null;
+            int plus = v.IndexOf('+');
+            return plus > 0 ? v[..plus] : v;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/housecarl-setup/Detect.cs
+++ b/src/housecarl-setup/Detect.cs
@@ -30,27 +30,55 @@ public static class Detect
     }
 
     /// <summary>Claude Code: the desktop app keeps ~/.claude.json and ~/.claude, and either one is it being here.
+    /// Installed is a FILE the install writes - the server exe or the copied manifest - never the destination
+    /// directory existing, which an emptied or half-deleted install leaves behind with nothing to upgrade from.
     /// The installed version is the copied plugin's own manifest, which is the file that shipped it.</summary>
     public static HostState Claude(string home)
     {
         bool present = File.Exists(Program.ClaudeJson(home)) || Directory.Exists(Path.Combine(home, ".claude"));
-        string dest  = Program.ClaudeSkillsDest(home);
-        bool installed = File.Exists(Program.ClaudeDestExe(home)) || Directory.Exists(dest);
-        string? version = installed
-            ? PluginVersion(Path.Combine(dest, ".claude-plugin", "plugin.json"))
-            : null;
+        string manifest = Program.ClaudeDestManifest(home);
+        bool installed = File.Exists(Program.ClaudeDestExe(home)) || File.Exists(manifest);
+        string? version = installed ? PluginVersion(manifest) : null;
         return new HostState("Claude Code", present, installed, version);
     }
 
-    /// <summary>Codex: ~/.codex (or CODEX_HOME) is it being here. A Codex install copies the server but not the
-    /// plugin manifest, so the version comes off the installed server exe, which build-plugin.ps1 stamps.</summary>
+    /// <summary>Codex: its config file (~/.codex/config.toml, or CODEX_HOME's) or the codex command on PATH is
+    /// it being here. A bare ~/.codex directory is not - an uninstalled Codex, or any tool that has touched
+    /// that path, leaves one, and the menu's bare-Enter default keys on this. A Codex install copies the
+    /// server but not the plugin manifest, so the version comes off the installed server exe, which
+    /// build-plugin.ps1 stamps.</summary>
     public static HostState Codex(string home, string? homeOverride)
     {
-        bool present = Directory.Exists(Program.CodexConfigHome(home));
+        bool present = File.Exists(Program.CodexConfigToml(home)) || OnPath("codex");
         string destExe = Program.CodexDestExe(home, homeOverride);
         bool installed = File.Exists(destExe);
         string? version = installed ? ExeVersion(destExe) : null;
         return new HostState("Codex", present, installed, version);
+    }
+
+    /// <summary>True when <paramref name="command"/> is an executable on PATH. Each PATH entry is tried bare
+    /// and with every PATHEXT extension, the way the shell resolves it. An entry that cannot be read is not
+    /// a match and is not an error.</summary>
+    private static bool OnPath(string command)
+    {
+        string[] dirs = (Environment.GetEnvironmentVariable("PATH") ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+        string[] exts = (Environment.GetEnvironmentVariable("PATHEXT") ?? ".EXE;.CMD;.BAT")
+            .Split(';', StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (string entry in dirs)
+        {
+            string dir = entry.Trim().Trim('"');
+            if (dir.Length == 0) continue;
+            try
+            {
+                if (File.Exists(Path.Combine(dir, command))) return true;
+                foreach (string ext in exts)
+                    if (File.Exists(Path.Combine(dir, command + ext))) return true;
+            }
+            catch (ArgumentException) { /* a malformed PATH entry is not a match */ }
+        }
+        return false;
     }
 
     /// <summary>The "version" of a plugin.json, or null when the file is absent, unreadable or has no version.</summary>

--- a/src/housecarl-setup/InternalsVisibleTo.cs
+++ b/src/housecarl-setup/InternalsVisibleTo.cs
@@ -1,0 +1,6 @@
+using System.Runtime.CompilerServices;
+
+// The CI probes drive the real installer (Program.TryInstall) and assert on where it put things. Without
+// this they would have to rebuild the destination paths themselves, and a guard holding its own copy of the
+// paths would follow the installer wherever it went. They call the path helpers instead.
+[assembly: InternalsVisibleTo("housecarl-generator")]

--- a/src/housecarl-setup/Plan.cs
+++ b/src/housecarl-setup/Plan.cs
@@ -24,7 +24,7 @@ public static class Plan
             plans.Add(new HostPlan(claude, new List<Line>
             {
                 new(Program.ClaudeSkillsDest(home), "skills + server"),
-                new(Program.ClaudeJson(home),       "registers the server  (backed up first)"),
+                new(Program.ClaudeJson(home),       BacksUpFirst),
             }));
 
         if (target is Program.Target.Codex or Program.Target.Both)
@@ -33,11 +33,15 @@ public static class Plan
                 new(Program.CodexServerDir(home, homeOverride),    "server"),
                 new(Program.CodexSkillsRoot(home),                 "skills"),
                 new(Program.CodexSkillRecord(home, homeOverride),  "records which skills were installed"),
-                new(Program.CodexConfigToml(home),                 "registers the server  (backed up first)"),
+                new(Program.CodexConfigToml(home),                 BacksUpFirst),
             }));
 
         return plans;
     }
+
+    /// <summary>What a host-config line puts there. The install copies the file to a ".houseCARL.bak"
+    /// beside it before editing it, and that copy is a file the plan would otherwise not name.</summary>
+    private const string BacksUpFirst = "registers the server  (a .houseCARL.bak copy is made first)";
 
     /// <summary>Print the plan: a heading per host saying install or upgrade, then one line per destination.</summary>
     public static void Print(List<HostPlan> plans, string version)

--- a/src/housecarl-setup/Plan.cs
+++ b/src/housecarl-setup/Plan.cs
@@ -1,0 +1,69 @@
+namespace HousecarlSetup;
+
+/// <summary>
+/// What the run is about to do, printed before it does any of it. Every destination here comes from the same
+/// path helpers on <see cref="Program"/> that <see cref="Program.TryInstall"/> copies to, so the plan cannot say
+/// one path and the install write another.
+/// </summary>
+public static class Plan
+{
+    /// <summary>One destination the install touches, and what it puts there.</summary>
+    public sealed record Line(string Path, string What);
+
+    /// <summary>One host's share of the plan.</summary>
+    public sealed record HostPlan(Detect.HostState Host, IReadOnlyList<Line> Lines);
+
+    /// <summary>The plan for a target, host by host, in install order.</summary>
+    public static List<HostPlan> For(
+        Program.Target target, string home, string? homeOverride,
+        Detect.HostState claude, Detect.HostState codex)
+    {
+        List<HostPlan> plans = new();
+
+        if (target is Program.Target.Claude or Program.Target.Both)
+            plans.Add(new HostPlan(claude, new List<Line>
+            {
+                new(Program.ClaudeSkillsDest(home), "skills + server"),
+                new(Program.ClaudeJson(home),       "registers the server  (backed up first)"),
+            }));
+
+        if (target is Program.Target.Codex or Program.Target.Both)
+            plans.Add(new HostPlan(codex, new List<Line>
+            {
+                new(Program.CodexServerDir(home, homeOverride), "server"),
+                new(Program.CodexSkillsRoot(home),              "skills"),
+                new(Program.CodexConfigToml(home),              "registers the server  (backed up first)"),
+            }));
+
+        return plans;
+    }
+
+    /// <summary>Print the plan: a heading per host saying install or upgrade, then one line per destination.</summary>
+    public static void Print(List<HostPlan> plans, string version)
+    {
+        bool everyHostUpgrading = plans.Count > 0 && plans.All(p => p.Host.Installed);
+        Ui.Heading(everyHostUpgrading ? "This will replace:" : "This will write:");
+
+        // One path column across every host, so the "what" side reads as a column rather than a ragged edge.
+        int pathWidth = plans.SelectMany(p => p.Lines).Select(l => l.Path.Length).DefaultIfEmpty(0).Max();
+
+        bool first = true;
+        foreach (HostPlan plan in plans)
+        {
+            if (!first) Console.WriteLine();
+            first = false;
+            Ui.PlanHost(plan.Host.Name, HostAction(plan.Host, version));
+            foreach (Line line in plan.Lines)
+                Ui.PlanLine(line.Path, line.What, pathWidth);
+        }
+
+        Ui.Body("Nothing else is touched. Your game, your mods and your MO2 profile are not read.");
+    }
+
+    /// <summary>What this run is to this host: a first install, or an upgrade off the version already there.</summary>
+    private static string HostAction(Detect.HostState host, string version)
+        => !host.Installed                ? "install " + version
+         : host.InstalledVersion is null  ? "upgrade to " + version
+         : host.InstalledVersion == version ? "reinstall " + version
+         :                                   "upgrade " + host.InstalledVersion + " to " + version;
+}

--- a/src/housecarl-setup/Plan.cs
+++ b/src/housecarl-setup/Plan.cs
@@ -30,9 +30,10 @@ public static class Plan
         if (target is Program.Target.Codex or Program.Target.Both)
             plans.Add(new HostPlan(codex, new List<Line>
             {
-                new(Program.CodexServerDir(home, homeOverride), "server"),
-                new(Program.CodexSkillsRoot(home),              "skills"),
-                new(Program.CodexConfigToml(home),              "registers the server  (backed up first)"),
+                new(Program.CodexServerDir(home, homeOverride),    "server"),
+                new(Program.CodexSkillsRoot(home),                 "skills"),
+                new(Program.CodexSkillRecord(home, homeOverride),  "records which skills were installed"),
+                new(Program.CodexConfigToml(home),                 "registers the server  (backed up first)"),
             }));
 
         return plans;
@@ -41,6 +42,7 @@ public static class Plan
     /// <summary>Print the plan: a heading per host saying install or upgrade, then one line per destination.</summary>
     public static void Print(List<HostPlan> plans, string version)
     {
+        bool anyHostInstalled = plans.Any(p => p.Host.Installed);
         bool everyHostUpgrading = plans.Count > 0 && plans.All(p => p.Host.Installed);
         Ui.Heading(everyHostUpgrading ? "This will replace:" : "This will write:");
 
@@ -57,13 +59,54 @@ public static class Plan
                 Ui.PlanLine(line.Path, line.What, pathWidth);
         }
 
-        Ui.Body("Nothing else is touched. Your game, your mods and your MO2 profile are not read.");
+        // The run deletes as well as writes, and the paths above are the only place that shows. A host with
+        // nothing installed has no previous skill set to take folders back from, so the sentence is printed
+        // only when one of the hosts above is being replaced.
+        List<string> body = new();
+        if (anyHostInstalled)
+        {
+            body.Add("Under the skills paths above, skill folders a previous houseCARL");
+            body.Add("installed and this version no longer ships are deleted.");
+        }
+        body.Add("Your game, your mods and your MO2 profile are not read.");
+        Ui.Body(body.ToArray());
     }
 
-    /// <summary>What this run is to this host: a first install, or an upgrade off the version already there.</summary>
-    private static string HostAction(Detect.HostState host, string version)
-        => !host.Installed                ? "install " + version
-         : host.InstalledVersion is null  ? "upgrade to " + version
-         : host.InstalledVersion == version ? "reinstall " + version
-         :                                   "upgrade " + host.InstalledVersion + " to " + version;
+    /// <summary>
+    /// What this run is to this host: a first install, or what it does to the version already there. The two
+    /// versions are compared, not just tested for equality, so a package older than the install says
+    /// "downgrade" rather than claiming the opposite of what it is about to do. A version either side cannot
+    /// parse gets "replace", which is true whichever direction it turns out to be.
+    /// </summary>
+    internal static string HostAction(Detect.HostState host, string version)
+    {
+        if (!host.Installed) return "install " + version;
+
+        string? installed = host.InstalledVersion;
+        if (installed is null) return "replace the installed version with " + version;
+        if (installed == version) return "reinstall " + version;
+
+        if (Number(installed) is not { } had || Number(version) is not { } coming)
+            return "replace " + installed + " with " + version;
+
+        int cmp = had.CompareTo(coming);
+        // Equal numbers with unequal strings is a pre-release either side (2.0.0-rc1 against 2.0.0), where the
+        // direction is real but not in the numbers, so this says what it knows rather than "reinstall".
+        return cmp < 0 ? "upgrade "   + installed + " to " + version
+             : cmp > 0 ? "downgrade " + installed + " to " + version
+             :           "replace "   + installed + " with " + version;
+    }
+
+    /// <summary>
+    /// The numeric part of a version, or null when it does not parse. A pre-release or build suffix
+    /// ("2.0.0-rc1", "2.0.0+abc") is cut off first, and the unspecified components are filled with zero so a
+    /// manifest's "2.0.0" and an exe resource's "2.0.0.0" compare equal instead of one reading as newer.
+    /// </summary>
+    private static Version? Number(string text)
+    {
+        int cut = text.IndexOfAny(new[] { '-', '+' });
+        string numeric = cut >= 0 ? text[..cut] : text;
+        if (!Version.TryParse(numeric, out Version? v)) return null;
+        return new Version(v.Major, v.Minor, Math.Max(v.Build, 0), Math.Max(v.Revision, 0));
+    }
 }

--- a/src/housecarl-setup/Program.cs
+++ b/src/housecarl-setup/Program.cs
@@ -72,8 +72,14 @@ public static class Program
             Console.WriteLine("    --claude   install for Claude Code only");
             Console.WriteLine("    --codex    install for Codex only");
             Console.WriteLine("    --both     install for both");
-            Console.WriteLine("    --yes      install without stopping at the plan (unattended runs)");
+            Console.WriteLine("    --yes      skip the confirm at the plan (it still asks which host,");
+            Console.WriteLine("               so an unattended run needs a host flag as well)");
             Console.WriteLine("    --skip-runtime-check   skip the .NET runtime preflight (custom DOTNET_ROOT etc.)");
+            Console.WriteLine();
+            Console.WriteLine("  Setup asks two questions - which host, and the confirm at the plan - and it");
+            Console.WriteLine("  never answers one for you. A run whose input is redirected has nobody to ask,");
+            Console.WriteLine("  so it refuses and names the flag it needed: --claude/--codex/--both for the");
+            Console.WriteLine("  host, --yes for the confirm.");
             return 0;
         }
 
@@ -146,24 +152,27 @@ public static class Program
                 return Finish(1);
             }
 
-            Target? target = ResolveTarget(args, claude, codex);
-            if (target is null)
+            Answer chose = ResolveTarget(args, claude, codex, out Target target);
+            if (chose == Answer.NoOneToAsk) return Finish(1);
+            if (chose == Answer.Quit)
             {
                 Console.WriteLine("Cancelled - nothing was installed.");
                 return Finish(0);
             }
 
             // ---- the plan, before anything is written ------------------------
-            Plan.Print(Plan.For(target.Value, home, homeOverride, claude, codex),
+            Plan.Print(Plan.For(target, home, homeOverride, claude, codex),
                        Detect.PluginVersion(srcManifest) ?? SetupVersion());
-            if (!Confirmed(args))
+            Answer confirmed = Confirm(args);
+            if (confirmed == Answer.NoOneToAsk) return Finish(1);
+            if (confirmed == Answer.Quit)
             {
                 Console.WriteLine("Cancelled - nothing was installed.");
                 return Finish(0);
             }
 
             Console.WriteLine();
-            InstallResult result = TryInstall(target.Value, pluginSrc, home, homeOverride);
+            InstallResult result = TryInstall(target, pluginSrc, home, homeOverride);
             if (result.Outcome == InstallOutcome.ServerInUse)
             {
                 string sentence = result.RefusedBeforeAnyCopy
@@ -180,7 +189,7 @@ public static class Program
                 return Finish(1);
             }
 
-            PrintNext(target.Value);
+            PrintNext(target);
             return Finish(0);
         }
         catch (Exception ex)
@@ -207,21 +216,41 @@ public static class Program
         Ui.Row(codex.Name,  codex.Summary);
     }
 
+    /// <summary>What came back from a question setup had to ask a person.</summary>
+    private enum Answer
+    {
+        /// <summary>They answered it: go on.</summary>
+        Yes,
+        /// <summary>They said no: stop, having changed nothing.</summary>
+        Quit,
+        /// <summary>There was nobody to ask (redirected input) and no flag that answered it in advance. The
+        /// refusal has already been printed; the run stops.</summary>
+        NoOneToAsk,
+    }
+
     /// <summary>
     /// The plan's confirm. It stands on every attended run, including one started with a host flag, because the
-    /// paths are the thing worth reading before they are written. An unattended run - <c>--yes</c>, or a run whose
-    /// input is redirected and so has nobody to press a key - goes straight on.
+    /// paths are the thing worth reading before they are written. <c>--yes</c> is the one way past it. A run
+    /// whose input is redirected has nobody to press a key, so without that flag it is refused rather than read
+    /// as a yes: the same rule as the host menu, which is the other question setup asks.
     /// </summary>
-    private static bool Confirmed(string[] args)
+    private static Answer Confirm(string[] args)
     {
-        if (args.Contains("--yes") || Console.IsInputRedirected) return true;
+        if (args.Contains("--yes")) return Answer.Yes;
         while (true)
         {
-            string? s = Ui.Prompt("  Press Enter to install, or q to quit.  > ");
-            if (s is null) return true; // no interactive input after all
+            string? s = Console.IsInputRedirected ? null : Ui.Prompt("  Press Enter to install, or q to quit.  > ");
+            if (s is null)
+            {
+                Ui.Problem(
+                    "Setup cannot ask you to confirm the plan above, because its input is redirected and there "
+                    + "is nobody to press a key — re-run with --yes to install without stopping at the plan.",
+                    "Nothing was installed.");
+                return Answer.NoOneToAsk;
+            }
             string answer = s.Trim().ToLowerInvariant();
-            if (answer.Length == 0) return true;
-            if (answer is "q" or "quit") return false;
+            if (answer.Length == 0) return Answer.Yes;
+            if (answer is "q" or "quit") return Answer.Quit;
             Console.WriteLine("  Press Enter to install, or type q to quit.");
         }
     }
@@ -335,6 +364,10 @@ public static class Program
     internal static string ClaudeDestExe(string home)
         => Path.Combine(ClaudeSkillsDest(home), "server", "housecarl-mcp.exe");
 
+    /// <summary>The plugin manifest the Claude install copies, which carries the installed version.</summary>
+    internal static string ClaudeDestManifest(string home)
+        => Path.Combine(ClaudeSkillsDest(home), ".claude-plugin", "plugin.json");
+
     /// <summary>The shared, cross-agent skills root the Codex install copies skill folders into, flat.</summary>
     internal static string CodexSkillsRoot(string home)
         => Path.Combine(home, ".agents", "skills");
@@ -363,6 +396,13 @@ public static class Program
     /// <summary>The Codex install's server exe path. Single source of truth so pre-flight == installer.</summary>
     internal static string CodexDestExe(string home, string? homeOverride)
         => Path.Combine(CodexServerDir(home, homeOverride), "housecarl-mcp.exe");
+
+    /// <summary>Where the Codex install records the skill folders it put in the shared ~/.agents/skills, so a
+    /// later upgrade can take back exactly those and nothing else. It sits in houseCARL's own data dir, beside
+    /// the server dir, not in the shared skills dir. The plan names it, because it is a file the install
+    /// writes outside the three roots the other lines cover.</summary>
+    internal static string CodexSkillRecord(string home, string? homeOverride)
+        => Path.Combine(Path.GetDirectoryName(CodexServerDir(home, homeOverride))!, "installed-skills.txt");
 
     /// <summary>
     /// True if <paramref name="destExe"/> already exists AND can't be opened for writing — i.e. a live
@@ -465,11 +505,27 @@ public static class Program
 
     // ---- target selection (flag or interactive prompt) --------------------
 
-    private static Target? ResolveTarget(string[] args, Detect.HostState claude, Detect.HostState codex)
+    /// <summary>
+    /// Which host(s) to install for: the flag if one was passed, else the menu. A run whose input is redirected
+    /// has nobody to pick, so it is refused naming the flags rather than defaulting to a host — the same rule
+    /// the plan's confirm follows.
+    /// </summary>
+    private static Answer ResolveTarget(
+        string[] args, Detect.HostState claude, Detect.HostState codex, out Target target)
     {
-        if (args.Contains("--both"))   return Target.Both;
-        if (args.Contains("--codex"))  return Target.Codex;
-        if (args.Contains("--claude")) return Target.Claude;
+        target = Target.Claude;
+        if (args.Contains("--both"))   { target = Target.Both;   return Answer.Yes; }
+        if (args.Contains("--codex"))  { target = Target.Codex;  return Answer.Yes; }
+        if (args.Contains("--claude")) { target = Target.Claude; return Answer.Yes; }
+
+        if (Console.IsInputRedirected)
+        {
+            Ui.Problem(
+                "Setup cannot ask which agent to install houseCARL for, because its input is redirected and "
+                + "there is nobody to answer — re-run with --claude, --codex or --both to say which.",
+                "Nothing was installed.");
+            return Answer.NoOneToAsk;
+        }
 
         Ui.Heading("Install houseCARL for which agent?");
         Ui.MenuItem("1", claude.Name, claude.Summary);
@@ -489,15 +545,23 @@ public static class Program
         while (true)
         {
             string? s = Ui.Prompt(question);
-            if (s is null) return null;        // no interactive input (redirected) - treat as cancel
+            if (s is null)
+            {
+                // The stream ended mid-question: nobody to ask, same as a redirected run.
+                Ui.Problem(
+                    "Setup cannot ask which agent to install houseCARL for, because its input ended — re-run "
+                    + "with --claude, --codex or --both to say which.",
+                    "Nothing was installed.");
+                return Answer.NoOneToAsk;
+            }
             string answer = s.Trim().ToLowerInvariant();
-            if (answer.Length == 0 && onlyHost is not null) return onlyHost;
+            if (answer.Length == 0 && onlyHost is not null) { target = onlyHost.Value; return Answer.Yes; }
             switch (answer)
             {
-                case "1": return Target.Claude;
-                case "2": return Target.Codex;
-                case "3": return Target.Both;
-                case "q": case "quit": return null;
+                case "1": target = Target.Claude; return Answer.Yes;
+                case "2": target = Target.Codex;  return Answer.Yes;
+                case "3": target = Target.Both;   return Answer.Yes;
+                case "q": case "quit": return Answer.Quit;
                 default: Console.WriteLine("  Please type 1, 2, 3, or q."); break;
             }
         }
@@ -665,12 +729,6 @@ public static class Program
             ? Directory.GetDirectories(skillsSrc).Select(d => Path.GetFileName(d)!).ToList()
             : null;
     }
-
-    /// <summary>Where the Codex install records the skill folders it put in the shared ~/.agents/skills, so a
-    /// later upgrade can take back exactly those and nothing else. It sits in houseCARL's own data dir, beside
-    /// the server dir, not in the shared skills dir.</summary>
-    private static string CodexSkillRecord(string home, string? homeOverride)
-        => Path.Combine(Path.GetDirectoryName(CodexServerDir(home, homeOverride))!, "installed-skills.txt");
 
     /// <summary>The skill folder names a previous Codex install recorded. Anything that is not a bare folder
     /// name is dropped, so a hand-edited record can never point the delete below at another path.</summary>

--- a/src/housecarl-setup/Program.cs
+++ b/src/housecarl-setup/Program.cs
@@ -72,6 +72,7 @@ public static class Program
             Console.WriteLine("    --claude   install for Claude Code only");
             Console.WriteLine("    --codex    install for Codex only");
             Console.WriteLine("    --both     install for both");
+            Console.WriteLine("    --yes      install without stopping at the plan (unattended runs)");
             Console.WriteLine("    --skip-runtime-check   skip the .NET runtime preflight (custom DOTNET_ROOT etc.)");
             return 0;
         }
@@ -115,7 +116,17 @@ public static class Program
                 return Finish(1);
             }
 
-            // ---- server runtime preflight ------------------------------------
+            // HOUSECARL_SETUP_HOME overrides the home dir (testing / unusual setups).
+            string? homeOverride = Environment.GetEnvironmentVariable("HOUSECARL_SETUP_HOME");
+            string home = string.IsNullOrWhiteSpace(homeOverride)
+                ? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
+                : homeOverride;
+
+            // ---- detection ---------------------------------------------------
+            // Read the machine before writing to it: which hosts are here, what houseCARL each already has,
+            // and the runtimes the bundled server needs. Reading only, so a run cancelled at the plan below
+            // leaves everything as it found it.
+            //
             // The bundled server is framework-dependent net9.0 + ASP.NET Core: it needs BOTH the
             // base .NET Runtime (Microsoft.NETCore.App) and the ASP.NET Core Runtime
             // (Microsoft.AspNetCore.App). On Windows those are TWO separate installers, and the
@@ -123,26 +134,29 @@ public static class Program
             // This exe ships self-contained precisely so it still runs on a machine with neither
             // and can say exactly what's missing, instead of the install "succeeding" into a
             // server that never starts.
-            if (!args.Contains("--skip-runtime-check"))
+            bool skipRuntimeCheck = args.Contains("--skip-runtime-check");
+            List<string> missingRuntimes = skipRuntimeCheck ? new List<string>() : MissingServerRuntimes();
+            Detect.HostState claude = Detect.Claude(home);
+            Detect.HostState codex  = Detect.Codex(home, homeOverride);
+            ReportDetected(claude, codex, missingRuntimes, skipRuntimeCheck);
+
+            if (missingRuntimes.Count > 0)
             {
-                List<string> missing = MissingServerRuntimes();
-                if (missing.Count > 0)
-                {
-                    ReportMissingRuntimes(missing);
-                    return Finish(1);
-                }
-                Ui.Ok(".NET Runtime " + ServerRuntimeMajor + " + ASP.NET Core Runtime " + ServerRuntimeMajor + ": found.");
-                Console.WriteLine();
+                ReportMissingRuntimes(missingRuntimes);
+                return Finish(1);
             }
 
-            // HOUSECARL_SETUP_HOME overrides the home dir (testing / unusual setups).
-            string? homeOverride = Environment.GetEnvironmentVariable("HOUSECARL_SETUP_HOME");
-            string home = string.IsNullOrWhiteSpace(homeOverride)
-                ? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
-                : homeOverride;
-
-            Target? target = ResolveTarget(args);
+            Target? target = ResolveTarget(args, claude, codex);
             if (target is null)
+            {
+                Console.WriteLine("Cancelled - nothing was installed.");
+                return Finish(0);
+            }
+
+            // ---- the plan, before anything is written ------------------------
+            Plan.Print(Plan.For(target.Value, home, homeOverride, claude, codex),
+                       Detect.PluginVersion(srcManifest) ?? SetupVersion());
+            if (!Confirmed(args))
             {
                 Console.WriteLine("Cancelled - nothing was installed.");
                 return Finish(0);
@@ -176,6 +190,39 @@ public static class Program
                 + "line below is what the failure reported, and the steps above it are how far it got.",
                 ex.Message);
             return Finish(1);
+        }
+    }
+
+    /// <summary>The detection block: one row per thing setup looked for, printed before any choice is offered.</summary>
+    private static void ReportDetected(
+        Detect.HostState claude, Detect.HostState codex, List<string> missingRuntimes, bool skipped)
+    {
+        Ui.Heading("Checking your machine");
+        string baseName = ".NET Runtime " + ServerRuntimeMajor;
+        string aspName  = "ASP.NET Core Runtime " + ServerRuntimeMajor;
+        string skipNote = "not checked (--skip-runtime-check)";
+        Ui.Row(baseName, skipped ? skipNote : missingRuntimes.Contains("Microsoft.NETCore.App") ? "not found" : "found");
+        Ui.Row(aspName,  skipped ? skipNote : missingRuntimes.Contains("Microsoft.AspNetCore.App") ? "not found" : "found");
+        Ui.Row(claude.Name, claude.Summary);
+        Ui.Row(codex.Name,  codex.Summary);
+    }
+
+    /// <summary>
+    /// The plan's confirm. It stands on every attended run, including one started with a host flag, because the
+    /// paths are the thing worth reading before they are written. An unattended run - <c>--yes</c>, or a run whose
+    /// input is redirected and so has nobody to press a key - goes straight on.
+    /// </summary>
+    private static bool Confirmed(string[] args)
+    {
+        if (args.Contains("--yes") || Console.IsInputRedirected) return true;
+        while (true)
+        {
+            string? s = Ui.Prompt("  Press Enter to install, or q to quit.  > ");
+            if (s is null) return true; // no interactive input after all
+            string answer = s.Trim().ToLowerInvariant();
+            if (answer.Length == 0) return true;
+            if (answer is "q" or "quit") return false;
+            Console.WriteLine("  Press Enter to install, or type q to quit.");
         }
     }
 
@@ -274,13 +321,38 @@ public static class Program
         return new InstallResult(InstallOutcome.Installed, null);
     }
 
+    // ---- destination paths (one source of truth for pre-flight, plan and installer) ----
+
+    /// <summary>Where the Claude install puts the plugin tree.</summary>
+    internal static string ClaudeSkillsDest(string home)
+        => Path.Combine(home, ".claude", "skills", PluginFolderName);
+
+    /// <summary>The Claude config file the MCP server is registered in.</summary>
+    internal static string ClaudeJson(string home)
+        => Path.Combine(home, ".claude.json");
+
     /// <summary>The Claude install's server exe path. Single source of truth so pre-flight == installer.</summary>
-    private static string ClaudeDestExe(string home)
-        => Path.Combine(home, ".claude", "skills", PluginFolderName, "server", "housecarl-mcp.exe");
+    internal static string ClaudeDestExe(string home)
+        => Path.Combine(ClaudeSkillsDest(home), "server", "housecarl-mcp.exe");
+
+    /// <summary>The shared, cross-agent skills root the Codex install copies skill folders into, flat.</summary>
+    internal static string CodexSkillsRoot(string home)
+        => Path.Combine(home, ".agents", "skills");
+
+    /// <summary>Codex's own config dir, honouring CODEX_HOME if the user set it.</summary>
+    internal static string CodexConfigHome(string home)
+    {
+        string? codexHomeEnv = Environment.GetEnvironmentVariable("CODEX_HOME");
+        return string.IsNullOrWhiteSpace(codexHomeEnv) ? Path.Combine(home, ".codex") : codexHomeEnv;
+    }
+
+    /// <summary>The Codex config file the MCP server is registered in.</summary>
+    internal static string CodexConfigToml(string home)
+        => Path.Combine(CodexConfigHome(home), "config.toml");
 
     /// <summary>The Codex install's server dir. Under a test home (HOUSECARL_SETUP_HOME) it hangs off that
     /// home so tests never touch the real LOCALAPPDATA; otherwise it lives under %LOCALAPPDATA%.</summary>
-    private static string CodexServerDir(string home, string? homeOverride)
+    internal static string CodexServerDir(string home, string? homeOverride)
     {
         string dataBase = string.IsNullOrWhiteSpace(homeOverride)
             ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
@@ -289,7 +361,7 @@ public static class Program
     }
 
     /// <summary>The Codex install's server exe path. Single source of truth so pre-flight == installer.</summary>
-    private static string CodexDestExe(string home, string? homeOverride)
+    internal static string CodexDestExe(string home, string? homeOverride)
         => Path.Combine(CodexServerDir(home, homeOverride), "housecarl-mcp.exe");
 
     /// <summary>
@@ -393,22 +465,34 @@ public static class Program
 
     // ---- target selection (flag or interactive prompt) --------------------
 
-    private static Target? ResolveTarget(string[] args)
+    private static Target? ResolveTarget(string[] args, Detect.HostState claude, Detect.HostState codex)
     {
         if (args.Contains("--both"))   return Target.Both;
         if (args.Contains("--codex"))  return Target.Codex;
         if (args.Contains("--claude")) return Target.Claude;
 
-        Console.WriteLine("Install houseCARL for which agent?");
-        Console.WriteLine("  [1] Claude Code");
-        Console.WriteLine("  [2] Codex");
-        Console.WriteLine("  [3] Both");
+        Ui.Heading("Install houseCARL for which agent?");
+        Ui.MenuItem("1", claude.Name, claude.Summary);
+        Ui.MenuItem("2", codex.Name,  codex.Summary);
+        Ui.MenuItem("3", "Both", "");
         Console.WriteLine();
+
+        // Exactly one host on this machine leaves nothing to choose between, so a bare Enter takes it.
+        Target? onlyHost = claude.Present && !codex.Present  ? Target.Claude
+                         : codex.Present  && !claude.Present ? Target.Codex
+                         :                                     null;
+        string question = onlyHost is null
+            ? "  Enter 1, 2, or 3 (or q to quit): "
+            : "  Enter 1, 2, or 3, or press Enter for "
+              + (onlyHost == Target.Claude ? claude.Name : codex.Name) + " (q to quit): ";
+
         while (true)
         {
-            string? s = Ui.Prompt("Enter 1, 2, or 3 (or q to quit): ");
+            string? s = Ui.Prompt(question);
             if (s is null) return null;        // no interactive input (redirected) - treat as cancel
-            switch (s.Trim().ToLowerInvariant())
+            string answer = s.Trim().ToLowerInvariant();
+            if (answer.Length == 0 && onlyHost is not null) return onlyHost;
+            switch (answer)
             {
                 case "1": return Target.Claude;
                 case "2": return Target.Codex;
@@ -423,9 +507,9 @@ public static class Program
 
     private static void InstallForClaude(string pluginSrc, string home, List<string> keptBack)
     {
-        string skillsDest = Path.Combine(home, ".claude", "skills", PluginFolderName);
+        string skillsDest = ClaudeSkillsDest(home);
         string destExe    = ClaudeDestExe(home);
-        string claudeJson = Path.Combine(home, ".claude.json");
+        string claudeJson = ClaudeJson(home);
 
         Ui.Step("Claude Code", "installing skills + server", skillsDest);
         CopyDirectory(pluginSrc, skillsDest);
@@ -467,14 +551,10 @@ public static class Program
         string destExe    = CodexDestExe(home, homeOverride);
 
         // Skills go FLAT under ~/.agents/skills/ (the cross-agent, user-scope skills dir).
-        string skillsRoot = Path.Combine(home, ".agents", "skills");
+        string skillsRoot = CodexSkillsRoot(home);
 
         // ~/.codex/config.toml, honoring CODEX_HOME if the user set it.
-        string? codexHomeEnv = Environment.GetEnvironmentVariable("CODEX_HOME");
-        string codexHome = string.IsNullOrWhiteSpace(codexHomeEnv)
-            ? Path.Combine(home, ".codex")
-            : codexHomeEnv;
-        string configToml = Path.Combine(codexHome, "config.toml");
+        string configToml = CodexConfigToml(home);
 
         Ui.Step("Codex", "installing the server", serverDest);
         CopyDirectory(Path.Combine(pluginSrc, "server"), serverDest);

--- a/src/housecarl-setup/Ui.cs
+++ b/src/housecarl-setup/Ui.cs
@@ -18,6 +18,9 @@ public static class Ui
 {
     private const int RuleWidth = 63;
 
+    // The label column of the detection block and the menu, wide enough for the longest label either prints.
+    private const int RowLabelWidth = 31;
+
     private static readonly bool NoColor =
         !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("NO_COLOR"));
 
@@ -49,6 +52,50 @@ public static class Ui
     /// <summary>A horizontal divider the width of the banner.</summary>
     public static void Rule()
         => Paint(OutColor, ConsoleColor.DarkGray, () => Console.WriteLine("  " + new string('─', RuleWidth)));
+
+    /// <summary>A section title: the detection block, the plan.</summary>
+    public static void Heading(string text)
+    {
+        Console.WriteLine();
+        Paint(OutColor, ConsoleColor.White, () => Console.WriteLine("  " + text));
+        Console.WriteLine();
+    }
+
+    /// <summary>One thing that was looked for, and what was found - the rows of the detection block.</summary>
+    public static void Row(string label, string value)
+    {
+        Console.Write("    " + label.PadRight(RowLabelWidth));
+        Paint(OutColor, ConsoleColor.DarkGray, () => Console.WriteLine(value));
+    }
+
+    /// <summary>One option in the pick-a-host menu, with what was detected beside it.</summary>
+    public static void MenuItem(string key, string label, string note)
+    {
+        if (note.Length == 0) { Console.WriteLine("    [" + key + "] " + label); return; }
+        Console.Write("    [" + key + "] " + label.PadRight(RowLabelWidth - 4));
+        Paint(OutColor, ConsoleColor.DarkGray, () => Console.WriteLine(note));
+    }
+
+    /// <summary>A host's heading in the plan, and whether this run installs or upgrades it.</summary>
+    public static void PlanHost(string host, string action)
+    {
+        Paint(OutColor, ConsoleColor.Cyan, () => Console.Write("    " + host));
+        Paint(OutColor, ConsoleColor.DarkGray, () => Console.WriteLine("  ·  " + action));
+    }
+
+    /// <summary>One destination in the plan: the exact path, and what goes there.</summary>
+    public static void PlanLine(string path, string what, int pathWidth)
+    {
+        Console.Write("      " + path.PadRight(pathWidth));
+        Paint(OutColor, ConsoleColor.DarkGray, () => Console.WriteLine("   " + what));
+    }
+
+    /// <summary>A plain line of prose at the body indent, with a blank line before it.</summary>
+    public static void Body(string text)
+    {
+        Console.WriteLine();
+        Console.WriteLine("  " + text);
+    }
 
     /// <summary>One step of the run: what is being done for which host, and the paths it touches.</summary>
     public static void Step(string host, string what, params string[] paths)

--- a/src/housecarl-setup/Ui.cs
+++ b/src/housecarl-setup/Ui.cs
@@ -90,11 +90,12 @@ public static class Ui
         Paint(OutColor, ConsoleColor.DarkGray, () => Console.WriteLine("   " + what));
     }
 
-    /// <summary>A plain line of prose at the body indent, with a blank line before it.</summary>
-    public static void Body(string text)
+    /// <summary>Prose at the body indent, one line each, with a single blank line before the first.</summary>
+    public static void Body(params string[] lines)
     {
         Console.WriteLine();
-        Console.WriteLine("  " + text);
+        foreach (string line in lines)
+            Console.WriteLine("  " + line);
     }
 
     /// <summary>One step of the run: what is being done for which host, and the paths it touches.</summary>
@@ -108,13 +109,6 @@ public static class Ui
 
     /// <summary>An item under the step above it.</summary>
     public static void Bullet(string text) => Console.WriteLine("      - " + text);
-
-    /// <summary>A check that passed.</summary>
-    public static void Ok(string text)
-    {
-        Paint(OutColor, ConsoleColor.Green, () => Console.Write("[check] "));
-        Console.WriteLine(text);
-    }
 
     /// <summary>
     /// A run that did not do what was asked: one plain sentence saying what went wrong and what to try, then


### PR DESCRIPTION
PR B of three on the installer. Setup now reads the machine before it writes to it and shows the user what it is about to do. A detection block after the banner says which hosts are here, whether houseCARL is already installed for each and at what version (Claude Code from the copied plugin's own manifest, Codex from the installed server exe, since a Codex install copies no manifest), and whether the two .NET runtimes are there. The host menu repeats that beside each option, and where exactly one host is found a bare Enter picks it. Before any file is copied the run prints the plan: one line per destination, the exact path, labelled install or upgrade per host. The plan's paths come from the same helpers `TryInstall` copies to — `ClaudeSkillsDest`, `ClaudeJson`, `CodexServerDir`, `CodexSkillsRoot`, `CodexConfigToml` on `Program`, extracted here from the inline paths the two installers used to build — so the plan and the install cannot drift. Enter proceeds and `q` quits; the stop stands on `--claude`, `--codex` and `--both` too, and a new `--yes` skips it, as does a run whose input is redirected. `TryInstall` keeps its signature and does the same writes, and `SetupSkillPruneProbe`, `SetupUpdateLockProbe` and `DescriptionVocabularyGuardProbe` are green unedited (127/127 in `ci-all`, 1926 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
