### PR TITLE
Add an uninstall to the setup program, with a summary block

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Flags, for an unattended run: `--claude` / `--codex` / `--both` pick the host, `
 
 Updating: quit Claude Code and Codex first. Setup cannot replace a server a session is running; if one is, it stops and says so.
 
-Uninstalling: `[4] Uninstall`, or `--uninstall` with a host flag. It removes the houseCARL trees it installed, the skill folders it recorded installing, and the `housecarl` entry in `~/.claude.json` and `~/.codex/config.toml` — each config copied to a `.houseCARL.bak` beside it first, and every other byte in it left as it was. The saved MO2 instance sits beside the server and goes with it; the patches houseCARL wrote live in the MO2 mods folder and are left alone.
+Uninstalling: `[4] Uninstall`, or `--uninstall` with a host flag. It removes the skill folders it recorded installing, the server, the rest of the files a houseCARL package ships, and the `housecarl` entry in `~/.claude.json` and `~/.codex/config.toml` — each config copied to a `.houseCARL.uninstall.bak` beside it first, and every other byte in it left as it was. Anything under those locations that houseCARL did not install stays where it is, and the run names it. The saved MO2 instance sits beside the server and goes with it; the patches houseCARL wrote live in the MO2 mods folder and are left alone. When it is over, the run lists what it actually took off.
 
 ### From source
 

--- a/README.md
+++ b/README.md
@@ -158,12 +158,17 @@ Dialogue and facegen are not skills. Their tools carry the bookkeeping, and the 
 
 1. Download `houseCARL-<version>.zip` from the [latest release](https://github.com/Avick3110/houseCARL/releases).
 2. Extract it and run `houseCARL-Setup.exe`.
-3. Select the host: `[1] Claude Code`, `[2] Codex`, `[3] Both`.
+3. Select the host: `[1] Claude Code`, `[2] Codex`, `[3] Both`, `[4] Uninstall`.
    - Claude Code: skills to `~/.claude/skills/housecarl/`, server registered in `~/.claude.json`. The CLI and the desktop app both read these.
    - Codex: server under `%LOCALAPPDATA%\houseCARL\server\`, skills flat under `~/.agents/skills/` with a `$housecarl` entry point, server registered as `[mcp_servers.housecarl]` in `~/.codex/config.toml`.
-4. Restart the host. On first use, houseCARL asks for the MO2 instance folder, the one containing `ModOrganizer.ini`. The instance can be changed at any time by asking.
+4. Read the plan. Setup prints what it found on the machine and then every path it is about to write, and writes nothing until Enter; `q` quits.
+5. Restart the host. The closing block says what was written and what to do next. On first use, houseCARL asks for the MO2 instance folder, the one containing `ModOrganizer.ini`. The instance can be changed at any time by asking.
+
+Flags, for an unattended run: `--claude` / `--codex` / `--both` pick the host, `--yes` skips the confirm at the plan, `--uninstall` removes instead of installing, `--skip-runtime-check` skips the .NET check. A run whose input is redirected has nobody to answer a question, so it stops and names the flag that answers it rather than assuming one.
 
 Updating: quit Claude Code and Codex first. Setup cannot replace a server a session is running; if one is, it stops and says so.
+
+Uninstalling: `[4] Uninstall`, or `--uninstall` with a host flag. It removes the houseCARL trees it installed, the skill folders it recorded installing, and the `housecarl` entry in `~/.claude.json` and `~/.codex/config.toml` — each config copied to a `.houseCARL.bak` beside it first, and every other byte in it left as it was. The saved MO2 instance sits beside the server and goes with it; the patches houseCARL wrote live in the MO2 mods folder and are left alone.
 
 ### From source
 

--- a/packaging/START-HERE.txt
+++ b/packaging/START-HERE.txt
@@ -53,12 +53,14 @@ REMOVING HOUSECARL
   to remove it from. FULLY QUIT Claude (and Codex) first, same as an
   update. It shows the removal plan and waits for the same Enter.
 
-  It removes the houseCARL folders it installed, the skills it recorded
-  installing, and the houseCARL entry in Claude's and Codex's config
-  files -- each config is copied to a  .houseCARL.bak  beside it first,
-  and nothing else in either file is changed. The MO2 folder you set is
-  stored beside the server, so it goes too. The patches houseCARL wrote
-  live in your MO2 mods folder and are left alone.
+  It removes the skills it recorded installing, the server, the rest of
+  the files a houseCARL package ships, and the houseCARL entry in
+  Claude's and Codex's config files -- each config is copied to a
+  .houseCARL.uninstall.bak  beside it first, and nothing else in either
+  file is changed. Anything you put in those folders yourself stays, and
+  the run names it. The MO2 folder you set is stored beside the server,
+  so it goes too. The patches houseCARL wrote live in your MO2 mods
+  folder and are left alone.
 
 
 COMMAND-LINE FLAGS  (you don't need these to install)

--- a/packaging/START-HERE.txt
+++ b/packaging/START-HERE.txt
@@ -13,8 +13,12 @@ INSTALL  (about 30 seconds, no command line)
 ------------------------------------------------------------------------
 
   1.  Double-click   houseCARL-Setup.exe   in this folder.
-      Let it finish. It adds houseCARL to Claude (the skills + the
-      local server) -- it does not touch your game or your mods.
+      It says what it found on your machine, asks which agent to
+      install for, then prints every path it is about to write and
+      waits: press Enter to go ahead, or q to quit. Nothing is
+      written before that keypress -- and it does not touch your
+      game or your mods. At the end it lists what it wrote and what
+      to do next.
 
   2.  FULLY restart Claude.
       Close and reopen the Claude desktop app, or restart the `claude`
@@ -41,6 +45,33 @@ UPDATING  (installing a newer houseCARL over an older one)
   Same as installing -- but FULLY QUIT Claude (and Codex) FIRST. The
   setup can't replace the houseCARL server while a session is running
   it; if one is, it stops and tells you to quit and re-run.
+
+
+REMOVING HOUSECARL
+------------------------------------------------------------------------
+  Run  houseCARL-Setup.exe  and pick  [4] Uninstall,  then which agent
+  to remove it from. FULLY QUIT Claude (and Codex) first, same as an
+  update. It shows the removal plan and waits for the same Enter.
+
+  It removes the houseCARL folders it installed, the skills it recorded
+  installing, and the houseCARL entry in Claude's and Codex's config
+  files -- each config is copied to a  .houseCARL.bak  beside it first,
+  and nothing else in either file is changed. The MO2 folder you set is
+  stored beside the server, so it goes too. The patches houseCARL wrote
+  live in your MO2 mods folder and are left alone.
+
+
+COMMAND-LINE FLAGS  (you don't need these to install)
+------------------------------------------------------------------------
+  --claude / --codex / --both   pick the agent without the menu
+  --yes                         skip the confirm at the plan
+  --uninstall                   remove instead of install
+  --skip-runtime-check          skip the .NET runtime check
+  --help                        the full list
+
+  Setup never answers its own questions: a run whose input is
+  redirected has nobody to press a key, so it stops and names the flag
+  that answers the question instead.
 
 
 REQUIREMENTS

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -14,27 +14,34 @@ saying it sets an expectation their install may contradict. Say what is known, a
 ## Unreleased
 
 - **Setup can take houseCARL back off the machine.** `[4] Uninstall` on the menu, or `--uninstall` with
-  `--claude`, `--codex` or `--both`, removes what an install wrote: the houseCARL tree at each install
-  location, the skill folders setup recorded installing, the record itself, and the `housecarl` entry in
-  `~/.claude.json` and `~/.codex/config.toml`. Each config file is copied to a `.houseCARL.bak` beside it
-  first and then spliced, so the entry goes and every other byte in the file stays where it was — the
-  `setup-uninstall` CI guard installs over two configs that already carry another MCP server and asserts both
-  are byte-identical afterwards. The saved MO2 instance in `houseCARL.user.json` sits beside the server and
-  goes with it; the patches houseCARL wrote live in your MO2 mods folder and are not touched. The shared
-  `~/.agents/skills` holds other agents' skills, so only folders the record names are removed there; what an
-  install with no record removes instead, per host, is on `Uninstall` in `src/housecarl-setup/Uninstall.cs`.
+  `--claude`, `--codex` or `--both`, removes what an install wrote: the skill folders setup recorded
+  installing, the server with the saved MO2 instance beside it, the rest of the files a houseCARL package
+  ships, the record itself, and the `housecarl` entry in `~/.claude.json` and `~/.codex/config.toml`. A file
+  or folder under those locations that houseCARL did not install is left where it is and named, and so is the
+  folder holding it. Each config file is copied to a `.houseCARL.uninstall.bak` beside it — a name of its own,
+  so the copy the install took is still there — and then spliced, so the entry goes and every other byte in
+  the file stays where it was, its BOM and each line's own newline included. A config that carries no entry
+  setup recognises is reported as not found and is not written to at all. The `setup-uninstall` CI guard
+  drives the splices over a table of config shapes and asserts the byte-for-byte result of each. The patches
+  houseCARL wrote live in your MO2 mods folder and are not touched. The shared `~/.agents/skills` holds other
+  agents' skills, so only folders the record names are removed there; what an install with no record removes
+  instead, per host, is on `Uninstall` in `src/housecarl-setup/Uninstall.cs`.
 - **The Claude install records which skills it wrote.** `installed-skills.txt` at the root of the installed
   tree, mirroring the one the Codex install has kept since it started sharing `~/.agents/skills`. It is what
   the uninstall reads to name the skills it is taking back. An install made before this version left none, and
   an uninstall of one says which route it took instead.
 - **A run says what it did when it is over.** Install and uninstall both close with the same block: the paths
   that were written or removed, host by host, then what to do next — restart the host, and for an install that
-  houseCARL asks for your Mod Organizer 2 folder the first time a tool is used. The block is the plan the
-  confirm was given for, printed again, on `Plan.PrintSummary` in `src/housecarl-setup/Plan.cs`, so it cannot
-  name a path the run never touched.
-- **The .NET runtime refusal now comes after the menu rather than before it.** The runtimes are the server's,
-  so only an install needs them; refusing at the detection block left a machine missing one with no way to
-  uninstall. The detection block still reports both runtimes before anything is chosen.
+  houseCARL asks for your Mod Organizer 2 folder the first time a tool is used. An install writes every line
+  of its plan, so its block is that plan printed again; a removal's is not, because a host with nothing
+  installed or a config with no entry of ours is a line the run does not act on. Each removal line is what
+  that step actually did, carried back from the run, on `Plan.PrintRemovalSummary` in
+  `src/housecarl-setup/Plan.cs` — a removal that took nothing off says so rather than claiming the paths it
+  intended to touch.
+- **The .NET runtime and broken-package refusals now come after the menu rather than before it.** The runtimes
+  and the package are the install's, so only an install needs them; refusing at the detection block left a
+  machine missing a runtime, or holding a half-unzipped download, with no way to reach `[4] Uninstall`. The
+  detection block still reports both runtimes before anything is chosen.
 
 - **The plugin's own `README.md` describes the 2.0 surface.** This is the file the installer copies to
   `~/.claude/skills/housecarl/README.md` and the marketplace shows. It is now the installed-copy subset of

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,29 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **Setup can take houseCARL back off the machine.** `[4] Uninstall` on the menu, or `--uninstall` with
+  `--claude`, `--codex` or `--both`, removes what an install wrote: the houseCARL tree at each install
+  location, the skill folders setup recorded installing, the record itself, and the `housecarl` entry in
+  `~/.claude.json` and `~/.codex/config.toml`. Each config file is copied to a `.houseCARL.bak` beside it
+  first and then spliced, so the entry goes and every other byte in the file stays where it was — the
+  `setup-uninstall` CI guard installs over two configs that already carry another MCP server and asserts both
+  are byte-identical afterwards. The saved MO2 instance in `houseCARL.user.json` sits beside the server and
+  goes with it; the patches houseCARL wrote live in your MO2 mods folder and are not touched. The shared
+  `~/.agents/skills` holds other agents' skills, so only folders the record names are removed there; what an
+  install with no record removes instead, per host, is on `Uninstall` in `src/housecarl-setup/Uninstall.cs`.
+- **The Claude install records which skills it wrote.** `installed-skills.txt` at the root of the installed
+  tree, mirroring the one the Codex install has kept since it started sharing `~/.agents/skills`. It is what
+  the uninstall reads to name the skills it is taking back. An install made before this version left none, and
+  an uninstall of one says which route it took instead.
+- **A run says what it did when it is over.** Install and uninstall both close with the same block: the paths
+  that were written or removed, host by host, then what to do next — restart the host, and for an install that
+  houseCARL asks for your Mod Organizer 2 folder the first time a tool is used. The block is the plan the
+  confirm was given for, printed again, on `Plan.PrintSummary` in `src/housecarl-setup/Plan.cs`, so it cannot
+  name a path the run never touched.
+- **The .NET runtime refusal now comes after the menu rather than before it.** The runtimes are the server's,
+  so only an install needs them; refusing at the detection block left a machine missing one with no way to
+  uninstall. The detection block still reports both runtimes before anything is chosen.
+
 - **The plugin's own `README.md` describes the 2.0 surface.** This is the file the installer copies to
   `~/.claude/skills/housecarl/README.md` and the marketplace shows. It is now the installed-copy subset of
   the top-level `README.md`, and says what it carries. It was still the 1.x text, including a claim that

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -60,12 +60,17 @@ Dialogue and facegen are not skills. Their tools carry the bookkeeping: `check f
 
 1. Download `houseCARL-<version>.zip` from the [latest release](https://github.com/Avick3110/houseCARL/releases).
 2. Extract it and run `houseCARL-Setup.exe`.
-3. Select the host: `[1] Claude Code`, `[2] Codex`, `[3] Both`.
+3. Select the host: `[1] Claude Code`, `[2] Codex`, `[3] Both`, `[4] Uninstall`.
    - Claude Code: skills to `~/.claude/skills/housecarl/`, server registered in `~/.claude.json`. The CLI and the desktop app both read these.
    - Codex: server under `%LOCALAPPDATA%\houseCARL\server\`, skills flat under `~/.agents/skills/` with a `$housecarl` entry point, server registered as `[mcp_servers.housecarl]` in `~/.codex/config.toml`.
-4. Restart the host.
+4. Read the plan. Setup prints what it found on the machine and then every path it is about to write, and writes nothing until Enter; `q` quits.
+5. Restart the host. The closing block says what was written and what to do next.
+
+Flags, for an unattended run: `--claude` / `--codex` / `--both` pick the host, `--yes` skips the confirm at the plan, `--uninstall` removes instead of installing, `--skip-runtime-check` skips the .NET check. A run whose input is redirected has nobody to answer a question, so it stops and names the flag that answers it rather than assuming one.
 
 Updating: quit Claude Code and Codex first. Setup cannot replace a server a session is running; if one is, it stops and says so. Setup overwrites only the files in the package, so the saved MO2 instance and tool paths in `houseCARL.user.json` survive a re-run.
+
+Uninstalling: `[4] Uninstall`, or `--uninstall` with a host flag. It removes the houseCARL trees it installed, the skill folders it recorded installing, and the `housecarl` entry in `~/.claude.json` and `~/.codex/config.toml` — each config copied to a `.houseCARL.bak` beside it first, and every other byte in it left as it was. `houseCARL.user.json` sits beside the server and goes with it; the patches houseCARL wrote live in the MO2 mods folder and are left alone.
 
 ### From source
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -70,7 +70,7 @@ Flags, for an unattended run: `--claude` / `--codex` / `--both` pick the host, `
 
 Updating: quit Claude Code and Codex first. Setup cannot replace a server a session is running; if one is, it stops and says so. Setup overwrites only the files in the package, so the saved MO2 instance and tool paths in `houseCARL.user.json` survive a re-run.
 
-Uninstalling: `[4] Uninstall`, or `--uninstall` with a host flag. It removes the houseCARL trees it installed, the skill folders it recorded installing, and the `housecarl` entry in `~/.claude.json` and `~/.codex/config.toml` — each config copied to a `.houseCARL.bak` beside it first, and every other byte in it left as it was. `houseCARL.user.json` sits beside the server and goes with it; the patches houseCARL wrote live in the MO2 mods folder and are left alone.
+Uninstalling: `[4] Uninstall`, or `--uninstall` with a host flag. It removes the skill folders it recorded installing, the server, the rest of the files a houseCARL package ships, and the `housecarl` entry in `~/.claude.json` and `~/.codex/config.toml` — each config copied to a `.houseCARL.uninstall.bak` beside it first, and every other byte in it left as it was. Anything under those locations that houseCARL did not install stays where it is, and the run names it. `houseCARL.user.json` sits beside the server and goes with it; the patches houseCARL wrote live in the MO2 mods folder and are left alone.
 
 ### From source
 

--- a/src/housecarl-generator/SetupUninstallProbe.cs
+++ b/src/housecarl-generator/SetupUninstallProbe.cs
@@ -1,0 +1,215 @@
+using System.Text.Json.Nodes;
+using SetupProgram = HousecarlSetup.Program;
+using SetupUninstall = HousecarlSetup.Uninstall;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// Setup uninstall guard (installer PR C). Until this there was no way to remove houseCARL other than deleting
+/// folders by hand and editing ~/.claude.json and ~/.codex/config.toml, and a hand edit of either is where a
+/// user loses the rest of the file. The removal is two splices beside the install's insert splices, so the
+/// property that matters is not "the entry is gone" but "the entry is gone AND every other byte is where it
+/// was". This drives the REAL <see cref="HousecarlSetup.Uninstall.TryUninstall"/> over a synthetic package, a
+/// temp home, and two host configs that already carry somebody else's MCP server:
+///
+///   T1  install for Both over the two pre-existing configs, then uninstall Both.
+///   T2  ~/.claude.json is byte-identical to before the install, and ~/.codex/config.toml likewise: the
+///       other server, the unrelated root key, the comment and the newline style all survive the round trip.
+///   T3  no houseCARL file is left: the Claude tree, the Codex server dir (the saved MO2 instance with it),
+///       the skill record and the houseCARL data dir are all gone.
+///   T4  under the SHARED ~/.agents/skills only the folders the record named went — a skill houseCARL never
+///       installed is untouched.
+///   T5  both configs were copied to a .houseCARL.bak before being edited.
+///   T6  an install too old to have left a Claude skill record still has its tree removed, and the run says
+///       that is the route it took.
+///   T7  with no Codex record, nothing under the shared skills root is removed, and the run says so.
+///   T8  a running session's server exe is pre-flighted: the uninstall refuses before deleting anything, and
+///       the installed tree is still there.
+///
+/// Self-contained: synthetic files in temp, no game data / no MO2 / no real host config. RED without the
+/// removal splices: T2 fails on both files (a whole-file rewrite reformats them, a naive line delete leaves the
+/// blank line the insert added), T3 leaves the tree, T4 takes the foreign skill with a directory diff, and T8
+/// deletes into a live install.
+///
+/// Run: dotnet run --project src/housecarl-generator setup-uninstall
+/// </summary>
+internal static class SetupUninstallProbe
+{
+    [CiProbe("setup-uninstall")]
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" setup uninstall guard — the removal takes back exactly what the install wrote");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        // Keep the Codex destination hermetic (the installer honours CODEX_HOME for config.toml).
+        Environment.SetEnvironmentVariable("CODEX_HOME", null);
+
+        string root = Path.Combine(Path.GetTempPath(), "hc-setup-uninstall-" + Guid.NewGuid().ToString("N"));
+        string pkg  = Path.Combine(root, "package");
+        string src  = Path.Combine(pkg, "housecarl");
+        string home = Path.Combine(root, "home");
+
+        // Asked of the installer's own path helpers, never rebuilt here.
+        string claudeDest   = SetupProgram.ClaudeSkillsDest(home);
+        string claudeJson   = SetupProgram.ClaudeJson(home);
+        string claudeRecord = SetupProgram.ClaudeSkillRecord(home);
+        string codexServer  = SetupProgram.CodexServerDir(home, home);
+        string codexSkills  = SetupProgram.CodexSkillsRoot(home);
+        string codexRecord  = SetupProgram.CodexSkillRecord(home, home);
+        string codexToml    = SetupProgram.CodexConfigToml(home);
+        string codexDataDir = Path.GetDirectoryName(codexServer)!;
+
+        var (codexPkgPath, _) = SetupUpdateLockProbe.CodexPackagePath();
+        string umbrellaPkgDir = Path.Combine(new[] { pkg }
+            .Concat((codexPkgPath ?? "codex/skills").Split('/'))
+            .Append("housecarl").ToArray());
+
+        try
+        {
+            // ---- a synthetic package ----
+            WriteFile(Path.Combine(src, ".claude-plugin", "plugin.json"), "{}");
+            WriteFile(Path.Combine(src, "server", "housecarl-mcp.exe"), "exe");
+            foreach (string s in new[] { "skill-one", "skill-two" })
+                WriteFile(Path.Combine(src, "skills", s, "SKILL.md"), s);
+            WriteFile(Path.Combine(umbrellaPkgDir, "SKILL.md"), "umbrella");
+
+            // ---- two host configs that already carry somebody else's server ----
+            WriteFile(claudeJson, ExistingClaudeJson());
+            WriteFile(codexToml, "# my own config\n[other]\nkey = 1\n");
+            string claudeBefore = File.ReadAllText(claudeJson);
+            string tomlBefore   = File.ReadAllText(codexToml);
+
+            // A skill some other tool put in the shared ~/.agents/skills.
+            WriteFile(Path.Combine(codexSkills, "someone-elses-skill", "SKILL.md"), "not ours");
+
+            Console.WriteLine("--- T1: install for Both, then uninstall Both ---");
+            var installed = SetupProgram.TryInstall(SetupProgram.Target.Both, src, home, home);
+            Check(installed.Outcome == SetupProgram.InstallOutcome.Installed, "the install ran");
+            Check(File.Exists(claudeRecord), "the Claude install recorded which skills it wrote");
+            Check(File.ReadAllText(claudeJson).Contains("housecarl"), "the Claude config carries the entry");
+            Check(File.ReadAllText(codexToml).Contains("[mcp_servers.housecarl]"), "the Codex config carries the table");
+            // The saved MO2 instance the server writes beside itself — the removal takes it with the server dir.
+            WriteFile(Path.Combine(codexServer, "houseCARL.user.json"), "{\"Mo2InstanceDir\":\"D:\\\\MO2\"}");
+            WriteFile(Path.Combine(claudeDest, "server", "houseCARL.user.json"), "{\"Mo2InstanceDir\":\"D:\\\\MO2\"}");
+
+            SetupUninstall.Result removed = null!;
+            string said = Capture(() => removed = SetupUninstall.TryUninstall(SetupProgram.Target.Both, home, home));
+            Check(removed.What == SetupUninstall.Outcome.Removed, "the uninstall ran");
+
+            Console.WriteLine();
+            Console.WriteLine("--- T2: both host configs are byte-identical to before the install ---");
+            Check(File.ReadAllText(claudeJson) == claudeBefore,
+                  "~/.claude.json is back to its original bytes, entry and all else");
+            Check(File.ReadAllText(codexToml) == tomlBefore,
+                  "~/.codex/config.toml is back to its original bytes");
+            Check(File.ReadAllText(claudeJson).Contains("\"other\""), "the other server is still registered");
+            Check(File.ReadAllText(codexToml).Contains("[other]"), "the other Codex table is still there");
+
+            Console.WriteLine();
+            Console.WriteLine("--- T3: no houseCARL file is left on the machine ---");
+            Check(!Directory.Exists(claudeDest), "the Claude tree is gone (skills, server and the saved MO2 instance)");
+            Check(!Directory.Exists(codexServer), "the Codex server dir is gone (the saved MO2 instance with it)");
+            Check(!File.Exists(codexRecord), "the Codex skill record is gone");
+            Check(!Directory.Exists(codexDataDir), "the emptied houseCARL data dir is gone");
+
+            Console.WriteLine();
+            Console.WriteLine("--- T4: under the shared skills root, only the recorded folders went ---");
+            Check(!Directory.Exists(Path.Combine(codexSkills, "skill-one")), "skill-one is gone");
+            Check(!Directory.Exists(Path.Combine(codexSkills, "skill-two")), "skill-two is gone");
+            Check(!Directory.Exists(Path.Combine(codexSkills, "housecarl")), "the umbrella skill is gone");
+            Check(Directory.Exists(Path.Combine(codexSkills, "someone-elses-skill")),
+                  "a skill houseCARL never installed is untouched");
+
+            Console.WriteLine();
+            Console.WriteLine("--- T5: each config was backed up before it was edited ---");
+            Check(File.Exists(claudeJson + ".houseCARL.bak"), "~/.claude.json.houseCARL.bak exists");
+            Check(File.Exists(codexToml + ".houseCARL.bak"), "config.toml.houseCARL.bak exists");
+            Check(File.ReadAllText(claudeJson + ".houseCARL.bak").Contains("housecarl"),
+                  "the backup holds the file as it was, entry included");
+
+            // ---- T6: an install with no Claude record ----
+            Console.WriteLine();
+            Console.WriteLine("--- T6: an install too old to have left a record still has its tree removed ---");
+            SetupProgram.TryInstall(SetupProgram.Target.Claude, src, home, home);
+            File.Delete(claudeRecord); // as an install from before the record existed leaves it
+            string oldSaid = Capture(() => SetupUninstall.TryUninstall(SetupProgram.Target.Claude, home, home));
+            Check(!Directory.Exists(claudeDest), "the tree it owns is removed anyway");
+            Check(oldSaid.Contains("before setup began recording"), "and the run says that is the route it took");
+
+            // ---- T7: no Codex record ----
+            Console.WriteLine();
+            Console.WriteLine("--- T7: with no Codex record, nothing under the shared skills root is removed ---");
+            SetupProgram.TryInstall(SetupProgram.Target.Codex, src, home, home);
+            File.Delete(codexRecord);
+            string noRecordSaid = Capture(() => SetupUninstall.TryUninstall(SetupProgram.Target.Codex, home, home));
+            Check(Directory.Exists(Path.Combine(codexSkills, "skill-one")),
+                  "the skills stay where they are rather than being guessed at by a directory diff");
+            Check(Directory.Exists(Path.Combine(codexSkills, "someone-elses-skill")), "so does the foreign skill");
+            Check(noRecordSaid.Contains("no record of which skills"), "and the run says why it removed none");
+            Check(!Directory.Exists(codexServer), "the server dir, which it does own, is still removed");
+            foreach (string d in new[] { "skill-one", "skill-two", "housecarl" })
+                if (Directory.Exists(Path.Combine(codexSkills, d))) Directory.Delete(Path.Combine(codexSkills, d), true);
+
+            // ---- T8: a live session's server exe ----
+            Console.WriteLine();
+            Console.WriteLine("--- T8: a server file in use refuses the removal before anything is deleted ---");
+            SetupProgram.TryInstall(SetupProgram.Target.Claude, src, home, home);
+            string liveExe = SetupProgram.ClaudeDestExe(home);
+            SetupUninstall.Result held;
+            using (new FileStream(liveExe, FileMode.Open, FileAccess.Read, FileShare.Read))
+                held = SetupUninstall.TryUninstall(SetupProgram.Target.Claude, home, home);
+            Check(held.What == SetupUninstall.Outcome.ServerInUse, "the removal refuses");
+            Check(held.RefusedBeforeAnyDelete, "at the pre-flight, before any delete");
+            Check(Directory.Exists(claudeDest), "the installed tree is still there");
+            Check(File.ReadAllText(claudeJson).Contains("housecarl"), "and so is the registration");
+        }
+        finally { try { Directory.Delete(root, recursive: true); } catch { /* non-fatal */ } }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0
+            ? "================ ALL PASS ================"
+            : $"================ {fail} CHECK(S) FAILED ================");
+        return fail == 0 ? 0 : 1;
+    }
+
+    /// <summary>A ~/.claude.json that already holds an unrelated root key and somebody else's MCP server, in the
+    /// indentation System.Text.Json writes — which is the indentation both splices reproduce, so a difference
+    /// after the round trip is the splice's, not the fixture's.</summary>
+    private static string ExistingClaudeJson()
+    {
+        JsonObject root = new()
+        {
+            ["numStartups"] = 7,
+            ["mcpServers"] = new JsonObject
+            {
+                ["other"] = new JsonObject
+                {
+                    ["type"]    = "stdio",
+                    ["command"] = @"C:\tools\other.exe",
+                },
+            },
+        };
+        return root.ToJsonString(new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+    }
+
+    private static void WriteFile(string path, string text)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, text);
+    }
+
+    /// <summary>Run something with the console captured, and return what it said.</summary>
+    private static string Capture(Action run)
+    {
+        var saved = Console.Out;
+        using var buf = new StringWriter();
+        Console.SetOut(buf);
+        try { run(); }
+        finally { Console.SetOut(saved); }
+        return buf.ToString();
+    }
+}

