### PR TITLE
Release a walked node's body when its pass ends

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -15,14 +15,14 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 - **A forward `walk=` no longer holds every record it reached.** A record body read from a plugin is a slice
   of that record group's whole byte array and keeps it alive, so caching one body per reached node until the
-  call returned pinned one array per source group per plugin: 230 KB per reached node, and a raised
+  call returned pinned one array per source group per plugin: 270 KB per reached node, and a raised
   `walk.max_nodes` ran the process out of memory. A reached node now costs its row — its identity, its links,
   its pull chain — and a body lives only for the gather pass that read it, so the reached set is gone before
   anything renders. Measured on a 3,801-plugin order, the forward closure from one NPC: at
   `walk.max_nodes: 10000`, 3,528 MB peak working set becomes 1,480 MB; at 40,000, 9,469 MB becomes 1,516 MB;
   at 1,000,000 — which used to die with `OutOfMemoryException` at 55,875 MB private after 471 s — the walk
-  now finishes, reaching the closure's full 195,848 nodes in 289 s at 1,656 MB. What the walk reports is
-  unchanged. The bound on `walk.max_nodes` itself is unchanged, and is the open half of this: see #719.
+  now finishes, reaching the closure's full 195,848 nodes in 287 s at 1,694 MB. What the walk reports is
+  unchanged, and so is what `walk.max_nodes` accepts: the parameter still takes any budget at or above 1.
 
 ## 2.0.0 — 2026-09-11
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -19,16 +19,18 @@ saying it sets an expectation their install may contradict. Say what is known, a
   `walk.max_nodes` ran the process out of memory. A reached node now costs its row — its identity, its links,
   its pull chain — and a body lives only for the gather pass that read it, so the reached set is gone before
   anything renders. Measured on a 3,801-plugin order, the forward closure from one NPC: at
-  `walk.max_nodes: 10000`, 3,528 MB peak working set becomes 1,480 MB; at 40,000, 9,469 MB becomes 1,516 MB;
-  at 1,000,000 — which used to die with `OutOfMemoryException` at 55,875 MB private after 471 s — the walk
-  now finishes, reaching the closure's full 195,848 nodes in 287 s at 1,694 MB. What the walk reports is
-  unchanged.
+  `walk.max_nodes: 10000`, 3,528 MB peak working set becomes 1,430 MB; at 40,000, 9,469 MB becomes 1,490 MB;
+  and at a budget big enough to exhaust the closure — which used to die with `OutOfMemoryException` at
+  55,875 MB private after 471 s — the walk now finishes, reaching that seed's full 195,848 nodes in 308 s at
+  1,808 MB. What the walk reports is unchanged.
 - **`walk.max_nodes` now has a hard upper bound of 250,000, and a higher budget is refused naming it.** Fixed,
   not derived from the machine: a reached node costs a row of a few KB wherever the walk runs, so the arithmetic
   is the same on every box, and a bound that moved with the machine would let one call succeed on one and be
   refused on another. It bounds the budget without bounding an answer — the whole forward closure a single seed
   reaches, measured on a 3,801-plugin order, is 195,848 nodes, so a walk that finishes still finishes. The bound
-  is on `walk.max_nodes`; `walk.depth` is unchanged.
+  is on the PER-SEED reading of the budget, which the parameter's own description separates: the forward walk and
+  the reverse carrier walk. The transitive reverse walk, where one budget is shared across every seed and every
+  hop, is unchanged, and so is `walk.depth`.
 
 ## 2.0.0 — 2026-09-11
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,17 @@ saying it sets an expectation their install may contradict. Say what is known, a
 
 ## Unreleased
 
+- **A forward `walk=` no longer holds every record it reached.** A record body read from a plugin is a slice
+  of that record group's whole byte array and keeps it alive, so caching one body per reached node until the
+  call returned pinned one array per source group per plugin: 230 KB per reached node, and a raised
+  `walk.max_nodes` ran the process out of memory. A reached node now costs its row — its identity, its links,
+  its pull chain — and a body lives only for the gather pass that read it, so the reached set is gone before
+  anything renders. Measured on a 3,801-plugin order, the forward closure from one NPC: at
+  `walk.max_nodes: 10000`, 3,528 MB peak working set becomes 1,480 MB; at 40,000, 9,469 MB becomes 1,516 MB;
+  at 1,000,000 — which used to die with `OutOfMemoryException` at 55,875 MB private after 471 s — the walk
+  now finishes, reaching the closure's full 195,848 nodes in 289 s at 1,656 MB. What the walk reports is
+  unchanged. The bound on `walk.max_nodes` itself is unchanged, and is the open half of this: see #719.
+
 ## 2.0.0 — 2026-09-11
 
 houseCARL 2.0.0 replaces the 1.x tool surface with 31 tools. The record plane is one grammar: a read is one call composed from four axes (SELECT × SOURCE × PROJECT × TRANSPORT); a write is one call composed from an op list, a lane and a transport; one record is a set of one. Record coverage is generated from Mutagen.Bethesda.Skyrim 0.54.4 at build time, 1,174 types, and the write pre-flight and the `mutagen-reference` skill are two renderings of that one artifact. The 1.x tool and parameter names are deleted, not deprecated: a retired tool name is refused with a refusal naming its successor, from `AliasTable.cs`; a retired parameter name is refused as an unknown parameter, with the parameters the tool does take. Seven skills ship. `housecarl_check` gains the facegen family. The installer shows what it will write before writing, and uninstalls. The entries below are in the order they landed.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -22,7 +22,13 @@ saying it sets an expectation their install may contradict. Say what is known, a
   `walk.max_nodes: 10000`, 3,528 MB peak working set becomes 1,480 MB; at 40,000, 9,469 MB becomes 1,516 MB;
   at 1,000,000 — which used to die with `OutOfMemoryException` at 55,875 MB private after 471 s — the walk
   now finishes, reaching the closure's full 195,848 nodes in 287 s at 1,694 MB. What the walk reports is
-  unchanged, and so is what `walk.max_nodes` accepts: the parameter still takes any budget at or above 1.
+  unchanged.
+- **`walk.max_nodes` now has a hard upper bound of 250,000, and a higher budget is refused naming it.** Fixed,
+  not derived from the machine: a reached node costs a row of a few KB wherever the walk runs, so the arithmetic
+  is the same on every box, and a bound that moved with the machine would let one call succeed on one and be
+  refused on another. It bounds the budget without bounding an answer — the whole forward closure a single seed
+  reaches, measured on a 3,801-plugin order, is 195,848 nodes, so a walk that finishes still finishes. The bound
+  is on `walk.max_nodes`; `walk.depth` is unchanged.
 
 ## 2.0.0 — 2026-09-11
 

--- a/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
+++ b/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
@@ -284,6 +284,34 @@ public sealed class RecordsWalkCostTests
         Assert.Equal(0, LoadOrderService.WalkBodiesHeldAtReturn);
     }
 
+    // ---- the node budget's hard upper bound ---------------------------------------------------------
+
+    /// <summary>The budget has a hard upper bound, so "no cap" cannot be spelled as a huge number and walked into
+    /// the ground. The refusal names the bound and what to pass instead.</summary>
+    [Fact]
+    public void ANodeBudgetPastTheCeilingIsRefusedNamingTheBound()
+    {
+        var response = RecordsTools.Records(Svc, types: Npc, plugins: Scope(),
+                                            walk: new RecordsTools.RecordsWalk { max_nodes = RecordsTools.RecordsWalk.Ceiling + 1 },
+                                            project: Chain(), counts_only: true);
+
+        Assert.StartsWith("error:", response);
+        Assert.Contains("walk.max_nodes=" + (RecordsTools.RecordsWalk.Ceiling + 1), response);
+        Assert.Contains(RecordsTools.RecordsWalk.Ceiling.ToString(), response);
+    }
+
+    /// <summary>And the bound itself is a legal budget, not one off it — the refusal is above, not at.</summary>
+    [Fact]
+    public void ANodeBudgetAtTheCeilingWalks()
+    {
+        var response = RecordsTools.Records(Svc, types: Npc, plugins: Scope(),
+                                            walk: new RecordsTools.RecordsWalk { depth = 1, max_nodes = RecordsTools.RecordsWalk.Ceiling },
+                                            project: Chain(), counts_only: true);
+
+        Assert.DoesNotContain("error:", response);
+        Assert.Contains($"reached={WalkCostWorld.Seeds * (WalkCostWorld.ItemsPerSeed + 1) + 1}", response);
+    }
+
     /// <summary>A seed at its node budget reads no further. The gather used to take every seed's whole hop frontier
     /// before the budget was consulted on dequeue, so a walk capped at one node still read — and pinned — every
     /// link off every seed to keep one of them. The budget now rides into the gather, and the cap itself is