--- a/src/housecarl-generator/SetupUninstallProbe.cs
+++ b/src/housecarl-generator/SetupUninstallProbe.cs
@@ -25,11 +25,21 @@ namespace HousecarlGenerator;
 ///   T7  with no Codex record, nothing under the shared skills root is removed, and the run says so.
 ///   T8  a running session's server exe is pre-flighted: the uninstall refuses before deleting anything, and
 ///       the installed tree is still there.
+///   T9  the TOML splice over a TABLE of config shapes, not one: our table in the middle with a comment above
+///       the table below it, CRLF, mixed newlines, no trailing newline, a subtable, the quoted and the spaced
+///       spellings of the key, a BOM, and a sibling [mcp_servers.housecarl2] that is not ours.
+///   T10 a config with no houseCARL entry is reported as NOT FOUND and is not written to or backed up.
+///   T11 a ~/.claude.json with no mcpServers key at all - the key the install CREATES - is byte-identical
+///       after install-then-uninstall, empty object and all.
+///   T12 a Claude tree with no record and somebody else's file in it: houseCARL's own files go, the foreign
+///       file and the folder holding it stay.
 ///
 /// Self-contained: synthetic files in temp, no game data / no MO2 / no real host config. RED without the
 /// removal splices: T2 fails on both files (a whole-file rewrite reformats them, a naive line delete leaves the
-/// blank line the insert added), T3 leaves the tree, T4 takes the foreign skill with a directory diff, and T8
-/// deletes into a live install.
+/// blank line the insert added), T3 leaves the tree, T4 takes the foreign skill with a directory diff, T8
+/// deletes into a live install, T9 loses the user's comment / newline style / BOM and misses the quoted
+/// spelling, T10 claims a removal that did not happen, T11 leaves "mcpServers": {} behind, and T12 takes the
+/// whole tree including the file houseCARL never wrote.
 ///
 /// Run: dotnet run --project src/housecarl-generator setup-uninstall
 /// </summary>
@@ -126,10 +136,15 @@ internal static class SetupUninstallProbe
 
             Console.WriteLine();
             Console.WriteLine("--- T5: each config was backed up before it was edited ---");
-            Check(File.Exists(claudeJson + ".houseCARL.bak"), "~/.claude.json.houseCARL.bak exists");
-            Check(File.Exists(codexToml + ".houseCARL.bak"), "config.toml.houseCARL.bak exists");
-            Check(File.ReadAllText(claudeJson + ".houseCARL.bak").Contains("housecarl"),
+            string bak = SetupUninstall.BackupSuffix;
+            Check(File.Exists(claudeJson + bak), "~/.claude.json" + bak + " exists");
+            Check(File.Exists(codexToml + bak), "config.toml" + bak + " exists");
+            Check(File.ReadAllText(claudeJson + bak).Contains("housecarl"),
                   "the backup holds the file as it was, entry included");
+            // The removal's backup has a name of its own, so the copy the INSTALL took - the file as it was
+            // before houseCARL was ever registered - is still there to go back to.
+            Check(File.ReadAllText(claudeJson + ".houseCARL.bak") == claudeBefore,
+                  "and the install's own .houseCARL.bak is untouched, still the pre-install file");
 
             // ---- T6: an install with no Claude record ----
             Console.WriteLine();
@@ -166,6 +181,73 @@ internal static class SetupUninstallProbe
             Check(held.RefusedBeforeAnyDelete, "at the pre-flight, before any delete");
             Check(Directory.Exists(claudeDest), "the installed tree is still there");
             Check(File.ReadAllText(claudeJson).Contains("housecarl"), "and so is the registration");
+
+            // ---- T9: the TOML splice over a table of shapes, not one fixture ----
+            Console.WriteLine();
+            Console.WriteLine("--- T9: the TOML splice keeps every byte that is not ours, whatever shape the file is ---");
+            foreach ((string label, string before, string? after) in TomlCases())
+                Check(SetupUninstall.RemoveTomlTable(before, "housecarl") == after, label);
+
+            string bomToml = Path.Combine(root, "bom-config.toml");
+            byte[] bom = { 0xEF, 0xBB, 0xBF };
+            WriteBytes(bomToml, bom, "[other]\nkey = 1\n\n[mcp_servers.housecarl]\ncommand = 'x'\n");
+            Check(SetupUninstall.UnregisterCodexMcpServer(bomToml, "housecarl") == SetupUninstall.ConfigEdit.Removed,
+                  "a config that starts with a BOM has its entry removed");
+            Check(File.ReadAllBytes(bomToml).SequenceEqual(Bytes(bom, "[other]\nkey = 1\n")),
+                  "and still starts with that BOM afterwards");
+
+            // ---- T10: nothing of ours in the file ----
+            Console.WriteLine();
+            Console.WriteLine("--- T10: a config with no houseCARL entry is reported as not found, not as removed ---");
+            string strangerToml = Path.Combine(root, "stranger-config.toml");
+            const string siblingTable = "[mcp_servers.housecarl2]\ncommand = 'x'\n";
+            WriteFile(strangerToml, siblingTable);
+            Check(SetupUninstall.UnregisterCodexMcpServer(strangerToml, "housecarl") == SetupUninstall.ConfigEdit.NotFound,
+                  "config.toml with only a same-prefix sibling table => NotFound");
+            Check(File.ReadAllText(strangerToml) == siblingTable, "the sibling table is left exactly as it was");
+            Check(!File.Exists(strangerToml + SetupUninstall.BackupSuffix), "and the file was not even backed up");
+
+            string strangerJson = Path.Combine(root, "stranger.claude.json");
+            string othersOnly = ExistingClaudeJson();
+            WriteFile(strangerJson, othersOnly);
+            Check(SetupUninstall.UnregisterClaudeMcpServer(strangerJson, "housecarl") == SetupUninstall.ConfigEdit.NotFound,
+                  "~/.claude.json with somebody else's server and none of ours => NotFound");
+            Check(File.ReadAllText(strangerJson) == othersOnly, "and it is left exactly as it was");
+
+            // ---- T11: the mcpServers key the install CREATES ----
+            Console.WriteLine();
+            Console.WriteLine("--- T11: a ~/.claude.json with no mcpServers key round-trips, the created key and all ---");
+            Capture(() => SetupUninstall.TryUninstall(SetupProgram.Target.Claude, home, home)); // clear T8's install
+            const string noServers = "{\n  \"numStartups\": 7\n}";
+            WriteFile(claudeJson, noServers);
+            Capture(() => SetupProgram.TryInstall(SetupProgram.Target.Claude, src, home, home));
+            Check(File.ReadAllText(claudeJson).Contains("mcpServers"), "the install created the mcpServers key");
+            Capture(() => SetupUninstall.TryUninstall(SetupProgram.Target.Claude, home, home));
+            Check(File.ReadAllText(claudeJson) == noServers,
+                  "and the uninstall took the whole key back out — no empty object left behind");
+
+            // ---- T12: the Claude tree is taken by record, and by the package layout without one ----
+            Console.WriteLine();
+            Console.WriteLine("--- T12: under the Claude tree, only what houseCARL installed is removed ---");
+            Capture(() => SetupProgram.TryInstall(SetupProgram.Target.Claude, src, home, home));
+            WriteFile(Path.Combine(claudeDest, "skills", "not-ours", "SKILL.md"), "somebody else's");
+            string byRecord = Capture(() => SetupUninstall.TryUninstall(SetupProgram.Target.Claude, home, home));
+            Check(Directory.Exists(Path.Combine(claudeDest, "skills", "not-ours")),
+                  "with a record, a skill folder houseCARL never installed survives under its own skills root");
+            Check(!Directory.Exists(Path.Combine(claudeDest, "skills", "skill-one")), "the recorded skills went");
+            Check(!Directory.Exists(Path.Combine(claudeDest, "server")), "so did the server dir");
+            Check(byRecord.Contains("still holds these"), "and the run names what it left behind");
+
+            Capture(() => SetupProgram.TryInstall(SetupProgram.Target.Claude, src, home, home));
+            File.Delete(claudeRecord); // as an install from before the record existed leaves it
+            WriteFile(Path.Combine(claudeDest, "my-notes.txt"), "mine");
+            string noRecordTree = Capture(() => SetupUninstall.TryUninstall(SetupProgram.Target.Claude, home, home));
+            Check(File.Exists(Path.Combine(claudeDest, "my-notes.txt")),
+                  "with no record, a file houseCARL never wrote survives, and the tree with it");
+            Check(!Directory.Exists(Path.Combine(claudeDest, "skills")), "the skills the package layout names went");
+            Check(!File.Exists(Path.Combine(claudeDest, ".claude-plugin", "plugin.json")), "so did the manifest");
+            Check(noRecordTree.Contains("went by the files a houseCARL package ships"),
+                  "and the run says it went by the package layout rather than by a record");
         }
         finally { try { Directory.Delete(root, recursive: true); } catch { /* non-fatal */ } }
 
@@ -194,6 +276,57 @@ internal static class SetupUninstallProbe
             },
         };
         return root.ToJsonString(new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+    }
+
+    /// <summary>
+    /// The config.toml shapes the removal splice has to leave alone around the one table it takes: the label,
+    /// the file before, and the file after — or null after, for a file that carries no table of ours at all.
+    /// One expectation per byte: whatever is not the table is in the "after" exactly as it was in the "before".
+    /// </summary>
+    private static (string Label, string Before, string? After)[] TomlCases() => new[]
+    {
+        ("our table in the middle: the comment above the NEXT table is not ours and stays",
+         "# my own config\n[other]\nkey = 1\n\n[mcp_servers.housecarl]\ncommand = 'x'\n\n# my foo server\n[mcp_servers.foo]\ncommand = 'f'\n",
+         (string?)"# my own config\n[other]\nkey = 1\n\n\n# my foo server\n[mcp_servers.foo]\ncommand = 'f'\n"),
+
+        ("a CRLF file stays CRLF",
+         "[other]\r\nkey = 1\r\n\r\n[mcp_servers.housecarl]\r\ncommand = 'x'\r\n",
+         "[other]\r\nkey = 1\r\n"),
+
+        ("a file mixing the two keeps each line's own newline",
+         "[a]\r\nx = 1\n[mcp_servers.housecarl]\ncommand = 'x'\n[b]\r\nz = 1\n",
+         "[a]\r\nx = 1\n[b]\r\nz = 1\n"),
+
+        ("a file that ended without a trailing newline still does",
+         "[mcp_servers.housecarl]\ncommand = 'x'\n\n[other]\nkey = 1",
+         "\n[other]\nkey = 1"),
+
+        ("our own subtables go with the table",
+         "[mcp_servers.housecarl]\ncommand = 'x'\n[mcp_servers.housecarl.env]\nA = 'b'\n\n[other]\nk = 1\n",
+         "\n[other]\nk = 1\n"),
+
+        ("the quoted spelling of the key is ours too",
+         "[other]\nkey = 1\n\n[mcp_servers.\"housecarl\"]\ncommand = 'x'\n",
+         "[other]\nkey = 1\n"),
+
+        ("and so is the spaced dotted spelling",
+         "[other]\nkey = 1\n\n[mcp_servers . housecarl]\ncommand = 'x'\n",
+         "[other]\nkey = 1\n"),
+
+        ("a sibling table that only starts with our name is not ours",
+         "[mcp_servers.housecarl2]\ncommand = 'x'\n", null),
+
+        ("neither is an array of tables under our name",
+         "[[mcp_servers.housecarl]]\ncommand = 'x'\n", null),
+    };
+
+    private static byte[] Bytes(byte[] prefix, string text)
+        => prefix.Concat(System.Text.Encoding.UTF8.GetBytes(text)).ToArray();
+
+    private static void WriteBytes(string path, byte[] prefix, string text)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllBytes(path, Bytes(prefix, text));
     }
 
     private static void WriteFile(string path, string text)

--- a/src/housecarl-setup/Plan.cs
+++ b/src/housecarl-setup/Plan.cs
@@ -39,16 +39,47 @@ public static class Plan
         return plans;
     }
 
+    /// <summary>The plan for a removal, host by host, in removal order. Same destinations as the install, said
+    /// as what comes off them, so the two cannot name different paths.</summary>
+    public static List<HostPlan> ForRemoval(
+        Program.Target target, string home, string? homeOverride,
+        Detect.HostState claude, Detect.HostState codex)
+    {
+        List<HostPlan> plans = new();
+
+        if (target is Program.Target.Claude or Program.Target.Both)
+            plans.Add(new HostPlan(claude, new List<Line>
+            {
+                new(Program.ClaudeSkillsDest(home), "skills, server, and the saved MO2 instance"),
+                new(Program.ClaudeJson(home),       RemovesEntry),
+            }));
+
+        if (target is Program.Target.Codex or Program.Target.Both)
+            plans.Add(new HostPlan(codex, new List<Line>
+            {
+                new(Program.CodexServerDir(home, homeOverride),   "server, and the saved MO2 instance"),
+                new(Program.CodexSkillsRoot(home),                "only the skills the record below names"),
+                new(Program.CodexSkillRecord(home, homeOverride), "the record itself"),
+                new(Program.CodexConfigToml(home),                RemovesEntry),
+            }));
+
+        return plans;
+    }
+
     /// <summary>What a host-config line puts there. The install copies the file to a ".houseCARL.bak"
     /// beside it before editing it, and that copy is a file the plan would otherwise not name.</summary>
     private const string BacksUpFirst = "registers the server  (a .houseCARL.bak copy is made first)";
 
-    /// <summary>Print the plan: a heading per host saying install or upgrade, then one line per destination.</summary>
-    public static void Print(List<HostPlan> plans, string version)
+    /// <summary>The removal's version of the line above: the same file, the same backup, the entry taken out.</summary>
+    private const string RemovesEntry = "removes the server entry  (a .houseCARL.bak copy is made first)";
+
+    /// <summary>Print the plan: a heading per host saying install, upgrade or removal, then one line per
+    /// destination.</summary>
+    public static void Print(List<HostPlan> plans, string version, bool removing = false)
     {
         bool anyHostInstalled = plans.Any(p => p.Host.Installed);
         bool everyHostUpgrading = plans.Count > 0 && plans.All(p => p.Host.Installed);
-        Ui.Heading(everyHostUpgrading ? "This will replace:" : "This will write:");
+        Ui.Heading(removing ? "This will remove:" : everyHostUpgrading ? "This will replace:" : "This will write:");
 
         // One path column across every host, so the "what" side reads as a column rather than a ragged edge.
         int pathWidth = plans.SelectMany(p => p.Lines).Select(l => l.Path.Length).DefaultIfEmpty(0).Max();
@@ -58,7 +89,7 @@ public static class Plan
         {
             if (!first) Console.WriteLine();
             first = false;
-            Ui.PlanHost(plan.Host.Name, HostAction(plan.Host, version));
+            Ui.PlanHost(plan.Host.Name, removing ? RemovalAction(plan.Host) : HostAction(plan.Host, version));
             foreach (Line line in plan.Lines)
                 Ui.PlanLine(line.Path, line.What, pathWidth);
         }
@@ -67,14 +98,70 @@ public static class Plan
         // nothing installed has no previous skill set to take folders back from, so the sentence is printed
         // only when one of the hosts above is being replaced.
         List<string> body = new();
-        if (anyHostInstalled)
+        if (removing)
         {
-            body.Add("Under the skills paths above, skill folders a previous houseCARL");
-            body.Add("installed and this version no longer ships are deleted.");
+            body.Add("Nothing else in those two config files is touched, and the patches");
+            body.Add("houseCARL wrote — which live in your MO2 mods folder — are left alone.");
         }
-        body.Add("Your game, your mods and your MO2 profile are not read.");
+        else
+        {
+            if (anyHostInstalled)
+            {
+                body.Add("Under the skills paths above, skill folders a previous houseCARL");
+                body.Add("installed and this version no longer ships are deleted.");
+            }
+            body.Add("Your game, your mods and your MO2 profile are not read.");
+        }
         Ui.Body(body.ToArray());
     }
+
+    /// <summary>
+    /// The block that closes a finished run: what went where, taken from the same plan the confirm was given
+    /// for, and then what the person does next. It is the plan in the past tense on purpose — a summary built
+    /// from its own list of paths could name one the run never touched.
+    /// </summary>
+    public static void PrintSummary(List<HostPlan> plans, string version, bool removing)
+    {
+        string hosts = string.Join(" and ", plans.Select(p => p.Host.Name));
+
+        Console.WriteLine();
+        Ui.Rule();
+        Ui.Done(removing
+            ? "houseCARL is removed from " + hosts + "."
+            : "houseCARL " + version + " is installed for " + hosts + ".");
+
+        Ui.Heading(removing ? "Removed" : "Written");
+        int pathWidth = plans.SelectMany(p => p.Lines).Select(l => l.Path.Length).DefaultIfEmpty(0).Max();
+        bool first = true;
+        foreach (HostPlan plan in plans)
+        {
+            if (!first) Console.WriteLine();
+            first = false;
+            Ui.PlanHost(plan.Host.Name, "");
+            foreach (Line line in plan.Lines)
+                Ui.PlanLine(line.Path, line.What, pathWidth);
+        }
+
+        Ui.Heading("Next");
+        foreach (HostPlan plan in plans)
+            Ui.Bullet(plan.Host.Name + ": fully quit and reopen it.");
+        Console.WriteLine("        \"Fully\" means every window, every terminal session, and any");
+        Console.WriteLine("        background session.");
+        if (!removing)
+        {
+            Ui.Bullet("On the first use of a houseCARL tool it asks you for your Mod Organizer 2");
+            Console.WriteLine("        folder, the one holding ModOrganizer.ini.");
+            if (plans.Count > 1)
+                Ui.Bullet("Each host runs its own server copy, so that folder is set once per host.");
+        }
+        Console.WriteLine();
+    }
+
+    /// <summary>What this run is to this host on a removal: what is there to take, said before it is taken.</summary>
+    internal static string RemovalAction(Detect.HostState host)
+        => !host.Installed          ? "houseCARL is not installed for it"
+         : host.InstalledVersion is null ? "remove the installed houseCARL"
+         :                            "remove houseCARL " + host.InstalledVersion;
 
     /// <summary>
     /// What this run is to this host: a first install, or what it does to the version already there. The two