--- a/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
+++ b/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
@@ -164,10 +164,7 @@ public sealed class RecordsWalkCostTests
         var seeks = LoadOrderResolver.BodySeeks - before;
 
         Assert.Contains($"seeds={WalkCostWorld.Seeds + 2}", response);
-        // The gather, plus the template report's own re-read of the chain, which the walk no longer pins (#719).
-        // That re-read is the CHAIN's length, not the seed count — the reports share one cache — so the claim this
-        // test makes is unchanged: a constant, not one walk per seed.
-        Assert.True(seeks <= 3, $"{WalkCostWorld.Seeds + 2} walk seeds cost {seeks} per-record plugin walks.");
+        Assert.True(seeks <= 1, $"{WalkCostWorld.Seeds + 2} walk seeds cost {seeks} per-record plugin walks.");
     }
 
     /// <summary>Every seed advances one hop together, so a hop's reached nodes are one gather too. Before, a closure
@@ -298,6 +295,39 @@ public sealed class RecordsWalkCostTests
         Assert.StartsWith("error:", response);
         Assert.Contains("walk.max_nodes=" + (RecordsTools.RecordsWalk.Ceiling + 1), response);
         Assert.Contains(RecordsTools.RecordsWalk.Ceiling.ToString(), response);
+    }
+
+    /// <summary>The template report costs no read of its own: on a template walk the reached nodes ARE the chain
+    /// nodes, so the report takes its facts off the bodies the walk already read. It re-read every chain node from
+    /// disk once the walk stopped pinning bodies, which is the seed-count-times-whole-plugin-seek shape of
+    /// #556.</summary>
+    [Fact]
+    public void ATemplateReportReadsNoChainNodeTheWalkAlreadyRead()
+    {
+        var before = LoadOrderResolver.BodySeeks;
+        var response = RecordsTools.Records(Svc, types: Npc, plugins: Scope(), walk: TemplateWalk(),
+                                            project: Chain(), counts_only: true);
+        var seeks = LoadOrderResolver.BodySeeks - before;
+
+        Assert.DoesNotContain("error:", response);
+        Assert.True(seeks <= 1, $"the template report over {WalkCostWorld.Seeds + 2} seeds cost {seeks} per-record plugin walks.");
+    }
+
+    /// <summary>The bound is on the PER-SEED reading of the budget. On the transitive reverse walk the same
+    /// parameter is one budget shared across every seed and every hop — a different quantity, on the lane where the
+    /// retention this PR fixes never existed — so this gate leaves it alone.</summary>
+    [Fact]
+    public void ATransitiveReverseWalkIsNotHeldToTheForwardCeiling()
+    {
+        var response = RecordsTools.Records(Svc, formids: new[] { _w.RevisitSeed },
+                                            walk: new RecordsTools.RecordsWalk
+                                            {
+                                                direction = "reverse", follow = "*", depth = 1,
+                                                max_nodes = RecordsTools.RecordsWalk.Ceiling + 1,
+                                            },
+                                            project: Fields(), counts_only: true);
+
+        Assert.DoesNotContain("hard upper bound", response);
     }
 
     /// <summary>And the bound itself is a legal budget, not one off it — the refusal is above, not at.</summary>

--- a/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
+++ b/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
@@ -164,7 +164,10 @@ public sealed class RecordsWalkCostTests
         var seeks = LoadOrderResolver.BodySeeks - before;
 
         Assert.Contains($"seeds={WalkCostWorld.Seeds + 2}", response);
-        Assert.True(seeks <= 1, $"{WalkCostWorld.Seeds + 2} walk seeds cost {seeks} per-record plugin walks.");
+        // The gather, plus the template report's own re-read of the chain, which the walk no longer pins (#719).
+        // That re-read is the CHAIN's length, not the seed count — the reports share one cache — so the claim this
+        // test makes is unchanged: a constant, not one walk per seed.
+        Assert.True(seeks <= 3, $"{WalkCostWorld.Seeds + 2} walk seeds cost {seeks} per-record plugin walks.");
     }
 
     /// <summary>Every seed advances one hop together, so a hop's reached nodes are one gather too. Before, a closure
@@ -204,6 +207,24 @@ public sealed class RecordsWalkCostTests
         var ceiling = perSeedCeiling * (WalkCostWorld.Seeds + 2);
         Assert.True(allocated < ceiling,
                     $"the walk allocated {allocated / 1048576} MB over {WalkCostWorld.Seeds + 2} seeds — past the {ceiling / 1048576} MB this world's seed count allows.");
+    }
+
+    /// <summary>A reached node costs its row, not its body. A record getter is a slice of its whole GRUP's byte
+    /// array and pins it, so caching every reached node's body until the call ended pinned one array per source
+    /// GRUP per plugin — 230 KB a reached node on a real order, and an OOM at a raised budget (#719). Bodies now
+    /// live for the gather pass that read them, and the reached set is gone before anything renders.</summary>
+    [Fact]
+    public void AWalkHoldsNoReachedBodiesPastTheGatherThatReadThem()
+    {
+        var response = RecordsTools.Records(Svc, types: Npc, plugins: Scope(),
+                                            walk: new RecordsTools.RecordsWalk { depth = 1 },
+                                            project: Chain(), counts_only: true);
+
+        var reached = WalkCostWorld.Seeds * (WalkCostWorld.ItemsPerSeed + 1) + 1;
+        Assert.Contains($"reached={reached}", response);
+        Assert.Equal(0, LoadOrderService.WalkBodiesHeldAtReturn);
+        Assert.True(LoadOrderService.WalkBodyHighWater <= BodyPrefetch.ChunkRows,
+                    $"the walk held {LoadOrderService.WalkBodyHighWater} bodies at once — past the {BodyPrefetch.ChunkRows} one gather pass allows.");
     }
 
     /// <summary>A seed at its node budget reads no further. The gather used to take every seed's whole hop frontier

--- a/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
+++ b/src/housecarl-mcp-tests/RecordsWalkCostTests.cs
@@ -211,7 +211,7 @@ public sealed class RecordsWalkCostTests
 
     /// <summary>A reached node costs its row, not its body. A record getter is a slice of its whole GRUP's byte
     /// array and pins it, so caching every reached node's body until the call ended pinned one array per source
-    /// GRUP per plugin — 230 KB a reached node on a real order, and an OOM at a raised budget (#719). Bodies now
+    /// GRUP per plugin — 270 KB a reached node on a real order, and an OOM at a raised budget (#719). Bodies now
     /// live for the gather pass that read them, and the reached set is gone before anything renders.</summary>
     [Fact]
     public void AWalkHoldsNoReachedBodiesPastTheGatherThatReadThem()
@@ -225,6 +225,63 @@ public sealed class RecordsWalkCostTests
         Assert.Equal(0, LoadOrderService.WalkBodiesHeldAtReturn);
         Assert.True(LoadOrderService.WalkBodyHighWater <= BodyPrefetch.ChunkRows,
                     $"the walk held {LoadOrderService.WalkBodyHighWater} bodies at once — past the {BodyPrefetch.ChunkRows} one gather pass allows.");