--- a/src/housecarl-setup/Plan.cs
+++ b/src/housecarl-setup/Plan.cs
@@ -71,7 +71,7 @@ public static class Plan
     private const string BacksUpFirst = "registers the server  (a .houseCARL.bak copy is made first)";
 
     /// <summary>The removal's version of the line above: the same file, the same backup, the entry taken out.</summary>
-    private const string RemovesEntry = "removes the server entry  (a .houseCARL.bak copy is made first)";
+    private const string RemovesEntry = "removes the server entry  (a " + Uninstall.BackupSuffix + " copy is made first)";
 
     /// <summary>Print the plan: a heading per host saying install, upgrade or removal, then one line per
     /// destination.</summary>
@@ -116,45 +116,80 @@ public static class Plan
     }
 
     /// <summary>
-    /// The block that closes a finished run: what went where, taken from the same plan the confirm was given
-    /// for, and then what the person does next. It is the plan in the past tense on purpose — a summary built
-    /// from its own list of paths could name one the run never touched.
+    /// The block that closes a finished install: what went where, taken from the same plan the confirm was
+    /// given for, and then what the person does next. An install writes every line of its plan, so the plan is
+    /// what it did.
     /// </summary>
-    public static void PrintSummary(List<HostPlan> plans, string version, bool removing)
+    public static void PrintSummary(List<HostPlan> plans, string version)
     {
-        string hosts = string.Join(" and ", plans.Select(p => p.Host.Name));
+        List<string> hosts = plans.Select(p => p.Host.Name).ToList();
 
         Console.WriteLine();
         Ui.Rule();
-        Ui.Done(removing
-            ? "houseCARL is removed from " + hosts + "."
-            : "houseCARL " + version + " is installed for " + hosts + ".");
+        Ui.Done("houseCARL " + version + " is installed for " + string.Join(" and ", hosts) + ".");
+        PrintBlock("Written", plans.Select(p => (p.Host.Name, (IReadOnlyList<Line>)p.Lines)).ToList());
 
-        Ui.Heading(removing ? "Removed" : "Written");
-        int pathWidth = plans.SelectMany(p => p.Lines).Select(l => l.Path.Length).DefaultIfEmpty(0).Max();
+        Ui.Heading("Next");
+        foreach (string host in hosts) Ui.Bullet(host + ": fully quit and reopen it.");
+        FullyMeans();
+        Ui.Bullet("On the first use of a houseCARL tool it asks you for your Mod Organizer 2");
+        Console.WriteLine("        folder, the one holding ModOrganizer.ini.");
+        if (plans.Count > 1)
+            Ui.Bullet("Each host runs its own server copy, so that folder is set once per host.");
+        Console.WriteLine();
+    }
+
+    /// <summary>
+    /// The block that closes a finished removal. Unlike the install's, it is NOT the plan printed again: a
+    /// removal's plan is what the run intends to take off, and a host with nothing installed, or a config with
+    /// no entry of ours, is a line the run does not act on. Every line here is what one step actually did,
+    /// carried back from <see cref="Uninstall.TryUninstall"/>, so the block cannot claim a removal that did not
+    /// happen.
+    /// </summary>
+    public static void PrintRemovalSummary(IReadOnlyList<Uninstall.HostResult> hosts)
+    {
+        string names = string.Join(" and ", hosts.Select(h => h.Host));
+        bool anything = hosts.Any(h => h.RemovedSomething);
+
+        Console.WriteLine();
+        Ui.Rule();
+        Ui.Done(anything
+            ? "houseCARL is removed from " + names + "."
+            : "There was no houseCARL to remove from " + names + ", so nothing was changed.");
+
+        PrintBlock(anything ? "Removed" : "Looked at", hosts
+            .Select(h => (h.Host, (IReadOnlyList<Line>)h.Steps.Select(s => new Line(s.Path, s.Did)).ToList()))
+            .ToList());
+
+        if (anything)
+        {
+            Ui.Heading("Next");
+            foreach (var h in hosts.Where(h => h.RemovedSomething)) Ui.Bullet(h.Host + ": fully quit and reopen it.");
+            FullyMeans();
+        }
+        Console.WriteLine();
+    }
+
+    /// <summary>The path-and-what block both summaries print, one heading and one group per host.</summary>
+    private static void PrintBlock(string heading, List<(string Host, IReadOnlyList<Line> Lines)> blocks)
+    {
+        Ui.Heading(heading);
+        int pathWidth = blocks.SelectMany(b => b.Lines).Select(l => l.Path.Length).DefaultIfEmpty(0).Max();
         bool first = true;
-        foreach (HostPlan plan in plans)
+        foreach (var block in blocks)
         {
             if (!first) Console.WriteLine();
             first = false;
-            Ui.PlanHost(plan.Host.Name, "");
-            foreach (Line line in plan.Lines)
+            Ui.PlanHost(block.Host, "");
+            foreach (Line line in block.Lines)
                 Ui.PlanLine(line.Path, line.What, pathWidth);
         }
+    }
 
-        Ui.Heading("Next");
-        foreach (HostPlan plan in plans)
-            Ui.Bullet(plan.Host.Name + ": fully quit and reopen it.");
+    private static void FullyMeans()
+    {
         Console.WriteLine("        \"Fully\" means every window, every terminal session, and any");
         Console.WriteLine("        background session.");
-        if (!removing)
-        {
-            Ui.Bullet("On the first use of a houseCARL tool it asks you for your Mod Organizer 2");
-            Console.WriteLine("        folder, the one holding ModOrganizer.ini.");
-            if (plans.Count > 1)
-                Ui.Bullet("Each host runs its own server copy, so that folder is set once per host.");
-        }
-        Console.WriteLine();
     }
 
     /// <summary>What this run is to this host on a removal: what is there to take, said before it is taken.</summary>

--- a/src/housecarl-setup/Program.cs
+++ b/src/housecarl-setup/Program.cs
@@ -99,14 +99,6 @@ public static class Program
             // The skills folder is checked with the manifest and the exe: a package always ships one, and a
             // package missing it is a broken unzip, not a version that dropped every skill.
             string srcSkills   = Path.Combine(pluginSrc, "skills");
-            // A removal reads nothing out of the package — what it takes off the machine is what the install put
-            // there — so a --uninstall run is not held to having one beside it.
-            bool needsPackage = !args.Contains("--uninstall");
-            if (needsPackage && (!File.Exists(srcManifest) || !File.Exists(srcExe) || !Directory.Exists(srcSkills)))
-            {
-                ReportBrokenPackage(pluginSrc, srcManifest, srcExe, srcSkills);
-                return Finish(1);
-            }
 
             // HOUSECARL_SETUP_HOME overrides the home dir (testing / unusual setups).
             string? homeOverride = Environment.GetEnvironmentVariable("HOUSECARL_SETUP_HOME");
@@ -146,6 +138,16 @@ public static class Program
             if (mode == Mode.Install && missingRuntimes.Count > 0)
             {
                 ReportMissingRuntimes(missingRuntimes);
+                return Finish(1);
+            }
+
+            // The package is the install's, for the same reason and after the same choice: a removal reads
+            // nothing out of it — what it takes off the machine is what the install put there — and refusing
+            // before the menu would leave a broken or half-unzipped package with no way to reach [4] Uninstall.
+            if (mode == Mode.Install
+                && (!File.Exists(srcManifest) || !File.Exists(srcExe) || !Directory.Exists(srcSkills)))
+            {
+                ReportBrokenPackage(pluginSrc, srcManifest, srcExe, srcSkills);
                 return Finish(1);
             }
 

--- a/src/housecarl-setup/Program.cs
+++ b/src/housecarl-setup/Program.cs
@@ -19,6 +19,8 @@ namespace HousecarlSetup;
 ///                     a fresh Codex install was confirmed to scan), and registers the server as
 ///                     [mcp_servers.housecarl] in ~/.codex/config.toml.
 ///   [3] Both        - both of the above.
+///   [4] Uninstall   - takes back what an install wrote, for either host or both. It is its own file,
+///                     <see cref="Uninstall"/>, which says exactly what comes off per host.
 ///
 /// The MO2 folder is intentionally NOT set here; houseCARL asks for it in chat on first use and stores
 /// it in user.json beside whichever server copy is running.
@@ -74,6 +76,8 @@ public static class Program
             Console.WriteLine("    --both     install for both");
             Console.WriteLine("    --yes      skip the confirm at the plan (it still asks which host,");
             Console.WriteLine("               so an unattended run needs a host flag as well)");
+            Console.WriteLine("    --uninstall   remove houseCARL instead of installing it, from the host");
+            Console.WriteLine("                  named by --claude/--codex/--both");
             Console.WriteLine("    --skip-runtime-check   skip the .NET runtime preflight (custom DOTNET_ROOT etc.)");
             Console.WriteLine();
             Console.WriteLine("  Setup asks two questions - which host, and the confirm at the plan - and it");
@@ -95,7 +99,10 @@ public static class Program
             // The skills folder is checked with the manifest and the exe: a package always ships one, and a
             // package missing it is a broken unzip, not a version that dropped every skill.
             string srcSkills   = Path.Combine(pluginSrc, "skills");
-            if (!File.Exists(srcManifest) || !File.Exists(srcExe) || !Directory.Exists(srcSkills))
+            // A removal reads nothing out of the package — what it takes off the machine is what the install put
+            // there — so a --uninstall run is not held to having one beside it.
+            bool needsPackage = !args.Contains("--uninstall");
+            if (needsPackage && (!File.Exists(srcManifest) || !File.Exists(srcExe) || !Directory.Exists(srcSkills)))
             {
                 if (!Directory.Exists(pluginSrc))
                 {
@@ -146,50 +153,69 @@ public static class Program
             Detect.HostState codex  = Detect.Codex(home, homeOverride);
             ReportDetected(claude, codex, missingRuntimes, skipRuntimeCheck);
 
-            if (missingRuntimes.Count > 0)
+            Answer chose = ResolveChoice(args, claude, codex, out Mode mode, out Target target);
+            if (chose == Answer.NoOneToAsk) return Finish(1);
+            if (chose == Answer.Quit)
+            {
+                Console.WriteLine("Cancelled - nothing was changed.");
+                return Finish(0);
+            }
+
+            // The runtimes are the SERVER's, so only an install needs them. The refusal is therefore made after
+            // the choice rather than before it: a machine missing a runtime is exactly a machine somebody may
+            // want to remove houseCARL from, and refusing at the detection block would leave no way to.
+            if (mode == Mode.Install && missingRuntimes.Count > 0)
             {
                 ReportMissingRuntimes(missingRuntimes);
                 return Finish(1);
             }
 
-            Answer chose = ResolveTarget(args, claude, codex, out Target target);
-            if (chose == Answer.NoOneToAsk) return Finish(1);
-            if (chose == Answer.Quit)
-            {
-                Console.WriteLine("Cancelled - nothing was installed.");
-                return Finish(0);
-            }
-
             // ---- the plan, before anything is written ------------------------
-            Plan.Print(Plan.For(target, home, homeOverride, claude, codex),
-                       Detect.PluginVersion(srcManifest) ?? SetupVersion());
-            Answer confirmed = Confirm(args);
+            string version = Detect.PluginVersion(srcManifest) ?? SetupVersion();
+            List<Plan.HostPlan> plans = mode == Mode.Install
+                ? Plan.For(target, home, homeOverride, claude, codex)
+                : Plan.ForRemoval(target, home, homeOverride, claude, codex);
+            Plan.Print(plans, version, removing: mode == Mode.Uninstall);
+            Answer confirmed = Confirm(args, mode);
             if (confirmed == Answer.NoOneToAsk) return Finish(1);
             if (confirmed == Answer.Quit)
             {
-                Console.WriteLine("Cancelled - nothing was installed.");
+                Console.WriteLine(mode == Mode.Install
+                    ? "Cancelled - nothing was installed."
+                    : "Cancelled - nothing was removed.");
                 return Finish(0);
             }
 
             Console.WriteLine();
+
+            if (mode == Mode.Uninstall)
+            {
+                Uninstall.Result removal = Uninstall.TryUninstall(target, home, homeOverride);
+                if (removal.What == Uninstall.Outcome.ServerInUse)
+                {
+                    ReportServerInUse(removal.Message, removal.RefusedBeforeAnyDelete
+                        ? "A houseCARL server file is in use, so setup stopped before removing anything — fully "
+                          + "quit Claude Code and Codex, then run this setup again."
+                        : "A houseCARL file went into use partway through the removal, so setup stopped — fully "
+                          + "quit Claude Code and Codex, then run this setup again to finish it.");
+                    return Finish(1);
+                }
+                Plan.PrintSummary(plans, version, removing: true);
+                return Finish(0);
+            }
+
             InstallResult result = TryInstall(target, pluginSrc, home, homeOverride);
             if (result.Outcome == InstallOutcome.ServerInUse)
             {
-                string sentence = result.RefusedBeforeAnyCopy
+                ReportServerInUse(result.Message, result.RefusedBeforeAnyCopy
                     ? "A houseCARL server file is in use, so setup stopped before changing anything — fully quit "
                       + "Claude Code and Codex, then run this setup again."
                     : "A houseCARL file went into use partway through the update, so setup stopped — fully quit "
-                      + "Claude Code and Codex, then run this setup again to finish it.";
-                List<string> detail = new();
-                if (result.Message is not null) detail.Add(result.Message);
-                detail.Add("");
-                detail.Add("\"Fully\" means every desktop window, every terminal session, and any");
-                detail.Add("background session.");
-                Ui.Problem(sentence, detail.ToArray());
+                      + "Claude Code and Codex, then run this setup again to finish it.");
                 return Finish(1);
             }
 
-            PrintNext(target);
+            Plan.PrintSummary(plans, version, removing: false);
             return Finish(0);
         }
         catch (Exception ex)
@@ -234,24 +260,27 @@ public static class Program
     /// whose input is redirected has nobody to press a key, so without that flag it is refused rather than read
     /// as a yes: the same rule as the host menu, which is the other question setup asks.
     /// </summary>
-    private static Answer Confirm(string[] args)
+    private static Answer Confirm(string[] args, Mode mode)
     {
         if (args.Contains("--yes")) return Answer.Yes;
+        string go = mode == Mode.Install ? "install" : "remove";
         while (true)
         {
-            string? s = Console.IsInputRedirected ? null : Ui.Prompt("  Press Enter to install, or q to quit.  > ");
+            string? s = Console.IsInputRedirected
+                ? null
+                : Ui.Prompt("  Press Enter to " + go + ", or q to quit.  > ");
             if (s is null)
             {
                 Ui.Problem(
                     "Setup cannot ask you to confirm the plan above, because its input is redirected and there "
-                    + "is nobody to press a key — re-run with --yes to install without stopping at the plan.",
-                    "Nothing was installed.");
+                    + "is nobody to press a key — re-run with --yes to " + go + " without stopping at the plan.",
+                    "Nothing was changed.");
                 return Answer.NoOneToAsk;
             }
             string answer = s.Trim().ToLowerInvariant();
             if (answer.Length == 0) return Answer.Yes;
             if (answer is "q" or "quit") return Answer.Quit;
-            Console.WriteLine("  Press Enter to install, or type q to quit.");
+            Console.WriteLine("  Press Enter to " + go + ", or type q to quit.");
         }
     }
 
@@ -368,6 +397,13 @@ public static class Program
     internal static string ClaudeDestManifest(string home)
         => Path.Combine(ClaudeSkillsDest(home), ".claude-plugin", "plugin.json");
 