+    }
+
+    /// <summary>The same walk with a pass small enough to SPLIT — every seed slice and every hop runs several
+    /// passes, so the release, the level snapshot, a seed skipped because an earlier one filled the pass, and the
+    /// per-pass node budget are all exercised. Building a world with a 2,000-link hop to meet the real pass size is
+    /// not a test; the pass size is the knob, the same way the render bound is.</summary>
+    [Theory]
+    [InlineData(1)]
+    [InlineData(7)]
+    [InlineData(64)]
+    public void AWalkSplitAcrossPassesReachesTheSameSetAndHoldsOnePass(int passRows)
+    {
+        var reached = WalkCostWorld.Seeds * (WalkCostWorld.ItemsPerSeed + 1) + 1;
+        string Walk() => RecordsTools.Records(Svc, types: Npc, plugins: Scope(),
+                                              walk: new RecordsTools.RecordsWalk { depth = 1 },
+                                              project: Chain(), counts_only: true);
+
+        var whole = Walk();
+        var split = WithPassRows(passRows, Walk);
+
+        Assert.Equal(whole, split);
+        Assert.Contains($"reached={reached}", split);
+        Assert.Equal(0, LoadOrderService.WalkBodiesHeldAtReturn);
+        Assert.True(LoadOrderService.WalkBodyHighWater <= passRows,
+                    $"a walk passing {passRows} keys at a time held {LoadOrderService.WalkBodyHighWater} bodies at once.");
+    }
+
+    /// <summary>The node budget is spent across passes, not per pass: a seed capped at one node records one node and
+    /// says the cap cut it, whether the hop it cut ran in one pass or twenty.</summary>
+    [Fact]
+    public void ASeedsNodeBudgetIsSpentAcrossPassesNotPerPass()
+    {
+        var response = WithPassRows(3, () =>
+            RecordsTools.Records(Svc, types: Npc, plugins: Scope(),
+                                 walk: new RecordsTools.RecordsWalk { depth = 2, max_nodes = 1 },
+                                 project: Chain(), counts_only: true));
+
+        Assert.Contains($"reached={WalkCostWorld.Seeds + 1}", response);
+        Assert.Equal(0, LoadOrderService.WalkBodiesHeldAtReturn);
+    }
+
+    /// <summary>A severity 'refuse' still names the first seed in seed order at the shallowest hop, and the pass it
+    /// abandoned is released rather than left to the collector, now that a hop is interleaved across passes.</summary>
+    [Fact]
+    public void ARefusingWalkSplitAcrossPassesRefusesTheSameWayAndHoldsNothing()
+    {
+        var refuse = new[] { new RecordsTools.RecordsWalkExclusion { match = "Ammunition", severity = "refuse" } };
+        string Walk() => RecordsTools.Records(Svc, types: Npc, plugins: Scope(),
+                                              walk: new RecordsTools.RecordsWalk { depth = 1, exclusions = refuse },
+                                              project: Chain(), counts_only: true);
+
+        var whole = Walk();
+        var split = WithPassRows(5, Walk);
+
+        Assert.StartsWith("error:", whole);
+        Assert.Equal(whole, split);
+        Assert.Equal(0, LoadOrderService.WalkBodiesHeldAtReturn);
     }
 
     /// <summary>A seed at its node budget reads no further. The gather used to take every seed's whole hop frontier
@@ -394,6 +451,15 @@ public sealed class RecordsWalkCostTests
         RenderBudget.MaxRenderRows = rows;
         try { return call(); }
         finally { RenderBudget.MaxRenderRows = prior; }
+    }
+
+    /// <summary>Run one call with the walk's gather pass shrunk, restored whatever happens.</summary>
+    static string WithPassRows(int rows, Func<string> call)
+    {
+        var prior = LoadOrderService.WalkPassRows;
+        LoadOrderService.WalkPassRows = rows;
+        try { return call(); }
+        finally { LoadOrderService.WalkPassRows = prior; }
     }
 
     /// <summary>Every NPC in the world, as walk seeds.</summary>

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -3978,8 +3978,9 @@ public sealed partial class LoadOrderService : IDisposable
             => bodyCache.TryGetValue(k, out var c) ? c
              : view.ResolveWinner(k) is { } w ? view.GetRecord(session, w.WinnerPlugin, k) : null;
 
-        // One node's template facts, memoised BY VALUE: shared chains stay one read per call (the seeds of a
-        // template walk mostly share theirs) and nothing is pinned between seeds.
+        // One node's template facts, memoised BY VALUE: nothing is pinned between seeds, shared chains stay one
+        // read per call, and the walk fills this as it reads, so the report only ever reads a chain node the walk
+        // did not reach itself — a node past this seed's depth or node cap.
         var templateFacts = new Dictionary<FormKey, WalkTemplateFact?>();
         WalkTemplateFact? TemplateFactOf(FormKey k)
         {
@@ -4070,6 +4071,10 @@ public sealed partial class LoadOrderService : IDisposable
             fact = body is null
                  ? new WalkNodeFact { Resolved = false }
                  : new WalkNodeFact { Resolved = true, Type = TypeOf(body), EditorId = body.EditorID };
+            // On a template walk the reached nodes ARE the chain nodes, so the report takes its facts off the body
+            // in hand here. Without this it re-read every chain node from disk — a whole-plugin seek each — after
+            // the walk had already held that body and let it go.
+            if (templateFollow && body is not null) templateFacts.TryAdd(k, FactOf(body));
             if (body is not null && !atCap && !Excluded(fact.Type)) fact.Links = LinksOf(body, followSegs, out _);
             if (nodeFacts is not null) nodeFacts[k] = fact;
             return fact;
@@ -4129,6 +4134,8 @@ public sealed partial class LoadOrderService : IDisposable
                 Label = $"{seedType} {FormIdToken.Of(seedFk)} ({seedBody.EditorID ?? "<no editorid>"})",
                 Visited = new HashSet<FormKey> { seedFk },
             };
+            // The seed's facts go in the shared memo too, for the seed that sits on another seed's chain.
+            if (st.SeedTemplateFact is { } sf) templateFacts.TryAdd(seedFk, sf);
 
             // First hop: seed_paths (each path's links) or every link on the seed.
             if (seedPaths is { Count: > 0 })

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -3859,10 +3859,33 @@ public sealed partial class LoadOrderService : IDisposable
     /// that claim to (#719). Set by <see cref="WalkForwardBatch"/>, which resets it on entry.</summary>
     internal static int WalkBodyHighWater;
 
-    /// <summary>How many record bodies the last forward walk was STILL holding when its hops finished — the other
-    /// half of the same claim, and the one the reported bug was: the reached set has to be gone before the render,
-    /// not at the end of the call. Zero on every walk.</summary>
+    /// <summary>How many record bodies the last forward walk was STILL holding when it returned — the other half of
+    /// the same claim, and the one the reported bug was: the reached set has to be gone before the render, not at
+    /// the end of the call. Zero on every walk, the refusal and the no-frontier returns included.</summary>
     internal static int WalkBodiesHeldAtReturn;
+
+    /// <summary>How many record bodies one forward-walk gather pass reads before it releases them — the seed slice
+    /// and the hop slice alike. <see cref="BodyPrefetch.ChunkRows"/>, so a plugin is enumerated exactly as often as
+    /// the gather already enumerated it; a test lowers it to split a hop the way a real order's does.</summary>
+    internal static int WalkPassRows = BodyPrefetch.ChunkRows;
+
+    /// <summary>Everything a walk takes from one reached node: its identity and its links, as values. It is what a
+    /// key is remembered by once its body is gone, so a node two seeds both reach is still ONE read per call —
+    /// which is what the body cache used to buy before it was the retention (#719).</summary>
+    sealed class WalkNodeFact
+    {
+        public bool Resolved;
+        public string? Type;
+        public string? EditorId;
+        public List<FormKey>? Links;
+    }
+
+    static readonly List<FormKey> EmptyKeys = new();
+
+    /// <summary>What the NPC template report needs from one node — values, never a getter, so reading a chain pins
+    /// no record group's bytes. Reused across seeds, which is what keeps a shared chain one read per call.</summary>
+    readonly record struct WalkTemplateFact(string TypeName, string? EditorId, FormKey Template, bool HasTemplate,
+                                            NpcConfiguration.TemplateFlag Flags, bool IsNpc, bool IsLeveled);
 
     /// <summary>One record the walk reached: its identity, its provenance (<see cref="PulledBy"/> — the parent
     /// node's label) and whether the walk entered it or recorded it as a boundary. A boundary's reason — an
@@ -3889,12 +3912,11 @@ public sealed partial class LoadOrderService : IDisposable
     /// advances every seed one hop at a time, so a hop's bodies can be gathered together; this holds what used to be
     /// locals of a per-seed loop.
     /// <para>It holds the seed's IDENTITY, never its body — a record getter is a slice of its whole GRUP's byte array
-    /// and pins it (#719). <see cref="SeedBody"/> is the one exception, kept only for the NPC template report, which
-    /// needs the seed record itself.</para></summary>
+    /// and pins it (#719). The NPC template report rides on <see cref="SeedTemplateFact"/>, which is values.</para></summary>
     sealed class WalkSeedState
     {
         public FormKey Key;
-        public INpcGetter? SeedBody;
+        public WalkTemplateFact? SeedTemplateFact;
         public string? EditorId;
         public string Type = "";
         public string Label = "";
@@ -3949,6 +3971,32 @@ public sealed partial class LoadOrderService : IDisposable
             IMajorRecordGetter? g = view.ResolveWinner(k) is { } w ? view.GetRecord(session, w.WinnerPlugin, k) : null;
             bodyCache[k] = g;
             return g;
+        }
+        // The same read WITHOUT the cache — for the template chain, whose nodes are read once, reduced to values,
+        // and dropped. Caching them would put the retention this walk exists to remove back on that one lane.
+        IMajorRecordGetter? FetchTransient(FormKey k)
+            => bodyCache.TryGetValue(k, out var c) ? c
+             : view.ResolveWinner(k) is { } w ? view.GetRecord(session, w.WinnerPlugin, k) : null;
+
+        // One node's template facts, memoised BY VALUE: shared chains stay one read per call (the seeds of a
+        // template walk mostly share theirs) and nothing is pinned between seeds.
+        var templateFacts = new Dictionary<FormKey, WalkTemplateFact?>();
+        WalkTemplateFact? TemplateFactOf(FormKey k)
+        {
+            if (templateFacts.TryGetValue(k, out var have)) return have;
+            var body = FetchTransient(k);
+            WalkTemplateFact? fact = body is null ? null : FactOf(body);
+            templateFacts[k] = fact;
+            return fact;
+        }
+        static WalkTemplateFact FactOf(IMajorRecordGetter b)
+        {
+            var npc = b as INpcGetter;
+            var t = npc?.Template;
+            return new WalkTemplateFact(RecordNaming.StripOverlay(b.GetType().Name), b.EditorID,
+                                        t is null || t.IsNull ? default : t.FormKey, t is not null && !t.IsNull,
+                                        npc?.Configuration.TemplateFlags ?? default, npc is not null,
+                                        b is ILeveledNpcGetter);
         }
         // The hop's bodies, one enumeration per source plugin. A key the gather does not return stays UNCACHED, so
         // Fetch still raises whatever the per-record read raises: the gather is an optimisation, not an error path.