+    /// <summary>Where the Claude install records the skill folders it put under its own skills root, so a later
+    /// uninstall takes back exactly those rather than every folder it finds. It sits at the root of the tree the
+    /// install owns, beside the copied manifest. An install made before this file existed leaves none, and the
+    /// uninstall says which route it took instead — see <see cref="Uninstall"/>.</summary>
+    internal static string ClaudeSkillRecord(string home)
+        => Path.Combine(ClaudeSkillsDest(home), "installed-skills.txt");
+
     /// <summary>The shared, cross-agent skills root the Codex install copies skill folders into, flat.</summary>
     internal static string CodexSkillsRoot(string home)
         => Path.Combine(home, ".agents", "skills");
@@ -416,7 +452,7 @@ public static class Program
     /// re-run"; a false negative is the exact mid-copy corruption this exists to prevent. Do NOT "tighten"
     /// this (e.g. to FileShare.Read) into a false-negative.
     /// </summary>
-    private static bool ServerExeInUse(string destExe)
+    internal static bool ServerExeInUse(string destExe)
     {
         if (!File.Exists(destExe)) return false;
         try
@@ -434,7 +470,7 @@ public static class Program
     private const int HrSharingViolation = unchecked((int)0x80070020);
     private const int HrLockViolation    = unchecked((int)0x80070021);
 
-    private static bool IsSharingViolation(IOException ex)
+    internal static bool IsSharingViolation(IOException ex)
         => ex.HResult == HrSharingViolation || ex.HResult == HrLockViolation;
 
     // ---- server runtime preflight ------------------------------------------
@@ -505,41 +541,60 @@ public static class Program
 
     // ---- target selection (flag or interactive prompt) --------------------
 
+    /// <summary>Whether this run puts houseCARL on the machine or takes it off.</summary>
+    public enum Mode { Install, Uninstall }
+
     /// <summary>
-    /// Which host(s) to install for: the flag if one was passed, else the menu. A run whose input is redirected
-    /// has nobody to pick, so it is refused naming the flags rather than defaulting to a host — the same rule
-    /// the plan's confirm follows.
+    /// What this run does and to which host(s): the flags if any were passed, else the menu. A run whose input is
+    /// redirected has nobody to pick, so it is refused naming the flags rather than defaulting to a host — the
+    /// same rule the plan's confirm follows. <c>--uninstall</c> takes the same host flags, so an unattended
+    /// removal is <c>--uninstall --both --yes</c>.
     /// </summary>
-    private static Answer ResolveTarget(
-        string[] args, Detect.HostState claude, Detect.HostState codex, out Target target)
+    private static Answer ResolveChoice(
+        string[] args, Detect.HostState claude, Detect.HostState codex, out Mode mode, out Target target)
     {
+        mode   = args.Contains("--uninstall") ? Mode.Uninstall : Mode.Install;
         target = Target.Claude;
         if (args.Contains("--both"))   { target = Target.Both;   return Answer.Yes; }
         if (args.Contains("--codex"))  { target = Target.Codex;  return Answer.Yes; }
         if (args.Contains("--claude")) { target = Target.Claude; return Answer.Yes; }
 
+        string verb = mode == Mode.Install ? "install houseCARL for" : "remove houseCARL from";
         if (Console.IsInputRedirected)
         {
             Ui.Problem(
-                "Setup cannot ask which agent to install houseCARL for, because its input is redirected and "
+                "Setup cannot ask which agent to " + verb + ", because its input is redirected and "
                 + "there is nobody to answer — re-run with --claude, --codex or --both to say which.",
-                "Nothing was installed.");
+                "Nothing was changed.");
             return Answer.NoOneToAsk;
         }
 
-        Ui.Heading("Install houseCARL for which agent?");
-        Ui.MenuItem("1", claude.Name, claude.Summary);
-        Ui.MenuItem("2", codex.Name,  codex.Summary);
-        Ui.MenuItem("3", "Both", "");
-        Console.WriteLine();
+        if (mode == Mode.Install)
+        {
+            Ui.Heading("Install houseCARL for which agent?");
+            Ui.MenuItem("1", claude.Name, claude.Summary);
+            Ui.MenuItem("2", codex.Name,  codex.Summary);
+            Ui.MenuItem("3", "Both", "");
+            Ui.MenuItem("4", "Uninstall", "remove houseCARL instead");
+            Console.WriteLine();
+        }
+        else
+        {
+            Ui.Heading("Remove houseCARL from which agent?");
+            Ui.MenuItem("1", claude.Name, claude.Summary);
+            Ui.MenuItem("2", codex.Name,  codex.Summary);
+            Ui.MenuItem("3", "Both", "");
+            Console.WriteLine();
+        }
 
         // Exactly one host on this machine leaves nothing to choose between, so a bare Enter takes it.
         Target? onlyHost = claude.Present && !codex.Present  ? Target.Claude
                          : codex.Present  && !claude.Present ? Target.Codex
                          :                                     null;
+        string keys     = mode == Mode.Install ? "1, 2, 3, or 4" : "1, 2, or 3";
         string question = onlyHost is null
-            ? "  Enter 1, 2, or 3 (or q to quit): "
-            : "  Enter 1, 2, or 3, or press Enter for "
+            ? "  Enter " + keys + " (or q to quit): "
+            : "  Enter " + keys + ", or press Enter for "
               + (onlyHost == Target.Claude ? claude.Name : codex.Name) + " (q to quit): ";
 
         while (true)
@@ -549,9 +604,9 @@ public static class Program
             {
                 // The stream ended mid-question: nobody to ask, same as a redirected run.
                 Ui.Problem(
-                    "Setup cannot ask which agent to install houseCARL for, because its input ended — re-run "
+                    "Setup cannot ask which agent to " + verb + ", because its input ended — re-run "
                     + "with --claude, --codex or --both to say which.",
-                    "Nothing was installed.");
+                    "Nothing was changed.");
                 return Answer.NoOneToAsk;
             }
             string answer = s.Trim().ToLowerInvariant();
@@ -561,8 +616,12 @@ public static class Program
                 case "1": target = Target.Claude; return Answer.Yes;
                 case "2": target = Target.Codex;  return Answer.Yes;
                 case "3": target = Target.Both;   return Answer.Yes;
+                // The menu's fourth key is the removal, and it asks the same host question over again, because
+                // which host to remove from is a different answer from which host to install for.
+                case "4" when mode == Mode.Install:
+                    return ResolveChoice(args.Append("--uninstall").ToArray(), claude, codex, out mode, out target);
                 case "q": case "quit": return Answer.Quit;
-                default: Console.WriteLine("  Please type 1, 2, 3, or q."); break;
+                default: Console.WriteLine("  Please type " + keys + ", or q."); break;
             }
         }
     }
@@ -597,6 +656,11 @@ public static class Program
                     .ToList()
                 : new List<string>();
             ReportRemoved("Claude Code", installedSkills, RemoveSkillDirs(installedSkills, stale, keptBack).Removed);
+
+            // What this install put under its own skills root, so an uninstall removes those by name. The prune
+            // above is a directory diff because this root is houseCARL's outright; the record is for the removal,
+            // which has no package to diff against.
+            File.WriteAllLines(ClaudeSkillRecord(home), shipped);
         }
 
         Ui.Step("Claude Code", "registering the MCP server", claudeJson);
@@ -678,21 +742,16 @@ public static class Program
         Console.WriteLine();
     }
 
-    // ---- NEXT steps --------------------------------------------------------
-
-    private static void PrintNext(Target target)
+    /// <summary>The held-file refusal, shared by the install and the removal: the caller's sentence, the path the
+    /// seam named, and what "fully" means.</summary>
+    private static void ReportServerInUse(string? detailFromSeam, string sentence)
     {
-        Console.WriteLine("houseCARL is installed.");
-        Console.WriteLine();
-        Console.WriteLine("  NEXT:");
-        if (target is Target.Claude or Target.Both)
-            Console.WriteLine("   - Claude Code: fully quit and reopen the Claude desktop app.");
-        if (target is Target.Codex or Target.Both)
-            Console.WriteLine("   - Codex: fully restart Codex (close every session), then check /mcp and /skills.");
-        Console.WriteLine("   - On first use of a houseCARL tool it will ask you to point it at your");
-        Console.WriteLine("     Mod Organizer 2 folder (the one containing ModOrganizer.ini).");
-        if (target is Target.Both)
-            Console.WriteLine("   - (Each host runs its own server copy, so you'll set the MO2 folder once per host.)");
+        List<string> detail = new();
+        if (detailFromSeam is not null) detail.Add(detailFromSeam);
+        detail.Add("");
+        detail.Add("\"Fully\" means every desktop window, every terminal session, and any");
+        detail.Add("background session.");
+        Ui.Problem(sentence, detail.ToArray());
     }
 
     /// <summary>This exe's own stamped version, with any "+sha" metadata trimmed. build-plugin.ps1 passes
@@ -732,7 +791,7 @@ public static class Program
 
     /// <summary>The skill folder names a previous Codex install recorded. Anything that is not a bare folder
     /// name is dropped, so a hand-edited record can never point the delete below at another path.</summary>
-    private static List<string> ReadSkillRecord(string recordPath)
+    internal static List<string> ReadSkillRecord(string recordPath)
     {
         if (!File.Exists(recordPath)) return new List<string>();
         return File.ReadAllLines(recordPath)
@@ -747,7 +806,7 @@ public static class Program
     /// <paramref name="keptBack"/> for the report at the end, and the install continues to the MCP
     /// registration. Cleanup cannot fail an install that otherwise worked — before the prune existed, the
     /// leftover simply survived and the install succeeded.</summary>
-    private static (List<string> Removed, List<string> Failed) RemoveSkillDirs(
+    internal static (List<string> Removed, List<string> Failed) RemoveSkillDirs(
         string skillsRoot, IEnumerable<string> names, List<string> keptBack)
     {
         List<string> removed = new();
@@ -813,7 +872,7 @@ public static class Program
 
     // ---- ~/.claude.json registration (JSON splice) ------------------------
 
-    private static readonly JsonSerializerOptions Indented = new() { WriteIndented = true };
+    internal static readonly JsonSerializerOptions Indented = new() { WriteIndented = true };
 
     /// <summary>
     /// Insert/replace mcpServers.<paramref name="name"/> WITHOUT reparsing the whole file. ~/.claude.json
@@ -864,7 +923,7 @@ public static class Program
     }
 
     /// <summary>Finds the `{ ... }` value of a DEPTH-1 (root-level) member named <paramref name="key"/>. String-aware.</summary>
-    private static (int start, int end)? FindRootMemberObject(string text, string key)
+    internal static (int start, int end)? FindRootMemberObject(string text, string key)
     {
         string token = "\"" + key + "\"";
         int depth = 0;
@@ -923,7 +982,7 @@ public static class Program
         return null;
     }
 
-    private static string LeadingIndentOfLineAt(string text, int index)
+    internal static string LeadingIndentOfLineAt(string text, int index)
     {
         int lineStart = text.LastIndexOf('\n', index) + 1;
         int j = lineStart;
@@ -931,7 +990,7 @@ public static class Program
         return text.Substring(lineStart, j - lineStart);
     }
 
-    private static string Reindent(string json, string indent)
+    internal static string Reindent(string json, string indent)
     {
         if (indent.Length == 0) return json;
         string[] lines = json.Split('\n');
@@ -940,6 +999,10 @@ public static class Program
     }
 
     // ---- ~/.codex/config.toml registration (TOML splice) ------------------
+
+    /// <summary>The line written above a [mcp_servers.housecarl] table setup created the file for. The removal
+    /// splice takes it back with the table, so the two spellings are one const.</summary>
+    internal const string TomlComment = "# houseCARL MCP server (added by houseCARL-Setup)";
 
     /// <summary>
     /// Insert/replace [mcp_servers.<paramref name="name"/>] in a TOML config.toml, leaving everything
@@ -954,7 +1017,7 @@ public static class Program
 
         if (!File.Exists(configTomlPath))
         {
-            string fresh = "# houseCARL MCP server (added by houseCARL-Setup)\n"
+            string fresh = TomlComment + "\n"
                          + "[mcp_servers." + name + "]\n"
                          + "command = '" + command + "'\n";
             File.WriteAllText(configTomlPath, fresh);
@@ -1005,7 +1068,7 @@ public static class Program
         {
             string trimmed = string.Join(nl, outLines).TrimEnd('\r', '\n');
             return trimmed.Length == 0
-                ? "# houseCARL MCP server (added by houseCARL-Setup)" + nl + string.Join(nl, body) + nl
+                ? TomlComment + nl + string.Join(nl, body) + nl
                 : trimmed + nl + nl + string.Join(nl, body) + nl;
         }
 

--- a/src/housecarl-setup/Program.cs
+++ b/src/housecarl-setup/Program.cs
@@ -104,28 +104,7 @@ public static class Program
             bool needsPackage = !args.Contains("--uninstall");
             if (needsPackage && (!File.Exists(srcManifest) || !File.Exists(srcExe) || !Directory.Exists(srcSkills)))
             {
-                if (!Directory.Exists(pluginSrc))
-                {
-                    Ui.Problem(
-                        "The houseCARL plugin folder is not next to this program, so there is nothing to "
-                        + "install — keep this program beside the unzipped 'housecarl' folder and run it again.",
-                        "Looked in:  " + pluginSrc);
-                }
-                else
-                {
-                    // The folder is there, so this is an incomplete unzip: name the piece that is missing.
-                    string missingWhat = !File.Exists(srcManifest) ? "manifest"
-                                       : !File.Exists(srcExe)      ? "server"
-                                       :                             "skills folder";
-                    string missingPath = !File.Exists(srcManifest) ? srcManifest
-                                       : !File.Exists(srcExe)      ? srcExe
-                                       :                             srcSkills;
-                    Ui.Problem(
-                        "The houseCARL plugin folder beside this program is missing its " + missingWhat
-                        + ", so the download did not unzip completely — unzip it again and run this setup.",
-                        "Looked in:  " + pluginSrc,
-                        "Missing:    " + missingPath);
-                }
+                ReportBrokenPackage(pluginSrc, srcManifest, srcExe, srcSkills);
                 return Finish(1);
             }
 
@@ -200,7 +179,7 @@ public static class Program
                           + "quit Claude Code and Codex, then run this setup again to finish it.");
                     return Finish(1);
                 }
-                Plan.PrintSummary(plans, version, removing: true);
+                Plan.PrintRemovalSummary(removal.Hosts);
                 return Finish(0);
             }
 
@@ -215,7 +194,7 @@ public static class Program
                 return Finish(1);
             }
 
-            Plan.PrintSummary(plans, version, removing: false);
+            Plan.PrintSummary(plans, version);
             return Finish(0);
         }
         catch (Exception ex)
@@ -289,6 +268,33 @@ public static class Program
     /// two-installer trap is the hard-won part and stays, but below the sentence: the ASP.NET Core installer
     /// does NOT carry the base .NET Runtime, so a machine can have one and not the other.
     /// </summary>
+    /// <summary>Said when the package beside this exe cannot be installed from: either the plugin folder is not
+    /// there at all, or it is there and missing a piece, which is a partial unzip and names the piece.</summary>
+    private static void ReportBrokenPackage(string pluginSrc, string srcManifest, string srcExe, string srcSkills)
+    {
+        if (!Directory.Exists(pluginSrc))
+        {
+            Ui.Problem(
+                "The houseCARL plugin folder is not next to this program, so there is nothing to "
+                + "install — keep this program beside the unzipped 'housecarl' folder and run it again.",
+                "Looked in:  " + pluginSrc);
+            return;
+        }
+
+        // The folder is there, so this is an incomplete unzip: name the piece that is missing.
+        string missingWhat = !File.Exists(srcManifest) ? "manifest"
+                           : !File.Exists(srcExe)      ? "server"
+                           :                             "skills folder";
+        string missingPath = !File.Exists(srcManifest) ? srcManifest
+                           : !File.Exists(srcExe)      ? srcExe
+                           :                             srcSkills;
+        Ui.Problem(
+            "The houseCARL plugin folder beside this program is missing its " + missingWhat
+            + ", so the download did not unzip completely — unzip it again and run this setup.",
+            "Looked in:  " + pluginSrc,
+            "Missing:    " + missingPath);
+    }
+
     private static void ReportMissingRuntimes(List<string> missing)
     {
         bool baseMissing = missing.Contains("Microsoft.NETCore.App");

--- a/src/housecarl-setup/Ui.cs
+++ b/src/housecarl-setup/Ui.cs
@@ -76,12 +76,18 @@ public static class Ui
         Paint(OutColor, ConsoleColor.DarkGray, () => Console.WriteLine(note));
     }
 