@@ -4006,19 +4054,53 @@ public sealed partial class LoadOrderService : IDisposable
             return links ?? new List<FormKey>();
         }
 
+        // What each reached key yielded, by value. Bodies no longer outlive their pass, so without this a key two
+        // seeds both reach would be READ once per seed rather than once per call. Kept only for a MULTI-seed walk:
+        // one seed's own visited set already stops it reading a key twice, so the memo would be pure cost there.
+        var nodeFacts = seeds.Count > 1 ? new Dictionary<FormKey, WalkNodeFact>() : null;
+
+        // The node's identity and, unless it is at the depth cap or an excluded class, its links — off the memo when
+        // the memo already holds what this row needs, off a body read otherwise.
+        WalkNodeFact FactFor(FormKey k, bool atCap)
+        {
+            var fact = nodeFacts is not null && nodeFacts.TryGetValue(k, out var f) ? f : null;
+            if (fact is not null && (!fact.Resolved || atCap || fact.Links is not null || Excluded(fact.Type))) return fact;
+
+            var body = Fetch(k);
+            fact = body is null
+                 ? new WalkNodeFact { Resolved = false }
+                 : new WalkNodeFact { Resolved = true, Type = TypeOf(body), EditorId = body.EditorID };
+            if (body is not null && !atCap && !Excluded(fact.Type)) fact.Links = LinksOf(body, followSegs, out _);
+            if (nodeFacts is not null) nodeFacts[k] = fact;
+            return fact;
+        }
+        bool Excluded(string? type)
+            => type is not null && exclusions.Any(x => x.Match.Equals(type, StringComparison.OrdinalIgnoreCase));
+
+        // Is this queued item's row already answerable from the memo? Then its body is not worth a gather slot.
+        bool Memoised(FormKey k, int hop)
+            => nodeFacts is not null && nodeFacts.TryGetValue(k, out var f)
+               && (!f.Resolved || hop >= depth || f.Links is not null || Excluded(f.Type));
+
         // ---- the seeds: parsed, then gathered together, then started on their first hop ----
+        // In SLICES of a pass, for the reason the hops are: a walk can be seeded from a spilled artifact holding
+        // thousands of FormIDs, and gathering them all first held one body — one pinned record group — per seed
+        // before a single hop had run.
         var rows = new WalkSeedResult?[seeds.Count];
         var states = new WalkSeedState?[seeds.Count];
         var seedKeys = new FormKey[seeds.Count];
-        var seedGather = new List<FormKey>(seeds.Count);
-        for (int i = 0; i < seeds.Count; i++)
+        for (int s0 = 0; s0 < seeds.Count; s0 += WalkPassRows)
+        {
+        int s1 = Math.Min(s0 + WalkPassRows, seeds.Count);
+        var seedGather = new List<FormKey>(s1 - s0);
+        for (int i = s0; i < s1; i++)
         {
             try { seedKeys[i] = view.ParseFormId(seeds[i]); seedGather.Add(seedKeys[i]); }
             catch (Exception ex) { rows[i] = new WalkSeedResult(seeds[i]?.Trim() ?? "", null, null, Array.Empty<WalkNodeRow>(), Array.Empty<string>(), null, null, $"bad FormID '{seeds[i]}': {ex.Message}"); }
         }
         Prefetch(seedGather);
 
-        for (int i = 0; i < seeds.Count; i++)
+        for (int i = s0; i < s1; i++)
         {
             if (rows[i] is not null) continue;
             ct.ThrowIfCancellationRequested();
@@ -4039,9 +4121,9 @@ public sealed partial class LoadOrderService : IDisposable
             var st = new WalkSeedState
             {
                 Key = seedFk,
-                // Only the template report needs the seed's own body past its first hop; every other consumer wants
-                // its identity, so nothing else keeps a getter alive (and with it a whole GRUP's bytes).
-                SeedBody = templateFollow ? seedBody as INpcGetter : null,
+                // The template report takes the seed's facts, not its body: a getter kept per seed would pin one
+                // record group per seed, which is the retention this walk exists to remove.
+                SeedTemplateFact = templateFollow && seedBody is INpcGetter ? FactOf(seedBody) : null,
                 EditorId = seedBody.EditorID,
                 Type = seedType,
                 Label = $"{seedType} {FormIdToken.Of(seedFk)} ({seedBody.EditorID ?? "<no editorid>"})",
@@ -4067,14 +4149,18 @@ public sealed partial class LoadOrderService : IDisposable
             }
             states[i] = st;
         }
+        // The slice's seed bodies have given up their identity and their first-hop links; they go now.
+        if (bodyCache.Count > WalkBodyHighWater) WalkBodyHighWater = bodyCache.Count;
+        bodyCache.Clear();
+        }
 
         // ---- the hops: every seed advances one hop together, so the hop's bodies are ONE gather ----
         // A node at the depth cap is recorded and not entered, so nothing is ever queued past `depth`.
         //
-        // A hop is worked in PASSES of at most BodyPrefetch.ChunkRows keys, and every body the pass gathered is
+        // A hop is worked in PASSES of at most WalkPassRows keys, and every body the pass gathered is
         // RELEASED when the pass ends (#719): a record getter is a slice of its whole GRUP's byte array and pins it,
         // so caching the bodies of a whole walk pinned one array per source GRUP per plugin for the life of the call
-        // — 230 KB a node on a real order, and an OOM on a raised budget. A reached node now costs its row: its
+        // — 270 KB a node on a real order, and an OOM on a raised budget. A reached node now costs its row: its
         // identity, its links, its provenance. The pass size IS the gather's own chunk size, so a plugin is
         // enumerated exactly as many times as before and no read gets slower.
         var atLevel = new int[states.Length];
@@ -4111,11 +4197,12 @@ public sealed partial class LoadOrderService : IDisposable
                 int took = 0, seenItems = 0;
                 foreach (var q in s.Frontier)
                 {
-                    if (seenItems >= atLevel[i] || frontier.Count >= BodyPrefetch.ChunkRows) break;
+                    if (seenItems >= atLevel[i] || frontier.Count >= WalkPassRows) break;
                     seenItems++;
                     // A key this seed already visited is dropped at dequeue, so gathering it would spend a slot on a
                     // body no row ever shows and push a node the seed DOES record back onto the per-record seek.
-                    if (q.Key.IsNull || s.Visited.Contains(q.Key) || bodyCache.ContainsKey(q.Key) || !gatherSeen.Add(q.Key)) continue;
+                    if (q.Key.IsNull || s.Visited.Contains(q.Key) || bodyCache.ContainsKey(q.Key)
+                        || Memoised(q.Key, q.Depth) || !gatherSeen.Add(q.Key)) continue;
                     frontier.Add(q.Key);
                     if (++took >= room) break;
                 }
@@ -4149,14 +4236,15 @@ public sealed partial class LoadOrderService : IDisposable
                         atLevel[si] = 0;
                         break;
                     }
-                    var body = Fetch(key);
-                    if (body is null)
+                    bool atCap = hop >= depth;
+                    var fact = FactFor(key, atCap);
+                    if (!fact.Resolved)
                     {
                         st.Nodes.Add(new WalkNodeRow(FormIdToken.Of(key), null, null, hop, pulledBy, "kept",
                                                      "unresolved — no active plugin defines this target (a missing endpoint)"));
                         continue;
                     }
-                    var type = TypeOf(body);
+                    var type = fact.Type!;
                     var excl = exclusions.FirstOrDefault(x => x.Match.Equals(type, StringComparison.OrdinalIgnoreCase));
                     if (excl.Match is not null)
                     {
@@ -4165,13 +4253,17 @@ public sealed partial class LoadOrderService : IDisposable
                         if (excl.Refuse)
                         {
                             refusal = $"the walk reached a {type} ({FormIdToken.Of(key)}, via {pulledBy}) — a node class this call excludes with severity 'refuse'. Nothing is returned for this call.";
+                            // A refusal returns nothing, so the pass in hand is dead: release it here rather than
+                            // leaving it to the collector, on the path that returns no rows to release it with.
+                            if (bodyCache.Count > WalkBodyHighWater) WalkBodyHighWater = bodyCache.Count;
+                            bodyCache.Clear();
+                            WalkBodiesHeldAtReturn = 0;
                             return Array.Empty<WalkSeedResult>();
                         }
-                        st.Nodes.Add(new WalkNodeRow(FormIdToken.Of(key), type, body.EditorID, hop, pulledBy, "kept", $"excluded ({type}, severity stop) — recorded as a boundary, not entered"));
+                        st.Nodes.Add(new WalkNodeRow(FormIdToken.Of(key), type, fact.EditorId, hop, pulledBy, "kept", $"excluded ({type}, severity stop) — recorded as a boundary, not entered"));
                         continue;
                     }
-                    bool atCap = hop >= depth;
-                    st.Nodes.Add(new WalkNodeRow(FormIdToken.Of(key), type, body.EditorID, hop, pulledBy,
+                    st.Nodes.Add(new WalkNodeRow(FormIdToken.Of(key), type, fact.EditorId, hop, pulledBy,
                                                  atCap ? "kept" : "expanded",
                                                  atCap ? $"at the walk.depth cap ({depth}) — not entered" : null));
                     if (atCap)
@@ -4179,8 +4271,8 @@ public sealed partial class LoadOrderService : IDisposable
                         st.Truncation ??= $"walk reached its depth cap ({depth}) on at least one chain — nodes at the cap are recorded, not entered; raise walk.depth to walk deeper.";
                         continue;
                     }
-                    var label = $"{type} {FormIdToken.Of(key)} ({body.EditorID ?? "<no editorid>"})";
-                    foreach (var l in LinksOf(body, followSegs, out _))
+                    var label = $"{type} {FormIdToken.Of(key)} ({fact.EditorId ?? "<no editorid>"})";
+                    foreach (var l in fact.Links ?? EmptyKeys)
                         if (!l.IsNull) st.Frontier.Enqueue((l, hop + 1, label));
                 }
                 // An empty frontier means this seed is finished — nothing but its own turn ever enqueues into it —
@@ -4194,34 +4286,33 @@ public sealed partial class LoadOrderService : IDisposable
             }
         }
 
-        WalkBodiesHeldAtReturn = bodyCache.Count;
-
         var results = new List<WalkSeedResult>(seeds.Count);
         for (int i = 0; i < seeds.Count; i++)
         {
             if (states[i] is not { } st) { results.Add(rows[i]!); continue; }
             IReadOnlyList<NpcTemplateCategory>? templateReport = null;
-            if (st.SeedBody is { } seedNpc) templateReport = NpcTemplateReport(Fetch, seedNpc, st.Key);
+            if (st.SeedTemplateFact is { } seedFact) templateReport = NpcTemplateReport(TemplateFactOf, seedFact, st.Key);
             results.Add(new WalkSeedResult(FormIdToken.Of(st.Key), st.Type, st.EditorId, st.Nodes, st.Cycles, st.Truncation, templateReport, null));
         }
-        bodyCache.Clear();
+        WalkBodiesHeldAtReturn = bodyCache.Count;
         return results;
     }
 
     /// <summary>The NPC_ TemplateFlags interpreter: a SET flag means the category is inherited and the seed's own
     /// local data for it is masked; the provider is the first record down the template chain whose flag for that
     /// category is CLEAR, so its own data is active. A chain ending in a leveled actor resolves at runtime, and a