-    /// <summary>A host's heading in the plan, and whether this run installs or upgrades it.</summary>
+    /// <summary>A host's heading in the plan, and whether this run installs, upgrades or removes it. An empty
+    /// action is the summary's use of this line, where the run is over and there is nothing left to say about it.</summary>
     public static void PlanHost(string host, string action)
     {
         Paint(OutColor, ConsoleColor.Cyan, () => Console.Write("    " + host));
+        if (action.Length == 0) { Console.WriteLine(); return; }
         Paint(OutColor, ConsoleColor.DarkGray, () => Console.WriteLine("  ·  " + action));
     }
+
+    /// <summary>The one sentence that closes a run that did what it was asked.</summary>
+    public static void Done(string sentence)
+        => Paint(OutColor, ConsoleColor.Green, () => Console.WriteLine("  " + sentence));
 
     /// <summary>One destination in the plan: the exact path, and what goes there.</summary>
     public static void PlanLine(string path, string what, int pathWidth)

--- a/src/housecarl-setup/Uninstall.cs
+++ b/src/housecarl-setup/Uninstall.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json.Nodes;
 
 namespace HousecarlSetup;
@@ -8,15 +9,22 @@ namespace HousecarlSetup;
 /// helpers, so a removal cannot go somewhere the install never wrote.
 ///
 /// What it removes, per host:
-///   Claude Code - the tree at ClaudeSkillsDest (skills, server, and the saved MO2 instance in the
-///                 houseCARL.user.json beside the server exe), and the mcpServers.housecarl entry in
-///                 ~/.claude.json.
+///   Claude Code - under the tree at ClaudeSkillsDest: the skill folders the record names (or, with no record,
+///                 the skills folder the package layout defines), the server dir with the saved MO2 instance in
+///                 the houseCARL.user.json beside it, and the rest of the entries the package ships
+///                 (<see cref="ClaudePackageEntries"/>) - then the tree itself only when nothing else is left
+///                 in it. Anything else somebody put there stays, and is named. Plus the mcpServers.housecarl
+///                 entry in ~/.claude.json.
 ///   Codex       - the server dir (the saved MO2 instance goes with it), the skill folders the Codex record
 ///                 names and no other, the record itself, and the [mcp_servers.housecarl] table in
 ///                 ~/.codex/config.toml.
 ///
 /// Both config edits are removal splices beside the insert splices on <see cref="Program"/>: the file is copied
-/// to a ".houseCARL.bak" first, the entry is taken out, and every other byte in the file is left as it was.
+/// to a ".houseCARL.uninstall.bak" first (a name of its own, so the copy the INSTALL took is still there), the
+/// entry is taken out, and every other byte in the file - its BOM, each line's own newline, its trailing state -
+/// is left as it was. An entry that is not in the file is reported as not found; nothing is written and nothing
+/// claims a removal that did not happen.
+///
 /// ~/.agents/skills is shared with every other agent's skills, so a folder the record does not list is never
 /// touched - an install too old to have left a record removes nothing there and says so.
 /// </summary>
@@ -25,13 +33,24 @@ public static class Uninstall
     /// <summary>What a non-interactive <see cref="TryUninstall"/> did.</summary>
     public enum Outcome
     {
-        /// <summary>The files and the host-config entries this target owns are gone.</summary>
+        /// <summary>The run finished. What it actually took off, per host, is in <see cref="Result.Hosts"/>.</summary>
         Removed,
         /// <summary>A houseCARL server file is in use (a live Claude/Codex session is running it), so it could
         /// not be deleted. Nothing was deleted when the refusal was at pre-flight
         /// (<see cref="Result.RefusedBeforeAnyDelete"/>).</summary>
         ServerInUse,
     }
+
+    /// <summary>One destination the run touched, and what it did to it - past tense, decided after the fact.</summary>
+    /// <param name="Path">The destination.</param>
+    /// <param name="Did">What happened to it, including "nothing" when there was nothing there.</param>
+    public sealed record Step(string Path, string Did);
+
+    /// <summary>One host's share of what the run did.</summary>
+    /// <param name="Host">The host's name, as the plan and the menu say it.</param>
+    /// <param name="Steps">Every destination this host's removal touched, in removal order.</param>
+    /// <param name="RemovedSomething">True when at least one of the steps above took something off.</param>
+    public sealed record HostResult(string Host, IReadOnlyList<Step> Steps, bool RemovedSomething);
 
     /// <summary>Result of a non-interactive uninstall - the probeable seam under the interactive prompt.</summary>
     /// <param name="What">What happened.</param>
@@ -41,6 +60,9 @@ public static class Uninstall
         /// <summary>True only when a <see cref="Outcome.ServerInUse"/> refusal happened at PRE-FLIGHT, before
         /// anything was deleted.</summary>
         public bool RefusedBeforeAnyDelete { get; init; }
+
+        /// <summary>What the run did, host by host. Empty on a refusal, because it did nothing.</summary>
+        public IReadOnlyList<HostResult> Hosts { get; init; } = Array.Empty<HostResult>();
     }
 
     /// <summary>
@@ -65,11 +87,12 @@ public static class Uninstall
                     { RefusedBeforeAnyDelete = true };
 
         List<string> keptBack = new();
+        List<HostResult> hosts = new();
 
         try
         {
-            if (target is Program.Target.Claude or Program.Target.Both) RemoveForClaude(home, keptBack);
-            if (target is Program.Target.Codex  or Program.Target.Both) RemoveForCodex(home, homeOverride, keptBack);
+            if (target is Program.Target.Claude or Program.Target.Both) hosts.Add(RemoveForClaude(home, keptBack));
+            if (target is Program.Target.Codex  or Program.Target.Both) hosts.Add(RemoveForCodex(home, homeOverride, keptBack));
         }
         catch (IOException ex) when (Program.IsSharingViolation(ex))
         {
@@ -77,98 +100,232 @@ public static class Uninstall
         }
 
         ReportKeptBack(keptBack);
-        return new Result(Outcome.Removed, null);
+        return new Result(Outcome.Removed, null) { Hosts = hosts };
     }
 
     // ---- Claude Code -------------------------------------------------------
 
-    private static void RemoveForClaude(string home, List<string> keptBack)
+    /// <summary>
+    /// The entries the package puts at the root of the Claude tree, which are the only ones a removal deletes
+    /// there. The list is scripts/build-plugin.ps1's step 7 (the plugin tree it assembles) plus the record the
+    /// install writes beside them. Anything else under the tree came from somewhere else and stays.
+    /// </summary>
+    private static readonly string[] ClaudePackageEntries =
+    {
+        ".claude-plugin", "server", "skills", ".mcp.json",
+        "LICENSE", "THIRD-PARTY-NOTICES.txt", "README.md", "CHANGELOG.md",
+        "installed-skills.txt",
+    };
+
+    private static HostResult RemoveForClaude(string home, List<string> keptBack)
     {
         string dest       = Program.ClaudeSkillsDest(home);
         string claudeJson = Program.ClaudeJson(home);
+        List<Step> steps  = new();
+        bool removedSomething = false;
 
-        if (Directory.Exists(dest))
+        if (!Directory.Exists(dest))
+        {
+            steps.Add(new Step(dest, "nothing was installed here"));
+        }
+        else
         {
             List<string> recorded = Program.ReadSkillRecord(Program.ClaudeSkillRecord(home));
             Ui.Step("Claude Code", "removing the skills, the server and the saved MO2 instance", dest);
-            foreach (string name in recorded) Ui.Bullet(name);
-            DeleteTree(dest, keptBack);
 
-            // An install from before setup started recording what it put here leaves no record. The tree is
-            // houseCARL's outright either way, so the removal is the same one - but which of the two it was is
-            // said rather than left for the reader to infer from a missing list of names.
+            // With a record, the skills come off BY NAME, so a folder somebody else put under the installed
+            // skills root survives. Without one there is no list to go by, and the fallback is the package
+            // layout: the skills folder is one of the entries the install writes, so it goes whole.
+            string skillsDir = Path.Combine(dest, "skills");
+            if (recorded.Count > 0 && Directory.Exists(skillsDir))
+            {
+                foreach (string name in Program.RemoveSkillDirs(skillsDir, recorded, keptBack).Removed) Ui.Bullet(name);
+                if (!Directory.EnumerateFileSystemEntries(skillsDir).Any()) DeleteEntry(skillsDir, keptBack);
+            }
+
+            foreach (string entry in ClaudePackageEntries)
+            {
+                if (entry == "skills" && recorded.Count > 0) continue; // taken by name above
+                DeleteEntry(Path.Combine(dest, entry), keptBack);
+            }
+
+            List<string> left = Directory.Exists(dest)
+                ? Directory.EnumerateFileSystemEntries(dest).Select(p => Path.GetFileName(p)!).ToList()
+                : new List<string>();
+
+            if (left.Count == 0)
+            {
+                DeleteEntry(dest, keptBack);
+                steps.Add(new Step(dest, "removed - the skills, the server and the saved MO2 instance"));
+            }
+            else
+            {
+                steps.Add(new Step(dest, "the files houseCARL installed removed; "
+                                       + Count(left.Count, "item") + " left in the folder"));
+                Ui.Note(
+                    "The houseCARL folder still holds these, so the folder itself was left in place — delete "
+                    + "them by hand if you want it gone:",
+                    left.Select(n => "- " + n).ToArray());
+            }
+            removedSomething = true;
+
+            // An install from before setup started recording what it put here leaves no record, so the skills
+            // could not be taken by name; which route this run took is said rather than left to be inferred
+            // from a missing list of names.
             if (recorded.Count == 0)
                 Ui.Note(
                     "This houseCARL was installed before setup began recording which skills it wrote, so the "
-                    + "removal above took the whole houseCARL folder it owns.",
+                    + "removal above went by the files a houseCARL package ships instead of by that record.",
                     dest);
         }
 
+        ConfigEdit json = ConfigEdit.FileMissing;
         if (File.Exists(claudeJson))
         {
             Ui.Step("Claude Code", "removing the MCP server entry", claudeJson);
-            UnregisterClaudeMcpServer(claudeJson, McpServerName);
+            json = UnregisterClaudeMcpServer(claudeJson, McpServerName);
         }
+        steps.Add(new Step(claudeJson, ConfigDid(json)));
+        // Said only when there WAS a houseCARL here: on a host that never had one, a config with no entry is
+        // the expected state, not something to point at.
+        if (json == ConfigEdit.NotFound && removedSomething) ReportEntryNotFound(claudeJson);
+        removedSomething |= json == ConfigEdit.Removed;
+
         Console.WriteLine();
+        return new HostResult("Claude Code", steps, removedSomething);
     }
 
     // ---- Codex -------------------------------------------------------------
 
-    private static void RemoveForCodex(string home, string? homeOverride, List<string> keptBack)
+    private static HostResult RemoveForCodex(string home, string? homeOverride, List<string> keptBack)
     {
         string serverDir  = Program.CodexServerDir(home, homeOverride);
         string skillsRoot = Program.CodexSkillsRoot(home);
         string record     = Program.CodexSkillRecord(home, homeOverride);
         string configToml = Program.CodexConfigToml(home);
+        List<Step> steps  = new();
+        bool removedSomething = false;
 
         if (Directory.Exists(serverDir))
         {
             Ui.Step("Codex", "removing the server and the saved MO2 instance", serverDir);
-            DeleteTree(serverDir, keptBack);
+            DeleteEntry(serverDir, keptBack);
+            steps.Add(new Step(serverDir, Directory.Exists(serverDir)
+                ? "could not be removed - see the note above"
+                : "removed - the server and the saved MO2 instance"));
+            removedSomething = true;
         }
+        else steps.Add(new Step(serverDir, "nothing was installed here"));
 
         List<string> recorded = Program.ReadSkillRecord(record);
         if (recorded.Count > 0)
         {
             Ui.Step("Codex", "removing the skills it installed", skillsRoot);
-            foreach (string name in Program.RemoveSkillDirs(skillsRoot, recorded, keptBack).Removed)
-                Ui.Bullet(name);
+            List<string> went = Program.RemoveSkillDirs(skillsRoot, recorded, keptBack).Removed;
+            foreach (string name in went) Ui.Bullet(name);
+            steps.Add(new Step(skillsRoot, went.Count == 0
+                ? "the skills the record named were already gone"
+                : "removed the " + Count(went.Count, "skill folder") + " the record named"));
+            removedSomething |= went.Count > 0;
         }
-        else if (Directory.Exists(skillsRoot))
+        else if (Directory.Exists(skillsRoot) && removedSomething)
         {
             // ~/.agents/skills holds every agent's skills. Without the record there is no way to tell which
             // folders there are houseCARL's, and a directory diff would take somebody else's, so nothing goes.
+            // Said only when there WAS a houseCARL here: the shared folder is somebody else's the rest of the
+            // time, and pointing at it would be pointing at a folder this run had no business in.
             Ui.Note(
                 "Setup has no record of which skills it put in the shared skills folder, so it removed none of "
                 + "them — delete the houseCARL ones by hand if you want them gone.",
                 skillsRoot);
+            steps.Add(new Step(skillsRoot, "nothing removed - setup has no record of what it put there"));
         }
+        else steps.Add(new Step(skillsRoot, "nothing was installed here"));
 
-        if (File.Exists(record)) File.Delete(record);
+        if (File.Exists(record))
+        {
+            File.Delete(record);
+            steps.Add(new Step(record, "removed"));
+            removedSomething = true;
+        }
+        else steps.Add(new Step(record, "was not there"));
 
         // The data dir exists only to hold the server dir and the record. Empty, it is a leftover; holding
         // anything else, it is not ours to take.
         string dataDir = Path.GetDirectoryName(serverDir)!;
         if (Directory.Exists(dataDir) && !Directory.EnumerateFileSystemEntries(dataDir).Any())
-            DeleteTree(dataDir, keptBack);
+            DeleteEntry(dataDir, keptBack);
 
+        ConfigEdit toml = ConfigEdit.FileMissing;
         if (File.Exists(configToml))
         {
             Ui.Step("Codex", "removing the MCP server entry", configToml);
-            UnregisterCodexMcpServer(configToml, McpServerName);
+            toml = UnregisterCodexMcpServer(configToml, McpServerName);
         }
+        steps.Add(new Step(configToml, ConfigDid(toml)));
+        if (toml == ConfigEdit.NotFound && removedSomething) ReportEntryNotFound(configToml);
+        removedSomething |= toml == ConfigEdit.Removed;
+
         Console.WriteLine();
+        return new HostResult("Codex", steps, removedSomething);
     }
 
     private const string McpServerName = "housecarl";
 