-    /// broken or missing link is reported rather than guessed.</summary>
-    static IReadOnlyList<NpcTemplateCategory> NpcTemplateReport(Func<FormKey, IMajorRecordGetter?> fetch,
-                                                                INpcGetter seed, FormKey seedFk)
+    /// broken or missing link is reported rather than guessed. It walks FACTS, not bodies, so reporting a chain
+    /// pins no record group's bytes (#719).</summary>
+    static IReadOnlyList<NpcTemplateCategory> NpcTemplateReport(Func<FormKey, WalkTemplateFact?> factOf,
+                                                                WalkTemplateFact seed, FormKey seedFk)
     {
         var report = new List<NpcTemplateCategory>();
         foreach (NpcConfiguration.TemplateFlag flag in Enum.GetValues(typeof(NpcConfiguration.TemplateFlag)))
         {
             var name = flag.ToString();
-            if (!seed.Configuration.TemplateFlags.HasFlag(flag))
+            if (!seed.Flags.HasFlag(flag))
             {
-                report.Add(new NpcTemplateCategory(name, false, FormIdToken.Of(seedFk), seed.EditorID,
+                report.Add(new NpcTemplateCategory(name, false, FormIdToken.Of(seedFk), seed.EditorId,
                                                    "local data ACTIVE (flag clear)"));
                 continue;
             }
@@ -4231,19 +4322,17 @@ public sealed partial class LoadOrderService : IDisposable
             var hops = new HashSet<FormKey> { seedFk };
             while (true)
             {
-                var t = cur.Template;
-                if (t is null || t.IsNull) { note = "flag SET but the template link is empty — the category inherits from nothing (worth a look)"; break; }
-                var nextKey = t.FormKey;
+                if (!cur.HasTemplate) { note = "flag SET but the template link is empty — the category inherits from nothing (worth a look)"; break; }
+                var nextKey = cur.Template;
                 if (!hops.Add(nextKey)) { note = $"template chain CYCLES at {nextKey} — no provider is reachable"; break; }
-                var body = fetch(nextKey);
-                if (body is null) { note = $"template target {nextKey} is unresolved — the chain is broken here"; break; }
-                if (body is ILeveledNpcGetter lvln)
-                { provKey = FormIdToken.Of(nextKey); provEid = lvln.EditorID; note = "a LEVELED actor — the concrete provider is rolled at runtime"; break; }
-                if (body is not INpcGetter npc)
-                { note = $"template target {nextKey} is a {RecordNaming.StripOverlay(body.GetType().Name)}, not an NPC or leveled actor"; break; }
-                if (!npc.Configuration.TemplateFlags.HasFlag(flag))
-                { provKey = FormIdToken.Of(nextKey); provEid = npc.EditorID; break; }
-                cur = npc;
+                if (factOf(nextKey) is not { } next) { note = $"template target {nextKey} is unresolved — the chain is broken here"; break; }
+                if (next.IsLeveled)
+                { provKey = FormIdToken.Of(nextKey); provEid = next.EditorId; note = "a LEVELED actor — the concrete provider is rolled at runtime"; break; }
+                if (!next.IsNpc)
+                { note = $"template target {nextKey} is a {next.TypeName}, not an NPC or leveled actor"; break; }
+                if (!next.Flags.HasFlag(flag))
+                { provKey = FormIdToken.Of(nextKey); provEid = next.EditorId; break; }
+                cur = next;
             }
             report.Add(new NpcTemplateCategory(name, true, provKey, provEid, note));
         }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -3853,6 +3853,17 @@ public sealed partial class LoadOrderService : IDisposable
 
     // ---- the traversal construct (walk=) ---------------------------------------------------------------
 
+    /// <summary>The most record bodies one forward walk held at once. Counted for the reason
+    /// <see cref="LoadOrderResolver.BodySeeks"/> is: whether the walk released a reached node's body or held the
+    /// whole reached set is invisible in the answer and only the memory differs, so this is what a test can hold
+    /// that claim to (#719). Set by <see cref="WalkForwardBatch"/>, which resets it on entry.</summary>
+    internal static int WalkBodyHighWater;
+
+    /// <summary>How many record bodies the last forward walk was STILL holding when its hops finished — the other
+    /// half of the same claim, and the one the reported bug was: the reached set has to be gone before the render,
+    /// not at the end of the call. Zero on every walk.</summary>
+    internal static int WalkBodiesHeldAtReturn;
+
     /// <summary>One record the walk reached: its identity, its provenance (<see cref="PulledBy"/> — the parent
     /// node's label) and whether the walk entered it or recorded it as a boundary. A boundary's reason — an
     /// exclusion stop, the depth cap, an unresolved link — rides in <see cref="Note"/>.</summary>
@@ -3876,11 +3887,15 @@ public sealed partial class LoadOrderService : IDisposable
 
     /// <summary>One seed's walk in progress: the rows it has proved and the frontier it has still to enter. The walk
     /// advances every seed one hop at a time, so a hop's bodies can be gathered together; this holds what used to be
-    /// locals of a per-seed loop.</summary>
+    /// locals of a per-seed loop.
+    /// <para>It holds the seed's IDENTITY, never its body — a record getter is a slice of its whole GRUP's byte array
+    /// and pins it (#719). <see cref="SeedBody"/> is the one exception, kept only for the NPC template report, which
+    /// needs the seed record itself.</para></summary>
     sealed class WalkSeedState
     {
         public FormKey Key;
-        public IMajorRecordGetter Body = null!;
+        public INpcGetter? SeedBody;
+        public string? EditorId;
         public string Type = "";
         public string Label = "";
         public List<WalkNodeRow> Nodes = new();
@@ -3923,8 +3938,11 @@ public sealed partial class LoadOrderService : IDisposable
             followSegs = follow!.Trim().Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
             if (followSegs.Length == 0) { refusal = $"walk.follow '{follow}' is not a usable field path."; return Array.Empty<WalkSeedResult>(); }
         }
+        bool templateFollow = followSegs is { Length: 1 } && followSegs[0].Equals("Template", StringComparison.OrdinalIgnoreCase);
 
         var bodyCache = new Dictionary<FormKey, IMajorRecordGetter?>();
+        WalkBodyHighWater = 0;
+        WalkBodiesHeldAtReturn = 0;
         IMajorRecordGetter? Fetch(FormKey k)
         {
             if (bodyCache.TryGetValue(k, out var c)) return c;
@@ -4021,7 +4039,10 @@ public sealed partial class LoadOrderService : IDisposable
             var st = new WalkSeedState
             {
                 Key = seedFk,
-                Body = seedBody,
+                // Only the template report needs the seed's own body past its first hop; every other consumer wants
+                // its identity, so nothing else keeps a getter alive (and with it a whole GRUP's bytes).
+                SeedBody = templateFollow ? seedBody as INpcGetter : null,
+                EditorId = seedBody.EditorID,
                 Type = seedType,
                 Label = $"{seedType} {FormIdToken.Of(seedFk)} ({seedBody.EditorID ?? "<no editorid>"})",
                 Visited = new HashSet<FormKey> { seedFk },
@@ -4049,8 +4070,28 @@ public sealed partial class LoadOrderService : IDisposable
 
         // ---- the hops: every seed advances one hop together, so the hop's bodies are ONE gather ----
         // A node at the depth cap is recorded and not entered, so nothing is ever queued past `depth`.
+        //
+        // A hop is worked in PASSES of at most BodyPrefetch.ChunkRows keys, and every body the pass gathered is
+        // RELEASED when the pass ends (#719): a record getter is a slice of its whole GRUP's byte array and pins it,
+        // so caching the bodies of a whole walk pinned one array per source GRUP per plugin for the life of the call
+        // — 230 KB a node on a real order, and an OOM on a raised budget. A reached node now costs its row: its
+        // identity, its links, its provenance. The pass size IS the gather's own chunk size, so a plugin is
+        // enumerated exactly as many times as before and no read gets slower.
+        var atLevel = new int[states.Length];
         for (int d = 1; d <= depth; d++)
         {
+            ct.ThrowIfCancellationRequested();
+            // How many queued items belong to THIS hop, snapshotted before anything is enqueued for the next one.
+            bool pending = false;
+            for (int i = 0; i < states.Length; i++)
+            {
+                atLevel[i] = states[i] is { } s0 ? s0.Frontier.Count : 0;
+                if (atLevel[i] > 0) pending = true;
+            }
+            if (!pending) break;
+
+            while (true)
+            {
             ct.ThrowIfCancellationRequested();
             // The gather is bounded by what each seed can still RECORD, not by the size of its frontier: a seed
             // whose node budget is spent reads nothing more, and a seed near its cap reads only what it can still
@@ -4058,32 +4099,39 @@ public sealed partial class LoadOrderService : IDisposable
             // itself is still enforced below — recorded and not entered, with the same sentence.
             var frontier = new List<FormKey>();
             var gatherSeen = new HashSet<FormKey>();
-            bool pending = false;
-            foreach (var s in states)
+            var take = new int[states.Length];
+            bool more = false;
+            for (int i = 0; i < states.Length; i++)
             {
-                if (s is null || s.Frontier.Count == 0) continue;
-                pending = true;
+                var s = states[i];
+                if (s is null || atLevel[i] == 0) continue;
+                more = true;
                 int room = maxNodes - s.Nodes.Count;
-                if (room <= 0) continue;                                  // at its cap: its turn below records the cut
-                int took = 0;
+                if (room <= 0) { take[i] = atLevel[i]; continue; }        // at its cap: its turn below records the cut
+                int took = 0, seenItems = 0;
                 foreach (var q in s.Frontier)
                 {
+                    if (seenItems >= atLevel[i] || frontier.Count >= BodyPrefetch.ChunkRows) break;
+                    seenItems++;
                     // A key this seed already visited is dropped at dequeue, so gathering it would spend a slot on a
                     // body no row ever shows and push a node the seed DOES record back onto the per-record seek.
-                    if (q.Key.IsNull || s.Visited.Contains(q.Key) || !gatherSeen.Add(q.Key)) continue;
+                    if (q.Key.IsNull || s.Visited.Contains(q.Key) || bodyCache.ContainsKey(q.Key) || !gatherSeen.Add(q.Key)) continue;
                     frontier.Add(q.Key);
                     if (++took >= room) break;
                 }
+                take[i] = seenItems;
             }
-            if (!pending) break;
+            if (!more) break;
             if (frontier.Count > 0) Prefetch(frontier);
 
-            foreach (var st in states)
+            for (int si = 0; si < states.Length; si++)
             {
-                if (st is null) continue;
+                var st = states[si];
+                if (st is null || take[si] == 0) continue;
                 ct.ThrowIfCancellationRequested();
-                int atLevel = st.Frontier.Count;
-                for (int q = 0; q < atLevel; q++)
+                int thisPass = take[si];
+                atLevel[si] -= thisPass;
+                for (int q = 0; q < thisPass; q++)
                 {
                     var (key, hop, pulledBy) = st.Frontier.Dequeue();
                     if (key.IsNull) continue;
@@ -4098,6 +4146,7 @@ public sealed partial class LoadOrderService : IDisposable
                     {
                         st.Truncation = $"walk truncated: the {maxNodes}-node cap was reached — what is listed IS reached and proved; raise walk.max_nodes to walk further.";
                         st.Frontier.Clear();
+                        atLevel[si] = 0;
                         break;
                     }
                     var body = Fetch(key);
@@ -4138,18 +4187,24 @@ public sealed partial class LoadOrderService : IDisposable
                 // and the results loop reads neither of these, so the bookkeeping goes back now rather than at return.
                 if (st.Frontier.Count == 0) { st.Visited = new(); st.Frontier = new(); }
             }
+            // The pass is over: the bodies it gathered have given up their identity and their links, so they go
+            // now rather than at the end of the call. This is the release the #719 retention was missing.
+            if (bodyCache.Count > WalkBodyHighWater) WalkBodyHighWater = bodyCache.Count;
+            bodyCache.Clear();
+            }
         }
+
+        WalkBodiesHeldAtReturn = bodyCache.Count;
 
         var results = new List<WalkSeedResult>(seeds.Count);
         for (int i = 0; i < seeds.Count; i++)
         {
             if (states[i] is not { } st) { results.Add(rows[i]!); continue; }
             IReadOnlyList<NpcTemplateCategory>? templateReport = null;
-            if (followSegs is { Length: 1 } && followSegs[0].Equals("Template", StringComparison.OrdinalIgnoreCase)
-                && st.Body is INpcGetter seedNpc)
-                templateReport = NpcTemplateReport(Fetch, seedNpc, st.Key);
-            results.Add(new WalkSeedResult(FormIdToken.Of(st.Key), st.Type, st.Body.EditorID, st.Nodes, st.Cycles, st.Truncation, templateReport, null));
+            if (st.SeedBody is { } seedNpc) templateReport = NpcTemplateReport(Fetch, seedNpc, st.Key);
+            results.Add(new WalkSeedResult(FormIdToken.Of(st.Key), st.Type, st.EditorId, st.Nodes, st.Cycles, st.Truncation, templateReport, null));
         }
+        bodyCache.Clear();
         return results;
     }
 

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -64,8 +64,15 @@ public static class RecordsTools
         [Description("Maximum hops from a seed (default 16). Nodes AT the cap are recorded, not entered, and the response says the cap cut the walk — never a silent stop.")]
         public int? depth { get; set; }
 
-        [Description("The node budget (default 2000, the read-expansion budget). Per seed on a forward walk and on the reverse carrier walk (each seed's carrier rows); ONE budget shared across every seed and every hop on the transitive reverse walk, whose hops are one frontier and not a per-seed expansion. A breach keeps what was proved and says which reading it spent. A reading form (summary/fields/rows/everything/aggregate) then renders the whole reached set — seeds times this budget at the worst — and reads a body per row, so it is held to the same render bound a scan is on EVERY walk lane, and refuses up front naming that lane's own levers: its seeds, this budget, and — on the forward and carrier walks, the two chain can draw — project.form='chain', which lists the same set without reading a body per rendered row (the walk reads one per reached node whatever the form).")]
+        [Description("The node budget (default 2000, the read-expansion budget; 250000 is the hard upper bound and a higher value is refused). Per seed on a forward walk and on the reverse carrier walk (each seed's carrier rows); ONE budget shared across every seed and every hop on the transitive reverse walk, whose hops are one frontier and not a per-seed expansion. A breach keeps what was proved and says which reading it spent. A reading form (summary/fields/rows/everything/aggregate) then renders the whole reached set — seeds times this budget at the worst — and reads a body per row, so it is held to the same render bound a scan is on EVERY walk lane, and refuses up front naming that lane's own levers: its seeds, this budget, and — on the forward and carrier walks, the two chain can draw — project.form='chain', which lists the same set without reading a body per rendered row (the walk reads one per reached node whatever the form).")]
         public int? max_nodes { get; set; }
+
+        /// <summary>The hard upper bound on <see cref="max_nodes"/> (Aaron, 2026-09-12). FIXED, not derived from the
+        /// machine: a reached node costs a row of a few KB wherever it runs, so the arithmetic is the same
+        /// everywhere, and a bound that moved with the machine would make one call succeed on one box and refuse on
+        /// another. 250,000 is above the whole forward closure a single seed reaches — 195,848 nodes measured on a
+        /// 3,801-plugin order — so it bounds the budget without bounding an answer.</summary>
+        internal const int Ceiling = 250_000;
 
         [Description("Node classes the walk must not enter, as data: [{\"match\": \"Race\", \"severity\": \"stop\"|\"refuse\"}] — match is the record type name a read reports; stop prunes there (recorded as a boundary), refuse fails the whole call loud.")]
         public RecordsWalkExclusion[]? exclusions { get; set; }
@@ -312,6 +319,8 @@ public static class RecordsTools
             if (walk.max_nodes is { } wn)
             {
                 if (wn < 1) return Wire.Refuse(json, $"error: walk.max_nodes={wn} — the node budget must be >= 1.");
+                if (wn > RecordsWalk.Ceiling)
+                    return Wire.Refuse(json, $"error: walk.max_nodes={wn} — the node budget's hard upper bound is {RecordsWalk.Ceiling}; pass that or less, which is above the whole forward closure a single seed reaches on a large order.");
                 walkMaxNodes = wn;
             }
             foreach (var x in walk.exclusions ?? Array.Empty<RecordsWalkExclusion>())

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -64,14 +64,16 @@ public static class RecordsTools
         [Description("Maximum hops from a seed (default 16). Nodes AT the cap are recorded, not entered, and the response says the cap cut the walk — never a silent stop.")]
         public int? depth { get; set; }
 
-        [Description("The node budget (default 2000, the read-expansion budget; 250000 is the hard upper bound and a higher value is refused). Per seed on a forward walk and on the reverse carrier walk (each seed's carrier rows); ONE budget shared across every seed and every hop on the transitive reverse walk, whose hops are one frontier and not a per-seed expansion. A breach keeps what was proved and says which reading it spent. A reading form (summary/fields/rows/everything/aggregate) then renders the whole reached set — seeds times this budget at the worst — and reads a body per row, so it is held to the same render bound a scan is on EVERY walk lane, and refuses up front naming that lane's own levers: its seeds, this budget, and — on the forward and carrier walks, the two chain can draw — project.form='chain', which lists the same set without reading a body per rendered row (the walk reads one per reached node whatever the form).")]
+        [Description("The node budget (default 2000, the read-expansion budget). Per seed on a forward walk and on the reverse carrier walk (each seed's carrier rows), where 250000 is the hard upper bound and a higher value is refused; ONE budget shared across every seed and every hop on the transitive reverse walk, whose hops are one frontier and not a per-seed expansion. A breach keeps what was proved and says which reading it spent. A reading form (summary/fields/rows/everything/aggregate) then renders the whole reached set — seeds times this budget at the worst — and reads a body per row, so it is held to the same render bound a scan is on EVERY walk lane, and refuses up front naming that lane's own levers: its seeds, this budget, and — on the forward and carrier walks, the two chain can draw — project.form='chain', which lists the same set without reading a body per rendered row (the walk reads one per reached node whatever the form).")]
         public int? max_nodes { get; set; }
 
-        /// <summary>The hard upper bound on <see cref="max_nodes"/> (Aaron, 2026-09-12). FIXED, not derived from the
-        /// machine: a reached node costs a row of a few KB wherever it runs, so the arithmetic is the same
-        /// everywhere, and a bound that moved with the machine would make one call succeed on one box and refuse on
-        /// another. 250,000 is above the whole forward closure a single seed reaches — 195,848 nodes measured on a
-        /// 3,801-plugin order — so it bounds the budget without bounding an answer.</summary>
+        /// <summary>The hard upper bound on the PER-SEED reading of <see cref="max_nodes"/> — the forward walk and
+        /// the reverse carrier walk (Aaron, 2026-09-12). FIXED, not derived from the machine: a reached node costs a
+        /// row of a few KB wherever it runs, so the arithmetic is the same everywhere, and a bound that moved with
+        /// the machine would make one call succeed on one box and refuse on another. 250,000 is above the whole
+        /// forward closure a single seed reaches — 195,848 nodes measured on a 3,801-plugin order — so it bounds the
+        /// budget without bounding an answer. NOT the transitive reverse walk, whose budget is one shared across
+        /// every seed and hop and whose cost is a clock rather than a live set (#727).</summary>
         internal const int Ceiling = 250_000;
 
         [Description("Node classes the walk must not enter, as data: [{\"match\": \"Race\", \"severity\": \"stop\"|\"refuse\"}] — match is the record type name a read reports; stop prunes there (recorded as a boundary), refuse fails the whole call loud.")]
@@ -319,8 +321,14 @@ public static class RecordsTools
             if (walk.max_nodes is { } wn)
             {
                 if (wn < 1) return Wire.Refuse(json, $"error: walk.max_nodes={wn} — the node budget must be >= 1.");
-                if (wn > RecordsWalk.Ceiling)
-                    return Wire.Refuse(json, $"error: walk.max_nodes={wn} — the node budget's hard upper bound is {RecordsWalk.Ceiling}; pass that or less, which is above the whole forward closure a single seed reaches on a large order.");
+                // The bound is on the PER-SEED reading of this budget — the forward walk and the reverse carrier
+                // walk. On the transitive reverse walk it is ONE budget shared across every seed and every hop, a
+                // different quantity measured on a different lane, and this number was not ruled for it (#727 is
+                // where that lane's own cost sits).
+                bool perSeedBudget = walkDirection == "forward"
+                                  || string.Equals(walk.follow?.Trim(), CarrierFollow, StringComparison.OrdinalIgnoreCase);
+                if (perSeedBudget && wn > RecordsWalk.Ceiling)
+                    return Wire.Refuse(json, $"error: walk.max_nodes={wn} — the node budget's hard upper bound is {RecordsWalk.Ceiling}; pass that or less, which is above the whole closure a single seed reaches on a large order.");
                 walkMaxNodes = wn;
             }
             foreach (var x in walk.exclusions ?? Array.Empty<RecordsWalkExclusion>())


### PR DESCRIPTION
A forward `walk=` cached one record body per reached node for the lifetime of the call. A Mutagen record getter is a `ReadOnlyMemorySlice<byte>` over the whole GRUP it was read from, and the slice keeps that array alive, so the cache pinned one whole-group byte array per source group per plugin the walk touched — measured at ~270 KB per reached node on Aaron's ARR 2.0 order, unreleased until the call returned, and an `OutOfMemoryException` at a raised `walk.max_nodes`. The walk now works both its seed set and each hop in passes of the gather's own chunk size and releases the pass's bodies when the pass ends, so a reached node costs its row — identity, links, pull chain — and nothing is held into the render. What a node yielded is remembered as values in a per-call memo, so a key two seeds both reach is still one read per call, which is what the body cache used to buy before it was the retention. The NPC template report walks those values too, rather than keeping a getter per seed. Plugins are enumerated as often as before, because the pass size is the chunk size the gather already split on.

## Where the bytes were

Profiled with `dotnet-gcdump` against a private Release build driven over stdio, forward `*` chain from Lydia (`0A2C8E:Skyrim.esm`) at `max_nodes: 10000`, `Perk` excluded with severity `stop`:

- At peak, the **live** managed heap (gcdump induces a gen2 GC, so this is live data, not slack) was **2.67 GB** against a 3.53 GB working set. The order index accounts for 340 MB of it; the rest is `System.Byte[]` — whole-GRUP arrays, five of them averaging 35 MB each, pinned through the `Dictionary<FormKey, IMajorRecordGetter?>` the gcdump shows by name.
- Immediately after the call, the live heap is **383 MB** (the index alone) while the working set stays at 3.55 GB. So the "20.6 GB still held 30 s later" in the issue is the GC not returning freed segments to the OS, not a second leak — the retention that matters is the in-call one, and that is what this fixes.

**Per reached node: ~270 KB before** ((3,528 − 830 MB idle) / 10,000), **~4.4 KB after** ((1,694 − 830 MB) / 195,848 on the million-node arm) — and what it now buys is the node row, not a body.

## Before and after

Private `housecarl-mcp.exe` — this branch's Release build against `main`'s, both built here, neither the installed server — one cold process per arm, working set and private bytes sampled every 250 ms from outside, max inside the call's window. 3,801-plugin ARR 2.0 order, 8C/16T, 32 GB. Arms 1–3: seed Lydia, forward `*`, `project.form='chain'`, `Perk` excluded severity `stop`. Baselines at 40,000 and 1,000,000 are the issue's; 10,000 was re-run here for parity and matched (3,528 MB against the issue's 3,415 MB).

| arm | peak WS before | peak WS after | WS 35 s after the call returned | elapsed | result |
|---|---:|---:|---:|---:|---|
| `max_nodes` 10,000 | 3,528 MB | **1,430 MB** | 3,549 → **1,140 MB** | 35.9 → 34.6 s | 10,000 reached, depth 5, unchanged |
| `max_nodes` 40,000 | 9,469 MB | **1,490 MB** | — → **1,198 MB** | 60.3 → 74.4 s | 40,000 reached, depth 7, unchanged |
| `max_nodes` 1,000,000 | **OOM at 55,875 MB private** after 471 s, 20.6 GB held 30 s later | **1,694 MB** | — → **1,347 MB** | 471 s (died) → 287 s (finished) | **now completes**: 195,848 nodes, the whole closure from that seed at depth 16 |
| **multi-seed**: 2,127 NPC_ defined in `BSHeartland.esm`, depth 2, `max_nodes` 50 | 1,753 MB | **1,506 MB** | 1,786 → **1,294 MB** | 24.8 → 26.4 s | 100,402 reached, byte-identical response |

The multi-seed arm is the one the review asked for, and it earned its place: with the per-pass release alone it ran 24.8 s → **34.3 s**, because releasing bodies per pass had also dropped the per-call read-once guarantee. The memo restores it at 26.4 s, within noise of the baseline, and the memory win survives. The 40,000 arm is ~14 s slower against the issue's own baseline; the 10,000 arm came out marginally faster, so those two straddle run-to-run noise on a different build and I did not chase it further.

The 1,000,000 arm is the striking one: the call that used to consume 56 GB and die now walks the seed's entire closure to exhaustion inside 1.7 GB. It is also the arm the new bound refuses (see below) — it was run before the bound landed, so I re-ran it at the bound on the same harness to check the bound does not cost an answer:

| arm | peak WS | WS 35 s after | elapsed | result |
|---|---:|---:|---:|---|
| `max_nodes` **250,000** (the bound) | 1,808 MB | 1,679 MB | 308 s | 195,848 nodes — the same whole closure |
| `max_nodes` **250,001** | 56 MB | 58 MB | **0.3 s** | refused, naming the bound |

The refusal costs 0.3 s and 56 MB because it lands before the load order resolves at all.

## Test

Eight tests in `RecordsWalkCostTests.cs`, on two new internal counters (`LoadOrderService.WalkBodyHighWater`, `WalkBodiesHeldAtReturn`) in the same idiom as the existing cost tests' `LoadOrderResolver.BodySeeks` and `BodyPrefetch.KeysWanted` — whether a walk released a node's body or held the whole reached set is invisible in the answer and visible only in memory, which is the argument those counters were added on:

- `AWalkHoldsNoReachedBodiesPastTheGatherThatReadThem` — nothing held at return, never more than one pass at once. Fails on the old code, where held-at-return was the whole reached set.
- `AWalkSplitAcrossPassesReachesTheSameSetAndHoldsOnePass` at pass sizes 1, 7 and 64 — the answer is byte-identical to the unsplit walk, and the high water follows the pass size. `LoadOrderService.WalkPassRows` is the knob, moved by the test the way `RenderBudget.MaxRenderRows` already is; building a world with a 2,000-link hop to meet the real pass size is not a test.
- `ASeedsNodeBudgetIsSpentAcrossPassesNotPerPass` — `max_nodes` is a budget for the walk, not for each pass of it.
- `ARefusingWalkSplitAcrossPassesRefusesTheSameWayAndHoldsNothing` — the `severity: 'refuse'` sentence still names the same seed at the same hop with a hop interleaved across passes, and that return releases its pass.

- `ATemplateReportReadsNoChainNodeTheWalkAlreadyRead` — on a template walk the reached nodes *are* the chain nodes, so the report takes its facts off the bodies the walk read rather than re-reading each one with a whole-plugin seek. `AWalkGathersItsSeedBodiesOncePerPluginNotOncePerSeed` keeps its ceiling of 1 seek because of it.
- `ATransitiveReverseWalkIsNotHeldToTheForwardCeiling` — the node-budget bound belongs to the per-seed lanes, and the shared-budget lane is not caught by it.

Full suite 1,936 passed, `ci-all` 128/128.

## The ceiling — set, on Aaron's ruling

`walk.max_nodes` now has a **hard upper bound of 250,000, fixed, not memory-derived** (`RecordsTools.RecordsWalk.Ceiling`). Two measurements decided the number:

1. **The closure is finite and smaller than the budget people reach for.** The full forward closure from an NPC on this order is 195,848 nodes at depth 16. `max_nodes: 1000000` was never asking for a million nodes; it was asking for "no cap", and the cap is what turned that into an OOM rather than an answer. So the bound sits above what a single seed actually reaches: it bounds the budget, not an answer, and a walk that finishes still finishes.
2. **A reached node costs ~4.4 KB of retained row**, stably, because it is a row and no longer a body. At the bound that is ~1 GB of node rows, keeping the whole call inside ~2.5 GB on this machine including the ~830 MB order index.

Fixed rather than memory-derived because the per-node cost is now a stable row, so a fixed number is honest arithmetic rather than a guess, and because a memory-derived bound would make the same call succeed on one machine and be refused on another — the opposite of a declared cost. The downstream cost, a reading form that reads a body per rendered row, is still bounded by `RenderBudget`, which is where machine-sized questions belong.

**The bound is on the PER-SEED reading of the budget** — the forward walk and the reverse carrier walk. On the transitive reverse walk the same parameter is one budget shared across every seed and every hop: a different quantity, on the lane where this retention never existed and whose cost is a clock rather than a live set, and it is not what was ruled. That lane is left exactly as it was; `ATransitiveReverseWalkIsNotHeldToTheForwardCeiling` pins it.

What landed: the gate refuses above the bound in one sentence naming it and what to pass — `walk.max_nodes=250001 — the node budget's hard upper bound is 250000; pass that or less, which is above the whole closure a single seed reaches on a large order.` — the parameter's description carries the bound inside the clause that already says the budget is per seed on those two lanes, and `ANodeBudgetPastTheCeilingIsRefusedNamingTheBound` / `ANodeBudgetAtTheCeilingWalks` test either side of it. `walk.depth` is untouched. The tool-surface md5 moves, as expected for a description change.

**Nothing under `.claude/skills/` teaches `max_nodes`** — grepped the whole tree, and the only non-code mentions are this changelog's own history — so there was no skill or reference text to update.

**The time figure is deliberately not in the surface text.** 195,848 nodes took 287 s, about 1.5 ms a node, so above roughly 200,000 the clock refuses before the memory does. That did not fit the description's shape in one clause without becoming a second sentence about a second cost, and it is not what the bound is measuring, so the description says the bound and the refusal says what to pass. Worth its own look if a walk's declared cost ever states seconds.

Closes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)