-    /// <summary>Delete a tree houseCARL owns. A tree that will not go (a read-only file inside it, a handle held
-    /// on one) is collected for the note at the end rather than thrown: the host-config entry still comes out,
-    /// and the run says what is still on disk.</summary>
-    private static void DeleteTree(string dir, List<string> keptBack)
+    /// <summary>The suffix of the copy a REMOVAL takes before it edits a config. It is not the install's
+    /// ".houseCARL.bak", so an uninstall never writes over the copy the install took of the file as it was
+    /// before houseCARL was ever in it.</summary>
+    internal const string BackupSuffix = ".houseCARL.uninstall.bak";
+
+    /// <summary>What a config splice found and did.</summary>
+    internal enum ConfigEdit
     {
-        try { Directory.Delete(dir, recursive: true); }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { keptBack.Add(dir); }
+        /// <summary>The config file is not on this machine, so there was nothing to edit.</summary>
+        FileMissing,
+        /// <summary>The file is there but carries no houseCARL entry; it was not written to.</summary>
+        NotFound,
+        /// <summary>The entry was taken out and the file rewritten.</summary>
+        Removed,
+    }
+
+    /// <summary>"1 item" / "3 items" — a count said as a sentence rather than as "item(s)".</summary>
+    private static string Count(int n, string noun) => n + " " + noun + (n == 1 ? "" : "s");
+
+    private static string ConfigDid(ConfigEdit edit) => edit switch
+    {
+        ConfigEdit.Removed     => "the server entry removed  (a " + BackupSuffix + " copy was made first)",
+        ConfigEdit.NotFound    => "no houseCARL entry was in it, so it was not written to",
+        _                      => "the file is not on this machine",
+    };
+
+    /// <summary>Said when a config file is there but carries no entry of ours: the file is named, so somebody
+    /// who registered houseCARL by hand under another spelling knows where to look, rather than being told the
+    /// entry was removed when it is still there.</summary>
+    private static void ReportEntryNotFound(string path)
+        => Ui.Note(
+            "This config file has no houseCARL entry setup recognises, so it was left alone — if houseCARL is "
+            + "still registered in it, the entry was written by hand and has to come out by hand.",
+            path);
+
+    /// <summary>Delete one entry houseCARL owns - a file, or a directory and everything in it. A reparse point
+    /// (a junction or a symlink) is removed as the LINK, never walked into, so whatever it points at is not
+    /// touched. An entry that will not go (a read-only file inside it, a handle held on one) is collected for
+    /// the note at the end rather than thrown: the host-config entry still comes out, and the run says what is
+    /// still on disk.</summary>
+    private static void DeleteEntry(string path, List<string> keptBack)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                if (File.GetAttributes(path).HasFlag(FileAttributes.ReparsePoint))
+                    Directory.Delete(path, recursive: false); // the link goes; its target does not
+                else
+                    Directory.Delete(path, recursive: true);
+            }
+            else if (File.Exists(path)) File.Delete(path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { keptBack.Add(path); }
     }
 
     /// <summary>Said at the end of an otherwise finished uninstall: what is still on disk.</summary>
@@ -178,10 +335,41 @@ public static class Uninstall
         List<string> detail = new(keptBack.Select(dir => "- " + dir)) { "" };
         detail.Add("A file in each is read-only or held open. Everything else is removed.");
         Ui.Note(
-            "houseCARL is removed, but these folders could not be deleted — delete them by hand so nothing of "
+            "houseCARL is removed, but these could not be deleted — delete them by hand so nothing of "
             + "houseCARL is left:",
             detail.ToArray());
     }
+
+    // ---- reading and writing a config without changing what is not ours ----
+
+    /// <summary>Read a config as text, saying whether it carried a UTF-8 BOM. <c>File.ReadAllText</c> eats a BOM
+    /// and <c>File.WriteAllText</c> does not put one back, so a file that had one would lose it on the round
+    /// trip; this pair carries it across.</summary>
+    private static (string Text, bool Bom) ReadTextKeepingBom(string path)
+    {
+        byte[] bytes = File.ReadAllBytes(path);
+        bool bom = bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF;
+        return (Encoding.UTF8.GetString(bytes, bom ? 3 : 0, bytes.Length - (bom ? 3 : 0)), bom);
+    }
+
+    /// <summary>Write a config back, with the BOM it had and no other.</summary>
+    private static void WriteTextKeepingBom(string path, string text, bool bom)
+        => File.WriteAllText(path, text, new UTF8Encoding(encoderShouldEmitUTF8Identifier: bom));
+
+    /// <summary>Cut text into lines that each KEEP their own terminator, so joining them back gives the original
+    /// bytes: a file mixing CRLF and LF keeps both, and one that ends without a newline still does.</summary>
+    internal static List<string> SplitKeepingNewlines(string text)
+    {
+        List<string> lines = new();
+        int start = 0;
+        for (int i = 0; i < text.Length; i++)
+            if (text[i] == '\n') { lines.Add(text.Substring(start, i - start + 1)); start = i + 1; }
+        if (start < text.Length) lines.Add(text.Substring(start));
+        return lines;
+    }
+
+    /// <summary>One line without its terminator.</summary>
+    private static string LineBody(string line) => line.TrimEnd('\n').TrimEnd('\r');
 
     // ---- ~/.claude.json removal (JSON splice) ------------------------------
 
@@ -190,85 +378,203 @@ public static class Uninstall
     /// <c>RegisterClaudeMcpServer</c>: only the small mcpServers object is parsed and spliced back, so every
     /// other byte - including the case-differing keys a whole-file parser rejects - is left as it was. Backs the
     /// file up first, and writes nothing at all when there is no entry of ours to take.
+    ///
+    /// When ours was the only entry, the whole mcpServers member goes with it: the install CREATES that member
+    /// in a file that never had one, and an empty object left behind is a key the user never wrote. An empty
+    /// mcpServers and no mcpServers mean the same thing to the host, so nothing of theirs is lost either way.
     /// </summary>
-    internal static void UnregisterClaudeMcpServer(string claudeJsonPath, string name)
+    internal static ConfigEdit UnregisterClaudeMcpServer(string claudeJsonPath, string name)
     {
-        if (!File.Exists(claudeJsonPath)) return;
+        if (!File.Exists(claudeJsonPath)) return ConfigEdit.FileMissing;
 
-        string text = File.ReadAllText(claudeJsonPath);
-        if (Program.FindRootMemberObject(text, "mcpServers") is not { } b) return;
+        var (text, bom) = ReadTextKeepingBom(claudeJsonPath);
+        if (Program.FindRootMemberObject(text, "mcpServers") is not { } b) return ConfigEdit.NotFound;
 
         string objText = text.Substring(b.start, b.end - b.start + 1);
         JsonObject servers = JsonNode.Parse(objText) as JsonObject
             ?? throw new InvalidDataException("mcpServers is not a JSON object.");
-        if (!servers.Remove(name)) return; // nothing of ours registered: the file is not touched
+        if (!servers.Remove(name)) return ConfigEdit.NotFound; // nothing of ours registered: the file is not touched
 
-        File.Copy(claudeJsonPath, claudeJsonPath + ".houseCARL.bak", overwrite: true);
-        string newObj = Program.Reindent(servers.ToJsonString(Program.Indented),
-                                         Program.LeadingIndentOfLineAt(text, b.start));
-        File.WriteAllText(claudeJsonPath, string.Concat(text.AsSpan(0, b.start), newObj, text.AsSpan(b.end + 1)));
+        File.Copy(claudeJsonPath, claudeJsonPath + BackupSuffix, overwrite: true);
+        string updated;
+        if (servers.Count == 0)
+        {
+            updated = RemoveRootMember(text, "mcpServers", b);
+        }
+        else
+        {
+            string newObj = Program.Reindent(servers.ToJsonString(Program.Indented),
+                                             Program.LeadingIndentOfLineAt(text, b.start));
+            updated = string.Concat(text.AsSpan(0, b.start), newObj, text.AsSpan(b.end + 1));
+        }
+        WriteTextKeepingBom(claudeJsonPath, updated, bom);
+        return ConfigEdit.Removed;
+    }
+
+    /// <summary>
+    /// Cut a root-level <c>"key": { ... }</c> member out of a JSON document, with the line it sits on and the
+    /// one comma that separated it from its neighbour - the exact inverse of the block
+    /// <c>RegisterClaudeMcpServer</c> splices in when it creates the member. Nothing else in the file moves.
+    /// </summary>
+    internal static string RemoveRootMember(string text, string key, (int start, int end) value)
+    {
+        int keyStart = text.LastIndexOf("\"" + key + "\"", value.start, StringComparison.Ordinal);
+        if (keyStart < 0) return text; // the caller found it; without the key there is nothing safe to cut
+
+        int cutStart = keyStart;
+        int nl = text.LastIndexOf('\n', keyStart);
+        if (nl >= 0 && text.AsSpan(nl + 1, keyStart - nl - 1).IsWhiteSpace()) cutStart = nl;
+
+        int cutEnd = value.end + 1;
+        int after = cutEnd;
+        while (after < text.Length && char.IsWhiteSpace(text[after])) after++;
+        if (after < text.Length && text[after] == ',')
+        {
+            cutEnd = after + 1;
+        }
+        else
+        {
+            // Last member of the object: the comma above it is what would be left dangling, so it comes too.
+            int before = cutStart - 1;
+            while (before >= 0 && char.IsWhiteSpace(text[before])) before--;
+            if (before >= 0 && text[before] == ',') cutStart = before;
+        }
+
+        return text.Remove(cutStart, cutEnd - cutStart);
     }
 
     // ---- ~/.codex/config.toml removal (TOML splice) ------------------------
 
     /// <summary>Take the [mcp_servers.&lt;name&gt;] table out of a TOML config, backing the file up first and
     /// writing nothing when the table is not there.</summary>
-    internal static void UnregisterCodexMcpServer(string configTomlPath, string name)
+    internal static ConfigEdit UnregisterCodexMcpServer(string configTomlPath, string name)
     {
-        if (!File.Exists(configTomlPath)) return;
-        string text = File.ReadAllText(configTomlPath);
-        string updated = RemoveTomlTable(text, name);
-        if (updated == text) return;
-        File.Copy(configTomlPath, configTomlPath + ".houseCARL.bak", overwrite: true);
-        File.WriteAllText(configTomlPath, updated);
+        if (!File.Exists(configTomlPath)) return ConfigEdit.FileMissing;
+        var (text, bom) = ReadTextKeepingBom(configTomlPath);
+        if (RemoveTomlTable(text, name) is not { } updated) return ConfigEdit.NotFound;
+        File.Copy(configTomlPath, configTomlPath + BackupSuffix, overwrite: true);
+        WriteTextKeepingBom(configTomlPath, updated, bom);
+        return ConfigEdit.Removed;
     }
 
     /// <summary>
     /// Drop the [mcp_servers.&lt;name&gt;] table and any of its subtables, the mirror of
-    /// <c>SpliceTomlTable</c>. Line-based, so nothing else in the file is reformatted, and the file's newline
-    /// style is kept.
+    /// <c>SpliceTomlTable</c>, or null when the file carries no such table. Line-based, and each line keeps its
+    /// own terminator, so the file's newline style, mixed or not, and its trailing state are what they were.
+    ///
+    /// The table body ends at the LAST line in it that is neither blank nor a comment. TOML attaches a comment
+    /// to the table under it, so blank lines and comments between our last key and the next header are the next
+    /// table's, not ours, and they stay.
     ///
     /// A table the insert APPENDED to the end of the file was written after a blank line, and one it wrote into
     /// a file it created was written under a comment line. Those go with the table when the table is last in the
     /// file, which is where the insert put them; a table with something after it leaves what is above it alone,
     /// because there the blank line is the user's own separator.
     /// </summary>
-    internal static string RemoveTomlTable(string text, string name)
+    internal static string? RemoveTomlTable(string text, string name)
     {
-        string nl   = text.Contains("\r\n") ? "\r\n" : "\n";
-        string head = "[mcp_servers." + name + "]";
-        string sub  = "[mcp_servers." + name + ".";
+        List<string> lines = SplitKeepingNewlines(text);
 
-        string[] lines = text.Replace("\r\n", "\n").Split('\n');
-        List<string> outLines = new();
-        bool removed = false;
-        for (int i = 0; i < lines.Length; i++)
+        int head = -1;
+        for (int i = 0; i < lines.Count && head < 0; i++)
+            if (HeaderOf(lines[i], name) == HeaderKind.Ours) head = i;
+        if (head < 0) return null;
+
+        int last = head;
+        for (int j = head + 1; j < lines.Count; j++)
         {
-            if (!removed && lines[i].Trim() == head)
-            {
-                int j = i + 1;
-                while (j < lines.Length)
-                {
-                    string t = lines[j].Trim();
-                    if (t.StartsWith("[") && t != head && !t.StartsWith(sub)) break;
-                    j++;
-                }
-                bool lastInFile = !lines.Skip(j).Any(l => l.Trim().Length > 0);
-                if (lastInFile)
-                {
-                    while (outLines.Count > 0 && outLines[^1].Trim().Length == 0) outLines.RemoveAt(outLines.Count - 1);
-                    if (outLines.Count > 0 && outLines[^1].Trim() == Program.TomlComment) outLines.RemoveAt(outLines.Count - 1);
-                }
-                i = j - 1;
-                removed = true;
-                continue;
-            }
-            outLines.Add(lines[i]);
+            string body = LineBody(lines[j]).Trim();
+            if (body.StartsWith("[") && HeaderOf(lines[j], name) is not HeaderKind.Ours and not HeaderKind.OurSub) break;
+            if (body.Length > 0 && !body.StartsWith("#")) last = j;
         }
 
-        if (!removed) return text;
+        int first = head;
+        bool lastInFile = !lines.Skip(last + 1).Any(l => LineBody(l).Trim().Length > 0);
+        if (lastInFile)
+        {
+            while (first > 0 && LineBody(lines[first - 1]).Trim().Length == 0) first--;
+            if (first > 0 && LineBody(lines[first - 1]).Trim() == Program.TomlComment) first--;
+        }
 
-        while (outLines.Count > 0 && outLines[^1].Trim().Length == 0) outLines.RemoveAt(outLines.Count - 1);
-        return outLines.Count == 0 ? "" : string.Join(nl, outLines) + nl;
+        lines.RemoveRange(first, last - first + 1);
+        return string.Concat(lines);
+    }
+
+    /// <summary>What a line is to the table being removed.</summary>
+    private enum HeaderKind
+    {
+        /// <summary>Not a table header at all.</summary>
+        None,
+        /// <summary>[mcp_servers.&lt;name&gt;], however it is spelled.</summary>
+        Ours,
+        /// <summary>A subtable of ours, which the install's table can carry.</summary>
+        OurSub,
+        /// <summary>Somebody else's table, which ends our body.</summary>
+        Other,
+    }
+
+    /// <summary>
+    /// Read a line as a table header. TOML spells one key several ways - <c>[mcp_servers.housecarl]</c>,
+    /// <c>[mcp_servers."housecarl"]</c>, <c>[mcp_servers . housecarl]</c> - and Codex accepts a config written
+    /// any of them, so a match on the exact string the install writes would leave a hand-written entry in place
+    /// while the run said it was removed.
+    /// </summary>
+    private static HeaderKind HeaderOf(string line, string name)
+    {
+        string t = StripComment(LineBody(line)).Trim();
+        if (t.Length < 2 || t[0] != '[' || t[^1] != ']') return HeaderKind.None;
+        if (t.StartsWith("[[")) return HeaderKind.Other; // an array of tables is never ours
+
+        List<string>? parts = SplitTomlKey(t[1..^1]);
+        if (parts is null || parts.Count < 2) return HeaderKind.Other;
+        if (parts[0] != "mcp_servers" || parts[1] != name) return HeaderKind.Other;
+        return parts.Count == 2 ? HeaderKind.Ours : HeaderKind.OurSub;
+    }
+
+    /// <summary>Cut a trailing <c># comment</c> off a line, leaving a '#' inside a quoted key where it is.</summary>
+    private static string StripComment(string line)
+    {
+        char quote = '\0';
+        for (int i = 0; i < line.Length; i++)
+        {
+            char c = line[i];
+            if (quote != '\0') { if (c == quote) quote = '\0'; }
+            else if (c == '"' || c == '\'') quote = c;
+            else if (c == '#') return line[..i];
+        }
+        return line;
+    }
+
+    /// <summary>Split a dotted TOML key into its parts, bare or quoted, or null when it does not parse as one.</summary>
+    private static List<string>? SplitTomlKey(string inner)
+    {
+        List<string> parts = new();
+        int i = 0;
+        while (true)
+        {
+            while (i < inner.Length && char.IsWhiteSpace(inner[i])) i++;
+            string part;
+            if (i < inner.Length && (inner[i] == '"' || inner[i] == '\''))
+            {
+                char q = inner[i++];
+                int s = i;
+                while (i < inner.Length && inner[i] != q) i++;
+                if (i >= inner.Length) return null; // unterminated quote
+                part = inner[s..i];
+                i++;
+            }
+            else
+            {
+                int s = i;
+                while (i < inner.Length && inner[i] != '.') i++;
+                part = inner[s..i].TrimEnd();
+            }
+            if (part.Length == 0) return null;
+            parts.Add(part);
+            while (i < inner.Length && char.IsWhiteSpace(inner[i])) i++;
+            if (i >= inner.Length) return parts;
+            if (inner[i] != '.') return null;
+            i++;
+        }
     }
 }

--- a/src/housecarl-setup/Uninstall.cs
+++ b/src/housecarl-setup/Uninstall.cs
@@ -1,0 +1,274 @@
+using System.Text.Json.Nodes;
+
+namespace HousecarlSetup;
+
+/// <summary>
+/// Taking back exactly what the install wrote, host by host. It is its own file because it is its own job -
+/// <see cref="Program"/> stays the install - and every path it deletes comes from <see cref="Program"/>'s path
+/// helpers, so a removal cannot go somewhere the install never wrote.
+///
+/// What it removes, per host:
+///   Claude Code - the tree at ClaudeSkillsDest (skills, server, and the saved MO2 instance in the
+///                 houseCARL.user.json beside the server exe), and the mcpServers.housecarl entry in
+///                 ~/.claude.json.
+///   Codex       - the server dir (the saved MO2 instance goes with it), the skill folders the Codex record
+///                 names and no other, the record itself, and the [mcp_servers.housecarl] table in
+///                 ~/.codex/config.toml.
+///
+/// Both config edits are removal splices beside the insert splices on <see cref="Program"/>: the file is copied
+/// to a ".houseCARL.bak" first, the entry is taken out, and every other byte in the file is left as it was.
+/// ~/.agents/skills is shared with every other agent's skills, so a folder the record does not list is never
+/// touched - an install too old to have left a record removes nothing there and says so.
+/// </summary>
+public static class Uninstall
+{
+    /// <summary>What a non-interactive <see cref="TryUninstall"/> did.</summary>
+    public enum Outcome
+    {
+        /// <summary>The files and the host-config entries this target owns are gone.</summary>
+        Removed,
+        /// <summary>A houseCARL server file is in use (a live Claude/Codex session is running it), so it could
+        /// not be deleted. Nothing was deleted when the refusal was at pre-flight
+        /// (<see cref="Result.RefusedBeforeAnyDelete"/>).</summary>
+        ServerInUse,
+    }
+
+    /// <summary>Result of a non-interactive uninstall - the probeable seam under the interactive prompt.</summary>
+    /// <param name="What">What happened.</param>
+    /// <param name="Message">Caller-facing detail for a non-<see cref="Outcome.Removed"/> outcome (else null).</param>
+    public sealed record Result(Outcome What, string? Message)
+    {
+        /// <summary>True only when a <see cref="Outcome.ServerInUse"/> refusal happened at PRE-FLIGHT, before
+        /// anything was deleted.</summary>
+        public bool RefusedBeforeAnyDelete { get; init; }
+    }
+
+    /// <summary>
+    /// Remove houseCARL for the chosen host(s), non-interactively. The seam <see cref="Program"/> drives after
+    /// the plan's confirm, and the one the CI guard drives directly.
+    ///
+    /// A running session holds its server exe open, so the lock is PRE-FLIGHTED at every destination this target
+    /// touches before anything is deleted - the same check the install makes, for the same reason: a delete that
+    /// throws partway leaves a half-removed tree. A folder that will not delete for any other reason (a
+    /// read-only file inside it, a handle held on one) is collected and said at the end rather than thrown, so
+    /// the host-config entry still comes out.
+    /// </summary>
+    public static Result TryUninstall(Program.Target target, string home, string? homeOverride)
+    {
+        List<string> destExes = new();
+        if (target is Program.Target.Claude or Program.Target.Both) destExes.Add(Program.ClaudeDestExe(home));
+        if (target is Program.Target.Codex  or Program.Target.Both) destExes.Add(Program.CodexDestExe(home, homeOverride));
+
+        foreach (string destExe in destExes)
+            if (Program.ServerExeInUse(destExe))
+                return new Result(Outcome.ServerInUse, "In use, or locked / read-only:  " + destExe)
+                    { RefusedBeforeAnyDelete = true };
+
+        List<string> keptBack = new();
+
+        try
+        {
+            if (target is Program.Target.Claude or Program.Target.Both) RemoveForClaude(home, keptBack);
+            if (target is Program.Target.Codex  or Program.Target.Both) RemoveForCodex(home, homeOverride, keptBack);
+        }
+        catch (IOException ex) when (Program.IsSharingViolation(ex))
+        {
+            return new Result(Outcome.ServerInUse, "The file was the server, or a config file setup writes.");
+        }
+
+        ReportKeptBack(keptBack);
+        return new Result(Outcome.Removed, null);
+    }
+
+    // ---- Claude Code -------------------------------------------------------
+
+    private static void RemoveForClaude(string home, List<string> keptBack)
+    {
+        string dest       = Program.ClaudeSkillsDest(home);
+        string claudeJson = Program.ClaudeJson(home);
+
+        if (Directory.Exists(dest))
+        {
+            List<string> recorded = Program.ReadSkillRecord(Program.ClaudeSkillRecord(home));
+            Ui.Step("Claude Code", "removing the skills, the server and the saved MO2 instance", dest);
+            foreach (string name in recorded) Ui.Bullet(name);
+            DeleteTree(dest, keptBack);
+
+            // An install from before setup started recording what it put here leaves no record. The tree is
+            // houseCARL's outright either way, so the removal is the same one - but which of the two it was is
+            // said rather than left for the reader to infer from a missing list of names.
+            if (recorded.Count == 0)
+                Ui.Note(
+                    "This houseCARL was installed before setup began recording which skills it wrote, so the "
+                    + "removal above took the whole houseCARL folder it owns.",
+                    dest);
+        }
+
+        if (File.Exists(claudeJson))
+        {
+            Ui.Step("Claude Code", "removing the MCP server entry", claudeJson);
+            UnregisterClaudeMcpServer(claudeJson, McpServerName);
+        }
+        Console.WriteLine();
+    }
+
+    // ---- Codex -------------------------------------------------------------
+
+    private static void RemoveForCodex(string home, string? homeOverride, List<string> keptBack)
+    {
+        string serverDir  = Program.CodexServerDir(home, homeOverride);
+        string skillsRoot = Program.CodexSkillsRoot(home);
+        string record     = Program.CodexSkillRecord(home, homeOverride);
+        string configToml = Program.CodexConfigToml(home);
+
+        if (Directory.Exists(serverDir))
+        {
+            Ui.Step("Codex", "removing the server and the saved MO2 instance", serverDir);
+            DeleteTree(serverDir, keptBack);
+        }
+
+        List<string> recorded = Program.ReadSkillRecord(record);
+        if (recorded.Count > 0)
+        {
+            Ui.Step("Codex", "removing the skills it installed", skillsRoot);
+            foreach (string name in Program.RemoveSkillDirs(skillsRoot, recorded, keptBack).Removed)
+                Ui.Bullet(name);
+        }
+        else if (Directory.Exists(skillsRoot))
+        {
+            // ~/.agents/skills holds every agent's skills. Without the record there is no way to tell which
+            // folders there are houseCARL's, and a directory diff would take somebody else's, so nothing goes.
+            Ui.Note(
+                "Setup has no record of which skills it put in the shared skills folder, so it removed none of "
+                + "them — delete the houseCARL ones by hand if you want them gone.",
+                skillsRoot);
+        }
+
+        if (File.Exists(record)) File.Delete(record);
+
+        // The data dir exists only to hold the server dir and the record. Empty, it is a leftover; holding
+        // anything else, it is not ours to take.
+        string dataDir = Path.GetDirectoryName(serverDir)!;
+        if (Directory.Exists(dataDir) && !Directory.EnumerateFileSystemEntries(dataDir).Any())
+            DeleteTree(dataDir, keptBack);
+
+        if (File.Exists(configToml))
+        {
+            Ui.Step("Codex", "removing the MCP server entry", configToml);
+            UnregisterCodexMcpServer(configToml, McpServerName);
+        }
+        Console.WriteLine();
+    }
+
+    private const string McpServerName = "housecarl";
+
+    /// <summary>Delete a tree houseCARL owns. A tree that will not go (a read-only file inside it, a handle held
+    /// on one) is collected for the note at the end rather than thrown: the host-config entry still comes out,
+    /// and the run says what is still on disk.</summary>
+    private static void DeleteTree(string dir, List<string> keptBack)
+    {
+        try { Directory.Delete(dir, recursive: true); }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { keptBack.Add(dir); }
+    }
+
+    /// <summary>Said at the end of an otherwise finished uninstall: what is still on disk.</summary>
+    private static void ReportKeptBack(List<string> keptBack)
+    {
+        if (keptBack.Count == 0) return;
+        List<string> detail = new(keptBack.Select(dir => "- " + dir)) { "" };
+        detail.Add("A file in each is read-only or held open. Everything else is removed.");
+        Ui.Note(
+            "houseCARL is removed, but these folders could not be deleted — delete them by hand so nothing of "
+            + "houseCARL is left:",
+            detail.ToArray());
+    }
+
+    // ---- ~/.claude.json removal (JSON splice) ------------------------------
+
+    /// <summary>
+    /// Take mcpServers.<paramref name="name"/> out WITHOUT reparsing the whole file, the mirror of
+    /// <c>RegisterClaudeMcpServer</c>: only the small mcpServers object is parsed and spliced back, so every
+    /// other byte - including the case-differing keys a whole-file parser rejects - is left as it was. Backs the
+    /// file up first, and writes nothing at all when there is no entry of ours to take.
+    /// </summary>
+    internal static void UnregisterClaudeMcpServer(string claudeJsonPath, string name)
+    {
+        if (!File.Exists(claudeJsonPath)) return;
+
+        string text = File.ReadAllText(claudeJsonPath);
+        if (Program.FindRootMemberObject(text, "mcpServers") is not { } b) return;
+
+        string objText = text.Substring(b.start, b.end - b.start + 1);
+        JsonObject servers = JsonNode.Parse(objText) as JsonObject
+            ?? throw new InvalidDataException("mcpServers is not a JSON object.");
+        if (!servers.Remove(name)) return; // nothing of ours registered: the file is not touched
+
+        File.Copy(claudeJsonPath, claudeJsonPath + ".houseCARL.bak", overwrite: true);
+        string newObj = Program.Reindent(servers.ToJsonString(Program.Indented),
+                                         Program.LeadingIndentOfLineAt(text, b.start));
+        File.WriteAllText(claudeJsonPath, string.Concat(text.AsSpan(0, b.start), newObj, text.AsSpan(b.end + 1)));
+    }
+
+    // ---- ~/.codex/config.toml removal (TOML splice) ------------------------
+
+    /// <summary>Take the [mcp_servers.&lt;name&gt;] table out of a TOML config, backing the file up first and
+    /// writing nothing when the table is not there.</summary>
+    internal static void UnregisterCodexMcpServer(string configTomlPath, string name)
+    {
+        if (!File.Exists(configTomlPath)) return;
+        string text = File.ReadAllText(configTomlPath);
+        string updated = RemoveTomlTable(text, name);
+        if (updated == text) return;
+        File.Copy(configTomlPath, configTomlPath + ".houseCARL.bak", overwrite: true);
+        File.WriteAllText(configTomlPath, updated);
+    }
+
+    /// <summary>
+    /// Drop the [mcp_servers.&lt;name&gt;] table and any of its subtables, the mirror of
+    /// <c>SpliceTomlTable</c>. Line-based, so nothing else in the file is reformatted, and the file's newline
+    /// style is kept.
+    ///
+    /// A table the insert APPENDED to the end of the file was written after a blank line, and one it wrote into
+    /// a file it created was written under a comment line. Those go with the table when the table is last in the
+    /// file, which is where the insert put them; a table with something after it leaves what is above it alone,
+    /// because there the blank line is the user's own separator.
+    /// </summary>
+    internal static string RemoveTomlTable(string text, string name)
+    {
+        string nl   = text.Contains("\r\n") ? "\r\n" : "\n";
+        string head = "[mcp_servers." + name + "]";
+        string sub  = "[mcp_servers." + name + ".";
+
+        string[] lines = text.Replace("\r\n", "\n").Split('\n');
+        List<string> outLines = new();
+        bool removed = false;
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (!removed && lines[i].Trim() == head)
+            {
+                int j = i + 1;
+                while (j < lines.Length)
+                {
+                    string t = lines[j].Trim();
+                    if (t.StartsWith("[") && t != head && !t.StartsWith(sub)) break;
+                    j++;
+                }
+                bool lastInFile = !lines.Skip(j).Any(l => l.Trim().Length > 0);
+                if (lastInFile)
+                {
+                    while (outLines.Count > 0 && outLines[^1].Trim().Length == 0) outLines.RemoveAt(outLines.Count - 1);
+                    if (outLines.Count > 0 && outLines[^1].Trim() == Program.TomlComment) outLines.RemoveAt(outLines.Count - 1);
+                }
+                i = j - 1;
+                removed = true;
+                continue;
+            }
+            outLines.Add(lines[i]);
+        }
+
+        if (!removed) return text;
+
+        while (outLines.Count > 0 && outLines[^1].Trim().Length == 0) outLines.RemoveAt(outLines.Count - 1);
+        return outLines.Count == 0 ? "" : string.Join(nl, outLines) + nl;
+    }
+}


### PR DESCRIPTION
PR C of three on the installer. It was written stacked on #710 (installer PR B, the plan screen) and is now rebased onto main, which #710 has merged into, so it targets main directly. Setup can now remove houseCARL as well as install it: `[4] Uninstall` on the menu, or `--uninstall` with `--claude`/`--codex`/`--both` and `--yes`, following the same one-rule stdin handling PR B added. It takes back exactly what the install wrote, per host — the tree at each install location, the skill folders setup recorded installing (only those, because `~/.agents/skills` is shared with every other agent's skills), the record itself, and the `housecarl` entry in `~/.claude.json` and `~/.codex/config.toml`, each backed up to a `.houseCARL.bak` and then spliced out beside the existing insert splice so every other byte in the file stays where it was. The Claude install now writes an installed-skills record too, mirroring the Codex one, so its removal is by record rather than by glob; an uninstall of an older install without one removes the `housecarl` tree it owns and says that is the route it took. The removal plan is shown before anything is deleted, with the same Enter/q confirm, and both install and uninstall now close with a summary block — what was written or removed, where, and what to do next — built from the same plan the confirm was given for so it cannot name a path the run never touched. The .NET runtime refusal moved to after the host choice, because the runtimes are the server's and refusing at the detection block left a machine missing one with no way to uninstall. `TryInstall` keeps its signature; a new `setup-uninstall` CI probe installs over two configs that already carry another MCP server, uninstalls, and asserts both files are byte-identical afterwards and no houseCARL file remains. `packaging/START-HERE.txt` and both README Install sections describe the new screens and flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
